### PR TITLE
Disable default Seccomp profile with privileged containers

### DIFF
--- a/cmd/podman/spec.go
+++ b/cmd/podman/spec.go
@@ -330,6 +330,11 @@ func createConfigToOCISpec(config *createConfig) (*spec.Spec, error) {
 		}
 	}
 
+	// Clear default Seccomp profile from Generator for privileged containers
+	if config.SeccompProfilePath == "unconfined" || config.Privileged {
+		configSpec.Linux.Seccomp = nil
+	}
+
 	// BIND MOUNTS
 	mounts, err := config.GetVolumeMounts()
 	if err != nil {


### PR DESCRIPTION
The OCI runtime-tools generator includes a default seccomp spec we were not accounting for. Clear it for privileged containers to make sure we don't leak Seccomp into a privileged container.