### PR TITLE
Use container cleanup() functions when removing

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -765,7 +765,7 @@ func (c *Container) cleanupCgroups() error {
 func (c *Container) cleanupNetwork() error {
 	// Stop the container's network namespace (if it has one)
 	if err := c.runtime.teardownNetNS(c); err != nil {
-		logrus.Errorf("unable cleanup network for container %s: %q", c.ID(), err)
+		logrus.Errorf("unable to cleanup network for container %s: %q", c.ID(), err)
 	}
 
 	c.state.NetNS = nil

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -465,7 +465,7 @@ func (r *OCIRuntime) updateContainerStatus(ctr *Container) error {
 		}
 		statusCode, err := strconv.Atoi(string(statusCodeStr))
 		if err != nil {
-			return errors.Wrapf(err, "error convertaing exit status code for container %s to int",
+			return errors.Wrapf(err, "error converting exit status code for container %s to int",
 				ctr.ID())
 		}
 		ctr.state.ExitCode = int32(statusCode)

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -219,13 +219,8 @@ func (r *Runtime) removeContainer(c *Container, force bool) error {
 		return errors.Wrapf(ErrCtrExists, "container %s has dependent containers which must be removed before it: %s", c.ID(), depsStr)
 	}
 
-	// Tear down the container's cgroups (if they exist)
-	if err := c.cleanupCgroups(); err != nil {
-		return err
-	}
-
-	// Stop the container's network namespace (if it has one)
-	if err := r.teardownNetNS(c); err != nil {
+	// Clean up network namespace, cgroups, mounts
+	if err := c.cleanup(); err != nil {
 		return err
 	}
 

--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -160,8 +160,8 @@ func (r *Runtime) RemovePod(p *Pod, removeCtrs, force bool) error {
 	// We can remove containers even if they have dependencies now
 	// As we have guaranteed their dependencies are in the pod
 	for _, ctr := range ctrs {
-		// Stop network NS
-		if err := r.teardownNetNS(ctr); err != nil {
+		// Clean up network namespace, cgroups, mounts
+		if err := ctr.cleanup(); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Instead of manually calling functions to tear down container resources as we remove them, just call the dedicated cleanup() function, to ensure that cleanup code only has to be in one place, not three.