### PR TITLE
Cleanup man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ MANPAGES_MD ?= $(wildcard docs/*.md pkg/*/docs/*.md)
 MANPAGES ?= $(MANPAGES_MD:%.md=%)
 
 $(MANPAGES): %: %.md .gopathok
-	$(GOMD2MAN) -in $< -out $@
+	@sed -e 's/\((podman.*\.md)\)//' -e 's/\[\(podman.*\)\]/\1/' $<  | $(GOMD2MAN) -in /dev/stdin -out $@
 
 docs: $(MANPAGES)
 

--- a/docs/libpod.conf.5.md
+++ b/docs/libpod.conf.5.md
@@ -1,6 +1,4 @@
-% libpod.conf(5) library for running OCI-based containers in Pods
-% Nathan Williams
-% APRIL 2018
+% libpod.conf "5"
 
 # NAME
 libpod.conf - libpod configuration file

--- a/docs/podman-attach.1.md
+++ b/docs/podman-attach.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-attach - See the output of pid 1 of a container or enter the container
-% Dan Walsh
-# podman-attach "1" "December 2017" "podman"
+% podman-attach "1"
 
 ## NAME
 podman\-attach - Attach to a running container

--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-build - Simple tool to build a container image
-% Tom Sweeney
-# podman-build "7" "December 2017" "podman"
+% podman-build "1"
 
 ## NAME
 podman\-build - Build a container image using a Dockerfile.

--- a/docs/podman-commit.1.md
+++ b/docs/podman-commit.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-commit - Tool to create new image based on the changed container
-% Urvashi Mohnani
-# podman-commit "1" "December 2017" "podman"
+% podman-commit "1"
 
 ## NAME
 podman\-commit - Create new image based on the changed container

--- a/docs/podman-cp.1.md
+++ b/docs/podman-cp.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-cp - Copy content between container's file system and the host
-% Dan Walsh
-# podman-cp "1" "August 2017" "podman"
+% podman-cp "1"
 
 ## NAME
 podman\-cp - Copy files/folders between a container and the local filesystem

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -1,5 +1,4 @@
-% podman(1) podman-create - Create a new container
-% Dan Walsh
+% podman-create "1"
 
 ## NAME
 podman\-create - Create a new container

--- a/docs/podman-diff.1.md
+++ b/docs/podman-diff.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-diff - Inspect changes on a container or image's filesystem
-% Dan Walsh
-# podman-diff "1" "August 2017" "podman"
+% podman-diff "1"
 
 ## NAME
 podman\-diff - Inspect changes on a container or image's filesystem

--- a/docs/podman-exec.1.md
+++ b/docs/podman-exec.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-exec - Execute a command in a running container
-% Brent Baude
-# podman-exec "1" "December 2017" "podman"
+% podman-exec "1"
 
 ## NAME
 podman\-exec - Execute a command in a running container

--- a/docs/podman-export.1.md
+++ b/docs/podman-export.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-export - Simple tool to export a container's filesystem as a tarball
-% Urvashi Mohnani
-# podman-export "1" "July 2017" "podman"
+% podman-export "1"
 
 ## NAME
 podman export - Export container's filesystem contents as a tar archive

--- a/docs/podman-history.1.md
+++ b/docs/podman-history.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-history - Simple tool to view the history of an image
-% Urvashi Mohnani
-% podman-history "1" "JULY 2017" "podman"
+% podman-history "1"
 
 ## NAME
 podman\-history - Shows the history of an image

--- a/docs/podman-images.1.md
+++ b/docs/podman-images.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-images - List images in local storage
-% Dan Walsh
-# podman-images "1" "March 2017" "podman"
+% podman-images "1"
 
 ## NAME
 podman\-images - List images in local storage

--- a/docs/podman-import.1.md
+++ b/docs/podman-import.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-import - Simple tool to import a tarball as an image
-% Urvashi Mohnani
-# podman-import "1" "November 2017" "podman"
+% podman-import "1"
 
 ## NAME
 podman\-import - Import a tarball and save it as a filesystem image

--- a/docs/podman-info.1.md
+++ b/docs/podman-info.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-version - Simple tool to view version information
-% Vincent Batts
-% podman-version "1" "JULY 2017" "podman"
+% podman-version "1"
 
 ## NAME
 podman\-info - Display system information

--- a/docs/podman-inspect.1.md
+++ b/docs/podman-inspect.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-inspect - Display a container or image's configuration
-% Dan Walsh
-# podman-inspect "1" "July 2017" "podman"
+% podman-inspect "1"
 
 ## NAME
 podman\-inspect - Display a container or image's configuration

--- a/docs/podman-kill.1.md
+++ b/docs/podman-kill.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-kill- Kill one or more containers with a signal
-% Brent Baude
-# podman-kill"1" "September 2017" "podman"
+% podman-kill "1"
 
 ## NAME
 podman\-kill - Kills one or more containers with a signal

--- a/docs/podman-load.1.md
+++ b/docs/podman-load.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-load - Simple tool to load an image from an archive to containers-storage
-% Urvashi Mohnani
-# podman-load "1" "July 2017" "podman"
+% podman-load  "1"
 
 ## NAME
 podman\-load - Load an image from docker archive

--- a/docs/podman-login.1.md
+++ b/docs/podman-login.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-login - Simple tool to login to a registry server
-% Urvashi Mohnani
-# podman-login "1" "August 2017" "podman"
+% podman-login "1"
 
 ## NAME
 podman\-login - Login to a container registry

--- a/docs/podman-logout.1.md
+++ b/docs/podman-logout.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-logout - Simple tool to logout of a registry server
-% Urvashi Mohnani
-# podman-logout "1" "August 2017" "podman"
+% podman-logout "1"
 
 ## NAME
 podman\-logout - Logout of a container registry

--- a/docs/podman-logs.1.md
+++ b/docs/podman-logs.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-logs - Fetch the logs of a container
-% Ryan Cole
-# podman-logs "1" "March 2017" "podman"
+% podman-logs "1"
 
 ## NAME
 podman\-logs - Fetch the logs of a container

--- a/docs/podman-mount.1.md
+++ b/docs/podman-mount.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-mount - Mount a working container's root filesystem.
-% Dan Walsh
-# podman-mount "1" "July 2017" "podman"
+% podman-mount "1"
 
 ## NAME
 podman\-mount - Mount a working container's root filesystem

--- a/docs/podman-pause.1.md
+++ b/docs/podman-pause.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-pause - Pause one or more containers
-% Dan Walsh
-# podman-pause "1" "September 2017" "podman"
+% podman-pause "1"
 
 ## NAME
 podman\-pause - Pause one or more containers

--- a/docs/podman-port.1.md
+++ b/docs/podman-port.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-port - List port mappings for the CONTAINER, or lookup the public-facing port that is NAT-ed to the PRIVATE_PORT
-% Brent Baude
-# podman-port "1" "January 2018" "podman"
+% podman-port "1"
 
 ## NAME
 podman\-port - List port mappings for a container

--- a/docs/podman-ps.1.md
+++ b/docs/podman-ps.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-ps - Simple tool to list containers
-% Urvashi Mohnani
-% podman-ps "1" "AUGUST 2017" "podman"
+% podman-ps "1"
 
 ## NAME
 podman\-ps - Prints out information about containers

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-pull - Simple tool to pull an image from a registry
-% Urvashi Mohnani
-# podman-pull "1" "July 2017" "podman"
+% podman-pull "1"
 
 ## NAME
 podman\-pull - Pull an image from a registry

--- a/docs/podman-push.1.md
+++ b/docs/podman-push.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-push - Push an image from local storage to elsewhere
-% Dan Walsh
-# podman-push "1" "June 2017" "podman"
+% podman-push "1"
 
 ## NAME
 podman\-push - Push an image from local storage to elsewhere

--- a/docs/podman-restart.1.md
+++ b/docs/podman-restart.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-restart - Restart a container
-% Matt Heon
-# podman-restart "1" "March 2017" "podman"
+% podman-restart "1"
 
 ## NAME
 podman\-restart - Restart a container

--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-rm - Remove one or more containers
-% Ryan Cole
-# podman-rm "1" "August 2017" "podman"
+% podman-rm "1"
 
 ## NAME
 podman\-rm - Remove one or more containers

--- a/docs/podman-rmi.1.md
+++ b/docs/podman-rmi.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-rmi - Removes one or more images
-% Dan Walsh
-# podman-rmi "1" "March 2017" "podman"
+% podman-rmi "1"
 
 ## NAME
 podman\-rmi - Removes one or more images

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -1,5 +1,4 @@
-% podman(1) podman-run - Run a command in a container
-% Dan Walsh
+% podman-run "1"
 
 ## NAME
 podman\-run - Run a command in a new container

--- a/docs/podman-save.1.md
+++ b/docs/podman-save.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-save - Simple tool to save an image to an archive
-% Urvashi Mohnani
-# podman-save "1" "July 2017" "podman"
+% podman-save "1"
 
 ## NAME
 podman\-save - Save an image to docker-archive or oci-archive

--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-search - Tool to search registries for an image
-% Urvashi Mohnani
-# podman-search "1" "January 2018" "podman"
+% podman-search "1"
 
 ## NAME
 podman\-search - Search a registry for an image

--- a/docs/podman-start.1.md
+++ b/docs/podman-start.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-start - Stop one or more containers
-% Brent Baude
-# podman-start "1" "November 2017" "podman"
+% podman-start "1"
 
 ## NAME
 podman\-start - Start one or more containers

--- a/docs/podman-stats.1.md
+++ b/docs/podman-stats.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-stats - Display a live stream of 1 or more containers' resource usage statistics
-% Ryan Cole
-# podman-stats "1" "July 2017" "podman"
+% podman-stats "1"
 
 ## NAME
 podman\-stats - Display a live stream of 1 or more containers' resource usage statistics

--- a/docs/podman-stop.1.md
+++ b/docs/podman-stop.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-stop - Stop one or more containers
-% Brent Baude
-# podman-stop "1" "September 2017" "podman"
+% podman-stop "1"
 
 ## NAME
 podman\-stop - Stop one or more containers

--- a/docs/podman-tag.1.md
+++ b/docs/podman-tag.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-tag - Add tags to an image
-% Ryan Cole
-# podman-tag "1" "July 2017" "podman"
+% podman-tag "1"
 
 ## NAME
 podman\-tag - Add an additional name to a local image

--- a/docs/podman-top.1.md
+++ b/docs/podman-top.1.md
@@ -1,5 +1,4 @@
-% podman(1) podman-top - display the running processes of a container
-% Brent Baude
+% podman-top "1"
 
 ## NAME
 podman\-top - Display the running processes of a container

--- a/docs/podman-umount.1.md
+++ b/docs/podman-umount.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-umount - Unmount a working container's root filesystem.
-% Dan Walsh
-# podman-umount "1" "July 2017" "podman"
+% podman-umount "1"
 
 ## NAME
 podman\-umount - Unmount a working container's root file system

--- a/docs/podman-unpause.1.md
+++ b/docs/podman-unpause.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-unpause - Unpause one or more containers
-% Dan Walsh
-# podman-unpause "1" "September 2017" "podman"
+% podman-unpause "1"
 
 ## NAME
 podman\-unpause - Unpause one or more containers

--- a/docs/podman-varlink.1.md
+++ b/docs/podman-varlink.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-varlink - Waits on a container
-% Brent Baude
-# podman-varlink "1" "April 2018" "podman"
+% podman-varlink "1"
 
 ## NAME
 podman\-varlink - Runs the varlink backend interface

--- a/docs/podman-version.1.md
+++ b/docs/podman-version.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-version - Simple tool to view version information
-% Urvashi Mohnani
-# podman-version "1" "July 2017" "podman"
+% podman-version "1"
 
 ## NAME
 podman\-version - Display the PODMAN Version Information

--- a/docs/podman-wait.1.md
+++ b/docs/podman-wait.1.md
@@ -1,6 +1,4 @@
-% podman(1) podman-wait - Waits on a container
-% Brent Baude
-# podman-wait "1" "September 2017" "podman"
+% podman-wait "1"
 
 ## NAME
 podman\-wait - Waits on one or more containers to stop and prints exit code

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -1,6 +1,5 @@
-% podman(1) podman - Simple management tool for pods and images
-% Dan Walsh
-# podman "1" "September 2016" "podman"
+% podman "1"
+
 ## NAME
 podman - Simple management tool for containers and images
 


### PR DESCRIPTION
Format md files to work properly when converted to man pages.
Add sed command to cleanup table in podman man page.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>