### PR TITLE
urfave/cli: fix regression in short-opts parsing

### DIFF
--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -43,6 +43,25 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	// It essentially repeats the test above but with the `-it` short option
+	// that broke execution at:
+	//     https://github.com/projectatomic/libpod/pull/1066#issuecomment-403562116
+	// To avoid a potential future regression, use this as a test.
+	It("podman uidmapping and gidmapping with short-opts", func() {
+		if os.Getenv("SKIP_USERNS") != "" {
+			Skip("Skip userns tests.")
+		}
+		if _, err := os.Stat("/proc/self/uid_map"); err != nil {
+			Skip("User namespaces not supported.")
+		}
+
+		session := podmanTest.Podman([]string{"run", "--uidmap=0:1:70000", "--gidmap=0:20000:70000", "-it", "busybox", "echo", "hello"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		ok, _ := session.GrepString("hello")
+		Expect(ok).To(BeTrue())
+	})
+
 	It("podman uidmapping and gidmapping --net=host", func() {
 		if os.Getenv("SKIP_USERNS") != "" {
 			Skip("Skip userns tests.")

--- a/vendor/github.com/urfave/cli/command.go
+++ b/vendor/github.com/urfave/cli/command.go
@@ -204,7 +204,7 @@ PARSE:
 			newArgs := Args{}
 			for i, arg := range args {
 				if arg != trimmed {
-					newArgs = append(newArgs, trimmed)
+					newArgs = append(newArgs, arg)
 					continue
 				}
 				shortOpts := translateShortOptions(set, Args{trimmed})
@@ -215,7 +215,12 @@ PARSE:
 				newArgs = append(newArgs, shortOpts...)
 				newArgs = append(newArgs, args[i+1:]...)
 				args = newArgs
-				// now parse again
+				// now reset the flagset parse again
+				set, err = flagSet(c.Name, c.Flags)
+				if err != nil {
+					return nil, err
+				}
+				set.SetOutput(ioutil.Discard)
 				goto PARSE
 			}
 		}


### PR DESCRIPTION
Add the actual argument, not the one we're looking for when searching
the to-be-translated short-opt string.  Otherwise, we're likely to hit
an infinite loop.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>

Cc: @giuseppe
Fixes: https://github.com/projectatomic/libpod/pull/1046#issuecomment-403547417