### PR TITLE
add support for podman-remote history

### DIFF
--- a/cmd/podman/history.go
+++ b/cmd/podman/history.go
@@ -1,15 +1,15 @@
 package main
 
 import (
+	"github.com/containers/libpod/libpod/adapter"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/containers/libpod/cmd/podman/formats"
-	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod/image"
-	units "github.com/docker/go-units"
+	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -72,11 +72,11 @@ func historyCmd(c *cli.Context) error {
 		return err
 	}
 
-	runtime, err := libpodruntime.GetRuntime(c)
+	runtime, err := adapter.GetRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}
-	defer runtime.Shutdown(false)
+	defer runtime.Runtime.Shutdown(false)
 
 	format := genHistoryFormat(c.String("format"), c.Bool("quiet"))
 
@@ -88,7 +88,7 @@ func historyCmd(c *cli.Context) error {
 		return errors.Errorf("podman history takes at most 1 argument")
 	}
 
-	image, err := runtime.ImageRuntime().NewFromLocal(args[0])
+	image, err := runtime.NewImageFromLocal(args[0])
 	if err != nil {
 		return err
 	}

--- a/libpod/adapter/runtime_remote.go
+++ b/libpod/adapter/runtime_remote.go
@@ -221,3 +221,28 @@ func (r RemoteRuntime) RemoveImage(force bool) error {
 func (r *LocalRuntime) RemoveImage(ctx context.Context, img *ContainerImage, force bool) (string, error) {
 	return iopodman.RemoveImage().Call(r.Conn, img.InputName, force)
 }
+
+// History returns the history of an image and its layers
+func (ci *ContainerImage) History(ctx context.Context) ([]*image.History, error) {
+	var imageHistories []*image.History
+
+	reply, err := iopodman.HistoryImage().Call(ci.Runtime.Conn, ci.InputName)
+	if err != nil {
+		return nil, err
+	}
+	for _, h := range reply {
+		created, err := splitStringDate(h.Created)
+		if err != nil {
+			return nil, err
+		}
+		ih := image.History{
+			ID:        h.Id,
+			Created:   &created,
+			CreatedBy: h.CreatedBy,
+			Size:      h.Size,
+			Comment:   h.Comment,
+		}
+		imageHistories = append(imageHistories, &ih)
+	}
+	return imageHistories, nil
+}

--- a/test/e2e/history_test.go
+++ b/test/e2e/history_test.go
@@ -1,5 +1,3 @@
-// +build !remoteclient
-
 package integration
 
 import (


### PR DESCRIPTION
this adds support to get the history for an image and its
layers using podman-remote.

Signed-off-by: baude <bbaude@redhat.com>