### PR TITLE
enable podman-remote version

### DIFF
--- a/API.md
+++ b/API.md
@@ -1654,6 +1654,8 @@ git_commit [string](https://godoc.org/builtin#string)
 built [int](https://godoc.org/builtin#int)
 
 os_arch [string](https://godoc.org/builtin#string)
+
+remote_api_version [int](https://godoc.org/builtin#int)
 ## Errors
 ### <a name="ContainerNotFound"></a>type ContainerNotFound
 

--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -38,7 +38,6 @@ func getAppCommands() []cli.Command {
 		topCommand,
 		umountCommand,
 		unpauseCommand,
-		versionCommand,
 		volumeCommand,
 		waitCommand,
 	}

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -96,6 +96,7 @@ func main() {
 		pullCommand,
 		rmiCommand,
 		tagCommand,
+		versionCommand,
 	}
 
 	app.Commands = append(app.Commands, getAppCommands()...)

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -9,7 +9,8 @@ type Version (
   go_version: string,
   git_commit: string,
   built: int,
-  os_arch: string
+  os_arch: string,
+  remote_api_version: int
 )
 
 type NotImplemented (

--- a/cmd/podman/version.go
+++ b/cmd/podman/version.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"text/tabwriter"
 	"time"
 
 	"github.com/containers/libpod/cmd/podman/formats"
@@ -26,20 +28,22 @@ func versionCmd(c *cli.Context) error {
 		default:
 			out = formats.StdoutTemplate{Output: output, Template: versionOutputFormat}
 		}
-		formats.Writer(out).Out()
-		return nil
+		return formats.Writer(out).Out()
 	}
-	fmt.Println("Version:      ", output.Version)
-	fmt.Println("Go Version:   ", output.GoVersion)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintf(w, "Version:\t%s\n", output.Version)
+	fmt.Fprintf(w, "RemoteAPI Version:\t%d\n", output.RemoteAPIVersion)
+	fmt.Fprintf(w, "Go Version:\t%s\n", output.GoVersion)
 	if output.GitCommit != "" {
-		fmt.Println("Git Commit:   ", output.GitCommit)
+		fmt.Fprintf(w, "Git Commit:\t%s\n", output.GitCommit)
 	}
 	// Prints out the build time in readable format
 	if output.Built != 0 {
-		fmt.Println("Built:        ", time.Unix(output.Built, 0).Format(time.ANSIC))
+		fmt.Fprintf(w, "Built:\t%s\n", time.Unix(output.Built, 0).Format(time.ANSIC))
 	}
 
-	fmt.Println("OS/Arch:      ", output.OsArch)
+	fmt.Fprintf(w, "OS/Arch:\t%s\n", output.OsArch)
 	return nil
 }
 

--- a/libpod/version.go
+++ b/libpod/version.go
@@ -19,11 +19,12 @@ var (
 
 //Version is an output struct for varlink
 type Version struct {
-	Version   string
-	GoVersion string
-	GitCommit string
-	Built     int64
-	OsArch    string
+	RemoteAPIVersion int64
+	Version          string
+	GoVersion        string
+	GitCommit        string
+	Built            int64
+	OsArch           string
 }
 
 // GetVersion returns a VersionOutput struct for varlink and podman
@@ -39,10 +40,11 @@ func GetVersion() (Version, error) {
 		}
 	}
 	return Version{
-		Version:   podmanVersion.Version,
-		GoVersion: runtime.Version(),
-		GitCommit: gitCommit,
-		Built:     buildTime,
-		OsArch:    runtime.GOOS + "/" + runtime.GOARCH,
+		RemoteAPIVersion: podmanVersion.RemoteAPIVersion,
+		Version:          podmanVersion.Version,
+		GoVersion:        runtime.Version(),
+		GitCommit:        gitCommit,
+		Built:            buildTime,
+		OsArch:           runtime.GOOS + "/" + runtime.GOARCH,
 	}, nil
 }

--- a/pkg/varlinkapi/system.go
+++ b/pkg/varlinkapi/system.go
@@ -16,11 +16,12 @@ func (i *LibpodAPI) GetVersion(call iopodman.VarlinkCall) error {
 	}
 
 	return call.ReplyGetVersion(iopodman.Version{
-		Version:    versionInfo.Version,
-		Go_version: versionInfo.GoVersion,
-		Git_commit: versionInfo.GitCommit,
-		Built:      versionInfo.Built,
-		Os_arch:    versionInfo.OsArch,
+		Remote_api_version: versionInfo.RemoteAPIVersion,
+		Version:            versionInfo.Version,
+		Go_version:         versionInfo.GoVersion,
+		Git_commit:         versionInfo.GitCommit,
+		Built:              versionInfo.Built,
+		Os_arch:            versionInfo.OsArch,
 	})
 }
 

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -1,5 +1,3 @@
-// +build !remoteclient
-
 package integration
 
 import (

--- a/version/version.go
+++ b/version/version.go
@@ -5,3 +5,8 @@ package version
 // of the top-level README.md file when this is
 // bumped.
 const Version = "1.0.1-dev"
+
+// RemoteAPIVersion is the version for the remote
+// client API.  It is used to determine compatibility
+// between a remote podman client and its backend
+const RemoteAPIVersion = 1


### PR DESCRIPTION
initial enablement of podman-remote version.  includes add a APIVersion const
that will allow us to check compatibility between host/client when connections
are made.

also added client related information to podman info.

Signed-off-by: baude <bbaude@redhat.com>