### PR TITLE
Cirrus: Block CNI use of google VPCs

### DIFF
--- a/contrib/cirrus/99-do-not-use-google-subnets.conflist
+++ b/contrib/cirrus/99-do-not-use-google-subnets.conflist
@@ -1,0 +1,21 @@
+{
+    "cniVersion": "0.4.0",
+    "name": "do-not-use-google-subnets",
+    "plugins": [
+        {
+            "type": "bridge",
+            "name": "do-not-use-google-subnets",
+            "bridge": "do-not-use-google-subnets",
+            "ipam": {
+                "type": "host-local",
+                "ranges": [
+                    [
+                        {
+                            "subnet": "10.128.0.0/9"
+                        }
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -321,13 +321,15 @@ EOF
 
 install_test_configs(){
     echo "Installing cni config, policy and registry config"
-    req_env_var GOSRC
-    sudo install -D -m 755 $GOSRC/cni/87-podman-bridge.conflist \
-                           /etc/cni/net.d/87-podman-bridge.conflist
-    sudo install -D -m 755 $GOSRC/test/policy.json \
-                           /etc/containers/policy.json
-    sudo install -D -m 755 $GOSRC/test/registries.conf \
-                           /etc/containers/registries.conf
+    req_env_var GOSRC SCRIPT_BASE
+    cd $GOSRC
+    install -v -D -m 644 ./cni/87-podman-bridge.conflist /etc/cni/net.d/
+    # This config must always sort last in the list of networks (podman picks first one
+    # as the default).  This config prevents allocation of network address space used
+    # by default in google cloud.  https://cloud.google.com/vpc/docs/vpc#ip-ranges
+    install -v -D -m 644 $SCRIPT_BASE/99-do-not-use-google-subnets.conflist /etc/cni/net.d/
+    install -v -D -m 644 ./test/policy.json /etc/containers/
+    install -v -D -m 644 ./test/registries.conf /etc/containers/
 }
 
 # Remove all files (except conmon, for now) provided by the distro version of podman.

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -57,8 +57,7 @@ esac
 # Reload to incorporate any changes from above
 source "$SCRIPT_BASE/lib.sh"
 
-install_test_configs
-
+# Must execute before possible setup_rootless()
 make install.tools
 
 case "$SPECIALMODE" in
@@ -93,3 +92,5 @@ case "$SPECIALMODE" in
     *)
         die 111 "Unsupported \$SPECIALMODE: $SPECIALMODE"
 esac
+
+install_test_configs


### PR DESCRIPTION
Specifically pertaining to executing tests in google cloud, there are
default, pre-allocated class-a subnetworks for each region (data-center).
Each includes a gateway using a `.1` LSB and all are routable from other
regions in google cloud via these gateways.

Because the default CNI configuration also utilizes class-a subnetworks,
this creates the possibility for IPv4 address-space clashes.  Since the
default regional cloud subnets are pre-defined/known, preventing clashes
can be accomplished by seeding these subnets in a dummy CNI configuration.

The default behavior of podman is to grab the highest priority CNI
configuration.  Name the dummy config. appropriate so it always loads
last.  Also name the bridge itself with an obvious name `do-not-use`,
such that any related testing errors should be easier to debug.

Also:

* Minor cleanup of `install_test_configs()`
* Move install_test_configs in `setup_environment.sh` to after possible
  run of `remove_packaged_podman_files()` because that also strips out
  `/etc/cni/net.d/87-podman-bridge.conflist`.

Signed-off-by: Chris Evich <cevich@redhat.com>