### PR TITLE
Re-add volume locks

### DIFF
--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -449,6 +449,13 @@ func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bu
 		return errors.Wrapf(err, "error unmarshalling volume %s config from DB", string(name))
 	}
 
+	// Get the lock
+	lock, err := s.runtime.lockManager.RetrieveLock(volume.config.LockID)
+	if err != nil {
+		return errors.Wrapf(err, "error retrieving lock for volume %q", string(name))
+	}
+	volume.lock = lock
+
 	volume.runtime = s.runtime
 	volume.valid = true
 

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -425,6 +425,26 @@ func (s *InMemoryState) RewritePodConfig(pod *Pod, newCfg *PodConfig) error {
 	return nil
 }
 
+// RewriteVolumeConfig rewrites a volume's configuration.
+// This function is DANGEROUS, even with in-memory state.
+// Please read the full comment in state.go before using it.
+func (s *InMemoryState) RewriteVolumeConfig(volume *Volume, newCfg *VolumeConfig) error {
+	if !volume.valid {
+		return define.ErrVolumeRemoved
+	}
+
+	// If the volume does not exist, return error
+	stateVol, ok := s.volumes[volume.Name()]
+	if !ok {
+		volume.valid = false
+		return errors.Wrapf(define.ErrNoSuchVolume, "volume with name %q not found in state", volume.Name())
+	}
+
+	stateVol.config = newCfg
+
+	return nil
+}
+
 // Volume retrieves a volume from its full name
 func (s *InMemoryState) Volume(name string) (*Volume, error) {
 	if name == "" {

--- a/libpod/runtime_renumber.go
+++ b/libpod/runtime_renumber.go
@@ -53,6 +53,23 @@ func (r *Runtime) renumberLocks() error {
 			return err
 		}
 	}
+	allVols, err := r.state.AllVolumes()
+	if err != nil {
+		return err
+	}
+	for _, vol := range allVols {
+		lock, err := r.lockManager.AllocateLock()
+		if err != nil {
+			return errors.Wrapf(err, "error allocating lock for volume %s", vol.Name())
+		}
+
+		vol.config.LockID = lock.ID()
+
+		// Write the new lock ID
+		if err := r.state.RewriteVolumeConfig(vol, vol.config); err != nil {
+			return err
+		}
+	}
 
 	r.newSystemEvent(events.Renumber)
 

--- a/libpod/runtime_volume.go
+++ b/libpod/runtime_volume.go
@@ -36,6 +36,10 @@ func (r *Runtime) RemoveVolume(ctx context.Context, v *Volume, force bool) error
 			return nil
 		}
 	}
+
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
 	return r.removeVolume(ctx, v, force)
 }
 

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -115,12 +115,20 @@ type State interface {
 	// answer is this: use this only very sparingly, and only if you really
 	// know what you're doing.
 	RewriteContainerConfig(ctr *Container, newCfg *ContainerConfig) error
-	// PLEASE READ THE ABOVE DESCRIPTION BEFORE USING.
+	// PLEASE READ THE DESCRIPTION FOR RewriteContainerConfig BEFORE USING.
 	// This function is identical to RewriteContainerConfig, save for the
 	// fact that it is used with pods instead.
 	// It is subject to the same conditions as RewriteContainerConfig.
 	// Please do not use this unless you know what you're doing.
 	RewritePodConfig(pod *Pod, newCfg *PodConfig) error
+	// PLEASE READ THE DESCRIPTION FOR RewriteContainerConfig BEFORE USING.
+	// This function is identical to RewriteContainerConfig, save for the
+	// fact that it is used with volumes instead.
+	// It is subject to the same conditions as RewriteContainerConfig.
+	// The exception is that volumes do not have IDs, so only volume name
+	// cannot be altered.
+	// Please do not use this unless you know what you're doing.
+	RewriteVolumeConfig(volume *Volume, newCfg *VolumeConfig) error
 
 	// Accepts full ID of pod.
 	// If the pod given is not in the set namespace, an error will be

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -2,6 +2,8 @@ package libpod
 
 import (
 	"time"
+
+	"github.com/containers/libpod/libpod/lock"
 )
 
 // Volume is the type used to create named volumes
@@ -11,21 +13,35 @@ type Volume struct {
 
 	valid   bool
 	runtime *Runtime
+	lock    lock.Locker
 }
 
 // VolumeConfig holds the volume's config information
 type VolumeConfig struct {
-	// Name of the volume
+	// Name of the volume.
 	Name string `json:"name"`
-
-	Labels        map[string]string `json:"labels"`
-	Driver        string            `json:"driver"`
-	MountPoint    string            `json:"mountPoint"`
-	CreatedTime   time.Time         `json:"createdAt,omitempty"`
-	Options       map[string]string `json:"options"`
-	IsCtrSpecific bool              `json:"ctrSpecific"`
-	UID           int               `json:"uid"`
-	GID           int               `json:"gid"`
+	// ID of the volume's lock.
+	LockID uint32 `json:"lockID"`
+	// Labels for the volume.
+	Labels map[string]string `json:"labels"`
+	// The volume driver. Empty string or local does not activate a volume
+	// driver, all other volumes will.
+	Driver string `json:"driver"`
+	// The location the volume is mounted at.
+	MountPoint string `json:"mountPoint"`
+	// Time the volume was created.
+	CreatedTime time.Time `json:"createdAt,omitempty"`
+	// Options to pass to the volume driver. For the local driver, this is
+	// a list of mount options. For other drivers, they are passed to the
+	// volume driver handling the volume.
+	Options map[string]string `json:"options"`
+	// Whether this volume was created for a specific container and will be
+	// removed with it.
+	IsCtrSpecific bool `json:"ctrSpecific"`
+	// UID the volume will be created as.
+	UID int `json:"uid"`
+	// GID the volume will be created as.
+	GID int `json:"gid"`
 }
 
 // Name retrieves the volume's name

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -154,4 +154,12 @@ var _ = Describe("Podman run with volumes", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
+
+	It("podman run with volume flag and multiple named volumes", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "-v", "testvol1:/testvol1", "-v", "testvol2:/testvol2", ALPINE, "grep", "/testvol", "/proc/self/mountinfo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("/testvol1"))
+		Expect(session.OutputToString()).To(ContainSubstring("/testvol2"))
+	})
 })


### PR DESCRIPTION
As part of work adding support for tmpfs/nfs/etc volumes, re-add locks to volumes. We need them to synchronize unmount/delete operations across volume removal in multiple processes.

After this is merged, a `podman system renumber` WILL be required to update lock IDs for all existing volumes to prevent hangs. Probably need specfile changes to make sure that runs.