### PR TITLE
WIP - Show c/storage (Buildah/CRI-O) containers in ps

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -420,6 +420,7 @@ type PortValues struct {
 type PsValues struct {
 	PodmanCommand
 	All       bool
+	External  bool
 	Filter    []string
 	Format    string
 	Last      int

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -120,6 +120,7 @@ func psInit(command *cliconfig.PsValues) {
 	command.SetUsageTemplate(UsageTemplate())
 	flags := command.Flags()
 	flags.BoolVarP(&command.All, "all", "a", false, "Show all the containers, default is only running containers")
+	flags.BoolVar(&command.External, "external", false, "Show containers in storage not controlled by Podman")
 	flags.StringSliceVarP(&command.Filter, "filter", "f", []string{}, "Filter output based on conditions given")
 	flags.StringVar(&command.Format, "format", "", "Pretty-print containers to JSON or using a Go template")
 	flags.IntVarP(&command.Last, "last", "n", -1, "Print the n last created containers (all states)")
@@ -160,7 +161,7 @@ func psCmd(c *cliconfig.PsValues) error {
 	if err := checkFlagsPassed(c); err != nil {
 		return errors.Wrapf(err, "error with flags passed")
 	}
-	if !c.Size {
+	if !c.Size && !c.All && !c.External {
 		runtime, err = adapter.GetRuntimeNoStore(getContext(), &c.PodmanCommand)
 	} else {
 		runtime, err = adapter.GetRuntime(getContext(), &c.PodmanCommand)
@@ -311,14 +312,15 @@ func psDisplay(c *cliconfig.PsValues, runtime *adapter.LocalRuntime) error {
 	)
 	opts := shared.PsOptions{
 		All:       c.All,
+		External:  c.External,
 		Format:    c.Format,
 		Last:      c.Last,
 		Latest:    c.Latest,
+		Namespace: c.Namespace,
 		NoTrunc:   c.NoTrunct,
 		Pod:       c.Pod,
 		Quiet:     c.Quiet,
 		Size:      c.Size,
-		Namespace: c.Namespace,
 		Sort:      c.Sort,
 		Sync:      c.Sync,
 	}

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -71,7 +71,7 @@ func rmiCmd(c *cliconfig.RmiValues) error {
 		response, err := runtime.RemoveImage(ctx, img, c.Force)
 		if err != nil {
 			if errors.Cause(err) == storage.ErrImageUsedByContainer {
-				fmt.Printf("A container associated with containers/storage, i.e. via Buildah, CRI-O, etc., may be associated with this image: %-12.12s\n", img.ID())
+				fmt.Printf("A container associated with containers/storage, i.e. via Buildah, CRI-O, etc., may be associated with this image: %-12.12s\nUsing the --force option will remove the container and image, but may cause failures for other dependent systems.", img.ID())
 			}
 			if !adapter.IsImageNotFound(err) {
 				exitCode = 2

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -147,6 +147,7 @@ type ContainerStats (
 
 type PsOpts (
     all: bool,
+    external: ?bool,
     filters: ?[]string,
     last: ?int,
     latest: ?bool,

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2383,6 +2383,7 @@ _podman_ps() {
      "
      local boolean_options="
 	  --all -a
+	  --external
 	  --help -h
 	  --latest -l
 	  --no-trunc

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -32,11 +32,18 @@ all the containers information.  By default it lists:
 
 **--all**, **-a**
 
-Show all the containers, default is only running containers
+Show all the containers including those created by other container technologies such as Buildah and CRI-O.  The default displays only running containers created by Podman.  Containers not created by Podman have an 'NA' status.
 
 **--pod**, **-p**
 
 Display the pods the containers are associated with
+
+**--external**
+
+Display containers that are not controlled by Podman but are stored in containers storage.  These containers
+are generally created via other container technology such as Buildah or CRI-O and may depend on the
+same container images that Podman is using.  These containers are denoted with a 'NA' in the COMMAND and
+STATUS column of the ps output.  These containers are also shown when using the `--all` option.
 
 **--no-trunc**
 
@@ -172,11 +179,18 @@ CONTAINER ID  IMAGE                            COMMAND    CREATED        STATUS 
 
 ```
 
+```
+$ podman ps --external
+CONTAINER ID  IMAGE                             COMMAND  CREATED      STATUS  PORTS  NAMES
+38a8a78596f9  docker.io/library/busybox:latest  NA       2 hours ago  NA             busybox-working-container
+fd7b786b5c32  docker.io/library/alpine:latest   NA       2 hours ago  NA             alpine-working-container
+```
+
 ## ps
 Print a list of containers
 
 ## SEE ALSO
-podman(1)
+podman(1), buildah(1), crio(8)
 
 ## HISTORY
 August 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -609,6 +609,12 @@ func (s *BoltState) UpdateContainer(ctr *Container) error {
 		return define.ErrDBClosed
 	}
 
+	// We're dealing with a non-Podman container, don't
+	// attempt to update, it won't go well.
+	if ctr.state.State == define.ContainerStateNA {
+		return nil
+	}
+
 	if !ctr.valid {
 		return define.ErrCtrRemoved
 	}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -393,6 +393,11 @@ func (c *Container) syncContainer() error {
 	if err := c.runtime.state.UpdateContainer(c); err != nil {
 		return err
 	}
+
+	// We've a non-Podman container, don't sync, it won't go well.
+	if c.state.State == define.ContainerStateNA {
+		return nil
+	}
 	// If runtime knows about the container, update its status in runtime
 	// And then save back to disk
 	if c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning, define.ContainerStateStopped, define.ContainerStatePaused) {

--- a/libpod/define/containerstate.go
+++ b/libpod/define/containerstate.go
@@ -28,6 +28,10 @@ const (
 	// ContainerStateRemoving indicates the container is in the process of
 	// being removed.
 	ContainerStateRemoving ContainerStatus = iota
+	// ContainerStateNA indicates the container is controlled by c/storage
+	// and not by libpod/Podman.  This status should ONLY be used by the
+	// ps command.
+	ContainerStateNA ContainerStatus = iota
 )
 
 // ContainerStatus returns a string representation for users
@@ -50,6 +54,8 @@ func (t ContainerStatus) String() string {
 		return "exited"
 	case ContainerStateRemoving:
 		return "removing"
+	case ContainerStateNA:
+		return "NA"
 	}
 	return "bad state"
 }
@@ -74,6 +80,8 @@ func StringToContainerStatus(status string) (ContainerStatus, error) {
 		return ContainerStateExited, nil
 	case ContainerStateRemoving.String():
 		return ContainerStateRemoving, nil
+	case ContainerStateNA.String():
+		return ContainerStateNA, nil
 	default:
 		return ContainerStateUnknown, errors.Wrapf(ErrInvalidArg, "unknown container state: %s", status)
 	}

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -230,7 +230,7 @@ func (ir *Runtime) GetImagesWithFilters(filters []string) ([]*Image, error) {
 }
 
 func (i *Image) reloadImage() error {
-	newImage, err := i.imageruntime.getImage(i.ID())
+	newImage, err := i.imageruntime.GetImage(i.ID())
 	if err != nil {
 		return errors.Wrapf(err, "unable to reload image")
 	}
@@ -259,7 +259,7 @@ func (i *Image) getLocalImage() (*storage.Image, error) {
 		i.InputName = dest.DockerReference().String()
 	}
 
-	img, err := i.imageruntime.getImage(stripSha256(i.InputName))
+	img, err := i.imageruntime.GetImage(stripSha256(i.InputName))
 	if err == nil {
 		return img.image, err
 	}
@@ -283,7 +283,7 @@ func (i *Image) getLocalImage() (*storage.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	img, err = i.imageruntime.getImage(ref.String())
+	img, err = i.imageruntime.GetImage(ref.String())
 	if err == nil {
 		return img.image, err
 	}
@@ -457,10 +457,30 @@ func (i *Image) Remove(ctx context.Context, force bool) error {
 	return nil
 }
 
-// getImage retrieves an image matching the given name or hash from system
+// TODO: Rework this method to not require an assembly of the fq name with transport
+/*
+// GetManifest tries to GET an images manifest, returns nil on success and err on failure
+func (i *Image) GetManifest() error {
+	pullRef, err := alltransports.ParseImageName(i.assembleFqNameTransport())
+	if err != nil {
+		return errors.Errorf("unable to parse '%s'", i.Names()[0])
+	}
+	imageSource, err := pullRef.NewImageSource(nil)
+	if err != nil {
+		return errors.Wrapf(err, "unable to create new image source")
+	}
+	_, _, err = imageSource.GetManifest(nil)
+	if err == nil {
+		return nil
+	}
+	return err
+}
+*/
+
+// GetImage retrieves an image matching the given name or hash from system
 // storage
 // If no matching image can be found, an error is returned
-func (ir *Runtime) getImage(image string) (*Image, error) {
+func (ir *Runtime) GetImage(image string) (*Image, error) {
 	var img *storage.Image
 	ref, err := is.Transport.ParseStoreReference(ir.store, image)
 	if err == nil {

--- a/libpod/image/prune.go
+++ b/libpod/image/prune.go
@@ -118,7 +118,7 @@ func (ir *Runtime) PruneImages(ctx context.Context, all bool, filter []string) (
 	for _, p := range pruneImages {
 		if err := p.Remove(ctx, true); err != nil {
 			if errors.Cause(err) == storage.ErrImageUsedByContainer {
-				logrus.Warnf("Failed to prune image %s as it is in use: %v", p.ID(), err)
+				logrus.Warnf("Failed to prune image %s as it is in use: %v.\nA container associated with containers/storage i.e. Buildah, CRI-O, etc., maybe associated with this image.\nUsing the rmi command with the --force option will remove the container and image, but may cause failures for other dependent systems.", p.ID(), err)
 				continue
 			}
 			return nil, errors.Wrap(err, "failed to prune image")

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -511,16 +511,17 @@ func (r *LocalRuntime) Ps(c *cliconfig.PsValues, opts shared.PsOptions) ([]share
 	var psContainers []shared.PsContainerOutput
 	last := int64(c.Last)
 	PsOpts := iopodman.PsOpts{
-		All:     c.All,
-		Filters: &c.Filter,
-		Last:    &last,
-		Latest:  &c.Latest,
-		NoTrunc: &c.NoTrunct,
-		Pod:     &c.Pod,
-		Quiet:   &c.Quiet,
-		Size:    &c.Size,
-		Sort:    &c.Sort,
-		Sync:    &c.Sync,
+		All:      c.All,
+		External: &c.External,
+		Filters:  &c.Filter,
+		Last:     &last,
+		Latest:   &c.Latest,
+		NoTrunc:  &c.NoTrunct,
+		Pod:      &c.Pod,
+		Quiet:    &c.Quiet,
+		Size:     &c.Size,
+		Sort:     &c.Sort,
+		Sync:     &c.Sync,
 	}
 	containers, err := iopodman.Ps().Call(r.Conn, PsOpts)
 	if err != nil {


### PR DESCRIPTION
WIP - Show c/storage (Buildah/CRI-O) containers in ps

Ready for review.  I still have some work to do with testing, varlink and documentation.  But thought I'd get this out for a look/feel kind of review at the moment.

The `podman ps --all` command will now show containers that are under the control of other c/storage container systems and the new `ps --external` option will show only containers that are
in c/storage but are not controlled by libpod.

In the below examples, the '*working-container' entries were created by Buildah.

```
podman ps -a
CONTAINER ID  IMAGE                             COMMAND  CREATED       STATUS                   PORTS  NAMES
9257ef8c786c  docker.io/library/busybox:latest  ls /etc  8 hours ago   Exited (0) 8 hours ago          gifted_jang
d302c81856da  docker.io/library/busybox:latest  NA       30 hours ago  NA                              busybox-working-container
7a5a7b099d33  localhost/tom:latest              ls -alF  30 hours ago  Exited (0) 30 hours ago         hopeful_hellman
01d601fca090  localhost/tom:latest              ls -alf  30 hours ago  Exited (1) 30 hours ago         determined_panini
ee58f429ff26  localhost/tom:latest              NA       33 hours ago  NA                              alpine-working-container

podman ps --external
CONTAINER ID  IMAGE                             COMMAND  CREATED       STATUS  PORTS  NAMES
d302c81856da  docker.io/library/busybox:latest  NA       30 hours ago  NA             busybox-working-container
ee58f429ff26  localhost/tom:latest              NA       33 hours ago  NA             alpine-working-container

```


Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>