### PR TITLE
use internal copy rather than tar for copy fix #6003

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1468,11 +1468,13 @@ func (c *Container) copyOwnerAndPerms(source, dest string) error {
 		}
 		return errors.Wrapf(err, "cannot stat `%s`", dest)
 	}
-	if err := os.Chmod(dest, info.Mode()); err != nil {
-		return errors.Wrapf(err, "cannot chmod `%s`", dest)
+	if (info.Mode() & os.ModeSymlink) != os.ModeSymlink {
+		if err := os.Chmod(dest, info.Mode()); err != nil {
+			return errors.Wrapf(err, "cannot chmod `%s`", dest)
+		}
 	}
-	if err := os.Chown(dest, int(info.Sys().(*syscall.Stat_t).Uid), int(info.Sys().(*syscall.Stat_t).Gid)); err != nil {
-		return errors.Wrapf(err, "cannot chown `%s`", dest)
+	if err := os.Lchown(dest, int(info.Sys().(*syscall.Stat_t).Uid), int(info.Sys().(*syscall.Stat_t).Gid)); err != nil {
+		return errors.Wrapf(err, "cannot lchown `%s`", dest)
 	}
 	return nil
 }


### PR DESCRIPTION
This patch uses internal copy to copy containers rather than
tar.  The problem with tar is that it does not copy symlinks pointing
outside of the volume.

This is a very tricky patch to get right because you have to get the 
ownerships and permissions right as well as handle symlinks 
correctly.  Off the shelf copy trees don't work because they dont
have the right combination of options to do the right thing.