### PR TITLE
allow switching of port-forward approaches when rootless/using slirp4netns

### DIFF
--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -66,7 +66,7 @@ func (c *Container) validate() error {
 
 	// Rootless has some requirements, compared to networks.
 	if rootless.IsRootless() {
-		if len(c.config.Networks) > 0 {
+		if !c.config.NetMode.IsSlirp4netns() && len(c.config.Networks) > 0 {
 			return errors.Wrapf(define.ErrInvalidArg, "cannot join CNI networks if running rootless")
 		}
 

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -173,6 +173,19 @@ type slirpFeatures struct {
 	HasEnableSeccomp       bool
 }
 
+type slirp4netnsCmdArg struct {
+	Proto     string `json:"proto,omitempty"`
+	HostAddr  string `json:"host_addr"`
+	HostPort  int32  `json:"host_port"`
+	GuestAddr string `json:"guest_addr"`
+	GuestPort int32  `json:"guest_port"`
+}
+
+type slirp4netnsCmd struct {
+	Execute string            `json:"execute"`
+	Args    slirp4netnsCmdArg `json:"arguments"`
+}
+
 func checkSlirpFlags(path string) (*slirpFeatures, error) {
 	cmd := exec.Command(path, "--help")
 	out, err := cmd.CombinedOutput()
@@ -226,6 +239,12 @@ func (r *Runtime) setupRootlessNetNS(ctr *Container) (err error) {
 	}
 	if slirpFeatures.HasEnableSeccomp {
 		cmdArgs = append(cmdArgs, "--enable-seccomp")
+	}
+
+	var apiSocket string
+	if havePortMapping && ctr.config.NetMode.IsPortForwardViaSlirpHostFwd() {
+		apiSocket = filepath.Join(ctr.runtime.config.Engine.TmpDir, fmt.Sprintf("%s.net", ctr.config.ID))
+		cmdArgs = append(cmdArgs, "--api-socket", apiSocket)
 	}
 
 	// the slirp4netns arguments being passed are describes as follows:
@@ -291,7 +310,11 @@ func (r *Runtime) setupRootlessNetNS(ctr *Container) (err error) {
 	}
 
 	if havePortMapping {
-		return r.setupRootlessPortMapping(ctr, netnsPath)
+		if ctr.config.NetMode.IsPortForwardViaSlirpHostFwd() {
+			return r.setupRootlessPortMappingViaSlirp(ctr, cmd, apiSocket)
+		} else {
+			return r.setupRootlessPortMappingViaRLK(ctr, netnsPath)
+		}
 	}
 	return nil
 }
@@ -342,7 +365,7 @@ func waitForSync(syncR *os.File, cmd *exec.Cmd, logFile io.ReadSeeker, timeout t
 	return nil
 }
 
-func (r *Runtime) setupRootlessPortMapping(ctr *Container, netnsPath string) (err error) {
+func (r *Runtime) setupRootlessPortMappingViaRLK(ctr *Container, netnsPath string) (err error) {
 	syncR, syncW, err := os.Pipe()
 	if err != nil {
 		return errors.Wrapf(err, "failed to open pipe")
@@ -416,6 +439,90 @@ func (r *Runtime) setupRootlessPortMapping(ctr *Container, netnsPath string) (er
 		return err
 	}
 	logrus.Debug("rootlessport is ready")
+	return nil
+}
+
+func (r *Runtime) setupRootlessPortMappingViaSlirp(ctr *Container, cmd *exec.Cmd, apiSocket string) (err error) {
+	const pidWaitTimeout = 60 * time.Second
+	chWait := make(chan error)
+	go func() {
+		interval := 25 * time.Millisecond
+		for i := time.Duration(0); i < pidWaitTimeout; i += interval {
+			// Check if the process is still running.
+			var status syscall.WaitStatus
+			pid, err := syscall.Wait4(cmd.Process.Pid, &status, syscall.WNOHANG, nil)
+			if err != nil {
+				break
+			}
+			if pid != cmd.Process.Pid {
+				continue
+			}
+			if status.Exited() || status.Signaled() {
+				chWait <- fmt.Errorf("slirp4netns exited with status %d", status.ExitStatus())
+			}
+			time.Sleep(interval)
+		}
+	}()
+	defer close(chWait)
+
+	// wait that API socket file appears before trying to use it.
+	if _, err := WaitForFile(apiSocket, chWait, pidWaitTimeout); err != nil {
+		return errors.Wrapf(err, "waiting for slirp4nets to create the api socket file %s", apiSocket)
+	}
+
+	// for each port we want to add we need to open a connection to the slirp4netns control socket
+	// and send the add_hostfwd command.
+	for _, i := range ctr.config.PortMappings {
+		conn, err := net.Dial("unix", apiSocket)
+		if err != nil {
+			return errors.Wrapf(err, "cannot open connection to %s", apiSocket)
+		}
+		defer func() {
+			if err := conn.Close(); err != nil {
+				logrus.Errorf("unable to close connection: %q", err)
+			}
+		}()
+		hostIP := i.HostIP
+		if hostIP == "" {
+			hostIP = "0.0.0.0"
+		}
+		apiCmd := slirp4netnsCmd{
+			Execute: "add_hostfwd",
+			Args: slirp4netnsCmdArg{
+				Proto:     i.Protocol,
+				HostAddr:  hostIP,
+				HostPort:  i.HostPort,
+				GuestPort: i.ContainerPort,
+			},
+		}
+		// create the JSON payload and send it.  Mark the end of request shutting down writes
+		// to the socket, as requested by slirp4netns.
+		data, err := json.Marshal(&apiCmd)
+		if err != nil {
+			return errors.Wrapf(err, "cannot marshal JSON for slirp4netns")
+		}
+		if _, err := conn.Write([]byte(fmt.Sprintf("%s\n", data))); err != nil {
+			return errors.Wrapf(err, "cannot write to control socket %s", apiSocket)
+		}
+		if err := conn.(*net.UnixConn).CloseWrite(); err != nil {
+			return errors.Wrapf(err, "cannot shutdown the socket %s", apiSocket)
+		}
+		buf := make([]byte, 2048)
+		readLength, err := conn.Read(buf)
+		if err != nil {
+			return errors.Wrapf(err, "cannot read from control socket %s", apiSocket)
+		}
+		// if there is no 'error' key in the received JSON data, then the operation was
+		// successful.
+		var y map[string]interface{}
+		if err := json.Unmarshal(buf[0:readLength], &y); err != nil {
+			return errors.Wrapf(err, "error parsing error status from slirp4netns")
+		}
+		if e, found := y["error"]; found {
+			return errors.Errorf("error from slirp4netns while setting up port redirection: %v", e)
+		}
+	}
+	logrus.Debug("slirp4netns port-forwarding setup via add_hostfwd is ready")
 	return nil
 }
 


### PR DESCRIPTION
This PR is [by request](https://github.com/containers/libpod/pull/6025#issuecomment-631316276) against master (the other [original PR](https://github.com/containers/libpod/pull/6025) was against the 1.9 branch as that's what i was asked to base it off of).

---

As of podman 1.8.0, because of commit da7595a, the default approach of providing port-forwarding in rootless mode has switched (and been hard-coded) to rootlessport, for the purpose of providing super performance.  The side-effect of this switch is source within the container to the port-forwarded service always appears to originate from 127.0.0.1 (see issue #5138).

This commit allows a user to specify if they want to revert to the previous approach
of leveraging slirp4netns add_hostfwd() api which, although not as stellar performance,
restores usefulness of seeing incoming traffic origin IP addresses.

The change should be transparent; when not specified, rootlessport will continue to be
used, however if specifying `--net slirp4netns:slirplisten` the old approach will be used.

Testing performed in rootless mode of relevant functionality:

<details><summary>Default behaviour scenario 1 (nothing specified, so not taking advantage of this commit original behaviour (higher performance rootlessport in use))</summary>

```
[test@test ~]$ podman run -d --name nginx -p 8080:80 docker.io/library/nginx:alpine
c0644bcd50c950a000305d0e548e3b1c40732af5c1f9bcbe1dffba244fc1a048
[test@test ~]$ podman logs -f nginx
127.0.0.1 - - [28/Apr/2020:18:19:47 +0000] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36" "-"
```
</details>
<details><summary>Default behaviour scenario 2 (specifying just --net slirp4netns, which is default when in rootless mode)</summary>

```
[test@test ~]$ podman run -d --name nginx -p 8080:80 --net slirp4netns docker.io/library/nginx:alpine
82e93b571cb013b05f586097544c081c78335f932a5fae071d27ca0f24014cf0
[test@test ~]$ podman logs -f nginx
127.0.0.1 - - [28/Apr/2020:18:20:10 +0000] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36" "-"
```
</details>
<details><summary>Restored (old, pre-1.8.0) behaviour, where source IP show true origin of port-forwarded traffic.</summary>

```
[test@test ~]$ podman run -d --name nginx -p 8080:80 --net slirp4netns:slirplisten docker.io/library/nginx:alpine
4c5f517d20df3bfc8767371cfefbe87835eb0a0e4e6c300c24b306c80fd3f59f
[test@test ~]$ podman logs -f nginx
192.168.0.22 - - [28/Apr/2020:18:19:14 +0000] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36" "-"
```
</details>

Note: the above may imply the restored port-forwarding via slirp4netns is not as performant as the new rootlessport approach, however the figures shared in the [original commit](https://github.com/containers/libpod/commit/da7595a69fc15d131c9d8123d0a165bdde4232b6?diff=split) that introduced rootlessport are as follows: `socat: 5.2 Gbps, slirp4netns: 8.3 Gbps, RootlessKit: 27.3 Gbps`, which are more than sufficient for many use cases where the origin of traffic is more important than limits that cannot be reached due to bottlenecks elsewhere.

`Signed-off-by: Aleks Mariusz <m.k@alek.cx>`