### PR TITLE
[v1.9] Backport nix derivation for static builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ contrib/spec/podman.spec
 *.rpm
 *.coverprofile
 /cmd/podmanV2/podmanV2
+result

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,51 @@
+{ system ? builtins.currentSystem }:
+let
+  pkgs = (import ./nixpkgs.nix {
+    config = {
+      packageOverrides = pkg: {
+        gpgme = (static pkg.gpgme);
+        libassuan = (static pkg.libassuan);
+        libgpgerror = (static pkg.libgpgerror);
+        libseccomp = (static pkg.libseccomp);
+        systemd = pkg.systemd.overrideAttrs(x: {
+          mesonFlags = x.mesonFlags ++ [ "-Dstatic-libsystemd=true" ];
+          postFixup = ''
+            ${x.postFixup}
+            sed -ri "s;$out/(.*);$nukedRef/\1;g" $lib/lib/libsystemd.a
+          '';
+        });
+      };
+    };
+  });
+
+  static = pkg: pkg.overrideAttrs(x: {
+    configureFlags = (x.configureFlags or []) ++
+      [ "--without-shared" "--disable-shared" ];
+    dontDisableStatic = true;
+    enableSharedExecutables = false;
+    enableStatic = true;
+  });
+
+  self = with pkgs; buildGoPackage rec {
+    name = "podman";
+    src = ./..;
+    goPackagePath = "github.com/containers/libpod";
+    doCheck = false;
+    enableParallelBuilding = true;
+    nativeBuildInputs = [ git go-md2man installShellFiles pkg-config ];
+    buildInputs = [ glibc glibc.static gpgme libapparmor libassuan libgpgerror libseccomp libselinux systemd ];
+    prePatch = ''
+      export LDFLAGS='-static-libgcc -static -s -w'
+      export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
+      export BUILDTAGS='static netgo varlink apparmor selinux seccomp systemd exclude_graphdriver_btrfs exclude_graphdriver_devicemapper'
+    '';
+    buildPhase = ''
+      pushd go/src/${goPackagePath}
+      patchShebangs .
+      make bin/podman
+    '';
+    installPhase = ''
+      install -Dm755 bin/podman $out/bin/podman
+    '';
+  };
+in self

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/nixos/nixpkgs",
+  "rev": "0f114432d4a9399e0b225d5be1599c7ebc5e2772",
+  "date": "2020-05-29T19:54:08-05:00",
+  "path": "/nix/store/ds31sjj3ppsk0xclkficx9p3w6qslmdc-nixpkgs",
+  "sha256": "1qd2dlc5dk98y0xdahv9k72ibv5dsy10jg25xqvj38sadxbs3g0j",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,8 @@
+let
+  json = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = import (builtins.fetchTarball {
+    name = "nixos-unstable";
+    url = "${json.url}/archive/${json.rev}.tar.gz";
+    inherit (json) sha256;
+  });
+in nixpkgs


### PR DESCRIPTION
Also see #6402

nix-based static binary could be found from:
- https://github.com/alvistack/libpod/releases/tag/v1.9.3
- https://github.com/alvistack/libpod/releases/tag/v2.0.0-rc2