### PR TITLE
podman-events: clarify streaming behaviour

### DIFF
--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -17,8 +17,10 @@ import (
 )
 
 var (
-	eventsDescription = "Monitor podman events"
-	eventsCommand     = &cobra.Command{
+	eventsDescription = `Monitor podman events.
+
+  By default, streaming mode is used, printing new events as they occur.  Previous events can be listed via --since and --until.`
+	eventsCommand = &cobra.Command{
 		Use:   "events",
 		Args:  validate.NoArgs,
 		Short: "Show podman events",

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -15,6 +15,8 @@ value to `file`.  Only `file` and `journald` are accepted. A `none` logger is al
 available but this logging mechanism completely disables events; nothing will be reported by
 `podman events`.
 
+By default, streaming mode is used, printing new events as they occur.  Previous events can be listed via `--since` and `--until`.
+
 The *container* event type will report the follow statuses:
  * attach
  * checkpoint


### PR DESCRIPTION
Unless `--since` or `--until` is specified, `podman events` will stream
new events.  Clarify this behavior in the `--help` message and man page
to avoid confusion.

Fixes: #6536
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@mheon @rhatdan @TomSweeneyRedHat PTAL