### PR TITLE
[WIP] Implement pod-network-reload

### DIFF
--- a/cmd/podman/networks/reload.go
+++ b/cmd/podman/networks/reload.go
@@ -1,0 +1,65 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/containers/libpod/cmd/podman/parse"
+	"github.com/containers/libpod/cmd/podman/registry"
+	"github.com/containers/libpod/cmd/podman/utils"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	networkReloadDescription = `reload container networks, recreating firewall rules`
+	networkReloadCommand     = &cobra.Command{
+		Use:   "reload [flags] CONTAINER [CONTAINER...]",
+		Short: "Reload firewall rules for one or more containers",
+		Long:  networkReloadDescription,
+		RunE:  networkReload,
+		Args: func(cmd *cobra.Command, args []string) error {
+			return parse.CheckAllLatestAndCIDFile(cmd, args, false, false)
+		},
+		Example: `podman network reload --latest
+  podman network reload 3c13ef6dd843
+  podman network reload test1 test2`,
+	}
+)
+
+var (
+	reloadOptions entities.NetworkReloadOptions
+)
+
+func reloadFlags(flags *pflag.FlagSet) {
+	flags.BoolVarP(&reloadOptions.All, "all", "a", false, "Reload networks of all containers")
+	flags.BoolVarP(&reloadOptions.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
+}
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode},
+		Command: networkReloadCommand,
+		Parent:  networkCmd,
+	})
+	flags := networkReloadCommand.Flags()
+	reloadFlags(flags)
+}
+
+func networkReload(cmd *cobra.Command, args []string) error {
+	responses, err := registry.ContainerEngine().NetworkReload(registry.Context(), args, reloadOptions)
+	if err != nil {
+		return err
+	}
+
+	var errs utils.OutputErrors
+	for _, r := range responses {
+		if r.Err == nil {
+			fmt.Println(r.Id)
+		} else {
+			errs = append(errs, r.Err)
+		}
+	}
+
+	return errs.PrintErrors()
+}

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -684,6 +684,32 @@ func (c *Container) Sync() error {
 	return nil
 }
 
+// ReloadNetwork reconfigures the container's network.
+// Technically speaking, it will tear down and then reconfigure the container's
+// network namespace, which will result in all firewall rules being recreated.
+// It is mostly intended to be used in cases where the system firewall has been
+// reloaded, and existing rules have been wiped out. It is expected that some
+// downtime will result, as the rules are destroyed as part of this process.
+// At present, this only works on root containers; it may be expanded to restart
+// slirp4netns in the future to work with rootless containers as well.
+// Requires that the container must be running or created.
+func (c *Container) ReloadNetwork() error {
+	if !c.batched {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+
+		if err := c.syncContainer(); err != nil {
+			return err
+		}
+	}
+
+	if !c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning) {
+		return errors.Wrapf(define.ErrCtrStateInvalid, "cannot reload network unless container network has been configured")
+	}
+
+	return c.reloadNetwork()
+}
+
 // Refresh is DEPRECATED and REMOVED.
 func (c *Container) Refresh(ctx context.Context) error {
 	// This has been deprecated for a long while, and is in the process of

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -190,6 +190,19 @@ func (c *Container) cleanupNetwork() error {
 	return nil
 }
 
+// reloadNetwork reloads the network for the given container, recreating
+// firewall rules.
+func (c *Container) reloadNetwork() error {
+	result, err := c.runtime.reloadContainerNetwork(c)
+	if err != nil {
+		return err
+	}
+
+	c.state.NetworkStatus = result
+
+	return c.save()
+}
+
 func (c *Container) getUserOverrides() *lookup.Overrides {
 	var hasPasswdFile, hasGroupFile bool
 	overrides := lookup.Overrides{}

--- a/libpod/networking_unsupported.go
+++ b/libpod/networking_unsupported.go
@@ -24,6 +24,10 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 	return nil, define.ErrNotImplemented
 }
 
+func (r *Runtime) reloadContainerNetwork(ctr *Container) ([]*cnitypes.Result, error) {
+	return nil, define.ErrNotImplemented
+}
+
 func getCNINetworksDir() (string, error) {
 	return "", define.ErrNotImplemented
 }

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -53,6 +53,7 @@ type ContainerEngine interface {
 	NetworkCreate(ctx context.Context, name string, options NetworkCreateOptions) (*NetworkCreateReport, error)
 	NetworkInspect(ctx context.Context, namesOrIds []string, options NetworkInspectOptions) ([]NetworkInspectReport, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) ([]*NetworkListReport, error)
+	NetworkReload(ctx context.Context, names []string, options NetworkReloadOptions) ([]*NetworkReloadReport, error)
 	NetworkRm(ctx context.Context, namesOrIds []string, options NetworkRmOptions) ([]*NetworkRmReport, error)
 	PlayKube(ctx context.Context, path string, opts PlayKubeOptions) (*PlayKubeReport, error)
 	PodCreate(ctx context.Context, opts PodCreateOptions) (*PodCreateReport, error)

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -26,6 +26,19 @@ type NetworkInspectOptions struct {
 // NetworkInspectReport describes the results from inspect networks
 type NetworkInspectReport map[string]interface{}
 
+// NetworkReloadOptions describes options for reloading container network
+// configuration.
+type NetworkReloadOptions struct {
+	All    bool
+	Latest bool
+}
+
+// NetworkReloadReport describes the results of reloading a container network.
+type NetworkReloadReport struct {
+	Id  string
+	Err error
+}
+
 // NetworkRmOptions describes options for removing networks
 type NetworkRmOptions struct {
 	Force bool

--- a/pkg/domain/infra/tunnel/network.go
+++ b/pkg/domain/infra/tunnel/network.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/containers/libpod/pkg/bindings/network"
 	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/pkg/errors"
 )
 
 func (ic *ContainerEngine) NetworkList(ctx context.Context, options entities.NetworkListOptions) ([]*entities.NetworkListReport, error) {
@@ -21,6 +22,10 @@ func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []stri
 		reports = append(reports, report...)
 	}
 	return reports, nil
+}
+
+func (ic *ContainerEngine) NetworkReload(ctx context.Context, names []string, options entities.NetworkReloadOptions) ([]*entities.NetworkReloadReport, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, options entities.NetworkRmOptions) ([]*entities.NetworkRmReport, error) {


### PR DESCRIPTION
This adds a new command, 'podman network reload', to reload the networks of existing containers, forcing recreation of firewall rules after e.g. `firewall-cmd --reload` wipes them out.

Under the hood, this works by calling CNI to tear down the existing network, then recreate it using identical settings. We request that CNI preserve the old IP and MAC address in most cases (where the container only had 1 IP/MAC), but there will be some downtime inherent to the teardown/bring-up approach. The architecture of CNI doesn't really make doing this without downtime easy (or maybe even possible...).

At present, this only works for root Podman, and only locally. I don't think there is much of a point to adding remote support (this is very much a local debugging command), but I think adding rootless support (to kill/recreate slirp4netns) could be valuable.

Still To-Do:
- Bash Completions
- Tests
- CNI is not honoring our requested IP and MAC address, need to figure that out.