### PR TITLE
container: fix creating a userns inside of a pod

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -392,7 +392,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 	}
 
 	for _, i := range c.config.Spec.Linux.Namespaces {
-		if i.Type == spec.UTSNamespace {
+		if i.Type == spec.UTSNamespace && i.Path == "" {
 			hostname := c.Hostname()
 			g.SetHostname(hostname)
 			g.AddProcessEnv("HOSTNAME", hostname)
@@ -591,7 +591,8 @@ func (c *Container) addNamespaceContainer(g *generate.Generator, ns LinuxNS, ctr
 
 	if specNS == spec.UTSNamespace {
 		hostname := nsCtr.Hostname()
-		g.SetHostname(hostname)
+		// Joining an existing namespace, cannot set the hostname
+		g.SetHostname("")
 		g.AddProcessEnv("HOSTNAME", hostname)
 	}
 


### PR DESCRIPTION
a couple of issues found while trying to create a new userns from a pod.

tests are missing since the OCI runtime doesn't support this yet, tracked here for crun: https://github.com/containers/crun/issues/396

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
