### PR TITLE
document CAP_SYS_ADMIN required for systemd PrivateNetwork

### DIFF
--- a/rootless.md
+++ b/rootless.md
@@ -17,7 +17,7 @@ can easily fail
   * As of Fedora 31 defaults to cgroup V2, which has full support of rootless cgroup management.  Note this requires the --cgroup-manager within rootless containers to use systemd, which new containers will get by default.
 * Some system unit configuration options do not work in the rootless container
   * systemd fails to apply several options and failures are silently ignored (e.g. CPUShares, MemoryLimit). Should work on cgroup V2.
-  * Use of certain options will cause service startup failures (e.g. PrivateNetwork).  The systemd services requiring `PrivateNetwork` can be made to work by passing `--cap-add SYS_ADMIN`, but the security implications should be carefully evaluated. In most cases, it's better to create an override.conf drop-in that sets `PrivateNetwork=no`.  This also applies to containers run by root.
+  * Use of certain options will cause service startup failures (e.g. PrivateNetwork).  The systemd services requiring `PrivateNetwork` can be made to work by passing `--cap-add SYS_ADMIN`, but the security implications should be carefully evaluated.  In most cases, it's better to create an override.conf drop-in that sets `PrivateNetwork=no`.  This also applies to containers run by root.
 * Can not share container images with CRI-O or other rootfull users
 * Difficult to use additional stores for sharing content
 * Does not work on NFS or parallel filesystem homedirs (e.g. [GPFS](https://www.ibm.com/support/knowledgecenter/en/SSFKCN/gpfs_welcome.html))

--- a/rootless.md
+++ b/rootless.md
@@ -17,7 +17,7 @@ can easily fail
   * As of Fedora 31 defaults to cgroup V2, which has full support of rootless cgroup management.  Note this requires the --cgroup-manager within rootless containers to use systemd, which new containers will get by default.
 * Some system unit configuration options do not work in the rootless container
   * systemd fails to apply several options and failures are silently ignored (e.g. CPUShares, MemoryLimit). Should work on cgroup V2.
-  * Use of certain options will cause service startup failures (e.g. PrivateNetwork).
+  * Use of certain options will cause service startup failures (e.g. PrivateNetwork).  The systemd services requiring `PrivateNetwork` can be made to work by passing `--cap-add SYS_ADMIN`, but the security implications should be carefully evaluated. In most cases, it's better to create an override.conf drop-in that sets `PrivateNetwork=no`.  This also applies to containers run by root.
 * Can not share container images with CRI-O or other rootfull users
 * Difficult to use additional stores for sharing content
 * Does not work on NFS or parallel filesystem homedirs (e.g. [GPFS](https://www.ibm.com/support/knowledgecenter/en/SSFKCN/gpfs_welcome.html))


### PR DESCRIPTION
This wasn't working for rootful containers either without the `--privileged` flag.  I did some searching and found that `CAP_SYS_ADMIN` is required for `PrivateNetwork` feature to work: https://stackoverflow.com/questions/39539188/why-unshareclone-newnet-requires-cap-sys-admin