### PR TITLE
APIv2:fix: Get volumes from `Binds` when creating

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -135,10 +135,10 @@ func makeCreateConfig(containerConfig *config.Config, input handlers.CreateConta
 		User:       input.User,
 	}
 	pidConfig := createconfig.PidConfig{PidMode: namespaces.PidMode(input.HostConfig.PidMode)}
-	volumes := make([]string, 0, len(input.Volumes))
-	for k := range input.Volumes {
-		volumes = append(volumes, k)
-	}
+	// TODO: We should check that these binds are all listed in the `Volumes`
+	// key since it doesn't make sense to define a `Binds` element for a
+	// container path which isn't defined as a volume
+	volumes := input.HostConfig.Binds
 
 	// Docker is more flexible about its input where podman throws
 	// away incorrectly formatted variables so we cannot reuse the


### PR DESCRIPTION
This change ensures that we pull volume bind specification strings from
the correct spot in the POSTed data when creating containers. We should
probably sanity check that the mapping keys in `Volumes` are a superset
of the binds listed in `HostConfig.Binds` but this cheap change removes
an annoying behaviour where named volumes or host mount would be
silently replaced with newly created anonymous volumes.