### PR TITLE
fix API: Create container with an invalid configuration

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -1,6 +1,7 @@
 package compat
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -40,6 +41,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(input.HostConfig.Links) > 0 {
 		utils.Error(w, utils.ErrLinkNotSupport.Error(), http.StatusBadRequest, errors.Wrapf(utils.ErrLinkNotSupport, "bad parameter"))
+		return
 	}
 	newImage, err := runtime.ImageRuntime().NewFromLocal(input.Image)
 	if err != nil {
@@ -51,7 +53,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "GetConfig()"))
 		return
 	}
-	cc, err := makeCreateConfig(containerConfig, input, newImage)
+	cc, err := makeCreateConfig(r.Context(), containerConfig, input, newImage)
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "makeCreatConfig()"))
 		return
@@ -60,7 +62,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	utils.CreateContainer(r.Context(), w, runtime, &cc)
 }
 
-func makeCreateConfig(containerConfig *config.Config, input handlers.CreateContainerConfig, newImage *image2.Image) (createconfig.CreateConfig, error) {
+func makeCreateConfig(ctx context.Context, containerConfig *config.Config, input handlers.CreateContainerConfig, newImage *image2.Image) (createconfig.CreateConfig, error) {
 	var (
 		err  error
 		init bool
@@ -77,6 +79,22 @@ func makeCreateConfig(containerConfig *config.Config, input handlers.CreateConta
 	workDir := "/"
 	if len(input.WorkingDir) > 0 {
 		workDir = input.WorkingDir
+	}
+
+	if len(input.Entrypoint) == 0 {
+		entrypointSlice, err := newImage.Entrypoint(ctx)
+		if err != nil {
+			return createconfig.CreateConfig{}, err
+		}
+		input.Entrypoint = entrypointSlice
+	}
+
+	if len(input.Cmd) == 0 {
+		cmdSlice, err := newImage.Cmd(ctx)
+		if err != nil {
+			return createconfig.CreateConfig{}, err
+		}
+		input.Cmd = cmdSlice
 	}
 
 	stopTimeout := containerConfig.Engine.StopTimeout
@@ -217,5 +235,16 @@ func makeCreateConfig(containerConfig *config.Config, input handlers.CreateConta
 
 		Pid: pidConfig,
 	}
+
+	fullCmd := append(input.Entrypoint, input.Cmd...)
+	if len(fullCmd) > 0 {
+		m.PodmanPath = fullCmd[0]
+		if len(fullCmd) == 1 {
+			m.Args = fullCmd
+		} else {
+			m.Args = fullCmd[1:]
+		}
+	}
+
 	return m, nil
 }

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -51,6 +51,19 @@ cid=$(jq -r '.[0].Id' <<<"$output")
 
 t DELETE libpod/containers/$cid 204
 
+# Ensure that API does not occur: Create Container creates an invalid and the container fails to start
+# https://github.com/containers/libpod/issues/6799
+CNAME=testArgs
+t POST libpod/containers/create?name=${CNAME} Image=${IMAGE} 201 \
+  .Id~[0-9a-f]\\{64\\}
+t GET libpod/containers/json?limit=1 200 \
+  length=1 \
+  .[0].Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.[0].Id' <<<"$output")
+# This step should start the container properly
+t POST libpod/containers/${cid}/start '' 204
+t DELETE libpod/containers/$cid 204
+
 CNAME=myfoo
 podman run --name $CNAME $IMAGE -td top
 t GET libpod/containers/json?all=true 200 \


### PR DESCRIPTION
Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>
fix https://github.com/containers/libpod/issues/6799
if use API to create containers, this will be null
```
        "Path": "",
        "Args": null,
```