### PR TITLE
In rootless + cgroupsv1, resource limits are an error

### DIFF
--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
-	"syscall"
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/libpod/libpod/define"
@@ -144,32 +143,6 @@ func movePauseProcessToScope() error {
 	}
 
 	return utils.RunUnderSystemdScope(int(pid), "user.slice", "podman-pause.scope")
-}
-
-func setRLimits() error { // nolint:deadcode,unused
-	rlimits := new(syscall.Rlimit)
-	rlimits.Cur = 1048576
-	rlimits.Max = 1048576
-	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
-		if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
-			return errors.Wrapf(err, "error getting rlimits")
-		}
-		rlimits.Cur = rlimits.Max
-		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
-			return errors.Wrapf(err, "error setting new rlimits")
-		}
-	}
-	return nil
-}
-
-func setUMask() { // nolint:deadcode,unused
-	// Be sure we can create directories with 0755 mode.
-	syscall.Umask(0022)
-}
-
-// checkInput can be used to verify any of the globalopt values
-func checkInput() error { // nolint:deadcode,unused
-	return nil
 }
 
 // SystemPrune removes unused data from the system. Pruning pods, containers, volumes and images.


### PR DESCRIPTION
However, in some cases (unset limits), we can completely remove the limit and avoid errors. This works around a bug where the Podman frontend is setting a Pids limit of 0 on some rootless systems.

For now, this is only implemented for the PID limit. It can easily be extended to other resource limits, but it is a fair bit of code to do so, so I leave that exercise to someone else.

Fixes #6834