### PR TITLE
Podman Pull tag parse fix

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -193,18 +193,13 @@ func sortImages(imageS []*entities.ImageSummary) []imageReporter {
 }
 
 func tokenRepoTag(tag string) (string, string) {
-	tokens := strings.Split(tag, ":")
-	switch len(tokens) {
-	case 0:
+	tagSplitIndex := strings.LastIndex(tag, ":")
+	if tagSplitIndex == -1 {
 		return tag, ""
-	case 1:
-		return tokens[0], ""
-	case 2:
-		return tokens[0], tokens[1]
-	case 3:
-		return tokens[0] + ":" + tokens[1], tokens[2]
-	default:
-		return "<N/A>", ""
+	} else {
+		repositoryString := tag[:tagSplitIndex]
+		tagString := tag[tagSplitIndex+1:]
+		return repositoryString, tagString
 	}
 }
 


### PR DESCRIPTION
Fix to issue where tags are split at the first occurrence of a colon ':' rather than the last occurrence in the input causing an issue when a port is included
https://bugzilla.redhat.com/show_bug.cgi?id=1853230