### PR TITLE
[WIP]enable more remote integration tests

### DIFF
--- a/pkg/domain/infra/tunnel/helpers.go
+++ b/pkg/domain/infra/tunnel/helpers.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func getContainersByContext(contextWithConnection context.Context, all bool, namesOrIDs []string) ([]entities.ListContainer, error) {
+func getContainersByContext(contextWithConnection context.Context, all bool, namesOrIDs []string, ignoreErrors bool) ([]entities.ListContainer, error) {
 	var (
 		cons []entities.ListContainer
 	)
@@ -36,7 +36,7 @@ func getContainersByContext(contextWithConnection context.Context, all bool, nam
 				break
 			}
 		}
-		if !found {
+		if !found && !ignoreErrors {
 			return nil, errors.Wrapf(define.ErrNoSuchCtr, "unable to find container %q", id)
 		}
 	}

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -128,15 +128,14 @@ func (ir *ImageEngine) Tag(ctx context.Context, nameOrID string, tags []string, 
 }
 
 func (ir *ImageEngine) Untag(ctx context.Context, nameOrID string, tags []string, options entities.ImageUntagOptions) error {
+	newImage, err := images.GetImage(ir.ClientCxt, nameOrID, bindings.PFalse)
+	if err != nil {
+		return err
+	}
 	// Remove all tags if none are provided
 	if len(tags) == 0 {
-		newImage, err := images.GetImage(ir.ClientCxt, nameOrID, bindings.PFalse)
-		if err != nil {
-			return err
-		}
-		tags = newImage.NamesHistory
+		tags = newImage.RepoTags
 	}
-
 	for _, newTag := range tags {
 		var (
 			tag, repo string
@@ -154,7 +153,7 @@ func (ir *ImageEngine) Untag(ctx context.Context, nameOrID string, tags []string
 		if len(repo) < 1 {
 			return errors.Errorf("invalid image name %q", nameOrID)
 		}
-		if err := images.Untag(ir.ClientCxt, nameOrID, tag, repo); err != nil {
+		if err := images.Untag(ir.ClientCxt, newImage.ID, tag, repo); err != nil {
 			return err
 		}
 	}

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -249,12 +249,13 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 	}
 	p := &PodmanTestIntegration{
 		PodmanTest: PodmanTest{
-			PodmanBinary:  podmanBinary,
-			ArtifactPath:  ARTIFACT_DIR,
-			TempDir:       tempDir,
-			RemoteTest:    remote,
-			ImageCacheFS:  storageFs,
-			ImageCacheDir: ImageCacheDir,
+			PodmanBinary:      podmanBinary,
+			PodmanLocalBinary: podmanBinary,
+			ArtifactPath:      ARTIFACT_DIR,
+			TempDir:           tempDir,
+			RemoteTest:        remote,
+			ImageCacheFS:      storageFs,
+			ImageCacheDir:     ImageCacheDir,
 		},
 		ConmonBinary:        conmonBinary,
 		CrioRoot:            filepath.Join(tempDir, "crio"),

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -107,13 +107,12 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create --entrypoint \"\"", func() {
-		Skip(v2remotefail)
-		session := podmanTest.Podman([]string{"create", "--entrypoint", "", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--name", "test", "--entrypoint", "", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 
-		result := podmanTest.Podman([]string{"inspect", "-l", "--format", "{{.Config.Entrypoint}}"})
+		result := podmanTest.Podman([]string{"inspect", "--format", "{{.Config.Entrypoint}}", "test"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(result.OutputToString()).To(Equal(""))
@@ -133,7 +132,6 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create --mount flag with multiple mounts", func() {
-		Skip(v2remotefail)
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
 		err := os.MkdirAll(vol1, 0755)
 		Expect(err).To(BeNil())
@@ -159,7 +157,6 @@ var _ = Describe("Podman create", func() {
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("skip failing test on ppc64le")
 		}
-		Skip(v2remotefail)
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
 		os.Mkdir(mountPath, 0755)
 		session := podmanTest.Podman([]string{"create", "--name", "test", "--mount", fmt.Sprintf("type=bind,src=%s,target=/create/test", mountPath), ALPINE, "grep", "/create/test", "/proc/self/mountinfo"})

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -67,9 +67,8 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec simple command using latest", func() {
-		// the remote client doesn't use latest
 		SkipIfRemote()
-		setup := podmanTest.RunTopContainer("test1")
+		setup := podmanTest.RunTopContainer("")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
@@ -122,13 +121,12 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec terminal doesn't hang", func() {
-		Skip(v2remotefail)
-		setup := podmanTest.Podman([]string{"run", "-dti", fedoraMinimal, "sleep", "+Inf"})
+		setup := podmanTest.Podman([]string{"run", "--name", "nohang", "-dti", fedoraMinimal, "sleep", "+Inf"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
 		for i := 0; i < 5; i++ {
-			session := podmanTest.Podman([]string{"exec", "-lti", "true"})
+			session := podmanTest.Podman([]string{"exec", "-ti", "nohang", "true"})
 			session.WaitWithDefaultTimeout()
 			Expect(session.ExitCode()).To(Equal(0))
 		}

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -174,7 +174,6 @@ var _ = Describe("Podman healthcheck run", func() {
 	})
 
 	It("podman healthcheck single healthy result changes failed to healthy", func() {
-		Skip(v2remotefail)
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-retries", "2", "--health-cmd", "ls /foo || exit 1", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Podman images", func() {
 		session = podmanTest.PodmanNoCache([]string{"images", "-qn"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(len(session.OutputToStringArray())).To(BeNumerically("==", 3))
+		Expect(len(session.OutputToStringArray())).To(BeNumerically("==", len(RESTORE_IMAGES)))
 	})
 
 	It("podman images with digests", func() {

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -120,7 +120,6 @@ var _ = Describe("Podman start", func() {
 	})
 
 	It("podman failed to start with --rm should delete the container", func() {
-		Skip(v2remotefail)
 		session := podmanTest.Podman([]string{"create", "--name", "test1", "-it", "--rm", ALPINE, "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -41,8 +41,6 @@ var _ = Describe("Podman stop", func() {
 	})
 
 	It("podman stop --ignore bogus container", func() {
-		SkipIfRemote()
-
 		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -198,14 +196,13 @@ var _ = Describe("Podman stop", func() {
 	})
 
 	It("podman stop all containers with one stopped", func() {
-		Skip(v2remotefail)
 		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session2 := podmanTest.RunTopContainer("test2")
 		session2.WaitWithDefaultTimeout()
 		Expect(session2.ExitCode()).To(Equal(0))
-		session3 := podmanTest.Podman([]string{"stop", "-l", "-t", "1"})
+		session3 := podmanTest.Podman([]string{"stop", "test2", "-t", "1"})
 		session3.WaitWithDefaultTimeout()
 		Expect(session3.ExitCode()).To(Equal(0))
 		session4 := podmanTest.Podman([]string{"stop", "-a", "-t", "1"})

--- a/test/e2e/untag_test.go
+++ b/test/e2e/untag_test.go
@@ -33,7 +33,6 @@ var _ = Describe("Podman untag", func() {
 	})
 
 	It("podman untag all", func() {
-		Skip(v2remotefail)
 		tags := []string{ALPINE, "registry.com/foo:bar", "localhost/foo:bar"}
 
 		cmd := []string{"tag"}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -35,6 +35,7 @@ type PodmanTestCommon interface {
 type PodmanTest struct {
 	PodmanMakeOptions  func(args []string, noEvents, noCache bool) []string
 	PodmanBinary       string
+	PodmanLocalBinary  string
 	ArtifactPath       string
 	TempDir            string
 	RemoteTest         bool


### PR DESCRIPTION
a bunch of remote integration tests can now be enabled either through code improvements, better tests, or parameter changes.  exec_test.go and images_test.go still have more than several that need to be addressed.

Signed-off-by: Brent Baude <bbaude@redhat.com>