### PR TITLE
Fix container and pod create commands for remote create

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -401,6 +401,9 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	}
 	var command []string
 
+	// Include the command used to create the container.
+	s.ContainerCreateCommand = os.Args
+
 	// Build the command
 	// If we have an entry point, it goes first
 	if c.Entrypoint != nil {

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -149,6 +149,8 @@ func create(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	createOptions.CreateCommand = os.Args
+
 	if replace {
 		if err := replacePod(createOptions.Name); err != nil {
 			return err

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1419,12 +1419,12 @@ func WithPreserveFDs(fd uint) CtrCreateOption {
 
 // WithCreateCommand adds the full command plus arguments of the current
 // process to the container config.
-func WithCreateCommand() CtrCreateOption {
+func WithCreateCommand(cmd []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
 			return define.ErrCtrFinalized
 		}
-		ctr.config.CreateCommand = os.Args
+		ctr.config.CreateCommand = cmd
 		return nil
 	}
 }
@@ -1625,12 +1625,12 @@ func WithPodHostname(hostname string) PodCreateOption {
 
 // WithPodCreateCommand adds the full command plus arguments of the current
 // process to the pod config.
-func WithPodCreateCommand() PodCreateOption {
+func WithPodCreateCommand(createCmd []string) PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
 			return define.ErrPodFinalized
 		}
-		pod.config.CreateCommand = os.Args
+		pod.config.CreateCommand = createCmd
 		return nil
 	}
 }

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -104,6 +104,7 @@ type PodRmReport struct {
 
 type PodCreateOptions struct {
 	CGroupParent       string
+	CreateCommand      []string
 	Hostname           string
 	Infra              bool
 	InfraImage         string
@@ -133,6 +134,7 @@ func (p PodCreateOptions) ToPodSpecGen(s *specgen.PodSpecGenerator) {
 	}
 	s.InfraImage = p.InfraImage
 	s.SharedNamespaces = p.Share
+	s.PodCreateCommand = p.CreateCommand
 
 	// Networking config
 	s.NetNS = p.Net.Network

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -406,10 +406,6 @@ func CreateContainerFromCreateConfig(ctx context.Context, r *libpod.Runtime, cre
 		return nil, err
 	}
 
-	// Set the CreateCommand explicitly.  Some (future) consumers of libpod
-	// might not want to set it.
-	options = append(options, libpod.WithCreateCommand())
-
 	ctr, err := r.NewContainer(ctx, runtimeSpec, options...)
 	if err != nil {
 		return nil, err

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -78,7 +78,9 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 	}
 
 	options := []libpod.CtrCreateOption{}
-	options = append(options, libpod.WithCreateCommand())
+	if s.ContainerCreateCommand != nil {
+		options = append(options, libpod.WithCreateCommand(s.ContainerCreateCommand))
+	}
 
 	var newImage *image.Image
 	if s.Rootfs != "" {

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -93,7 +93,9 @@ func createPodOptions(p *specgen.PodSpecGenerator) ([]libpod.PodCreateOption, er
 		options = append(options, libpod.WithInfraContainerPorts(ports))
 	}
 	options = append(options, libpod.WithPodCgroups())
-	options = append(options, libpod.WithPodCreateCommand())
+	if p.PodCreateCommand != nil {
+		options = append(options, libpod.WithPodCreateCommand(p.PodCreateCommand))
+	}
 	if len(p.InfraConmonPidFile) > 0 {
 		options = append(options, libpod.WithInfraConmonPidFile(p.InfraConmonPidFile))
 	}

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -49,6 +49,12 @@ type PodBasicConfig struct {
 	// Conflicts with NoInfra=true.
 	// Optional.
 	SharedNamespaces []string `json:"shared_namespaces,omitempty"`
+	// PodCreateCommand is the command used to create this pod.
+	// This will be shown in the output of Inspect() on the pod, and may
+	// also be used by some tools that wish to recreate the pod
+	// (e.g. `podman generate systemd --new`).
+	// Optional.
+	PodCreateCommand []string `json:"pod_create_command,omitempty"`
 }
 
 // PodNetworkConfig contains networking configuration for a pod.

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -135,6 +135,13 @@ type ContainerBasicConfig struct {
 	// Remove indicates if the container should be removed once it has been started
 	// and exits
 	Remove bool `json:"remove,omitempty"`
+	// ContainerCreateCommand is the command that was used to create this
+	// container.
+	// This will be shown in the output of Inspect() on the container, and
+	// may also be used by some tools that wish to recreate the container
+	// (e.g. `podman generate systemd --new`).
+	// Optional.
+	ContainerCreateCommand []string `json:"containerCreateCommand,omitempty"`
 	// PreserveFDs is a number of additional file descriptors (in addition
 	// to 0, 1, 2) that will be passed to the executed process. The total FDs
 	// passed will be 3 + PreserveFDs.

--- a/pkg/varlinkapi/create.go
+++ b/pkg/varlinkapi/create.go
@@ -915,10 +915,6 @@ func CreateContainerFromCreateConfig(ctx context.Context, r *libpod.Runtime, cre
 		return nil, err
 	}
 
-	// Set the CreateCommand explicitly.  Some (future) consumers of libpod
-	// might not want to set it.
-	options = append(options, libpod.WithCreateCommand())
-
 	ctr, err := r.NewContainer(ctx, runtimeSpec, options...)
 	if err != nil {
 		return nil, err

--- a/test/e2e/pod_inspect_test.go
+++ b/test/e2e/pod_inspect_test.go
@@ -59,7 +59,6 @@ var _ = Describe("Podman pod inspect", func() {
 	})
 
 	It("podman pod inspect (CreateCommand)", func() {
-		Skip(v2remotefail)
 		podName := "myTestPod"
 		createCommand := []string{"pod", "create", "--name", podName, "--hostname", "rudolph", "--share", "net"}
 


### PR DESCRIPTION
In `podman inspect` output for containers and pods, we include the command that was used to create the container. This is also used by `podman generate systemd --new` to generate unit files.

With remote podman, the generated create commands were incorrect since we sourced directly from os.Args on the server side, which was guaranteed to be `podman system service` (or some variant thereof). The solution is to pass the command along in the Specgen or PodSpecgen, where we can source it from the client's os.Args.

This will still be VERY iffy for mixed local/remote use (doing a `podman --remote run ...` on a remote client then a `podman generate systemd --new` on the server on the same container will not work, because the `--remote` flag will slip in) but at the very least the output of `podman inspect` will be correct. We can look into properly handling `--remote` (parsing it out would be a little iffy) in a future PR.