### PR TITLE
Fix & add notes regarding problematic language in codebase

### DIFF
--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -580,7 +580,7 @@ process.
 
    Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Podman
    bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the Podman
-   container. The `OPTIONS` are a comma delimited list and can be:
+   container. The `OPTIONS` are a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
 
    * [rw|ro]
    * [z|Z|O]
@@ -643,7 +643,7 @@ be specified only for bind mounted volumes and not for internal volumes or
 named volumes. For mount propagation to work on the source mount point (mount point
 where source dir is mounted on) has to have the right propagation properties. For
 shared volumes, the source mount point has to be shared. And for slave volumes,
-the source mount has to be either shared or slave.
+the source mount has to be either shared or slave. <sup>[[1]](#Footnote1)</sup>
 
 Use `df <source-dir>` to determine the source mount and then use
 `findmnt -o TARGET,PROPAGATION <source-mount-dir>` to determine propagation
@@ -651,7 +651,7 @@ properties of source mount, if `findmnt` utility is not available, the source mo
 can be determined by looking at the mount entry in `/proc/self/mountinfo`. Look
 at `optional fields` and see if any propagation properties are specified.
 `shared:X` means the mount is `shared`, `master:X` means the mount is `slave` and if
-nothing is there that means the mount is `private`.
+nothing is there that means the mount is `private`. <sup>[[1]](#Footnote1)</sup>
 
 To change propagation properties of a mount point use the `mount` command. For
 example, to bind mount the source directory `/foo` do
@@ -755,3 +755,6 @@ podman(1), buildah(1), containers-registries.conf(5), crun(8), runc(8), useradd(
 May 2018, Minor revisions added by Joe Doss <joe@solidadmin.com>
 
 December 2017, Originally compiled by Tom Sweeney <tsweeney@redhat.com>
+
+## FOOTNOTES
+<a name="Footnote1">1</a>: The Podman project is committed to inclusivity, a core value of open source. The `master` and `slave` mount propagation terminology used here is problematic and divisive, and should be changed. However, these terms are currently used within the Linux kernel and must be used as-is at this time. When the kernel maintainers rectify this usage, Podman will follow suit immediately.

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -488,7 +488,7 @@ Tune a container's memory swappiness behavior. Accepts an integer between 0 and 
 
 Attach a filesystem mount to the container
 
-Current supported mount TYPES are `bind`, `volume`, and `tmpfs`.
+Current supported mount TYPES are `bind`, `volume`, and `tmpfs`. <sup>[[1]](#Footnote1)</sup>
 
        e.g.
 
@@ -884,7 +884,7 @@ Set the UTS mode for the container
 
 Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, podman
 bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the podman
-container. The `OPTIONS` are a comma delimited list and can be:
+container. The `OPTIONS` are a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
 
 * [rw|ro]
 * [z|Z]
@@ -936,7 +936,7 @@ this behavior by specifying a volume mount propagation property. Making a
 volume `shared` mounts done under that volume inside container will be
 visible on host and vice versa. Making a volume `slave` enables only one
 way mount propagation and that is mounts done on host under that volume
-will be visible inside container but not the other way around.
+will be visible inside container but not the other way around. <sup>[[1]](#Footnote1)</sup>
 
 To control mount propagation property of volume one can use `:[r]shared`,
 `:[r]slave` or `:[r]private` propagation flag. Propagation property can
@@ -944,7 +944,7 @@ be specified only for bind mounted volumes and not for internal volumes or
 named volumes. For mount propagation to work source mount point (mount point
 where source dir is mounted on) has to have right propagation properties. For
 shared volumes, source mount point has to be shared. And for slave volumes,
-source mount has to be either shared or slave.
+source mount has to be either shared or slave. <sup>[[1]](#Footnote1)</sup>
 
 If you want to recursively mount a volume and all of it's submounts into a
 container, then you can use the `rbind` option.  By default the bind option is
@@ -971,7 +971,7 @@ properties of source mount. If `findmnt` utility is not available, then one
 can look at mount entry for source mount point in `/proc/self/mountinfo`. Look
 at `optional fields` and see if any propagation properties are specified.
 `shared:X` means mount is `shared`, `master:X` means mount is `slave` and if
-nothing is there that means mount is `private`.
+nothing is there that means mount is `private`. <sup>[[1]](#Footnote1)</sup>
 
 To change propagation properties of a mount point use `mount` command. For
 example, if one wants to bind mount source directory `/foo` one can do
@@ -1117,3 +1117,6 @@ November 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 September 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 
 August 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+
+## FOOTNOTES
+<a name="Footnote1">1</a>: The Podman project is committed to inclusivity, a core value of open source. The `master` and `slave` mount propagation terminology used here is problematic and divisive, and should be changed. However, these terms are currently used within the Linux kernel and must be used as-is at this time. When the kernel maintainers rectify this usage, Podman will follow suit immediately.

--- a/docs/source/markdown/podman-image-trust.1.md
+++ b/docs/source/markdown/podman-image-trust.1.md
@@ -30,8 +30,8 @@ If no configuration is found for any of these scopes, the default value (specifi
 
 Trust **type** provides a way to:
 
-Whitelist ("accept") or
-Blacklist ("reject") registries or
+Allowlist ("accept") or
+Denylist ("reject") registries or
 Require signature (“signedBy”).
 
 Trust may be updated using the command **podman image trust set** for an existing trust scope.

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -495,7 +495,7 @@ Tune a container's memory swappiness behavior. Accepts an integer between *0* an
 
 Attach a filesystem mount to the container
 
-Current supported mount TYPEs are **bind**, **volume**, and **tmpfs**.
+Current supported mount TYPEs are **bind**, **volume**, and **tmpfs**. <sup>[[1]](#Footnote1)</sup>
 
        e.g.
 
@@ -754,7 +754,7 @@ Security Options
 - **label=disable**: Turn off label separation for the container
 - **no-new-privileges**: Disable container processes from gaining additional privileges
 - **seccomp=unconfined**: Turn off seccomp confinement for the container
-- **seccomp**=_profile.json_:  Whitelisted syscalls seccomp JSON file to be used as a seccomp filter
+- **seccomp**=_profile.json_:  Allowed syscall list seccomp JSON file to be used as a seccomp filter
 
 Note: Labeling can be disabled for all containers by setting **label=false** in the **libpod.conf**(5) file.
 
@@ -924,7 +924,7 @@ container. Similarly, _source-volume_:_/container-dir_ will mount the volume
 in the host to the container. If no such named volume exists, Podman will
 create one.
 
-The _options_ is a comma delimited list and can be:
+The _options_ is a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
 
 * **rw**|**ro**
 * **z**|**Z**
@@ -974,7 +974,7 @@ this behavior by specifying a volume mount propagation property. Making a
 volume shared mounts done under that volume inside container will be
 visible on host and vice versa. Making a volume **slave** enables only one
 way mount propagation and that is mounts done on host under that volume
-will be visible inside container but not the other way around.
+will be visible inside container but not the other way around. <sup>[[1]](#Footnote1)</sup>
 
 To control mount propagation property of volume one can use [**r**]**shared**,
 [**r**]**slave** or [**r**]**private** propagation flag. Propagation property can
@@ -982,7 +982,7 @@ be specified only for bind mounted volumes and not for internal volumes or
 named volumes. For mount propagation to work source mount point (mount point
 where source dir is mounted on) has to have right propagation properties. For
 shared volumes, source mount point has to be shared. And for slave volumes,
-source mount has to be either shared or slave.
+source mount has to be either shared or slave. <sup>[[1]](#Footnote1)</sup>
 
 If you want to recursively mount a volume and all of its submounts into a
 container, then you can use the **rbind** option.  By default the bind option is
@@ -1009,7 +1009,7 @@ properties of source mount. If **findmnt**(1) utility is not available, then one
 can look at mount entry for source mount point in _/proc/self/mountinfo_. Look
 at the "optional fields" and see if any propagation properties are specified.
 In there, **shared:N** means the mount is shared, **master:N** means mount
-is slave, and if nothing is there, the mount is private.
+is slave, and if nothing is there, the mount is private. <sup>[[1]](#Footnote1)</sup>
 
 To change propagation properties of a mount point, use **mount**(8) command. For
 example, if one wants to bind mount source directory _/foo_, one can do
@@ -1400,3 +1400,6 @@ July 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 
 April 2014, Originally compiled by William Henry <whenry@redhat.com> based on docker.com source material and internal work.
+
+## FOOTNOTES
+<a name="Footnote1">1</a>: The Podman project is committed to inclusivity, a core value of open source. The `master` and `slave` mount propagation terminology used here is problematic and divisive, and should be changed. However, these terms are currently used within the Linux kernel and must be used as-is at this time. When the kernel maintainers rectify this usage, Podman will follow suit immediately.

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -641,7 +641,7 @@ func ValidateSysctls(strSlice []string) (map[string]string, error) {
 			}
 		}
 		if !foundMatch {
-			return nil, errors.Errorf("sysctl '%s' is not whitelisted", arr[0])
+			return nil, errors.Errorf("sysctl '%s' is not allowed", arr[0])
 		}
 	}
 	return sysctl, nil

--- a/rootless.md
+++ b/rootless.md
@@ -30,7 +30,7 @@ can easily fail
 * Only other supported driver is VFS.
 * No CNI Support
   * CNI wants to modify IPTables, plus other network manipulation that requires CAP_SYS_ADMIN.
-  * There is potential we could probably do some sort of blacklisting of the relevant plugins, and add a new plugin for rootless networking - slirp4netns as one example and there may be others
+  * There is potential we could probably do some sort of denylisting of the relevant plugins, and add a new plugin for rootless networking - slirp4netns as one example and there may be others
 * Cannot use ping out of the box.
   * [(Can be fixed by setting sysctl on host)](https://github.com/containers/libpod/blob/master/troubleshooting.md#6-rootless-containers-cannot-ping-hosts)
 * Requires new shadow-utils (not found in older (RHEL7/Centos7 distros) Should be fixed in RHEL7.7 release)


### PR DESCRIPTION
Podman is committed to inclusivity, a core value of open source. Historically, there have been technology terms that are problematic and divisive, and should be changed. We are currently taking time to audit our repository in order to eliminate such terminology, and replace it with more inclusive terms. We are starting where we can, with our own code, comments, and documentation. However, such terms may be used in dependencies, and must be used in our repositories at the current moment for compatibility. Podman will change these terms in our repo as soon as new and better terminology is available to us via our dependencies.

For more information: https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language?sc_cid=701600000011gf0AAA

Signed-off-by: Ashley Cui <acui@redhat.com>