### PR TITLE
Fix a bug where --pids-limit was parsed incorrectly

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -202,7 +202,7 @@ func createInit(c *cobra.Command) error {
 	}
 	if c.Flags().Changed("pids-limit") {
 		val := c.Flag("pids-limit").Value.String()
-		pidsLimit, err := strconv.ParseInt(val, 0, 10)
+		pidsLimit, err := strconv.ParseInt(val, 10, 32)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1015,4 +1015,21 @@ USER mail`
 			Expect(session.ExitCode()).To(Equal(0))
 		}
 	})
+
+	It("podman run verify pids-limit", func() {
+		cgroupsv2, err := cgroups.IsCgroup2UnifiedMode()
+		Expect(err).To(BeNil())
+
+		if !cgroupsv2 {
+			// Need v2 to ensure that cgroupfs looks the way we
+			// expect.
+			Skip("Test requires cgroups v2 to be enabled")
+		}
+
+		limit := "4321"
+		session := podmanTest.Podman([]string{"run", "--pids-limit", limit, "--rm", ALPINE, "cat", "/sys/fs/cgroup/pids.max"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(limit))
+	})
 })


### PR DESCRIPTION
The --pids-limit flag was using strconv.ParseInt with bad arguments, resulting in it being unable to parse standard integers (1024, for example, would produce an 'out of range' error).

Change the arguments to make sense (base 10, max 32-bit) and add a test to ensure we don't regress again.

Fixes #6908

Currently only against v2.0 branch, as it looks like changes that caused this have not landed in master yet.