### PR TITLE
Fix: Hijacking endpoints to follow rfc 7230 semantics

### DIFF
--- a/pkg/api/handlers/compat/exec.go
+++ b/pkg/api/handlers/compat/exec.go
@@ -173,21 +173,11 @@ func ExecStartHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Hijack the connection
-	hijacker, ok := w.(http.Hijacker)
-	if !ok {
-		utils.InternalServerError(w, errors.Errorf("unable to hijack connection"))
-		return
-	}
-
-	connection, buffer, err := hijacker.Hijack()
+	connection, buffer, err := AttachConnection(w, r)
 	if err != nil {
-		utils.InternalServerError(w, errors.Wrapf(err, "error hijacking connection"))
+		utils.InternalServerError(w, err)
 		return
 	}
-
-	fmt.Fprintf(connection, AttachHeader)
-
 	logrus.Debugf("Hijack for attach of container %s exec session %s successful", sessionCtr.ID(), sessionID)
 
 	if err := sessionCtr.ExecHTTPStartAndAttach(sessionID, connection, buffer, nil, nil, nil); err != nil {


### PR DESCRIPTION
After this patch v2 hijacking endpoints, exec/start and containers/attach follow rfc 7230 specification.

Connection will only be upgraded, if client specifies upgrade headers:

For tcp connections:

```
Connection: Upgrade
Upgrade: tcp
```

For unix socket connections:

```
Connection: Upgrade
Upgrade: sock
```

There are currently no checks if upgrade type actually matches with available protocols. Implementation just echoes protocol that client requested

Signed-off-by: Sami Korhonen <skorhone@gmail.com>