### PR TITLE
Fix: Remove hijacked connections from active connections list

### DIFF
--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -255,14 +255,14 @@ func (t *IdleTracker) ConnState(conn net.Conn, state http.ConnState) {
 	oldActive := len(t.active)
 	logrus.Debugf("IdleTracker %p:%v %d/%d connection(s)", conn, state, t.ActiveConnections(), t.TotalConnections())
 	switch state {
-	case http.StateNew, http.StateActive, http.StateHijacked:
+	case http.StateNew, http.StateActive:
 		t.active[conn] = struct{}{}
 		// stop the timer if we transitioned from idle
 		if oldActive == 0 {
 			t.timer.Stop()
 		}
 		t.total++
-	case http.StateIdle, http.StateClosed:
+	case http.StateIdle, http.StateClosed, http.StateHijacked:
 		delete(t.active, conn)
 		// Restart the timer if we've become idle
 		if oldActive > 0 && len(t.active) == 0 {


### PR DESCRIPTION
StateHijacked is a terminal state. If hijacked connection is registered as an active connection, connection will never be unregistered. This causes two issues

First issue is that active connection counters are off.

Second issue is a resource leak caused by connection object that is stored to a map.

After this patch hijacked connections are no longer visible in counters. If a counter for hijacked connections is required, podman must track connections returned by Hijacker.Hijack()

It might make sense to develop abstraction layer for hijacking - and move all hijacking related code to a
separate package. Hijacking code is prone to resource leaks and it should be thoroughly tested.

Signed-off-by: Sami Korhonen <skorhone@gmail.com>