### PR TITLE
log API: add context to allow for cancelling

### DIFF
--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -32,6 +32,8 @@ var (
 		Long:  logsDescription,
 		Args: func(cmd *cobra.Command, args []string) error {
 			switch {
+			case registry.IsRemote() && logsOptions.Latest:
+				return errors.New(cmd.Name() + " does not support 'latest' when run remotely")
 			case registry.IsRemote() && len(args) > 1:
 				return errors.New(cmd.Name() + " does not support multiple containers when run remotely")
 			case logsOptions.Latest && len(args) > 0:

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -353,7 +353,7 @@ func (c *Container) HTTPAttach(httpCon net.Conn, httpBuf *bufio.ReadWriter, stre
 			logOpts.WaitGroup.Wait()
 			close(logChan)
 		}()
-		if err := c.ReadLog(logOpts, logChan); err != nil {
+		if err := c.ReadLog(context.Background(), logOpts, logChan); err != nil {
 			return err
 		}
 		logrus.Debugf("Done reading logs for container %s, %d bytes", c.ID(), logSize)

--- a/libpod/container_log_unsupported.go
+++ b/libpod/container_log_unsupported.go
@@ -3,11 +3,13 @@
 package libpod
 
 import (
+	"context"
+
 	"github.com/containers/libpod/v2/libpod/define"
 	"github.com/containers/libpod/v2/libpod/logs"
 	"github.com/pkg/errors"
 )
 
-func (c *Container) readFromJournal(options *logs.LogOptions, logChannel chan *logs.LogLine) error {
+func (c *Container) readFromJournal(_ context.Context, _ *logs.LogOptions, _ chan *logs.LogLine) error {
 	return errors.Wrapf(define.ErrOSNotSupported, "Journald logging only enabled with systemd on linux")
 }

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -924,7 +924,7 @@ func (ic *ContainerEngine) ContainerLogs(ctx context.Context, containers []strin
 	}
 	logChannel := make(chan *logs.LogLine, chSize)
 
-	if err := ic.Libpod.Log(ctrs, logOpts, logChannel); err != nil {
+	if err := ic.Libpod.Log(ctx, ctrs, logOpts, logChannel); err != nil {
 		return err
 	}
 

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -754,7 +754,7 @@ func (i *VarlinkAPI) GetContainersLogs(call iopodman.VarlinkCall, names []string
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
-	if err := i.Runtime.Log(containers, &options, logChannel); err != nil {
+	if err := i.Runtime.Log(getContext(), containers, &options, logChannel); err != nil {
 		return err
 	}
 	go func() {

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -121,7 +121,6 @@ var _ = Describe("Podman logs", func() {
 	})
 
 	It("latest and container name should fail", func() {
-		SkipIfRemote() // -l not supported
 		results := podmanTest.Podman([]string{"logs", "-l", "foobar"})
 		results.WaitWithDefaultTimeout()
 		Expect(results).To(ExitWithError())
@@ -159,7 +158,6 @@ var _ = Describe("Podman logs", func() {
 	})
 
 	It("using journald for container with container tag", func() {
-		SkipIfRemote()
 		Skip("need to verify images have correct packages for journald")
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "--log-opt=tag={{.ImageName}}", "-d", ALPINE, "sh", "-c", "echo podman; sleep 0.1; echo podman; sleep 0.1; echo podman"})
 		logc.WaitWithDefaultTimeout()
@@ -178,7 +176,6 @@ var _ = Describe("Podman logs", func() {
 
 	It("using journald for container name", func() {
 		Skip("need to verify images have correct packages for journald")
-		SkipIfRemote()
 		containerName := "inside-journal"
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "-d", "--name", containerName, ALPINE, "sh", "-c", "echo podman; sleep 0.1; echo podman; sleep 0.1; echo podman"})
 		logc.WaitWithDefaultTimeout()
@@ -273,7 +270,6 @@ var _ = Describe("Podman logs", func() {
 	})
 
 	It("streaming output", func() {
-		Skip(v2remotefail)
 		containerName := "logs-f-rm"
 
 		logc := podmanTest.Podman([]string{"run", "--rm", "--name", containerName, "-dt", ALPINE, "sh", "-c", "echo podman; sleep 1; echo podman"})
@@ -314,7 +310,6 @@ var _ = Describe("Podman logs", func() {
 	})
 
 	It("follow output stopped container", func() {
-		Skip(v2remotefail)
 		containerName := "logs-f"
 
 		logc := podmanTest.Podman([]string{"run", "--name", containerName, "-d", ALPINE, "true"})


### PR DESCRIPTION
Add a `context.Context` to the log APIs to allow for cancelling
streaming (e.g., via `podman logs -f`).  This fixes issues for
the remote API where some go routines of the server will continue
writing and produce nothing but heat and waste CPU cycles.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>