### PR TITLE
Fix: Correct connection counters for hijacked connections

### DIFF
--- a/pkg/api/handlers/compat/exec.go
+++ b/pkg/api/handlers/compat/exec.go
@@ -173,21 +173,11 @@ func ExecStartHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Hijack the connection
-	hijacker, ok := w.(http.Hijacker)
-	if !ok {
-		utils.InternalServerError(w, errors.Errorf("unable to hijack connection"))
-		return
-	}
-
-	connection, buffer, err := hijacker.Hijack()
+	connection, buffer, err := AttachConnection(w, r)
 	if err != nil {
-		utils.InternalServerError(w, errors.Wrapf(err, "error hijacking connection"))
+		utils.InternalServerError(w, err)
 		return
 	}
-
-	fmt.Fprintf(connection, AttachHeader)
-
 	logrus.Debugf("Hijack for attach of container %s exec session %s successful", sessionCtr.ID(), sessionID)
 
 	if err := sessionCtr.ExecHTTPStartAndAttach(sessionID, connection, buffer, nil, nil, nil); err != nil {

--- a/pkg/api/server/handler_api.go
+++ b/pkg/api/server/handler_api.go
@@ -37,6 +37,7 @@ func (s *APIServer) APIHandler(h http.HandlerFunc) http.HandlerFunc {
 			c := context.WithValue(r.Context(), "decoder", s.Decoder) //nolint
 			c = context.WithValue(c, "runtime", s.Runtime)            //nolint
 			c = context.WithValue(c, "shutdownFunc", s.Shutdown)      //nolint
+			c = context.WithValue(c, "idletracker", s.idleTracker)    //nolint
 			r = r.WithContext(c)
 
 			h(w, r)

--- a/pkg/api/server/idletracker/idletracker.go
+++ b/pkg/api/server/idletracker/idletracker.go
@@ -1,0 +1,74 @@
+package idletracker
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type IdleTracker struct {
+	http     map[net.Conn]struct{}
+	hijacked int
+	total    int
+	mux      sync.Mutex
+	timer    *time.Timer
+	Duration time.Duration
+}
+
+func NewIdleTracker(idle time.Duration) *IdleTracker {
+	return &IdleTracker{
+		http:     make(map[net.Conn]struct{}),
+		Duration: idle,
+		timer:    time.NewTimer(idle),
+	}
+}
+
+func (t *IdleTracker) ConnState(conn net.Conn, state http.ConnState) {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+
+	oldActive := t.ActiveConnections()
+	logrus.Debugf("IdleTracker %p:%v %d/%d connection(s)", conn, state, oldActive, t.TotalConnections())
+	switch state {
+	case http.StateNew, http.StateActive:
+		t.http[conn] = struct{}{}
+		// stop the timer if we transitioned from idle
+		if oldActive == 0 {
+			t.timer.Stop()
+		}
+		t.total++
+	case http.StateHijacked:
+		// hijacked connections are handled elsewhere
+		delete(t.http, conn)
+		t.hijacked++
+	case http.StateIdle, http.StateClosed:
+		delete(t.http, conn)
+		// Restart the timer if we've become idle
+		if oldActive > 0 && len(t.http) == 0 {
+			t.timer.Stop()
+			t.timer.Reset(t.Duration)
+		}
+	}
+}
+
+func (t *IdleTracker) TrackHijackedClosed() {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+
+	t.hijacked--
+}
+
+func (t *IdleTracker) ActiveConnections() int {
+	return len(t.http) + t.hijacked
+}
+
+func (t *IdleTracker) TotalConnections() int {
+	return t.total
+}
+
+func (t *IdleTracker) Done() <-chan time.Time {
+	return t.timer.C
+}

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -10,12 +10,12 @@ import (
 	"runtime"
 	goRuntime "runtime"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
 	"github.com/containers/libpod/v2/libpod"
 	"github.com/containers/libpod/v2/pkg/api/handlers"
+	"github.com/containers/libpod/v2/pkg/api/server/idletracker"
 	"github.com/coreos/go-systemd/v22/activation"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/schema"
@@ -24,14 +24,14 @@ import (
 )
 
 type APIServer struct {
-	http.Server                     // The  HTTP work happens here
-	*schema.Decoder                 // Decoder for Query parameters to structs
-	context.Context                 // Context to carry objects to handlers
-	*libpod.Runtime                 // Where the real work happens
-	net.Listener                    // mux for routing HTTP API calls to libpod routines
-	context.CancelFunc              // Stop APIServer
-	idleTracker        *IdleTracker // Track connections to support idle shutdown
-	pprof              *http.Server // Sidecar http server for providing performance data
+	http.Server                                 // The  HTTP work happens here
+	*schema.Decoder                             // Decoder for Query parameters to structs
+	context.Context                             // Context to carry objects to handlers
+	*libpod.Runtime                             // Where the real work happens
+	net.Listener                                // mux for routing HTTP API calls to libpod routines
+	context.CancelFunc                          // Stop APIServer
+	idleTracker        *idletracker.IdleTracker // Track connections to support idle shutdown
+	pprof              *http.Server             // Sidecar http server for providing performance data
 }
 
 // Number of seconds to wait for next request, if exceeded shutdown server
@@ -68,7 +68,7 @@ func newServer(runtime *libpod.Runtime, duration time.Duration, listener *net.Li
 	}
 
 	router := mux.NewRouter().UseEncodedPath()
-	idle := NewIdleTracker(duration)
+	idle := idletracker.NewIdleTracker(duration)
 
 	server := APIServer{
 		Server: http.Server{
@@ -230,56 +230,4 @@ func (s *APIServer) Shutdown() error {
 // Close immediately stops responding to clients and exits
 func (s *APIServer) Close() error {
 	return s.Server.Close()
-}
-
-type IdleTracker struct {
-	active   map[net.Conn]struct{}
-	total    int
-	mux      sync.Mutex
-	timer    *time.Timer
-	Duration time.Duration
-}
-
-func NewIdleTracker(idle time.Duration) *IdleTracker {
-	return &IdleTracker{
-		active:   make(map[net.Conn]struct{}),
-		Duration: idle,
-		timer:    time.NewTimer(idle),
-	}
-}
-
-func (t *IdleTracker) ConnState(conn net.Conn, state http.ConnState) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
-
-	oldActive := len(t.active)
-	logrus.Debugf("IdleTracker %p:%v %d/%d connection(s)", conn, state, t.ActiveConnections(), t.TotalConnections())
-	switch state {
-	case http.StateNew, http.StateActive:
-		t.active[conn] = struct{}{}
-		// stop the timer if we transitioned from idle
-		if oldActive == 0 {
-			t.timer.Stop()
-		}
-		t.total++
-	case http.StateIdle, http.StateClosed, http.StateHijacked:
-		delete(t.active, conn)
-		// Restart the timer if we've become idle
-		if oldActive > 0 && len(t.active) == 0 {
-			t.timer.Stop()
-			t.timer.Reset(t.Duration)
-		}
-	}
-}
-
-func (t *IdleTracker) ActiveConnections() int {
-	return len(t.active)
-}
-
-func (t *IdleTracker) TotalConnections() int {
-	return t.total
-}
-
-func (t *IdleTracker) Done() <-chan time.Time {
-	return t.timer.C
 }

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -255,14 +255,14 @@ func (t *IdleTracker) ConnState(conn net.Conn, state http.ConnState) {
 	oldActive := len(t.active)
 	logrus.Debugf("IdleTracker %p:%v %d/%d connection(s)", conn, state, t.ActiveConnections(), t.TotalConnections())
 	switch state {
-	case http.StateNew, http.StateActive, http.StateHijacked:
+	case http.StateNew, http.StateActive:
 		t.active[conn] = struct{}{}
 		// stop the timer if we transitioned from idle
 		if oldActive == 0 {
 			t.timer.Stop()
 		}
 		t.total++
-	case http.StateIdle, http.StateClosed:
+	case http.StateIdle, http.StateClosed, http.StateHijacked:
 		delete(t.active, conn)
 		// Restart the timer if we've become idle
 		if oldActive > 0 && len(t.active) == 0 {


### PR DESCRIPTION
This patch fixes connection counters for v2 endpoints
    
Idletracker was moved to a new package to prevent package cycle. Hijacking code still remains in wrong place and should be moved later to isolated package

This pull request is based on two other pull requests that are already pending (#6913 and #6914). Feel free to close those requests, if you want everything as a single patch
    
Signed-off-by: Sami Korhonen <skorhone@gmail.com>