### PR TITLE
version/info: format: allow more json variants

### DIFF
--- a/cmd/podman/parse/json.go
+++ b/cmd/podman/parse/json.go
@@ -1,0 +1,9 @@
+package parse
+
+import "regexp"
+
+var jsonFormatRegex = regexp.MustCompile(`^(\s*json\s*|\s*{{\s*json\s*\.\s*}}\s*)$`)
+
+func MatchesJSONFormat(s string) bool {
+	return jsonFormatRegex.Match([]byte(s))
+}

--- a/cmd/podman/parse/json_test.go
+++ b/cmd/podman/parse/json_test.go
@@ -1,0 +1,30 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchesJSONFormat(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"json", true},
+		{" json", true},
+		{"json ", true},
+		{"  json   ", true},
+		{"{{json .}}", true},
+		{"{{ json .}}", true},
+		{"{{json .   }}", true},
+		{"  {{  json .    }}   ", true},
+		{"{{json }}", false},
+		{"{{json .", false},
+		{"json . }}", false},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, MatchesJSONFormat(tt.input))
+	}
+}

--- a/cmd/podman/system/info.go
+++ b/cmd/podman/system/info.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"text/template"
 
+	"github.com/containers/libpod/v2/cmd/podman/parse"
 	"github.com/containers/libpod/v2/cmd/podman/registry"
 	"github.com/containers/libpod/v2/cmd/podman/validate"
 	"github.com/containers/libpod/v2/pkg/domain/entities"
@@ -68,7 +69,7 @@ func info(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if inFormat == "json" {
+	if parse.MatchesJSONFormat(inFormat) {
 		b, err := json.MarshalIndent(info, "", "  ")
 		if err != nil {
 			return err

--- a/cmd/podman/system/version.go
+++ b/cmd/podman/system/version.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/containers/buildah/pkg/formats"
+	"github.com/containers/libpod/v2/cmd/podman/parse"
 	"github.com/containers/libpod/v2/cmd/podman/registry"
 	"github.com/containers/libpod/v2/cmd/podman/validate"
 	"github.com/containers/libpod/v2/libpod/define"
@@ -41,7 +42,7 @@ func version(cmd *cobra.Command, args []string) error {
 	}
 
 	switch {
-	case versionFormat == "json", versionFormat == "{{ json .}}":
+	case parse.MatchesJSONFormat(versionFormat):
 		s, err := json.MarshalToString(versions)
 		if err != nil {
 			return err


### PR DESCRIPTION
Allow more variants to yield json output for `podman version` and
`podman info`.  Instead of comparing strings, use a regex and add
unit and e2e tests.

Fixes: #6927
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>