### PR TITLE
Ensure sig-proxy default is propagated in start

### DIFF
--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -82,6 +82,7 @@ func start(cmd *cobra.Command, args []string) error {
 	if cmd.Flag("sig-proxy").Changed {
 		sigProxy = startOptions.SigProxy
 	}
+	startOptions.SigProxy = sigProxy
 
 	if sigProxy && !startOptions.Attach {
 		return errors.Wrapf(define.ErrInvalidArg, "you cannot use sig-proxy without --attach")


### PR DESCRIPTION
We properly determined what sig-proxy should be set to, but we never passed that along to the backend. As such, cases where the
default swapped (mostly when `--attach` was specified but the `--sig-proxy` flag was not) were not handled correctly

Fixes #6928