### PR TITLE
Correctly print STDOUT on non-terminal remote exec

### DIFF
--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -457,15 +457,15 @@ func ExecStartAndAttach(ctx context.Context, sessionID string, streams *define.A
 
 			switch {
 			case fd == 0:
-				if streams.AttachOutput {
+				if streams.AttachInput {
+					// Write STDIN to STDOUT (echoing characters
+					// typed by another attach session)
 					if _, err := streams.OutputStream.Write(frame[0:l]); err != nil {
 						return err
 					}
 				}
 			case fd == 1:
-				if streams.AttachInput {
-					// Write STDIN to STDOUT (echoing characters
-					// typed by another attach session)
+				if streams.AttachOutput {
 					if _, err := streams.OutputStream.Write(frame[0:l]); err != nil {
 						return err
 					}

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -79,7 +79,6 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec environment test", func() {
-		Skip(v2remotefail)
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
@@ -99,7 +98,6 @@ var _ = Describe("Podman exec", func() {
 
 	It("podman exec os.Setenv env", func() {
 		// remote doesn't properly interpret os.Setenv
-		SkipIfRemote()
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
@@ -159,7 +157,6 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec with user only in container", func() {
-		Skip(v2remotefail)
 		testUser := "test123"
 		setup := podmanTest.Podman([]string{"run", "--name", "test1", "-d", fedoraMinimal, "sleep", "60"})
 		setup.WaitWithDefaultTimeout()
@@ -176,7 +173,6 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec with user from run", func() {
-		Skip(v2remotefail)
 		testUser := "guest"
 		setup := podmanTest.Podman([]string{"run", "--user", testUser, "-d", ALPINE, "top"})
 		setup.WaitWithDefaultTimeout()
@@ -196,7 +192,6 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec simple working directory test", func() {
-		Skip(v2remotefail)
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))


### PR DESCRIPTION
I confused STDIN and STDOUT's file descriptors (it's 0 and 1, I thought they were 1 and 0). As such, we were looking at whether
we wanted to print STDIN when we looked to print STDOUT. This bool was set when `-i` was set in at the `podman exec` command line, which masked the problem when it was set.

Fixes #6890
Fixes #6891
Fixes #6892