### PR TITLE
Fix handling of entrypoint

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -367,9 +367,10 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	s.Annotations = annotations
 
 	s.WorkDir = c.Workdir
-	entrypoint := []string{}
 	userCommand := []string{}
+	var command []string
 	if c.Entrypoint != nil {
+		entrypoint := []string{}
 		if ep := *c.Entrypoint; len(ep) > 0 {
 			// Check if entrypoint specified is json
 			if err := json.Unmarshal([]byte(*c.Entrypoint), &entrypoint); err != nil {
@@ -377,17 +378,14 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 			}
 		}
 		s.Entrypoint = entrypoint
+		// Build the command
+		// If we have an entry point, it goes first
+		command = entrypoint
 	}
-	var command []string
 
 	// Include the command used to create the container.
 	s.ContainerCreateCommand = os.Args
 
-	// Build the command
-	// If we have an entry point, it goes first
-	if c.Entrypoint != nil {
-		command = entrypoint
-	}
 	if len(inputCommand) > 0 {
 		// User command overrides data CMD
 		command = append(command, inputCommand...)

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -81,7 +81,7 @@ func makeCreateConfig(ctx context.Context, containerConfig *config.Config, input
 		workDir = input.WorkingDir
 	}
 
-	if len(input.Entrypoint) == 0 {
+	if input.Entrypoint == nil {
 		entrypointSlice, err := newImage.Entrypoint(ctx)
 		if err != nil {
 			return createconfig.CreateConfig{}, err

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -87,7 +87,7 @@ func makeCommand(ctx context.Context, s *specgen.SpecGenerator, img *image.Image
 	finalCommand := []string{}
 
 	entrypoint := s.Entrypoint
-	if len(entrypoint) == 0 && img != nil {
+	if entrypoint == nil && img != nil {
 		newEntry, err := img.Entrypoint(ctx)
 		if err != nil {
 			return nil, err

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -101,6 +101,11 @@ ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.LineInOuputStartsWith("Linux")).To(BeTrue())
+
+		session = podmanTest.Podman([]string{"run", "--entrypoint", "", "foobar.com/entrypoint:latest", "uname"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOuputStartsWith("Linux")).To(BeTrue())
 	})
 
 	It("podman run user entrypoint with command overrides image entrypoint and image cmd", func() {


### PR DESCRIPTION
If a user specifies an entrypoint of "" then we should not use the images
entrypoint.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>