### PR TITLE
Fix "Error: unrecognized protocol \"TCP\" in port mapping"

### DIFF
--- a/pkg/specgen/generate/ports.go
+++ b/pkg/specgen/generate/ports.go
@@ -356,6 +356,7 @@ func checkProtocol(protocol string, allowSCTP bool) ([]string, error) {
 	splitProto := strings.Split(protocol, ",")
 	// Don't error on duplicates - just deduplicate
 	for _, p := range splitProto {
+		p = strings.ToLower(p)
 		switch p {
 		case protoTCP, "":
 			protocols[protoTCP] = struct{}{}

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -88,6 +88,20 @@ var _ = Describe("Podman run networking", func() {
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal(""))
 	})
 
+	It("podman run -p 8080:80/TCP", func() {
+		name := "testctr"
+		// "TCP" in upper characters
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "8080:80/TCP", "--name", name, ALPINE, "/bin/sh"})
+		session.WaitWithDefaultTimeout()
+		inspectOut := podmanTest.InspectContainer(name)
+		Expect(len(inspectOut)).To(Equal(1))
+		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
+		// "tcp" in lower characters
+		Expect(len(inspectOut[0].NetworkSettings.Ports["80/tcp"])).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("8080"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal(""))
+	})
+
 	It("podman run -p 80/udp", func() {
 		name := "testctr"
 		session := podmanTest.Podman([]string{"create", "-t", "-p", "80/udp", "--name", name, ALPINE, "/bin/sh"})


### PR DESCRIPTION
"TCP" in upper characters was not recognized as a valid protocol name.

Fix #6948
