### PR TITLE
add systemd to fedora image

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -392,7 +392,6 @@ install_test_configs() {
     # as the default).  This config prevents allocation of network address space used
     # by default in google cloud.  https://cloud.google.com/vpc/docs/vpc#ip-ranges
     install -v -D -m 644 $SCRIPT_BASE/99-do-not-use-google-subnets.conflist /etc/cni/net.d/
-    install -v -D -m 644 ./test/policy.json /etc/containers/
     install -v -D -m 644 ./test/registries.conf /etc/containers/
 }
 

--- a/test/e2e/config_amd64.go
+++ b/test/e2e/config_amd64.go
@@ -5,9 +5,11 @@ var (
 	STORAGE_OPTIONS          = "--storage-driver vfs"
 	ROOTLESS_STORAGE_FS      = "vfs"
 	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"
-	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, registry, infra, labels, healthcheck}
+	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, registry, infra, labels, healthcheck, ubi_init, ubi_minimal}
 	nginx                    = "quay.io/libpod/alpine_nginx:latest"
 	BB_GLIBC                 = "docker.io/library/busybox:glibc"
 	registry                 = "docker.io/library/registry:2.6"
 	labels                   = "quay.io/libpod/alpine_labels:latest"
+	ubi_minimal              = "registry.access.redhat.com/ubi8-minimal"
+	ubi_init                 = "registry.access.redhat.com/ubi8-init"
 )

--- a/test/e2e/system_df_test.go
+++ b/test/e2e/system_df_test.go
@@ -56,7 +56,7 @@ var _ = Describe("podman system df", func() {
 		images := strings.Fields(session.OutputToStringArray()[1])
 		containers := strings.Fields(session.OutputToStringArray()[2])
 		volumes := strings.Fields(session.OutputToStringArray()[3])
-		Expect(images[1]).To(Equal("9"))
+		Expect(images[1]).To(Equal("11"))
 		Expect(containers[1]).To(Equal("2"))
 		Expect(volumes[2]).To(Equal("1"))
 	})

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -81,13 +81,8 @@ WantedBy=multi-user.target
 	})
 
 	It("podman run container with systemd PID1", func() {
-		systemdImage := "fedora"
-		pull := podmanTest.Podman([]string{"pull", systemdImage})
-		pull.WaitWithDefaultTimeout()
-		Expect(pull.ExitCode()).To(Equal(0))
-
 		ctrName := "testSystemd"
-		run := podmanTest.Podman([]string{"run", "--name", ctrName, "-t", "-i", "-d", systemdImage, "/usr/sbin/init"})
+		run := podmanTest.Podman([]string{"run", "--name", ctrName, "-t", "-i", "-d", ubi_init, "/sbin/init"})
 		run.WaitWithDefaultTimeout()
 		Expect(run.ExitCode()).To(Equal(0))
 		ctrID := run.OutputToString()


### PR DESCRIPTION
fedora removed the systemd package from its standard container image causing our systemd pid1 test to fail.

thanks to dwalsh for fix!

Signed-off-by: Brent Baude <bbaude@redhat.com>