### PR TITLE
logformatter: update MAGIC BLOB string

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,7 +71,7 @@ env:
     # Service-account client_email - needed to build images
     SERVICE_ACCOUNT: ENCRYPTED[702a8e07e27a6faf7988fcddcc068c2ef2bb182a5aa671f5ccb7fbbfb891c823aa4a7856fb17240766845dbd68bd3f90]
     # Service account username part of client_email - for ssh'ing into VMs
-    GCE_SSH_USERNAME: ENCRYPTED[d579f2d3000bb678c9af37c3615e92bcf3726e9afc47748c129cef23ee799faaafd4baba64048329205d162069d90060]
+    GCE_SSH_USERNAME: 'cirrus-ci'
 
 # Default VM to use unless set or modified by task
 gce_instance:

--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -418,10 +418,27 @@ END_HTML
         }
     }
 
-    # FIXME: if Cirrus magic envariables are available, write a link to results
+    # If Cirrus magic envariables are available, write a link to results.
+    # FIXME: it'd be so nice to make this a clickable live link.
+    #
+    # STATIC_MAGIC_BLOB is the name of a google-storage bucket. It is
+    # unlikely to change often, but if it does you will suddenly start
+    # seeing errors when trying to view formatted logs:
+    #
+    #    AccessDeniedAccess denied.Anonymous caller does not have storage.objects.get access to the Google Cloud Storage object.
+    #
+    # This happened in July 2020 when github.com/containers/libpod was
+    # renamed to podman. If something like that ever happens again, you
+    # will need to get the new magic blob value from:
+    #
+    #   https://console.cloud.google.com/storage/browser?project=libpod-218412
+    #
+    # You will also probably need to set the bucket Public by clicking on
+    # the bucket name, then the Permissions tab. This is safe, since this
+    # project is fully open-source.
     if ($have_formatted_log && $ENV{CIRRUS_TASK_ID}) {
         my $URL_BASE          = "https://storage.googleapis.com";
-        my $STATIC_MAGIC_BLOB = "cirrus-ci-5385732420009984-fcae48";
+        my $STATIC_MAGIC_BLOB = "cirrus-ci-6707778565701632-fcae48";
         my $ARTIFACT_NAME     = "html";
 
         my $URL = "${URL_BASE}/${STATIC_MAGIC_BLOB}/artifacts/$ENV{CIRRUS_REPO_FULL_NAME}/$ENV{CIRRUS_TASK_ID}/${ARTIFACT_NAME}/${outfile}";


### PR DESCRIPTION
Fallout from libpod->podman repo name move: the HTML logs
created by logformatter are no longer accessible. They
render as:

    https://storage.googleapis.com/SECRET-5385732420009984-fcae48/artifacts/containers/podman/6313596734930944/html/integration_test.log.html

(yes, "SECRET" instead of "cirrus-ci". I have no idea what
that's about, but that's not the focus of this PR, and I'm
going to ignore it for the time being and hope it goes away).

The focus of this PR is to change "podman" in the URL above
back to "libpod", because that's what the Google storage
bucket is called. This is unfortunate hardcoding, because
the way the code was written it used $CIRRUS_REPO_FULL_NAME
as defined by Cirrus.

I have no idea if this will work. It's possible that instead
of this, the proper change is to update the magic blob string.
Chris is OOTO this week, so I'll just try random fixes in
hopes of getting something to work.

Signed-off-by: Ed Santiago <santiago@redhat.com>