### PR TITLE
Mask out /sys/dev to prevent information leak from the host

### DIFF
--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -150,6 +150,7 @@ func BlockAccessToKernelFilesystems(privileged, pidModeIsHost bool, g *generate.
 			"/proc/scsi",
 			"/sys/firmware",
 			"/sys/fs/selinux",
+			"/sys/dev",
 		} {
 			g.AddLinuxMaskedPaths(mp)
 		}


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>