### PR TITLE
system tests: new tests for run, exec

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -242,4 +242,46 @@ echo $rand        |   0 | $rand
     run_podman rmi myi
 }
 
+# #6735 : complex interactions with multiple user namespaces
+# The initial report has to do with bind mounts, but that particular
+# symptom only manifests on a fedora container image -- we have no
+# reproducer on alpine. Checking directory ownership is good enough.
+@test "podman run : user namespace preserved root ownership" {
+    for priv in "" "--privileged"; do
+        for user in "--user=0" "--user=100"; do
+            for keepid in "" "--userns=keep-id"; do
+                opts="$priv $user $keepid"
+
+                for dir in /etc /usr;do
+                    run_podman run --rm $opts $IMAGE stat -c '%u:%g:%n' $dir
+                    remove_same_dev_warning      # grumble
+                    is "$output" "0:0:$dir" "run $opts ($dir)"
+                done
+            done
+        done
+    done
+}
+
+# #6829 : add username to /etc/passwd inside container if --userns=keep-id
+@test "podman run : add username to /etc/passwd if --userns=keep-id" {
+    # Default: always run as root
+    run_podman run --rm $IMAGE id -un
+    is "$output" "root" "id -un on regular container"
+
+    # This would always work on root, but is new behavior on rootless: #6829
+    # adds a user entry to /etc/passwd
+    run_podman run --rm --userns=keep-id $IMAGE id -un
+    is "$output" "$(id -un)" "username on container with keep-id"
+
+    # --privileged should make no difference
+    run_podman run --rm --privileged --userns=keep-id $IMAGE id -un
+    remove_same_dev_warning      # grumble
+    is "$output" "$(id -un)" "username on container with keep-id"
+
+    # ...but explicitly setting --user should override keep-id
+    run_podman run --rm --privileged --userns=keep-id --user=0 $IMAGE id -un
+    remove_same_dev_warning      # grumble
+    is "$output" "root" "--user=0 overrides keep-id"
+}
+
 # vim: filetype=sh

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -6,8 +6,6 @@
 load helpers
 
 @test "podman exec - basic test" {
-    skip_if_remote
-
     rand_filename=$(random_string 20)
     rand_content=$(random_string 50)
 
@@ -76,6 +74,26 @@ load helpers
 
     # Clean up
     run_podman exec $cid touch /stop
+    run_podman wait $cid
+    run_podman rm $cid
+}
+
+# #6829 : add username to /etc/passwd inside container if --userns=keep-id
+# #6593 : doesn't actually work with podman exec
+@test "podman exec - with keep-id" {
+    skip "Please enable once #6593 is fixed"
+
+    run_podman run -d --userns=keep-id $IMAGE sh -c \
+               "echo READY;while [ ! -f /stop ]; do sleep 1; done"
+    cid="$output"
+    wait_for_ready $cid
+
+    run_podman exec $cid id -un
+    is "$output" "$(id -un)" "container is running as current user"
+
+    # Until #6593 gets fixed, this just hangs. The server process barfs with:
+    #   unable to find user <username>: no matching entries in passwd file
+    run_podman exec --user=$(id -un) $cid touch /stop
     run_podman wait $cid
     run_podman rm $cid
 }

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -19,15 +19,8 @@ function check_label() {
 
     # FIXME: on some CI systems, 'run --privileged' emits a spurious
     # warning line about dup devices. Ignore it.
+    remove_same_dev_warning
     local context="$output"
-    if [ ${#lines[@]} -gt 1 ]; then
-        if expr "${lines[0]}" : "WARNING: .* type, major" >/dev/null; then
-            echo "# ${lines[0]} [ignored]" >&3
-            context="${lines[1]}"
-        else
-            die "FAILED: too much output, expected one single line"
-        fi
-    fi
 
     is "$context" ".*_u:system_r:.*" "SELinux role should always be system_r"
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -392,5 +392,37 @@ function find_exec_pid_files() {
         find $storage_path -type f -iname 'exec_pid_*'
     fi
 }
+
+
+#############################
+#  remove_same_dev_warning  #  Filter out useless warning from output
+#############################
+#
+# On some CI systems, 'podman run --privileged' emits a useless warning:
+#
+#    WARNING: The same type, major and minor should not be used for multiple devices.
+#
+# This obviously screws us up when we look at output results.
+#
+# This function removes the warning from $output and $lines
+#
+function remove_same_dev_warning() {
+    # No input arguments. We operate in-place on $output and $lines
+
+    local i=0
+    local -a new_lines=()
+    while [[ $i -lt ${#lines[@]} ]]; do
+        if expr "${lines[$i]}" : 'WARNING: .* same type, major.* multiple' >/dev/null; then
+            :
+        else
+            new_lines+=("${lines[$i]}")
+        fi
+        i=$(( i + 1 ))
+    done
+
+    lines=("${new_lines[@]}")
+    output=$(printf '%s\n' "${lines[@]}")
+}
+
 # END   miscellaneous tools
 ###############################################################################

--- a/test/system/helpers.t
+++ b/test/system/helpers.t
@@ -23,7 +23,8 @@ rc=0
 function check_result {
     testnum=$(expr $testnum + 1)
     if [ "$1" = "$2" ]; then
-        echo "ok $testnum $3 = $1"
+        # Multi-level echo flattens newlines, makes success messages readable
+        echo $(echo "ok $testnum $3 = $1")
     else
         echo "not ok $testnum $3"
         echo "#  expected: $2"
@@ -140,6 +141,73 @@ while read var expect name; do
 done < <(parse_table "$table")
 
 # END   dprint
+###############################################################################
+# BEGIN remove_same_dev_warning
+
+# Test-helper function: runs remove_same_dev_warning, compares resulting
+# value of $lines and $output to expected values given on command line
+function check_same_dev() {
+    local testname="$1"; shift
+    local -a expect_lines=("$@")
+    local nl="
+"
+
+    remove_same_dev_warning
+
+    # After processing, check the expected number of lines
+    check_result "${#lines[@]}" "${#@}" "$testname: expected # of lines"
+
+    # ...and each expected line
+    local expect_output=""
+    local i=0
+    while [ $i -lt ${#expect_lines[@]} ]; do
+        check_result "${lines[$i]}" "${expect_lines[$i]}" "$testname: line $i"
+        expect_output+="${expect_lines[$i]}$nl"
+        i=$(( i + 1 ))
+    done
+
+    # ...and the possibly-multi-line $output
+    check_result "$output" "${expect_output%%$nl}"  "$testname: output"
+}
+
+# Simplest case: nothing removed.
+declare -a lines=("a b c" "d" "e f")
+check_same_dev "abc" "a b c" "d" "e f"
+
+# Confirm that the warning message is removed from the beginning
+declare -a lines=(
+    "WARNING: The same type, major and minor should not be used for multiple devices."
+    "a"
+    "b"
+    "c"
+)
+check_same_dev "warning is removed" a b c
+
+# ...and from the middle (we do not expect to see this)
+declare -a lines=(
+    "WARNING: The same type, major and minor should not be used for multiple devices."
+    "a"
+    "b"
+    "WARNING: The same type, major and minor should not be used for multiple devices."
+    "c"
+)
+check_same_dev "multiple warnings removed" a b c
+
+# Corner case: two lines of output, only one of which we care about
+declare -a lines=(
+    "WARNING: The same type, major and minor should not be used for multiple devices."
+    "this is the only line we care about"
+)
+check_same_dev "one-line output" "this is the only line we care about"
+
+# Corner case: one line of output, but we expect zero.
+declare -a lines=(
+    "WARNING: The same type, major and minor should not be used for multiple devices."
+)
+check_same_dev "zero-line output"
+
+
+# END   remove_same_dev_warning
 ###############################################################################
 
 exit $rc


### PR DESCRIPTION
 - Issue #6735 : problem with multiple namespaces; confirms
   combinations of --userns=keep-id, --privileged, --user=XX

 - Issue #6829 : --userns=keep-id will add a /etc/passwd entry

 - Issue #6593 : podman exec, with --userns=keep-id, errors
   (test is currently skipped because issue remains live)

Signed-off-by: Ed Santiago <santiago@redhat.com>