### PR TITLE
play-kube: add suport for "IfNotPresent" pull type

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -555,7 +555,7 @@ func ValidatePullType(pullType string) (PullType, error) {
 	switch pullType {
 	case "always":
 		return PullImageAlways, nil
-	case "missing":
+	case "missing", "IfNotPresent":
 		return PullImageMissing, nil
 	case "never":
 		return PullImageNever, nil


### PR DESCRIPTION
This change prevents this exception when loading a pod spec
using the "IfNotPresent" pull policy:
  Error: invalid pull type "IfNotPresent"