### PR TITLE
[CI:DOCS]Do not copy policy.json into gating image

### DIFF
--- a/contrib/gate/Dockerfile
+++ b/contrib/gate/Dockerfile
@@ -27,7 +27,6 @@ RUN set -x && \
 # Install cni config
 COPY cni/87-podman-bridge.conflist /etc/cni/net.d/87-podman-bridge.conflist
 # Make sure we have some policy for pulling images
-COPY test/policy.json /etc/containers/policy.json
 COPY test/redhat_sigstore.yaml /etc/containers/registries.d/registry.access.redhat.com.yaml
 
 WORKDIR "$GOSRC"


### PR DESCRIPTION
test/policy.json should not need to be copied into the gating image

Signed-off-by: Brent Baude <bbaude@redhat.com>