### PR TITLE
docs: user namespace can't be shared in pods

### DIFF
--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -108,7 +108,7 @@ If another pod with the same name already exists, replace and remove it.  The de
 
 **--share**=*namespace*
 
-A comma delimited list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared. The namespaces to choose from are ipc, net, pid, user, uts.
+A comma delimited list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared. The namespaces to choose from are ipc, net, pid, uts.
 
 The operator can identify a pod in three ways:
 UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”)


### PR DESCRIPTION
When running "podman pod create --share user" the errors appears:
Error: User sharing functionality not supported on pod level
Fix docs and remove 'user' from shareable parameters.