### PR TITLE
[DNM]Fixed the build_rpm.sh and spec file for CentOS-8.2

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -8,7 +8,7 @@ SHORT_COMMIT ?= $(shell git rev-parse --short=8 HEAD)
 srpm:
 	mkdir -p $(topdir)
 	sh $(current_dir)/prepare.sh
-	rpmbuild -bs -D "dist %{nil}" -D "_sourcedir build/" -D "_srcrpmdir $(outdir)" -D "_topdir $(topdir)" --nodeps contrib/spec/podman.spec
+	rpmbuild -bs -D "dist %{nil}" -D "_sourcedir build/" -D "_srcrpmdir $(outdir)" -D "_topdir $(topdir)" --nodeps ${extra_arg:-""} contrib/spec/podman.spec
 
 rpm:
 	mkdir -p $(topdir)
@@ -18,7 +18,7 @@ rpm:
 
 build_binary:
 	mkdir -p $(topdir)
-	rpmbuild --rebuild -D "_rpmdir $(outdir)" -D "_topdir $(topdir)" $(outdir)/podman-*.git$(SHORT_COMMIT).src.rpm
+	rpmbuild --rebuild -D "_rpmdir $(outdir)" -D "_topdir $(topdir)" ${extra_arg:-""} $(outdir)/podman-*.git$(SHORT_COMMIT).src.rpm
 
 clean:
 	rm -fr rpms

--- a/.copr/prepare.sh
+++ b/.copr/prepare.sh
@@ -6,7 +6,9 @@ if [ ! -e /usr/bin/git ]; then
     dnf -y install git-core
 fi
 
-git fetch --unshallow || :
+if [ -f $(git rev-parse --git-dir)/shallow ]; then
+    git fetch --unshallow
+fi
 
 COMMIT=$(git rev-parse HEAD)
 COMMIT_SHORT=$(git rev-parse --short=8 HEAD)
@@ -26,7 +28,12 @@ if [ ${OS_TEST} -eq 0 ]; then
     sed -i "s/${BR}/${NEWBR}/g" contrib/spec/podman.spec
 fi
 
-mkdir build/
+mkdir -p build/
 git archive --prefix "libpod-${COMMIT_SHORT}/" --format "tar.gz" HEAD -o "build/libpod-${COMMIT_SHORT}.tar.gz"
-git clone https://github.com/containers/conmon
-cd conmon && git checkout 6f3572558b97bc60dd8f8c7f0807748e6ce2c440 && git archive --prefix "conmon/" --format "tar.gz" HEAD -o "../build/conmon.tar.gz"
+if [ ! -d conmon ]; then
+    git clone -n --quiet https://github.com/containers/conmon
+fi
+pushd conmon
+git checkout 6f3572558b97bc60dd8f8c7f0807748e6ce2c440
+git archive --prefix "conmon/" --format "tar.gz" HEAD -o "../build/conmon.tar.gz"
+popd

--- a/Makefile
+++ b/Makefile
@@ -541,3 +541,17 @@ vendor:
 	validate \
 	install.libseccomp.sudo \
 	vendor
+
+package:  ## Build rpm packages
+	## TODO(ssbarnea): make version number predictable, it should not change
+	## on each execution, producing duplicates.
+	rm -rf build/* *.src.rpm ~/rpmbuild/RPMS/*
+	./contrib/build_rpm.sh
+
+# Remember that rpms install exec to /usr/bin/podman while a `make install`
+# installs them to /usr/local/bin/podman which is likely before. Always use
+# a full path to test installed podman or you risk to call another executable.
+package-install: package  ## Install rpm packages
+	sudo ${PKG_MANAGER} -y install ${HOME}/rpmbuild/RPMS/*/*.rpm
+	/usr/bin/podman version
+	/usr/bin/podman info  # will catch a broken conmon

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -1,8 +1,9 @@
 %global with_devel 0
 %global with_bundled 1
-%global with_debug 1
 %global with_check 0
 %global with_unit_test 0
+%bcond_without doc
+%bcond_without debug
 
 %if 0%{?fedora} >= 28
 %bcond_without varlink
@@ -10,7 +11,7 @@
 %bcond_with varlink
 %endif
 
-%if 0%{?with_debug}
+%if %{with debug}
 %global _find_debuginfo_dwz_opts %{nil}
 %global _dwz_low_mem_die_limit 0
 %else
@@ -52,12 +53,13 @@ ExclusiveArch: aarch64 %{arm} ppc64le s390x x86_64
 # The COPR process will uncomment this
 #BuildRequires: golang-bin
 #
-BuildRequires: btrfs-progs-devel
 BuildRequires: glib2-devel
 BuildRequires: glibc-devel
 BuildRequires: glibc-static
 BuildRequires: git
+%if %{with doc}
 BuildRequires: go-md2man
+%endif
 BuildRequires: gpgme-devel
 BuildRequires: libassuan-devel
 BuildRequires: libgpg-error-devel
@@ -349,6 +351,15 @@ This package contains unit tests for project
 providing packages with %{import_path} prefix.
 %endif
 
+%if %{with doc}
+%package manpages
+Summary: Man pages for the %{name} commands
+BuildArch: noarch
+
+%description manpages
+Man pages for the %{name} commands
+%endif
+
 %prep
 %autosetup -Sgit -n %{repo}-%{shortcommit0}
 
@@ -373,7 +384,12 @@ export GOPATH=$(pwd)/_build:$(pwd):%{gopath}
 export BUILDTAGS="varlink selinux seccomp $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh) $(hack/libdm_tag.sh) exclude_graphdriver_devicemapper"
 
 GOPATH=$GOPATH go generate ./cmd/podman/varlink/...
-BUILDTAGS=$BUILDTAGS GOMD2MAN=go-md2man make binaries docs
+
+%if %{with doc}
+BUILDTAGS=$BUILDTAGS make binaries docs
+%else
+BUILDTAGS=$BUILDTAGS make binaries
+%endif
 
 # build conmon
 pushd conmon
@@ -394,7 +410,9 @@ install -dp %{buildroot}%{_usr}/lib/systemd/user
 PODMAN_VERSION=%{version} %{__make} PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir} \
         install.bin \
         install.remote \
+%if %{with doc}
         install.man \
+%endif
         install.cni \
         install.systemd \
         install.completions
@@ -480,8 +498,6 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/vendor:%{gopath}
 %license LICENSE
 %doc README.md CONTRIBUTING.md pkg/hooks/README-hooks.md install.md code-of-conduct.md transfer.md
 %{_bindir}/%{name}
-%{_mandir}/man1/*.1*
-%{_mandir}/man5/*.5*
 %{_datadir}/bash-completion/completions/*
 %{_datadir}/zsh/site-functions/*
 %{_libexecdir}/%{name}/conmon
@@ -510,6 +526,12 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/vendor:%{gopath}
 %license LICENSE
 %doc README.md CONTRIBUTING.md pkg/hooks/README-hooks.md install.md code-of-conduct.md transfer.md
 %{_bindir}/%{name}-remote
+
+%if %{with doc}
+%files manpages
+%{_mandir}/man1/*.1*
+%{_mandir}/man5/*.5*
+%endif
 
 %changelog
 * Sat Aug 4 2018 Dan Walsh <dwalsh@redhat.com> - 0.8.1-1.git6b4ab2a

--- a/hack/get_release_info.sh
+++ b/hack/get_release_info.sh
@@ -4,9 +4,10 @@
 # a script allows uniform behavior across multiple environments and
 # distributions.  The script expects a single argument, as reflected below.
 
-set -e
+set -euo pipefail
 
-cd "${GOSRC:-$(dirname $0)/../}"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${GOSRC:-${DIR}/../}"
 
 valid_args() {
     REGEX='^\s+[[:upper:]]+\*[)]'


### PR DESCRIPTION
In RDO side, in order to test, podman-1.6.x version on
rdo/tripleo side, We are pulling most of the chanages
from master in order to build the rpm and consume it.

It is not a complete cherry-pick as we included multiple
changes to it.

The changes contains:
* https://github.com/containers/podman/commit/1414a063f5f198dd165fcfabc1afd4cb008ba402
* https://github.com/containers/podman/commit/eb3cbdd62865ffe8b3566e0f932404b8e56f6227
* https://github.com/containers/podman/commit/9f6fc7011025986c893b633ef09e146105ffecc1

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>