### PR TITLE
The compat create endpoint should 404 on no such image

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/libpod/v2/libpod"
+	"github.com/containers/libpod/v2/libpod/define"
 	image2 "github.com/containers/libpod/v2/libpod/image"
 	"github.com/containers/libpod/v2/pkg/api/handlers"
 	"github.com/containers/libpod/v2/pkg/api/handlers/utils"
@@ -45,6 +46,11 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	newImage, err := runtime.ImageRuntime().NewFromLocal(input.Image)
 	if err != nil {
+		if errors.Cause(err) == define.ErrNoSuchImage {
+			utils.Error(w, "No such image", http.StatusNotFound, err)
+			return
+		}
+
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "NewFromLocal()"))
 		return
 	}


### PR DESCRIPTION
This matches Docker behavior, and will make the Docker frontend work with `podman system service` (Docker tries to create, then if that fails with 404 sends a request to pull the image).

Fixes #6960
