### PR TITLE
abi: set default umask and rlimits

### DIFF
--- a/cmd/podman/early_init_linux.go
+++ b/cmd/podman/early_init_linux.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/containers/libpod/v2/libpod/define"
+	"github.com/pkg/errors"
+)
+
+func setRLimits() error {
+	rlimits := new(syscall.Rlimit)
+	rlimits.Cur = define.RLimitDefaultValue
+	rlimits.Max = define.RLimitDefaultValue
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
+		if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
+			return errors.Wrapf(err, "error getting rlimits")
+		}
+		rlimits.Cur = rlimits.Max
+		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
+			return errors.Wrapf(err, "error setting new rlimits")
+		}
+	}
+	return nil
+}
+
+func setUMask() {
+	// Be sure we can create directories with 0755 mode.
+	syscall.Umask(0022)
+}
+
+func earlyInitHook() {
+	if err := setRLimits(); err != nil {
+		fmt.Fprint(os.Stderr, "Failed to set rlimits: "+err.Error())
+	}
+
+	setUMask()
+}

--- a/cmd/podman/early_init_unsupported.go
+++ b/cmd/podman/early_init_unsupported.go
@@ -1,0 +1,6 @@
+// +build !linux
+
+package main
+
+func earlyInitHook() {
+}

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -77,6 +77,7 @@ func init() {
 	cobra.OnInitialize(
 		loggingHook,
 		syslogHook,
+		earlyInitHook,
 	)
 
 	rootFlags(rootCmd, registry.PodmanConfig())

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -82,3 +82,6 @@ const (
 	SdNotifyModeConmon    = "conmon"
 	SdNotifyModeIgnore    = "ignore"
 )
+
+// DefaultRlimitValue is the value set by default for nofile and nproc
+const RLimitDefaultValue = uint64(1048576)

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
-	"syscall"
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/libpod/v2/libpod/define"
@@ -144,27 +143,6 @@ func movePauseProcessToScope() error {
 	}
 
 	return utils.RunUnderSystemdScope(int(pid), "user.slice", "podman-pause.scope")
-}
-
-func setRLimits() error { // nolint:deadcode,unused
-	rlimits := new(syscall.Rlimit)
-	rlimits.Cur = 1048576
-	rlimits.Max = 1048576
-	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
-		if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
-			return errors.Wrapf(err, "error getting rlimits")
-		}
-		rlimits.Cur = rlimits.Max
-		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
-			return errors.Wrapf(err, "error setting new rlimits")
-		}
-	}
-	return nil
-}
-
-func setUMask() { // nolint:deadcode,unused
-	// Be sure we can create directories with 0755 mode.
-	syscall.Umask(0022)
 }
 
 // checkInput can be used to verify any of the globalopt values

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -505,10 +505,9 @@ func BlockAccessToKernelFilesystems(privileged, pidModeIsHost bool, g *generate.
 
 func addRlimits(config *CreateConfig, g *generate.Generator) error {
 	var (
-		kernelMax  uint64 = 1048576
-		isRootless        = rootless.IsRootless()
-		nofileSet         = false
-		nprocSet          = false
+		isRootless = rootless.IsRootless()
+		nofileSet  = false
+		nprocSet   = false
 	)
 
 	for _, u := range config.Resources.Ulimit {
@@ -538,8 +537,8 @@ func addRlimits(config *CreateConfig, g *generate.Generator) error {
 	// files and number of processes to the maximum they can be set to
 	// (without overriding a sysctl)
 	if !nofileSet {
-		max := kernelMax
-		current := kernelMax
+		max := define.RLimitDefaultValue
+		current := define.RLimitDefaultValue
 		if isRootless {
 			var rlimit unix.Rlimit
 			if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit); err != nil {
@@ -555,8 +554,8 @@ func addRlimits(config *CreateConfig, g *generate.Generator) error {
 		g.AddProcessRlimits("RLIMIT_NOFILE", max, current)
 	}
 	if !nprocSet {
-		max := kernelMax
-		current := kernelMax
+		max := define.RLimitDefaultValue
+		current := define.RLimitDefaultValue
 		if isRootless {
 			var rlimit unix.Rlimit
 			if err := unix.Getrlimit(unix.RLIMIT_NPROC, &rlimit); err != nil {

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -20,10 +20,9 @@ import (
 
 func addRlimits(s *specgen.SpecGenerator, g *generate.Generator) error {
 	var (
-		kernelMax  uint64 = 1048576
-		isRootless        = rootless.IsRootless()
-		nofileSet         = false
-		nprocSet          = false
+		isRootless = rootless.IsRootless()
+		nofileSet  = false
+		nprocSet   = false
 	)
 
 	if s.Rlimits == nil {
@@ -45,8 +44,8 @@ func addRlimits(s *specgen.SpecGenerator, g *generate.Generator) error {
 	// files and number of processes to the maximum they can be set to
 	// (without overriding a sysctl)
 	if !nofileSet {
-		max := kernelMax
-		current := kernelMax
+		max := define.RLimitDefaultValue
+		current := define.RLimitDefaultValue
 		if isRootless {
 			var rlimit unix.Rlimit
 			if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit); err != nil {
@@ -62,8 +61,8 @@ func addRlimits(s *specgen.SpecGenerator, g *generate.Generator) error {
 		g.AddProcessRlimits("RLIMIT_NOFILE", max, current)
 	}
 	if !nprocSet {
-		max := kernelMax
-		current := kernelMax
+		max := define.RLimitDefaultValue
+		current := define.RLimitDefaultValue
 		if isRootless {
 			var rlimit unix.Rlimit
 			if err := unix.Getrlimit(unix.RLIMIT_NPROC, &rlimit); err != nil {


### PR DESCRIPTION
the code got lost in the migration to podman 2.0, reintroduce it.

Closes: https://github.com/containers/podman/issues/6989

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>