### PR TITLE
fix: system df error when an image has no name

### DIFF
--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -230,13 +230,18 @@ func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.System
 			}
 		}
 
-		named, err := reference.ParseNormalizedNamed(name)
-		if err != nil {
-			return nil, err
-		}
-		repository = named.Name()
-		if tagged, isTagged := named.(reference.NamedTagged); isTagged {
-			tag = tagged.Tag()
+		if len(name) > 0 {
+			named, err := reference.ParseNormalizedNamed(name)
+			if err != nil {
+				return nil, err
+			}
+			repository = named.Name()
+			if tagged, isTagged := named.(reference.NamedTagged); isTagged {
+				tag = tagged.Tag()
+			}
+		} else {
+			repository = "<none>"
+			tag = "<none>"
 		}
 
 		report := entities.SystemDfImageReport{

--- a/test/e2e/system_df_test.go
+++ b/test/e2e/system_df_test.go
@@ -60,4 +60,18 @@ var _ = Describe("podman system df", func() {
 		Expect(containers[1]).To(Equal("2"))
 		Expect(volumes[2]).To(Equal("1"))
 	})
+
+	It("podman system df image with no tag", func() {
+		session := podmanTest.PodmanNoCache([]string{"create", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.PodmanNoCache([]string{"image", "untag", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.PodmanNoCache([]string{"system", "df"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
When an image has no name/tag system df will
error because it tries to parse an empty name.

This commit makes sure we only parse non
empty names and set the repository and tag
to "\<none>\" otherwise.

Closes #7015

Signed-off-by: Paul Holzinger <paul.holzinger@web.de>