### PR TITLE
Re-enable a generate kube test that failed on Ubuntu

### DIFF
--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -254,8 +254,6 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman generate with user and reimport kube on pod", func() {
-		// This test fails on ubuntu due to https://github.com/seccomp/containers-golang/pull/27
-		SkipIfNotFedora()
 		podName := "toppod"
 		_, rc, _ := podmanTest.CreatePod(podName)
 		Expect(rc).To(Equal(0))


### PR DESCRIPTION
The fix was a new runc version, which we may have sucked in.

Fixes #6506
