### PR TITLE
BATS tests: more resilient remove_same_dev_warning

### DIFF
--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -75,11 +75,17 @@ var _ = Describe("Podman run device", func() {
 
 	It("podman run device host device and container device parameter are directories", func() {
 		SkipIfRootless()
-		SystemExec("mkdir", []string{"/dev/foodevdir"})
-		SystemExec("mknod", []string{"/dev/foodevdir/null", "c", "1", "3"})
-		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/foodevdir:/dev/bar", ALPINE, "ls", "/dev/bar/null"})
+		Expect(os.MkdirAll("/dev/foodevdir", os.ModePerm)).To(BeNil())
+		defer os.RemoveAll("/dev/foodevdir")
+
+		mknod := SystemExec("mknod", []string{"/dev/foodevdir/null", "c", "1", "3"})
+		mknod.WaitWithDefaultTimeout()
+		Expect(mknod.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/foodevdir:/dev/bar", ALPINE, "stat", "-c%t:%T", "/dev/bar/null"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("1:3"))
 	})
 
 	It("podman run device host device with --privileged", func() {

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -404,7 +404,13 @@ function find_exec_pid_files() {
 #
 # This obviously screws us up when we look at output results.
 #
-# This function removes the warning from $output and $lines
+# This function removes the warning from $output and $lines. We don't
+# do a full string match because there's another variant of that message:
+#
+#    WARNING: Creating device "/dev/null" with same type, major and minor as existing "/dev/foodevdir/null".
+#
+# (We should never again see that precise error ever again, but we could
+# see variants of it).
 #
 function remove_same_dev_warning() {
     # No input arguments. We operate in-place on $output and $lines
@@ -412,7 +418,7 @@ function remove_same_dev_warning() {
     local i=0
     local -a new_lines=()
     while [[ $i -lt ${#lines[@]} ]]; do
-        if expr "${lines[$i]}" : 'WARNING: .* same type, major.* multiple' >/dev/null; then
+        if expr "${lines[$i]}" : 'WARNING: .* same type, major' >/dev/null; then
             :
         else
             new_lines+=("${lines[$i]}")


### PR DESCRIPTION
Some CI tests are flaking in the SELinux test, possibly because
there's a new variation of the "multiple devices" warning I hadn't
seen before:

   WARNING: Creating device "/dev/null" with same type, major and minor as existing "/dev/foodevdir/null".

Solution: in remove_same_dev_warning(), remove "multiple" from
the match string.

Also: fix a Go test that wasn't cleaning up after itself. And
add an actual test to it, not just check-exit-status.

Signed-off-by: Ed Santiago <santiago@redhat.com>