### PR TITLE
docs: Fix formatting mistake

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1120,7 +1120,7 @@ required for VPN, without it containers need to be run with the --network=host f
 
 Environment variables within containers can be set using multiple different options:  This section describes the precedence.
 
-Precedence Order:
+Precedence order (later entries override earlier entries):
 
 - **--env-host** : Host environment of the process executing Podman is added.
 - Container image : Any environment variables specified in the container image.

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1121,13 +1121,11 @@ required for VPN, without it containers need to be run with the --network=host f
 Environment variables within containers can be set using multiple different options:  This section describes the precedence.
 
 Precedence Order:
-	   **--env-host** : Host environment of the process executing Podman is added.
 
-	   Container image : Any environment variables specified in the container image.
-
-	   **--env-file** : Any environment variables specified via env-files.  If multiple files specified, then they override each other in order of entry.
-
-	   **--env** : Any environment variables specified will override previous settings.
+- **--env-host** : Host environment of the process executing Podman is added.
+- Container image : Any environment variables specified in the container image.
+- **--env-file** : Any environment variables specified via env-files.  If multiple files specified, then they override each other in order of entry.
+- **--env** : Any environment variables specified will override previous settings.
 
 Create containers and set the environment ending with a __*__ and a *****
 

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1123,6 +1123,7 @@ Environment variables within containers can be set using multiple different opti
 Precedence order (later entries override earlier entries):
 
 - **--env-host** : Host environment of the process executing Podman is added.
+- **--http-proxy**: By default, several environment variables will be passed in from the host, such as **http_proxy** and **no_proxy**. See **--http-proxy** for details.
 - Container image : Any environment variables specified in the container image.
 - **--env-file** : Any environment variables specified via env-files.  If multiple files specified, then they override each other in order of entry.
 - **--env** : Any environment variables specified will override previous settings.

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1399,7 +1399,7 @@ required for VPN, without it containers need to be run with the **--network=host
 ## ENVIRONMENT
 
 Environment variables within containers can be set using multiple different options,
-in the following order of precedence:
+in the following order of precedence (later entries override earlier entries):
 
 - **--env-host**: Host environment of the process executing Podman is added.
 - Container image: Any environment variables specified in the container image.

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1402,6 +1402,7 @@ Environment variables within containers can be set using multiple different opti
 in the following order of precedence (later entries override earlier entries):
 
 - **--env-host**: Host environment of the process executing Podman is added.
+- **--http-proxy**: By default, several environment variables will be passed in from the host, such as **http_proxy** and **no_proxy**. See **--http-proxy** for details.
 - Container image: Any environment variables specified in the container image.
 - **--env-file**: Any environment variables specified via env-files.  If multiple files specified, then they override each other in order of entry.
 - **--env**: Any environment variables specified will override previous settings.


### PR DESCRIPTION
Part of this section was a code block, and part of it was absorbed into the preceding normal paragraph.

Before/after:

![image](https://user-images.githubusercontent.com/2390950/88001136-06392d80-cac5-11ea-99ab-4865ed529882.png)
