### PR TITLE
unit tests: root check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,7 @@ testunit: libpodimage ## Run unittest on the built image
 
 .PHONY: localunit
 localunit: test/goecho/goecho varlink_generate
+	hack/check_root.sh make localunit
 	ginkgo \
 		-r \
 		$(TESTFLAGS) \

--- a/hack/check_root.sh
+++ b/hack/check_root.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if ! [ $(id -u) = 0 ]; then
+   echo "Please run as root! '$@' requires root privileges."
+   exit 1
+fi


### PR DESCRIPTION
The unit tests currently require running as root.  This has caused some
confusion that justifies adding a root check to `make localunit` and
error out for non-root users instead of starting the tests deemed to
fail.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>