### PR TITLE
make localunit: record coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 /conmon/
 contrib/spec/podman.spec
 *.coverprofile
+coverprofile
+/.coverage
 /docs/*.[158]
 /docs/*.[158].gz
 /docs/build/


### PR DESCRIPTION
Inspirsed by CRI-O's coverage logic.  Initial coverage is at 15.7
percent.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>