### PR TITLE
Do not print an error message on non-0 exec exit code

### DIFF
--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -729,10 +729,6 @@ func (c *Container) Exec(config *ExecConfig, streams *define.AttachStreams, resi
 		return -1, err
 	}
 
-	if exitCode != 0 {
-		return exitCode, errors.Wrapf(define.ErrOCIRuntime, "exec session exited with non-zero exit code %d", exitCode)
-	}
-
 	return exitCode, nil
 }
 

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -92,7 +92,7 @@ func (c *Container) runHealthCheck() (define.HealthCheckStatus, error) {
 	hcResult := define.HealthCheckSuccess
 	config := new(ExecConfig)
 	config.Command = newCommand
-	_, hcErr := c.Exec(config, streams, nil)
+	exitCode, hcErr := c.Exec(config, streams, nil)
 	if hcErr != nil {
 		errCause := errors.Cause(hcErr)
 		hcResult = define.HealthCheckFailure
@@ -104,6 +104,9 @@ func (c *Container) runHealthCheck() (define.HealthCheckStatus, error) {
 		} else {
 			returnCode = 125
 		}
+	} else if exitCode != 0 {
+		hcResult = define.HealthCheckFailure
+		returnCode = 1
 	}
 	timeEnd := time.Now()
 	if c.HealthCheckConfig().StartPeriod > 0 {


### PR DESCRIPTION
This was added with an earlier exec rework, and honestly is very confusing. Podman is printing an error message, but the error had nothing to do with Podman; it was the executable we ran inside the container that errored, and per `podman run` convention we should set the Podman exit code to the process's exit code and print no error.