### PR TITLE
Improve Docs for `podman system reset`

### DIFF
--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -7,7 +7,7 @@ podman\-system\-reset - Reset storage back to initial state
 **podman system reset** [*options*]
 
 ## DESCRIPTION
-**podman system reset** removes all pods, containers, images and volumes.
+**podman system reset** removes all pods, containers, images and volumes. Must be run after changing any of the following values in the `containers.conf` file: `static_dir`, `tmp_dir` or `volume_path`.
 
 ## OPTIONS
 **--force**, **-f**

--- a/docs/source/system.rst
+++ b/docs/source/system.rst
@@ -10,3 +10,5 @@ System
 :doc:`prune <markdown/podman-system-prune.1>` Remove unused data
 
 :doc:`renumber <markdown/podman-system-renumber.1>` Migrate lock numbers
+
+:doc:`reset <markdown/podman-system-reset.1>` Reset podman storage


### PR DESCRIPTION
When changing the `containers.conf` `volume_path` value, it was not documented that I needed to run `podman system reset` for this value to take effect. Also, `podman system reset` was not present in the index for `podman system`