### PR TITLE
CI: attempt to fix flake in login test

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -152,6 +152,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	return []byte(path)
 }, func(data []byte) {
+	cwd, _ := os.Getwd()
+	INTEGRATION_ROOT = filepath.Join(cwd, "../../")
 	LockTmpDir = string(data)
 })
 


### PR DESCRIPTION
Fixes: #5212

...or at least I hope it does. The symptom seems to be that
INTEGRATION_ROOT is not being defined in some code flows.
This PR blindly implements a suggestion from Miloslav,
setting INTEGRATION_ROOT in one more place.

We won't actually know for a long time if this works or
not, because the test failure is a flake.

Signed-off-by: Ed Santiago <santiago@redhat.com>