### PR TITLE
The `podman start --attach` command should not print ID

### DIFF
--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -99,7 +99,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, r := range responses {
-		if r.Err == nil {
+		if r.Err == nil && !startOptions.Attach {
 			fmt.Println(r.RawInput)
 		} else {
 			errs = append(errs, r.Err)


### PR DESCRIPTION
Somewhere in the Podman v2 rewrite, we allowed `podman start --attach` to print the container ID of the started container after exiting from the attach session (via detach key or the container exiting naturally). We should never print the ID when `--attach` is given, which makes the fix simple - make the print statement conditional on `--attach` not being present.

Wierdly, this only happened with `--interactive` was given to `podman start`. I don't know why that is, but this resolves the issue without having to dig any deeper, so I'm content.

Fixes #7055 