### PR TITLE
Speedup static build by utilizing CI cache on `/nix` folder

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -760,21 +760,33 @@ success_task:
 static_build_task:
     depends_on:
         - "gating"
+
     gce_instance:
         image_name: "${FEDORA_CACHE_IMAGE_NAME}"
         cpu: 8
         memory: 12
         disk: 200
-    script: |
+
+    init_script: |
         set -ex
         setenforce 0
         growpart /dev/sda 1 || true
         resize2fs /dev/sda1 || true
         yum -y install podman
+
+    nix_cache:
+      folder: '.cache'
+      fingerprint_script: |
+        echo "nix-v1-$(sha1sum nix/nixpkgs.json | head -c 40)"
+
+    build_script: |
+        set -ex
         mkdir -p /nix
-        podman run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix
+        mkdir -p .cache
+        mount --bind .cache /nix
+        if [[ -z $(ls -A /nix) ]]; then podman run --rm --privileged -ti -v /:/mnt nixos/nix cp -rfT /nix /mnt/nix; fi
         podman run --rm --privileged -ti -v /nix:/nix -v ${PWD}:${PWD} -w ${PWD} nixos/nix nix --print-build-logs --option cores 8 --option max-jobs 8 build --file nix/
+        chown -Rf $(whoami) .cache
+
     binaries_artifacts:
         path: "result/bin/podman"
-    on_failure:
-        failed_branch_script: '$CIRRUS_WORKING_DIR/$SCRIPT_BASE/notice_branch_failure.sh |& ${TIMESTAMP}'

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "02591d02a910b3b92092153c5f3419a8d696aa1d",
-  "date": "2020-07-09T03:52:28+02:00",
-  "sha256": "1pp9v4rqmgx1b298gxix8b79m8pvxy1rcf8l25rxxxxnkr5ls1ng",
+  "rev": "b49e7987632e4c7ab3a093fdfc433e1826c4b9d7",
+  "date": "2020-07-26T09:18:52+02:00",
+  "sha256": "1mj6fy0p24izmasl653s5z4f2ka9v3b6mys45kjrqmkv889yk2r6",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Also see:
- https://github.com/containers/crun/pull/428
- https://github.com/containers/conmon/pull/189
- https://github.com/containers/skopeo/pull/973
- https://github.com/containers/buildah/pull/2428
- https://github.com/containers/podman/pull/7076
- https://github.com/cri-o/cri-o/pull/4012

Signed-off-by: Wong Hoi Sing Edison <hswong3i@gmail.com>