### PR TITLE
Lower missing runtime from Errorf to Infof

### DIFF
--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -45,8 +45,8 @@ func getMissingRuntime(name string, r *Runtime) OCIRuntime {
 		return runtime
 	}
 
-	// Once for each missing runtime, we want to error.
-	logrus.Errorf("OCI Runtime %s is in use by a container, but is not available (not in configuration file or not installed)", name)
+	// Once for each missing runtime, we want to print info.
+	logrus.Infof("OCI Runtime %s is in use by a container, but is not available (not in configuration file or not installed)", name)
 
 	newRuntime := new(MissingRuntime)
 	newRuntime.name = name


### PR DESCRIPTION
Creating a container with --runtime=...  Can cause a situation where all of the tools that look at containers starts generating an ugly error message that
does not effect the running of the tool, but gives the users a bad experience.

Also users can not fix this situation easily without removing the container or
figuring out how to edit containers.conf.

From looking at the problem, it does not look like a real issue and should just be printed at the Info level.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>