### PR TITLE
replace the html/template package with text/template

### DIFF
--- a/cmd/podman/networks/inspect.go
+++ b/cmd/podman/networks/inspect.go
@@ -3,10 +3,10 @@ package network
 import (
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"io"
 	"os"
 	"strings"
+	"text/template"
 
 	"github.com/containers/libpod/v2/cmd/podman/registry"
 	"github.com/containers/libpod/v2/pkg/domain/entities"

--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -3,10 +3,10 @@ package network
 import (
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"os"
 	"strings"
 	"text/tabwriter"
+	"text/template"
 
 	"github.com/containers/libpod/v2/cmd/podman/registry"
 	"github.com/containers/libpod/v2/cmd/podman/validate"

--- a/cmd/podman/system/df.go
+++ b/cmd/podman/system/df.go
@@ -2,11 +2,11 @@ package system
 
 import (
 	"fmt"
-	"html/template"
 	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
+	"text/template"
 	"time"
 
 	"github.com/containers/libpod/v2/cmd/podman/registry"

--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -3,9 +3,9 @@ package system
 import (
 	"bufio"
 	"context"
-	"html/template"
 	"os"
 	"strings"
+	"text/template"
 
 	"github.com/containers/buildah/pkg/formats"
 	"github.com/containers/libpod/v2/cmd/podman/registry"

--- a/cmd/podman/volumes/inspect.go
+++ b/cmd/podman/volumes/inspect.go
@@ -2,9 +2,9 @@ package volumes
 
 import (
 	"fmt"
-	"html/template"
 	"os"
 	"strings"
+	"text/template"
 
 	"github.com/containers/buildah/pkg/formats"
 	"github.com/containers/libpod/v2/cmd/podman/registry"

--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -3,11 +3,11 @@ package volumes
 import (
 	"context"
 	"fmt"
-	"html/template"
 	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
+	"text/template"
 
 	"github.com/containers/libpod/v2/cmd/podman/registry"
 	"github.com/containers/libpod/v2/cmd/podman/validate"


### PR DESCRIPTION
Currently some commands use the html/template package.
This can lead to invalid output.
e.g. `system df --verbose` will print `&lt;none&gt;`
instead of `<none>` with an untaged image.