### PR TITLE
API events: fix parsing error

### DIFF
--- a/pkg/api/handlers/compat/events.go
+++ b/pkg/api/handlers/compat/events.go
@@ -29,8 +29,14 @@ func filtersFromRequest(r *http.Request) ([]string, error) {
 		compatFilters map[string]map[string]bool
 		filters       map[string][]string
 		libpodFilters []string
+		raw           []byte
 	)
-	raw := []byte(r.Form.Get("filters"))
+
+	if _, found := r.URL.Query()["filters"]; found {
+		raw = []byte(r.Form.Get("filters"))
+	} else {
+		return []string{}, nil
+	}
 
 	// Backwards compat with older versions of Docker.
 	if err := json.Unmarshal(raw, &compatFilters); err == nil {

--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -68,4 +68,8 @@ else
     _show_ok 0 "Time for ten /info requests" "<= 5 seconds" "$delta_t seconds"
 fi
 
+# Simple events test (see #7078)
+t GET "events?stream=false"  200
+t GET "libpod/events?stream=false"  200
+
 # vim: filetype=sh


### PR DESCRIPTION
Fix an error where an absent "filters" parameter led to JSON parsing
errors.

Fixes: #7078
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>