### PR TITLE
[CI:DOCS] apiv2 fix volumes not included field

### DIFF
--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -128,7 +128,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//        The boolean `dangling` filter is not yet implemented for this endpoint.
 	// responses:
 	//   '200':
-	//     "$ref": "#/responses/DockerVolumeList"
+	//     "$ref": "#/responses/VolumeListResponse"
 	//   '500':
 	//     "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/volumes"), s.APIHandler(compat.ListVolumes)).Methods(http.MethodGet)

--- a/pkg/domain/entities/volumes.go
+++ b/pkg/domain/entities/volumes.go
@@ -59,6 +59,42 @@ type VolumeConfigResponse struct {
 	Anonymous bool `json:"Anonymous"`
 }
 
+// VolumeInfo Volume list response
+// swagger:model VolumeInfo
+type VolumeInfo struct {
+
+	// Date/Time the volume was created.
+	CreatedAt string `json:"CreatedAt,omitempty"`
+
+	// Name of the volume driver used by the volume. Only supports local driver
+	// Required: true
+	Driver string `json:"Driver"`
+
+	// User-defined key/value metadata.
+	// Always included
+	Labels map[string]string `json:"Labels"`
+
+	// Mount path of the volume on the host.
+	// Required: true
+	Mountpoint string `json:"Mountpoint"`
+
+	// Name of the volume.
+	// Required: true
+	Name string `json:"Name"`
+
+	// The driver specific options used when creating the volume.
+	// Required: true
+	Options map[string]string `json:"Options"`
+
+	// The level at which the volume exists.
+	// Libpod does not implement volume scoping, and this is provided solely for
+	// Docker compatibility. The value is only "local".
+	// Required: true
+	Scope string `json:"Scope"`
+
+	// TODO: We don't include the volume `Status` for now
+}
+
 type VolumeRmOptions struct {
 	All   bool
 	Force bool
@@ -94,16 +130,24 @@ type VolumeListReport struct {
 	VolumeConfigResponse
 }
 
+// VolumeListBody Volume list response
+// swagger:model VolumeListBody
+type VolumeListBody struct {
+	Volumes []*VolumeInfo
+}
+
+// Volume list response
+// swagger:response VolumeListResponse
+type SwagVolumeListResponse struct {
+	// in:body
+	Body struct {
+		VolumeListBody
+	}
+}
+
 /*
  * Docker API compatibility types
  */
-// swagger:response DockerVolumeList
-type SwagDockerVolumeListResponse struct {
-	// in:body
-	Body struct {
-		docker_api_types_volume.VolumeListOKBody
-	}
-}
 
 // swagger:model DockerVolumeCreate
 type DockerVolumeCreate docker_api_types_volume.VolumeCreateBody


### PR DESCRIPTION
Do not use volume from docker since UsageData field is not need. It's nullable in docker API and expensive to add.

Signed-off-by: Qi Wang <qiwan@redhat.com>