### PR TITLE
add newline to output in error message

### DIFF
--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -33,7 +33,7 @@ func PodmanConfig() *entities.PodmanConfig {
 
 func newPodmanConfig() {
 	if err := setXdgDirs(); err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
this fixes the following output (I think? I wasn't actually able to get the build working locally)

```console
$ sudo -u wat podman run ubuntu:bionic bash -c 'echo hello world'
cannot resolve /home/wat: lstat /home/wat: no such file or directory$
```