### PR TITLE
compat/info.go: TrimPrefix(CGroupsVersion, "v")

### DIFF
--- a/pkg/api/handlers/compat/info.go
+++ b/pkg/api/handlers/compat/info.go
@@ -119,7 +119,7 @@ func GetInfo(w http.ResponseWriter, r *http.Request) {
 		BuildahVersion:     infoData.Host.BuildahVersion,
 		CPURealtimePeriod:  sysInfo.CPURealtimePeriod,
 		CPURealtimeRuntime: sysInfo.CPURealtimeRuntime,
-		CgroupVersion:      infoData.Host.CGroupsVersion,
+		CgroupVersion:      strings.TrimPrefix(infoData.Host.CGroupsVersion, "v"),
 		Rootless:           rootless.IsRootless(),
 		SwapFree:           infoData.Host.SwapFree,
 		SwapTotal:          infoData.Host.SwapTotal,


### PR DESCRIPTION
For compatibility with Docker: https://github.com/moby/moby/blob/846b7e24ba549a972a2672ffdd88b140da688736/api/swagger.yaml#L4528-L4534
