### PR TITLE
Specifying --ipc=host --pid=host is broken

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -10,7 +10,7 @@ type ContainerCLIOpts struct {
 	BlkIOWeightDevice []string
 	CapAdd            []string
 	CapDrop           []string
-	CGroupsNS         string
+	CgroupNS          string
 	CGroupsMode       string
 	CGroupParent      string
 	CIDFile           string

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -195,7 +195,7 @@ func createInit(c *cobra.Command) error {
 	cliVals.IPC = c.Flag("ipc").Value.String()
 	cliVals.UTS = c.Flag("uts").Value.String()
 	cliVals.PID = c.Flag("pid").Value.String()
-	cliVals.CGroupsNS = c.Flag("cgroupns").Value.String()
+	cliVals.CgroupNS = c.Flag("cgroupns").Value.String()
 	if c.Flag("entrypoint").Changed {
 		val := c.Flag("entrypoint").Value.String()
 		cliVals.Entrypoint = &val


### PR DESCRIPTION
For some reason we were overwriting memory when handling both
--pid=host and --ipc=host.  Simplified the code to handle this
correctly, and add test to make sure it does not happen again.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>