### PR TITLE
System tests: add environment, volume tests

### DIFF
--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1411,9 +1411,9 @@ required for VPN, without it containers need to be run with the **--network=host
 Environment variables within containers can be set using multiple different options,
 in the following order of precedence (later entries override earlier entries):
 
-- **--env-host**: Host environment of the process executing Podman is added.
-- **--http-proxy**: By default, several environment variables will be passed in from the host, such as **http_proxy** and **no_proxy**. See **--http-proxy** for details.
 - Container image: Any environment variables specified in the container image.
+- **--http-proxy**: By default, several environment variables will be passed in from the host, such as **http_proxy** and **no_proxy**. See **--http-proxy** for details.
+- **--env-host**: Host environment of the process executing Podman is added.
 - **--env-file**: Any environment variables specified via env-files.  If multiple files specified, then they override each other in order of entry.
 - **--env**: Any environment variables specified will override previous settings.
 

--- a/test/system/helpers.t
+++ b/test/system/helpers.t
@@ -6,7 +6,7 @@
 # anything if we have to mess with them.
 #
 
-source $(dirname $0)/helpers.bash
+source "$(dirname $0)"/helpers.bash
 
 die() {
     echo "$(basename $0): $*" >&2


### PR DESCRIPTION
Tests for #7094, in which symlinks in a volume would
cause chown errors and nonrunnable containers.

Tests for environment variable precedence, now
include --env-host and proxy settings

Fix a bug caught by covscan in helpers.t ('source'
path would fail if path included spaces).

Fix podman-run man page: it was incorrect in stating
precedence between in-image environment and --env-host.

Fixes: #7099

Signed-off-by: Ed Santiago <santiago@redhat.com>