### PR TITLE
Reenable remote system tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,21 +353,19 @@ remotesystem:
 	# Start podman server using tmp socket; loop-wait for it;
 	# test podman-remote; kill server, clean up tmp socket file.
 	# podman server spews copious unhelpful output; ignore it.
-	# FIXME FIXME FIXME: remove 'exit 0' after #6538 and #6539 are fixed
-	exit 0;\
 	rc=0;\
 	if timeout -v 1 true; then \
 		SOCK_FILE=$(shell mktemp --dry-run --tmpdir podman.XXXXXX);\
 		export PODMAN_SOCKET=unix:$$SOCK_FILE; \
-		./bin/podman system service --timeout=0 $$PODMAN_SOCKET &> $(if $(PODMAN_SERVER_LOG),$(PODMAN_SERVER_LOG),/dev/null) & \
+		./bin/podman system service --timeout=0 $$PODMAN_SOCKET > $(if $(PODMAN_SERVER_LOG),$(PODMAN_SERVER_LOG),/dev/null) 2>&1 & \
 		retry=5;\
-		while [[ $$retry -ge 0 ]]; do\
+		while [ $$retry -ge 0 ]; do\
 			echo Waiting for server...;\
 			sleep 1;\
-			./bin/podman-remote --url $$PODMAN_SOCKET info &>/dev/null && break;\
+			./bin/podman-remote --url $$PODMAN_SOCKET info >/dev/null 2>&1 && break;\
 			retry=$$(expr $$retry - 1);\
 		done;\
-		if [[ $$retry -lt 0 ]]; then\
+		if [ $$retry -lt 0 ]; then\
 			echo "Error: ./bin/podman system service did not come up on $$SOCK_FILE" >&2;\
 			exit 1;\
 		fi;\

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -96,6 +96,8 @@ echo $rand        |   0 | $rand
     # Believe it or not, 'sh -c' resulted in different behavior
     run_podman 0 run --rm $IMAGE sh -c /bin/true
     run_podman 1 run --rm $IMAGE sh -c /bin/false
+
+    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 }
 
 @test "podman run --name" {
@@ -202,6 +204,8 @@ echo $rand        |   0 | $rand
 }
 
 @test "podman run docker-archive" {
+    skip_if_remote "FIXME: pending #7116"
+
     # Create an image that, when run, outputs a random magic string
     expect=$(random_string 20)
     run_podman run --name myc --entrypoint="[\"/bin/echo\",\"$expect\"]" $IMAGE
@@ -247,6 +251,8 @@ echo $rand        |   0 | $rand
 # symptom only manifests on a fedora container image -- we have no
 # reproducer on alpine. Checking directory ownership is good enough.
 @test "podman run : user namespace preserved root ownership" {
+    skip_if_remote "FIXME: pending #7195"
+
     for priv in "" "--privileged"; do
         for user in "--user=0" "--user=100"; do
             for keepid in "" "--userns=keep-id"; do
@@ -260,10 +266,14 @@ echo $rand        |   0 | $rand
             done
         done
     done
+
+    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 }
 
 # #6829 : add username to /etc/passwd inside container if --userns=keep-id
 @test "podman run : add username to /etc/passwd if --userns=keep-id" {
+    skip_if_remote "FIXME: pending #7195"
+
     # Default: always run as root
     run_podman run --rm $IMAGE id -un
     is "$output" "root" "id -un on regular container"
@@ -282,10 +292,14 @@ echo $rand        |   0 | $rand
     run_podman run --rm --privileged --userns=keep-id --user=0 $IMAGE id -un
     remove_same_dev_warning      # grumble
     is "$output" "root" "--user=0 overrides keep-id"
+
+    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 }
 
 # #6991 : /etc/passwd is modifiable
 @test "podman run : --userns=keep-id: passwd file is modifiable" {
+    skip_if_remote "FIXME: pending #7195"
+
     run_podman run -d --userns=keep-id $IMAGE sh -c 'while ! test -e /stop; do sleep 0.1; done'
     cid="$output"
 

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -25,6 +25,8 @@ load helpers
 }
 
 @test "podman logs - multi" {
+    skip_if_remote "logs does not support multiple containers when run remotely"
+
     # Simple helper to make the container starts, below, easier to read
     local -a cid
     doit() {

--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -12,9 +12,12 @@ load helpers
     run_podman stop $cid
     t1=$SECONDS
 
-    # Confirm that container is stopped
+    # Confirm that container is stopped. Podman-remote unfortunately
+    # cannot tell the difference between "stopped" and "exited", and
+    # spits them out interchangeably, so we need to recognize either.
     run_podman inspect --format '{{.State.Status}} {{.State.ExitCode}}' $cid
-    is "$output" "exited \+137" "Status and exit code of stopped container"
+    is "$output" "\\(stopped\|exited\\) \+137" \
+       "Status and exit code of stopped container"
 
     # The initial SIGTERM is ignored, so this operation should take
     # exactly 10 seconds. Give it some leeway.

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -44,6 +44,8 @@ load helpers
 #
 # See https://github.com/containers/podman/issues/3795
 @test "podman rm -f" {
+    skip_if_remote "FIXME: pending #7117"
+
     rand=$(random_string 30)
     ( sleep 3; run_podman rm -f $rand ) &
     run_podman 137 run --name $rand $IMAGE sleep 30

--- a/test/system/110-history.bats
+++ b/test/system/110-history.bats
@@ -3,6 +3,8 @@
 load helpers
 
 @test "podman history - basic tests" {
+    skip_if_remote "FIXME: pending #7122"
+
     tests="
                                  | .*[0-9a-f]\\\{12\\\} .* CMD .* LABEL
 --format '{{.ID}} {{.Created}}'  | .*[0-9a-f]\\\{12\\\} .* ago

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -28,6 +28,8 @@ verify_iid_and_name() {
 
 
 @test "podman load - by image ID" {
+    skip_if_remote "FIXME: pending #7123"
+
     # FIXME: how to build a simple archive instead?
     get_iid_and_name
 
@@ -74,7 +76,9 @@ verify_iid_and_name() {
     verify_iid_and_name $img_name
 }
 
-@test "podman load - NAME and NAME:TAG arguments work (requires: #2674)" {
+@test "podman load - NAME and NAME:TAG arguments work" {
+    skip_if_remote "FIXME: pending #7124"
+
     get_iid_and_name
     run_podman save $iid -o $archive
     run_podman rmi $iid

--- a/test/system/130-kill.bats
+++ b/test/system/130-kill.bats
@@ -6,6 +6,8 @@
 load helpers
 
 @test "podman kill - test signal handling in containers" {
+    skip_if_remote "FIXME: pending #7135"
+
     # podman-remote and crun interact poorly in f31: crun seems to gobble up
     # some signals.
     # Workaround: run 'env --default-signal sh' instead of just 'sh' in

--- a/test/system/140-diff.bats
+++ b/test/system/140-diff.bats
@@ -6,9 +6,16 @@
 load helpers
 
 @test "podman diff" {
+    n=$(random_string 10)          # container name
     rand_file=$(random_string 10)
-    run_podman run $IMAGE sh -c "touch /$rand_file;rm /etc/services"
-    run_podman diff --format json -l
+    run_podman run --name $n $IMAGE sh -c "touch /$rand_file;rm /etc/services"
+
+    # If running local, test `-l` (latest) option. This can't work with remote.
+    if ! is_remote; then
+        n=-l
+    fi
+
+    run_podman diff --format json $n
 
     # Expected results for each type of diff
     declare -A expect=(
@@ -22,7 +29,7 @@ load helpers
         is "$result" "${expect[$field]}" "$field"
     done
 
-    run_podman rm -l
+    run_podman rm $n
 }
 
 # vim: filetype=sh

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -93,6 +93,7 @@ Labels.l       | $mylabel
     is "$(<$mountpoint/myfile)" "$rand" "we see content created in container"
 
     # Clean up
+    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman volume rm $myvolume
 }
 
@@ -134,12 +135,14 @@ EOF
     is "$output" "got here -$rand-" "script in volume is runnable with default (exec)"
 
     # Clean up
+    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman volume rm $myvolume
 }
 
 
 # Anonymous temporary volumes, and persistent autocreated named ones
 @test "podman volume, implicit creation with run" {
+    skip_if_remote "FIXME: pending #7128"
 
     # No hostdir arg: create anonymous container with random name
     rand=$(random_string)
@@ -172,6 +175,7 @@ EOF
     run_podman run --rm -v $myvol:/myvol:z $IMAGE \
                sh -c "cp /myvol/myfile /myvol/myfile2"
 
+    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman volume rm $myvol
 
     # Autocreated volumes should also work with keep-id
@@ -180,6 +184,7 @@ EOF
     run_podman run --rm -v $myvol:/myvol:z --userns=keep-id $IMAGE \
                touch /myvol/myfile
 
+    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman volume rm $myvol
 }
 
@@ -187,6 +192,7 @@ EOF
 # Confirm that container sees the correct id
 @test "podman volume with --userns=keep-id" {
     is_rootless || skip "only meaningful when run rootless"
+    skip_if_remote "FIXME: pending #7195"
 
     myvoldir=${PODMAN_TMPDIR}/volume_$(random_string)
     mkdir $myvoldir

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -25,6 +25,7 @@ function _check_health {
 
 
 @test "podman healthcheck" {
+    skip_if_remote "FIXME: pending #7137"
 
     # Create an image with a healthcheck script; said script will
     # pass until the file /uh-oh gets created (by us, via exec)

--- a/test/system/300-cli-parsing.bats
+++ b/test/system/300-cli-parsing.bats
@@ -10,6 +10,8 @@ load helpers
     #   Error: invalid argument "true=\"false\"" for "-l, --label" \
     #      flag: parse error on line 1, column 5: bare " in non-quoted-field
     run_podman run --rm --label 'true="false"' $IMAGE true
+
+    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 }
 
 # vim: filetype=sh

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -101,6 +101,11 @@ EOF
 
 # #6957 - mask out /proc/acpi, /sys/dev, and other sensitive system files
 @test "sensitive mount points are masked without --privileged" {
+    # Weird error, maybe a flake?
+    #   can only attach to created or running containers: container state improper
+    # https://github.com/containers/podman/pull/7111#issuecomment-666858715
+    skip_if_remote "FIXME: Weird flake"
+
     # FIXME: this should match the list in pkg/specgen/generate/config_linux.go
     local -a mps=(
         /proc/acpi
@@ -160,6 +165,8 @@ EOF
             die "$path: Unknown file type '$type'"
         fi
     done
+
+    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 }
 
 # vim: filetype=sh

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -16,6 +16,7 @@ function check_label() {
     # FIXME: it'd be nice to specify the command to run, e.g. 'ls -dZ /',
     # but alpine ls (from busybox) doesn't support -Z
     run_podman run --rm $args $IMAGE cat -v /proc/self/attr/current
+    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 
     # FIXME: on some CI systems, 'run --privileged' emits a spurious
     # warning line about dup devices. Ignore it.

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -240,12 +240,29 @@ function is_remote() {
     [[ "$PODMAN" =~ -remote ]]
 }
 
+###########################
+#  _add_label_if_missing  #  make sure skip messages include rootless/remote
+###########################
+function _add_label_if_missing() {
+    local msg="$1"
+    local want="$2"
+
+    if [ -z "$msg" ]; then
+        echo
+    elif expr "$msg" : ".*$want" &>/dev/null; then
+        echo "$msg"
+    else
+        echo "[$want] $msg"
+    fi
+}
+
 ######################
 #  skip_if_rootless  #  ...with an optional message
 ######################
 function skip_if_rootless() {
     if is_rootless; then
-        skip "${1:-not applicable under rootless podman}"
+        local msg=$(_add_label_if_missing "$1" "rootless")
+        skip "${msg:-not applicable under rootless podman}"
     fi
 }
 
@@ -254,7 +271,8 @@ function skip_if_rootless() {
 ####################
 function skip_if_remote() {
     if is_remote; then
-        skip "${1:-test does not work with podman-remote}"
+        local msg=$(_add_label_if_missing "$1" "remote")
+        skip "${msg:-test does not work with podman-remote}"
     fi
 }
 


### PR DESCRIPTION
podman-remote is in better shape now. Let's see what needs
to be done to reenable remote system tests.

Signed-off-by: Ed Santiago <santiago@redhat.com>