### PR TITLE
Fix building from http or '-' options

### DIFF
--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -177,6 +177,27 @@ Labels.$label_name | $label_value
     run_podman rmi -f build_test
 }
 
+@test "podman build - stdin test" {
+    if is_remote && is_rootless; then
+        skip "unreliable with podman-remote and rootless; #2972"
+    fi
+
+    # Random workdir, and multiple random strings to verify command & env
+    workdir=/$(random_string 10)
+    PODMAN_TIMEOUT=240 run_podman build -t build_test - << EOF
+FROM  $IMAGE
+RUN mkdir $workdir
+WORKDIR $workdir
+RUN /bin/echo 'Test'
+EOF
+    is "$output" ".*STEP 5: COMMIT" "COMMIT seen in log"
+
+    run_podman run --rm build_test pwd
+    is "$output" "$workdir" "pwd command in container"
+
+    run_podman rmi -f build_test
+}
+
 function teardown() {
     # A timeout or other error in 'build' can leave behind stale images
     # that podman can't even see and which will cascade into subsequent


### PR DESCRIPTION
When copying from a URL, podman will download and create a context
directory in a temporary file.  The problem was that this directory
was being removed as soon as the function that created it was returned.

Later the build code would look for content in the temporary directory
and fail to find it, blowing up the build.

By pulling the extraction code back into the build function, we keep the
temporary directory around until the build completes.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>