### PR TITLE
Fix missing OCI Runtime

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -52,7 +52,7 @@ case "$CG_FS_TYPE" in
             if [[ "$OS_RELEASE_ID" == "ubuntu" ]]; then
                 echo "export OCI_RUNTIME=/usr/lib/cri-o-runc/sbin/runc" >> /etc/environment
             else
-                echo "export OCI_RUNTIME=/usr/bin/runc" >> /etc/environment
+                echo "export OCI_RUNTIME=runc" >> /etc/environment
             fi
         fi
         ;;
@@ -61,7 +61,7 @@ case "$CG_FS_TYPE" in
             # This is necessary since we've built/installed from source,
             # which uses runc as the default.
             warn "Forcing testing with crun instead of runc"
-            echo "export OCI_RUNTIME=/usr/bin/crun" >> /etc/environment
+            echo "export OCI_RUNTIME=crun" >> /etc/environment
         fi
         ;;
     *) die_unknown CG_FS_TYPE
@@ -127,6 +127,9 @@ case "$PRIV_NAME" in
             echo "$_suns" >> /etc/environment
             source /etc/environment
         fi
+
+# Reload to incorporate any changes from above
+source "$SCRIPT_BASE/lib.sh"
         ;;
     rootless)
         _ru="export ROOTLESS_USER='${ROOTLESS_USER:-some${RANDOM}dude}'"

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -127,9 +127,6 @@ case "$PRIV_NAME" in
             echo "$_suns" >> /etc/environment
             source /etc/environment
         fi
-
-# Reload to incorporate any changes from above
-source "$SCRIPT_BASE/lib.sh"
         ;;
     rootless)
         _ru="export ROOTLESS_USER='${ROOTLESS_USER:-some${RANDOM}dude}'"

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -383,14 +383,12 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 		// If the string starts with / it's a path to a runtime
 		// executable.
 		if strings.HasPrefix(runtime.config.Engine.OCIRuntime, "/") {
-			name := filepath.Base(runtime.config.Engine.OCIRuntime)
-
-			ociRuntime, err := newConmonOCIRuntime(name, []string{runtime.config.Engine.OCIRuntime}, runtime.conmonPath, runtime.runtimeFlags, runtime.config)
+			ociRuntime, err := newConmonOCIRuntime(runtime.config.Engine.OCIRuntime, []string{runtime.config.Engine.OCIRuntime}, runtime.conmonPath, runtime.runtimeFlags, runtime.config)
 			if err != nil {
 				return err
 			}
 
-			runtime.ociRuntimes[name] = ociRuntime
+			runtime.ociRuntimes[runtime.config.Engine.OCIRuntime] = ociRuntime
 			runtime.defaultOCIRuntime = ociRuntime
 		} else {
 			ociRuntime, ok := runtime.ociRuntimes[runtime.config.Engine.OCIRuntime]

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -235,14 +235,7 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 
 	ociRuntime := os.Getenv("OCI_RUNTIME")
 	if ociRuntime == "" {
-		var err error
-		ociRuntime, err = exec.LookPath("crun")
-		// If we cannot find the crun binary, setting to something static as we have no way
-		// to return an error.  The tests will fail and point out that the runc binary could
-		// not be found nicely.
-		if err != nil {
-			ociRuntime = "/usr/bin/runc"
-		}
+		ociRuntime = "crun"
 	}
 	os.Setenv("DISABLE_HC_SYSTEMD", "true")
 	CNIConfigDir := "/etc/cni/net.d"

--- a/test/endpoint/setup.go
+++ b/test/endpoint/setup.go
@@ -51,14 +51,7 @@ func Setup(tempDir string) *EndpointTestIntegration {
 
 	ociRuntime := os.Getenv("OCI_RUNTIME")
 	if ociRuntime == "" {
-		var err error
-		ociRuntime, err = exec.LookPath("runc")
-		// If we cannot find the runc binary, setting to something static as we have no way
-		// to return an error.  The tests will fail and point out that the runc binary could
-		// not be found nicely.
-		if err != nil {
-			ociRuntime = "/usr/bin/runc"
-		}
+		ociRuntime = "runc"
 	}
 	os.Setenv("DISABLE_HC_SYSTEMD", "true")
 	CNIConfigDir := "/etc/cni/net.d"

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -460,4 +460,17 @@ json-file | f
     is "$output" "$expect" "podman run with --tz=local, matches host"
 }
 
+# run with --runtime should preserve the named runtime
+@test "podman run : full path to --runtime is preserved" {
+    skip_if_cgroupsv1
+    skip_if_remote
+    run_podman run -d --runtime '/usr/bin/crun' $IMAGE sleep 60
+    cid="$output"
+
+    run_podman inspect --format '{{.OCIRuntime}}' $cid
+    is "$output" "/usr/bin/crun"
+
+    run_podman kill $cid
+}
+
 # vim: filetype=sh

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -253,6 +253,7 @@ function is_cgroupsv1() {
     ! is_cgroupsv2
 }
 
+# True if cgroups v2 are enabled
 function is_cgroupsv2() {
     cgroup_type=$(stat -f -c %T /sys/fs/cgroup)
     test "$cgroup_type" = "cgroup2fs"
@@ -302,6 +303,15 @@ function skip_if_no_selinux() {
         skip "selinux not available"
     elif ! /usr/sbin/selinuxenabled; then
         skip "selinux disabled"
+    fi
+}
+
+#######################
+#  skip_if_cgroupsv1  #  ...with an optional message
+#######################
+function skip_if_cgroupsv1() {
+    if ! is_cgroupsv2; then
+        skip "${1:-test requires cgroupsv2}"
     fi
 }
 


### PR DESCRIPTION
Problem: when we create a container with `--runtime=/PATH/TO/RUNTIME` and then call other Podman commands without that flag, Podman may fail because it can't find the OCI runtime.

Solution: make containers remember the full path of the OCI runtime they were created with (if and only if they were made with an OCI runtime specified by full path) and re-initialize the OCI runtime on subsequently retrieving the container from the database (if and only if the runtime does not already exist).