### PR TITLE
Fix `podman image search` missing description

### DIFF
--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -520,7 +520,7 @@ func (ir *ImageEngine) Search(ctx context.Context, term string, opts entities.Im
 	for i := range searchResults {
 		reports[i].Index = searchResults[i].Index
 		reports[i].Name = searchResults[i].Name
-		reports[i].Description = searchResults[i].Index
+		reports[i].Description = searchResults[i].Description
 		reports[i].Stars = searchResults[i].Stars
 		reports[i].Official = searchResults[i].Official
 		reports[i].Automated = searchResults[i].Automated


### PR DESCRIPTION
`podman image search` returned wrong results for the image "Description" as
it was mapped to the wrong field ("ID") in the search results.

Signed-off-by: Ralf Haferkamp <rhafer@suse.com>