### PR TITLE
Add test case for description being present in search result

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -677,7 +677,7 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 	for i := range searchResults {
 		reports[i].Index = searchResults[i].Index
 		reports[i].Name = searchResults[i].Name
-		reports[i].Description = searchResults[i].Index
+		reports[i].Description = searchResults[i].Description
 		reports[i].Stars = searchResults[i].Stars
 		reports[i].Official = searchResults[i].Official
 		reports[i].Automated = searchResults[i].Automated

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -638,6 +638,7 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 	query := struct {
 		Term      string   `json:"term"`
 		Limit     int      `json:"limit"`
+		NoTrunc   bool     `json:"noTrunc"`
 		Filters   []string `json:"filters"`
 		TLSVerify bool     `json:"tlsVerify"`
 	}{
@@ -650,7 +651,8 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	options := image.SearchOptions{
-		Limit: query.Limit,
+		Limit:   query.Limit,
+		NoTrunc: query.NoTrunc,
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.InsecureSkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -972,6 +972,10 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    type: integer
 	//    description: maximum number of results
 	//  - in: query
+	//    name: noTrunc
+	//    type: boolean
+	//    description: do not truncate any of the result strings
+	//  - in: query
 	//    name: filters
 	//    type: string
 	//    description: |

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -439,6 +439,7 @@ func Search(ctx context.Context, term string, opts entities.ImageSearchOptions) 
 	params := url.Values{}
 	params.Set("term", term)
 	params.Set("limit", strconv.Itoa(opts.Limit))
+	params.Set("noTrunc", strconv.FormatBool(opts.NoTrunc))
 	for _, f := range opts.Filters {
 		params.Set("filters", f)
 	}

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strconv"
 	"text/template"
 
@@ -96,6 +97,15 @@ registries = ['{{.Host}}:{{.Port}}']`
 		search.WaitWithDefaultTimeout()
 		Expect(search.ExitCode()).To(Equal(0))
 		Expect(search.LineInOutputContains("quay.io/libpod/gate")).To(BeTrue())
+	})
+
+	It("podman search image with description", func() {
+		search := podmanTest.Podman([]string{"search", "quay.io/libpod/whalesay"})
+		search.WaitWithDefaultTimeout()
+		Expect(search.ExitCode()).To(Equal(0))
+		output := fmt.Sprintf("%s", search.Out.Contents())
+		match, _ := regexp.MatchString(`(?m)^quay.io\s+quay.io/libpod/whalesay\s+Static image used for automated testing.+$`, output)
+		Expect(match).To(BeTrue())
 	})
 
 	It("podman search format flag", func() {


### PR DESCRIPTION
Test for a specific static image and match the description to avoid
regression like https://github.com/containers/podman/pull/7131

Also apply the fix above to the api implementation.

Signed-off-by: Ralf Haferkamp <rhafer@suse.com>