### PR TITLE
bindings: skip flaky pause/unpause test

### DIFF
--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -280,6 +280,7 @@ var _ = Describe("Podman containers ", func() {
 	})
 
 	It("podman wait to pause|unpause condition", func() {
+		Skip("FIXME: https://github.com/containers/podman/issues/6518")
 		var (
 			name           = "top"
 			exitCode int32 = -1


### PR DESCRIPTION
The "podman wait to pause|unpause condition" test is failing
several times a day, always a flake. Issue #6518.

Disable it until the cause can be identified and fixed.

Signed-off-by: Ed Santiago <santiago@redhat.com>