### PR TITLE
Don't crash when giving bogus format commands

### DIFF
--- a/cmd/podman/images/history.go
+++ b/cmd/podman/images/history.go
@@ -125,7 +125,10 @@ func history(cmd *cobra.Command, args []string) error {
 	}
 	format := hdr + "{{range . }}" + row + "{{end}}"
 
-	tmpl := template.Must(template.New("report").Parse(format))
+	tmpl, err := template.New("report").Parse(format)
+	if err != nil {
+		return err
+	}
 	w := tabwriter.NewWriter(os.Stdout, 8, 2, 2, ' ', 0)
 	err = tmpl.Execute(w, hr)
 	if err != nil {

--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -168,7 +168,11 @@ func writeTemplate(imgs []imageReporter) error {
 		}
 	}
 	format := hdr + "{{range . }}" + row + "{{end}}"
-	tmpl := template.Must(template.New("list").Parse(format))
+	tmpl, err := template.New("list").Parse(format)
+	if err != nil {
+		return err
+	}
+	tmpl = template.Must(tmpl, nil)
 	w := tabwriter.NewWriter(os.Stdout, 8, 2, 2, ' ', 0)
 	defer w.Flush()
 	return tmpl.Execute(w, imgs)

--- a/cmd/podman/system/connection/list.go
+++ b/cmd/podman/system/connection/list.go
@@ -75,7 +75,11 @@ func list(_ *cobra.Command, _ []string) error {
 
 	// TODO: Allow user to override format
 	format := "{{range . }}{{.Name}}\t{{.Identity}}\t{{.URI}}\n{{end}}"
-	tmpl := template.Must(template.New("connection").Parse(format))
+	tmpl, err := template.New("connection").Parse(format)
+	if err != nil {
+		return err
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 8, 2, 2, ' ', 0)
 	defer w.Flush()
 


### PR DESCRIPTION
Currently if you give a bogus flag to --format it will crash
the formatter.  With this change we will get a nice error.

podman images --format '{{ bogus }}'
Error: template: list:1: function "bogus" not defined

versus
 /bin/podman.old images --format '{{ bogus }}'
panic: template: list:1: function "bogus" not defined

goroutine 1 [running]:

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>