### PR TITLE
Return NamesHistory when returning remote images

### DIFF
--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -203,15 +203,6 @@ func ImageToImageSummary(l *libpodImage.Image) (*entities.ImageSummary, error) {
 		return nil, errors.Wrapf(err, "Failed to obtain RepoTags for image %s", l.ID())
 	}
 
-	history, err := l.History(context.TODO())
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to obtain History for image %s", l.ID())
-	}
-	historyIds := make([]string, len(history))
-	for i, h := range history {
-		historyIds[i] = h.ID
-	}
-
 	digests := make([]string, len(l.Digests()))
 	for i, d := range l.Digests() {
 		digests[i] = string(d)
@@ -233,7 +224,7 @@ func ImageToImageSummary(l *libpodImage.Image) (*entities.ImageSummary, error) {
 		Digest:       string(l.Digest()),
 		Digests:      digests,
 		ConfigDigest: string(l.ConfigDigest),
-		History:      historyIds,
+		History:      l.NamesHistory(),
 	}
 	return &is, nil
 }


### PR DESCRIPTION
We are returning bogus data in podman-remote images --format json.
This change will match the same data returned my podman images --format json.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>