### PR TITLE
fix pod creation with "new:" syntax

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -124,7 +124,7 @@ func create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if _, err := createPodIfNecessary(s); err != nil {
+	if _, err := createPodIfNecessary(s, cliVals.Net); err != nil {
 		return err
 	}
 
@@ -283,7 +283,7 @@ func openCidFile(cidfile string) (*os.File, error) {
 // createPodIfNecessary automatically creates a pod when requested.  if the pod name
 // has the form new:ID, the pod ID is created and the name in the spec generator is replaced
 // with ID.
-func createPodIfNecessary(s *specgen.SpecGenerator) (*entities.PodCreateReport, error) {
+func createPodIfNecessary(s *specgen.SpecGenerator, netOpts *entities.NetOptions) (*entities.PodCreateReport, error) {
 	if !strings.HasPrefix(s.Pod, "new:") {
 		return nil, nil
 	}
@@ -292,11 +292,10 @@ func createPodIfNecessary(s *specgen.SpecGenerator) (*entities.PodCreateReport, 
 		return nil, errors.Errorf("new pod name must be at least one character")
 	}
 	createOptions := entities.PodCreateOptions{
-		Name:  podName,
-		Infra: true,
-		Net: &entities.NetOptions{
-			PublishPorts: s.PortMappings,
-		},
+		Name:          podName,
+		Infra:         true,
+		Net:           netOpts,
+		CreateCommand: os.Args,
 	}
 	s.Pod = podName
 	return registry.ContainerEngine().PodCreate(context.Background(), createOptions)

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -176,7 +176,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	runOpts.Spec = s
 
-	if _, err := createPodIfNecessary(s); err != nil {
+	if _, err := createPodIfNecessary(s, cliVals.Net); err != nil {
 		return err
 	}
 

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -462,6 +462,10 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 func GetNamespaceOptions(ns []string) ([]libpod.PodCreateOption, error) {
 	var options []libpod.PodCreateOption
 	var erroredOptions []libpod.PodCreateOption
+	if ns == nil {
+		//set the default namespaces
+		ns = strings.Split(specgen.DefaultKernelNamespaces, ",")
+	}
 	for _, toShare := range ns {
 		switch toShare {
 		case "cgroup":

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -812,7 +812,11 @@ USER mail`
 	})
 
 	It("podman run --pod automatically", func() {
-		session := podmanTest.Podman([]string{"run", "--pod", "new:foobar", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"run", "-d", "--pod", "new:foobar", ALPINE, "nc", "-l", "-p", "8080"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"run", "--pod", "foobar", ALPINE, "/bin/sh", "-c", "echo test | nc -w 1 127.0.0.1 8080"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 


### PR DESCRIPTION
When you execute podman create/run with the --pod new:\<name\> syntax
the pod was created but the namespaces where not shared and
therefore containers could not communicate over localhost.

Add the default namespaces and pass the network options to the
pod create options.

Closes #7087 