### PR TITLE
Ensure that 'rmi --force' evicts Podman containers

### DIFF
--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -51,7 +51,7 @@ func (r *Runtime) RemoveImage(ctx context.Context, img *image.Image, force bool)
 			imageCtrs = append(imageCtrs, ctr)
 		}
 	}
-	if len(imageCtrs) > 0 && len(img.Names()) <= 1 {
+	if len(imageCtrs) > 0 && (len(img.Names()) <= 1 || (force && img.InputIsID())) {
 		if force {
 			for _, ctr := range imageCtrs {
 				if err := r.removeContainer(ctx, ctr, true, false, false); err != nil {


### PR DESCRIPTION
The logic for `podman rmi --force` includes a bit of code that will remove Libpod containers using Libpod's container removal logic - this ensures that they're cleanly and completely removed. For other containers (Buildah, CRI-O, etc) we fall back to manually removing the containers using the image from c/storage.

Unfortunately, our logic for invoking the Podman removal function had an error, and it did not properly handle cases where we were force-removing an image with >1 name. Force-removing such images by ID guarantees their removal, not just an untag of a single name; our code for identifying whether to remove containers did not proper detect this case, so we fell through and deleted the Podman containers as storage containers, leaving traces of them in the Libpod DB.

Fixes #7153
