### PR TITLE
fix podman system df format error

### DIFF
--- a/cmd/podman/system/df.go
+++ b/cmd/podman/system/df.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"text/template"
@@ -69,6 +70,14 @@ func printSummary(reports *entities.SystemDfReport, userFormat string) error {
 
 	//	Images
 	if len(userFormat) > 0 {
+		if !strings.HasSuffix(userFormat, `\n`) {
+			userFormat += `\n`
+		}
+		// should be Unquoto from cmd line
+		userFormat, err := strconv.Unquote(`"` + userFormat + `"`)
+		if err != nil {
+			return err
+		}
 		format = userFormat
 	}
 

--- a/test/system/320-system-df.bats
+++ b/test/system/320-system-df.bats
@@ -24,9 +24,10 @@ function teardown() {
     run_podman run -d -v /myvol2 --name c2 $IMAGE \
                sh -c 'while ! test -e /stop; do sleep 0.1;done'
 
-    run_podman system df --format '{{ .Type }}:{{ .Total }}:{{ .Active }}--'
-    # FIXME: if/when #7149 gets fixed, split this into three tests (i.e. test "${lines[0]}", [1], [2] )
-    is "$output" "Images:1:1--Containers:2:1--Local Volumes:2:1--"
+    run_podman system df --format '{{ .Type }}:{{ .Total }}:{{ .Active }}'
+    is "${lines[0]}" "Images:1:1"        "system df : Images line"
+    is "${lines[1]}" "Containers:2:1"    "system df : Containers line"
+    is "${lines[2]}" "Local Volumes:2:1" "system df : Volumes line"
 
     # Try -v. (Grrr. No way to specify individual formats)
     #


### PR DESCRIPTION
Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>
Fixes: https://github.com/containers/podman/issues/7149
```
root@develop:~/zgz/podman# podman  system df --format  "{{.Type}}\t{{.Total}}"
Images\t4Containers\t2Local Volumes\t0root@develop:~/zgz/podman# ^C
root@develop:~/zgz/podman# ./bin/podman  system df --format  "{{.Type}}\t{{.Total}}"
Images         4
Containers     2
Local Volumes  0
```