### PR TITLE
Handle single character images

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -594,11 +594,9 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// I know mitr hates this ... but doing for now
-	if len(query.Repo) > 1 {
+	if len(query.Repo) > 0 {
 		destImage = fmt.Sprintf("%s:%s", query.Repo, tag)
 	}
-
 	commitImage, err := ctr.Commit(r.Context(), destImage, options)
 	if err != nil && !strings.Contains(err.Error(), "is not running") {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "CommitFailure"))

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -49,6 +49,21 @@ var _ = Describe("Podman commit", func() {
 		Expect(StringInSlice("foobar.com/test1-image:latest", data[0].RepoTags)).To(BeTrue())
 	})
 
+	It("podman commit single letter container", func() {
+		_, ec, _ := podmanTest.RunLsContainer("test1")
+		Expect(ec).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+
+		session := podmanTest.Podman([]string{"commit", "test1", "a"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		check := podmanTest.Podman([]string{"inspect", "localhost/a:latest"})
+		check.WaitWithDefaultTimeout()
+		data := check.InspectImageJSON()
+		Expect(StringInSlice("localhost/a:latest", data[0].RepoTags)).To(BeTrue())
+	})
+
 	It("podman container commit container", func() {
 		_, ec, _ := podmanTest.RunLsContainer("test1")
 		Expect(ec).To(Equal(0))


### PR DESCRIPTION
Currently you can only specify multiple character for image names
when executing podman-remote commit

podman-remote commit a b
Will complete, but will save the image without a name.

podman-remote commit a bb
Works.

This PR fixes and now returns an error if the user doees not specify an
image name to commit to.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>