### PR TITLE
rootless: do not ignore errors if mappings are specified

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -860,7 +860,7 @@ reexec_in_user_namespace (int ready, char *pause_pid_file_path, char *file_to_re
       fprintf (stderr, "cannot read from sync pipe: %s\n", strerror (errno));
       _exit (EXIT_FAILURE);
     }
-  if (b != '0')
+  if (ret != 1 || b != '0')
     _exit (EXIT_FAILURE);
 
   if (syscall_setresgid (0, 0, 0) < 0)

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -224,6 +224,10 @@ func becomeRootInUserNS(pausePid, fileToRead string, fileOutput *os.File) (bool,
 	uidsMapped := false
 	if uids != nil {
 		err := tryMappingTool("newuidmap", pid, os.Geteuid(), uids)
+		// If some mappings were specified, do not ignore the error
+		if err != nil && len(uids) > 0 {
+			return false, -1, err
+		}
 		uidsMapped = err == nil
 	}
 	if !uidsMapped {
@@ -246,6 +250,10 @@ func becomeRootInUserNS(pausePid, fileToRead string, fileOutput *os.File) (bool,
 	gidsMapped := false
 	if gids != nil {
 		err := tryMappingTool("newgidmap", pid, os.Getegid(), gids)
+		// If some mappings were specified, do not ignore the error
+		if err != nil && len(gids) > 0 {
+			return false, -1, err
+		}
 		gidsMapped = err == nil
 	}
 	if !gidsMapped {


### PR DESCRIPTION
when setting up the user namespace do not ignore errors from newuidmap/newgidmap if there are mappings configured.

The single user mapping is a fallback only when there are not mappings specified for the user.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>