### PR TITLE
2.0 backports

### DIFF
--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -214,7 +214,6 @@ the exit codes follow the `chroot` standard, see below:
 ## FILES
 
 **containers.conf** (`/usr/share/containers/containers.conf`)
-
     Podman has builtin defaults for command line options. These defaults can be overridden using the containers.conf configuration files.
 
 Distributions ship the `/usr/share/containers/containers.conf` file with their default settings. Administrators can override fields in this file by creating the `/etc/containers/containers.conf` file.  Users can further modify defaults by creating the `$HOME/.config/containers/containers.conf` file. Podman merges its builtin defaults with the specified fields from these files, if they exist. Fields specified in the users file override the administrator's file, which overrides the distribution's file, which override the built-in defaults.

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
-	github.com/rootless-containers/rootlesskit v0.9.5
+	github.com/rootless-containers/rootlesskit v0.10.0
 	github.com/seccomp/containers-golang v0.5.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ github.com/prometheus/procfs v0.0.5 h1:3+auTFlqw+ZaQYJARz6ArODtkaIwtvBTx3N2NehQl
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
-github.com/rootless-containers/rootlesskit v0.9.5 h1:ygvFn6ms/14MlRQmMK8OSLKwwtHeRLFNblm+rOIndA0=
-github.com/rootless-containers/rootlesskit v0.9.5/go.mod h1:OZQfuRPb+2MA1p+hmjHmSmDRv9SdTzlQ3taNA/0d7XM=
+github.com/rootless-containers/rootlesskit v0.10.0 h1:62HHP8s8qYYcolEtAsuo4GU6qau6pWmcQ1Te+TZTFds=
+github.com/rootless-containers/rootlesskit v0.10.0/go.mod h1:OZQfuRPb+2MA1p+hmjHmSmDRv9SdTzlQ3taNA/0d7XM=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8 h1:2c1EFnZHIPCW8qKWgHMH/fX2PkSabFc5mrVzfUNdg5U=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=

--- a/pkg/api/handlers/compat/info.go
+++ b/pkg/api/handlers/compat/info.go
@@ -119,7 +119,7 @@ func GetInfo(w http.ResponseWriter, r *http.Request) {
 		BuildahVersion:     infoData.Host.BuildahVersion,
 		CPURealtimePeriod:  sysInfo.CPURealtimePeriod,
 		CPURealtimeRuntime: sysInfo.CPURealtimeRuntime,
-		CgroupVersion:      infoData.Host.CGroupsVersion,
+		CgroupVersion:      strings.TrimPrefix(infoData.Host.CGroupsVersion, "v"),
 		Rootless:           rootless.IsRootless(),
 		SwapFree:           infoData.Host.SwapFree,
 		SwapTotal:          infoData.Host.SwapTotal,

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -402,7 +402,7 @@ func (ir *ImageEngine) Search(ctx context.Context, term string, opts entities.Im
 	for i := range searchResults {
 		reports[i].Index = searchResults[i].Index
 		reports[i].Name = searchResults[i].Name
-		reports[i].Description = searchResults[i].Index
+		reports[i].Description = searchResults[i].Description
 		reports[i].Stars = searchResults[i].Stars
 		reports[i].Official = searchResults[i].Official
 		reports[i].Automated = searchResults[i].Automated

--- a/vendor/github.com/rootless-containers/rootlesskit/pkg/port/builtin/child/child.go
+++ b/vendor/github.com/rootless-containers/rootlesskit/pkg/port/builtin/child/child.go
@@ -119,11 +119,13 @@ func (d *childDriver) handleConnectRequest(c *net.UnixConn, req *msg.Request) er
 	if err != nil {
 		return err
 	}
+	defer targetConnFile.Close()
 	oob := unix.UnixRights(int(targetConnFile.Fd()))
 	f, err := c.File()
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	for {
 		err = unix.Sendmsg(int(f.Fd()), []byte("dummy"), oob, nil, 0)
 		if err != unix.EINTR {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -467,7 +467,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/rootless-containers/rootlesskit v0.9.5
+# github.com/rootless-containers/rootlesskit v0.10.0
 github.com/rootless-containers/rootlesskit/pkg/msgutil
 github.com/rootless-containers/rootlesskit/pkg/port
 github.com/rootless-containers/rootlesskit/pkg/port/builtin


### PR DESCRIPTION
A set of commits from PRs marked as backports:

* Switch references from libpod.conf to containers.conf
* Bump github.com/rootless-containers/rootlesskit from 0.9.5 to 0.10.0
* compat/info.go: TrimPrefix(CGroupsVersion, "v")
* Fix building from http or '-' options
* Fix `podman image search` missing description