### PR TITLE
Ensure libpod/define does not include libpod/image

### DIFF
--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -2,23 +2,20 @@ package define
 
 import (
 	"errors"
-
-	"github.com/containers/podman/v2/libpod/image"
-	"github.com/containers/podman/v2/utils"
 )
 
 var (
 	// ErrNoSuchCtr indicates the requested container does not exist
-	ErrNoSuchCtr = image.ErrNoSuchCtr
+	ErrNoSuchCtr = errors.New("no such container")
 
 	// ErrNoSuchPod indicates the requested pod does not exist
-	ErrNoSuchPod = image.ErrNoSuchPod
+	ErrNoSuchPod = errors.New("no such pod")
 
 	// ErrNoSuchImage indicates the requested image does not exist
-	ErrNoSuchImage = image.ErrNoSuchImage
+	ErrNoSuchImage = errors.New("no such image")
 
 	// ErrNoSuchTag indicates the requested image tag does not exist
-	ErrNoSuchTag = image.ErrNoSuchTag
+	ErrNoSuchTag = errors.New("no such tag")
 
 	// ErrNoSuchVolume indicates the requested volume does not exist
 	ErrNoSuchVolume = errors.New("no such volume")
@@ -76,7 +73,7 @@ var (
 
 	// ErrDetach indicates that an attach session was manually detached by
 	// the user.
-	ErrDetach = utils.ErrDetach
+	ErrDetach = errors.New("detached from container")
 
 	// ErrWillDeadlock indicates that the requested operation will cause a
 	// deadlock. This is usually caused by upgrade issues, and is resolved

--- a/libpod/image/errors.go
+++ b/libpod/image/errors.go
@@ -1,17 +1,16 @@
 package image
 
 import (
-	"errors"
+	"github.com/containers/podman/v2/libpod/define"
 )
 
-// Copied directly from libpod errors to avoid circular imports
 var (
 	// ErrNoSuchCtr indicates the requested container does not exist
-	ErrNoSuchCtr = errors.New("no such container")
+	ErrNoSuchCtr = define.ErrNoSuchCtr
 	// ErrNoSuchPod indicates the requested pod does not exist
-	ErrNoSuchPod = errors.New("no such pod")
+	ErrNoSuchPod = define.ErrNoSuchPod
 	// ErrNoSuchImage indicates the requested image does not exist
-	ErrNoSuchImage = errors.New("no such image")
+	ErrNoSuchImage = define.ErrNoSuchImage
 	// ErrNoSuchTag indicates the requested image tag does not exist
-	ErrNoSuchTag = errors.New("no such tag")
+	ErrNoSuchTag = define.ErrNoSuchTag
 )

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -51,7 +52,7 @@ func ExecCmdWithStdStreams(stdin io.Reader, stdout, stderr io.Writer, env []stri
 
 // ErrDetach is an error indicating that the user manually detached from the
 // container.
-var ErrDetach = errors.New("detached from container")
+var ErrDetach = define.ErrDetach
 
 // CopyDetachable is similar to io.Copy but support a detach key sequence to break out.
 func CopyDetachable(dst io.Writer, src io.Reader, keys []byte) (written int64, err error) {


### PR DESCRIPTION
The define package under Libpod is intended to be an extremely minimal package, including constants and very little else. However, as a result of some legacy code, it was dragging in all of libpod/image (and, less significantly, the util package). Fortunately, this was just to ensure that error constants were not duplicating, and there's nothing preventing us from importing in the other direction and keeping libpod/define free of dependencies.
