### PR TITLE
implement the exitcode when start a container with attach

### DIFF
--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -99,12 +99,17 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, r := range responses {
-		if r.Err == nil && !startOptions.Attach {
-			fmt.Println(r.RawInput)
+		if r.Err == nil {
+			if startOptions.Attach {
+				// Implement the exitcode when the only one container is enabled attach
+				registry.SetExitCode(r.ExitCode)
+			} else {
+				fmt.Println(r.RawInput)
+			}
 		} else {
 			errs = append(errs, r.Err)
 		}
 	}
-	// TODO need to understand an implement exitcodes
+
 	return errs.PrintErrors()
 }

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -86,6 +86,18 @@ var _ = Describe("Podman start", func() {
 		Expect(session.OutputToString()).To(Equal(name))
 	})
 
+	It("podman start single container with attach and test the signal", func() {
+		SkipIfRemote()
+		session := podmanTest.Podman([]string{"create", "--entrypoint", "sh", ALPINE, "-c", "exit 1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+		session = podmanTest.Podman([]string{"start", "--attach", cid})
+		session.WaitWithDefaultTimeout()
+		// It should forward the signal
+		Expect(session.ExitCode()).To(Equal(1))
+	})
+
 	It("podman start multiple containers", func() {
 		session := podmanTest.Podman([]string{"create", "-d", "--name", "foobar99", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>
Fixes: https://github.com/containers/podman/issues/7150
will be ok if use the docker
```
[root@centos7 ~]# docker create --name test --entrypoint=sh alpine:3.12 -c 'exit 1'
4dbc2dc4355a754a62a16910a3037578b1efa83d07d63889c1fd773b3c974d8a
[root@centos7 ~]# docker start -a test
[root@centos7 ~]# echo $?
1
[root@centos7 ~]# 
```
before and after fix
```
[root@sz-test podman]# podman create --name test --entrypoint=sh docker.io/library/alpine:3.12 -c 'exit 1'
59694fc44140e81ddc9c2beaaec9613a689a6ccebf29a09c2e3f749a389f5088
[root@sz-test podman]# podman start -a test
[root@sz-test podman]# echo $?
0
[root@sz-test podman]# ./bin/podman start -a test
[root@sz-test podman]# echo $?
1
```