### PR TITLE
Remove some unnecessary []byte to string conversions

### DIFF
--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -4,7 +4,6 @@ package events
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -50,7 +49,7 @@ func (e EventJournalD) Write(ee Event) error {
 	case Volume:
 		m["PODMAN_NAME"] = ee.Name
 	}
-	return journal.Send(fmt.Sprintf("%s", ee.ToHumanReadable()), journal.PriInfo, m)
+	return journal.Send(string(ee.ToHumanReadable()), journal.PriInfo, m)
 }
 
 // Read reads events from the journal and sends qualified events to the event channel

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -241,7 +241,7 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(mountCmd1.ExitCode()).To(Equal(0))
 		os.Stdout.Sync()
 		os.Stderr.Sync()
-		mountOut1 := strings.Join(strings.Fields(fmt.Sprintf("%s", mountCmd1.Out.Contents())), " ")
+		mountOut1 := strings.Join(strings.Fields(string(mountCmd1.Out.Contents())), " ")
 		fmt.Printf("Output: %s", mountOut1)
 		Expect(strings.Contains(mountOut1, volName)).To(BeFalse())
 
@@ -257,7 +257,7 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(mountCmd2.ExitCode()).To(Equal(0))
 		os.Stdout.Sync()
 		os.Stderr.Sync()
-		mountOut2 := strings.Join(strings.Fields(fmt.Sprintf("%s", mountCmd2.Out.Contents())), " ")
+		mountOut2 := strings.Join(strings.Fields(string(mountCmd2.Out.Contents())), " ")
 		fmt.Printf("Output: %s", mountOut2)
 		Expect(strings.Contains(mountOut2, volName)).To(BeTrue())
 
@@ -278,7 +278,7 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(mountCmd3.ExitCode()).To(Equal(0))
 		os.Stdout.Sync()
 		os.Stderr.Sync()
-		mountOut3 := strings.Join(strings.Fields(fmt.Sprintf("%s", mountCmd3.Out.Contents())), " ")
+		mountOut3 := strings.Join(strings.Fields(string(mountCmd3.Out.Contents())), " ")
 		fmt.Printf("Output: %s", mountOut3)
 		Expect(strings.Contains(mountOut3, volName)).To(BeFalse())
 	})

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -103,7 +103,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		search := podmanTest.Podman([]string{"search", "quay.io/libpod/whalesay"})
 		search.WaitWithDefaultTimeout()
 		Expect(search.ExitCode()).To(Equal(0))
-		output := fmt.Sprintf("%s", search.Out.Contents())
+		output := string(search.Out.Contents())
 		match, _ := regexp.MatchString(`(?m)^quay.io\s+quay.io/libpod/whalesay\s+Static image used for automated testing.+$`, output)
 		Expect(match).To(BeTrue())
 	})

--- a/test/endpoint/endpoint.go
+++ b/test/endpoint/endpoint.go
@@ -192,12 +192,12 @@ func (p *EndpointTestIntegration) Varlink(endpoint, message string, more bool) *
 }
 
 func (s *EndpointSession) StdErrToString() string {
-	fields := strings.Fields(fmt.Sprintf("%s", s.Err.Contents()))
+	fields := strings.Fields(string(s.Err.Contents()))
 	return strings.Join(fields, " ")
 }
 
 func (s *EndpointSession) OutputToString() string {
-	fields := strings.Fields(fmt.Sprintf("%s", s.Out.Contents()))
+	fields := strings.Fields(string(s.Out.Contents()))
 	return strings.Join(fields, " ")
 }
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -215,7 +215,7 @@ func (s *PodmanSession) OutputToString() string {
 // where each array item is a line split by newline
 func (s *PodmanSession) OutputToStringArray() []string {
 	var results []string
-	output := fmt.Sprintf("%s", s.Out.Contents())
+	output := string(s.Out.Contents())
 	for _, line := range strings.Split(output, "\n") {
 		if line != "" {
 			results = append(results, line)
@@ -226,14 +226,14 @@ func (s *PodmanSession) OutputToStringArray() []string {
 
 // ErrorToString formats session stderr to string
 func (s *PodmanSession) ErrorToString() string {
-	fields := strings.Fields(fmt.Sprintf("%s", s.Err.Contents()))
+	fields := strings.Fields(string(s.Err.Contents()))
 	return strings.Join(fields, " ")
 }
 
 // ErrorToStringArray returns the stderr output as a []string
 // where each array item is a line split by newline
 func (s *PodmanSession) ErrorToStringArray() []string {
-	output := fmt.Sprintf("%s", s.Err.Contents())
+	output := string(s.Err.Contents())
 	return strings.Split(output, "\n")
 }
 


### PR DESCRIPTION
Some calls to `Sprintf("%s")` can be avoided by using direct string
type assertions.

Indirect follow-up of https://github.com/containers/podman/pull/7141