### PR TITLE
rootless: system service joins immediately the namespaces

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -205,7 +205,7 @@ can_use_shortcut ()
 
       if (strcmp (argv[argc], "mount") == 0
           || strcmp (argv[argc], "search") == 0
-          || strcmp (argv[argc], "system") == 0)
+          || (strcmp (argv[argc], "system") == 0 && argv[argc+1] && strcmp (argv[argc+1], "service") != 0))
         {
           ret = false;
           break;


### PR DESCRIPTION
when there is a pause process running, let the "system service" podman
instance join immediately the existing namespaces.

Closes: https://github.com/containers/podman/issues/7180
Closes: https://github.com/containers/podman/issues/6660

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>