### PR TITLE
podman.service: drop install section

### DIFF
--- a/contrib/systemd/system/podman.service
+++ b/contrib/systemd/system/podman.service
@@ -8,7 +8,3 @@ StartLimitIntervalSec=0
 [Service]
 Type=simple
 ExecStart=/usr/bin/podman system service
-
-[Install]
-WantedBy=multi-user.target
-Also=podman.socket


### PR DESCRIPTION
podman.service is socket activated through podman.socket. It should not
have its own [Install] section, it does not make sense to systemctl
enable podman.service.

This leads to podman.service always running on a Debian system, as
Debian's policy is to enable/start running services by default.

We don't want a daemon :^)

Fixes: #7190
Reported-by: @martinpitt
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>