### PR TITLE
Restore "table" --format from V1

### DIFF
--- a/cmd/podman/containers/diff.go
+++ b/cmd/podman/containers/diff.go
@@ -1,6 +1,7 @@
 package containers
 
 import (
+	"github.com/containers/podman/v2/cmd/podman/parse"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/cmd/podman/report"
 	"github.com/containers/podman/v2/cmd/podman/validate"
@@ -52,11 +53,11 @@ func diff(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	switch diffOpts.Format {
-	case "":
-		return report.ChangesToTable(results)
-	case "json":
+	switch {
+	case parse.MatchesJSONFormat(diffOpts.Format):
 		return report.ChangesToJSON(results)
+	case diffOpts.Format == "":
+		return report.ChangesToTable(results)
 	default:
 		return errors.New("only supported value for '--format' is 'json'")
 	}

--- a/cmd/podman/parse/json.go
+++ b/cmd/podman/parse/json.go
@@ -2,8 +2,9 @@ package parse
 
 import "regexp"
 
-var jsonFormatRegex = regexp.MustCompile(`^(\s*json\s*|\s*{{\s*json\s*\.\s*}}\s*)$`)
+var jsonFormatRegex = regexp.MustCompile(`^\s*(json|{{\s*json\s*( \.)?\s*}})\s*$`)
 
+// MatchesJSONFormat test CLI --format string to be a JSON request
 func MatchesJSONFormat(s string) bool {
 	return jsonFormatRegex.Match([]byte(s))
 }

--- a/cmd/podman/parse/json_test.go
+++ b/cmd/podman/parse/json_test.go
@@ -1,6 +1,8 @@
 package parse
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,18 +15,31 @@ func TestMatchesJSONFormat(t *testing.T) {
 	}{
 		{"json", true},
 		{" json", true},
-		{"json ", true},
+		{" json ", true},
 		{"  json   ", true},
+		{"{{json}}", true},
+		{"{{json }}", true},
 		{"{{json .}}", true},
 		{"{{ json .}}", true},
-		{"{{json .   }}", true},
-		{"  {{  json .    }}   ", true},
-		{"{{json }}", false},
-		{"{{json .", false},
+		{"{{ json . }}", true},
+		{"  {{   json   .  }}  ", true},
+		{"{{ json .", false},
 		{"json . }}", false},
+		{"{{.ID }} json .", false},
+		{"json .", false},
+		{"{{json.}}", false},
 	}
 
 	for _, tt := range tests {
 		assert.Equal(t, tt.expected, MatchesJSONFormat(tt.input))
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		label := "MatchesJSONFormat/" + strings.ReplaceAll(tc.input, " ", "_")
+		t.Run(label, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, MatchesJSONFormat(tc.input), fmt.Sprintf("Scanning %q failed", tc.input))
+		})
 	}
 }

--- a/cmd/podman/report/format.go
+++ b/cmd/podman/report/format.go
@@ -1,0 +1,68 @@
+package report
+
+import (
+	"reflect"
+	"strings"
+)
+
+// tableReplacer will remove 'table ' prefix and clean up tabs
+var tableReplacer = strings.NewReplacer(
+	"table ", "",
+	`\t`, "\t",
+	`\n`, "\n",
+	" ", "\t",
+)
+
+// escapedReplacer will clean up escaped characters from CLI
+var escapedReplacer = strings.NewReplacer(
+	`\t`, "\t",
+	`\n`, "\n",
+)
+
+// NormalizeFormat reads given go template format provided by CLI and munges it into what we need
+func NormalizeFormat(format string) string {
+	f := format
+	// two replacers used so we only remove the prefix keyword `table`
+	if strings.HasPrefix(f, "table ") {
+		f = tableReplacer.Replace(f)
+	} else {
+		f = escapedReplacer.Replace(format)
+	}
+
+	if !strings.HasSuffix(f, "\n") {
+		f += "\n"
+	}
+
+	return f
+}
+
+// Headers queries the interface for field names
+func Headers(object interface{}, overrides map[string]string) []map[string]string {
+	value := reflect.ValueOf(object)
+	if value.Kind() == reflect.Ptr {
+		value = value.Elem()
+	}
+
+	// Column header will be field name upper-cased.
+	headers := make(map[string]string, value.NumField())
+	for i := 0; i < value.Type().NumField(); i++ {
+		field := value.Type().Field(i)
+		// Recurse to find field names from promoted structs
+		if field.Type.Kind() == reflect.Struct && field.Anonymous {
+			h := Headers(reflect.New(field.Type).Interface(), nil)
+			for k, v := range h[0] {
+				headers[k] = v
+			}
+			continue
+		}
+		headers[field.Name] = strings.ToUpper(field.Name)
+	}
+
+	if len(overrides) > 0 {
+		// Override column header as provided
+		for k, v := range overrides {
+			headers[k] = strings.ToUpper(v)
+		}
+	}
+	return []map[string]string{headers}
+}

--- a/cmd/podman/report/format_test.go
+++ b/cmd/podman/report/format_test.go
@@ -1,0 +1,35 @@
+package report
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeFormat(t *testing.T) {
+	cases := []struct {
+		format   string
+		expected string
+	}{
+		{"table {{.ID}}", "{{.ID}}\n"},
+		{"table {{.ID}} {{.C}}", "{{.ID}}\t{{.C}}\n"},
+		{"{{.ID}}", "{{.ID}}\n"},
+		{"{{.ID}}\n", "{{.ID}}\n"},
+		{"{{.ID}} {{.C}}", "{{.ID}} {{.C}}\n"},
+		{"\t{{.ID}}", "\t{{.ID}}\n"},
+		{`\t` + "{{.ID}}", "\t{{.ID}}\n"},
+		{"table {{.ID}}\t{{.C}}", "{{.ID}}\t{{.C}}\n"},
+		{"{{.ID}} table {{.C}}", "{{.ID}} table {{.C}}\n"},
+	}
+	for _, tc := range cases {
+		tc := tc
+
+		label := strings.ReplaceAll(tc.format, " ", "<sp>")
+		t.Run("NormalizeFormat/"+label, func(t *testing.T) {
+			t.Parallel()
+			actual := NormalizeFormat(tc.format)
+			if actual != tc.expected {
+				t.Errorf("Expected %q, actual %q", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -50,15 +50,17 @@ var _ = Describe("Podman Info", func() {
 			{"{{ json .}}", true, 0},
 			{"{{json .   }}", true, 0},
 			{"  {{  json .    }}   ", true, 0},
-			{"{{json }}", false, 125},
+			{"{{json }}", true, 0},
 			{"{{json .", false, 125},
-			{"json . }}", false, 0}, // Note: this does NOT fail but produces garbage
+			{"json . }}", false, 0}, // without opening {{ template seen as string literal
 		}
 		for _, tt := range tests {
 			session := podmanTest.Podman([]string{"info", "--format", tt.input})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(tt.exitCode))
-			Expect(session.IsJSONOutputValid()).To(Equal(tt.success))
+
+			desc := fmt.Sprintf("JSON test(%q)", tt.input)
+			Expect(session).Should(Exit(tt.exitCode), desc)
+			Expect(session.IsJSONOutputValid()).To(Equal(tt.success), desc)
 		}
 	})
 

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/containers/podman/v2/test/utils"
@@ -68,15 +69,17 @@ var _ = Describe("Podman version", func() {
 			{"{{ json .}}", true, 0},
 			{"{{json .   }}", true, 0},
 			{"  {{  json .    }}   ", true, 0},
-			{"{{json }}", false, 125},
+			{"{{json }}", true, 0},
 			{"{{json .", false, 125},
-			{"json . }}", false, 0}, // Note: this does NOT fail but produces garbage
+			{"json . }}", false, 0}, // without opening {{ template seen as string literal
 		}
 		for _, tt := range tests {
 			session := podmanTest.Podman([]string{"version", "--format", tt.input})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(Exit(tt.exitCode))
-			Expect(session.IsJSONOutputValid()).To(Equal(tt.success))
+
+			desc := fmt.Sprintf("JSON test(%q)", tt.input)
+			Expect(session).Should(Exit(tt.exitCode), desc)
+			Expect(session.IsJSONOutputValid()).To(Equal(tt.success), desc)
 		}
 	})
 


### PR DESCRIPTION
* --format "table {{.field..." will print fields out in a table with
  headings.  Table keyword is removed, spaces between fields are
  converted to tabs.
* Update parse.MatchesJSONFormat()'s regex to be more inclusive
* Add report.Headers(), obtain all the field names to be used as
  column names, a map of field name to column name may be provided
  to override the field names.

Note: This PR provides the functions to support this feature.  Once merged, follow-on PR's will implement the necessary changes in the podman commands.

Signed-off-by: Jhon Honce <jhonce@redhat.com>