### PR TITLE
Do not set host IP on ports when 0.0.0.0 requested

### DIFF
--- a/cmd/podman/common/util.go
+++ b/cmd/podman/common/util.go
@@ -175,12 +175,15 @@ func parseSplitPort(hostIP, hostPort *string, ctrPort string, protocol *string) 
 	if hostIP != nil {
 		if *hostIP == "" {
 			return newPort, errors.Errorf("must provide a non-empty container host IP to publish")
+		} else if *hostIP != "0.0.0.0" {
+			// If hostIP is 0.0.0.0, leave it unset - CNI treats
+			// 0.0.0.0 and empty differently, Docker does not.
+			testIP := net.ParseIP(*hostIP)
+			if testIP == nil {
+				return newPort, errors.Errorf("cannot parse %q as an IP address", *hostIP)
+			}
+			newPort.HostIP = testIP.String()
 		}
-		testIP := net.ParseIP(*hostIP)
-		if testIP == nil {
-			return newPort, errors.Errorf("cannot parse %q as an IP address", *hostIP)
-		}
-		newPort.HostIP = testIP.String()
 	}
 	if hostPort != nil {
 		if *hostPort == "" {

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -634,7 +634,8 @@ Both hostPort and containerPort can be specified as a range of ports.
 When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range.
 (e.g., `podman run -p 1234-1236:1222-1224 --name thisWorks -t busybox`
 but not `podman run -p 1230-1236:1230-1240 --name RangeContainerPortsBiggerThanRangeHostPorts -t busybox`)
-With ip: `podman run -p 127.0.0.1:$HOSTPORT:$CONTAINERPORT --name CONTAINER -t someimage`
+With host IP: `podman run -p 127.0.0.1:$HOSTPORT:$CONTAINERPORT --name CONTAINER -t someimage`
+If host IP is set to 0.0.0.0 or not set at all, the port will be bound on all IPs on the host.
 Host port does not have to be specified (e.g. `podman run -p 127.0.0.1::80`).
 If it is not, the container port will be randomly assigned a port on the host.
 Use `podman port` to see the actual mapping: `podman port CONTAINER $CONTAINERPORT`

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -647,6 +647,8 @@ Both hostPort and containerPort can be specified as a range of ports.
 
 When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range.
 
+If host IP is set to 0.0.0.0 or not set at all, the port will be bound on all IPs on the host.
+
 Host port does not have to be specified (e.g. `podman run -p 127.0.0.1::80`).
 If it is not, the container port will be randomly assigned a port on the host.
 

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -236,6 +236,18 @@ var _ = Describe("Podman run networking", func() {
 		Expect((hp1 == "4000" && hp2 == "8000") || (hp1 == "8000" && hp2 == "4000")).To(BeTrue())
 	})
 
+	It("podman run -p 0.0.0.0:8080:80", func() {
+		name := "testctr"
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "0.0.0.0:8080:80", "--name", name, ALPINE, "/bin/sh"})
+		session.WaitWithDefaultTimeout()
+		inspectOut := podmanTest.InspectContainer(name)
+		Expect(len(inspectOut)).To(Equal(1))
+		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
+		Expect(len(inspectOut[0].NetworkSettings.Ports["80/tcp"])).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("8080"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal(""))
+	})
+
 	It("podman run network expose host port 80 to container port 8000", func() {
 		SkipIfRootless()
 		session := podmanTest.Podman([]string{"run", "-dt", "-p", "80:8000", ALPINE, "/bin/sh"})


### PR DESCRIPTION
Docker and CNI have very different ideas of what 0.0.0.0 means. Docker takes it to be 0.0.0.0/0 - that is, bind to every IPv4 address on the host. CNI (and, thus, root Podman) take it to mean the literal IP 0.0.0.0. Instead, CNI interprets the empty string ("") as "bind to all IPs".

We could ask CNI to change, but given this is established behavior, that's unlikely. Instead, let's just catch 0.0.0.0 and turn it into "" when we parse ports.

Fixes #7014
