### PR TITLE
Missing return after early exit

### DIFF
--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -24,6 +24,7 @@ func ContainerExists(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Cause(err) == define.ErrNoSuchCtr {
 			utils.ContainerNotFound(w, name, err)
+			return
 		}
 		utils.InternalServerError(w, err)
 		return


### PR DESCRIPTION
the exists code was plagued by a missing return statement meant to trigger an early exit.

Fixes: #7197

Signed-off-by: Brent Baude <bbaude@redhat.com>