### PR TITLE
Improve error message when creating a pod/ctr with the same name

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -2347,11 +2347,19 @@ func (s *BoltState) AddPod(pod *Pod) error {
 		// Check if we already have something with the given ID and name
 		idExist := idsBkt.Get(podID)
 		if idExist != nil {
-			return errors.Wrapf(define.ErrPodExists, "ID %s is in use", pod.ID())
+			err = define.ErrPodExists
+			if allPodsBkt.Get(idExist) == nil {
+				err = define.ErrCtrExists
+			}
+			return errors.Wrapf(err, "ID \"%s\" is in use", pod.ID())
 		}
 		nameExist := namesBkt.Get(podName)
 		if nameExist != nil {
-			return errors.Wrapf(define.ErrPodExists, "name %s is in use", pod.Name())
+			err = define.ErrPodExists
+			if allPodsBkt.Get(nameExist) == nil {
+				err = define.ErrCtrExists
+			}
+			return errors.Wrapf(err, "name \"%s\" is in use", pod.Name())
 		}
 
 		// We are good to add the pod

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -586,11 +586,19 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 		// Check if we already have a container with the given ID and name
 		idExist := idsBucket.Get(ctrID)
 		if idExist != nil {
-			return errors.Wrapf(define.ErrCtrExists, "ID %s is in use", ctr.ID())
+			err = define.ErrCtrExists
+			if allCtrsBucket.Get(idExist) == nil {
+				err = define.ErrPodExists
+			}
+			return errors.Wrapf(err, "ID \"%s\" is in use", ctr.ID())
 		}
 		nameExist := namesBucket.Get(ctrName)
 		if nameExist != nil {
-			return errors.Wrapf(define.ErrCtrExists, "name %s is in use", ctr.Name())
+			err = define.ErrCtrExists
+			if allCtrsBucket.Get(nameExist) == nil {
+				err = define.ErrPodExists
+			}
+			return errors.Wrapf(err, "name \"%s\" is in use", ctr.Name())
 		}
 
 		// No overlapping containers


### PR DESCRIPTION
Check if there is an pod or container an return
the appropriate error message instead of blindly
return 'container exists' with `podman create` and
'pod exists' with `podman pod create`.

Example:
```
$ podman pod create --name test
f0ebce3c66d4634e92b64bcd42c006b3538f6e519f640b84efdff6e1b692b397
$ podman create --name test alpine
Error: name test is in use: container already exists
$ ./bin/podman create --name test alpine
Error: name "test" is in use: pod already exists
```