### PR TITLE
Accept multiple Content-Types for building an image

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -33,9 +33,21 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if hdr, found := r.Header["Content-Type"]; found && len(hdr) > 0 {
-		if hdr[0] != "application/x-tar" {
+		validContentTypes := []string{
+			"application/tar",
+			"application/x-tar",
+			"application/x-gtar",
+		}
+
+		isValidContentType := false
+		for _, validContentType := range validContentTypes {
+			if validContentType == hdr[0] {
+				isValidContentType = true
+			}
+		}
+		if !isValidContentType {
 			utils.BadRequest(w, "Content-Type", hdr[0],
-				fmt.Errorf("Content-Type: %s is not supported. Should be \"application/x-tar\"", hdr[0]))
+				fmt.Errorf("Content-Type: %s is not supported. Should be one of %s", hdr[0], validContentTypes))
 			return
 		}
 	}

--- a/pkg/api/server/docs.go
+++ b/pkg/api/server/docs.go
@@ -52,6 +52,8 @@
 //
 //     Consumes:
 //     - application/json
+//     - application/tar
 //     - application/x-tar
+//     - application/x-gtar
 // swagger:meta
 package server


### PR DESCRIPTION
Signed-off-by: orenbm oren.benmeir@cyberark.com
Fixes: #7185

Currently we accept only the 'application/x-tar' header when sending
the tar file for building an image. However, [this header has the aliases
'application/tar' and 'application/x-gtar'](http://help.dottoro.com/lapuadlp.php) 
so we should accept those as well.

Furthermore, [docker-compose uses 'application/tar'](https://docs.docker.com/engine/api/v1.25/#operation/ImageBuild) so accepting this content-type
will take us one step further in supporting docker-compose with the Podman API.