### PR TITLE
podman: support --mount type=devpts

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -494,7 +494,7 @@ Tune a container's memory swappiness behavior. Accepts an integer between 0 and 
 
 Attach a filesystem mount to the container
 
-Current supported mount TYPES are `bind`, `volume`, and `tmpfs`. <sup>[[1]](#Footnote1)</sup>
+Current supported mount TYPES are `bind`, `volume`, `tmpfs` and `devpts`. <sup>[[1]](#Footnote1)</sup>
 
        e.g.
 
@@ -505,6 +505,8 @@ Current supported mount TYPES are `bind`, `volume`, and `tmpfs`. <sup>[[1]](#Foo
        type=volume,source=vol1,destination=/path/in/container,ro=true
 
        type=tmpfs,tmpfs-size=512M,destination=/path/in/container
+
+       type=devpts,destination=/dev/pts
 
        Common Options:
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -501,7 +501,7 @@ Tune a container's memory swappiness behavior. Accepts an integer between *0* an
 
 Attach a filesystem mount to the container
 
-Current supported mount TYPEs are **bind**, **volume**, and **tmpfs**. <sup>[[1]](#Footnote1)</sup>
+Current supported mount TYPEs are **bind**, **volume**, **tmpfs** and **devpts**. <sup>[[1]](#Footnote1)</sup>
 
        e.g.
 
@@ -512,6 +512,8 @@ Current supported mount TYPEs are **bind**, **volume**, and **tmpfs**. <sup>[[1]
        type=volume,source=vol1,destination=/path/in/container,ro=true
 
        type=tmpfs,tmpfs-size=512M,destination=/path/in/container
+
+       type=devpts,destination=/dev/pts
 
        Common Options:
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -811,6 +811,14 @@ USER mail`
 		Expect(len(session.OutputToStringArray())).To(Equal(1))
 	})
 
+	It("podman run --mount type=devpts,target=/foo/bar", func() {
+		SkipIfRootless()
+		session := podmanTest.Podman([]string{"run", "--mount", "type=devpts,target=/foo/bar", fedoraMinimal, "stat", "-f", "-c%T", "/foo/bar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("devpts"))
+	})
+
 	It("podman run --pod automatically", func() {
 		session := podmanTest.Podman([]string{"run", "-d", "--pod", "new:foobar", ALPINE, "nc", "-l", "-p", "8080"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Allow to create a devpts mount.

This is useful for containers that bind mount /dev/ from the host but
at the same time want to create a terminal.

It can be used as:

podman run -v /dev:/dev --mount type=devpts,target=/dev/pts ...

Closes: https://github.com/containers/podman/issues/6804

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>