### PR TITLE
Refactor parsing to not require --remote to be first flag

### DIFF
--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -207,6 +207,10 @@ func WaitContainerReady(p PodmanTestCommon, id string, expStr string, timeout in
 
 // OutputToString formats session output to string
 func (s *PodmanSession) OutputToString() string {
+	if s == nil || s.Out == nil || s.Out.Contents() == nil {
+		return ""
+	}
+
 	fields := strings.Fields(string(s.Out.Contents()))
 	return strings.Join(fields, " ")
 }


### PR DESCRIPTION
Use cobra.Command.FParseErrWhitelist to no longer require --remote to be
the first argument in flags when using CLI

* tweaked test utils to prevent panics

Fixes: #7211

Signed-off-by: Jhon Honce <jhonce@redhat.com>