### PR TITLE
support outbound-addr

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -560,9 +560,14 @@ Valid values are:
 - `ns:<path>`: path to a network namespace to join
 - `private`: create a new namespace for the container (default)
 - `slirp4netns[:OPTIONS,...]`: use slirp4netns to create a user network stack.  This is the default for rootless containers.  It is possible to specify these additional options:
-  **port_handler=rootlesskit**: Use rootlesskit for port forwarding.  Default.
-  **port_handler=slirp4netns**: Use the slirp4netns port forwarding.
-  **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`).  Default to false.
+  - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
+  - **enable_ipv6=true|false**: Enable IPv6. Default is false. (Required for `outbound_addr6`).
+  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp should bind to (ipv4 traffic only).
+  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp should bind to.
+  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp should bind to (ipv6 traffic only).
+  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp should bind to.
+  - **port_handler=rootlesskit**: Use rootlesskit for port forwarding. Default.
+  - **port_handler=slirp4netns**: Use the slirp4netns port forwarding.
 
 **--network-alias**=*alias*
 

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -1,11 +1,14 @@
 package integration
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	. "github.com/containers/podman/v2/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/uber/jaeger-client-go/utils"
 )
 
 var _ = Describe("Podman run networking", func() {
@@ -276,6 +279,53 @@ var _ = Describe("Podman run networking", func() {
 		session := podmanTest.Podman([]string{"run", "--network", "slirp4netns:allow_host_loopback=true", ALPINE, "ping", "-c1", "10.0.2.2"})
 		session.Wait(30)
 		Expect(session.ExitCode()).To(Equal(0))
+	})
+
+	It("podman run network bind to 127.0.0.1", func() {
+		slirp4netnsHelp := SystemExec("slirp4netns", []string{"--help"})
+		Expect(slirp4netnsHelp.ExitCode()).To(Equal(0))
+		networkConfiguration := "slirp4netns:outbound_addr=127.0.0.1,allow_host_loopback=true"
+
+		if strings.Contains(slirp4netnsHelp.OutputToString(), "outbound-addr") {
+			ncListener := StartSystemExec("nc", []string{"-v", "-n", "-l", "-p", "8083"})
+			session := podmanTest.Podman([]string{"run", "--network", networkConfiguration, "-dt", ALPINE, "nc", "-w", "2", "10.0.2.2", "8083"})
+			session.Wait(30)
+			ncListener.Wait(30)
+
+			Expect(session.ExitCode()).To(Equal(0))
+			Expect(ncListener.ExitCode()).To(Equal(0))
+			Expect(ncListener.ErrorToString()).To(ContainSubstring("127.0.0.1"))
+		} else {
+			session := podmanTest.Podman([]string{"run", "--network", networkConfiguration, "-dt", ALPINE, "nc", "-w", "2", "10.0.2.2", "8083"})
+			session.Wait(30)
+			Expect(session.ExitCode()).ToNot(Equal(0))
+			Expect(session.ErrorToString()).To(ContainSubstring("outbound_addr not supported"))
+		}
+	})
+
+	It("podman run network bind to HostIP", func() {
+		ip, err := utils.HostIP()
+		Expect(err).To(BeNil())
+
+		slirp4netnsHelp := SystemExec("slirp4netns", []string{"--help"})
+		Expect(slirp4netnsHelp.ExitCode()).To(Equal(0))
+		networkConfiguration := fmt.Sprintf("slirp4netns:outbound_addr=%s,allow_host_loopback=true", ip.String())
+
+		if strings.Contains(slirp4netnsHelp.OutputToString(), "outbound-addr") {
+			ncListener := StartSystemExec("nc", []string{"-v", "-n", "-l", "-p", "8084"})
+			session := podmanTest.Podman([]string{"run", "--network", networkConfiguration, "-dt", ALPINE, "nc", "-w", "2", "10.0.2.2", "8084"})
+			session.Wait(30)
+			ncListener.Wait(30)
+
+			Expect(session.ExitCode()).To(Equal(0))
+			Expect(ncListener.ExitCode()).To(Equal(0))
+			Expect(ncListener.ErrorToString()).To(ContainSubstring(ip.String()))
+		} else {
+			session := podmanTest.Podman([]string{"run", "--network", networkConfiguration, "-dt", ALPINE, "nc", "-w", "2", "10.0.2.2", "8084"})
+			session.Wait(30)
+			Expect(session.ExitCode()).ToNot(Equal(0))
+			Expect(session.ErrorToString()).To(ContainSubstring("outbound_addr not supported"))
+		}
 	})
 
 	It("podman run network expose ports in image metadata", func() {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -341,6 +341,16 @@ func SystemExec(command string, args []string) *PodmanSession {
 	return &PodmanSession{session}
 }
 
+// StartSystemExec is used to start exec a system command
+func StartSystemExec(command string, args []string) *PodmanSession {
+	c := exec.Command(command, args...)
+	session, err := gexec.Start(c, GinkgoWriter, GinkgoWriter)
+	if err != nil {
+		Fail(fmt.Sprintf("unable to run command: %s %s", command, strings.Join(args, " ")))
+	}
+	return &PodmanSession{session}
+}
+
 // StringInSlice determines if a string is in a string slice, returns bool
 func StringInSlice(s string, sl []string) bool {
 	for _, i := range sl {


### PR DESCRIPTION
Changes to support binding to specific outbound address. Mentioned in #6064. Follow ups to #6324 and #6965.