### PR TITLE
Build without Volume Mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV GOSRC=$GOPATH/src/github.com/containers/podman
 ENV SCRIPT_BASE=./contrib/cirrus
 ENV PACKER_BASE=$SCRIPT_BASE/packer
 
-ADD / $GOSRC
+ADD . $GOSRC
 WORKDIR $GOSRC
 
 # Re-use repositories and package setup as in VMs under CI

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,10 @@ libpodimage: ## Build the libpod image
 
 .PHONY: dbuild
 dbuild: libpodimage
-	${CONTAINER_RUNTIME} run --name=${LIBPOD_INSTANCE} --privileged -v ${PWD}:/go/src/${PROJECT} --rm ${LIBPOD_IMAGE} make all
+	-${CONTAINER_RUNTIME} rm ${LIBPOD_INSTANCE}
+	${CONTAINER_RUNTIME} run --name=${LIBPOD_INSTANCE} --privileged ${LIBPOD_IMAGE} make all
+	${CONTAINER_RUNTIME} cp ${LIBPOD_INSTANCE}:/var/tmp/go/src/github.com/containers/podman/bin/podman bin/
+	-${CONTAINER_RUNTIME} rm ${LIBPOD_INSTANCE}
 
 .PHONY: dbuild-podman-remote
 dbuild-podman-remote: libpodimage


### PR DESCRIPTION
as it's currently not working for me and maybe for others.
But I don't know about other people's opinion, I find building this way
even more elegent as the build tooling writer has more
control over what to actually take.

```
$ python -c "import this"
The Zen of Python, by Tim Peters

Beautiful is better than ugly.
Explicit is better than implicit. <- i.e. it's this
Simple is better than complex.
[...]
```

I'll still continue debugging the volume mounting though, no worries.