### PR TITLE
podman-remote send name and tag

### DIFF
--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -196,7 +196,11 @@ func (ir *ImageEngine) Load(ctx context.Context, opts entities.ImageLoadOptions)
 		return nil, err
 	}
 	defer f.Close()
-	return images.Load(ir.ClientCxt, f, &opts.Name)
+	ref := opts.Name
+	if len(opts.Tag) > 0 {
+		ref += ":" + opts.Tag
+	}
+	return images.Load(ir.ClientCxt, f, &ref)
 }
 
 func (ir *ImageEngine) Import(ctx context.Context, opts entities.ImageImportOptions) (*entities.ImageImportReport, error) {

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -77,8 +77,6 @@ verify_iid_and_name() {
 }
 
 @test "podman load - NAME and NAME:TAG arguments work" {
-    skip_if_remote "FIXME: pending #7124"
-
     get_iid_and_name
     run_podman save $iid -o $archive
     run_podman rmi $iid


### PR DESCRIPTION
when loading an image with podman-remote load, we need to send a name and a tag to the endpoint

Fixes: #7124

Signed-off-by: Brent Baude <bbaude@redhat.com>