### PR TITLE
remove --latest for all remote commands

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"runtime"
 	"runtime/pprof"
-	"strconv"
 	"strings"
 
 	"github.com/containers/common/pkg/config"
@@ -111,15 +110,6 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := registry.PodmanConfig()
-
-	// Validate --remote and --latest not given on same command
-	latest := cmd.Flags().Lookup("latest")
-	if latest != nil {
-		value, _ := strconv.ParseBool(latest.Value.String())
-		if cfg.Remote && value {
-			return errors.Errorf("For %s \"--remote\" and \"--latest\", are mutually exclusive flags", cmd.CommandPath())
-		}
-	}
 
 	// Prep the engines
 	if _, err := registry.NewImageEngine(cmd, args); err != nil {

--- a/cmd/podman/validate/args.go
+++ b/cmd/podman/validate/args.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -47,17 +48,20 @@ func IDOrLatestArgs(cmd *cobra.Command, args []string) error {
 // CheckAllLatestAndCIDFile checks that --all and --latest are used correctly.
 // If cidfile is set, also check for the --cidfile flag.
 func CheckAllLatestAndCIDFile(c *cobra.Command, args []string, ignoreArgLen bool, cidfile bool) error {
+	var specifiedLatest bool
 	argLen := len(args)
-	if c.Flags().Lookup("all") == nil || c.Flags().Lookup("latest") == nil {
-		if !cidfile {
-			return errors.New("unable to lookup values for 'latest' or 'all'")
-		} else if c.Flags().Lookup("cidfile") == nil {
-			return errors.New("unable to lookup values for 'latest', 'all' or 'cidfile'")
+	if !registry.IsRemote() {
+		specifiedLatest, _ = c.Flags().GetBool("latest")
+		if c.Flags().Lookup("all") == nil || c.Flags().Lookup("latest") == nil {
+			if !cidfile {
+				return errors.New("unable to lookup values for 'latest' or 'all'")
+			} else if c.Flags().Lookup("cidfile") == nil {
+				return errors.New("unable to lookup values for 'latest', 'all' or 'cidfile'")
+			}
 		}
 	}
 
 	specifiedAll, _ := c.Flags().GetBool("all")
-	specifiedLatest, _ := c.Flags().GetBool("latest")
 	specifiedCIDFile := false
 	if cid, _ := c.Flags().GetStringArray("cidfile"); len(cid) > 0 {
 		specifiedCIDFile = true
@@ -98,17 +102,21 @@ func CheckAllLatestAndCIDFile(c *cobra.Command, args []string, ignoreArgLen bool
 // CheckAllLatestAndPodIDFile checks that --all and --latest are used correctly.
 // If withIDFile is set, also check for the --pod-id-file flag.
 func CheckAllLatestAndPodIDFile(c *cobra.Command, args []string, ignoreArgLen bool, withIDFile bool) error {
+	var specifiedLatest bool
 	argLen := len(args)
-	if c.Flags().Lookup("all") == nil || c.Flags().Lookup("latest") == nil {
-		if !withIDFile {
-			return errors.New("unable to lookup values for 'latest' or 'all'")
-		} else if c.Flags().Lookup("pod-id-file") == nil {
-			return errors.New("unable to lookup values for 'latest', 'all' or 'pod-id-file'")
+	if !registry.IsRemote() {
+		// remote clients have no latest flag
+		specifiedLatest, _ = c.Flags().GetBool("latest")
+		if c.Flags().Lookup("all") == nil || c.Flags().Lookup("latest") == nil {
+			if !withIDFile {
+				return errors.New("unable to lookup values for 'latest' or 'all'")
+			} else if c.Flags().Lookup("pod-id-file") == nil {
+				return errors.New("unable to lookup values for 'latest', 'all' or 'pod-id-file'")
+			}
 		}
 	}
 
 	specifiedAll, _ := c.Flags().GetBool("all")
-	specifiedLatest, _ := c.Flags().GetBool("latest")
 	specifiedPodIDFile := false
 	if pid, _ := c.Flags().GetStringArray("pod-id-file"); len(pid) > 0 {
 		specifiedPodIDFile = true

--- a/cmd/podman/validate/latest.go
+++ b/cmd/podman/validate/latest.go
@@ -7,9 +7,8 @@ import (
 
 func AddLatestFlag(cmd *cobra.Command, b *bool) {
 	// Initialization flag verification
-	cmd.Flags().BoolVarP(b, "latest", "l", false,
-		"Act on the latest container podman is aware of\nNot supported with the \"--remote\" flag")
-	if registry.IsRemote() {
-		_ = cmd.Flags().MarkHidden("latest")
+	if !registry.IsRemote() {
+		cmd.Flags().BoolVarP(b, "latest", "l", false,
+			"Act on the latest container podman is aware of\nNot supported with the \"--remote\" flag")
 	}
 }


### PR DESCRIPTION
instead of hiding the latest options for podman-remote or catching an error if podman --remote <cmd> -l is used, we no longer add the latest option to any remote command.  podman will error with a "unknown flag" option.

Fixes: #7127

Signed-off-by: Brent Baude <bbaude@redhat.com>