### PR TITLE
correct go-binding key for volumes

### DIFF
--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -98,7 +98,7 @@ func Remove(ctx context.Context, nameOrID string, force, volumes *bool) error {
 		params.Set("force", strconv.FormatBool(*force))
 	}
 	if volumes != nil {
-		params.Set("vols", strconv.FormatBool(*volumes))
+		params.Set("v", strconv.FormatBool(*volumes))
 	}
 	response, err := conn.DoRequest(nil, http.MethodDelete, "/containers/%s", params, nil, nameOrID)
 	if err != nil {

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -142,8 +142,6 @@ EOF
 
 # Anonymous temporary volumes, and persistent autocreated named ones
 @test "podman volume, implicit creation with run" {
-    skip_if_remote "FIXME: pending #7128"
-
     # No hostdir arg: create anonymous container with random name
     rand=$(random_string)
     run_podman run -v /myvol $IMAGE sh -c "echo $rand >/myvol/myfile"


### PR DESCRIPTION
the go binding for remove container was using 'vols' for a key to remove volumes associated to the container.  the correct key should be "v" and is documented as such.

Fixes: #7128

Signed-off-by: Brent Baude <bbaude@redhat.com>