### PR TITLE
Handle podman-remote run --rm

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -96,8 +96,6 @@ echo $rand        |   0 | $rand
     # Believe it or not, 'sh -c' resulted in different behavior
     run_podman 0 run --rm $IMAGE sh -c /bin/true
     run_podman 1 run --rm $IMAGE sh -c /bin/false
-
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 }
 
 @test "podman run --name" {
@@ -266,8 +264,6 @@ echo $rand        |   0 | $rand
             done
         done
     done
-
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 }
 
 # #6829 : add username to /etc/passwd inside container if --userns=keep-id
@@ -292,8 +288,6 @@ echo $rand        |   0 | $rand
     run_podman run --rm --privileged --userns=keep-id --user=0 $IMAGE id -un
     remove_same_dev_warning      # grumble
     is "$output" "root" "--user=0 overrides keep-id"
-
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 }
 
 # #6991 : /etc/passwd is modifiable

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -91,7 +91,6 @@ ADD https://github.com/containers/podman/blob/master/README.md /tmp/
 EOF
     run_podman build -t add_url $tmpdir
     run_podman run --rm add_url stat /tmp/README.md
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman rmi -f add_url
 
     # Now test COPY. That should fail.

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -93,7 +93,6 @@ Labels.l       | $mylabel
     is "$(<$mountpoint/myfile)" "$rand" "we see content created in container"
 
     # Clean up
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman volume rm $myvolume
 }
 
@@ -135,7 +134,6 @@ EOF
     is "$output" "got here -$rand-" "script in volume is runnable with default (exec)"
 
     # Clean up
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman volume rm $myvolume
 }
 
@@ -173,7 +171,6 @@ EOF
     run_podman run --rm -v $myvol:/myvol:z $IMAGE \
                sh -c "cp /myvol/myfile /myvol/myfile2"
 
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman volume rm $myvol
 
     # Autocreated volumes should also work with keep-id
@@ -182,7 +179,6 @@ EOF
     run_podman run --rm -v $myvol:/myvol:z --userns=keep-id $IMAGE \
                touch /myvol/myfile
 
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman volume rm $myvol
 }
 

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -93,7 +93,6 @@ function teardown() {
     is "$output" "$message" "message sent from one container to another"
 
     # Clean up. First the nc -l container...
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman rm $cid1
 
     # ...then, from pause container, find the image ID of the pause image...
@@ -104,7 +103,6 @@ function teardown() {
     pause_iid="$output"
 
     # ...then rm the pod, then rmi the pause image so we don't leave strays.
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman pod rm $podname
     run_podman rmi $pause_iid
 
@@ -215,7 +213,6 @@ function random_ip() {
     is "$output" ".*options $dns_opt"        "--dns-opt was added"
 
     # pod inspect
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
     run_podman pod inspect --format '{{.Name}}: {{.ID}} : {{.NumContainers}} : {{.Labels}}' mypod
     is "$output" "mypod: $pod_id : 1 : map\[${labelname}:${labelvalue}]" \
        "pod inspect --format ..."

--- a/test/system/300-cli-parsing.bats
+++ b/test/system/300-cli-parsing.bats
@@ -10,8 +10,6 @@ load helpers
     #   Error: invalid argument "true=\"false\"" for "-l, --label" \
     #      flag: parse error on line 1, column 5: bare " in non-quoted-field
     run_podman run --rm --label 'true="false"' $IMAGE true
-
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 }
 
 # vim: filetype=sh

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -165,8 +165,6 @@ EOF
             die "$path: Unknown file type '$type'"
         fi
     done
-
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 }
 
 # vim: filetype=sh

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -16,7 +16,6 @@ function check_label() {
     # FIXME: it'd be nice to specify the command to run, e.g. 'ls -dZ /',
     # but alpine ls (from busybox) doesn't support -Z
     run_podman run --rm $args $IMAGE cat -v /proc/self/attr/current
-    if is_remote; then sleep 2;fi   # FIXME: pending #7119
 
     # FIXME: on some CI systems, 'run --privileged' emits a spurious
     # warning line about dup devices. Ignore it.


### PR DESCRIPTION
We need to remove the container after it has exited for
podman-remote run --rm commands.  If we don't remove this
container at this step, we open ourselves up to race conditions.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>