### PR TITLE
run, create: add new security-opt proc-opts 

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -511,6 +511,8 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 			}
 
 			switch con[0] {
+			case "proc-opts":
+				s.ProcOpts = strings.Split(con[1], ",")
 			case "label":
 				// TODO selinux opts and label opts are the same thing
 				s.ContainerSecurityConfig.SelinuxOpts = append(s.ContainerSecurityConfig.SelinuxOpts, con[1])

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -756,6 +756,9 @@ Security Options
 - `seccomp=unconfined` : Turn off seccomp confinement for the container
 - `seccomp=profile.json` :  White listed syscalls seccomp Json file to be used as a seccomp filter
 
+- `proc-opts=OPTIONS` : Comma separated list of options to use for the /proc mount.  More details for the
+  possible mount options are specified at **proc(5)** man page.
+
 Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
 
 **--shm-size**=*size*
@@ -1168,7 +1171,7 @@ b
 NOTE: Use the environment variable `TMPDIR` to change the temporary storage location of downloaded container images. Podman defaults to use `/var/tmp`.
 
 ## SEE ALSO
-**subgid**(5), **subuid**(5), **containers.conf**(5), **systemd.unit**(5), **setsebool**(8), **slirp4netns**(1), **fuse-overlayfs**(1).
+**subgid**(5), **subuid**(5), **containers.conf**(5), **systemd.unit**(5), **setsebool**(8), **slirp4netns**(1), **fuse-overlayfs**(1), **proc**(5)**.
 
 ## HISTORY
 October 2017, converted from Docker documentation to Podman by Dan Walsh for Podman <dwalsh@redhat.com>

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -774,6 +774,8 @@ Security Options
 - **no-new-privileges**: Disable container processes from gaining additional privileges
 - **seccomp=unconfined**: Turn off seccomp confinement for the container
 - **seccomp**=_profile.json_:  Allowed syscall list seccomp JSON file to be used as a seccomp filter
+- **proc-opts**=_OPTIONS_ : Comma separated list of options to use for the /proc mount.  More details
+  for the possible mount options are specified at **proc(5)** man page.
 
 Note: Labeling can be disabled for all containers by setting **label=false** in the **containers.conf**(5) file.
 
@@ -1449,7 +1451,7 @@ b
 NOTE: Use the environment variable `TMPDIR` to change the temporary storage location of downloaded container images. Podman defaults to use `/var/tmp`.
 
 ## SEE ALSO
-**subgid**(5), **subuid**(5), **containers.conf**(5), **systemd.unit**(5), **setsebool**(8), **slirp4netns**(1), **fuse-overlayfs**(1).
+**subgid**(5), **subuid**(5), **containers.conf**(5), **systemd.unit**(5), **setsebool**(8), **slirp4netns**(1), **fuse-overlayfs**(1), **proc**(5)**.
 
 ## HISTORY
 September 2018, updated by Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -125,6 +125,7 @@ type SecurityConfig struct {
 	ReadOnlyRootfs          bool              //read-only
 	ReadOnlyTmpfs           bool              //read-only-tmpfs
 	Sysctl                  map[string]string //sysctl
+	ProcOpts                []string
 }
 
 // CreateConfig is a pre OCI spec structure.  It represents user input from varlink or the CLI

--- a/pkg/spec/security.go
+++ b/pkg/spec/security.go
@@ -76,6 +76,8 @@ func (c *SecurityConfig) SetSecurityOpts(runtime *libpod.Runtime, securityOpts [
 			}
 
 			switch con[0] {
+			case "proc-opts":
+				c.ProcOpts = strings.Split(con[1], ",")
 			case "label":
 				c.LabelOpts = append(c.LabelOpts, con[1])
 			case "apparmor":

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -18,6 +18,18 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func setProcOpts(s *specgen.SpecGenerator, g *generate.Generator) {
+	if s.ProcOpts == nil {
+		return
+	}
+	for i := range g.Config.Mounts {
+		if g.Config.Mounts[i].Destination == "/proc" {
+			g.Config.Mounts[i].Options = s.ProcOpts
+			return
+		}
+	}
+}
+
 func addRlimits(s *specgen.SpecGenerator, g *generate.Generator) error {
 	var (
 		isRootless = rootless.IsRootless()
@@ -340,6 +352,8 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	} else {
 		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseFalse
 	}
+
+	setProcOpts(s, &g)
 
 	return configSpec, nil
 }

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -289,6 +289,8 @@ type ContainerSecurityConfig struct {
 	ReadOnlyFilesystem bool `json:"read_only_filesystem,omittempty"`
 	// Umask is the umask the init process of the container will be run with.
 	Umask string `json:"umask,omitempty"`
+	// ProcOpts are the options used for the proc mount.
+	ProcOpts []string `json:"procfs_opts,omitempty"`
 }
 
 // ContainerCgroupConfig contains configuration information about a container's

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -827,6 +827,15 @@ USER mail`
 		Expect(isSharedOnly).Should(BeTrue())
 	})
 
+	It("podman run --security-opts proc-opts=", func() {
+		session := podmanTest.Podman([]string{"run", "--security-opt", "proc-opts=nosuid,exec", fedoraMinimal, "findmnt", "-noOPTIONS", "/proc"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		output := session.OutputToString()
+		Expect(output).To(ContainSubstring("nosuid"))
+		Expect(output).To(Not(ContainSubstring("exec")))
+	})
+
 	It("podman run --mount type=bind,bind-nonrecursive", func() {
 		SkipIfRootless()
 		session := podmanTest.Podman([]string{"run", "--mount", "type=bind,bind-nonrecursive,slave,src=/,target=/host", fedoraMinimal, "findmnt", "-nR", "/host"})


### PR DESCRIPTION
it allows to customize the options passed down to the OCI runtime for
setting up the /proc mount.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>