### PR TITLE
Add BuilderIdentityAnnotation to identify buildah version

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -386,6 +386,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		runtimeFlags = append(runtimeFlags, "--systemd-cgroup")
 	}
 
+	labels := append([]string{buildah.BuilderIdentityAnnotation + "=" + buildah.Version}, flags.Label...)
 	opts := imagebuildah.BuildOptions{
 		AddCapabilities: flags.CapAdd,
 		AdditionalTags:  tags,
@@ -422,7 +423,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		IIDFile:                 flags.Iidfile,
 		In:                      stdin,
 		Isolation:               isolation,
-		Labels:                  flags.Label,
+		Labels:                  labels,
 		Layers:                  flags.Layers,
 		NamespaceOptions:        nsValues,
 		NoCache:                 flags.NoCache,

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -136,7 +136,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// convert label formats
-	var labels = []string{}
+	var labels = []string{buildah.BuilderIdentityAnnotation + "=" + buildah.Version}
 	if _, found := r.URL.Query()["labels"]; found {
 		var m = map[string]string{}
 		if err := json.Unmarshal([]byte(query.Labels), &m); err != nil {

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -199,7 +199,7 @@ WORKDIR /test
 		Expect(result.OutputToString()).To(Equal("/test"))
 	})
 
-	It("podman images filter after image", func() {
+	It("podman images filter since image", func() {
 		podmanTest.RestoreAllArtifacts()
 		rmi := podmanTest.PodmanNoCache([]string{"rmi", "busybox"})
 		rmi.WaitWithDefaultTimeout()
@@ -208,7 +208,7 @@ WORKDIR /test
 		dockerfile := `FROM docker.io/library/alpine:latest
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
-		result := podmanTest.PodmanNoCache([]string{"images", "-q", "-f", "after=docker.io/library/alpine:latest"})
+		result := podmanTest.PodmanNoCache([]string{"images", "-q", "-f", "since=foobar.com/before:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
 		Expect(len(result.OutputToStringArray())).To(Equal(0))
@@ -223,7 +223,7 @@ WORKDIR /test
 		dockerfile := `FROM docker.io/library/alpine:latest
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
-		result := podmanTest.PodmanNoCache([]string{"image", "list", "-q", "-f", "after=docker.io/library/alpine:latest"})
+		result := podmanTest.PodmanNoCache([]string{"image", "list", "-q", "-f", "after=foobar.com/before:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
 		Expect(len(result.OutputToStringArray())).To(Equal(0))
@@ -237,7 +237,7 @@ WORKDIR /test
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "dangling=true"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(len(result.OutputToStringArray())).To(Equal(0))
+		Expect(len(result.OutputToStringArray())).To(Equal(1))
 	})
 
 	It("podman check for image with sha256: prefix", func() {


### PR DESCRIPTION
Record the version of buildah used to build the image as a label
in the image.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>