### PR TITLE
Ensure that exec errors write exit codes to the DB

### DIFF
--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -210,7 +210,6 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec missing working directory test", func() {
-		Skip(v2remotefail)
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
@@ -225,7 +224,6 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec cannot be invoked", func() {
-		Skip(v2remotefail)
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
@@ -236,7 +234,6 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec command not found", func() {
-		Skip(v2remotefail)
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -19,6 +19,15 @@ load helpers
     run_podman exec $cid sh -c "cat /$rand_filename"
     is "$output" "$rand_content" "Can exec and see file in running container"
 
+
+    # Specially defined situations: exec a dir, or no such command.
+    # We don't check the full error message because runc & crun differ.
+    run_podman 126 exec $cid /etc
+    is "$output" ".*permission denied"  "podman exec /etc"
+    run_podman 127 exec $cid /no/such/command
+    is "$output" ".*such file or dir"   "podman exec /no/such/command"
+
+    # Done
     run_podman exec $cid rm -f /$rand_filename
 
     run_podman wait $cid


### PR DESCRIPTION
In local Podman, the frontend interprets the error and exit code given by the Exec API to determine the appropriate exit code to set for Podman itself; special cases like a missing executable receive special exit codes.

Exec for the remote API, however, has to do this inside Libpod itself, as Libpod will be directly queried (via the Inspect API for exec sessions) to get the exit code. This was done correctly when the exec session started properly, but we did not properly handle cases where the OCI runtime fails before the exec session can properly start. Making two error returns that would otherwise not set exit code actually do so should resolve the issue.

Fixes #6893
