### PR TITLE
Fix handling of working dir

### DIFF
--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -142,11 +142,6 @@ func (s *SpecGenerator) Validate() error {
 		return err
 	}
 
-	// The following are defaults as needed by container creation
-	if len(s.WorkDir) < 1 {
-		s.WorkDir = "/"
-	}
-
 	// Set defaults if network info is not provided
 	if s.NetNS.NSMode == "" {
 		s.NetNS.NSMode = Bridge

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -135,14 +135,17 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 	s.Annotations = annotations
 
 	// workdir
-	if newImage != nil {
-		workingDir, err := newImage.WorkingDir(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if len(s.WorkDir) < 1 && len(workingDir) > 1 {
+	if s.WorkDir == "" {
+		if newImage != nil {
+			workingDir, err := newImage.WorkingDir(ctx)
+			if err != nil {
+				return nil, err
+			}
 			s.WorkDir = workingDir
 		}
+	}
+	if s.WorkDir == "" {
+		s.WorkDir = "/"
 	}
 
 	if len(s.SeccompProfilePath) < 1 {

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -241,13 +241,7 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 	// If the user did not set an workdir but the image did, ensure it is
 	// created.
 	if s.WorkDir == "" && img != nil {
-		newWD, err := img.WorkingDir(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if newWD != "" {
-			options = append(options, libpod.WithCreateWorkingDir())
-		}
+		options = append(options, libpod.WithCreateWorkingDir())
 	}
 	if s.StopSignal != nil {
 		options = append(options, libpod.WithStopSignal(*s.StopSignal))

--- a/test/e2e/run_working_dir.go
+++ b/test/e2e/run_working_dir.go
@@ -1,0 +1,69 @@
+package integration
+
+import (
+	"os"
+	"strings"
+
+	. "github.com/containers/podman/v2/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman run", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest *PodmanTestIntegration
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanTestCreate(tempdir)
+		podmanTest.Setup()
+		podmanTest.SeedImages()
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+		f := CurrentGinkgoTestDescription()
+		processTestResult(f)
+
+	})
+
+	It("podman run a container without workdir", func() {
+		session := podmanTest.Podman([]string{"run", ALPINE, "pwd"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("/"))
+	})
+
+	It("podman run a container using non existing --workdir", func() {
+		if !strings.Contains(podmanTest.OCIRuntime, "crun") {
+			Skip("Test only works on crun")
+		}
+		session := podmanTest.Podman([]string{"run", "--workdir", "/home/foobar", ALPINE, "pwd"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(127))
+	})
+
+	It("podman run a container on an image with a workdir", func() {
+		SkipIfRemote()
+		dockerfile := `FROM alpine
+RUN  mkdir -p /home/foobar
+WORKDIR  /etc/foobar`
+		podmanTest.BuildImage(dockerfile, "test", "false")
+
+		session := podmanTest.Podman([]string{"run", "test", "pwd"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("/etc/foobar"))
+
+		session = podmanTest.Podman([]string{"run", "--workdir", "/home/foobar", "test", "pwd"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("/home/foobar"))
+	})
+})


### PR DESCRIPTION
Buildah and podman build can create images without a working dir.

FROM fedora
WORKDIR /test

If you build this image with caching twice, the second time the image
will not have a working dir.

Similarly if you execute

podman run --workdir /foobar fedora

It blows up since the workingdir is not created automatically.

Finally there was duplicated code for getting the workingdir
out of an image, that this PR removes.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>