### PR TITLE
Default .Repository and .Tag values to <none>

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -195,6 +195,7 @@ func sortImages(imageS []*entities.ImageSummary) ([]imageReporter, error) {
 		} else {
 			h.ImageSummary = *e
 			h.Repository = "<none>"
+			h.Tag = "<none>"
 			imgs = append(imgs, h)
 		}
 		listFlag.readOnly = e.IsReadOnly()
@@ -205,27 +206,34 @@ func sortImages(imageS []*entities.ImageSummary) ([]imageReporter, error) {
 }
 
 func tokenRepoTag(ref string) (string, string, error) {
-
 	if ref == "<none>:<none>" {
 		return "<none>", "<none>", nil
 	}
 
 	repo, err := reference.Parse(ref)
 	if err != nil {
-		return "", "", err
+		return "<none>", "<none>", err
 	}
 
 	named, ok := repo.(reference.Named)
 	if !ok {
-		return ref, "", nil
+		return ref, "<none>", nil
+	}
+	name := named.Name()
+	if name == "" {
+		name = "<none>"
 	}
 
 	tagged, ok := repo.(reference.Tagged)
 	if !ok {
-		return named.Name(), "", nil
+		return name, "<none>", nil
+	}
+	tag := tagged.Tag()
+	if tag == "" {
+		tag = "<none>"
 	}
 
-	return named.Name(), tagged.Tag(), nil
+	return name, tag, nil
 
 }
 

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -28,8 +28,6 @@ verify_iid_and_name() {
 
 
 @test "podman load - by image ID" {
-    skip_if_remote "FIXME: pending #7123"
-
     # FIXME: how to build a simple archive instead?
     get_iid_and_name
 


### PR DESCRIPTION
Refactor the processing of Repository and Tag fields to default to <none>
when printing via --format flag. Previously, the default format would
print <none> but --format {{.Tag}} would not in some cases.

Fixes #7123

Signed-off-by: Jhon Honce <jhonce@redhat.com>