### PR TITLE
Remove TEST_ from TEST_REMOTE_*

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,7 +59,7 @@ env:
     #### Default to NOT operating in any special-case testing mode
     ####
     SPECIALMODE: "none"  # don't do anything special
-    TEST_REMOTE_CLIENT: 'false'  # don't test remote client by default
+    RCLI: 'false'  # don't test remote client by default
     ADD_SECOND_PARTITION: 'false'  # will certainly fail inside containers
     MOD_CONTAINERS_CONF: 'true'  # Update containers.conf runtime if required by OS environment
 
@@ -422,8 +422,8 @@ testing_task:
     env:
         ADD_SECOND_PARTITION: 'true'
         matrix:
-          - TEST_REMOTE_CLIENT: 'true'
-          - TEST_REMOTE_CLIENT: 'false'
+          - RCLI: 'true'
+          - RCLI: 'false'
 
     networking_script: '${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/networking.sh'
     setup_environment_script: '$SCRIPT_BASE/setup_environment.sh |& ${TIMESTAMP}'
@@ -470,8 +470,8 @@ special_testing_rootless_task:
         ADD_SECOND_PARTITION: 'true'
         SPECIALMODE: 'rootless'  # See docs
         matrix:
-          - TEST_REMOTE_CLIENT: 'true'
-          - TEST_REMOTE_CLIENT: 'false'
+          - RCLI: 'true'
+          - RCLI: 'false'
 
     timeout_in: 60m
 
@@ -674,8 +674,8 @@ verify_test_built_images_task:
     env:
         ADD_SECOND_PARTITION: 'true'
         matrix:
-          - TEST_REMOTE_CLIENT: 'true'
-          - TEST_REMOTE_CLIENT: 'false'
+          - RCLI: 'true'
+          - RCLI: 'false'
         matrix:
             PACKER_BUILDER_NAME: "${FEDORA_NAME}"
             PACKER_BUILDER_NAME: "${PRIOR_FEDORA_NAME}"

--- a/contrib/cirrus/apiv2_test.sh
+++ b/contrib/cirrus/apiv2_test.sh
@@ -7,7 +7,7 @@ source $(dirname $0)/lib.sh
 req_env_var GOSRC SCRIPT_BASE OS_RELEASE_ID OS_RELEASE_VER CONTAINER_RUNTIME VARLINK_LOG
 
 LOCAL_OR_REMOTE=local
-if [[ "$TEST_REMOTE_CLIENT" = "true" ]]; then
+if [[ "$RCLI" = "true" ]]; then
     LOCAL_OR_REMOTE=remote
 fi
 

--- a/contrib/cirrus/build_release.sh
+++ b/contrib/cirrus/build_release.sh
@@ -4,11 +4,11 @@ set -e
 
 source $(dirname $0)/lib.sh
 
-req_env_var TEST_REMOTE_CLIENT OS_RELEASE_ID GOSRC
+req_env_var RCLI OS_RELEASE_ID GOSRC
 
 cd $GOSRC
 
-if [[ "$TEST_REMOTE_CLIENT" == "true" ]] && [[ -z "$CROSS_PLATFORM" ]]
+if [[ "$RCLI" == "true" ]] && [[ -z "$CROSS_PLATFORM" ]]
 then
     CROSS_PLATFORM=linux
 fi

--- a/contrib/cirrus/check_image.sh
+++ b/contrib/cirrus/check_image.sh
@@ -6,7 +6,7 @@ source $(dirname $0)/lib.sh
 
 EVIL_UNITS="$($CIRRUS_WORKING_DIR/$PACKER_BASE/systemd_banish.sh --list)"
 
-req_env_var PACKER_BUILDER_NAME TEST_REMOTE_CLIENT EVIL_UNITS OS_RELEASE_ID CG_FS_TYPE
+req_env_var PACKER_BUILDER_NAME RCLI EVIL_UNITS OS_RELEASE_ID CG_FS_TYPE
 
 NFAILS=0
 echo "Validating VM image"

--- a/contrib/cirrus/container_test.sh
+++ b/contrib/cirrus/container_test.sh
@@ -18,7 +18,7 @@ if [ "${ID}" != "fedora" ] || [ "${CONTAINER_RUNTIME}" != "" ]; then
     INTEGRATION_TEST_ENVS="SKIP_USERNS=1"
 fi
 
-echo "$(date --rfc-3339=seconds) $(basename $0) started with '$*' and TEST_REMOTE_CLIENT='${TEST_REMOTE_CLIENT}'"
+echo "$(date --rfc-3339=seconds) $(basename $0) started with '$*' and RCLI='${RCLI}'"
 
 pwd
 
@@ -57,9 +57,9 @@ while getopts "bituv" opt; do
     esac
 done
 
-# The TEST_REMOTE_CLIENT environment variable decides whether
+# The RCLI environment variable decides whether
 # to test varlinke
-if [[ "$TEST_REMOTE_CLIENT" == "true" ]]; then
+if [[ "$RCLI" == "true" ]]; then
     remote=1
 fi
 

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -7,7 +7,7 @@ source $(dirname $0)/lib.sh
 req_env_var GOSRC SCRIPT_BASE OS_RELEASE_ID OS_RELEASE_VER CONTAINER_RUNTIME VARLINK_LOG
 
 LOCAL_OR_REMOTE=local
-if [[ "$TEST_REMOTE_CLIENT" = "true" ]]; then
+if [[ "$RCLI" = "true" ]]; then
     LOCAL_OR_REMOTE=remote
 fi
 

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -96,12 +96,12 @@ LILTO="timeout_attempt_delay_command 120s 5 30s"
 BIGTO="timeout_attempt_delay_command 300s 5 60s"
 
 # Safe env. vars. to transfer from root -> $ROOTLESS_USER  (go env handled separately)
-ROOTLESS_ENV_RE='(CIRRUS_.+)|(ROOTLESS_.+)|(.+_IMAGE.*)|(.+_BASE)|(.*DIRPATH)|(.*FILEPATH)|(SOURCE.*)|(DEPEND.*)|(.+_DEPS_.+)|(OS_REL.*)|(.+_ENV_RE)|(TRAVIS)|(CI.+)|(TEST_REMOTE.*)'
+ROOTLESS_ENV_RE='(CIRRUS_.+)|(ROOTLESS_.+)|(.+_IMAGE.*)|(.+_BASE)|(.*DIRPATH)|(.*FILEPATH)|(SOURCE.*)|(DEPEND.*)|(.+_DEPS_.+)|(OS_REL.*)|(.+_ENV_RE)|(TRAVIS)|(CI.+)|(REMOTE.*)'
 # Unsafe env. vars for display
 SECRET_ENV_RE='(IRCID)|(ACCOUNT)|(GC[EP]..+)|(SSH)'
 
 SPECIALMODE="${SPECIALMODE:-none}"
-TEST_REMOTE_CLIENT="${TEST_REMOTE_CLIENT:-false}"
+RCLI="${RCLI:-false}"
 export CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-podman}
 
 # When running as root, this may be empty or not, as a user, it MUST be set.

--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -4,7 +4,7 @@ set -e
 
 source $(dirname $0)/lib.sh
 
-req_env_var CIRRUS_WORKING_DIR OS_RELEASE_ID TEST_REMOTE_CLIENT
+req_env_var CIRRUS_WORKING_DIR OS_RELEASE_ID RCLI
 
 # Assume there are other log collection commands to follow - Don't
 # let one break another that may be useful, but also keep any
@@ -34,12 +34,12 @@ case $1 in
     journal) showrun journalctl -b ;;
     podman) showrun ./bin/podman system info ;;
     varlink)
-       if [[ "$TEST_REMOTE_CLIENT" == "true" ]]
+       if [[ "$RCLI" == "true" ]]
        then
           echo "(Trailing 100 lines of $VARLINK_LOG)"
           showrun tail -100 $VARLINK_LOG
        else
-          die 0 "\$TEST_REMOTE_CLIENT is not 'true': $TEST_REMOTE_CLIENT"
+          die 0 "\$RCLI is not 'true': $RCLI"
        fi
        ;;
     packages)

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -103,7 +103,7 @@ case "$SPECIALMODE" in
                 tee -a /etc/environment) && eval "$X" && echo "$X"
             X=$(echo "export SPECIALMODE='${SPECIALMODE}'" | \
                 tee -a /etc/environment) && eval "$X" && echo "$X"
-            X=$(echo "export TEST_REMOTE_CLIENT='${TEST_REMOTE_CLIENT}'" | \
+            X=$(echo "export RCLI='${RCLI}'" | \
                 tee -a /etc/environment) && eval "$X" && echo "$X"
             setup_rootless
         fi

--- a/contrib/cirrus/system_test.sh
+++ b/contrib/cirrus/system_test.sh
@@ -7,7 +7,7 @@ source $(dirname $0)/lib.sh
 req_env_var GOSRC SCRIPT_BASE OS_RELEASE_ID OS_RELEASE_VER CONTAINER_RUNTIME VARLINK_LOG
 
 LOCAL_OR_REMOTE=local
-if [[ "$TEST_REMOTE_CLIENT" = "true" ]]; then
+if [[ "$RCLI" = "true" ]]; then
     LOCAL_OR_REMOTE=remote
 fi
 


### PR DESCRIPTION
We know these are TEST_, hoping this makes the display in
cirrus easier for users to see true|false, since this is the
valuable information is.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>