### PR TITLE
enable use of iidfile for remote build

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -1385,6 +1385,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    description: |
 	//      output configuration TBD
 	//      (As of version 1.xx)
+	//  - in: query
+	//    name: iidfile
+	//    type: string
+	//    default:
+	//    description: file to store the image id in upon completion
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -289,6 +289,10 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		params.Set("labels", l)
 	}
 
+	if iidFile := options.IIDFile; len(iidFile) > 0 {
+		params.Set("iidfile", iidFile)
+	}
+
 	// TODO network?
 	if OS := options.OS; len(OS) > 0 {
 		platform += OS


### PR DESCRIPTION
podman/buildah build allows for --iidfile which stores the id of the newly built image.  the api more or less was able to handle this but it wasnt being sent by the go bindings.  it also was not documented on the libpod side of the documentation because of a copy and paste with compat.

Signed-off-by: Brent Baude <bbaude@redhat.com>