### PR TITLE
Replace deepcopy on history results

### DIFF
--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/docker/reference"
@@ -73,8 +74,16 @@ func (ir *ImageEngine) History(ctx context.Context, nameOrID string, opts entiti
 	}
 
 	for i, layer := range results {
-		hold := entities.ImageHistoryLayer{}
-		_ = utils.DeepCopy(&hold, layer)
+		// Created time comes over as an int64 so needs conversion to time.time
+		t := time.Unix(layer.Created, 0)
+		hold := entities.ImageHistoryLayer{
+			ID:        layer.ID,
+			Created:   t.UTC(),
+			CreatedBy: layer.CreatedBy,
+			Tags:      layer.Tags,
+			Size:      layer.Size,
+			Comment:   layer.Comment,
+		}
 		history.Layers[i] = hold
 	}
 	return &history, nil

--- a/test/system/110-history.bats
+++ b/test/system/110-history.bats
@@ -3,8 +3,6 @@
 load helpers
 
 @test "podman history - basic tests" {
-    skip_if_remote "FIXME: pending #7122"
-
     tests="
                                  | .*[0-9a-f]\\\{12\\\} .* CMD .* LABEL
 --format '{{.ID}} {{.Created}}'  | .*[0-9a-f]\\\{12\\\} .* ago


### PR DESCRIPTION
the deepcopy in the remote history code path was throwing an uncaught error on a type mismatch.  we now manually do the conversion and fix the type mismatch on the fly.

Fixes: #7122

Signed-off-by: Brent Baude <bbaude@redhat.com>