### PR TITLE
Do not use image CMD if user gave ENTRYPOINT

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -387,8 +387,6 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	s.Annotations = annotations
 
 	s.WorkDir = c.Workdir
-	userCommand := []string{}
-	var command []string
 	if c.Entrypoint != nil {
 		entrypoint := []string{}
 		if ep := *c.Entrypoint; len(ep) > 0 {
@@ -398,27 +396,13 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 			}
 		}
 		s.Entrypoint = entrypoint
-		// Build the command
-		// If we have an entry point, it goes first
-		command = entrypoint
 	}
 
 	// Include the command used to create the container.
 	s.ContainerCreateCommand = os.Args
 
 	if len(inputCommand) > 0 {
-		// User command overrides data CMD
-		command = append(command, inputCommand...)
-		userCommand = append(userCommand, inputCommand...)
-	}
-
-	switch {
-	case len(inputCommand) > 0:
-		s.Command = userCommand
-	case c.Entrypoint != nil:
-		s.Command = []string{}
-	default:
-		s.Command = command
+		s.Command = inputCommand
 	}
 
 	// SHM Size

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -96,8 +96,10 @@ func makeCommand(ctx context.Context, s *specgen.SpecGenerator, img *image.Image
 
 	finalCommand = append(finalCommand, entrypoint...)
 
+	// Only use image command if the user did not manually set an
+	// entrypoint.
 	command := s.Command
-	if command == nil && img != nil {
+	if command == nil && img != nil && s.Entrypoint == nil {
 		newCmd, err := img.Cmd(ctx)
 		if err != nil {
 			return nil, err

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1143,7 +1143,7 @@ USER mail`
 		Expect(session.ErrorToString()).To(ContainSubstring("Invalid umask"))
 	})
 
-	It("podman run makes entrypoint from image", func() {
+	It("podman run makes workdir from image", func() {
 		// BuildImage does not seem to work remote
 		SkipIfRemote()
 		dockerfile := `FROM busybox
@@ -1153,5 +1153,14 @@ WORKDIR /madethis`
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("/madethis"))
+	})
+
+	It("podman run --entrypoint does not use image command", func() {
+		session := podmanTest.Podman([]string{"run", "--entrypoint", "/bin/echo", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		// We can't guarantee the output is completely empty, some
+		// nonprintables seem to work their way in.
+		Expect(session.OutputToString()).To(Not(ContainSubstring("/bin/sh")))
 	})
 })


### PR DESCRIPTION
This matches Docker behavior, and seems to make sense - the CMD may have been specific to the original entrypoint and probably does not make sense if it was changed.

While we're in here, greatly simplify the logic for populating the SpecGen's Command. We create the full command when making the OCI spec, so the client should not be doing any more than setting it to the Command the user passed in, and completely ignoring ENTRYPOINT.

Fixes #7115
