### PR TITLE
[CI:DOCS] Add missing pages for docs.podman.io

### DIFF
--- a/commands-demo.md
+++ b/commands-demo.md
@@ -27,11 +27,11 @@
 | [podman-generate-systemd(1)](https://podman.readthedocs.io/en/latest/markdown/podman-generate-systemd.1.html)         | Generate systemd unit file(s) for a container or pod. Not supported for the remote client  |
 | [podman-history(1)](https://podman.readthedocs.io/en/latest/markdown/podman-history.1.html)                           | Shows the history of an image                                              |
 | [podman-image(1)](https://podman.readthedocs.io/en/latest/image.html)                                                 | Manage Images                                                              |
-| [podman-image-exists(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-exists.1.html)                 | Check if an image exists in local storage                                  |
 | [podman-image-diff(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-diff.html)                       | Inspect changes on an image's filesystem.                                  |
+| [podman-image-exists(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-exists.1.html)                 | Check if an image exists in local storage                                  |
 | [podman-image-prune(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-prune.1.html)                   | Remove all unused images from the local store                              |
-| [podman-image-sign(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-sign.1.html)                     | Create a signature for an image                                            |
 | [podman-image-search(1)](https://podman.readthedocs.io/en/latest/markdown/podman-search.1.html)                       | Search a registry for an image.                                            |
+| [podman-image-sign(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-sign.1.html)                     | Create a signature for an image                                            |
 | [podman-image-tree(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-tree.1.html)                     | Prints layer hierarchy of an image in a tree format                        |
 | [podman-image-trust(1)](https://podman.readthedocs.io/en/latest/markdown/podman-image-trust.1.html)                   | Manage container registry image trust policy                               |
 | [podman-images(1)](https://podman.readthedocs.io/en/latest/markdown/podman-images.1.html)                             | List images in local storage                                               | [![...](/docs/source/markdown/play.png)](https://podman.io/asciinema/podman/images/)        | [Here](https://github.com/containers/Demos/blob/master/podman_cli/podman_images.sh) |
@@ -58,9 +58,9 @@
 | [podman-pod-exists(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-exists.1.html)                     | Check if a pod exists in local storage                                     |
 | [podman-pod-inspect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-inspect.1.html)                   | Displays information describing a pod                                      |
 | [podman-pod-kill(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-kill.1.html)                         | Kill the main process of each container in one or more pods                |
-| [podman-pod-ps(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-ps.1.html)                             | Prints out information about pods                                          |
 | [podman-pod-pause(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pause.1.html)                           | Pause one or more containers                                               |
 | [podman-pod-prune(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-prune.1.html)                       | Remove all stopped pods and their containers                               |
+| [podman-pod-ps(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-ps.1.html)                             | Prints out information about pods                                          |
 | [podman-pod-restart](https://podman.readthedocs.io/en/latest/markdown/podman-pod-restart.1.html)                      | Restart one or more pods                                                   |
 | [podman-pod-rm(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-rm.1.html)                             | Remove one or more stopped pods and containers                             |
 | [podman-pod-start(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pod-start.1.html)                       | Start one or more pods                                                     |

--- a/docs/source/Commands.rst
+++ b/docs/source/Commands.rst
@@ -6,11 +6,13 @@ Commands
 
 :doc:`attach <markdown/podman-attach.1>` Attach to a running container
 
+:doc:`auto-update <markdown/podman-auto-update.1>` Auto update containers according to their auto-update policy
+
 :doc:`build <markdown/podman-build.1>` Build an image using instructions from Containerfiles
 
 :doc:`commit <markdown/podman-commit.1>` Create new image based on the changed container
 
-:doc:`containers <managecontainers>` Manage Containers
+:doc:`container <managecontainers>` Manage Containers
 
 :doc:`cp <markdown/podman-cp.1>` Copy files/folders between a container and the local filesystem
 
@@ -51,6 +53,8 @@ Commands
 :doc:`logout <markdown/podman-logout.1>` Logout of a container registry
 
 :doc:`logs <markdown/podman-logs.1>` Fetch the logs of a container
+
+:doc:`manifest <manifest>` Create and manipulate manifest lists and image indexes
 
 :doc:`mount <markdown/podman-mount.1>` Mount a working container's root filesystem
 
@@ -99,6 +103,8 @@ Commands
 :doc:`unpause <markdown/podman-unpause.1>` Unpause the processes in one or more containers
 
 :doc:`unshare <markdown/podman-unshare.1>` Run a command in a modified user namespace
+
+:doc:`untag <markdown/podman-untag.1>` Removes one or more names from a locally-stored image
 
 :doc:`version <markdown/podman-version.1>` Display the Podman Version Information
 

--- a/docs/source/connection.rst
+++ b/docs/source/connection.rst
@@ -1,0 +1,12 @@
+Manage the destination(s) for Podman service(s)
+=================
+
+:doc:`add <markdown/podman-system-connection-add.1>` Record destination for the Podman service
+
+:doc:`default <markdown/podman-system-connection-default.1>` Set named destination as default for the Podman service
+
+:doc:`list <markdown/podman-system-connection-list.1>` List the destination for the Podman service(s)
+
+:doc:`remove <markdown/podman-system-connection-remove.1>` Delete named destination
+
+:doc:`rename <markdown/podman-system-connection-rename.1>` Rename the destination for Podman service

--- a/docs/source/image.rst
+++ b/docs/source/image.rst
@@ -4,6 +4,8 @@ Image
 
 :doc:`build <markdown/podman-build.1>` Build an image using instructions from Containerfiles
 
+:doc:`diff <markdown/podman-image-diff.1>` Inspect changes on an image's filesystem
+
 :doc:`exists <markdown/podman-image-exists.1>` Check if an image exists in local storage
 
 :doc:`history <markdown/podman-history.1>` Show history of a specified image
@@ -16,6 +18,8 @@ Image
 
 :doc:`load <markdown/podman-load.1>` Load an image from container archive
 
+:doc:`mount <markdown/podman-images-mount.1>` Mount an image's root filesystem.
+
 :doc:`prune <markdown/podman-image-prune.1>` Remove unused images
 
 :doc:`pull <markdown/podman-pull.1>` Pull an image from a registry
@@ -26,6 +30,8 @@ Image
 
 :doc:`save <markdown/podman-save.1>` Save image to an archive
 
+:doc:`search <markdown/podman-search.1>` Search a registry for an image
+
 :doc:`sign <markdown/podman-image-sign.1>` Sign an image
 
 :doc:`tag <markdown/podman-tag.1>` Add an additional name to a local image
@@ -33,3 +39,7 @@ Image
 :doc:`tree <markdown/podman-image-tree.1>` Prints layer hierarchy of an image in a tree format
 
 :doc:`trust <markdown/podman-image-trust.1>` Manage container image trust policy
+
+:doc:`untag <markdown/podman-untag.1>` Removes one or more names from a locally-stored image
+
+:doc:`unmount <markdown/podman-unmount.1>` Unmount an image's root filesystem

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ If you are completely new to containers, we recommend that you check out the :do
    :caption: Contents:
 
    Introduction
+   :doc:`<markdown/podman.1>` Simple management tool for pods, containers and images
    Commands
    Reference
    Tutorials

--- a/docs/source/managecontainers.rst
+++ b/docs/source/managecontainers.rst
@@ -57,7 +57,7 @@ Manage Containers
 
 :doc:`top <markdown/podman-top.1>` Display the running processes of a container
 
-:doc:`umount <markdown/podman-umount.1>` Unmounts working container's root filesystem
+:doc:`unmount <markdown/podman-unmount.1>` Unmounts working container's root filesystem
 
 :doc:`unpause <markdown/podman-unpause.1>` Unpause the processes in one or more containers
 

--- a/docs/source/manifest.rst
+++ b/docs/source/manifest.rst
@@ -1,0 +1,14 @@
+Create and manipulate manifest lists and image indexes
+=================
+
+:doc:`add <markdown/podman-manifest-add.1>` Add an image to a manifest list or image index
+
+:doc:`annotate <markdown/podman-manifest-annotate.1>` Add or update information about an entry in a manifest list or image index
+
+:doc:`create <markdown/podman-manifest-create.1>` Create a manifest list or image index
+
+:doc:`inspect <markdown/podman-manifest-inspect.1>` Display a manifest list or image index
+
+:doc:`push <markdown/podman-manifest-push.1>` Push a manifest list or image index to a registry
+
+:doc:`remove <markdown/podman-manifest-remove.1>` Remove an image from a manifest list or image index

--- a/docs/source/markdown/podman-image.1.md
+++ b/docs/source/markdown/podman-image.1.md
@@ -20,8 +20,8 @@ The image command allows you to manage images
 | import   | [podman-import(1)](podman-import.1.md)              | Import a tarball and save it as a filesystem image.                         |
 | inspect  | [podman-inspect(1)](podman-inspect.1.md)            | Display a image or image's configuration.                                   |
 | list     | [podman-images(1)](podman-images.1.md)              | List the container images on the system.(alias ls)                          |
-| mount    | [podman-image-mount(1)](podman-image-mount.1.md)    | Mount an image's root filesystem.                                           |
 | load     | [podman-load(1)](podman-load.1.md)                  | Load an image from the docker archive.                                      |
+| mount    | [podman-image-mount(1)](podman-image-mount.1.md)    | Mount an image's root filesystem.                                           |
 | prune    | [podman-image-prune(1)](podman-image-prune.1.md)    | Remove all unused images from the local store.                              |
 | pull     | [podman-pull(1)](podman-pull.1.md)                  | Pull an image from a registry.                                              |
 | push     | [podman-push(1)](podman-push.1.md)                  | Push an image from local storage to elsewhere.                              |
@@ -30,10 +30,10 @@ The image command allows you to manage images
 | search   | [podman-search(1)](podman-search.1.md)              | Search a registry for an image.                                             |
 | sign     | [podman-image-sign(1)](podman-image-sign.1.md)      | Create a signature for an image.                                            |
 | tag      | [podman-tag(1)](podman-tag.1.md)                    | Add an additional name to a local image.                                    |
-| untag    | [podman-untag(1)](podman-untag.1.md)                | Removes one or more names from a locally-stored image.                      |
-| unmount   | [podman-image-unmount(1)](podman-image-unmount.1.md)  | Unmount an image's root filesystem.                                         |
 | tree     | [podman-image-tree(1)](podman-image-tree.1.md)      | Prints layer hierarchy of an image in a tree format.                        |
 | trust    | [podman-image-trust(1)](podman-image-trust.1.md)    | Manage container registry image trust policy.                               |
+| unmount   | [podman-image-unmount(1)](podman-image-unmount.1.md)  | Unmount an image's root filesystem.                                         |
+| untag    | [podman-untag(1)](podman-untag.1.md)                | Removes one or more names from a locally-stored image.                      |
 
 ## SEE ALSO
 podman

--- a/docs/source/markdown/podman-system-connection.1.md
+++ b/docs/source/markdown/podman-system-connection.1.md
@@ -13,13 +13,13 @@ The user will be prompted for the ssh login password or key file pass phrase as 
 
 ## COMMANDS
 
-| Command  | Man Page                                                                     | Description                                                |
-| -------  | ---------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| add      | [podman-system-connection-add(1)](podman-system-connection-add.1.md)         | Record destination for the Podman service |
-| default  | [podman-system-connection-default(1)](podman-system-connection-default.1.md) | Set named destination as default for the Podman service |
-| list     | [podman-system-connection-list(1)](podman-system-connection-list.1.md)       | List the destination for the Podman service(s) |
-| remove   | [podman-system-connection-remove(1)](podman-system-connection-remove.1.md)   | Delete named destination |
-| rename   | [podman-system-connection-rename(1)](podman-system-connection-rename.1.md)   | Rename the destination for Podman service |
+| Command  | Man Page                                                                      | Description                                                |
+| -------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| add      | [podman-system-connection\-add(1)](podman-system-connection-add.1.md)         | Record destination for the Podman service                  |
+| default  | [podman-system-connection\-default(1)](podman-system-connection-default.1.md) | Set named destination as default for the Podman service    |
+| list     | [podman-system-connection\-list(1)](podman-system-connection-list.1.md)       | List the destination for the Podman service(s)             |
+| remove   | [podman-system-connection\-remove(1)](podman-system-connection-remove.1.md)   | Delete named destination                                   |
+| rename   | [podman-system-connection\-rename(1)](podman-system-connection-rename.1.md)   | Rename the destination for Podman service                  |
 
 ## EXAMPLE
 ```

--- a/docs/source/system.rst
+++ b/docs/source/system.rst
@@ -1,6 +1,8 @@
 System
 ======
 
+:doc:`connection <markdown/podman-system-conection.1>` Manage the destination(s) for Podman service(s)
+
 :doc:`df <markdown/podman-system-df.1>` Show podman disk usage
 
 :doc:`info <markdown/podman-info.1>` Display podman system information
@@ -12,3 +14,5 @@ System
 :doc:`renumber <markdown/podman-system-renumber.1>` Migrate lock numbers
 
 :doc:`reset <markdown/podman-system-reset.1>` Reset podman storage
+
+:doc:`service <markdown/podman-system-service.1>` Run an API service

--- a/transfer.md
+++ b/transfer.md
@@ -38,10 +38,10 @@ There are other equivalents for these tools
 | Existing Step | `Podman` (and friends) |
 | :--- | :--- |
 | `docker attach`  | [`podman attach`](./docs/source/markdown/podman-attach.1.md)    |
-| `docker cp`      | [`podman cp`](./docs/source/markdown/podman-cp.1.md)            |
 | `docker build`   | [`podman build`](./docs/source/markdown/podman-build.1.md)      |
 | `docker commit`  | [`podman commit`](./docs/source/markdown/podman-commit.1.md)    |
 | `docker container`|[`podman container`](./docs/source/markdown/podman-container.1.md) |
+| `docker cp`      | [`podman cp`](./docs/source/markdown/podman-cp.1.md)            |
 | `docker create`  | [`podman create`](./docs/source/markdown/podman-create.1.md)    |
 | `docker diff`    | [`podman diff`](./docs/source/markdown/podman-diff.1.md)        |
 | `docker events`  | [`podman events`](./docs/source/markdown/podman-events.1.md)    |
@@ -59,10 +59,10 @@ There are other equivalents for these tools
 | `docker network ls`      | [`podman network ls`](./docs/source/markdown/podman-network-ls.1.md)           |
 | `docker network rm`      | [`podman network rm`](./docs.source/markdown/podman-network-rm.1.md)           |
 | `docker pause`   | [`podman pause`](./docs/source/markdown/podman-pause.1.md)      |
+| `docker port`    | [`podman port`](./docs/source/markdown/podman-port.1.md)        |
 | `docker ps`      | [`podman ps`](./docs/source/markdown/podman-ps.1.md)            |
 | `docker pull`    | [`podman pull`](./docs/source/markdown/podman-pull.1.md)        |
 | `docker push`    | [`podman push`](./docs/source/markdown/podman-push.1.md)        |
-| `docker port`    | [`podman port`](./docs/source/markdown/podman-port.1.md)        |
 | `docker restart` | [`podman restart`](./docs/source/markdown/podman-restart.1.md)  |
 | `docker rm`      | [`podman rm`](./docs/source/markdown/podman-rm.1.md)            |
 | `docker rmi`     | [`podman rmi`](./docs/source/markdown/podman-rmi.1.md)          |
@@ -71,20 +71,20 @@ There are other equivalents for these tools
 | `docker search`  | [`podman search`](./docs/source/markdown/podman-search.1.md)    |
 | `docker start`   | [`podman start`](./docs/source/markdown/podman-start.1.md)      |
 | `docker stop`    | [`podman stop`](./docs/source/markdown/podman-stop.1.md)        |
+| `docker system df`     | [`podman system df`](./docs/source/markdown/podman-system-df.1.md)          |
+| `docker system info`   | [`podman system info`](./docs/source/markdown/podman-system-info.1.md)      |
+| `docker system prune`  | [`podman system prune`](./docs/source/markdown/podman-system-prune.1.md)    |
+| `docker system`        | [`podman system`](./docs/source/markdown/podman-system.1.md)                |
 | `docker tag`     | [`podman tag`](./docs/source/markdown/podman-tag.1.md)          |
 | `docker top`     | [`podman top`](./docs/source/markdown/podman-top.1.md)          |
 | `docker unpause` | [`podman unpause`](./docs/source/markdown/podman-unpause.1.md)  |
 | `docker version` | [`podman version`](./docs/source/markdown/podman-version.1.md)  |
-| `docker volume`  | [`podman volume`](./docs/source/markdown/podman-volume.1.md)			|
 | `docker volume create` | [`podman volume create`](./docs/source/markdown/podman-volume-create.1.md)  |
 | `docker volume inspect`| [`podman volume inspect`](./docs/source/markdown/podman-volume-inspect.1.md)|
 | `docker volume ls`     | [`podman volume ls`](./docs/source/markdown/podman-volume-ls.1.md)          |
 | `docker volume prune`  | [`podman volume prune`](./docs/source/markdown/podman-volume-prune.1.md)    |
 | `docker volume rm`     | [`podman volume rm`](./docs/source/markdown/podman-volume-rm.1.md)          |
-| `docker system`        | [`podman system`](./docs/source/markdown/podman-system.1.md)                |
-| `docker system df`     | [`podman system df`](./docs/source/markdown/podman-system-df.1.md)          |
-| `docker system prune`  | [`podman system prune`](./docs/source/markdown/podman-system-prune.1.md)    |
-| `docker system info`   | [`podman system info`](./docs/source/markdown/podman-system-info.1.md)      |
+| `docker volume`  | [`podman volume`](./docs/source/markdown/podman-volume.1.md)			|
 | `docker wait`          | [`podman wait`](./docs/source/markdown/podman-wait.1.md)		       |
 
 **** Use mount to take advantage of the entire linux tool chain rather then just cp.  Read [`here`](./docs/podman-cp.1.md) for more information.
@@ -95,8 +95,8 @@ Those Docker commands currently do not have equivalents in `podman`:
 
 | Missing command | Description|
 | :--- | :--- |
-| `docker container update`  | podman does not support altering running containers. We recommend recreating containers with the correct arguments.|
 | `docker container rename`   | podman does not support `container rename` - or the `rename` shorthand. We recommend using `podman rm` and  `podman create` to create a container with a specific name.|
+| `docker container update`  | podman does not support altering running containers. We recommend recreating containers with the correct arguments.|
 | `docker node`     ||
 | `docker plugin`   | podman does not support plugins.  We recommend you use alternative OCI Runtimes or OCI Runtime Hooks to alter behavior of podman.|
 | `docker secret`   ||
@@ -108,22 +108,21 @@ Those Docker commands currently do not have equivalents in `podman`:
 
 The following podman commands do not have a Docker equivalent:
 
-* [`podman generate`](./docs/source/markdown/podman-generate.1.md)
-* [`podman generate kube`](./docs/source/markdown/podman-generate-kube.1.md)
 * [`podman container checkpoint`](/docs/source/markdown/podman-container-checkpoint.1.md)
 * [`podman container cleanup`](/docs/source/markdown/podman-container-cleanup.1.md)
 * [`podman container exists`](/docs/source/markdown/podman-container-exists.1.md)
 * [`podman container refresh`](/docs/source/markdown/podman-container-refresh.1.md)
-* [`podman container runlabel`](/docs/source/markdown/podman-container-runlabel.1.md)
 * [`podman container restore`](/docs/source/markdown/podman-container-restore.1.md)
+* [`podman container runlabel`](/docs/source/markdown/podman-container-runlabel.1.md)
+* [`podman generate kube`](./docs/source/markdown/podman-generate-kube.1.md)
+* [`podman generate`](./docs/source/markdown/podman-generate.1.md)
 * [`podman healthcheck run`](/docs/source/markdown/podman-healthcheck-run.1.md)
 * [`podman image exists`](./docs/source/markdown/podman-image-exists.1.md)
 * [`podman image sign`](./docs/source/markdown/podman-image-sign.1.md)
 * [`podman image trust`](./docs/source/markdown/podman-image-trust.1.md)
 * [`podman mount`](./docs/source/markdown/podman-mount.1.md)
-* [`podman play`](./docs/source/markdown/podman-play.1.md)
 * [`podman play kube`](./docs/source/markdown/podman-play-kube.1.md)
-* [`podman pod`](./docs/source/markdown/podman-pod.1.md)
+* [`podman play`](./docs/source/markdown/podman-play.1.md)
 * [`podman pod create`](./docs/source/markdown/podman-pod-create.1.md)
 * [`podman pod exists`](./docs/source/markdown/podman-pod-exists.1.md)
 * [`podman pod inspect`](./docs/source/markdown/podman-pod-inspect.1.md)
@@ -136,4 +135,5 @@ The following podman commands do not have a Docker equivalent:
 * [`podman pod stop`](./docs/source/markdown/podman-pod-stop.1.md)
 * [`podman pod top`](./docs/source/markdown/podman-pod-top.1.md)
 * [`podman pod unpause`](./docs/source/markdown/podman-pod-unpause.1.md)
+* [`podman pod`](./docs/source/markdown/podman-pod.1.md)
 * [`podman umount`](./docs/source/markdown/podman-umount.1.md)


### PR DESCRIPTION
Lots of references to man pages missing from docs.podman.io

Also fix sort order in man page.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>