### PR TITLE
generate systemd: fix error handling

### DIFF
--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -20,9 +20,10 @@ func (ic *ContainerEngine) GenerateSystemd(ctx context.Context, nameOrID string,
 	if ctrErr == nil {
 		// Generate the unit for the container.
 		s, err := generate.ContainerUnit(ctr, options)
-		if err == nil {
-			return &entities.GenerateSystemdReport{Output: s}, nil
+		if err != nil {
+			return nil, err
 		}
+		return &entities.GenerateSystemdReport{Output: s}, nil
 	}
 
 	// If it's not a container, we either have a pod or garbage.

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -53,6 +53,18 @@ var _ = Describe("Podman generate systemd", func() {
 		Expect(session).To(ExitWithError())
 	})
 
+	It("podman generate systemd bad restart-policy value", func() {
+		session := podmanTest.Podman([]string{"create", "--name", "foobar", "alpine", "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"generate", "systemd", "--restart-policy", "bogus", "foobar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitWithError())
+		found, _ := session.ErrorGrepString("Error: bogus is not a valid restart policy")
+		Expect(found).Should(BeTrue())
+	})
+
 	It("podman generate systemd good timeout value", func() {
 		session := podmanTest.Podman([]string{"create", "--name", "foobar", "alpine", "top"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Fix a bug in the error handling which returned nil instead of an error
and ultimately lead to nil dereferences in the client.  To prevent
future regressions, add a test and check for the error message.

Fixes: #7271
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>