### PR TITLE
Makefile: fix varlink detection conditional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -648,9 +648,9 @@ endef
 		$(call go-get,github.com/cpuguy83/go-md2man); \
 	fi
 
-# $BUILD_TAGS variable is used in hack/golangci-lint.sh
+# $(BUILD_TAGS) variable is used in hack/golangci-lint.sh
 .PHONY: varlink_generate
-ifneq (or $(findstring varlink,$(BUILDTAGS)),$(findstring varlink,$(BUILD_TAGS)))
+ifeq (or $(findstring varlink,$(BUILDTAGS)),$(findstring varlink,$(BUILD_TAGS)))
 varlink_generate: .gopathok pkg/varlink/iopodman.go ## Generate varlink
 else
 varlink_generate:


### PR DESCRIPTION
Previously, varlink_generate was being run when varlink
wasn't specified in the build tags. This commit corrects that.

Plus, a small cosmetic change in a Makefile comment.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@vrothberg @TomSweeneyRedHat @rhatdan @mheon PTAL