### PR TITLE
Img Pull - Error pass through

### DIFF
--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -226,7 +226,7 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, options entiti
 	if err != nil {
 		imageRef, err = alltransports.ParseImageName(fmt.Sprintf("%s%s", dockerPrefix, rawImage))
 		if err != nil {
-			return nil, errors.Errorf("invalid image reference %q", rawImage)
+			return nil, errors.Wrapf(err, "invalid image reference %q", rawImage)
 		}
 	}
 


### PR DESCRIPTION
Did some digging on https://github.com/containers/podman/issues/6721
Realized it was a feature not yet supported rather than a bug, changed error to pass through higher error for better diagnosis

Example output due to change:

    Original
 ➜  $ podman pull docker.io/fedora:32@sha256:e69b5a62ce23c673885bddc94e6679c9b2af683059637ceddb9cff458537a326
Error: invalid image reference "docker.io/fedora:32@sha256:e69b5a62ce23c673885bddc94e6679c9b2af683059637ceddb9cff458537a326"

    Modified
➜  #$podman pull docker.io/fedora:32@sha256:e69b5a62ce23c673885bddc94e6679c9b2af683059637ceddb9cff458537a326
Error: Docker references with both a tag and digest are currently not supported


Signed-off-by: Parker Van Roy <pvanroy@redhat.com>