### PR TITLE
Ensure pod infra containers have an exit command

### DIFF
--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -310,7 +310,11 @@ type ContainerMiscConfig struct {
 	// OCIRuntime used to create the container
 	OCIRuntime string `json:"runtime,omitempty"`
 	// ExitCommand is the container's exit command.
-	// This Command will be executed when the container exits
+	// This Command will be executed when the container exits by Conmon.
+	// It is usually used to invoke post-run cleanup - for example, in
+	// Podman, it invokes `podman container cleanup`, which in turn calls
+	// Libpod's Cleanup() API to unmount the container and clean up its
+	// network.
 	ExitCommand []string `json:"exitCommand,omitempty"`
 	// IsInfra is a bool indicating whether this container is an infra container used for
 	// sharing kernel namespaces in a pod

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -2130,3 +2130,23 @@ func WithPodHostNetwork() PodCreateOption {
 		return nil
 	}
 }
+
+// WithPodInfraExitCommand sets an exit command for the pod's infra container.
+// Semantics are identical to WithExitCommand() above - the ID of the container
+// will be appended to the end of the provided command (note that this will
+// specifically be the ID of the infra container *and not the pod's id*.
+func WithPodInfraExitCommand(exitCmd []string) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return define.ErrPodFinalized
+		}
+
+		if !pod.config.InfraContainer.HasInfraContainer {
+			return errors.Wrapf(define.ErrInvalidArg, "cannot configure pod infra container exit command as no infra container is being created")
+		}
+
+		pod.config.InfraContainer.ExitCommand = exitCmd
+
+		return nil
+	}
+}

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -81,7 +81,15 @@ type podState struct {
 	InfraContainerID string
 }
 
-// InfraContainerConfig is the configuration for the pod's infra container
+// InfraContainerConfig is the configuration for the pod's infra container.
+// Generally speaking, these are equivalent to container configuration options
+// you will find in container_config.go (and even named identically), save for
+// HasInfraContainer (which determines if an infra container is even created -
+// if it is false, no other options in this struct will be used) and HostNetwork
+// (this involves the created OCI spec, and as such is not represented directly
+// in container_config.go).
+// Generally speaking, aside from those two exceptions, these options will set
+// the equivalent field in the container's configuration.
 type InfraContainerConfig struct {
 	ConmonPidFile      string               `json:"conmonPidFile"`
 	HasInfraContainer  bool                 `json:"makeInfraContainer"`
@@ -96,6 +104,7 @@ type InfraContainerConfig struct {
 	UseImageHosts      bool                 `json:"useImageHosts,omitempty"`
 	HostAdd            []string             `json:"hostsAdd,omitempty"`
 	Networks           []string             `json:"networks,omitempty"`
+	ExitCommand        []string             `json:"exitCommand,omitempty"`
 }
 
 // ID retrieves the pod's ID

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -83,6 +83,9 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, rawIm
 			return nil, errors.Wrapf(err, "error removing network namespace from pod %s infra container", p.ID())
 		}
 
+		// For each option in InfraContainerConfig - if set, pass into
+		// the infra container we're creating with the appropriate
+		// With... option.
 		if p.config.InfraContainer.StaticIP != nil {
 			options = append(options, WithStaticIP(p.config.InfraContainer.StaticIP))
 		}
@@ -106,6 +109,9 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, rawIm
 		}
 		if len(p.config.InfraContainer.HostAdd) > 0 {
 			options = append(options, WithHosts(p.config.InfraContainer.HostAdd))
+		}
+		if len(p.config.InfraContainer.ExitCommand) > 0 {
+			options = append(options, WithExitCommand(p.config.InfraContainer.ExitCommand))
 		}
 	}
 

--- a/pkg/bindings/test/pods_test.go
+++ b/pkg/bindings/test/pods_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Podman pods", func() {
 		Expect(response.State).To(Equal(define.PodStateExited))
 		for _, i := range response.Containers {
 			Expect(define.StringToContainerStatus(i.State)).
-				To(Equal(define.ContainerStateStopped))
+				To(Equal(define.ContainerStateExited))
 		}
 
 		// Stop an already stopped pod
@@ -309,7 +309,7 @@ var _ = Describe("Podman pods", func() {
 		Expect(response.State).To(Equal(define.PodStateExited))
 		for _, i := range response.Containers {
 			Expect(define.StringToContainerStatus(i.State)).
-				To(Equal(define.ContainerStateStopped))
+				To(Equal(define.ContainerStateExited))
 		}
 		_, err = pods.Stop(bt.conn, newpod2, nil)
 		Expect(err).To(BeNil())
@@ -318,7 +318,7 @@ var _ = Describe("Podman pods", func() {
 		Expect(response.State).To(Equal(define.PodStateExited))
 		for _, i := range response.Containers {
 			Expect(define.StringToContainerStatus(i.State)).
-				To(Equal(define.ContainerStateStopped))
+				To(Equal(define.ContainerStateExited))
 		}
 		_, err = pods.Prune(bt.conn)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
Most Libpod containers are made via `pkg/specgen/generate` which includes code to generate an appropriate exit command which will handle unmounting the container's storage, cleaning up the container's network, etc. There is one notable exception: pod infra containers, which are made entirely within Libpod and do not touch pkg/specgen. As such, no cleanup process, network never cleaned up, bad things can happen.

There is good news, though - it's not that difficult to add this, and it's done in this PR. Generally speaking, we don't allow passing options directly to the infra container at create time, but we do (optionally) proxy a pre-approved set of options into it when we create it. Add ExitCommand to these options, and set it at time of pod creation using the same code we use to generate exit commands for normal containers.
