### PR TITLE
Update nix pin with `make nixpkgs`

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,6 +7,15 @@ let
         libassuan = (static pkg.libassuan);
         libgpgerror = (static pkg.libgpgerror);
         libseccomp = (static pkg.libseccomp);
+        glib = (static pkg.glib).overrideAttrs(x: {
+          outputs = [ "bin" "out" "dev" ];
+          mesonFlags = [
+            "-Ddefault_library=static"
+            "-Ddevbindir=${placeholder ''dev''}/bin"
+            "-Dgtk_doc=false"
+            "-Dnls=disabled"
+          ];
+        });
       };
     };
   });

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "b49e7987632e4c7ab3a093fdfc433e1826c4b9d7",
-  "date": "2020-07-26T09:18:52+02:00",
-  "sha256": "1mj6fy0p24izmasl653s5z4f2ka9v3b6mys45kjrqmkv889yk2r6",
+  "rev": "d6a445fe821052861b379d9b6c02d21623c25464",
+  "date": "2020-08-11T04:28:16+01:00",
+  "sha256": "064scwaxg8qg4xbmq07hag57saa4bhsb4pgg5h5vfs4nhhwvchg9",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Update nix pin with `make nixpkgs`

Also sync nix `packageOverrides` across skopeo/buildah/podman/cri-o for utilizing local build cache, see
- https://github.com/containers/crun/pull/450
- https://github.com/containers/conmon/pull/189
- https://github.com/containers/skopeo/pull/973
- https://github.com/containers/buildah/pull/2533
- https://github.com/containers/podman/pull/7286
- https://github.com/cri-o/cri-o/pull/4065

```release-note
Update nix pin with `make `nixpkgs`
```