### PR TITLE
Enable systemd mode for /usr/local/sbin/init

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -801,8 +801,8 @@ Run container in systemd mode. The default is *true*.
 
 The value *always* enforces the systemd mode is enforced without
 looking at the executable name.  Otherwise, if set to true and the
-command you are running inside the container is systemd, /usr/sbin/init
-or /sbin/init.
+command you are running inside the container is systemd, /usr/sbin/init,
+/sbin/init or /usr/local/sbin/init.
 
 If the command you are running inside of the container is systemd,
 Podman will setup tmpfs mount points in the following directories:

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -831,8 +831,8 @@ Run container in systemd mode. The default is **true**.
 
 The value *always* enforces the systemd mode is enforced without
 looking at the executable name.  Otherwise, if set to **true** and the
-command you are running inside the container is systemd, _/usr/sbin/init_
-or _/sbin/init_.
+command you are running inside the container is systemd, _/usr/sbin/init_,
+_/sbin/init_ or _/usr/local/sbin/init_.
 
 If the command you are running inside of the container is systemd
 Podman will setup tmpfs mount points in the following directories:

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -164,13 +164,14 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 		}
 
 		if len(command) > 0 {
-			if command[0] == "/usr/sbin/init" || command[0] == "/sbin/init" || (filepath.Base(command[0]) == "systemd") {
+			if command[0] == "/usr/sbin/init" || command[0] == "/sbin/init" || command[0] == "/usr/local/sbin/init" || (filepath.Base(command[0]) == "systemd") {
 				useSystemd = true
 			}
 		}
 	default:
 		return nil, errors.Wrapf(err, "invalid value %q systemd option requires 'true, false, always'", s.Systemd)
 	}
+	logrus.Debugf("using systemd mode: %t", useSystemd)
 	if useSystemd {
 		// is StopSignal was not set by the user then set it to systemd
 		// expected StopSigal

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -164,7 +164,12 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 		}
 
 		if len(command) > 0 {
-			if command[0] == "/usr/sbin/init" || command[0] == "/sbin/init" || command[0] == "/usr/local/sbin/init" || (filepath.Base(command[0]) == "systemd") {
+			useSystemdCommands := map[string]bool{
+				"/sbin/init":           true,
+				"/usr/sbin/init":       true,
+				"/usr/local/sbin/init": true,
+			}
+			if useSystemdCommands[command[0]] || (filepath.Base(command[0]) == "systemd") {
 				useSystemd = true
 			}
 		}

--- a/pkg/varlinkapi/create.go
+++ b/pkg/varlinkapi/create.go
@@ -704,7 +704,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot parse bool %s", c.String("systemd"))
 		}
-		if x && (command[0] == "/usr/sbin/init" || command[0] == "/sbin/init" || (filepath.Base(command[0]) == "systemd")) {
+		if x && (command[0] == "/usr/sbin/init" || command[0] == "/sbin/init" || command[0] == "/usr/local/sbin/init" || (filepath.Base(command[0]) == "systemd")) {
 			systemd = true
 		}
 	}

--- a/pkg/varlinkapi/create.go
+++ b/pkg/varlinkapi/create.go
@@ -704,7 +704,12 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot parse bool %s", c.String("systemd"))
 		}
-		if x && (command[0] == "/usr/sbin/init" || command[0] == "/sbin/init" || command[0] == "/usr/local/sbin/init" || (filepath.Base(command[0]) == "systemd")) {
+		useSystemdCommands := map[string]bool{
+			"/sbin/init":           true,
+			"/usr/sbin/init":       true,
+			"/usr/local/sbin/init": true,
+		}
+		if x && (useSystemdCommands[command[0]] || (filepath.Base(command[0]) == "systemd")) {
 			systemd = true
 		}
 	}


### PR DESCRIPTION
Podman 1.6.2 changed systemd mode auto-detection from commands ending in
``init`` to hard-coded paths ``/sbin/init`` and ``/usr/sbin/init``. This
broke FreeIPA container. ``podman run`` and ``podman create`` now
activate systemd mode when the command is ``/usr/local/sbin/init``.

Fixes: https://github.com/containers/podman/issues/7287
Signed-off-by: Christian Heimes <cheimes@redhat.com>