### PR TITLE
Show c/storage (Buildah/CRI-O) containers in ps

### DIFF
--- a/cmd/podman/utils/alias.go
+++ b/cmd/podman/utils/alias.go
@@ -19,6 +19,8 @@ func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "network"
 	case "timeout":
 		name = "time"
+	case "namespace":
+		name = "ns"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2679,6 +2679,7 @@ _podman_ps() {
 	  --pod -p
 	  --quiet -q
 	  --size -s
+	  --storage
 	  --namespace --ns
 	  --sync
      "

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -23,6 +23,8 @@ When the URL is an Containerfile, the Containerfile is downloaded to a temporary
 
 When a Git repository is set as the URL, the repository is cloned locally and then set as the context.
 
+NOTE: `podman build` uses code sourced from the `buildah` project to build container images.  This `buildah` code creates `buildah` containers for the `RUN` options in container storage. In certain situations, when the `podman build` crashes or users kill the `podman build` process, these external containers can be left in container storage. Use the `podman ps --all --storage` command to see these contaienrs. External containers can be removed with the `podman rm --storage` command.
+
 ## OPTIONS
 
 **--add-host**=*host*
@@ -804,7 +806,7 @@ If you are using a useradd command within a Containerfile with a large UID/GID, 
 If you are using `useradd` within your build script, you should pass the `--no-log-init or -l` option to the `useradd` command.  This option tells useradd to stop creating the lastlog file.
 
 ## SEE ALSO
-podman(1), buildah(1), containers-registries.conf(5), crun(8), runc(8), useradd(8)
+podman(1), buildah(1), containers-registries.conf(5), crun(8), runc(8), useradd(8), podman-ps(1), podman-rm(1)
 
 ## HISTORY
 Aug 2020, Additional options and .dockerignore added by Dan Walsh <dwalsh@redhat.com>

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -32,11 +32,17 @@ all the containers information.  By default it lists:
 
 **--all**, **-a**
 
-Show all the containers, default is only running containers
+Show all the containers created by Podman, default is only running containers.
+
+Note: Podman shares containers storage with other tools such as Buildah and CRI-O. In some cases these `external` containers might also exist in the same storage. Use the `--storage` option to see these external containers. External containers show the 'storage' status.
 
 **--pod**, **-p**
 
 Display the pods the containers are associated with
+
+**--storage**
+
+Display external containers that are not controlled by Podman but are stored in containers storage.  These external containers are generally created via other container technology such as Buildah or CRI-O and may depend on the same container images that Podman is also using.  External containers are denoted with either a 'buildah' or 'storage' in the COMMAND and STATUS column of the ps output. Only used with the --all option.
 
 **--no-trunc**
 
@@ -174,11 +180,20 @@ CONTAINER ID  IMAGE                            COMMAND    CREATED        STATUS 
 
 ```
 
+```
+$ podman ps --storage -a
+CONTAINER ID  IMAGE                             COMMAND  CREATED      STATUS  PORTS  NAMES
+69ed779d8ef9f  redis:alpine  "redis-server"  25 hours ago  Created                   6379/tcp  k8s_container1_podsandbox1_redhat.test.crio_redhat-test-crio_1
+38a8a78596f9  docker.io/library/busybox:latest  buildah  2 hours ago  storage        busybox-working-container
+fd7b786b5c32  docker.io/library/alpine:latest   buildah  2 hours ago  storage        alpine-working-container
+f78620804e00  scratch                           buildah  2 hours ago  storage        working-container
+```
+
 ## ps
 Print a list of containers
 
 ## SEE ALSO
-podman(1)
+podman(1), buildah(1), crio(8)
 
 ## HISTORY
 August 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/source/markdown/podman-rm.1.md
+++ b/docs/source/markdown/podman-rm.1.md
@@ -45,9 +45,9 @@ The latest option is not supported on the remote client.
 
 **--storage**
 
-Remove the container from the storage library only.
-This is only possible with containers that are not present in libpod (cannot be seen by **podman ps**).
-It is used to remove containers from **podman build** and **buildah**, and orphan containers which were only partially removed by **podman rm**.
+Remove external containers from the storage library.
+This is only possible with containers that are not present in libpod can be seen by **podman ps --all --storage**).
+It is used to remove external containers from **podman build** and **buildah**, and orphan containers which were only partially removed by **podman rm**.
 The storage option conflicts with the **--all**, **--latest**, and **--volumes** options.
 
 **--volumes**, **-v**
@@ -96,7 +96,7 @@ $ podman rm -f --latest
   **125** The command fails for a reason other than container did not exist or is paused/running
 
 ## SEE ALSO
-podman(1), podman-image-rm(1)
+podman(1), podman-image-rm(1), podman-ps(1), podman-build(1)
 
 ## HISTORY
 August 2017, Originally compiled by Ryan Cole <rycole@redhat.com>

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -161,4 +161,8 @@ var (
 	// ErrNetworkOnPodContainer indicates the user wishes to alter network attributes on a container
 	// in a pod.  This cannot be done as the infra container has all the network information
 	ErrNetworkOnPodContainer = errors.New("network cannot be configured when it is shared with a pod")
+
+	// ErrStoreNotInitialized indicates that the container storage was never
+	// initilized.
+	ErrStoreNotInitialized = errors.New("the container storage was never initilized")
 )

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -466,6 +466,14 @@ func (ir *Runtime) getImage(image string) (*storage.Image, error) {
 	return img, nil
 }
 
+func (ir *Runtime) ImageNames(id string) ([]string, error) {
+	myImage, err := ir.getImage(id)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting image %s ", id)
+	}
+	return myImage.Names, nil
+}
+
 // GetImages retrieves all images present in storage
 func (ir *Runtime) GetImages() ([]*Image, error) {
 	return ir.getImages(false)

--- a/libpod/image/prune.go
+++ b/libpod/image/prune.go
@@ -137,7 +137,7 @@ func (ir *Runtime) PruneImages(ctx context.Context, all bool, filter []string) (
 		}
 		if err := p.Remove(ctx, true); err != nil {
 			if errors.Cause(err) == storage.ErrImageUsedByContainer {
-				logrus.Warnf("Failed to prune image %s as it is in use: %v", p.ID(), err)
+				logrus.Warnf("Failed to prune image %s as it is in use: %v.\nA container associated with containers/storage i.e. Buildah, CRI-O, etc., maybe associated with this image.\nUsing the rmi command with the --force option will remove the container and image, but may cause failures for other dependent systems.", p.ID(), err)
 				continue
 			}
 			return nil, errors.Wrap(err, "failed to prune image")

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -282,6 +282,7 @@ type ContainerListOptions struct {
 	Quiet     bool
 	Size      bool
 	Sort      string
+	Storage   bool
 	Sync      bool
 	Watch     uint
 }


### PR DESCRIPTION
The `podman ps --all` command will now show containers that
are under the control of other c/storage container systems and
the new `ps --external` option will show only containers that are
in c/storage but are not controlled by libpod.

In the below examples, the '*working-container' entries were created
by Buildah.

```
podman ps -a
CONTAINER ID  IMAGE                             COMMAND  CREATED       STATUS                   PORTS  NAMES
9257ef8c786c  docker.io/library/busybox:latest  ls /etc  8 hours ago   Exited (0) 8 hours ago          gifted_jang
d302c81856da  docker.io/library/busybox:latest  buildah  30 hours ago  external                        busybox-working-container
7a5a7b099d33  localhost/tom:latest              ls -alF  30 hours ago  Exited (0) 30 hours ago         hopeful_hellman
01d601fca090  localhost/tom:latest              ls -alf  30 hours ago  Exited (1) 30 hours ago         determined_panini
ee58f429ff26  localhost/tom:latest              buildah  33 hours ago  external                        alpine-working-container

podman ps --external
CONTAINER ID  IMAGE                             COMMAND  CREATED       STATUS    PORTS  NAMES
d302c81856da  docker.io/library/busybox:latest  buildah  30 hours ago  external         busybox-working-container
ee58f429ff26  localhost/tom:latest              buildah  33 hours ago  external         alpine-working-container

```
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>