### PR TITLE
Fix hang when `path` doesn't exist

### DIFF
--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -389,13 +389,11 @@ func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []st
 			lastErr = nil
 			break
 		} else {
-			fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_DGRAM, 0)
+			r, w, err := os.Pipe()
 			if err != nil {
 				lastErr = err
 				continue
 			}
-
-			r, w := os.NewFile(uintptr(fds[0]), "read file"), os.NewFile(uintptr(fds[1]), "write file")
 
 			defer errorhandling.CloseQuiet(r)
 


### PR DESCRIPTION
I'm not sure if this is an OS-specific issue, but on CentOS 8, if `path` doesn't exist, this hangs while waiting to read from this socket, even though the socket is closed by the `reexec_in_user_namespace`.  Switching to a pipe fixes the problem, and pipes shouldn't be an issue since this is Linux-specific code.