### PR TITLE
add xz as a recommended pkg

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -91,6 +91,7 @@ Recommends: container-selinux
 Recommends: slirp4netns
 Recommends: fuse-overlayfs
 %endif
+Recommends: xz
 
 # vendored libraries
 # awk '{print "Provides: bundled(golang("$1")) = "$2}' vendor.conf | sort


### PR DESCRIPTION
xz package is required by buildah and podman when building a
image and ADD a tar.xz file archive is used

See https://github.com/containers/buildah/issues/2525

Signed-off-by: Job Cespedes Ortiz <jobcespedes@gmail.com>