### PR TITLE
Add support for setting the CIDR when using slirp4netns

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -563,6 +563,7 @@ Valid values are:
 - `private`: create a new namespace for the container (default)
 - `slirp4netns[:OPTIONS,...]`: use slirp4netns to create a user network stack.  This is the default for rootless containers.  It is possible to specify these additional options:
   - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
+  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
   - **enable_ipv6=true|false**: Enable IPv6. Default is false. (Required for `outbound_addr6`).
   - **outbound_addr=INTERFACE**: Specify the outbound interface slirp should bind to (ipv4 traffic only).
   - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp should bind to.

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -570,9 +570,15 @@ Valid _mode_ values are:
 - **ns:**_path_: path to a network namespace to join;
 - `private`: create a new namespace for the container (default)
 - **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack.  This is the default for rootless containers.  It is possible to specify these additional options:
-  **port_handler=rootlesskit**: Use rootlesskit for port forwarding.  Default.
-  **port_handler=slirp4netns**: Use the slirp4netns port forwarding.
-  **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`).  Default to false.
+  - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
+  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
+  - **enable_ipv6=true|false**: Enable IPv6. Default is false. (Required for `outbound_addr6`).
+  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp should bind to (ipv4 traffic only).
+  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp should bind to.
+  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp should bind to (ipv6 traffic only).
+  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp should bind to.
+  - **port_handler=rootlesskit**: Use rootlesskit for port forwarding. Default.
+  - **port_handler=slirp4netns**: Use the slirp4netns port forwarding.
 
 **--network-alias**=*alias*
 

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -293,6 +293,22 @@ var _ = Describe("Podman run networking", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman run slirp4netns network with different cidr", func() {
+		slirp4netnsHelp := SystemExec("slirp4netns", []string{"--help"})
+		Expect(slirp4netnsHelp.ExitCode()).To(Equal(0))
+
+		networkConfiguration := "slirp4netns:cidr=192.168.0.0/24,allow_host_loopback=true"
+		session := podmanTest.Podman([]string{"run", "--network", networkConfiguration, ALPINE, "ping", "-c1", "192.168.0.2"})
+		session.Wait(30)
+
+		if strings.Contains(slirp4netnsHelp.OutputToString(), "cidr") {
+			Expect(session.ExitCode()).To(Equal(0))
+		} else {
+			Expect(session.ExitCode()).ToNot(Equal(0))
+			Expect(session.ErrorToString()).To(ContainSubstring("cidr not supported"))
+		}
+	})
+
 	It("podman run network bind to 127.0.0.1", func() {
 		slirp4netnsHelp := SystemExec("slirp4netns", []string{"--help"})
 		Expect(slirp4netnsHelp.ExitCode()).To(Equal(0))


### PR DESCRIPTION
This adds support for the --cidr parameter that is supported
by slirp4netns since v0.3.0. It allows the user to change the
IP range that is used for the network inside the container.

Changing the IP range can fix address conflicts with outside
networks or, which is the issue I had, with the virtualbox NAT
network mode which uses the same range (10.0.2.0/24).

This was referenced in https://github.com/rootless-containers/slirp4netns/issues/70 but
never got resolved.