### PR TITLE
Use `bash` binary from env instead of /bin/bash for scripts

### DIFF
--- a/contrib/build_rpm.sh
+++ b/contrib/build_rpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 # returned path can vary: /usr/bin/dnf /bin/dnf ...

--- a/contrib/cirrus/add_second_partition.sh
+++ b/contrib/cirrus/add_second_partition.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # N/B: This script could mega f*!@up your disks if run by mistake.
 #      it is left without the execute-bit on purpose!

--- a/contrib/cirrus/apiv2_test.sh
+++ b/contrib/cirrus/apiv2_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/build_release.sh
+++ b/contrib/cirrus/build_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/build_swagger.sh
+++ b/contrib/cirrus/build_swagger.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/build_vm_images.sh
+++ b/contrib/cirrus/build_vm_images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source $(dirname $0)/lib.sh

--- a/contrib/cirrus/check_image.sh
+++ b/contrib/cirrus/check_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/contrib/cirrus/container_test.sh
+++ b/contrib/cirrus/container_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xeo pipefail
 
 export GOPATH=/var/tmp/go

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -376,7 +376,7 @@ install_scl_git() {
     echo "Installing SoftwareCollections updated 'git' version."
     ooe.sh $SUDO yum -y install rh-git29
     cat << "EOF" | $SUDO tee /usr/bin/git
-#!/bin/bash
+#!/usr/bin/env bash
 
 scl enable rh-git29 -- git $@
 EOF

--- a/contrib/cirrus/lib.sh.t
+++ b/contrib/cirrus/lib.sh.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Unit tests for some functions in lib.sh
 #

--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/networking.sh
+++ b/contrib/cirrus/networking.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script attempts basic confirmation of functional networking
 # by connecting to a set of essential external servers and failing

--- a/contrib/cirrus/notice_branch_failure.sh
+++ b/contrib/cirrus/notice_branch_failure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/ooe.sh
+++ b/contrib/cirrus/ooe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script executes a command while logging all output to a temporary
 # file.  If the command exits non-zero, then all output is sent to the console,

--- a/contrib/cirrus/packer/fedora_base-setup.sh
+++ b/contrib/cirrus/packer/fedora_base-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # N/B: This script is not intended to be run by humans.  It is used to configure the
 # fedora base image for importing, so that it will boot in GCE

--- a/contrib/cirrus/packer/fedora_packaging.sh
+++ b/contrib/cirrus/packer/fedora_packaging.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is called from fedora_setup.sh and various Dockerfiles.
 # It's not intended to be used outside of those contexts.  It assumes the lib.sh

--- a/contrib/cirrus/packer/fedora_setup.sh
+++ b/contrib/cirrus/packer/fedora_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is called by packer on the subject fedora VM, to setup the podman
 # build/test environment.  It's not intended to be used outside of this context.

--- a/contrib/cirrus/packer/image-builder-image_base-setup.sh
+++ b/contrib/cirrus/packer/image-builder-image_base-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is called by packer on a vanilla CentOS VM, to setup the image
 # used for building images FROM base images. It's not intended to be used

--- a/contrib/cirrus/packer/make-user-data.sh
+++ b/contrib/cirrus/packer/make-user-data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is utilized by Makefile, it's not intended to be run by humans
 

--- a/contrib/cirrus/packer/prior-fedora_base-setup.sh
+++ b/contrib/cirrus/packer/prior-fedora_base-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # N/B: This script is not intended to be run by humans.  It is used to configure the
 # fedora base image for importing, so that it will boot in GCE

--- a/contrib/cirrus/packer/systemd_banish.sh
+++ b/contrib/cirrus/packer/systemd_banish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set +e  # Not all of these exist on every platform
 

--- a/contrib/cirrus/packer/ubuntu_packaging.sh
+++ b/contrib/cirrus/packer/ubuntu_packaging.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is called from ubuntu_setup.sh and various Dockerfiles.
 # It's not intended to be used outside of those contexts.  It assumes the lib.sh

--- a/contrib/cirrus/packer/ubuntu_setup.sh
+++ b/contrib/cirrus/packer/ubuntu_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is called by packer on the subject Ubuntu VM, to setup the podman
 # build/test environment.  It's not intended to be used outside of this context.

--- a/contrib/cirrus/packer/xfedora_setup.sh
+++ b/contrib/cirrus/packer/xfedora_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is called by packer on the subject fedora VM, to setup the podman
 # build/test environment.  It's not intended to be used outside of this context.

--- a/contrib/cirrus/rootless_test.sh
+++ b/contrib/cirrus/rootless_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/setup_container_environment.sh
+++ b/contrib/cirrus/setup_container_environment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 source $(dirname $0)/lib.sh

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/success.sh
+++ b/contrib/cirrus/success.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/system_test.sh
+++ b/contrib/cirrus/system_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/unit_test.sh
+++ b/contrib/cirrus/unit_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/update_meta.sh
+++ b/contrib/cirrus/update_meta.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source $(dirname $0)/lib.sh
 

--- a/contrib/cirrus/upload_release_archive.sh
+++ b/contrib/cirrus/upload_release_archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/contrib/gate/entrypoint.sh
+++ b/contrib/gate/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/imgprune/entrypoint.sh
+++ b/contrib/imgprune/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/imgts/entrypoint.sh
+++ b/contrib/imgts/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/imgts/lib_entrypoint.sh
+++ b/contrib/imgts/lib_entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/upldrel/entrypoint.sh
+++ b/contrib/upldrel/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/docs/remote-docs.sh
+++ b/docs/remote-docs.sh
@@ -1,5 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 # Assemble remote man pages for darwin or windows from markdown files
+set -e
 
 PLATFORM=$1                         ## linux, windows or darwin
 TARGET=${2}                         ## where to output files

--- a/hack/apparmor_tag.sh
+++ b/hack/apparmor_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if pkg-config libapparmor 2> /dev/null ; then
 	echo apparmor
 fi

--- a/hack/btrfs_installed_tag.sh
+++ b/hack/btrfs_installed_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cc -E - > /dev/null 2> /dev/null << EOF
 #include <btrfs/ioctl.h>
 EOF

--- a/hack/btrfs_tag.sh
+++ b/hack/btrfs_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cc -E - > /dev/null 2> /dev/null << EOF
 #include <btrfs/version.h>
 EOF

--- a/hack/check_root.sh
+++ b/hack/check_root.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if ! [ $(id -u) = 0 ]; then
    echo "Please run as root! '$@' requires root privileges."
    exit 1

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/get_release_info.sh
+++ b/hack/get_release_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script produces various bits of metadata needed by Makefile.  Using
 # a script allows uniform behavior across multiple environments and

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,6 +1,7 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
 # Need to run linter twice to cover all the build tags code paths
+set -e
 
 declare -A BUILD_TAGS
 # TODO: add systemd tag

--- a/hack/install_bats.sh
+++ b/hack/install_bats.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/install_catatonit.sh
+++ b/hack/install_catatonit.sh
@@ -1,7 +1,8 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 BASE_PATH="/usr/libexec/podman"
 CATATONIT_PATH="${BASE_PATH}/catatonit"
 CATATONIT_VERSION="v0.1.4"
+set -e
 
 if [ -f $CATATONIT_PATH ]; then
 	echo "skipping ... catatonit is already installed"

--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/libdm_tag.sh
+++ b/hack/libdm_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT

--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # man-page-checker - validate and cross-reference man page names
 #

--- a/hack/podman-commands.sh
+++ b/hack/podman-commands.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Compare commands listed by 'podman help' against those in 'man podman'.
 # Recurse into subcommands as well.

--- a/hack/podmanv2-retry
+++ b/hack/podmanv2-retry
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # podman-try - try running a command via PODMAN1; use PODMAN2 as fallback
 #

--- a/hack/selinux_tag.sh
+++ b/hack/selinux_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if pkg-config libselinux 2> /dev/null ; then
 	echo selinux
 fi

--- a/hack/tree_status.sh
+++ b/hack/tree_status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SUGGESTION="${SUGGESTION:-sync the vendor.conf and commit all changes.}"

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage: test-apiv2 [PORT]
 #

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -23,7 +23,7 @@ load helpers
     # as a user, the parent directory must be world-readable.
     test_script=$PODMAN_TMPDIR/fail-if-writable
     cat >$test_script <<"EOF"
-#!/bin/bash
+#!/usr/bin/env bash
 
 path="$1"
 

--- a/test/system/helpers.t
+++ b/test/system/helpers.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # regression tests for helpers.bash
 #

--- a/test/test_podman_baseline.sh
+++ b/test/test_podman_baseline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # test_podman_baseline.sh
 # A script to be run at the command line with Podman installed.
 # This should be run against a new kit to provide base level testing
@@ -215,7 +215,7 @@ podman run $image ls /
 ########
 FILE=./runecho.sh
 /bin/cat <<EOM >$FILE
-#!/bin/bash
+#!/usr/bin/env bash
 for i in {1..9};
 do
     echo "This is a new container pull ipbabble [" \$i "]"

--- a/test/test_podman_build.sh
+++ b/test/test_podman_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # test_podman_build.sh
 #

--- a/test/test_podman_pods.sh
+++ b/test/test_podman_pods.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # test_podman_pods.sh
 # A script to be run at the command line with Podman installed.
 # This should be run against a new kit to provide base level testing


### PR DESCRIPTION
It's not possible to run any of the scripts on distributions which do
have `bash` not in `/bin`. This is being fixed by using `/usr/bin/env
bash` instead.
