### PR TITLE
e2e tests: use actual temp dirs, not "/tmp/dir"

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -127,8 +127,10 @@ var _ = Describe("Podman build", func() {
 		defer Expect(os.Chdir(cwd)).To(BeNil())
 
 		// Write target and fake files
-		targetPath := filepath.Join(os.TempDir(), "dir")
-		Expect(os.MkdirAll(targetPath, 0755)).To(BeNil())
+		targetPath, err := CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
 
 		fakeFile := filepath.Join(os.TempDir(), "Containerfile")
 		Expect(ioutil.WriteFile(fakeFile, []byte("FROM alpine"), 0755)).To(BeNil())
@@ -162,7 +164,10 @@ var _ = Describe("Podman build", func() {
 		Expect(os.Chdir(os.TempDir())).To(BeNil())
 		defer Expect(os.Chdir(cwd)).To(BeNil())
 
-		targetPath := filepath.Join(os.TempDir(), "dir")
+		targetPath, err := CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
 		targetFile := filepath.Join(targetPath, "idFile")
 
 		session := podmanTest.PodmanNoCache([]string{"build", "build/basicalpine", "--iidfile", targetFile})

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -257,8 +257,10 @@ var _ = Describe("Podman commit", func() {
 		cwd, err := os.Getwd()
 		Expect(err).To(BeNil())
 		Expect(os.Chdir(os.TempDir())).To(BeNil())
-		targetPath := filepath.Join(os.TempDir(), "dir")
-		Expect(os.MkdirAll(targetPath, 0755)).To(BeNil())
+		targetPath, err := CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
 		targetFile := filepath.Join(targetPath, "idFile")
 		defer Expect(os.RemoveAll(targetFile)).To(BeNil())
 		defer Expect(os.Chdir(cwd)).To(BeNil())

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -296,8 +296,10 @@ var _ = Describe("Podman pod create", func() {
 		cwd, err := os.Getwd()
 		Expect(err).To(BeNil())
 		Expect(os.Chdir(os.TempDir())).To(BeNil())
-		targetPath := filepath.Join(os.TempDir(), "dir")
-		Expect(os.MkdirAll(targetPath, 0755)).To(BeNil())
+		targetPath, err := CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
 		targetFile := filepath.Join(targetPath, "idFile")
 		defer Expect(os.RemoveAll(targetFile)).To(BeNil())
 		defer Expect(os.Chdir(cwd)).To(BeNil())


### PR DESCRIPTION
One of the --iidfile tests was flaking:

   Error: failed to write image ID to file "/tmp/dir/idFile": open /tmp/dir/idFile: no such file or directory

Root cause: test was actually not mkdir'ing /tmp/dir. Test was
mostly passing because _other_ tests in the suite were mkdir'ing
it, but once in a while this test ran before the others.

Solution: fixed this test to use CreateTempDirInTempDir(). And,
since hardcoded tempdirs are bad practice, grepped for '"dir"'
and fixed all other instances too.

Signed-off-by: Ed Santiago <santiago@redhat.com>