### PR TITLE
Ensure DefaultEnvVariables is used in Specgen

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -12,13 +12,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-// DefaultEnvVariables sets $PATH and $TERM.
-var DefaultEnvVariables = map[string]string{
-	"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-	"TERM": "xterm",
-}
-
 const whiteSpaces = " \t"
+
+// DefaultEnvVariables returns a default environment, with $PATH and $TERM set.
+func DefaultEnvVariables() map[string]string {
+	return map[string]string{
+		"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"TERM": "xterm",
+	}
+}
 
 // Slice transforms the specified map of environment variables into a
 // slice. If a value is non-empty, the key and value are joined with '='.

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -321,13 +321,13 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 	// config.
 	var defaultEnv map[string]string
 	if runtimeConfig == nil {
-		defaultEnv = env.DefaultEnvVariables
+		defaultEnv = env.DefaultEnvVariables()
 	} else {
 		defaultEnv, err = env.ParseSlice(runtimeConfig.Containers.Env)
 		if err != nil {
 			return nil, errors.Wrap(err, "Env fields in containers.conf failed ot parse")
 		}
-		defaultEnv = env.Join(env.DefaultEnvVariables, defaultEnv)
+		defaultEnv = env.Join(env.DefaultEnvVariables(), defaultEnv)
 	}
 
 	if err := addRlimits(config, &g); err != nil {


### PR DESCRIPTION
When we rewrote Podman's pkg/spec, one of the things that was lost was our use of a set of default environment variables, that ensure all containers have at least $PATH and $TERM set.

While we're in the process of re-adding it, change it from a variable to a function, so we can ensure the Join function does not overwrite it and corrupt the defaults.
