### PR TITLE
generate systemd: quote arguments with whitespace

### DIFF
--- a/pkg/systemd/generate/common.go
+++ b/pkg/systemd/generate/common.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -52,4 +53,16 @@ func filterPodFlags(command []string) []string {
 		processed = append(processed, s)
 	}
 	return processed
+}
+
+// quoteArguments makes sure that all arguments with at least one whitespace
+// are quoted to make sure those are interpreted as one argument instead of
+// multiple ones.
+func quoteArguments(command []string) []string {
+	for i := range command {
+		if strings.ContainsAny(command[i], " \t") {
+			command[i] = strconv.Quote(command[i])
+		}
+	}
+	return command
 }

--- a/pkg/systemd/generate/common_test.go
+++ b/pkg/systemd/generate/common_test.go
@@ -28,3 +28,28 @@ func TestFilterPodFlags(t *testing.T) {
 		}
 	}
 }
+
+func TestQuoteArguments(t *testing.T) {
+	tests := []struct {
+		input  []string
+		output []string
+	}{
+		{
+			[]string{"foo", "bar=\"arg\""},
+			[]string{"foo", "bar=\"arg\""},
+		},
+		{
+			[]string{"foo", "bar=\"arg with space\""},
+			[]string{"foo", "\"bar=\\\"arg with space\\\"\""},
+		},
+		{
+			[]string{"foo", "bar=\"arg with\ttab\""},
+			[]string{"foo", "\"bar=\\\"arg with\\ttab\\\"\""},
+		},
+	}
+
+	for _, test := range tests {
+		quoted := quoteArguments(test.input)
+		assert.Equal(t, test.output, quoted)
+	}
+}

--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -241,6 +241,7 @@ func executeContainerTemplate(info *containerInfo, options entities.GenerateSyst
 			startCommand = append(startCommand, "--replace")
 		}
 		startCommand = append(startCommand, info.CreateCommand[index:]...)
+		startCommand = quoteArguments(startCommand)
 
 		info.ExecStartPre = "/bin/rm -f {{.PIDFile}} {{.ContainerIDFile}}"
 		info.ExecStart = strings.Join(startCommand, " ")

--- a/pkg/systemd/generate/containers_test.go
+++ b/pkg/systemd/generate/containers_test.go
@@ -117,7 +117,7 @@ After=network-online.target
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=always
 ExecStartPre=/bin/rm -f %t/jadda-jadda.pid %t/jadda-jadda.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/jadda-jadda.pid --cidfile %t/jadda-jadda.ctr-id --cgroups=no-conmon -d --replace --name jadda-jadda --hostname hello-world awesome-image:latest command arg1 ... argN
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/jadda-jadda.pid --cidfile %t/jadda-jadda.ctr-id --cgroups=no-conmon -d --replace --name jadda-jadda --hostname hello-world awesome-image:latest command arg1 ... argN "foo=arg \"with \" space"
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/jadda-jadda.ctr-id -t 42
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/jadda-jadda.ctr-id
 PIDFile=%t/jadda-jadda.pid
@@ -296,7 +296,7 @@ WantedBy=multi-user.target default.target`
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       42,
 				PodmanVersion:     "CI",
-				CreateCommand:     []string{"I'll get stripped", "container", "run", "--name", "jadda-jadda", "--hostname", "hello-world", "awesome-image:latest", "command", "arg1", "...", "argN"},
+				CreateCommand:     []string{"I'll get stripped", "container", "run", "--name", "jadda-jadda", "--hostname", "hello-world", "awesome-image:latest", "command", "arg1", "...", "argN", "foo=arg \"with \" space"},
 				EnvVariable:       EnvVariable,
 			},
 			goodWithNameAndGeneric,

--- a/pkg/systemd/generate/pods.go
+++ b/pkg/systemd/generate/pods.go
@@ -292,6 +292,7 @@ func executePodTemplate(info *podInfo, options entities.GenerateSystemdOptions) 
 		}
 
 		startCommand = append(startCommand, podCreateArgs...)
+		startCommand = quoteArguments(startCommand)
 
 		info.ExecStartPre1 = "/bin/rm -f {{.PIDFile}} {{.PodIDFile}}"
 		info.ExecStartPre2 = strings.Join(startCommand, " ")

--- a/pkg/systemd/generate/pods_test.go
+++ b/pkg/systemd/generate/pods_test.go
@@ -75,7 +75,7 @@ Before=container-1.service container-2.service
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/pod-123abc.pid %t/pod-123abc.pod-id
-ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/pod-123abc.pid --pod-id-file %t/pod-123abc.pod-id --name foo --replace
+ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/pod-123abc.pid --pod-id-file %t/pod-123abc.pod-id --name foo "bar=arg with space" --replace
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/pod-123abc.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/pod-123abc.pod-id -t 10
 ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/pod-123abc.pod-id
@@ -118,7 +118,7 @@ WantedBy=multi-user.target default.target`
 				StopTimeout:      10,
 				PodmanVersion:    "CI",
 				RequiredServices: []string{"container-1", "container-2"},
-				CreateCommand:    []string{"podman", "pod", "create", "--name", "foo"},
+				CreateCommand:    []string{"podman", "pod", "create", "--name", "foo", "bar=arg with space"},
 			},
 			podGoodNamedNew,
 			true,


### PR DESCRIPTION
Make sure that arguments with whitespace are properly quoted so they are
interpreted as one (and not multiple ones) by systemd.

Now `-e tz="america/new york"` will be generated as `-e "tz=america/new york"`.
The quotes are moving but the argument is still correct.

Fixes: #7285
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>