### PR TITLE
Re-disable sdnotify tests to try to fix CI

### DIFF
--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -12,6 +12,8 @@ _SOCAT_LOG=
 function setup() {
     skip_if_remote
 
+    skip "FIXME FIXME FIXME, is this what's causing the CI hang???"
+
     # Skip if systemd is not running
     systemctl list-units &>/dev/null || skip "systemd not available"
 


### PR DESCRIPTION
Some CI tests are hanging, timing out in 60 or 120 minutes.
I wonder if it's #7316, the bug where all podman commands
hang forever if NOTIFY_SOCKET is set?

Signed-off-by: Ed Santiago <santiago@redhat.com>