### PR TITLE
fix podman version output to include git commit and builttime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ else
 	BUILD_INFO ?= $(shell date "+$(DATE_FMT)")
 	ISODATE ?= $(shell date --iso-8601)
 endif
-LIBPOD := ${PROJECT}/libpod
+LIBPOD := ${PROJECT}/v2/libpod
 GCFLAGS ?= all=-trimpath=${PWD}
 ASMFLAGS ?= all=-trimpath=${PWD}
 LDFLAGS_PODMAN ?= \

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -24,6 +24,13 @@ function setup() {
     is "${lines[0]}" "Version:[ ]\+[1-9][0-9.]\+" "Version line 1"
     is "$output" ".*Go Version: \+"               "'Go Version' in output"
     is "$output" ".*API Version: \+"		  "API version in output"
+
+    # Test that build date is reasonable, e.g. after 2019-01-01
+    local built=$(expr "$output" : ".*Built: \+\(.*\)" | head -n1)
+    local built_t=$(date --date="$built" +%s)
+    if [ $built_t -lt 1546300800 ]; then
+        die "Preposterous 'Built' time in podman version: '$built'"
+    fi
 }
 
 


### PR DESCRIPTION
Add the go module version v2 to the libpod path.

Fixes #7359 