### PR TITLE
system tests: enable more remote tests; cleanup

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -3,8 +3,6 @@
 load helpers
 
 @test "podman info - basic test" {
-    skip_if_remote "capitalization inconsistencies"
-
     run_podman info
 
     expected_keys="
@@ -28,8 +26,6 @@ runRoot:
 }
 
 @test "podman info - json" {
-    skip_if_remote "capitalization inconsistencies"
-
     run_podman info --format=json
 
     expr_nvr="[a-z0-9-]\\\+-[a-z0-9.]\\\+-[a-z0-9]\\\+\."

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -75,8 +75,6 @@ Size        | [0-9]\\\+
 }
 
 @test "podman images - filter" {
-    skip_if_remote "podman commit -q is broken in podman-remote"
-
     run_podman inspect --format '{{.ID}}' $IMAGE
     iid=$output
 

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -178,6 +178,14 @@ function check_help() {
     # Called with no args -- start with 'podman --help'. check_help() will
     # recurse for any subcommands.
     check_help
+
+    # Test for regression of #7273 (spurious "--remote" help on output)
+    for helpopt in help --help; do
+        run_podman $helpopt
+        is "${lines[0]}" "Manage pods, containers and images" \
+           "podman $helpopt: first line of output"
+    done
+
 }
 
 # vim: filetype=sh

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -63,7 +63,7 @@ echo $rand        |   0 | $rand
 
 # 'run --preserve-fds' passes a number of additional file descriptors into the container
 @test "podman run --preserve-fds" {
-    skip_if_remote
+    skip_if_remote "preserve-fds is meaningless over remote"
 
     content=$(random_string 20)
     echo "$content" > $PODMAN_TMPDIR/tempfile
@@ -150,8 +150,6 @@ echo $rand        |   0 | $rand
 
 # 'run --rmi' deletes the image in the end unless it's used by another container
 @test "podman run --rmi" {
-    skip_if_remote
-
     # Name of a nonlocal image. It should be pulled in by the first 'run'
     NONLOCAL_IMAGE=busybox
     run_podman 1 image exists $NONLOCAL_IMAGE

--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -6,7 +6,7 @@ load helpers
 @test "podman mount - basic test" {
     # Only works with root (FIXME: does it work with rootless + vfs?)
     skip_if_rootless "mount does not work rootless"
-    skip_if_remote
+    skip_if_remote "mounting remote is meaningless"
 
     f_path=/tmp/tmpfile_$(random_string 8)
     f_content=$(random_string 30)

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -39,7 +39,7 @@ load helpers
 }
 
 @test "podman exec - leak check" {
-    skip_if_remote
+    skip_if_remote "test is meaningless over remote"
 
     # Start a container in the background then run exec command
     # three times and make sure no any exec pid hash file leak
@@ -61,7 +61,7 @@ load helpers
 # Issue #4785 - piping to exec statement - fixed in #4818
 # Issue #5046 - piping to exec truncates results (actually a conmon issue)
 @test "podman exec - cat from stdin" {
-    skip_if_remote
+    skip_if_remote "FIXME: pending #7360"
 
     run_podman run -d $IMAGE sh -c 'while [ ! -e /stop ]; do sleep 0.1;done'
     cid="$output"

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -96,9 +96,8 @@ function teardown() {
     run_podman rm $cid1
 
     # ...then, from pause container, find the image ID of the pause image...
-    # FIXME: if #6283 gets implemented, use 'inspect --format ...'
-    run_podman pod inspect $podname
-    pause_cid=$(jq -r '.Containers[0].Id' <<<"$output")
+    run_podman pod inspect --format '{{(index .Containers 0).ID}}' $podname
+    pause_cid="$output"
     run_podman container inspect --format '{{.Image}}' $pause_cid
     pause_iid="$output"
 

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -18,7 +18,7 @@ fi
 UNIT_FILE="$UNIT_DIR/$SERVICE_NAME.service"
 
 function setup() {
-    skip_if_remote
+    skip_if_remote "systemd tests are meaningless over remote"
 
     basic_setup
 }

--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -10,7 +10,7 @@ _SOCAT_PID=
 _SOCAT_LOG=
 
 function setup() {
-    skip_if_remote
+    skip_if_remote "systemd tests are meaningless over remote"
 
     skip "FIXME FIXME FIXME, is this what's causing the CI hang???"
 

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -7,7 +7,7 @@ load helpers
 
 # Copied from tsweeney's https://github.com/containers/podman/issues/4827
 @test "podman networking: port on localhost" {
-    skip_if_remote
+    skip_if_remote "FIXME: reevaluate this one after #7360 is fixed"
     random_1=$(random_string 30)
     random_2=$(random_string 30)
 
@@ -62,8 +62,6 @@ load helpers
 
 # Issue #5466 - port-forwarding doesn't work with this option and -d
 @test "podman networking: port with --userns=keep-id" {
-    skip_if_remote
-
     # FIXME: randomize port, and create second random host port
     myport=54321
 


### PR DESCRIPTION
info, images, run, networking tests: remove some skip_if_remote()s
that were added in the varlink days. All of these tests now seem
to work with APIv2.

help test: check that first output line from 'podman --help'
is the program description (regression check for #7273).

load test: clean up stray images, rewrite test to make it conform
to existing convention. In the process, discover and file #7337

exec test (and networking): file #7360, and add FIXME comment
to skip()s suggesting evaluating those tests once that is fixed.

pod test: now that #6328 is fixed, use 'podman pod inspect --format'
instead of relying on jq

Various other tests: add an explanation of why test is disabled
so we can more easily distinguish "this will never be meaningful
under remote" vs "hey, doesn't work for now, but maybe someday".

Signed-off-by: Ed Santiago <santiago@redhat.com>