### PR TITLE
Implement --connection flag

### DIFF
--- a/cmd/podman/early_init_linux.go
+++ b/cmd/podman/early_init_linux.go
@@ -32,7 +32,7 @@ func setUMask() {
 
 func earlyInitHook() {
 	if err := setRLimits(); err != nil {
-		fmt.Fprint(os.Stderr, "Failed to set rlimits: "+err.Error())
+		fmt.Fprintf(os.Stderr, "Failed to set rlimits: %s\n", err.Error())
 	}
 
 	setUMask()

--- a/cmd/podman/system/connection/add.go
+++ b/cmd/podman/system/connection/add.go
@@ -95,7 +95,7 @@ func add(cmd *cobra.Command, args []string) error {
 		uri.Host = net.JoinHostPort(uri.Hostname(), cmd.Flag("port").DefValue)
 	}
 
-	if uri.Path == "" {
+	if uri.Path == "" || uri.Path == "/" {
 		if uri.Path, err = getUDS(cmd, uri); err != nil {
 			return errors.Wrapf(err, "failed to connect to  %q", uri.String())
 		}

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -3602,22 +3602,32 @@ _podman_volume() {
 
 _podman_podman() {
      local options_with_args="
-	   --config -c
+	   --cni-config-dir
+	   --conmon
+	   --connection -c
+	   --events-backend
+	   --hooks-dir
+	   --identity
+	   --log-level
+	   --namespace
+	   --network-cmd-path
 	   --root
 	   --runroot
 	   --storage-driver
 	   --storage-opt
-	   --log-level
-	   --namespace
-    "
+	   --tmpdir
+	   --runtime
+	   --url
+     "
      local boolean_options="
 	   --help
-	   -h
-	   --version
-	   -v
 	   --syslog
+	   --version
+	   -h
+	   -r, --remote
+	   -v
      "
-     commands="
+    commands="
     attach
     auto-update
     build

--- a/docs/source/markdown/podman-remote.1.md
+++ b/docs/source/markdown/podman-remote.1.md
@@ -23,7 +23,7 @@ Podman-remote provides a local client interacting with a Podman backend node thr
 
 ## GLOBAL OPTIONS
 
-**--connection**=*name*
+**--connection**=*name*, **-c**
 
 Remote connection name
 

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -31,6 +31,9 @@ Note: CGroup manager is not supported in rootless mode when using CGroups Versio
 **--cni-config-dir**
 Path of the configuration directory for CNI networks.  (Default: `/etc/cni/net.d`)
 
+**--connection**, **-c**
+Connection to use for remote podman (Default connection is configured in `containers.conf`)
+
 **--conmon**
 Path of the conmon binary (Default path is configured in `containers.conf`)
 


### PR DESCRIPTION
* Implements --connection flag
  * override --url and/or --identity fields from `containers.conf`
  * --connection flag has higher precedence than `ActiveService` from `containers.conf`.  Which is set via `podman system connection default`
* Add newline to error message printed on stderr
* Added --connection to bash completion and documentation
* Updated bindings to query server in case of no path or `/`

Closes #jira-991
Fixes #7276

Signed-off-by: Jhon Honce <jhonce@redhat.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
