### PR TITLE
Cirrus: special-case CI colon-IMG and colon-DOCS only in subject

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -179,8 +179,8 @@ container_image_build_task:
 rpmbuild_task:
 
     only_if: >-
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
         $CIRRUS_BRANCH != $DEST_BRANCH
 
     depends_on:
@@ -207,8 +207,8 @@ rpmbuild_task:
 vendor_task:
 
     only_if: >-
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     depends_on:
         - "gating"
@@ -239,8 +239,8 @@ vendor_task:
 varlink_api_task:
 
     only_if: >-
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     depends_on:
         - "gating"
@@ -278,8 +278,8 @@ build_each_commit_task:
 
     only_if: >-
         $CIRRUS_BRANCH != $DEST_BRANCH &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     gce_instance:
         cpu: 8
@@ -310,8 +310,8 @@ build_without_cgo_task:
 
     only_if: >-
         $CIRRUS_BRANCH != $DEST_BRANCH &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     gce_instance:
         cpu: 8
@@ -400,8 +400,8 @@ testing_task:
 
     # Only test build cache-images, if that's what's requested
     only_if: >-
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     matrix:
         - name: "test ${FEDORA_NAME}"
@@ -463,8 +463,8 @@ special_testing_rootless_task:
         - "build_without_cgo"
 
     only_if: >-
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     env:
         ADD_SECOND_PARTITION: 'true'
@@ -499,8 +499,8 @@ special_testing_in_podman_task:
         - "build_without_cgo"
 
     only_if: >-
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     matrix:
         - name: "in-podman ${PRIOR_FEDORA_NAME}"
@@ -537,8 +537,8 @@ special_testing_cross_task:
         - "vendor"
 
     only_if: >-
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     matrix:
         - name: 'cross-platform: windows'
@@ -575,8 +575,8 @@ special_testing_bindings_task:
         - "vendor"
 
     only_if: >-
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     env:
         SPECIALMODE: 'bindings'  # See docs
@@ -602,8 +602,8 @@ special_testing_endpoint_task:
         - "vendor"
 
     only_if: >-
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     env:
         SPECIALMODE: 'endpoint'  # See docs
@@ -625,8 +625,8 @@ test_build_cache_images_task:
 
     only_if: >-
         $CIRRUS_BRANCH != $DEST_BRANCH &&
-        $CIRRUS_CHANGE_MESSAGE =~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE =~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
     depends_on:
         - "gating"
@@ -659,8 +659,8 @@ verify_test_built_images_task:
 
     only_if: >-
         $CIRRUS_BRANCH != $DEST_BRANCH &&
-        $CIRRUS_CHANGE_MESSAGE =~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+        $CIRRUS_CHANGE_TITLE =~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
 
 
     depends_on:
@@ -700,7 +700,7 @@ verify_test_built_images_task:
 docs_task:
 
     # Don't run this when building/testing new VM images
-    only_if: $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*'
+    only_if: $CIRRUS_CHANGE_TITLE !=~ '.*CI:IMG.*'
 
     depends_on:
         - "gating"


### PR DESCRIPTION
As of a few minutes ago (relative to this commit), Cirrus
defines the CIRRUS_CHANGE_TITLE envariable as "First line
of CIRRUS_CHANGE_MESSAGE"[1]. Replace all conditionals
accordingly.

 [1] https://github.com/cirruslabs/cirrus-ci-docs/commit/f8d2530c602709a24d9113691a43e6a20f7020b9

Reasoning: up until this PR, the presence of CI:IMG
or CI:DOCS *in the body* of the commit message would trigger
those magic CI code flows. This violates POLA, and actually
led to a bad PR (#7317) being merged because CI never ran.

Fixes: #7374

Signed-off-by: Ed Santiago <santiago@redhat.com>