### PR TITLE
Unmount c/storage containers before removing them

### DIFF
--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -144,6 +144,10 @@ func storageContainers(imageID string, store storage.Store) ([]string, error) {
 // Removes the containers passed in the array.
 func removeStorageContainers(ctrIDs []string, store storage.Store) error {
 	for _, ctrID := range ctrIDs {
+		if _, err := store.Unmount(ctrID, true); err != nil {
+			return errors.Wrapf(err, "could not unmount container %q to remove it", ctrID)
+		}
+
 		if err := store.DeleteContainer(ctrID); err != nil {
 			return errors.Wrapf(err, "could not remove container %q", ctrID)
 		}


### PR DESCRIPTION
When `podman rmi --force` is run, it will remove any containers that depend on the image. This includes Podman containers, but also any other c/storage users who may be using it. With Podman containers, we use the standard Podman removal function for containers, which handles all edge cases nicely, shutting down running containers, ensuring they're unmounted, etc.

Unfortunately, no such convient function exists (or can exist) for all c/storage containers. Identifying the PID of a Buildah, CRI-O, or Podman container is extremely different, and those are just the implementations under the containers org. We can't reasonably be able to know if a c/storage container is *in use* and safe for removal if it's not a Podman container.

At the very least, though, we can attempt to unmount a storage container before removing it. If it is in use, this will fail (probably with a not-particularly-helpful error message), but if it is not in use but not fully cleaned up, this should make our removing it much more robust than it normally is.
