### PR TITLE
fix podman load oci-archive's tar with name

### DIFF
--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -452,7 +452,11 @@ func (ir *ImageEngine) Load(ctx context.Context, opts entities.ImageLoadOptions)
 	if !opts.Quiet {
 		writer = os.Stderr
 	}
-	name, err := ir.Libpod.LoadImage(ctx, opts.Name, opts.Input, writer, opts.SignaturePolicy)
+	iName := opts.Name
+	if opts.Tag != "" {
+		iName += ":" + opts.Tag
+	}
+	name, err := ir.Libpod.LoadImage(ctx, iName, opts.Input, writer, opts.SignaturePolicy)
 	if err != nil {
 		return nil, err
 	}

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -51,8 +51,7 @@ verify_iid_and_name() {
     run_podman images $fqin --format '{{.Repository}}:{{.Tag}}'
     is "$output" "$fqin" "image preserves name across save/load"
 
-    # FIXME: when/if 7337 gets fixed, load with a new tag
-    if false; then
+    # load with a new tag, when src file is oci-archive
     local new_name=x$(random_string 14 | tr A-Z a-z)
     local new_tag=t$(random_string 6 | tr A-Z a-z)
     run_podman rmi $fqin
@@ -60,7 +59,6 @@ verify_iid_and_name() {
     run_podman load -i $archive $fqin
     run_podman images $fqin --format '{{.Repository}}:{{.Tag}}'
     is "$output" "$fqin" "image can be loaded with new name:tag"
-    fi
 
     # Clean up
     run_podman rmi $fqin


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/7337
fixes this problem:
```
$ podman pull alpine
$ podman save --format oci-archive alpine:latest > /tmp/FOO.tar
$ podman load -i /tmp/FOO.tar foo
Error: error pulling "foo": unable to pull dir:/tmp/FOO.tar: error determining pull goal for image "dir:/tmp/FOO.tar": error parsing dest reference name "localhost/tmp/FOO.tar": error parsing named reference "localhost/tmp/FOO.tar": invalid reference format: repository name must be lowercase
```
Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>