### PR TITLE
fix pod creation with "new:" syntax followup + allow hostname

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -297,7 +297,12 @@ func createPodIfNecessary(s *specgen.SpecGenerator, netOpts *entities.NetOptions
 		Infra:         true,
 		Net:           netOpts,
 		CreateCommand: os.Args,
+		Hostname:      s.ContainerBasicConfig.Hostname,
 	}
+	// Unset config values we passed to the pod to prevent them being used twice for the container and pod.
+	s.ContainerBasicConfig.Hostname = ""
+	s.ContainerNetworkConfig = specgen.ContainerNetworkConfig{}
+
 	s.Pod = podName
 	return registry.ContainerEngine().PodCreate(context.Background(), createOptions)
 }

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -531,8 +531,8 @@ var _ = Describe("Podman run networking", func() {
 		SkipIfRemote()
 		SkipIfRootless()
 		netName := "podmantestnetwork"
-		ipAddr := "10.20.30.128"
-		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.20.30.0/24", netName})
+		ipAddr := "10.25.30.128"
+		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.30.0/24", netName})
 		create.WaitWithDefaultTimeout()
 		Expect(create.ExitCode()).To(BeZero())
 
@@ -540,5 +540,33 @@ var _ = Describe("Podman run networking", func() {
 		run.WaitWithDefaultTimeout()
 		Expect(run.ExitCode()).To(BeZero())
 		Expect(run.OutputToString()).To(ContainSubstring(ipAddr))
+
+		netrm := podmanTest.Podman([]string{"network", "rm", netName})
+		netrm.WaitWithDefaultTimeout()
+		Expect(netrm.ExitCode()).To(BeZero())
+	})
+
+	It("podman run with new:pod and static-ip", func() {
+		SkipIfRemote()
+		SkipIfRootless()
+		netName := "podmantestnetwork2"
+		ipAddr := "10.25.40.128"
+		podname := "testpod"
+		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.40.0/24", netName})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(BeZero())
+
+		run := podmanTest.Podman([]string{"run", "-t", "-i", "--rm", "--pod", "new:" + podname, "--net", netName, "--ip", ipAddr, ALPINE, "ip", "addr"})
+		run.WaitWithDefaultTimeout()
+		Expect(run.ExitCode()).To(BeZero())
+		Expect(run.OutputToString()).To(ContainSubstring(ipAddr))
+
+		podrm := podmanTest.Podman([]string{"pod", "rm", "-f", podname})
+		podrm.WaitWithDefaultTimeout()
+		Expect(podrm.ExitCode()).To(BeZero())
+
+		netrm := podmanTest.Podman([]string{"network", "rm", netName})
+		netrm.WaitWithDefaultTimeout()
+		Expect(netrm.ExitCode()).To(BeZero())
 	})
 })

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -867,6 +867,14 @@ USER mail`
 		Expect(match).To(BeTrue())
 	})
 
+	It("podman run --pod new with hostname", func() {
+		hostname := "abc"
+		session := podmanTest.Podman([]string{"run", "--pod", "new:foobar", "--hostname", hostname, ALPINE, "cat", "/etc/hostname"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(hostname))
+	})
+
 	It("podman run --rm should work", func() {
 		session := podmanTest.Podman([]string{"run", "--name", "test", "--rm", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Fixes: 4c75fe3f70ed ("fix pod creation with "new:" syntax")

Commit 4c75fe3f70ed passes all net options to the pod but forgot
to unset the options for the container creation. This leads to
erros when using flags like `--ip` since we tried setting
the ip on the pod and container which obviously fails.

I didn't notice the bug because we don't throw an error when
specifing port bindings on a container which joins the pods
network namespace. (#7373)

Also allow the use of `--hostname` and pass that option to the
pod and unset it for the container. The container has to use
the pods hostname anyway. This would error otherwise.

Added tests to prevent regression.
