### PR TITLE
In podman 1.* regression on --cap-add

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containernetworking/cni v0.7.2-0.20200304161608-4fae32b84921
 	github.com/containernetworking/plugins v0.8.6
 	github.com/containers/buildah v1.15.1
-	github.com/containers/common v0.14.7
+	github.com/containers/common v0.14.8
 	github.com/containers/conmon v2.0.18+incompatible
 	github.com/containers/image/v5 v5.5.2
 	github.com/containers/psgo v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/containers/buildah v1.15.1 h1:fVYZedNKir1B7qW43KR3zmkjHH+ZAmPoPQix9zH
 github.com/containers/buildah v1.15.1/go.mod h1:AQPeirYl0bqtXuJaxM9d/xslMm+1qrABc73AEFw0M9U=
 github.com/containers/common v0.14.0 h1:hiZFDPf6ajKiDmojN5f5X3gboKPO73NLrYb0RXfrQiA=
 github.com/containers/common v0.14.0/go.mod h1:9olhlE+WhYof1npnMJdyRMX14/yIUint6zyHzcyRVAg=
-github.com/containers/common v0.14.7 h1:KcyupqUqY9GFnxBck5Ww/tMstbvEmekQys8k8GiYAC0=
-github.com/containers/common v0.14.7/go.mod h1:9olhlE+WhYof1npnMJdyRMX14/yIUint6zyHzcyRVAg=
+github.com/containers/common v0.14.8 h1:u0dwl1GV6tpxtVhFlPuTLx5pN7pXV+/GkP1Y34l0mjI=
+github.com/containers/common v0.14.8/go.mod h1:9olhlE+WhYof1npnMJdyRMX14/yIUint6zyHzcyRVAg=
 github.com/containers/conmon v2.0.18+incompatible h1:rjwjNnE756NuXcdE/uUmj4kDbrykslPuBMHI31wh43E=
 github.com/containers/conmon v2.0.18+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.4.4/go.mod h1:g7cxNXitiLi6pEr9/L9n/0wfazRuhDKXU15kV86N8h8=

--- a/vendor/github.com/containers/common/pkg/capabilities/capabilities.go
+++ b/vendor/github.com/containers/common/pkg/capabilities/capabilities.go
@@ -57,9 +57,9 @@ func AllCapabilities() []string {
 	return capabilityList
 }
 
-// normalizeCapabilities normalizes caps by adding a "CAP_" prefix (if not yet
+// NormalizeCapabilities normalizes caps by adding a "CAP_" prefix (if not yet
 // present).
-func normalizeCapabilities(caps []string) ([]string, error) {
+func NormalizeCapabilities(caps []string) ([]string, error) {
 	normalized := make([]string, len(caps))
 	for i, c := range caps {
 		c = strings.ToUpper(c)
@@ -98,7 +98,7 @@ func MergeCapabilities(base, adds, drops []string) ([]string, error) {
 	var caps []string
 
 	// Normalize the base capabilities
-	base, err := normalizeCapabilities(base)
+	base, err := NormalizeCapabilities(base)
 	if err != nil {
 		return nil, err
 	}
@@ -106,11 +106,11 @@ func MergeCapabilities(base, adds, drops []string) ([]string, error) {
 		// Nothing to tweak; we're done
 		return base, nil
 	}
-	capDrop, err := normalizeCapabilities(drops)
+	capDrop, err := NormalizeCapabilities(drops)
 	if err != nil {
 		return nil, err
 	}
-	capAdd, err := normalizeCapabilities(adds)
+	capAdd, err := NormalizeCapabilities(adds)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.14.7-dev"
+const Version = "0.14.8"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/containers/buildah/pkg/secrets
 github.com/containers/buildah/pkg/supplemented
 github.com/containers/buildah/pkg/umask
 github.com/containers/buildah/util
-# github.com/containers/common v0.14.7
+# github.com/containers/common v0.14.8
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/auth
 github.com/containers/common/pkg/capabilities


### PR DESCRIPTION
In podman 1.0 if  you executed a command like:

podman run --user dwalsh --cap-add net_bind_service alpine nc -l 80

It would work, and the user dwalsh would get the capability,  in
podman 2.0, only root and the binding set gets the capability.

This change restores us back to the way podman 1.0 worked.
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>