### PR TITLE
fix apiv2 will create containers with incorrect commands

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -483,11 +483,12 @@ func (c *Container) setupStorage(ctx context.Context) error {
 
 	// Set the default Entrypoint and Command
 	if containerInfo.Config != nil {
+		// Set CMD in the container to the default configuration only if ENTRYPOINT is not set by the user.
+		if c.config.Entrypoint == nil && c.config.Command == nil {
+			c.config.Command = containerInfo.Config.Config.Cmd
+		}
 		if c.config.Entrypoint == nil {
 			c.config.Entrypoint = containerInfo.Config.Config.Entrypoint
-		}
-		if c.config.Command == nil {
-			c.config.Command = containerInfo.Config.Config.Cmd
 		}
 	}
 

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -319,6 +319,14 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 		SizeRootFs:      &inspect.SizeRootFs,
 	}
 
+	// set Path and Args
+	processArgs := l.Config().Spec.Process.Args
+	if len(processArgs) > 0 {
+		cb.Path = processArgs[0]
+	}
+	if len(processArgs) > 1 {
+		cb.Args = processArgs[1:]
+	}
 	stopTimeout := int(l.StopTimeout())
 
 	exposedPorts := make(nat.PortSet)
@@ -346,7 +354,7 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 		OpenStdin:       inspect.Config.OpenStdin,
 		StdinOnce:       inspect.Config.StdinOnce,
 		Env:             inspect.Config.Env,
-		Cmd:             inspect.Config.Cmd,
+		Cmd:             l.Command(),
 		Healthcheck:     nil,
 		ArgsEscaped:     false,
 		Image:           imageName,

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -87,20 +87,21 @@ func makeCreateConfig(ctx context.Context, containerConfig *config.Config, input
 		workDir = input.WorkingDir
 	}
 
+	// Only use image's Cmd when the user does not set the entrypoint
+	if input.Entrypoint == nil && len(input.Cmd) == 0 {
+		cmdSlice, err := newImage.Cmd(ctx)
+		if err != nil {
+			return createconfig.CreateConfig{}, err
+		}
+		input.Cmd = cmdSlice
+	}
+
 	if input.Entrypoint == nil {
 		entrypointSlice, err := newImage.Entrypoint(ctx)
 		if err != nil {
 			return createconfig.CreateConfig{}, err
 		}
 		input.Entrypoint = entrypointSlice
-	}
-
-	if len(input.Cmd) == 0 {
-		cmdSlice, err := newImage.Cmd(ctx)
-		if err != nil {
-			return createconfig.CreateConfig{}, err
-		}
-		input.Cmd = cmdSlice
 	}
 
 	stopTimeout := containerConfig.Engine.StopTimeout

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -180,7 +180,16 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 		g.AddMount(cgroupMnt)
 	}
 	g.SetProcessCwd(config.WorkDir)
-	g.SetProcessArgs(config.Command)
+
+	ProcessArgs := make([]string, 0)
+	if len(config.Entrypoint) > 0 {
+		ProcessArgs = config.Entrypoint
+	}
+	if len(config.Command) > 0 {
+		ProcessArgs = append(ProcessArgs, config.Command...)
+	}
+	g.SetProcessArgs(ProcessArgs)
+
 	g.SetProcessTerminal(config.Tty)
 
 	for key, val := range config.Annotations {

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -151,4 +151,31 @@ t DELETE images/localhost/newrepo:v2?force=true 200
 t DELETE libpod/containers/$cid 204
 t DELETE libpod/containers/myctr 204
 
+
+# test apiv2 create container with correct entrypoint and cmd
+# --data '{"Image":"quay.io/libpod/alpine_labels:latest","Entrypoint":["echo"],"Cmd":["param1","param2"]}'
+t POST containers/create '"Image":"'$IMAGE'","Entrypoint":["echo"],"Cmd":["param1","param2"]' 201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .Config.Entrypoint[0]="echo" \
+  .Config.Cmd[0]="param1" \
+  .Config.Cmd[1]="param2" \
+  .Path="echo" \
+  .Args[0]="param1" \
+  .Args[1]="param2"
+t DELETE containers/$cid 204
+
+# test only set the entrpoint, Cmd should be []
+t POST containers/create '"Image":"'$IMAGE'","Entrypoint":["echo","param1"]' 201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .Config.Entrypoint[0]="echo" \
+  .Config.Entrypoint[1]="param1" \
+  .Config.Cmd='[]' \
+  .Path="echo" \
+  .Args[0]="param1"
+t DELETE containers/$cid 204
+
 # vim: filetype=sh


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/7235#issuecomment-678066986

```
$  podman inspect docker.io/zhangguanzhang/travis --format '{{.Config.Entrypoint}}'
[travis]
```
use the apiv2 to create the container
```
$  podman system  service --time 0 tcp:127.0.0.1:8081 &
$ curl http://localhost:8081/v1.40/containers/create?name=test-api2 -X POST \
  -H "Content-Type: application/json" \
  --data '{"Image":"docker.io/zhangguanzhang/travis","Cmd":["echo","param1"]}'
```
check the output
```
$ curl -s http://localhost:8081/v1.40/containers/test-api2/json | jq .Path
"" <--- wrong, should be `travis`
$ curl -s http://localhost:8081/v1.40/containers/test-api2/json | jq .Args
null <--- wrong, should be `["echo","param1"]`
```
and run command is incorrect
```
$ podman start test-api2
test-api2
$ podman logs test-api2
param1
```
if not use apiv2 to run this
```
$ podman container create --name cli-run  docker.io/zhangguanzhang/travis echo param1
$ podman start cli-run
cli-run
$ podman logs cli-run
unknown command echo <-- it will run `travis echo param1`, it is correct
```
after fix
```
$ ./bin/podman system  service --time 0 tcp:127.0.0.1:8081 &
$ curl http://localhost:8081/v1.40/containers/create?name=test-api2 \
  -X POST -H "Content-Type: application/json"\
   --data '{"Image":"docker.io/zhangguanzhang/travis","Cmd":["echo","param1"]}'
$ curl -s http://localhost:8081/v1.40/containers/test-api2/json | jq .Config.Entrypoint
[
  "travis"
]
$ curl -s http://localhost:8081/v1.40/containers/test-api2/json | jq .Config.Cmd
[
  "echo",
  "param1"
]
$ curl -s http://localhost:8081/v1.40/containers/test-api2/json | jq .Path
"travis"
$ curl -s http://localhost:8081/v1.40/containers/test-api2/json | jq .Args
[
  "echo",
  "param1"
]
$ 
```

Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>