### PR TITLE
Silence pull log on podman build -q

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -282,7 +282,9 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 	stdin = os.Stdin
 	stdout = os.Stdout
 	stderr = os.Stderr
-	reporter = os.Stderr
+	if !flags.Quiet {
+		reporter = os.Stderr
+	}
 
 	if c.Flag("logfile").Changed {
 		f, err := os.OpenFile(flags.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)


### PR DESCRIPTION
-q did not completely quiet

closes containers/podman#7401

Signed-off-by: Ashley Cui <acui@redhat.com>