### PR TITLE
Fix up some error messages

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -120,7 +120,7 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 			if os.IsNotExist(err) {
 				continue
 			}
-			return nil, errors.Wrapf(err, "cannot stat %s", path)
+			return nil, errors.Wrapf(err, "cannot stat OCI runtime %s path %q", name, path)
 		}
 		if !stat.Mode().IsRegular() {
 			continue

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -90,7 +90,7 @@ func DevicesFromPath(g *generate.Generator, devicePath string) error {
 	}
 	st, err := os.Stat(resolvedDevicePath)
 	if err != nil {
-		return errors.Wrapf(err, "cannot stat %s", devicePath)
+		return errors.Wrapf(err, "cannot stat device path %s", devicePath)
 	}
 	if st.IsDir() {
 		found := false


### PR DESCRIPTION
We have a lot of 'cannot stat %s' errors in our codebase. These are terrible and confusing and utterly useless without context. Add some context to a few of them so we actually know what part of the code is failing.
