### PR TITLE
DO NOT MERGE: change readme for ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,3 +185,5 @@ The Cirrus CI integration within this repository contains a `static_build` job
 which produces a static Podman binary for testing purposes. Please note that
 this binary is not officially supported with respect to feature-completeness
 and functionality and should be only used for testing.
+
+## CHANGE README for CI CHECK


### PR DESCRIPTION
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

only checking if https://github.com/containers/podman/pull/7429 is to  blame for  `@cirrus-ci
special_testing_rootless RCLI:true` failure