### PR TITLE
Remove test comment for now-succeeding tests

### DIFF
--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -90,7 +90,6 @@ load helpers
 }
 
 # #6829 : add username to /etc/passwd inside container if --userns=keep-id
-# #6593 : doesn't actually work with podman exec
 @test "podman exec - with keep-id" {
     run_podman run -d --userns=keep-id $IMAGE sh -c \
                "echo READY;while [ ! -f /stop ]; do sleep 1; done"
@@ -100,8 +99,6 @@ load helpers
     run_podman exec $cid id -un
     is "$output" "$(id -un)" "container is running as current user"
 
-    # Until #6593 gets fixed, this just hangs. The server process barfs with:
-    #   unable to find user <username>: no matching entries in passwd file
     run_podman exec --user=$(id -un) $cid touch /stop
     run_podman wait $cid
     run_podman rm $cid


### PR DESCRIPTION
The related issue seems fixed so the test execution should work as intended.
