### PR TITLE
run test: use explicit uid/gid

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -286,10 +286,10 @@ echo $rand        |   0 | $rand
     cid="$output"
 
     gecos="$(random_string 6) $(random_string 8)"
-    run_podman exec --user root $cid adduser -D -g "$gecos" -s /bin/sh newuser3
+    run_podman exec --user root $cid adduser -u 4242 -G ping -D -g "$gecos" -s /bin/sh newuser3
     is "$output" "" "output from adduser"
     run_podman exec $cid tail -1 /etc/passwd
-    is "$output" "newuser3:x:1000:1000:$gecos:/home/newuser3:/bin/sh" \
+    is "$output" "newuser3:x:4242:999:$gecos:/home/newuser3:/bin/sh" \
        "newuser3 added to /etc/passwd in container"
 
     run_podman exec $cid touch /stop


### PR DESCRIPTION
Fixes Fedora gating test failure: if the host tests are running
under UID 1000, --userns=keep-id will (of course) add current
user as 1000, and the in-container 'adduser' will assign 1001.
To prevent that, assign UID 4242 (and hope that that's not
our calling user's UID).

Signed-off-by: Ed Santiago <santiago@redhat.com>