### PR TITLE
fix panic when checking len on nil object

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -1246,7 +1246,12 @@ func areParentAndChild(parent, child *imgspecv1.Image) bool {
 	// the child and candidate parent should share all of the
 	// candidate parent's diff IDs, which together would have
 	// controlled which layers were used
-	if len(parent.RootFS.DiffIDs) > len(child.RootFS.DiffIDs) {
+
+	// issue #7444 describes a panic where the length of child.RootFS.DiffIDs
+	// is checked but child is nil.  Adding a simple band-aid approach to prevent
+	// the problem until the origin of the problem can be worked out in the issue
+	// itself.
+	if child == nil || len(parent.RootFS.DiffIDs) > len(child.RootFS.DiffIDs) {
 		return false
 	}
 	childUsesCandidateDiffs := true


### PR DESCRIPTION
issue #7444 describes a problem where an image does not have a manifest file and cannot be processed by our library correctly.  the origin of the panic is because we are checking the len of a nil object's attribute.  this is a temporary fix to protect from the panic in the future.  the origin of the problem is more interesting and requires more work when the code author returns from pto.

Signed-off-by: Brent Baude <bbaude@redhat.com>