### PR TITLE
Fix log level case regression

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -226,7 +226,7 @@ func persistentPostRunE(cmd *cobra.Command, args []string) error {
 func loggingHook() {
 	var found bool
 	for _, l := range logLevels {
-		if l == logLevel {
+		if l == strings.ToLower(logLevel) {
 			found = true
 			break
 		}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1204,4 +1204,16 @@ WORKDIR /madethis`
 		// nonprintables seem to work their way in.
 		Expect(session.OutputToString()).To(Not(ContainSubstring("/bin/sh")))
 	})
+
+	It("podman run a container with log-level (lower case)", func() {
+		session := podmanTest.Podman([]string{"--log-level=info", "run", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
+	It("podman run a container with log-level (upper case)", func() {
+		session := podmanTest.Podman([]string{"--log-level=INFO", "run", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
With previous versions of Podman (like v1.9.2) it was always possible to
specify the log level in any case, for example `INFO`. This behavior has
silently changed, where the `--log-level` flag only accepts lower case
levels. This commit re-enables the old behavior and adds an e2e test for
it.
