### PR TITLE
spec: modprobe fuse with --device .*/fuse

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -215,6 +215,10 @@ Note: if the user only has access rights via a group, accessing the device
 from inside a rootless container will fail. The **crun**(1) runtime offers a
 workaround for this by adding the option **--annotation run.oci.keep_original_groups=1**.
 
+Podman may load kernel modules required for using the specified
+device. The devices that podman will load modules when necessary are:
+/dev/fuse.
+
 **--device-cgroup-rule**="type major:minor mode"
 
 Add a rule to the cgroup allowed devices list. The rule is expected to be in the format specified in the Linux kernel documentation (Documentation/cgroup-v1/devices.txt):

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -231,6 +231,10 @@ Note: if the user only has access rights via a group, accessing the device
 from inside a rootless container will fail. The **crun**(1) runtime offers a
 workaround for this by adding the option **--annotation run.oci.keep_original_groups=1**.
 
+Podman may load kernel modules required for using the specified
+device. The devices that podman will load modules when necessary are:
+/dev/fuse.
+
 **--device-cgroup-rule**=rule
 
 Add a rule to the cgroup allowed devices list

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -248,6 +248,13 @@ func addDevice(g *generate.Generator, device string) error {
 		}
 		g.Config.Mounts = append(g.Config.Mounts, devMnt)
 		return nil
+	} else if src == "/dev/fuse" {
+		// if the user is asking for fuse inside the container
+		// make sure the module is loaded.
+		f, err := unix.Open(src, unix.O_RDONLY|unix.O_NONBLOCK, 0)
+		if err == nil {
+			unix.Close(f)
+		}
 	}
 	dev.Path = dst
 	g.AddDevice(*dev)


### PR DESCRIPTION
If the container uses the /dev/fuse device, attempt to load the fuse
kernel module first so that nested containers can use it.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1872240

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>