### PR TITLE
BATS: fix corner case in --userns=keep-id test

### DIFF
--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -12,7 +12,7 @@ load helpers
     rand_content=$(random_string 50)
 
     tmpdir=$PODMAN_TMPDIR/build-test
-    run mkdir -p $tmpdir || die "Could not mkdir $tmpdir"
+    mkdir -p $tmpdir
     dockerfile=$tmpdir/Dockerfile
     cat >$dockerfile <<EOF
 FROM $IMAGE


### PR DESCRIPTION
The test that does 'adduser' in a keep-id container had a
really dumb bug: if the user running the test has UID 1000,
then podman itself (via keep-id) will add the "1000" passwd
entry, and the in-container "adduser" will allocate 1001,
making our test fail. This triggered in f31/f32 podman gating
tests, but (?!?) never in rawhide gating tests.

Solution: explicitly feed a UID to adduser. Make sure that
it's not the same as the UID of the current user.

Also (unrelated): fix a ridiculous "run mkdir || die". At
the time I wrote that I probably had no idea how BATS works.

Signed-off-by: Ed Santiago <santiago@redhat.com>