### PR TITLE
Update rootless_tutorial.md

### DIFF
--- a/docs/tutorials/rootless_tutorial.md
+++ b/docs/tutorials/rootless_tutorial.md
@@ -95,7 +95,7 @@ If this is required, the administrator must verify that the UID of the user is p
 
 To change its value the administrator can use a call similar to: `sysctl -w "net.ipv4.ping_group_range=0 2000000"`.
 
-To make the change persistent, the administrator will need to add a file in `/etc/sysctl.d` that contains `net.ipv4.ping_group_range=0 $MAX_UID`.
+To make the change persistent, the administrator will need to add a file with the `.conf` file extension in `/etc/sysctl.d` that contains `net.ipv4.ping_group_range=0 $MAX_UID`, where `$MAX_UID` is the highest assignable UID of the user running the container.
 
 
 ## User Actions

--- a/docs/tutorials/rootless_tutorial.md
+++ b/docs/tutorials/rootless_tutorial.md
@@ -95,7 +95,7 @@ If this is required, the administrator must verify that the UID of the user is p
 
 To change its value the administrator can use a call similar to: `sysctl -w "net.ipv4.ping_group_range=0 2000000"`.
 
-To make the change persistent, the administrator will need to add a file with the `.conf` file extension in `/etc/sysctl.d` that contains `net.ipv4.ping_group_range=0 $MAX_GID`, where `$MAX_GID` is the highest assignable GID of the user running the container.
+To make the change persist, the administrator will need to add a file with the `.conf` file extension in `/etc/sysctl.d` that contains `net.ipv4.ping_group_range=0 $MAX_GID`, where `$MAX_GID` is the highest assignable GID of the user running the container.
 
 ## User Actions
 


### PR DESCRIPTION
Adds clarifications in persistently setting unprivileged ping permissions. Any files in `/etc/sysctl.d/` must end in `.conf` to be read by systemd, and $MAX_UID is not set automatically, thus benefits from some explanation of what to set it to.