### PR TITLE
bindings: reenable flaky(?) pause/unpause test

### DIFF
--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -2,7 +2,6 @@ package test_bindings
 
 import (
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/containers/podman/v2/pkg/bindings"
 	"github.com/containers/podman/v2/pkg/bindings/containers"
 	"github.com/containers/podman/v2/pkg/specgen"
-	"github.com/containers/podman/v2/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -182,14 +180,6 @@ var _ = Describe("Podman containers ", func() {
 	})
 
 	It("podman remove a paused container by id with force", func() {
-		// FIXME: Skip on F31 and later
-		host := utils.GetHostDistributionInfo()
-		osVer, err := strconv.Atoi(host.Version)
-		Expect(err).To(BeNil())
-		if host.Distribution == "fedora" && osVer >= 31 {
-			Skip("FIXME: https://github.com/containers/podman/issues/5325")
-		}
-
 		// Removing a paused container with force should work
 		var name = "top"
 		cid, err := bt.RunTopContainer(&name, bindings.PFalse, nil)
@@ -280,7 +270,6 @@ var _ = Describe("Podman containers ", func() {
 	})
 
 	It("podman wait to pause|unpause condition", func() {
-		Skip("FIXME: https://github.com/containers/podman/issues/6518")
 		var (
 			name           = "top"
 			exitCode int32 = -1


### PR DESCRIPTION
Reference: #6518, a very-frequently-flaking CI test, disabled
a month ago (#7143) because it was triggering so often in CI.
Unfortunately, that seems to have simply swept the problem
under the rug. AFAICT nobody has bothered to look at the
root bug, so let's just reenable. If the problem persists,
I'll let annoyed developers squeaky-wheel 6158 so there's
some incentive to fix it. If the problem has miraculously
gone away in the last month, that's a win too.

(This test failure does not reproduce on my laptop, nor
does it lend itself to devising a simple reproducer on
a test VM.)

Also: since #5325 appears to have been closed as fixed,
remove a 'Skip' that references it. Unfortunately this
also requires removing a lot of other cruft. This was
an incidental oh-by-the-way addition that I thought
would be trivial but ended up causing a much larger diff.

Signed-off-by: Ed Santiago <santiago@redhat.com>