### PR TITLE
Don't create ~/.config after removing storage.conf

### DIFF
--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -83,9 +83,6 @@ func GetRootlessConfigHomeDir() (string, error) {
 				return
 			}
 			tmpDir := filepath.Join(resolvedHome, ".config")
-			if err := os.MkdirAll(tmpDir, 0755); err != nil {
-				logrus.Errorf("unable to make temp dir %s", tmpDir)
-			}
 			st, err := os.Stat(tmpDir)
 			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && st.Mode().Perm() >= 0700 {
 				cfgHomeDir = tmpDir


### PR DESCRIPTION
Fixes #7509. There is no need to create a ~/.config directory now that
~/.config/containers/storage.conf is not created automatically. Podman
has no use for it if it does not exist already.