### PR TITLE
[v1.9] Fix login using authconfig credentials

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -131,7 +131,7 @@ func loginCmd(c *cliconfig.LoginValues) error {
 	}
 
 	// If no username and no password is specified, try to use existing ones.
-	if c.Username == "" && password == "" && authConfig.Username == "" && authConfig.Password != "" {
+	if c.Username == "" && password == "" && authConfig.Username != "" && authConfig.Password != "" {
 		fmt.Println("Authenticating with existing credentials...")
 		if err := docker.CheckAuth(ctx, sc, authConfig.Username, authConfig.Password, server); err == nil {
 			fmt.Println("Existing credentials are valid. Already logged in to", server)


### PR DESCRIPTION
In 1.9 authconfig credentials login is broken because if no username or password was provided we use the authconfig credentials only if they don't provide a username, which is incorrect.