### PR TITLE
Fix authconfig authentication in 1.9

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -131,7 +131,7 @@ func loginCmd(c *cliconfig.LoginValues) error {
 	}
 
 	// If no username and no password is specified, try to use existing ones.
-	if c.Username == "" && password == "" && authConfig.Username == "" && authConfig.Password != "" {
+	if c.Username == "" && password == "" && authConfig.Username != "" && authConfig.Password != "" {
 		fmt.Println("Authenticating with existing credentials...")
 		if err := docker.CheckAuth(ctx, sc, authConfig.Username, authConfig.Password, server); err == nil {
 			fmt.Println("Existing credentials are valid. Already logged in to", server)


### PR DESCRIPTION
In the current 1.9 branch, if you pass an authfile with valid credentials, it is ignored.

This patch fixes it by checking that the username from the authfile is not empty in order to use those credentials.

Signed-off-by: Antoine Reversat <a.reversat@gmail.com>