### PR TITLE
We should not be mounting /run as noexec when run with --systemd

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -563,7 +563,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 // systemd expects to have /run, /run/lock and /tmp on tmpfs
 // It also expects to be able to write to /sys/fs/cgroup/systemd and /var/log/journal
 func (c *Container) setupSystemd(mounts []spec.Mount, g generate.Generator) error {
-	options := []string{"rw", "rprivate", "noexec", "nosuid", "nodev"}
+	options := []string{"rw", "rprivate", "nosuid", "nodev"}
 	for _, dest := range []string{"/run", "/run/lock"} {
 		if MountExists(mounts, dest) {
 			continue
@@ -627,7 +627,7 @@ func (c *Container) setupSystemd(mounts []spec.Mount, g generate.Generator) erro
 			Destination: "/sys/fs/cgroup/systemd",
 			Type:        "bind",
 			Source:      "/sys/fs/cgroup/systemd",
-			Options:     []string{"bind", "nodev", "noexec", "nosuid", "rprivate"},
+			Options:     []string{"bind", "nodev", "nosuid", "rprivate"},
 		}
 		g.AddMount(systemdMnt)
 		g.AddLinuxMaskedPaths("/sys/fs/cgroup/systemd/release_agent")

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -919,6 +919,14 @@ USER mail`
 		Expect(session.OutputToString()).To(Not(ContainSubstring("/dev/shm type tmpfs (ro,")))
 	})
 
+	It("podman run readonly container should NOT mount /run noexec", func() {
+		session := podmanTest.Podman([]string{"run", "--read-only", ALPINE, "sh", "-c", "mount  | grep \"/run \""})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		Expect(session.OutputToString()).To(Not(ContainSubstring("noexec")))
+	})
+
 	It("podman run with bad healthcheck retries", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "[\"foo\"]", "--health-retries", "0", ALPINE, "top"})
 		session.Wait()

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -146,4 +146,12 @@ WantedBy=multi-user.target
 		Expect(len(conData)).To(Equal(1))
 		Expect(conData[0].Config.SystemdMode).To(BeTrue())
 	})
+
+	It("podman run --systemd container should NOT mount /run noexec", func() {
+		session := podmanTest.Podman([]string{"run", "--systemd", "always", ALPINE, "sh", "-c", "mount  | grep \"/run \""})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		Expect(session.OutputToString()).To(Not(ContainSubstring("noexec")))
+	})
 })


### PR DESCRIPTION
The system defaults /run to "exec" mode, and we default --read-only
mounts on /run to "exec", so --systemd should follow suit.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>