### PR TITLE
APIv2 Add network list filtering

### DIFF
--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -61,6 +61,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//  - networks (compat)
 	// summary: List networks
 	// description: Display summary of network configurations
+	// parameters:
+	//  - in: query
+	//    name: filters
+	//    type: string
+	//    description: JSON encoded value of the filters (a map[string][]string) to process on the networks list. Only the name filter is supported.
 	// produces:
 	// - application/json
 	// responses:
@@ -152,6 +157,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//  - networks
 	// summary: List networks
 	// description: Display summary of network configurations
+	// parameters:
+	//  - in: query
+	//    name: filter
+	//    type: string
+	//    description: Provide filter values (e.g. 'name=podman')
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -111,7 +111,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    required: true
 	//    description: the name of the network
 	//  - in: query
-	//    name: Force
+	//    name: force
 	//    type: boolean
 	//    description: remove containers associated with network
 	// produces:

--- a/pkg/bindings/network/network.go
+++ b/pkg/bindings/network/network.go
@@ -70,7 +70,7 @@ func Remove(ctx context.Context, nameOrID string, force *bool) ([]*entities.Netw
 }
 
 // List returns a summary of all CNI network configurations
-func List(ctx context.Context) ([]*entities.NetworkListReport, error) {
+func List(ctx context.Context, options entities.NetworkListOptions) ([]*entities.NetworkListReport, error) {
 	var (
 		netList []*entities.NetworkListReport
 	)
@@ -78,7 +78,11 @@ func List(ctx context.Context) ([]*entities.NetworkListReport, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/networks/json", nil, nil)
+	params := url.Values{}
+	if options.Filter != "" {
+		params.Set("filter", options.Filter)
+	}
+	response, err := conn.DoRequest(nil, http.MethodGet, "/networks/json", params, nil)
 	if err != nil {
 		return netList, err
 	}

--- a/pkg/domain/infra/tunnel/network.go
+++ b/pkg/domain/infra/tunnel/network.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (ic *ContainerEngine) NetworkList(ctx context.Context, options entities.NetworkListOptions) ([]*entities.NetworkListReport, error) {
-	return network.List(ic.ClientCxt)
+	return network.List(ic.ClientCxt, options)
 }
 
 func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []string, options entities.NetworkInspectOptions) ([]entities.NetworkInspectReport, error) {

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -21,6 +21,27 @@ if root; then
   t POST libpod/networks/create '"Subnet":{"IP":"10.10.1.0","Mask":[0,255,255,0]}' 500 \
     .cause~'.*mask is invalid'
 
+  # network list
+  t GET libpod/networks/json 200
+  t GET libpod/networks/json?filter=name=network1 200 \
+    length=1 \
+    .[0].Name=network1
+  t GET networks 200
+
+  #network list docker endpoint
+  #filters={"name":["network1","network2"]}
+  t GET networks?filters=%7B%22name%22%3A%5B%22network1%22%2C%22network2%22%5D%7D 200 \
+    length=2
+  #filters={"name":["network"]}
+  t GET networks?filters=%7B%22name%22%3A%5B%22network%22%5D%7D 200 \
+    length=2
+  # invalid filter filters={"label":"abc"}
+  t GET networks?filters=%7B%22label%22%3A%5B%22abc%22%5D%7D 500 \
+    .cause="only the name filter for listing networks is implemented"
+  # invalid filter filters={"label":"abc","name":["network"]}
+  t GET networks?filters=%7B%22label%22%3A%22abc%22%2C%22name%22%3A%5B%22network%22%5D%7D 500 \
+    .cause="only the name filter for listing networks is implemented"
+
   # clean the network
   t DELETE libpod/networks/network1 200 \
     .[0].Name~network1 \

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (


### PR DESCRIPTION
Add the filter option to the libpod endpoint.
Add support for the name filter on the docker endpoint.

Add apiv2 tests for the network list endpoints.
Enable podman network integration tests for remote.
