### PR TITLE
Fix system df inconsistent

### DIFF
--- a/cmd/podman/system/df.go
+++ b/cmd/podman/system/df.go
@@ -134,7 +134,7 @@ func printSummary(reports *entities.SystemDfReport, userFormat string) error {
 	for _, v := range reports.Volumes {
 		activeVolumes += v.Links
 		volumesSize += v.Size
-		volumesReclaimable += v.Size
+		volumesReclaimable += v.ReclaimableSize
 	}
 	volumeSummary := dfSummary{
 		Type:        "Local Volumes",
@@ -182,7 +182,7 @@ func printVerbose(reports *entities.SystemDfReport) error {
 		dfContainers = append(dfContainers, &dfContainer{SystemDfContainerReport: d})
 	}
 	containerHeaders := "CONTAINER ID\tIMAGE\tCOMMAND\tLOCAL VOLUMES\tSIZE\tCREATED\tSTATUS\tNAMES\n"
-	containerRow := "{{.ContainerID}}\t{{.Image}}\t{{.Command}}\t{{.LocalVolumes}}\t{{.Size}}\t{{.Created}}\t{{.Status}}\t{{.Names}}\n"
+	containerRow := "{{.ContainerID}}\t{{.Image}}\t{{.Command}}\t{{.LocalVolumes}}\t{{.RWSize}}\t{{.Created}}\t{{.Status}}\t{{.Names}}\n"
 	format = containerHeaders + "{{range . }}" + containerRow + "{{end}}"
 	if err := writeTemplate(w, format, dfContainers); err != nil {
 		return nil
@@ -257,8 +257,8 @@ func (d *dfContainer) Command() string {
 	return strings.Join(d.SystemDfContainerReport.Command, " ")
 }
 
-func (d *dfContainer) Size() string {
-	return units.HumanSize(float64(d.SystemDfContainerReport.Size))
+func (d *dfContainer) RWSize() string {
+	return units.HumanSize(float64(d.SystemDfContainerReport.RWSize))
 }
 
 func (d *dfContainer) Created() string {

--- a/pkg/domain/entities/system.go
+++ b/pkg/domain/entities/system.go
@@ -75,9 +75,10 @@ type SystemDfContainerReport struct {
 
 // SystemDfVolumeReport describes a volume and its size
 type SystemDfVolumeReport struct {
-	VolumeName string
-	Links      int
-	Size       int64
+	VolumeName      string
+	Links           int
+	Size            int64
+	ReclaimableSize int64
 }
 
 // SystemResetOptions describes the options for resetting your

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -313,6 +313,7 @@ func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.System
 	}
 
 	dfVolumes := make([]*entities.SystemDfVolumeReport, 0, len(vols))
+	var reclaimableSize int64
 	for _, v := range vols {
 		var consInUse int
 		volSize, err := sizeOfPath(v.MountPoint())
@@ -323,15 +324,19 @@ func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.System
 		if err != nil {
 			return nil, err
 		}
+		if len(inUse) == 0 {
+			reclaimableSize += volSize
+		}
 		for _, viu := range inUse {
 			if util.StringInSlice(viu, runningContainers) {
 				consInUse++
 			}
 		}
 		report := entities.SystemDfVolumeReport{
-			VolumeName: v.Name(),
-			Links:      consInUse,
-			Size:       volSize,
+			VolumeName:      v.Name(),
+			Links:           consInUse,
+			Size:            volSize,
+			ReclaimableSize: reclaimableSize,
 		}
 		dfVolumes = append(dfVolumes, &report)
 	}


### PR DESCRIPTION
Use RWSzir as system df verbose containers size to remain consistent with the summery. Volume is reclaimable only if not used by containers.
Close #7405 

Signed-off-by: Qi Wang <qiwan@redhat.com>