### PR TITLE
Make an entry in /etc/group when we modify /etc/passwd

### DIFF
--- a/libpod/container_internal_linux_test.go
+++ b/libpod/container_internal_linux_test.go
@@ -29,16 +29,42 @@ func TestGenerateUserPasswdEntry(t *testing.T) {
 			Mountpoint: "/does/not/exist/tmp/",
 		},
 	}
-	user, err := c.generateUserPasswdEntry()
+	user, _, _, err := c.generateUserPasswdEntry(0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, user, "123:x:123:456:container user:/:/bin/sh\n")
+	assert.Equal(t, user, "123:*:123:456:container user:/:/bin/sh\n")
 
 	c.config.User = "567"
-	user, err = c.generateUserPasswdEntry()
+	user, _, _, err = c.generateUserPasswdEntry(0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, user, "567:x:567:0:container user:/:/bin/sh\n")
+	assert.Equal(t, user, "567:*:567:0:container user:/:/bin/sh\n")
+}
+
+func TestGenerateUserGroupEntry(t *testing.T) {
+	c := Container{
+		config: &ContainerConfig{
+			Spec: &spec.Spec{},
+			ContainerSecurityConfig: ContainerSecurityConfig{
+				User: "123:456",
+			},
+		},
+		state: &ContainerState{
+			Mountpoint: "/does/not/exist/tmp/",
+		},
+	}
+	group, _, err := c.generateUserGroupEntry(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, group, "456:x:456:123\n")
+
+	c.config.User = "567"
+	group, _, err = c.generateUserGroupEntry(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, group, "567:x:567:567\n")
 }

--- a/test/e2e/run_passwd_test.go
+++ b/test/e2e/run_passwd_test.go
@@ -71,4 +71,58 @@ USER 1000`
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Not(ContainSubstring("passwd")))
 	})
+
+	It("podman run with no user specified does not change --group specified", func() {
+		session := podmanTest.Podman([]string{"run", "--read-only", BB, "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOutputContains("/etc/group")).To(BeFalse())
+	})
+
+	It("podman run group specified in container", func() {
+		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "root:bin", BB, "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOutputContains("/etc/group")).To(BeFalse())
+	})
+
+	It("podman run non-numeric group not specified in container", func() {
+		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "root:doesnotexist", BB, "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+	})
+
+	It("podman run numeric group specified in container", func() {
+		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "root:11", BB, "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOutputContains("/etc/group")).To(BeFalse())
+	})
+
+	It("podman run numeric group not specified in container", func() {
+		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "20001:20001", BB, "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOutputContains("/etc/group")).To(BeTrue())
+	})
+
+	It("podman run numeric user not specified in container modifies group", func() {
+		session := podmanTest.Podman([]string{"run", "--read-only", "-u", "20001", BB, "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOutputContains("/etc/group")).To(BeTrue())
+	})
+
+	It("podman run numeric group from image and no group file", func() {
+		SkipIfRemote()
+		dockerfile := `FROM alpine
+RUN rm -f /etc/passwd /etc/shadow /etc/group
+USER 1000`
+		imgName := "testimg"
+		podmanTest.BuildImage(dockerfile, imgName, "false")
+		session := podmanTest.Podman([]string{"run", "--rm", imgName, "ls", "/etc/"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Not(ContainSubstring("/etc/group")))
+	})
 })


### PR DESCRIPTION
To ensure that the user running in the container ahs a valid entry in /etc/passwd so lookup functions for the current user will not error, Podman previously began adding entries to the passwd file. We did not, however, add entries to the group file, and this created problems - our passwd entries included the group the user is in, but said group might not exist. The solution is to mirror our logic for /etc/passwd modifications to also edit /etc/group in the container.

Unfortunately, this is not a catch-all solution. Our logic here is only advanced enough to *add* to the group file - so if the group already exists but we add a user not a part of it, we will not modify that existing entry, and things remain inconsistent. We can look into adding this later if we absolutely need to, but it would involve adding significant complexity to this already massively complicated function.

While we're here, address an edge case where Podman could add a user or group whose UID overlapped with an existing user or group.

Fixes #7503
Fixes #7389
