### PR TITLE
Fix unconfined AppArmor profile usage for unsupported systems

### DIFF
--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -60,7 +60,7 @@ func setLabelOpts(s *specgen.SpecGenerator, runtime *libpod.Runtime, pidConfig s
 func setupApparmor(s *specgen.SpecGenerator, rtc *config.Config, g *generate.Generator) error {
 	hasProfile := len(s.ApparmorProfile) > 0
 	if !apparmor.IsEnabled() {
-		if hasProfile {
+		if hasProfile && s.ApparmorProfile != "unconfined" {
 			return errors.Errorf("Apparmor profile %q specified, but Apparmor is not enabled on this system", s.ApparmorProfile)
 		}
 		return nil

--- a/test/e2e/run_apparmor_test.go
+++ b/test/e2e/run_apparmor_test.go
@@ -155,4 +155,17 @@ profile aa-test-profile flags=(attach_disconnected,mediate_deleted) {
 		inspect := podmanTest.InspectContainer(cid)
 		Expect(inspect[0].AppArmorProfile).To(Equal(""))
 	})
+
+	It("podman run apparmor disabled unconfined", func() {
+		skipIfAppArmorEnabled()
+
+		session := podmanTest.Podman([]string{"create", "--security-opt", "apparmor=unconfined", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		cid := session.OutputToString()
+		// Verify that apparmor.Profile is being set
+		inspect := podmanTest.InspectContainer(cid)
+		Expect(inspect[0].AppArmorProfile).To(Equal(""))
+	})
 })


### PR DESCRIPTION
If we select "unconfined" as AppArmor profile, then we should not error
even if the host does not support it at all. This behavior has been
fixed and a corresponding e2e test has been added as well.

Fixes https://github.com/containers/podman/issues/7545