### PR TITLE
[2.0] make image parent check more robust

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -1242,6 +1242,14 @@ func areParentAndChild(parent, child *imgspecv1.Image) bool {
 	// the child and candidate parent should share all of the
 	// candidate parent's diff IDs, which together would have
 	// controlled which layers were used
+
+	// Both, child and parent, may be nil when the storage is left in an
+	// incoherent state.  Issue #7444 describes such a case when a build
+	// has been killed.
+	if child == nil || parent == nil {
+		return false
+	}
+
 	if len(parent.RootFS.DiffIDs) > len(child.RootFS.DiffIDs) {
 		return false
 	}

--- a/libpod/image/layer_tree.go
+++ b/libpod/image/layer_tree.go
@@ -32,7 +32,9 @@ func (t *layerTree) toOCI(ctx context.Context, i *Image) (*ociv1.Image, error) {
 	oci, exists := t.ociCache[i.ID()]
 	if !exists {
 		oci, err = i.ociv1Image(ctx)
-		t.ociCache[i.ID()] = oci
+		if err == nil {
+			t.ociCache[i.ID()] = oci
+		}
 	}
 	return oci, err
 }


### PR DESCRIPTION
Follow up on issue #7444 and make the parent checks more robust.
We can end up with an incoherent storage when, for instance, a
build has been killed.

Backport of commit a6f8586 and commit 238abf6.  Squashed for easier
tracking and referencing.

Fixes: #7444
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1876576

Signed-off-by: Brent Baude <bbaude@redhat.com>
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>