### PR TITLE
podman stop: do not cleanup for auto-removal

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -174,6 +174,12 @@ func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []strin
 				return err
 			}
 		}
+		if c.AutoRemove() {
+			// Issue #7384: if the container is configured for
+			// auto-removal, it might already have been removed at
+			// this point.
+			return nil
+		}
 		return c.Cleanup(ctx)
 	})
 	if err != nil {


### PR DESCRIPTION
Do not perform a container clean up for containers configured for
auto-removal (e.g., via `podman run --rm`).  There is a small race
window with the other process performing the removal where a clean up
during podman-stop may fail since the container has already been removed
and cleaned up.  As the removing process will clean up the container,
we don't have to do it during podman-stop.

Fixes: #7384
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>