### PR TITLE
remote run: fix error checks

### DIFF
--- a/pkg/errorhandling/errorhandling.go
+++ b/pkg/errorhandling/errorhandling.go
@@ -57,3 +57,11 @@ func CloseQuiet(f *os.File) {
 		logrus.Errorf("unable to close file %s: %q", f.Name(), err)
 	}
 }
+
+// Contains checks if err's message contains sub's message. Contains should be
+// used iff either err or sub has lost type information (e.g., due to
+// marshaling).  For typed errors, please use `errors.Contains(...)` or `Is()`
+// in recent version of Go.
+func Contains(err error, sub error) bool {
+	return strings.Contains(err.Error(), sub.Error())
+}


### PR DESCRIPTION
As error types are not preserved on the client side (due to marshaling),
we cannot use `errors.Cause(...)` and friends but, unfortunately, have
to fall back to looking for substring the error messages.

Change the error checks in remote run to do substring matches and fix
issue #7340.

Fixes: #7340
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>