### PR TITLE
Don't setup the Image/ContainerEngine when calling a cmd with subcmds

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -104,8 +104,8 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 	// TODO: Remove trace statement in podman V2.1
 	logrus.Debugf("Called %s.PersistentPreRunE(%s)", cmd.Name(), strings.Join(os.Args, " "))
 
-	// Help is a special case, no need for more setup
-	if cmd.Name() == "help" {
+	// Help and commands with subcommands are special cases, no need for more setup
+	if cmd.Name() == "help" || cmd.HasSubCommands() {
 		return nil
 	}
 
@@ -204,8 +204,8 @@ func persistentPostRunE(cmd *cobra.Command, args []string) error {
 	// TODO: Remove trace statement in podman V2.1
 	logrus.Debugf("Called %s.PersistentPostRunE(%s)", cmd.Name(), strings.Join(os.Args, " "))
 
-	// Help is a special case, no need for more cleanup
-	if cmd.Name() == "help" {
+	// Help and commands with subcommands are special cases, no need for more cleanup
+	if cmd.Name() == "help" || cmd.HasSubCommands() {
 		return nil
 	}
 

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -69,6 +69,17 @@ function setup() {
     is "$output" "Error: unknown flag: --remote" "podman version --remote"
 }
 
+# Check that just calling "podman-remote" prints the usage message even
+# without a running endpoint. Use "podman --remote" for this as this works the same.
+@test "podman-remote: check for command usage message without a running endpoint" {
+    if is_remote; then
+        skip "only applicable on a local run since this requires no endpoint"
+    fi
+
+    run_podman 125 --remote
+    is "$output" "Error: missing command 'podman COMMAND'" "podman remote show usage message without running endpoint"
+}
+
 # This is for development only; it's intended to make sure our timeout
 # in run_podman continues to work. This test should never run in production
 # because it will, by definition, fail.


### PR DESCRIPTION
There is no need to setup the image and container engine when calling
a command with subcommands since we only print a usage message.
e.g `podman`,`podman container`

This also allows the remote client to show the usage message on
these commands without a running endpoint. I added a test for this.

Run without an endpoint with this commit:
```
$ bin/podman-remote
Error: missing command 'podman-remote COMMAND'
Try 'podman-remote --help' for more information.
```
Before:
```
$ bin/podman-remote
Error: Get "http://d/v1.0.0/libpod../../../_ping": dial unix ///run/user/1000/podman/podman.sock: connect: no such file or directory
```