### PR TITLE
Fix podman ps -l

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -798,6 +798,9 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 }
 
 func (ic *ContainerEngine) ContainerList(ctx context.Context, options entities.ContainerListOptions) ([]entities.ListContainer, error) {
+	if options.Latest {
+		options.Last = 1
+	}
 	return ps.GetContainerLists(ic.Libpod, options)
 }
 

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -104,11 +104,13 @@ var _ = Describe("Podman ps", func() {
 		SkipIfRemote()
 		_, ec, _ := podmanTest.RunLsContainer("")
 		Expect(ec).To(Equal(0))
+		_, ec, _ = podmanTest.RunLsContainer("")
+		Expect(ec).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"ps", "--latest"})
+		result := podmanTest.Podman([]string{"ps", "-q", "--latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
-		Expect(len(result.OutputToStringArray())).Should(BeNumerically(">", 0))
+		Expect(len(result.OutputToStringArray())).Should(Equal(1))
 	})
 
 	It("podman ps last flag", func() {


### PR DESCRIPTION
Currently the --latest flag is ignored by podman ps command.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>