### PR TITLE
generate systemd: catch `--name=foo`

### DIFF
--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -220,6 +220,9 @@ func executeContainerTemplate(info *containerInfo, options entities.GenerateSyst
 			case "--replace":
 				hasReplaceParam = true
 			}
+			if strings.HasPrefix(p, "--name=") {
+				hasNameParam = true
+			}
 		}
 
 		if !hasDetachParam {

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Podman generate systemd", func() {
 		Expect(found).To(BeTrue())
 	})
 
-	It("podman generate systemd --new", func() {
+	It("podman generate systemd --new --name foo", func() {
 		n := podmanTest.Podman([]string{"create", "--name", "foo", "alpine", "top"})
 		n.WaitWithDefaultTimeout()
 		Expect(n.ExitCode()).To(Equal(0))
@@ -200,6 +200,29 @@ var _ = Describe("Podman generate systemd", func() {
 
 		// Grepping the output (in addition to unit tests)
 		found, _ := session.GrepString("# container-foo.service")
+		Expect(found).To(BeTrue())
+
+		found, _ = session.GrepString(" --replace ")
+		Expect(found).To(BeTrue())
+
+		found, _ = session.GrepString("stop --ignore --cidfile %t/container-foo.ctr-id -t 42")
+		Expect(found).To(BeTrue())
+	})
+
+	It("podman generate systemd --new --name=foo", func() {
+		n := podmanTest.Podman([]string{"create", "--name=foo", "alpine", "top"})
+		n.WaitWithDefaultTimeout()
+		Expect(n.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"generate", "systemd", "-t", "42", "--name", "--new", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		// Grepping the output (in addition to unit tests)
+		found, _ := session.GrepString("# container-foo.service")
+		Expect(found).To(BeTrue())
+
+		found, _ = session.GrepString(" --replace ")
 		Expect(found).To(BeTrue())
 
 		found, _ = session.GrepString("stop --ignore --cidfile %t/container-foo.ctr-id -t 42")


### PR DESCRIPTION
The systemd generator looks for certain flags in the containers' create
commands to determine which flags need to be added.  In case of named
containers, the generator adds the `--replace` flag to prevent name
conflicts at container creation.  Fix the generator to not only cover
the `--name foo` syntax but also the `--name=foo` one.

Fixes: #7157
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>