### PR TITLE
remote kill: don't wait for the container to stop

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -174,7 +174,7 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "unable to kill Container %s", name))
 	}
 
-	if utils.IsLibpodRequest(r) {
+	if !utils.IsLibpodRequest(r) {
 		// the kill behavior for docker differs from podman in that they appear to wait
 		// for the Container to croak so the exit code is accurate immediately after the
 		// kill is sent.  libpod does not.  but we can add a wait here only for the docker

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"syscall"
 
 	"github.com/containers/podman/v2/libpod"
 	"github.com/containers/podman/v2/libpod/define"
@@ -169,16 +170,16 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = con.Kill(uint(sig))
+	signal := uint(sig)
+
+	err = con.Kill(signal)
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "unable to kill Container %s", name))
 	}
 
-	if !utils.IsLibpodRequest(r) {
-		// the kill behavior for docker differs from podman in that they appear to wait
-		// for the Container to croak so the exit code is accurate immediately after the
-		// kill is sent.  libpod does not.  but we can add a wait here only for the docker
-		// side of things and mimic that behavior
+	// Docker waits for the container to stop if the signal is 0 or
+	// SIGKILL.
+	if !utils.IsLibpodRequest(r) && (signal == 0 || syscall.Signal(signal) == syscall.SIGKILL) {
 		if _, err = con.Wait(); err != nil {
 			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to wait for Container %s", con.ID()))
 			return

--- a/test/system/130-kill.bats
+++ b/test/system/130-kill.bats
@@ -6,8 +6,6 @@
 load helpers
 
 @test "podman kill - test signal handling in containers" {
-    skip_if_remote "FIXME: pending #7135"
-
     # podman-remote and crun interact poorly in f31: crun seems to gobble up
     # some signals.
     # Workaround: run 'env --default-signal sh' instead of just 'sh' in


### PR DESCRIPTION
Invert the branch logic to match the comment.  Docker seems to wait for
the container while Podman does not.

Fixes: #7135
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>