### PR TITLE
Make oom-score-adj actually work

### DIFF
--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -353,6 +353,9 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseFalse
 	}
 
+	if s.OOMScoreAdj != nil {
+		g.SetProcessOOMScoreAdj(*s.OOMScoreAdj)
+	}
 	setProcOpts(s, &g)
 
 	return configSpec, nil

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -325,10 +325,10 @@ USER bin`
 			Expect(session.ExitCode()).To(Equal(0))
 		}
 
-		session = podmanTest.Podman([]string{"run", "--rm", "--oom-score-adj=100", fedoraMinimal, "cat", "/proc/self/oom_score_adj"})
+		session = podmanTest.Podman([]string{"run", "--rm", "--oom-score-adj=111", fedoraMinimal, "cat", "/proc/self/oom_score_adj"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(ContainSubstring("100"))
+		Expect(session.OutputToString()).To(Equal("111"))
 	})
 
 	It("podman run limits host test", func() {


### PR DESCRIPTION
During the redesign of podman 2.0, we dropped the support for --oom-score-adj.
Test for this flag was bogus and thus passing when it was broken.

Basically just need to set the value in the spec.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1877187

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>