### PR TITLE
remote run: consult events for exit code

### DIFF
--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -44,8 +44,6 @@ load helpers
 #
 # See https://github.com/containers/podman/issues/3795
 @test "podman rm -f" {
-    skip_if_remote "FIXME: pending #7117"
-
     rand=$(random_string 30)
     ( sleep 3; run_podman rm -f $rand ) &
     run_podman 137 run --name $rand $IMAGE sleep 30


### PR DESCRIPTION
After attaching to a container, we wait for the container to finish and
return its exit code.  Waiting for the container may not always succeed,
for instance, when the container has been force removed by another
process.  In such case, we have to look at the *last* container-exit
event.

Also refactor the `ContainerRun` method a bit to return early on errors
and de-spaghetti the code.

Enable the remote-disabled system test.

Fixes: #7117
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>