### PR TITLE
Fix podman container runlabel --display

### DIFF
--- a/pkg/domain/infra/abi/containers_runlabel.go
+++ b/pkg/domain/infra/abi/containers_runlabel.go
@@ -36,6 +36,11 @@ func (ic *ContainerEngine) ContainerRunlabel(ctx context.Context, label string, 
 		return err
 	}
 
+	if options.Display {
+		fmt.Printf("command: %s\n", strings.Join(append([]string{os.Args[0]}, cmd[1:]...), " "))
+		return nil
+	}
+
 	stdErr := os.Stderr
 	stdOut := os.Stdout
 	stdIn := os.Stdin

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -72,6 +72,21 @@ var _ = Describe("podman container runlabel", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 	})
+
+	It("podman container runlabel --display", func() {
+		SkipIfRemote()
+		image := "podman-runlabel-test:ls"
+		podmanTest.BuildImage(LsDockerfile, image, "false")
+
+		result := podmanTest.Podman([]string{"container", "runlabel", "--display", "RUN", image})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(result.OutputToString()).To(ContainSubstring(podmanTest.PodmanBinary + " -la"))
+
+		result = podmanTest.Podman([]string{"rmi", image})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+	})
 	It("podman container runlabel bogus label should result in non-zero exit code", func() {
 		result := podmanTest.Podman([]string{"container", "runlabel", "RUN", ALPINE})
 		result.WaitWithDefaultTimeout()


### PR DESCRIPTION
Current podman container runlabel --display is being ignored.

This is just supposed to display the command that would be run, and
then exit, but instead is actually running the command.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1877186

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>