### PR TITLE
Extend the flags of the `manifest add` command

### DIFF
--- a/cmd/podman/manifest/add.go
+++ b/cmd/podman/manifest/add.go
@@ -4,14 +4,26 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containers/common/pkg/auth"
+	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/pkg/domain/entities"
+	"github.com/containers/podman/v2/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
+// manifestAddOptsWrapper wraps entities.ManifestAddOptions and prevents leaking
+// CLI-only fields into the API types.
+type manifestAddOptsWrapper struct {
+	entities.ManifestAddOptions
+
+	TLSVerifyCLI   bool // CLI only
+	CredentialsCLI string
+}
+
 var (
-	manifestAddOpts = entities.ManifestAddOptions{}
+	manifestAddOpts = manifestAddOptsWrapper{}
 	addCmd          = &cobra.Command{
 		Use:   "add [flags] LIST LIST",
 		Short: "Add images to a manifest list or image index",
@@ -33,15 +45,48 @@ func init() {
 	flags.BoolVar(&manifestAddOpts.All, "all", false, "add all of the list's images if the image is a list")
 	flags.StringSliceVar(&manifestAddOpts.Annotation, "annotation", nil, "set an `annotation` for the specified image")
 	flags.StringVar(&manifestAddOpts.Arch, "arch", "", "override the `architecture` of the specified image")
+	flags.StringVar(&manifestAddOpts.Authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	flags.StringVar(&manifestAddOpts.CertDir, "cert-dir", "", "use certificates at the specified path to access the registry")
+	flags.StringVar(&manifestAddOpts.CredentialsCLI, "creds", "", "use `[username[:password]]` for accessing the registry")
+
 	flags.StringSliceVar(&manifestAddOpts.Features, "features", nil, "override the `features` of the specified image")
 	flags.StringVar(&manifestAddOpts.OS, "os", "", "override the `OS` of the specified image")
 	flags.StringVar(&manifestAddOpts.OSVersion, "os-version", "", "override the OS `version` of the specified image")
+	flags.BoolVar(&manifestAddOpts.TLSVerifyCLI, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	flags.StringVar(&manifestAddOpts.Variant, "variant", "", "override the `Variant` of the specified image")
+
+	if registry.IsRemote() {
+		_ = flags.MarkHidden("authfile")
+		_ = flags.MarkHidden("cert-dir")
+		_ = flags.MarkHidden("tls-verify")
+	}
 }
 
 func add(cmd *cobra.Command, args []string) error {
+	if err := auth.CheckAuthFile(manifestPushOpts.Authfile); err != nil {
+		return err
+	}
+
 	manifestAddOpts.Images = []string{args[1], args[0]}
-	listID, err := registry.ImageEngine().ManifestAdd(context.Background(), manifestAddOpts)
+
+	if manifestAddOpts.CredentialsCLI != "" {
+		creds, err := util.ParseRegistryCreds(manifestAddOpts.CredentialsCLI)
+		if err != nil {
+			return err
+		}
+		manifestAddOpts.Username = creds.Username
+		manifestAddOpts.Password = creds.Password
+	}
+
+	// TLS verification in c/image is controlled via a `types.OptionalBool`
+	// which allows for distinguishing among set-true, set-false, unspecified
+	// which is important to implement a sane way of dealing with defaults of
+	// boolean CLI flags.
+	if cmd.Flags().Changed("tls-verify") {
+		manifestAddOpts.SkipTLSVerify = types.NewOptionalBool(!manifestAddOpts.TLSVerifyCLI)
+	}
+
+	listID, err := registry.ImageEngine().ManifestAdd(context.Background(), manifestAddOpts.ManifestAddOptions)
 	if err != nil {
 		return errors.Wrapf(err, "error adding to manifest list %s", args[0])
 	}

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1846,6 +1846,9 @@ _podman_manifest() {
 _podman_manifest_add() {
 	 local options_with_args="
      --annotation
+     --authfile
+     --cert-dir
+     --creds
      --arch
      --features
      --os
@@ -1857,6 +1860,7 @@ _podman_manifest_add() {
      --all
      --help
      -h
+     --tls-verify
      "
 
      _complete_ "$options_with_args" "$boolean_options"

--- a/docs/source/markdown/podman-manifest-add.1.md
+++ b/docs/source/markdown/podman-manifest-add.1.md
@@ -33,6 +33,25 @@ the image.  If *imageName* refers to a manifest list or image index, the
 architecture information will be retrieved from it.  Otherwise, it will be
 retrieved from the image's configuration information.
 
+**--authfile**=*path*
+
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
+
+Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
+environment variable. `export REGISTRY_AUTH_FILE=path`
+
+**--cert-dir**=*path*
+
+Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
+Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
+
+**--creds**=*creds*
+
+The [username[:password]] to use to authenticate with the registry if required.
+If one or both values are not supplied, a command line prompt will appear and the
+value can be entered.  The password is entered without echo.
+
 **--features**
 
 Specify the features list which the list or index records as requirements for
@@ -49,6 +68,10 @@ configuration information.
 
 Specify the OS version which the list or index records as a requirement for the
 image.  This option is rarely used.
+
+**--tls-verify**
+
+Require HTTPS and verify certificates when talking to container registries (defaults to true). (Not available for remote commands)
 
 **--variant**
 

--- a/pkg/domain/entities/manifest.go
+++ b/pkg/domain/entities/manifest.go
@@ -9,14 +9,19 @@ type ManifestCreateOptions struct {
 }
 
 type ManifestAddOptions struct {
-	All        bool     `json:"all" schema:"all"`
-	Annotation []string `json:"annotation" schema:"annotation"`
-	Arch       string   `json:"arch" schema:"arch"`
-	Features   []string `json:"features" schema:"features"`
-	Images     []string `json:"images" schema:"images"`
-	OS         string   `json:"os" schema:"os"`
-	OSVersion  string   `json:"os_version" schema:"os_version"`
-	Variant    string   `json:"variant" schema:"variant"`
+	All           bool               `json:"all" schema:"all"`
+	Annotation    []string           `json:"annotation" schema:"annotation"`
+	Arch          string             `json:"arch" schema:"arch"`
+	Authfile      string             `json:"-" schema:"-"`
+	CertDir       string             `json:"-" schema:"-"`
+	Features      []string           `json:"features" schema:"features"`
+	Images        []string           `json:"images" schema:"images"`
+	OS            string             `json:"os" schema:"os"`
+	OSVersion     string             `json:"os_version" schema:"os_version"`
+	Password      string             `json:"-" schema:"-"`
+	SkipTLSVerify types.OptionalBool `json:"-" schema:"-"`
+	Username      string             `json:"-" schema:"-"`
+	Variant       string             `json:"variant" schema:"variant"`
 }
 
 type ManifestAnnotateOptions struct {

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -208,6 +208,7 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, names []string, opts en
 	}
 	sys.AuthFilePath = opts.Authfile
 	sys.DockerInsecureSkipTLSVerify = opts.SkipTLSVerify
+	sys.DockerCertPath = opts.CertDir
 
 	if opts.Username != "" && opts.Password != "" {
 		sys.DockerAuthConfig = &types.DockerAuthConfig{

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -102,7 +102,24 @@ func (ir *ImageEngine) ManifestAdd(ctx context.Context, opts entities.ManifestAd
 		}
 		manifestAddOpts.Annotation = annotations
 	}
-	listID, err := listImage.AddManifest(*ir.Libpod.SystemContext(), manifestAddOpts)
+
+	// Set the system context.
+	sys := ir.Libpod.SystemContext()
+	if sys != nil {
+		sys = &types.SystemContext{}
+	}
+	sys.AuthFilePath = opts.Authfile
+	sys.DockerInsecureSkipTLSVerify = opts.SkipTLSVerify
+	sys.DockerCertPath = opts.CertDir
+
+	if opts.Username != "" && opts.Password != "" {
+		sys.DockerAuthConfig = &types.DockerAuthConfig{
+			Username: opts.Username,
+			Password: opts.Password,
+		}
+	}
+
+	listID, err := listImage.AddManifest(*sys, manifestAddOpts)
 	if err != nil {
 		return listID, err
 	}


### PR DESCRIPTION
This PR is a propagation of https://github.com/containers/buildah/pull/2593 as required by [this comment](https://github.com/containers/buildah/pull/2593#issuecomment-689108912).

On top of extending the `manifest add` flags, the PR also fixes a minor issue with the `manifest push` command: the value provided by users via the `cert-dir` flag wasn't actually be used by the code.