### PR TITLE
podman container runlabel should pull the image if it does not exist

### DIFF
--- a/cmd/podman/containers/runlabel.go
+++ b/cmd/podman/containers/runlabel.go
@@ -30,7 +30,7 @@ var (
 		RunE:  runlabel,
 		Args:  cobra.MinimumNArgs(2),
 		Example: `podman container runlabel run imageID
-  podman container runlabel --pull install imageID arg1 arg2
+  podman container runlabel install imageID arg1 arg2
   podman container runlabel --display run myImage`,
 	}
 )
@@ -51,7 +51,7 @@ func init() {
 	flags.StringVar(&runlabelOptions.Optional1, "opt1", "", "Optional parameter to pass for install")
 	flags.StringVar(&runlabelOptions.Optional2, "opt2", "", "Optional parameter to pass for install")
 	flags.StringVar(&runlabelOptions.Optional3, "opt3", "", "Optional parameter to pass for install")
-	flags.BoolP("pull", "p", false, "Pull the image if it does not exist locally prior to executing the label contents")
+	flags.BoolVarP(&runlabelOptions.Pull, "pull", "p", true, "Pull the image if it does not exist locally prior to executing the label contents")
 	flags.BoolVarP(&runlabelOptions.Quiet, "quiet", "q", false, "Suppress output information when installing images")
 	flags.BoolVar(&runlabelOptions.Replace, "replace", false, "Replace existing container with a new one from the image")
 	flags.StringVar(&runlabelOptions.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
@@ -61,6 +61,7 @@ func init() {
 	_ = flags.MarkHidden("opt1")
 	_ = flags.MarkHidden("opt2")
 	_ = flags.MarkHidden("opt3")
+	_ = flags.MarkHidden("pull")
 	_ = flags.MarkHidden("signature-policy")
 
 	if err := flags.MarkDeprecated("pull", "podman will pull if not found in local storage"); err != nil {

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -29,6 +29,8 @@ var _ = Describe("podman container runlabel", func() {
 	)
 
 	BeforeEach(func() {
+		// runlabel is not supported for remote connections
+		SkipIfRemote()
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)
@@ -46,7 +48,6 @@ var _ = Describe("podman container runlabel", func() {
 	})
 
 	It("podman container runlabel (podman --version)", func() {
-		SkipIfRemote()
 		image := "podman-runlabel-test:podman"
 		podmanTest.BuildImage(PodmanDockerfile, image, "false")
 
@@ -60,7 +61,6 @@ var _ = Describe("podman container runlabel", func() {
 	})
 
 	It("podman container runlabel (ls -la)", func() {
-		SkipIfRemote()
 		image := "podman-runlabel-test:ls"
 		podmanTest.BuildImage(LsDockerfile, image, "false")
 
@@ -72,9 +72,7 @@ var _ = Describe("podman container runlabel", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 	})
-
 	It("podman container runlabel --display", func() {
-		SkipIfRemote()
 		image := "podman-runlabel-test:ls"
 		podmanTest.BuildImage(LsDockerfile, image, "false")
 
@@ -115,7 +113,6 @@ var _ = Describe("podman container runlabel", func() {
 	})
 
 	It("runlabel should fail with nonexist authfile", func() {
-		SkipIfRemote()
 		image := "podman-runlabel-test:podman"
 		podmanTest.BuildImage(PodmanDockerfile, image, "false")
 


### PR DESCRIPTION
Since --pull is deprecated, remove it from help and hide if from --help
Also set it to true by default.

Share image pull code betweern podman image pull and podman container runlabel.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1877181

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>