### PR TITLE
libpod: read mappings when joining a container userns

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -380,6 +380,8 @@ func (c *Container) setupStorageMapping(dest, from *storage.IDMappingOptions) {
 			}
 			dest.GIDMap = append(dest.GIDMap, g)
 		}
+		dest.HostUIDMapping = false
+		dest.HostGIDMapping = false
 	}
 }
 

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/ocicni/pkg/ocicni"
+	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -897,6 +898,17 @@ func WithUserNSFrom(nsCtr *Container) CtrCreateOption {
 		ctr.config.UserNsCtr = nsCtr.ID()
 		ctr.config.IDMappings = nsCtr.config.IDMappings
 
+		g := generate.NewFromSpec(ctr.config.Spec)
+
+		g.ClearLinuxUIDMappings()
+		for _, uidmap := range nsCtr.config.IDMappings.UIDMap {
+			g.AddLinuxUIDMapping(uint32(uidmap.HostID), uint32(uidmap.ContainerID), uint32(uidmap.Size))
+		}
+		g.ClearLinuxGIDMappings()
+		for _, gidmap := range nsCtr.config.IDMappings.GIDMap {
+			g.AddLinuxGIDMapping(uint32(gidmap.HostID), uint32(gidmap.ContainerID), uint32(gidmap.Size))
+		}
+		ctr.config.IDMappings = nsCtr.config.IDMappings
 		return nil
 	}
 }

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -277,6 +277,13 @@ var _ = Describe("Podman UserNS support", func() {
 
 		ok, _ := session.GrepString("4998")
 		Expect(ok).To(BeTrue())
+
+		session = podmanTest.Podman([]string{"run", "--rm", "--userns=container:" + ctrName, "--net=container:" + ctrName, "alpine", "cat", "/proc/self/uid_map"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		ok, _ = session.GrepString("4998")
+		Expect(ok).To(BeTrue())
 	})
 
 	It("podman --user with volume", func() {


### PR DESCRIPTION
when joining an existing container user namespace, read the existing
mappings so the storage can be created with the correct ownership.

Closes: https://github.com/containers/podman/issues/7547

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>