### PR TITLE
[CI:DOCS] Add auth.json(5) link to login/logout docs

### DIFF
--- a/docs/source/markdown/podman-login.1.md
+++ b/docs/source/markdown/podman-login.1.md
@@ -12,9 +12,13 @@ and password. If the registry is not specified, the first registry under [regist
 from registries.conf will be used. **podman login** reads in the username and password from STDIN.
 The username and password can also be set using the **username** and **password** flags.
 The path of the authentication file can be specified by the user by setting the **authfile**
-flag. The default path used is **${XDG\_RUNTIME\_DIR}/containers/auth.json**. If there is a valid
-username and password in the **authfile** , Podman will use those existing credentials if the user does not pass in a username.
-If those credentials are not present, Podman will then use any existing credentials found in **$HOME/.docker/config.json**.
+flag. The default path for reading and writing credentials is **${XDG\_RUNTIME\_DIR}/containers/auth.json**.
+Podman will use existing credentials if the user does not pass in a username.
+Podman will first search for the username and password in the **${XDG\_RUNTIME\_DIR}/containers/auth.json**, if they are not valid,
+Podman will then use any existing credentials found in **$HOME/.docker/config.json**.
+If those credentials are not present, Podman will create **${XDG\_RUNTIME\_DIR}/containers/auth.json** (if the file does not exist) and
+will then store the username and password from STDIN as a base64 encoded string in it.
+For more details about format and configurations of the auth,json file, please refer to containers-auth.json(5)
 
 **podman [GLOBAL OPTIONS]**
 
@@ -104,7 +108,7 @@ Login Succeeded!
 ```
 
 ## SEE ALSO
-podman(1), podman-logout(1)
+podman(1), podman-logout(1), containers-auth.json(5)
 
 ## HISTORY
 August 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/source/markdown/podman-logout.1.md
+++ b/docs/source/markdown/podman-logout.1.md
@@ -10,7 +10,7 @@ podman\-logout - Logout of a container registry
 **podman logout** logs out of a specified registry server by deleting the cached credentials
 stored in the **auth.json** file. If the registry is not specified, the first registry under [registries.search]
 from registries.conf will be used. The path of the authentication file can be overridden by the user by setting the **authfile** flag.
-The default path used is **${XDG\_RUNTIME\_DIR}/containers/auth.json**.
+The default path used is **${XDG\_RUNTIME\_DIR}/containers/auth.json**. For more details about format and configurations of the auth,json file, please refer to containers-auth.json(5)
 All the cached credentials can be removed by setting the **all** flag.
 
 **podman [GLOBAL OPTIONS]**
@@ -54,7 +54,7 @@ Remove login credentials for all registries
 ```
 
 ## SEE ALSO
-podman(1), podman-login(1)
+podman(1), podman-login(1), containers-auth.json(5)
 
 ## HISTORY
 August 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>


### PR DESCRIPTION
Add auth.json(5) link to login/logout docs. Provide more details about the usage of auth.json by podman-login.

Signed-off-by: Qi Wang <qiwan@redhat.com>