### PR TITLE
Allowed underscores to remain in name for YAML (Kube generate)

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -191,7 +191,7 @@ func addContainersAndVolumesToPodObject(containers []v1.Container, volumes []v1.
 	labels["app"] = removeUnderscores(podName)
 	om := v12.ObjectMeta{
 		// The name of the pod is container_name-libpod
-		Name:   removeUnderscores(podName),
+		Name:   podName,
 		Labels: labels,
 		// CreationTimestamp seems to be required, so adding it; in doing so, the timestamp
 		// will reflect time this is run (not container create time) because the conversion


### PR DESCRIPTION
https://github.com/containers/podman/issues/7020 Change to 'name:' field in yaml generation

There is a 'labels' field with a similar remove underscores that I am not sure about!
Signed-off-by: Parker Van Roy <pvanroy@redhat.com>