### PR TITLE
play/generate: support shareProcessNamespace

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -69,12 +69,20 @@ func (p *Pod) GenerateForKube() (*v1.Pod, []v1.ServicePort, error) {
 			return nil, servicePorts, err
 		}
 		servicePorts = containerPortsToServicePorts(ports)
+
 	}
 	pod, err := p.podWithContainers(allContainers, ports)
 	if err != nil {
 		return nil, servicePorts, err
 	}
 	pod.Spec.HostAliases = extraHost
+
+	if p.SharesPID() {
+		// unfortunately, go doesn't have a nice way to specify a pointer to a bool
+		b := true
+		pod.Spec.ShareProcessNamespace = &b
+	}
+
 	return pod, servicePorts, nil
 }
 

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -132,7 +132,11 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		libpod.WithInfraContainer(),
 		libpod.WithPodName(podName),
 	}
-	// TODO for now we just used the default kernel namespaces; we need to add/subtract this from yaml
+	// TODO we only configure Process namespace. We also need to account for Host{IPC,Network,PID}
+	// which is not currently possible with pod create
+	if podYAML.Spec.ShareProcessNamespace != nil && *podYAML.Spec.ShareProcessNamespace {
+		podOptions = append(podOptions, libpod.WithPodPID())
+	}
 
 	hostname := podYAML.Spec.Hostname
 	if hostname == "" {


### PR DESCRIPTION
this is an option that allows a user to specify whether to share PID namespace in the pod
for play kube and generate kube

associated test added

fixes https://github.com/containers/podman/issues/4059

Signed-off-by: Peter Hunt <pehunt@redhat.com>