### PR TITLE
Force Attach() to send a SIGWINCH and redraw

### DIFF
--- a/libpod/oci_attach_linux.go
+++ b/libpod/oci_attach_linux.go
@@ -31,7 +31,7 @@ const (
 // Attach to the given container
 // Does not check if state is appropriate
 // started is only required if startContainer is true
-func (c *Container) attach(streams *define.AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, started chan bool) error {
+func (c *Container) attach(streams *define.AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, started chan bool, attachRdy chan<- bool) error {
 	if !streams.AttachOutput && !streams.AttachError && !streams.AttachInput {
 		return errors.Wrapf(define.ErrInvalidArg, "must provide at least one stream to attach to")
 	}
@@ -74,6 +74,9 @@ func (c *Container) attach(streams *define.AttachStreams, keys string, resize <-
 	}
 
 	receiveStdoutError, stdinDone := setupStdioChannels(streams, conn, detachKeys)
+	if attachRdy != nil {
+		attachRdy <- true
+	}
 	return readStdio(streams, receiveStdoutError, stdinDone)
 }
 

--- a/libpod/oci_attach_unsupported.go
+++ b/libpod/oci_attach_unsupported.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-func (c *Container) attach(streams *define.AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, started chan bool) error {
+func (c *Container) attach(streams *define.AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, started chan bool, attachRdy chan<- bool) error {
 	return define.ErrNotImplemented
 }
 


### PR DESCRIPTION
Basically, we want to force the application in the container to (iff the container was made with a terminal) redraw said terminal immediately after an attach completes, so the fresh Attach session will be able to see what's going on (e.g. will have a shell prompt). Our current attach functions are unfortunately geared more towards `podman run` than `podman attach` and will start forwarding resize events *immediately* instead of waiting until the attach session is alive (much safer for short-lived `podman run` sessions, but broken for the `podman attach` case). To avoid a major rewrite, let's just manually send a SIGWINCH after attach succeeds to force a redraw.

Fixes #6253
