### PR TITLE
[v2.0.5-rhel] add github action to add branch prefix to PR title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,17 @@
+name: "add branch to title"
+
+on: pull_request
+
+jobs:
+  update_pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: tzkhan/pr-update-action@v1.1.1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        branch-regex: '^(?!master).*$'
+        title-template: '[v2.0.5-rhel]'
+        title-prefix-space: true
+        replace-title: false
+        body-template: "**Note that this PR targets a non-main branch**"
+        replace-body: false


### PR DESCRIPTION
**Note that this PR targets a non-main branch**

Add a GitHub action to the stable branch to prefix the PR title with the
branch name (i.e., "[v2.0.5-rhel]").  The intention behind is to make
backports, or commits in general, to non-master branches more obvious.
The target branch of a pull request is not easily visible in the GitHub
web interface, and that can lead to unintentionally merging PRs to stable
branches.

Unfortunately, I did not manage to automatically extract and set the
target branch name as the PR prefix.  The action [1] supports a %branch%
macro but that evaluates to the source branch.  Hence, for the time
being, we have to hard-code the branch in the .yml file and update it
once we can auto-set the target branch name.  I opened an issue asking
for help.

Since the action enforces a non-empty body template, the PR body is also
prefixed with a bold note that the PR is targetting a non-main branch.

[1] https://github.com/tzkhan/pr-update-action

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>