### PR TITLE
Dump default AppArmor profile

### DIFF
--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -9,6 +9,7 @@ type Info struct {
 	Store      *StoreInfo             `json:"store"`
 	Registries map[string]interface{} `json:"registries"`
 	Version    Version                `json:"version"`
+	AppArmor   string                 `json:"AppArmor"`
 }
 
 //HostInfo describes the libpod host

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/containers/buildah"
+	"github.com/containers/common/pkg/apparmor"
 	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/libpod/linkmode"
 	"github.com/containers/podman/v2/pkg/cgroups"
@@ -62,6 +63,13 @@ func (r *Runtime) info() (*define.Info, error) {
 	}
 
 	info.Registries = registries
+
+	apparmorDefaultProfile, err := apparmorInfo()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting AppArmor")
+	}
+	info.AppArmor = string(apparmorDefaultProfile)
+
 	return &info, nil
 }
 
@@ -332,4 +340,8 @@ func (r *Runtime) GetHostDistributionInfo() define.DistributionInfo {
 		}
 	}
 	return dist
+}
+
+func apparmorInfo() ([]byte, error) {
+	return apparmor.DefaultContent("default")
 }


### PR DESCRIPTION
Lately I've been struggling a lot to debug an AppArmor related issue: the default profile was too tight for my application (buildah BTW :smile:) and I had to find how to relax it.

The default AppArmor profile is dynamically generated by podman at runtime and, once loaded into the kernel, there's no way to print it in a human-readable form. The only way to read the default profile is to start a spelunking session inside of the vendored source code, not fun/doable for the average user :cry:  

This "issue" is common also with docker, where apparently things are going to get better thanks to [this PR](https://github.com/moby/moby/pull/39923).

This draft PR provides a way to let the average user dump the default AppArmor profile. Right now I just added this information to the `podman info` output. OFC this could be moved/changed/dropped... I'm basically looking for your feedback :smile: 

This is an example of the feature in action:

```
$ ./bin/podman info
AppArmor: |2


  #include <tunables/global>


  profile default flags=(attach_disconnected,mediate_deleted) {

    #include <abstractions/base>


    network,
    capability,
    file,
    umount,


    # Allow signals from privileged profiles and from within the same profile
    signal (receive) peer=unconfined,
    signal (send,receive) peer=default,


    deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
    # deny write to files not in /proc/<number>/** or /proc/sys/**
    deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
    deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
    deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
    deny @{PROC}/sysrq-trigger rwklx,
    deny @{PROC}/kcore rwklx,

    deny mount,

    deny /sys/[^f]*/** wklx,
    deny /sys/f[^s]*/** wklx,
    deny /sys/fs/[^c]*/** wklx,
    deny /sys/fs/c[^g]*/** wklx,
    deny /sys/fs/cg[^r]*/** wklx,
    deny /sys/firmware/** rwklx,
    deny /sys/kernel/security/** rwklx,


    # suppress ptrace denials when using using 'ps' inside a container
    ptrace (trace,read) peer=default,

  }
host:
  arch: amd64
  buildahVersion: 1.16.0-dev
  cgroupVersion: v1
  conmon:
    package: conmon-2.0.20-2.1.x86_64
    path: /usr/bin/conmon
    version: 'conmon version 2.0.20, commit: unknown'
  cpus: 8
  distribution:
    distribution: '"opensuse-tumbleweed"'
    version: "20200904"
  eventLogger: journald
[ ... goes on ... ]
```