### PR TITLE
Fix podman pod create --infra-command and --infra-image

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1659,6 +1659,36 @@ func WithUmask(umask string) CtrCreateOption {
 
 // Pod Creation Options
 
+// WithInfraImage sets the infra image for libpod.
+// An infra image is used for inter-container kernel
+// namespace sharing within a pod. Typically, an infra
+// container is lightweight and is there to reap
+// zombie processes within its pid namespace.
+func WithInfraImage(img string) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return define.ErrPodFinalized
+		}
+
+		pod.config.InfraContainer.InfraImage = img
+
+		return nil
+	}
+}
+
+// WithInfraCommand sets the command to
+// run on pause container start up.
+func WithInfraCommand(cmd []string) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return define.ErrPodFinalized
+		}
+
+		pod.config.InfraContainer.InfraCommand = cmd
+		return nil
+	}
+}
+
 // WithPodName sets the name of the pod.
 func WithPodName(name string) PodCreateOption {
 	return func(pod *Pod) error {

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -105,6 +105,8 @@ type InfraContainerConfig struct {
 	HostAdd            []string             `json:"hostsAdd,omitempty"`
 	Networks           []string             `json:"networks,omitempty"`
 	ExitCommand        []string             `json:"exitCommand,omitempty"`
+	InfraImage         string               `json:"infraImage,omitempty"`
+	InfraCommand       []string             `json:"infraCommand,omitempty"`
 }
 
 // ID retrieves the pod's ID

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -227,23 +227,6 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 
 	// TODO flag to set CNI plugins dir?
 
-	// TODO I don't think these belong here?
-	// Will follow up with a different PR to address
-	//
-	// Pod create options
-
-	infraImageFlag := fs.Lookup("infra-image")
-	if infraImageFlag != nil && infraImageFlag.Changed {
-		infraImage, _ := fs.GetString("infra-image")
-		options = append(options, libpod.WithDefaultInfraImage(infraImage))
-	}
-
-	infraCommandFlag := fs.Lookup("infra-command")
-	if infraCommandFlag != nil && infraImageFlag.Changed {
-		infraCommand, _ := fs.GetString("infra-command")
-		options = append(options, libpod.WithDefaultInfraCommand(infraCommand))
-	}
-
 	if !opts.withFDS {
 		options = append(options, libpod.WithEnableSDNotify())
 	}

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -84,6 +84,15 @@ func createPodOptions(p *specgen.PodSpecGenerator, rt *libpod.Runtime) ([]libpod
 	if len(p.CNINetworks) > 0 {
 		options = append(options, libpod.WithPodNetworks(p.CNINetworks))
 	}
+
+	if len(p.InfraImage) > 0 {
+		options = append(options, libpod.WithInfraImage(p.InfraImage))
+	}
+
+	if len(p.InfraCommand) > 0 {
+		options = append(options, libpod.WithInfraCommand(p.InfraCommand))
+	}
+
 	switch p.NetNS.NSMode {
 	case specgen.Bridge, specgen.Default, "":
 		logrus.Debugf("Pod using default network mode")

--- a/pkg/specgen/pod_validate.go
+++ b/pkg/specgen/pod_validate.go
@@ -95,12 +95,5 @@ func (p *PodSpecGenerator) Validate() error {
 		return exclusivePodOptions("NoManageHosts", "HostAdd")
 	}
 
-	// Set Defaults
-	if len(p.InfraImage) < 1 {
-		p.InfraImage = containerConfig.Engine.InfraImage
-	}
-	if len(p.InfraCommand) < 1 {
-		p.InfraCommand = []string{containerConfig.Engine.InfraCommand}
-	}
 	return nil
 }


### PR DESCRIPTION
Currently infr-command and --infra-image commands are ignored
from the user.  This PR instruments them and adds tests for
each combination.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>