### PR TITLE
Fix for incorrect evaluation of error condition within libpod.LabelVolumePath.

### DIFF
--- a/libpod/util_linux_test.go
+++ b/libpod/util_linux_test.go
@@ -1,0 +1,39 @@
+package libpod
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLabelVolumePath(t *testing.T) {
+	// Set up mocked SELinux functions for testing.
+	oldRelabel := lvpRelabel
+	oldInitLabels := lvpInitLabels
+	oldReleaseLabel := lvpReleaseLabel
+	defer func() {
+		lvpRelabel = oldRelabel
+		lvpInitLabels = oldInitLabels
+		lvpReleaseLabel = oldReleaseLabel
+	}()
+
+	// Relabel returns ENOTSUP unconditionally.
+	lvpRelabel = func(path string, fileLabel string, shared bool) error {
+		return syscall.ENOTSUP
+	}
+
+	// InitLabels and ReleaseLabel both return dummy values and nil errors.
+	lvpInitLabels = func(options []string) (string, string, error) {
+		pLabel := "system_u:system_r:container_t:s0:c1,c2"
+		mLabel := "system_u:object_r:container_file_t:s0:c1,c2"
+		return pLabel, mLabel, nil
+	}
+	lvpReleaseLabel = func(label string) error {
+		return nil
+	}
+
+	// LabelVolumePath should not return an error if the operation is unsupported.
+	err := LabelVolumePath("/foo/bar")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
While reading through `libpod/util_linux.go`, I noticed the following line: https://github.com/containers/podman/blob/master/libpod/util_linux.go#L105 

A reading of the surrounding code and in particular the logging/error text seems to indicate that the desired behavior is not to regard it as an error if the filesystem does not support labeling, simply logging the condition and moving on; while all other errors should be propagated accordingly. This does not match the actual behavior of the function, which is precisely the opposite.

In this PR I have corrected this comparison and added a test for the changes.

Because this condition only arises in unusual combinations of filesystems, I implemented my test by mocking the SELinux labeling function calls, which is admittedly somewhat tightly-coupled. If a test of a more end-to-end nature is desired, I would need some advice on how best to implement it.