### PR TITLE
move `rootless-cni-infra` image to quay.io

### DIFF
--- a/contrib/rootless-cni-infra/Containerfile
+++ b/contrib/rootless-cni-infra/Containerfile
@@ -33,3 +33,5 @@ COPY --from=dnsname /dnsname /opt/cni/bin
 COPY rootless-cni-infra /usr/local/bin
 ENV CNI_PATH=/opt/cni/bin
 CMD ["sleep", "infinity"]
+
+ENV ROOTLESS_CNI_INFRA_VERSION=1

--- a/contrib/rootless-cni-infra/README.md
+++ b/contrib/rootless-cni-infra/README.md
@@ -16,6 +16,8 @@ Podman then allocates a CNI netns in the infra container, by executing an equiva
 The allocated netns is deallocated when the container is being removed, by executing an equivalent of:
 `podman exec rootless-cni-infra rootless-cni-infra dealloc $CONTAINER_ID $NETWORK_NAME`.
 
+The container images live on `quay.io/libpod/rootless-cni-infra`.  The tags have the format `$version-$architecture`.  Please make sure to increase the version number in the Containerfile (i.e., `ROOTLESS_CNI_INFRA_VERSION`) when applying changes to this directory.  After committing the changes, upload the image(s) with the corresponding tag.
+
 ## Directory layout
 
 * `/run/rootless-cni-infra/${CONTAINER_ID}/pid`: PID of the `sleep infinity` process that corresponds to the allocated netns

--- a/contrib/rootless-cni-infra/rootless-cni-infra
+++ b/contrib/rootless-cni-infra/rootless-cni-infra
@@ -2,7 +2,6 @@
 set -eu
 
 ARG0="$0"
-VERSION="0.1.0"
 BASE="/run/rootless-cni-infra"
 
 # CLI subcommand: "alloc $CONTAINER_ID $NETWORK_NAME $POD_NAME"
@@ -126,7 +125,7 @@ cmd_entrypoint_help() {
 
 # CLI subcommand: "version"
 cmd_entrypoint_version() {
-	echo "{\"version\": \"${VERSION}\"}"
+	echo "{\"version\": \"${ROOTLESS_CNI_INFRA_VERSION}\"}"
 }
 
 # parse args

--- a/libpod/rootless_cni_linux.go
+++ b/libpod/rootless_cni_linux.go
@@ -22,10 +22,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Built from ../contrib/rootless-cni-infra.
 var rootlessCNIInfraImage = map[string]string{
-	// Built from ../contrib/rootless-cni-infra
-	// TODO: move to Podman's official quay
-	"amd64": "ghcr.io/akihirosuda/podman-rootless-cni-infra:gd34868a13-amd64",
+	"amd64": "quay.io/libpod/rootless-cni-infra@sha256:8aa681c4c08dee3ec5d46ff592fddd0259a35626717006d6b77ee786b1d02967", // 1-amd64
 }
 
 const (


### PR DESCRIPTION
Please refer to the individual commits.

Fixes: #7617