### PR TITLE
Usability: prevent "-l" with arguments

### DIFF
--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -37,7 +37,7 @@ var (
 			case registry.IsRemote() && len(args) > 1:
 				return errors.New(cmd.Name() + " does not support multiple containers when run remotely")
 			case logsOptions.Latest && len(args) > 0:
-				return errors.New("no containers can be specified when using 'latest'")
+				return errors.New("--latest and containers cannot be used together")
 			case !logsOptions.Latest && len(args) < 1:
 				return errors.New("specify at least one container name or ID to log")
 			}

--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -78,6 +78,9 @@ func mount(_ *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
+	if len(args) > 0 && mountOpts.Latest {
+		return errors.Errorf("--latest and containers cannot be used together")
+	}
 	reports, err := registry.ContainerEngine().ContainerMount(registry.GetContext(), args, mountOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/containers/restart.go
+++ b/cmd/podman/containers/restart.go
@@ -80,6 +80,9 @@ func restart(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 && !restartOptions.Latest && !restartOptions.All {
 		return errors.Wrapf(define.ErrInvalidArg, "you must provide at least one container name or ID")
 	}
+	if len(args) > 0 && restartOptions.Latest {
+		return errors.Wrapf(define.ErrInvalidArg, "--latest and containers cannot be used together")
+	}
 
 	if cmd.Flag("time").Changed {
 		restartOptions.Timeout = &restartTimeout

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -80,7 +80,7 @@ func restore(_ *cobra.Command, args []string) error {
 		}
 	}
 	if (restoreOptions.All || restoreOptions.Latest) && argLen > 0 {
-		return errors.Errorf("no arguments are needed with --all or --latest")
+		return errors.Errorf("--all or --latest and containers cannot be used together")
 	}
 	if argLen < 1 && !restoreOptions.All && !restoreOptions.Latest && restoreOptions.Import == "" {
 		return errors.Errorf("you must provide at least one name or id")

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -74,6 +74,9 @@ func start(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 && !startOptions.Latest {
 		return errors.New("start requires at least one argument")
 	}
+	if len(args) > 0 && startOptions.Latest {
+		return errors.Errorf("--latest and containers cannot be used together")
+	}
 	if len(args) > 1 && startOptions.Attach {
 		return errors.Errorf("you cannot start and attach multiple containers at once")
 	}

--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -93,7 +93,7 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 	tmpType := i.options.Type
 	if i.options.Latest {
 		if len(namesOrIDs) > 0 {
-			return errors.New("latest and containers are not allowed")
+			return errors.New("--latest and containers cannot be used together")
 		}
 		tmpType = ContainerType // -l works with --type=all
 	}

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -46,6 +46,9 @@ func inspect(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 && !inspectOptions.Latest {
 		return errors.Errorf("you must provide the name or id of a running pod")
 	}
+	if len(args) > 0 && inspectOptions.Latest {
+		return errors.Errorf("--latest and containers cannot be used together")
+	}
 
 	if !inspectOptions.Latest {
 		inspectOptions.NameOrID = args[0]

--- a/cmd/podman/validate/args.go
+++ b/cmd/podman/validate/args.go
@@ -37,6 +37,9 @@ func IDOrLatestArgs(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 && !given {
 			return fmt.Errorf("%q requires a name, id, or the \"--latest\" flag", cmd.CommandPath())
 		}
+		if len(args) > 0 && given {
+			return fmt.Errorf("--latest and containers cannot be used together")
+		}
 	}
 	return nil
 }
@@ -83,7 +86,7 @@ func CheckAllLatestAndCIDFile(c *cobra.Command, args []string, ignoreArgLen bool
 
 	if argLen > 0 {
 		if specifiedLatest {
-			return errors.Errorf("no arguments are needed with --latest")
+			return errors.Errorf("--latest and containers cannot be used together")
 		} else if cidfile && (specifiedLatest || specifiedCIDFile) {
 			return errors.Errorf("no arguments are needed with --latest or --cidfile")
 		}
@@ -138,7 +141,7 @@ func CheckAllLatestAndPodIDFile(c *cobra.Command, args []string, ignoreArgLen bo
 
 	if argLen > 0 {
 		if specifiedLatest {
-			return errors.Errorf("no arguments are needed with --latest")
+			return errors.Errorf("--latest and pods cannot be used together")
 		} else if withIDFile && (specifiedLatest || specifiedPodIDFile) {
 			return errors.Errorf("no arguments are needed with --latest or --pod-id-file")
 		}


### PR DESCRIPTION
Add new system check confirming that "podman foo -l arg"
throws an error; and fix lots of instances where code
was not doing this check.

I'll probably need to add something similar for --all but
that can wait.

Signed-off-by: Ed Santiago <santiago@redhat.com>