### PR TITLE
run/create: record raw image

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -110,7 +110,9 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	imageName := args[0]
+	rawImageName := ""
 	if !cliVals.RootFS {
+		rawImageName = args[0]
 		name, err := pullImage(args[0])
 		if err != nil {
 			return err
@@ -121,6 +123,7 @@ func create(cmd *cobra.Command, args []string) error {
 	if err := common.FillOutSpecGen(s, &cliVals, args); err != nil {
 		return err
 	}
+	s.RawImageName = rawImageName
 
 	if _, err := createPodIfNecessary(s, cliVals.Net); err != nil {
 		return err

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -130,7 +130,9 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	imageName := args[0]
+	rawImageName := ""
 	if !cliVals.RootFS {
+		rawImageName = args[0]
 		name, err := pullImage(args[0])
 		if err != nil {
 			return err
@@ -177,6 +179,7 @@ func run(cmd *cobra.Command, args []string) error {
 	if err := common.FillOutSpecGen(s, &cliVals, args); err != nil {
 		return err
 	}
+	s.RawImageName = rawImageName
 	runOpts.Spec = s
 
 	if _, err := createPodIfNecessary(s, cliVals.Net); err != nil {

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -95,7 +95,7 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		if len(names) > 0 {
 			imgName = names[0]
 		}
-		options = append(options, libpod.WithRootFSFromImage(newImage.ID(), imgName, s.Image))
+		options = append(options, libpod.WithRootFSFromImage(newImage.ID(), imgName, s.RawImageName))
 	}
 	if err := s.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid config provided")

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -89,6 +89,9 @@ type ContainerBasicConfig struct {
 	// If not given, a default location will be used.
 	// Optional.
 	ConmonPidFile string `json:"conmon_pid_file,omitempty"`
+	// RawImageName is the user-specified and unprocessed input referring
+	// to a local or a remote image.
+	RawImageName string `json:"raw_image_name,omitempty"`
 	// RestartPolicy is the container's restart policy - an action which
 	// will be taken when the container exits.
 	// If not given, the default policy, which does nothing, will be used.

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -41,7 +41,8 @@ function teardown() {
     fi
 
     cname=$(random_string)
-    run_podman create --name $cname --label "io.containers.autoupdate=image" --detach $IMAGE top
+    # See #7407 for --pull=always.
+    run_podman create --pull=always --name $cname --label "io.containers.autoupdate=image" --detach $IMAGE top
 
     run_podman generate systemd --new $cname
     echo "$output" > "$UNIT_FILE"


### PR DESCRIPTION
Record the user-specified "raw" image name in the SpecGenerator, so we
can pass it along to the config when creating a container.  We need a
separate field as the image name in the generator may be set to the
ID of the previously pulled image - ultimately the cause of #7404.

Reverting the image name from the ID to the user input would not work
since "alpine" for pulling iterates over the search registries in the
registries.conf but looking up "alpine" normalizes to
"localhost/alpine".

Recording the raw-image name directly in the generator was the best of
the options I considered as no hidden magic from search registries or
normalizations (that may or may not change in the future) can interfere.
The auto-update backend enforces that the raw-image name is a
fully-qualified reference, so we need to worry about that in the front
end.

Fixes: #7407
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>