### PR TITLE
Fix --systemd=always regression

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -635,7 +635,7 @@ func (c *Container) setupSystemd(mounts []spec.Mount, g generate.Generator) erro
 			Destination: "/sys/fs/cgroup/systemd",
 			Type:        "bind",
 			Source:      "/sys/fs/cgroup/systemd",
-			Options:     []string{"bind", "nodev", "nosuid", "rprivate"},
+			Options:     []string{"bind", "nodev", "noexec", "nosuid", "rprivate"},
 		}
 		g.AddMount(systemdMnt)
 		g.AddLinuxMaskedPaths("/sys/fs/cgroup/systemd/release_agent")


### PR DESCRIPTION
The kernel will not allow you to modify existing mount flags on a volume
when bind mounting it to another place.  Since /sys/fs/cgroup/systemd is
mounted noexec on the host, it needs to be mounted with the same flags
in the rootless container.

Fixes: https://github.com/containers/podman/issues/7639

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>