### PR TITLE
Refactor API version values

### DIFF
--- a/pkg/api/handlers/compat/ping.go
+++ b/pkg/api/handlers/compat/ping.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/containers/buildah"
-	"github.com/containers/podman/v2/pkg/api/handlers/utils"
 )
 
 // Ping returns headers to client about the service
@@ -14,13 +13,12 @@ import (
 // Clients will use the Header availability to test which backend engine is in use.
 // Note: Additionally handler supports GET and HEAD methods
 func Ping(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("API-Version", utils.APIVersion[utils.CompatTree][utils.CurrentAPIVersion].String())
+	// Note API-Version and Libpod-API-Version are set in handler_api.go
 	w.Header().Set("BuildKit-Version", "")
 	w.Header().Set("Docker-Experimental", "true")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Pragma", "no-cache")
 
-	w.Header().Set("Libpod-API-Version", utils.APIVersion[utils.LibpodTree][utils.CurrentAPIVersion].String())
 	w.Header().Set("Libpod-Buildha-Version", buildah.Version)
 	w.WriteHeader(http.StatusOK)
 

--- a/pkg/api/handlers/compat/version.go
+++ b/pkg/api/handlers/compat/version.go
@@ -30,6 +30,7 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "Failed to obtain system memory info"))
 		return
 	}
+
 	components := []docker.ComponentVersion{{
 		Name:    "Podman Engine",
 		Version: versionInfo.Version,
@@ -46,6 +47,9 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 		},
 	}}
 
+	apiVersion := utils.APIVersion[utils.CompatTree][utils.CurrentAPIVersion]
+	minVersion := utils.APIVersion[utils.CompatTree][utils.MinimalAPIVersion]
+
 	utils.WriteResponse(w, http.StatusOK, entities.ComponentVersion{
 		Version: docker.Version{
 			Platform: struct {
@@ -53,7 +57,7 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 			}{
 				Name: fmt.Sprintf("%s/%s/%s-%s", goRuntime.GOOS, goRuntime.GOARCH, infoData.Host.Distribution.Distribution, infoData.Host.Distribution.Version),
 			},
-			APIVersion:    components[0].Details["APIVersion"],
+			APIVersion:    fmt.Sprintf("%d.%d", apiVersion.Major, apiVersion.Minor),
 			Arch:          components[0].Details["Arch"],
 			BuildTime:     components[0].Details["BuildTime"],
 			Components:    components,
@@ -61,7 +65,7 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 			GitCommit:     components[0].Details["GitCommit"],
 			GoVersion:     components[0].Details["GoVersion"],
 			KernelVersion: components[0].Details["KernelVersion"],
-			MinAPIVersion: components[0].Details["MinAPIVersion"],
+			MinAPIVersion: fmt.Sprintf("%d.%d", minVersion.Major, minVersion.Minor),
 			Os:            components[0].Details["Os"],
 			Version:       components[0].Version,
 		}})

--- a/pkg/api/handlers/utils/handler.go
+++ b/pkg/api/handlers/utils/handler.go
@@ -43,8 +43,8 @@ var (
 	//       clients to shop for the Version they wish to support
 	APIVersion = map[VersionTree]map[VersionLevel]semver.Version{
 		LibpodTree: {
-			CurrentAPIVersion: semver.MustParse("1.0.0"),
-			MinimalAPIVersion: semver.MustParse("1.0.0"),
+			CurrentAPIVersion: semver.MustParse("2.0.0"),
+			MinimalAPIVersion: semver.MustParse("2.0.0"),
 		},
 		CompatTree: {
 			CurrentAPIVersion: semver.MustParse("1.40.0"),

--- a/pkg/api/server/handler_api.go
+++ b/pkg/api/server/handler_api.go
@@ -40,6 +40,10 @@ func (s *APIServer) APIHandler(h http.HandlerFunc) http.HandlerFunc {
 			c = context.WithValue(c, "idletracker", s.idleTracker)    //nolint
 			r = r.WithContext(c)
 
+			v := utils.APIVersion[utils.CompatTree][utils.CurrentAPIVersion]
+			w.Header().Set("API-Version", fmt.Sprintf("%d.%d", v.Major, v.Minor))
+			w.Header().Set("Libpod-API-Version", utils.APIVersion[utils.LibpodTree][utils.CurrentAPIVersion].String())
+
 			h(w, r)
 		}
 		fn(w, r)

--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -18,11 +18,11 @@ t HEAD libpod/_ping 200
 for i in /version version; do
     t GET  $i      200                           \
       .Components[0].Name="Podman Engine"        \
-      .Components[0].Details.APIVersion=1.0.0    \
-      .Components[0].Details.MinAPIVersion=1.0.0 \
+      .Components[0].Details.APIVersion=2.0.0    \
+      .Components[0].Details.MinAPIVersion=2.0.0 \
       .Components[0].Details.Os=linux            \
-      .ApiVersion=1.0.0                          \
-      .MinAPIVersion=1.0.0                       \
+      .ApiVersion=1.40                          \
+      .MinAPIVersion=1.24                       \
       .Os=linux
 done
 


### PR DESCRIPTION
 * API-Version header now Major.Minor to support tools parsing this
   header
 * Libpod Version updated to 2.0.0 to reflect changes in API field
   values
 * API-Version and Libpod-API-Version headers are now included in all
   results

Fixes #7327

 * Header support tested against goland 2020.2 and
    https://www.jetbrains.com/help/idea/docker.html plugin

Signed-off-by: Jhon Honce <jhonce@redhat.com>