### PR TITLE
Fix CI breakage due to PR collision

### DIFF
--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -78,7 +78,7 @@ func wait(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("%q requires a name, id, or the \"--latest\" flag", cmd.CommandPath())
 	}
 	if waitOptions.Latest && len(args) > 0 {
-		return errors.New("--latest and containers are not allowed")
+		return errors.New("--latest and containers cannot be used together")
 	}
 
 	waitOptions.Condition, err = define.StringToContainerStatus(waitCondition)


### PR DESCRIPTION
PR #7633 disallowed "-l" (--latest) with container args.

PR #7630 made changes to the "podman wait" command. The error
message it issues is inconsistent (and incompatible) with
the one required by the new BATS --help test. Fix that.

This is entirely my fault. I was aware of #7630, and I was
careful to check the output message format, but I was not
careful enough (I trusted my eyes, not my code).

Signed-off-by: Ed Santiago <santiago@redhat.com>