### PR TITLE
podman version and --version: fix format, exit

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -80,10 +80,6 @@ func init() {
 	)
 
 	rootFlags(rootCmd, registry.PodmanConfig())
-
-	// "version" is a local flag to avoid collisions with sub-commands that use "-v"
-	var dummyVersion bool
-	rootCmd.Flags().BoolVarP(&dummyVersion, "version", "v", false, "Version of Podman")
 }
 
 func Execute() {

--- a/cmd/podman/system/version.go
+++ b/cmd/podman/system/version.go
@@ -47,12 +47,9 @@ func version(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		_, err = io.WriteString(os.Stdout, s)
+		_, err = io.WriteString(os.Stdout, s+"\n")
 		return err
 	case cmd.Flag("format").Changed:
-		if !strings.HasSuffix(versionFormat, "\n") {
-			versionFormat += "\n"
-		}
 		out := formats.StdoutTemplate{Output: versions, Template: versionFormat}
 		err := out.Out()
 		if err != nil {


### PR DESCRIPTION
Three unrelated fixes to version output:

  * podman version --format json: was missing a newline
  * podman version --format TEMPLATE: had too many newlines

  * podman --version: would neither display version nor exit
    if followed by a subcommand ('podman --version ps')

The first two were easy: I used my best tweezers to delicately
pluck and transfer the misplaced \n and place it where needed.

The third was a doozy of a rabbit hole. As best I can tell,
a workaround was added in root.go to override cobra's built-in
Version handling, apparently to avoid having cobra add "-v"
as an alias for "--version". As best I can tell, cobra only
does this if the "-v" shortcut is not already taken (at
least as of Nov 2019: https://github.com/spf13/cobra/pull/996 ).
Also as best I can tell that workaround is purely vestigial,
and removing it is safe. I've manually tested "-v" in podman run,
system df, and rm. I've run system tests.

Signed-off-by: Ed Santiago <santiago@redhat.com>