### PR TITLE
Add labels to a pod created via play kube

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -132,6 +132,11 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		libpod.WithInfraContainer(),
 		libpod.WithPodName(podName),
 	}
+
+	if podYAML.ObjectMeta.Labels != nil {
+		podOptions = append(podOptions, libpod.WithPodLabels(podYAML.ObjectMeta.Labels))
+	}
+
 	// TODO we only configure Process namespace. We also need to account for Host{IPC,Network,PID}
 	// which is not currently possible with pod create
 	if podYAML.Spec.ShareProcessNamespace != nil && *podYAML.Spec.ShareProcessNamespace {


### PR DESCRIPTION
When using `podman play kube` with a YAML file that has pod labels,
apply those labels to the pods that podman makes.

For example, this Deployment spec has labels on a pod:

	apiVersion: apps/v1
	kind: Deployment
	metadata:
	  name: myapp
	  labels:
	    app: myapp
	spec:
	  selector:
	    matchLabels:
	      app: myapp
	  template:
	    metadata:
	      labels:
		app: myapp
	    spec:
	      containers:
	      - name: web
		image: nginx
		ports:
		- containerPort: 80

The pods that podman creates will have the label "app" set to "myapp" so
that these pods can be found with `podman pods ps --filter label=app`.

Signed-off-by: Jordan Christiansen <xordspar0@gmail.com>