### PR TITLE
Fix "rootless-cni-infra + runc fails with ENODEV"

### DIFF
--- a/libpod/rootless_cni_linux.go
+++ b/libpod/rootless_cni_linux.go
@@ -255,7 +255,7 @@ func startRootlessCNIInfraContainer(ctx context.Context, r *Runtime) (*Container
 		Destination: "/etc/cni/net.d",
 		Type:        "bind",
 		Source:      r.config.Network.NetworkConfigDir,
-		Options:     []string{"ro"},
+		Options:     []string{"ro", "bind"},
 	}
 	g.AddMount(etcCNINetD)
 


### PR DESCRIPTION
runc always expect "bind" to be present in opts even when the type is "bind".

Fix #7652
