### PR TITLE
image list: return all associated names

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -184,13 +184,26 @@ func sortImages(imageS []*entities.ImageSummary) ([]imageReporter, error) {
 	for _, e := range imageS {
 		var h imageReporter
 		if len(e.RepoTags) > 0 {
+			tagged := []imageReporter{}
+			untagged := []imageReporter{}
 			for _, tag := range e.RepoTags {
 				h.ImageSummary = *e
 				h.Repository, h.Tag, err = tokenRepoTag(tag)
 				if err != nil {
 					return nil, errors.Wrapf(err, "error parsing repository tag %q:", tag)
 				}
-				imgs = append(imgs, h)
+				if h.Tag == "<none>" {
+					untagged = append(untagged, h)
+				} else {
+					tagged = append(tagged, h)
+				}
+			}
+			// Note: we only want to display "<none>" if we
+			// couldn't find any tagged name in RepoTags.
+			if len(tagged) > 0 {
+				imgs = append(imgs, tagged...)
+			} else {
+				imgs = append(imgs, untagged[0])
 			}
 		} else {
 			h.ImageSummary = *e

--- a/libpod/image/utils.go
+++ b/libpod/image/utils.go
@@ -86,33 +86,6 @@ func hasTransport(image string) bool {
 	return strings.Contains(image, "://")
 }
 
-// ReposToMap parses the specified repotags and returns a map with repositories
-// as keys and the corresponding arrays of tags or digests-as-strings as values.
-func ReposToMap(names []string) (map[string][]string, error) {
-	// map format is repo -> []tag-or-digest
-	repos := make(map[string][]string)
-	for _, name := range names {
-		var repository, tag string
-		if len(name) > 0 {
-			named, err := reference.ParseNormalizedNamed(name)
-			if err != nil {
-				return nil, err
-			}
-			repository = named.Name()
-			if ref, ok := named.(reference.NamedTagged); ok {
-				tag = ref.Tag()
-			} else if ref, ok := named.(reference.Canonical); ok {
-				tag = ref.Digest().String()
-			}
-		}
-		repos[repository] = append(repos[repository], tag)
-	}
-	if len(repos) == 0 {
-		repos["<none>"] = []string{"<none>"}
-	}
-	return repos, nil
-}
-
 // GetAdditionalTags returns a list of reference.NamedTagged for the
 // additional tags given in images
 func GetAdditionalTags(images []string) ([]reference.NamedTagged, error) {

--- a/pkg/domain/infra/abi/images_list.go
+++ b/pkg/domain/infra/abi/images_list.go
@@ -23,33 +23,13 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 
 	summaries := []*entities.ImageSummary{}
 	for _, img := range images {
-		var repoTags []string
-		if opts.All {
-			pairs, err := libpodImage.ReposToMap(img.Names())
-			if err != nil {
-				return nil, err
-			}
-
-			for repo, tags := range pairs {
-				for _, tag := range tags {
-					repoTags = append(repoTags, repo+":"+tag)
-				}
-			}
-		} else {
-			repoTags, err = img.RepoTags()
-			if err != nil {
-				return nil, err
-			}
-		}
-
 		digests := make([]string, len(img.Digests()))
 		for j, d := range img.Digests() {
 			digests[j] = string(d)
 		}
 
 		e := entities.ImageSummary{
-			ID: img.ID(),
-
+			ID:           img.ID(),
 			ConfigDigest: string(img.ConfigDigest),
 			Created:      img.Created().Unix(),
 			Dangling:     img.Dangling(),
@@ -61,7 +41,7 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 			ReadOnly:     img.IsReadOnly(),
 			SharedSize:   0,
 			VirtualSize:  img.VirtualSize,
-			RepoTags:     repoTags,
+			RepoTags:     img.Names(), // may include tags and digests
 		}
 		e.Labels, _ = img.Labels(context.TODO())
 


### PR DESCRIPTION
Always return all associated names / repo tags of an image and fix a bug
with malformed repo tags.

Previously, Podman returned all names only with `--all` but this flag
only instructs to list intermediate images and should not alter
associated names.  With `--all` Podman queried the repo tags of an image
which splits all *tagged* names into repository and tag which is then
reassembled to eventually be parsed again in the frontend.  Lot's of
redundant CPU heat and buggy as the reassembly didn't consider digests
which ultimately broke parsing in the frontend.

Fixes: #7651
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>