### PR TITLE
Fix play_kube_test deployment template

### DIFF
--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -158,12 +158,12 @@ spec:
         {{- with .Labels }}{{ range $key, $value := . }}
         {{ $key }}: {{ $value }}
         {{- end }}{{ end }}
-      {{ with .Annotations }}
-        annotations:
-        {{ range $key, $value := . }}
-          {{ $key }}: {{ $value }}
-        {{ end }}
-      {{ end }}
+      {{- with .Annotations }}
+      annotations:
+      {{- range $key, $value := . }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
+      {{- end }}
     spec:
       hostname: {{ .Hostname }}
       containers:


### PR DESCRIPTION
Annotations were at the wrong indentation, making them a part of the
labels map.