### PR TITLE
Install bats as root

### DIFF
--- a/hack/install_bats.sh
+++ b/hack/install_bats.sh
@@ -4,13 +4,19 @@ set -e
 
 die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
 
+if [[ "$(type -t bats)" != "" ]]; then
+	# bats is already installed.
+	exit 0
+fi
+
 buildDir=$(mktemp -d)
 git clone https://github.com/bats-core/bats-core $buildDir
 
 pushd $buildDir
 pwd
 git reset --hard ${VERSION}
-./install.sh /usr/local
+echo "Installing bats to /usr/local (requires root)"
+sudo ./install.sh /usr/local
 popd
 
 rm -rf $buildDir


### PR DESCRIPTION
Installing bats to /usr/local requires root privileges. Without this, `make install.tools` fails. However, if I do `sudo make install.tools`, then all of the other dependencies and git clones in the current directory end up owned by root. This limits root privileges to the part that needs it.

I'm not sure this is a very good solution. I wanted to open discussion about this issue because currently it's difficult to get a working test environment without digging into the Makefile and install scripts to see what's going on. Otherwise `make install.tools` fails like this:

```
HEAD is now at c706d14 Bats 1.1.0
install: cannot create directory ‘/usr/local/libexec’: Permission denied
install: cannot change permissions of ‘/usr/local/share/man/man1’: No such file or directory
install: cannot change permissions of ‘/usr/local/share/man/man7’: No such file or directory
make: *** [Makefile:640: .install.bats] Error 1
```

Another possible solution is installing bats to _output like the Go dependencies and invoking bats as `$GOBIN/bats`. Any other ideas?