### PR TITLE
enable --iidfile for podman-remote build

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -179,8 +179,6 @@ var _ = Describe("Podman build", func() {
 	})
 
 	It("podman build basic alpine and print id to external file", func() {
-		SkipIfRemote()
-
 		// Switch to temp dir and restore it afterwards
 		cwd, err := os.Getwd()
 		Expect(err).To(BeNil())


### PR DESCRIPTION
for podman-remote build operations, the iidfile, when used, needs to write the file to the client's local filesystem.

Signed-off-by: baude <bbaude@redhat.com>