### PR TITLE
system tests: new tests

### DIFF
--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -35,4 +35,34 @@ load helpers
     fi
 }
 
+
+@test "podman image mount" {
+    skip_if_remote "mounting remote is meaningless"
+    skip_if_rootless "too hard to test rootless"
+
+    # Start with clean slate
+    run_podman image umount -a
+
+    run_podman image mount $IMAGE
+    mount_path="$output"
+
+    test -d $mount_path
+
+    # Image is custom-built and has a file containing the YMD tag. Check it.
+    testimage_file="/home/podman/testimage-id"
+    test -e "$mount_path$testimage_file"
+    is $(< "$mount_path$testimage_file") "$PODMAN_TEST_IMAGE_TAG"  \
+       "Contents of $testimage_file in image"
+
+    # 'image mount', no args, tells us what's mounted
+    run_podman image mount
+    is "$output" "$IMAGE $mount_path" "podman image mount with no args"
+
+    # Clean up
+    run_podman image umount $IMAGE
+
+    run_podman image mount
+    is "$output" "" "podman image mount, no args, after umount"
+}
+
 # vim: filetype=sh

--- a/test/system/build-testimage
+++ b/test/system/build-testimage
@@ -26,23 +26,51 @@ create_time_z=$(env TZ=UTC date +'%Y-%m-%dT%H:%M:%SZ')
 
 set -ex
 
+# We'll need to create a Containerfile plus various other files to add in
+#
 # Please document the reason for all flags, apk's, and anything non-obvious
+tmpdir=$(mktemp -t -d $(basename $0).tmp.XXXXXXX)
+cd $tmpdir
+
+# 'image mount' test will confirm that this file exists and has our YMD tag
+echo $YMD >testimage-id
+
+# 'pod' test will use this for --infra-command
+cat >pause <<EOF
+#!/bin/sh
 #
-#    --squash-all    : needed by 'tree' test in 070-build.bats
-#    busybox-extras  : provides httpd needed in 500-networking.bats
+# Trivial little pause script, used in one of the pod tests
 #
-podman rmi -f testimage &> /dev/null || true
-podman build --squash-all -t testimage - <<EOF
+echo Confirmed: testimage pause invoked as \$0
+while :; do
+    sleep 0.1
+done
+EOF
+chmod 755 pause
+
+# alpine because it's small and light and reliable
+# busybox-extras provides httpd needed in 500-networking.bats
+cat >Containerfile <<EOF
 FROM docker.io/library/alpine:3.12.0
 RUN apk add busybox-extras
+ADD testimage-id pause /home/podman/
 LABEL created_by=$create_script
 LABEL created_at=$create_time_z
+WORKDIR /home/podman
 CMD ["/bin/echo", "This container is intended for podman CI testing"]
 EOF
 
+# --squash-all    : needed by 'tree' test in 070-build.bats
+podman rmi -f testimage &> /dev/null || true
+podman build --squash-all -t testimage .
+
+# Clean up
+cd /tmp
+rm -rf $tmpdir
+
 # Tag and push to quay.
-podman tag testimage quay.io/edsantiago/testimage:$YMD
-podman push quay.io/edsantiago/testimage:$YMD
+podman tag testimage quay.io/libpod/testimage:$YMD
+podman push quay.io/libpod/testimage:$YMD
 
 # Side note: there should always be a testimage tagged ':00000000'
 # (eight zeroes) in the same location; this is used by tests which
@@ -54,6 +82,6 @@ podman push quay.io/edsantiago/testimage:$YMD
 #
 #    podman pull docker.io/library/busybox:1.32.0
 #    podman tag  docker.io/library/busybox:1.32.0 \
-#                quay.io/edsantiago/testimage:00000000
-#    podman push quay.io/edsantiago/testimage:00000000
+#                quay.io/libpod/testimage:00000000
+#    podman push quay.io/libpod/testimage:00000000
 #


### PR DESCRIPTION
- podman network create: new test

- podman pull by-sha + podman images -a (#7651)

- podman image mount: new test

- podman pod: --infra-image and --infra-command (#7167)

For convenience and robustness, build a new testimage
containing a custom file /home/podman/testimage-id
with contents YYYYMMDD (same as image tag). The
image-mount test checks that this file exists and
has the desired content. New testimage also includes
a dummy 'pause' executable, for testing pod infra.

Updates from testimage:20200902 to :20200917

Signed-off-by: Ed Santiago <santiago@redhat.com>