### PR TITLE
Fix podman image unmount to only report images unmounted

### DIFF
--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -191,6 +191,15 @@ func (ir *ImageEngine) Unmount(ctx context.Context, nameOrIDs []string, options 
 	reports := []*entities.ImageUnmountReport{}
 	for _, img := range images {
 		report := entities.ImageUnmountReport{Id: img.ID()}
+		mounted, _, err := img.Mounted()
+		if err != nil {
+			// Errors will be caught in Unmount call below
+			// Default assumption to mounted
+			mounted = true
+		}
+		if !mounted {
+			continue
+		}
 		if err := img.Unmount(options.Force); err != nil {
 			if options.All && errors.Cause(err) == storage.ErrLayerNotMounted {
 				logrus.Debugf("Error umounting image %s, storage.ErrLayerNotMounted", img.ID())

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -348,6 +348,25 @@ var _ = Describe("Podman mount", func() {
 		Expect(umount.ExitCode()).To(Equal(0))
 	})
 
+	It("podman umount --all", func() {
+		setup := podmanTest.PodmanNoCache([]string{"pull", fedoraMinimal})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+
+		setup = podmanTest.PodmanNoCache([]string{"pull", ALPINE})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+
+		mount := podmanTest.Podman([]string{"image", "mount", fedoraMinimal})
+		mount.WaitWithDefaultTimeout()
+		Expect(mount.ExitCode()).To(Equal(0))
+
+		umount := podmanTest.Podman([]string{"image", "umount", "--all"})
+		umount.WaitWithDefaultTimeout()
+		Expect(umount.ExitCode()).To(Equal(0))
+		Expect(len(umount.OutputToStringArray())).To(Equal(1))
+	})
+
 	It("podman mount many", func() {
 		setup := podmanTest.PodmanNoCache([]string{"pull", fedoraMinimal})
 		setup.WaitWithDefaultTimeout()
@@ -401,6 +420,10 @@ var _ = Describe("Podman mount", func() {
 		mount.WaitWithDefaultTimeout()
 		Expect(mount.ExitCode()).To(Equal(0))
 		Expect(mount.OutputToString()).To(Equal(""))
+
+		umount = podmanTest.PodmanNoCache([]string{"image", "umount", fedoraMinimal, ALPINE})
+		umount.WaitWithDefaultTimeout()
+		Expect(umount.ExitCode()).To(Equal(0))
 
 		mount1 = podmanTest.PodmanNoCache([]string{"image", "mount", "--all"})
 		mount1.WaitWithDefaultTimeout()


### PR DESCRIPTION
Currently `podman image unmount` report every image that is mounted
when it unmounts them. We should only report unmounted actually mounted images.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>