### PR TITLE
 rootless-cni-infra: fix flakiness during bringing up lo interface

### DIFF
--- a/contrib/rootless-cni-infra/Containerfile
+++ b/contrib/rootless-cni-infra/Containerfile
@@ -34,4 +34,4 @@ COPY rootless-cni-infra /usr/local/bin
 ENV CNI_PATH=/opt/cni/bin
 CMD ["sleep", "infinity"]
 
-ENV ROOTLESS_CNI_INFRA_VERSION=1
+ENV ROOTLESS_CNI_INFRA_VERSION=2

--- a/contrib/rootless-cni-infra/rootless-cni-infra
+++ b/contrib/rootless-cni-infra/rootless-cni-infra
@@ -4,6 +4,23 @@ set -eu
 ARG0="$0"
 BASE="/run/rootless-cni-infra"
 
+wait_unshare_net() {
+	pid="$1"
+	# NOTE: busybox shell doesn't support the `for ((i=0; i < $MAX; i++)); do foo; done` statement
+	i=0
+	while :; do
+		if [ "$(readlink /proc/self/ns/net)" != "$(readlink /proc/${pid}/ns/net)" ]; then
+			break
+		fi
+		sleep 0.1
+		if [ $i -ge 10 ]; then
+			echo >&2 "/proc/${pid}/ns/net cannot be unshared"
+			exit 1
+		fi
+		i=$((i + 1))
+	done
+}
+
 # CLI subcommand: "alloc $CONTAINER_ID $NETWORK_NAME $POD_NAME"
 cmd_entrypoint_alloc() {
 	if [ "$#" -ne 3 ]; then
@@ -24,6 +41,7 @@ cmd_entrypoint_alloc() {
 	else
 		unshare -n sleep infinity &
 		pid="$!"
+		wait_unshare_net "${pid}"
 		echo "${pid}" >"${dir}/pid"
 		nsenter -t "${pid}" -n ip link set lo up
 	fi

--- a/libpod/rootless_cni_linux.go
+++ b/libpod/rootless_cni_linux.go
@@ -25,7 +25,7 @@ import (
 
 // Built from ../contrib/rootless-cni-infra.
 var rootlessCNIInfraImage = map[string]string{
-	"amd64": "quay.io/libpod/rootless-cni-infra@sha256:8aa681c4c08dee3ec5d46ff592fddd0259a35626717006d6b77ee786b1d02967", // 1-amd64
+	"amd64": "quay.io/libpod/rootless-cni-infra@sha256:e92c3a6367f8e554121b96d39af1f19f0f9ac5a32922b290112e13bc661d3a29", // 2-amd64
 }
 
 const (


### PR DESCRIPTION
Fix #7618
    
This bumps up `ROOTLESS_CNI_INFRA_VERSION` to 2