### PR TITLE
Fix incorrect parsing of create/run --volumes-from

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -509,7 +509,7 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 		"volume", "v", containerConfig.Volumes(),
 		"Bind mount a volume into the container",
 	)
-	createFlags.StringSliceVar(
+	createFlags.StringArrayVar(
 		&cf.VolumesFrom,
 		"volumes-from", []string{},
 		"Mount volumes from the specified container(s)",

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1070,11 +1070,11 @@ change propagation properties of source mount. Say `/` is source mount for
 
 **--volumes-from**[=*CONTAINER*[:*OPTIONS*]]
 
-Mount volumes from the specified container(s).
-*OPTIONS* is a comma delimited list with the following available elements:
+Mount volumes from the specified container(s). Used to share volumes between
+containers. The *options* is a comma delimited list with the following available elements:
 
-* [rw|ro]
-* z
+* **rw**|**ro**
+* **z**
 
 Mounts already mounted volumes from a source container onto another
 container. You must supply the source's container-id or container-name.
@@ -1083,9 +1083,8 @@ the target container. You can share volumes even if the source container
 is not running.
 
 By default, Podman mounts the volumes in the same mode (read-write or
-read-only) as it is mounted in the source container. Optionally, you
-can change this by suffixing the container-id with either the `ro` or
-`rw` keyword.
+read-only) as it is mounted in the source container.
+You can change this by adding a `ro` or `rw` _option_.
 
 Labeling systems like SELinux require that proper labels are placed on volume
 content mounted into a container. Without a label, the security system might

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1100,7 +1100,7 @@ will convert /foo into a shared mount point. Alternatively, one can directly
 change propagation properties of source mount. Say, if _/_ is source mount for
 _/foo_, then use **mount --make-shared /** to convert _/_ into a shared mount.
 
-**--volumes-from**[=*container-id*[:*options*]]
+**--volumes-from**[=*CONTAINER*[:*OPTIONS*]]
 
 Mount volumes from the specified container(s). Used to share volumes between
 containers. The *options* is a comma delimited list with the following available elements:
@@ -1108,19 +1108,23 @@ containers. The *options* is a comma delimited list with the following available
 * **rw**|**ro**
 * **z**
 
-You can share volumes even if the source container is not running.
+Mounts already mounted volumes from a source container onto another
+container. You must supply the source's container-id or container-name.
+To share a volume, use the --volumes-from option when running
+the target container. You can share volumes even if the source container
+is not running.
 
 By default, Podman mounts the volumes in the same mode (read-write or
 read-only) as it is mounted in the source container.
-You can change this by adding a **ro** or **rw** _option_.
+You can change this by adding a `ro` or `rw` _option_.
 
 Labeling systems like SELinux require that proper labels are placed on volume
 content mounted into a container. Without a label, the security system might
 prevent the processes running inside the container from using the content. By
 default, Podman does not change the labels set by the OS.
 
-To change a label in the container context, you can add **z** to the volume mount.
-This suffix tells Podman to relabel file objects on the shared volumes. The **z**
+To change a label in the container context, you can add `z` to the volume mount.
+This suffix tells Podman to relabel file objects on the shared volumes. The `z`
 option tells Podman that two containers share the volume content. As a result,
 podman labels the content with a shared content label. Shared volume labels allow
 all containers to read/write content.

--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -195,9 +195,9 @@ func getVolumesFrom(volumesFrom []string, runtime *libpod.Runtime) (map[string]s
 		splitVol := strings.SplitN(volume, ":", 2)
 		if len(splitVol) == 2 {
 			splitOpts := strings.Split(splitVol[1], ",")
+			setRORW := false
+			setZ := false
 			for _, opt := range splitOpts {
-				setRORW := false
-				setZ := false
 				switch opt {
 				case "z":
 					if setZ {


### PR DESCRIPTION
Add a bunch of tests to ensure that --volumes-from works as expected.

Also align the podman create and run man page.

Fixes #7701 