### PR TITLE
Cirrus: Fix decrypt failure

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -55,13 +55,13 @@ env:
     #### Credentials and other secret-sauces, decrypted at runtime when authorized.
     ####
     # Freenode IRC credentials for posting status messages
-    IRCID: ENCRYPTED[e87bba62a8e924dc70bdb2b66b16f6ab4a60d2870e6e5534ae9e2b0076f483c71c84091c655ca239101e6816c5ec0883]
+    IRCID: disabled
     # Needed to build GCE images, within a GCE VM
-    SERVICE_ACCOUNT: ENCRYPTED[99e9a0b1c23f8dd29e83dfdf164f064cfd17afd9b895ca3b5e4c41170bd4290a8366fe2ad8e7a210b9f751711d1d002a]
+    SERVICE_ACCOUNT: ENCRYPTED[a28959877b2c9c36f151781b0a05407218cda646c7d047fc556e42f55e097e897ab63ee78369dae141dcf0b46a9d0cdd]
     # User ID for cirrus to ssh into VMs
     GCE_SSH_USERNAME: cirrus-ci
     # Name where this repositories cloud resources are located
-    GCP_PROJECT_ID: ENCRYPTED[7c80e728e046b1c76147afd156a32c1c57d4a1ac1eab93b7e68e718c61ca8564fc61fef815952b8ae0a64e7034b8fe4f]
+    GCP_PROJECT_ID: libpod-218412
 
 
 # Default VM to use unless set or modified by task
@@ -230,12 +230,6 @@ build_each_commit_task:
 # CRITICAL: Update metadata on VM images referenced by this repository state
 meta_task:
 
-    depends_on:
-        - "gating"
-        - "vendor"
-        - "varlink_api"
-        - "build_each_commit"
-
     container:
         image: "quay.io/libpod/imgts:v1.4.2-stable"  # see contrib/imgts
         cpu: 1
@@ -249,9 +243,9 @@ meta_task:
             ${IMAGE_BUILDER_CACHE_IMAGE_NAME}
         BUILDID: "${CIRRUS_BUILD_ID}"
         REPOREF: "${CIRRUS_CHANGE_IN_REPO}"
-        GCPJSON: ENCRYPTED[950d9c64ad78f7b1f0c7e499b42dc058d2b23aa67e38b315e68f557f2aba0bf83068d4734f7b1e1bdd22deabe99629df]
-        GCPNAME: ENCRYPTED[b05d469a0dba8cb479cb00cc7c1f6747c91d17622fba260a986b976aa6c817d4077eacffd4613d6d5f23afc4084fab1d]
-        GCPPROJECT: ENCRYPTED[7c80e728e046b1c76147afd156a32c1c57d4a1ac1eab93b7e68e718c61ca8564fc61fef815952b8ae0a64e7034b8fe4f]
+        GCPJSON: ENCRYPTED[3a198350077849c8df14b723c0f4c9fece9ebe6408d35982e7adf2105a33f8e0e166ed3ed614875a0887e1af2b8775f4]
+        GCPNAME: ENCRYPTED[2f9738ef295a706f66a13891b40e8eaa92a89e0e87faf8bed66c41eca72bf76cfd190a6f2d0e8444c631fdf15ed32ef6]
+        GCPPROJECT: libpod-218412
         CIRRUS_CLONE_DEPTH: 1  # source not used
 
     timeout_in: 10m


### PR DESCRIPTION
I Noted that the last cron-based branch-build had failed with an error from Cirrus-CI regarding decryption of variables.  Upon examination, found several encrypted values to be invalid.  Replaced the critical ones, and disabled any useless/disabled values/facilities (i.e. IRC notifications, and GCS release uploads).

Signed-off-by: Chris Evich <cevich@redhat.com>