### PR TITLE
add missing return for compat kill

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -175,6 +175,7 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 	err = con.Kill(signal)
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "unable to kill Container %s", name))
+		return
 	}
 
 	// Docker waits for the container to stop if the signal is 0 or


### PR DESCRIPTION
on an error condition in kill for the compatibility layer, we were missing a return.

Signed-off-by: baude <bbaude@redhat.com>