### PR TITLE
podman-remote untag image is broken

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -566,19 +566,22 @@ func UntagImage(w http.ResponseWriter, r *http.Request) {
 		utils.ImageNotFound(w, name, errors.Wrapf(err, "Failed to find image %s", name))
 		return
 	}
-	tag := "latest"
-	if len(r.Form.Get("tag")) > 0 {
-		tag = r.Form.Get("tag")
+	tags := []string{}
+	if len(r.Form.Get("repo")) > 0 {
+		repo := r.Form.Get("repo")
+		tag := "latest"
+		if len(r.Form.Get("tag")) > 0 {
+			tag = r.Form.Get("tag")
+		}
+		tags = []string{fmt.Sprintf("%s:%s", repo, tag)}
+	} else {
+		tags = newImage.Names()
 	}
-	if len(r.Form.Get("repo")) < 1 {
-		utils.Error(w, "repo tag is required", http.StatusBadRequest, errors.New("repo parameter is required to tag an image"))
-		return
-	}
-	repo := r.Form.Get("repo")
-	tagName := fmt.Sprintf("%s:%s", repo, tag)
-	if err := newImage.UntagImage(tagName); err != nil {
-		utils.Error(w, "failed to untag", http.StatusInternalServerError, err)
-		return
+	for _, tag := range tags {
+		if err := newImage.UntagImage(tag); err != nil {
+			utils.Error(w, "failed to untag", http.StatusInternalServerError, err)
+			return
+		}
 	}
 	utils.WriteResponse(w, http.StatusCreated, "")
 }

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -229,8 +229,12 @@ func Untag(ctx context.Context, nameOrID, tag, repo string) error {
 		return err
 	}
 	params := url.Values{}
-	params.Set("tag", tag)
-	params.Set("repo", repo)
+	if len(tag) > 0 {
+		params.Set("tag", tag)
+	}
+	if len(repo) > 0 {
+		params.Set("repo", repo)
+	}
 	response, err := conn.DoRequest(nil, http.MethodPost, "/images/%s/untag", params, nil, nameOrID)
 	if err != nil {
 		return err

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/docker/reference"
-	"github.com/containers/podman/v2/pkg/bindings"
 	images "github.com/containers/podman/v2/pkg/bindings/images"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/domain/utils"
@@ -139,15 +138,9 @@ func (ir *ImageEngine) Tag(ctx context.Context, nameOrID string, tags []string, 
 }
 
 func (ir *ImageEngine) Untag(ctx context.Context, nameOrID string, tags []string, options entities.ImageUntagOptions) error {
-	// Remove all tags if none are provided
 	if len(tags) == 0 {
-		newImage, err := images.GetImage(ir.ClientCxt, nameOrID, bindings.PFalse)
-		if err != nil {
-			return err
-		}
-		tags = newImage.NamesHistory
+		return images.Untag(ir.ClientCxt, nameOrID, "", "")
 	}
-
 	for _, newTag := range tags {
 		var (
 			tag, repo string

--- a/test/e2e/untag_test.go
+++ b/test/e2e/untag_test.go
@@ -33,7 +33,6 @@ var _ = Describe("Podman untag", func() {
 	})
 
 	It("podman untag all", func() {
-		SkipIfRemote("FIXME This should work on podman-remote")
 		setup := podmanTest.PodmanNoCache([]string{"pull", ALPINE})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))


### PR DESCRIPTION
There seems to be some questionable code in NamesHistory which is not
returning the true value of the history.  Basically this ends up truncating
the last item on the list which causes the test to fail.

Not sure if this code is still necessary or what it breaks.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>