### PR TITLE
Fix up attach tests for podman remote

### DIFF
--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -389,6 +389,15 @@ func (ic *ContainerEngine) ContainerLogs(_ context.Context, nameOrIDs []string, 
 }
 
 func (ic *ContainerEngine) ContainerAttach(ctx context.Context, nameOrID string, options entities.AttachOptions) error {
+	ctrs, err := getContainersByContext(ic.ClientCxt, false, false, []string{nameOrID})
+	if err != nil {
+		return err
+	}
+	ctr := ctrs[0]
+	if ctr.State != define.ContainerStateRunning.String() {
+		return errors.Errorf("you can only attach to running containers")
+	}
+
 	return containers.Attach(ic.ClientCxt, nameOrID, &options.DetachKeys, nil, bindings.PTrue, options.Stdin, options.Stdout, options.Stderr, nil)
 }
 

--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -40,7 +40,6 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman attach to non-running container", func() {
-		SkipIfRemote()
 		session := podmanTest.Podman([]string{"create", "--name", "test1", "-d", "-i", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -51,8 +50,8 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman container attach to non-running container", func() {
-		SkipIfRemote()
 		session := podmanTest.Podman([]string{"container", "create", "--name", "test1", "-d", "-i", ALPINE, "ls"})
+
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -87,7 +86,6 @@ var _ = Describe("Podman attach", func() {
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 	})
 	It("podman attach to the latest container", func() {
-		SkipIfRemote()
 		session := podmanTest.Podman([]string{"run", "-d", "--name", "test1", ALPINE, "/bin/sh", "-c", "while true; do echo test1; sleep 1; done"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -96,7 +94,11 @@ var _ = Describe("Podman attach", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		results := podmanTest.Podman([]string{"attach", "-l"})
+		cid := "-l"
+		if IsRemote() {
+			cid = "test2"
+		}
+		results := podmanTest.Podman([]string{"attach", cid})
 		time.Sleep(2 * time.Second)
 		results.Signal(syscall.SIGTSTP)
 		Expect(results.OutputToString()).To(ContainSubstring("test2"))

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -19,6 +19,10 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
+func IsRemote() bool {
+	return true
+}
+
 func SkipIfRemote() {
 	ginkgo.Skip("This function is not enabled for remote podman")
 }

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -12,6 +12,10 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
+func IsRemote() bool {
+	return false
+}
+
 func SkipIfRemote() {
 }
 

--- a/test/e2e/libpod_suite_varlink_test.go
+++ b/test/e2e/libpod_suite_varlink_test.go
@@ -19,6 +19,10 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
+func IsRemote() bool {
+	return true
+}
+
 func SkipIfRemote() {
 	ginkgo.Skip("This function is not enabled for remote podman")
 }


### PR DESCRIPTION
When we execute podman-remote attach, we were not checking if the
container was in the correct state, this is leading to timeouts and
we had turned off remote testing.

Also added an IfRemote() function so we can turn on more tests when
using the "-l" flag for local, but use container name for remote.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>