### PR TITLE
Sign multi-arch images

### DIFF
--- a/cmd/podman/images/sign.go
+++ b/cmd/podman/images/sign.go
@@ -47,6 +47,7 @@ func init() {
 	certDirFlagName := "cert-dir"
 	flags.StringVar(&signOptions.CertDir, certDirFlagName, "", "`Pathname` of a directory containing TLS certificates and keys")
 	_ = signCommand.RegisterFlagCompletionFunc(certDirFlagName, completion.AutocompleteDefault)
+	flags.BoolVarP(&signOptions.All, "all", "a", false, "Sign all the manifests of the multi-architecture image")
 }
 
 func sign(cmd *cobra.Command, args []string) error {

--- a/docs/source/markdown/podman-image-sign.1.md
+++ b/docs/source/markdown/podman-image-sign.1.md
@@ -19,6 +19,10 @@ By default, the signature will be written into `/var/lib/containers/sigstore` fo
 
 Print usage statement.
 
+#### **--all**, **-a**
+
+Sign all the manifests of the multi-architecture image (default false).
+
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -344,6 +344,7 @@ type SignOptions struct {
 	Directory string
 	SignBy    string
 	CertDir   string
+	All       bool
 }
 
 // SignReport describes the result of signing

--- a/test/e2e/image_sign_test.go
+++ b/test/e2e/image_sign_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -57,5 +58,20 @@ var _ = Describe("Podman image sign", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		_, err = os.Stat(filepath.Join(sigDir, "library"))
 		Expect(err).To(BeNil())
+	})
+
+	It("podman sign --all multi-arch image", func() {
+		cmd := exec.Command("gpg", "--import", "sign/secret-key.asc")
+		err := cmd.Run()
+		Expect(err).To(BeNil())
+		sigDir := filepath.Join(podmanTest.TempDir, "test-sign-multi")
+		err = os.MkdirAll(sigDir, os.ModePerm)
+		Expect(err).To(BeNil())
+		session := podmanTest.Podman([]string{"image", "sign", "--all", "--directory", sigDir, "--sign-by", "foo@bar.com", "docker://library/alpine"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		fInfos, err := ioutil.ReadDir(filepath.Join(sigDir, "library"))
+		Expect(err).To(BeNil())
+		Expect(len(fInfos) > 1).To(BeTrue())
 	})
 })


### PR DESCRIPTION
podman image sign handles muti-arch images.
--all option to create signature for each manifest from the image manifest list.

close:  https://bugzilla.redhat.com/show_bug.cgi?id=1770037

Signed-off-by: Qi Wang <qiwan@redhat.com>