### PR TITLE
update stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,3 +22,4 @@ jobs:
         stale-pr-label: 'stale-pr'
         days-before-stale: 30
         days-before-close: 365
+        remove-stale-when-updated: true


### PR DESCRIPTION
Update the GitHub action to mark issues and PRs as stale.  There are a
couple of useful features, most importantly, the bot will remove the
stale label from issues as soon as there's either an activity or a
comment.

This reduces some manual overhead: the stale bot will only drop a
comment on issues and PRs that are not marked as stale.  Hence, as we
appreciated the reminders, we had to manually remove the label which
should now turn into campfire tales.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>