### PR TITLE
Add option to not switch cgroup when user doesn't own it

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -188,7 +188,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 	// 3) command doesn't require Parent Namespace
 	_, found := cmd.Annotations[registry.ParentNSRequired]
 	if !registry.IsRemote() && rootless.IsRootless() && !found {
-		err := registry.ContainerEngine().SetupRootless(registry.Context(), cmd)
+		err := registry.ContainerEngine().SetupRootless(registry.Context(), cmd, cfg.CgroupCheck)
 		if err != nil {
 			return err
 		}
@@ -256,6 +256,7 @@ func rootFlags(cmd *cobra.Command, opts *entities.PodmanConfig) {
 
 	pFlags := cmd.PersistentFlags()
 	pFlags.StringVar(&cfg.Engine.CgroupManager, "cgroup-manager", cfg.Engine.CgroupManager, "Cgroup manager to use (\"cgroupfs\"|\"systemd\")")
+	pFlags.BoolVar(&opts.CgroupCheck, "cgroup-check-user", true, "If user doesn't own current cgroup, change cgroup to user.slice (if exists)")
 	pFlags.StringVar(&opts.CPUProfile, "cpu-profile", "", "Path for the cpu profiling results")
 	pFlags.StringVar(&opts.ConmonPath, "conmon", "", "Path of the conmon binary")
 	pFlags.StringVar(&cfg.Engine.NetworkCmdPath, "network-cmd-path", cfg.Engine.NetworkCmdPath, "Path to the command for configuring the network")

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -28,6 +28,10 @@ The CGroup manager to use for container cgroups. Supported values are cgroupfs o
 Note: Setting this flag can cause certain commands to break when called on containers previously created by the other CGroup manager type.
 Note: CGroup manager is not supported in rootless mode when using CGroups Version V1.
 
+**--cgroup-check-user**=*boolean*
+
+Whether or not to check if user owns current CGroup. If set to true and user doesn't own current CGroup, try switching to a CGroup the user owns. (Default: `true`)
+
 **--cni-config-dir**
 Path of the configuration directory for CNI networks.  (Default: `/etc/cni/net.d`)
 

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -42,6 +42,7 @@ type PodmanConfig struct {
 	CPUProfile     string           // Hidden: Should CPU profile be taken
 	EngineMode     EngineMode       // ABI or Tunneling mode
 	Identity       string           // ssh identity for connecting to server
+	CgroupCheck    bool             // whether to check ownership of cgroup
 	MaxWorks       int              // maximum number of parallel threads
 	RegistriesConf string           // allows for specifying a custom registries.conf
 	Remote         bool             // Connection to Podman API Service will use RESTful API

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -69,7 +69,7 @@ type ContainerEngine interface {
 	PodStop(ctx context.Context, namesOrIds []string, options PodStopOptions) ([]*PodStopReport, error)
 	PodTop(ctx context.Context, options PodTopOptions) (*StringSliceReport, error)
 	PodUnpause(ctx context.Context, namesOrIds []string, options PodunpauseOptions) ([]*PodUnpauseReport, error)
-	SetupRootless(ctx context.Context, cmd *cobra.Command) error
+	SetupRootless(ctx context.Context, cmd *cobra.Command, cgroupCheck bool) error
 	Shutdown(ctx context.Context)
 	SystemDf(ctx context.Context, options SystemDfOptions) (*SystemDfReport, error)
 	Unshare(ctx context.Context, args []string) error

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -58,14 +58,14 @@ func (ic *ContainerEngine) Info(ctx context.Context) (*define.Info, error) {
 	return info, err
 }
 
-func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command) error {
+func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command, cgroupCheck bool) error {
 	// do it only after podman has already re-execed and running with uid==0.
 	if os.Geteuid() == 0 {
 		ownsCgroup, err := cgroups.UserOwnsCurrentSystemdCgroup()
 		if err != nil {
 			logrus.Warnf("Failed to detect the owner for the current cgroup: %v", err)
 		}
-		if !ownsCgroup {
+		if !ownsCgroup && cgroupCheck {
 			conf, err := ic.Config(context.Background())
 			if err != nil {
 				return err

--- a/pkg/domain/infra/tunnel/system.go
+++ b/pkg/domain/infra/tunnel/system.go
@@ -18,7 +18,7 @@ func (ic *ContainerEngine) VarlinkService(_ context.Context, _ entities.ServiceO
 	panic(errors.New("varlink service is not supported when tunneling"))
 }
 
-func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command) error {
+func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command, cgroupCheck bool) error {
 	panic(errors.New("rootless engine mode is not supported when tunneling"))
 }
 


### PR DESCRIPTION
Hello,
I've added a command line option which makes it possible to not switch cgroup when user doesn't own it.

We need this change in our environment because we're using podman for PBS jobs and if podman changes cgroup to user.slice of user who started the job rather than keep the PBS' cgroup, we can't properly monitor how much resources the job is using.

I hope this change looks alright to you and can be merged