### PR TITLE
pkg/hooks: support all hooks

### DIFF
--- a/pkg/hooks/1.0.0/hook.go
+++ b/pkg/hooks/1.0.0/hook.go
@@ -67,7 +67,14 @@ func (hook *Hook) Validate(extensionStages []string) (err error) {
 		return errors.New("missing required property: stages")
 	}
 
-	validStages := map[string]bool{"prestart": true, "poststart": true, "poststop": true}
+	validStages := map[string]bool{
+		"createContainer": true,
+		"createRuntime":   true,
+		"prestart":        true,
+		"poststart":       true,
+		"poststop":        true,
+		"startContainer":  true,
+	}
 	for _, stage := range extensionStages {
 		validStages[stage] = true
 	}

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -120,12 +120,18 @@ func (m *Manager) Hooks(config *rspec.Spec, annotations map[string]string, hasBi
 					extensionStageHooks[stage] = append(extensionStageHooks[stage], namedHook.hook.Hook)
 				} else {
 					switch stage {
+					case "createContainer":
+						config.Hooks.CreateContainer = append(config.Hooks.CreateContainer, namedHook.hook.Hook)
+					case "createRuntime":
+						config.Hooks.CreateRuntime = append(config.Hooks.CreateRuntime, namedHook.hook.Hook)
 					case "prestart":
 						config.Hooks.Prestart = append(config.Hooks.Prestart, namedHook.hook.Hook)
 					case "poststart":
 						config.Hooks.Poststart = append(config.Hooks.Poststart, namedHook.hook.Hook)
 					case "poststop":
 						config.Hooks.Poststop = append(config.Hooks.Poststop, namedHook.hook.Hook)
+					case "startContainer":
+						config.Hooks.StartContainer = append(config.Hooks.StartContainer, namedHook.hook.Hook)
 					default:
 						return extensionStageHooks, fmt.Errorf("hook %q: unknown stage %q", namedHook.name, stage)
 					}


### PR DESCRIPTION
Add support for the missing hook types [1]:
- createContainer
- createRuntime
- startContainer

Otherwise, Podman won't inject them into the runtime config (and pass it
on to runc/crun) but error out.

[1] https://github.com/opencontainers/runtime-spec/blob/44341cdd36f6fee6ddd73e602f9e3eca1466052f/runtime.md#lifecycle

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>