### PR TITLE
Include cgroup manager in `podman info` output

### DIFF
--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -15,6 +15,7 @@ type Info struct {
 type HostInfo struct {
 	Arch           string                 `json:"arch"`
 	BuildahVersion string                 `json:"buildahVersion"`
+	CgroupManager  string                 `json:"cgroupManager"`
 	CGroupsVersion string                 `json:"cgroupVersion"`
 	Conmon         *ConmonInfo            `json:"conmon"`
 	CPUs           int                    `json:"cpus"`

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -87,6 +87,7 @@ func (r *Runtime) hostInfo() (*define.HostInfo, error) {
 	info := define.HostInfo{
 		Arch:           runtime.GOARCH,
 		BuildahVersion: buildah.Version,
+		CgroupManager:  r.config.Engine.CgroupManager,
 		Linkmode:       linkmode.Linkmode(),
 		CPUs:           runtime.NumCPU(),
 		Distribution:   hostDistributionInfo,

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -19,6 +19,8 @@ graphRoot:
 graphStatus:
 imageStore:\\\s\\\+number: 1
 runRoot:
+cgroupManager:
+cgroupVersion: v
 "
     while read expect; do
         is "$output" ".*$expect" "output includes '$expect'"


### PR DESCRIPTION
This is very useful for debugging cgroups v2, especially on rootless - we need to ensure people are correctly using systemd cgroups in these cases.
