### PR TITLE
fix allowing inspect manifest of non-local image

### DIFF
--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/containers/podman/v2/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman manifest", func() {
@@ -47,6 +48,16 @@ var _ = Describe("Podman manifest", func() {
 		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+	})
+
+	It("podman manifest inspect", func() {
+		session := podmanTest.Podman([]string{"manifest", "inspect", BB})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.PodmanNoCache([]string{"manifest", "inspect", "docker.io/library/busybox"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
 	})
 
 	It("podman manifest add", func() {


### PR DESCRIPTION
Add support of `podman manifest inspect` returning manifest list of non-local manifest.
Close https://github.com/containers/podman/issues/7726

Signed-off-by: Qi Wang <qiwan@redhat.com>