### PR TITLE
[v2.1] fix build with varlink

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -123,6 +123,7 @@ gating_task:
         # N/B: need 'clean' so some committed files are re-generated.
         - '/usr/local/bin/entrypoint.sh clean podman-remote |& ${TIMESTAMP}'
         - '/usr/local/bin/entrypoint.sh clean podman xref_helpmsgs_manpages BUILDTAGS="exclude_graphdriver_devicemapper selinux seccomp" |& ${TIMESTAMP}'
+        - '/usr/local/bin/entrypoint.sh clean BUILDTAGS="varlink" binaries |& ${TIMESTAMP}'
         - '/usr/local/bin/entrypoint.sh local-cross |& ${TIMESTAMP}'
 
     # Verify some aspects of ci/related scripts

--- a/pkg/varlinkapi/system.go
+++ b/pkg/varlinkapi/system.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	goruntime "runtime"
+	"strconv"
 	"time"
 
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
@@ -22,13 +23,18 @@ func (i *VarlinkAPI) GetVersion(call iopodman.VarlinkCall) error {
 		return err
 	}
 
+	int64APIVersion, err := strconv.ParseInt(versionInfo.APIVersion, 10, 64)
+	if err != nil {
+		return err
+	}
+
 	return call.ReplyGetVersion(
 		versionInfo.Version,
 		versionInfo.GoVersion,
 		versionInfo.GitCommit,
 		time.Unix(versionInfo.Built, 0).Format(time.RFC3339),
 		versionInfo.OsArch,
-		versionInfo.APIVersion,
+		int64APIVersion,
 	)
 }
 


### PR DESCRIPTION
also add a cirrus task for building binaries with varlink.
From: Chris Evich <cevich@redhat.com>

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>
(cherry picked from commit 16763c3df0eaf3b6e5b7883c60b59f051f811cda)
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@mheon @rhatdan @TomSweeneyRedHat PTAL backport of #7734 