### PR TITLE
remote load: check if input is directory

### DIFF
--- a/docs/source/markdown/podman-load.1.md
+++ b/docs/source/markdown/podman-load.1.md
@@ -9,8 +9,10 @@ podman\-load - Load an image from a container image archive into container stora
 **podman image load** [*options*] [*name*[:*tag*]]
 
 ## DESCRIPTION
-**podman load** loads an image from either an **oci-archive** or **docker-archive** stored on the local machine into container storage. **podman load** reads from stdin by default or a file if the **input** option is set.
+**podman load** loads an image from either an **oci-archive** or a **docker-archive** stored on the local machine into container storage. **podman load** reads from stdin by default or a file if the **input** option is set.
 You can also specify a name for the image if the archive does not contain a named reference, of if you want an additional name for the local image.
+
+The local client further supports loading an **oci-dir** or a **docker-dir** as created with **podman save** (1).
 
 The **quiet** option suppresses the progress output when set.
 Note: `:` is a restricted character and cannot be part of the file name.

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -199,6 +199,13 @@ func (ir *ImageEngine) Load(ctx context.Context, opts entities.ImageLoadOptions)
 		return nil, err
 	}
 	defer f.Close()
+	fInfo, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if fInfo.IsDir() {
+		return nil, errors.Errorf("remote client supports archives only but %q is a directory", opts.Input)
+	}
 	ref := opts.Name
 	if len(opts.Tag) > 0 {
 		ref += ":" + opts.Tag

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Podman load", func() {
 	})
 
 	It("podman load directory", func() {
-		SkipIfRemote("FIXME: Remote Load is broken.")
+		SkipIfRemote("Remote does not support loading directories")
 		outdir := filepath.Join(podmanTest.TempDir, "alpine")
 
 		save := podmanTest.PodmanNoCache([]string{"save", "--format", "oci-dir", "-o", outdir, ALPINE})
@@ -137,6 +137,22 @@ var _ = Describe("Podman load", func() {
 		result := podmanTest.Podman([]string{"load", "-i", outdir})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
+	})
+
+	It("podman-remote load directory", func() {
+		// Remote-only test looking for the specific remote error
+		// message when trying to load a directory.
+		if !IsRemote() {
+			Skip("Remote only test")
+		}
+
+		result := podmanTest.Podman([]string{"load", "-i", podmanTest.TempDir})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(125))
+
+		errMsg := fmt.Sprintf("remote client supports archives only but %q is a directory", podmanTest.TempDir)
+		found, _ := result.ErrorGrepString(errMsg)
+		Expect(found).Should(BeTrue())
 	})
 
 	It("podman load bogus file", func() {


### PR DESCRIPTION
The remote client does not support loading directories yet.  To prevent
confusing error messages and to make the behaviour more explicit, check
if the input points to a directory and throw an error if needed.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>