### PR TITLE
e2e tests: SkipIfRemote(): add a reason

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Podman build", func() {
 	// Check that builds with different values for the squash options
 	// create the appropriate number of layers, then clean up after.
 	It("podman build basic alpine with squash", func() {
-		SkipIfRemote() // FIXME: This is broken should be fixed
+		SkipIfRemote("FIXME: This is broken should be fixed")
 		session := podmanTest.PodmanNoCache([]string{"build", "-f", "build/squash/Dockerfile.squash-a", "-t", "test-squash-a:latest", "build/squash"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -221,7 +221,7 @@ var _ = Describe("Podman build", func() {
 	})
 
 	It("podman build --http_proxy flag", func() {
-		SkipIfRemote() // FIXME: This is broken should be fixed
+		SkipIfRemote("FIXME: This is broken should be fixed")
 		os.Setenv("http_proxy", "1.2.3.4")
 		podmanTest.RestoreAllArtifacts()
 		dockerfile := `FROM docker.io/library/alpine:latest

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Podman commit", func() {
 	It("podman commit with volume mounts and --include-volumes", func() {
 		// We need to figure out how volumes are going to work correctly with the remote
 		// client.  This does not currently work.
-		SkipIfRemote() // --testing Remote Volumes
+		SkipIfRemote("--testing Remote Volumes")
 		s := podmanTest.Podman([]string{"run", "--name", "test1", "-v", "/tmp:/foo", "alpine", "date"})
 		s.WaitWithDefaultTimeout()
 		Expect(s.ExitCode()).To(Equal(0))

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Podman cp", func() {
 	})
 
 	It("podman cp stdin/stdout", func() {
-		SkipIfRemote() // podman-remote cp not implemented yet
+		SkipIfRemote("FIXME: podman-remote cp not implemented yet")
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -346,7 +346,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create --signature-policy", func() {
-		SkipIfRemote() // SigPolicy not handled by remote
+		SkipIfRemote("SigPolicy not handled by remote")
 		session := podmanTest.Podman([]string{"create", "--pull=always", "--signature-policy", "/no/such/file", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -285,7 +285,7 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec preserves container groups with --user and --group-add", func() {
-		SkipIfRemote() // FIXME: This is broken SECCOMP Failues?
+		SkipIfRemote("FIXME: This is broken SECCOMP Failues?")
 
 		dockerfile := `FROM fedora-minimal
 RUN groupadd -g 4000 first

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Podman Info", func() {
 		if !rootless.IsRootless() {
 			Skip("test of rootless_storage_path is only meaningful as rootless")
 		}
-		SkipIfRemote() // Only tests storage on local client
+		SkipIfRemote("Only tests storage on local client")
 		oldHOME, hasHOME := os.LookupEnv("HOME")
 		defer func() {
 			if hasHOME {

--- a/test/e2e/init_test.go
+++ b/test/e2e/init_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Podman init", func() {
 	})
 
 	It("podman init latest container", func() {
-		SkipIfRemote() // Testing --latest flag
+		SkipIfRemote("--latest flag n/a")
 		session := podmanTest.Podman([]string{"create", "-d", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Podman inspect", func() {
 	})
 
 	It("podman inspect -l with additional input should fail", func() {
-		SkipIfRemote() // testing --latest flag
+		SkipIfRemote("--latest flag n/a")
 		result := podmanTest.Podman([]string{"inspect", "-l", "1234foobar"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(125))
@@ -173,7 +173,7 @@ var _ = Describe("Podman inspect", func() {
 	})
 
 	It("podman inspect --latest with no container fails", func() {
-		SkipIfRemote() // testing --latest flag
+		SkipIfRemote("testing --latest flag")
 
 		session := podmanTest.Podman([]string{"inspect", "--latest"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -23,8 +23,8 @@ func IsRemote() bool {
 	return true
 }
 
-func SkipIfRemote() {
-	ginkgo.Skip("This function is not enabled for remote podman")
+func SkipIfRemote(reason string) {
+	ginkgo.Skip("[remote]: " + reason)
 }
 
 func SkipIfRootless() {

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -16,7 +16,7 @@ func IsRemote() bool {
 	return false
 }
 
-func SkipIfRemote() {
+func SkipIfRemote(string) {
 }
 
 func SkipIfRootless() {

--- a/test/e2e/libpod_suite_varlink_test.go
+++ b/test/e2e/libpod_suite_varlink_test.go
@@ -23,8 +23,8 @@ func IsRemote() bool {
 	return true
 }
 
-func SkipIfRemote() {
-	ginkgo.Skip("This function is not enabled for remote podman")
+func SkipIfRemote(reason string) {
+	ginkgo.Skip("[remote]: " + reason)
 }
 
 func SkipIfRootless() {

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Podman load", func() {
 	})
 
 	It("podman load directory", func() {
-		SkipIfRemote() // FIXME: Remote Load is broken.
+		SkipIfRemote("FIXME: Remote Load is broken.")
 		outdir := filepath.Join(podmanTest.TempDir, "alpine")
 
 		save := podmanTest.PodmanNoCache([]string{"save", "--format", "oci-dir", "-o", outdir, ALPINE})
@@ -227,7 +227,7 @@ var _ = Describe("Podman load", func() {
 	})
 
 	It("podman load localhost registry from dir", func() {
-		SkipIfRemote() // FIXME: podman-remote load is currently broken.
+		SkipIfRemote("FIXME: podman-remote load is currently broken.")
 		outfile := filepath.Join(podmanTest.TempDir, "load")
 
 		setup := podmanTest.PodmanNoCache([]string{"tag", BB, "hello:world"})

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Podman logs", func() {
 	})
 
 	It("two containers showing short container IDs", func() {
-		SkipIfRemote() // FIXME: remote does not support multiple containers
+		SkipIfRemote("FIXME: remote does not support multiple containers")
 		log1 := podmanTest.Podman([]string{"run", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		log1.WaitWithDefaultTimeout()
 		Expect(log1.ExitCode()).To(Equal(0))

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Podman manifest", func() {
 	})
 
 	It("podman manifest annotate", func() {
-		SkipIfRemote() // Not supporting annotate on remote connections
+		SkipIfRemote("Not supporting annotate on remote connections")
 		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -184,7 +184,7 @@ var _ = Describe("Podman manifest", func() {
 	})
 
 	It("podman manifest push purge", func() {
-		SkipIfRemote() // remote does not support --purge
+		SkipIfRemote("remote does not support --purge")
 		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Podman namespaces", func() {
 	})
 
 	It("podman namespace test", func() {
-		SkipIfRemote() // FIXME This should work on Remote
+		SkipIfRemote("FIXME This should work on Remote")
 		podman1 := podmanTest.Podman([]string{"--namespace", "test1", "run", "-d", ALPINE, "echo", "hello"})
 		podman1.WaitWithDefaultTimeout()
 		Expect(podman1.ExitCode()).To(Equal(0))

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with name and subnet", func() {
-		SkipIfRemote() // FIXME, this should work on --remote
+		SkipIfRemote("FIXME, this should work on --remote")
 		var (
 			results []network.NcList
 		)

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -793,7 +793,7 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman play kube seccomp container level", func() {
-		SkipIfRemote() // FIXME This is broken
+		SkipIfRemote("FIXME This is broken")
 		// expect play kube is expected to set a seccomp label if it's applied as an annotation
 		jsonFile, err := podmanTest.CreateSeccompJson(seccompPwdEPERM)
 		if err != nil {
@@ -820,7 +820,7 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman play kube seccomp pod level", func() {
-		SkipIfRemote() // FIXME: This should work with --remote
+		SkipIfRemote("FIXME: This should work with --remote")
 		// expect play kube is expected to set a seccomp label if it's applied as an annotation
 		jsonFile, err := podmanTest.CreateSeccompJson(seccompPwdEPERM)
 		if err != nil {

--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -225,7 +225,7 @@ var _ = Describe("Podman pod create", func() {
 	})
 
 	It("podman pod container can override pod pid NS", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.Podman([]string{"pod", "create", "--share", "pid"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -257,7 +257,7 @@ var _ = Describe("Podman pod create", func() {
 	})
 
 	It("podman pod container can override pod not sharing pid", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.Podman([]string{"pod", "create", "--share", "net"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -283,7 +283,7 @@ var _ = Describe("Podman pod create", func() {
 	})
 
 	It("podman pod container can override pod ipc NS", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.Podman([]string{"pod", "create", "--share", "ipc"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -380,7 +380,7 @@ var _ = Describe("Podman pod create", func() {
 	})
 
 	It("podman run --add-host in pod", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.Podman([]string{"pod", "create"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/pod_pod_namespaces.go
+++ b/test/e2e/pod_pod_namespaces.go
@@ -61,7 +61,7 @@ var _ = Describe("Podman pod create", func() {
 	})
 
 	It("podman pod container dontshare PIDNS", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.Podman([]string{"pod", "create"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman pod ps latest", func() {
-		SkipIfRemote() // Testing --latest flag
+		SkipIfRemote("--latest flag n/a")
 		_, ec, podid1 := podmanTest.CreatePod("")
 		Expect(ec).To(Equal(0))
 

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman image prune skip cache images", func() {
-		SkipIfRemote() // FIXME should work on podman --remote
+		SkipIfRemote("FIXME should work on podman --remote")
 		podmanTest.BuildImage(pruneImage, "alpine_bash:latest", "true")
 
 		none := podmanTest.Podman([]string{"images", "-a"})
@@ -110,7 +110,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman image prune dangling images", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		podmanTest.BuildImage(pruneImage, "alpine_bash:latest", "true")
 		podmanTest.BuildImage(pruneImage, "alpine_bash:latest", "true")
 
@@ -147,7 +147,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system image prune unused images", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		podmanTest.RestoreAllArtifacts()
 		podmanTest.BuildImage(pruneImage, "alpine_bash:latest", "true")
 		prune := podmanTest.PodmanNoCache([]string{"system", "prune", "-a", "--force"})

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman ps latest flag", func() {
-		SkipIfRemote() // --latest is not supported on podman-remote
+		SkipIfRemote("--latest is not supported on podman-remote")
 		_, ec, _ := podmanTest.RunLsContainer("")
 		Expect(ec).To(Equal(0))
 		_, ec, _ = podmanTest.RunLsContainer("")

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull from docker-archive", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		podmanTest.RestoreArtifact(ALPINE)
 		tarfn := filepath.Join(podmanTest.TempDir, "alp.tar")
 		session := podmanTest.PodmanNoCache([]string{"save", "-o", tarfn, "alpine"})
@@ -297,7 +297,7 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull from oci-archive", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		podmanTest.RestoreArtifact(ALPINE)
 		tarfn := filepath.Join(podmanTest.TempDir, "oci-alp.tar")
 		session := podmanTest.PodmanNoCache([]string{"save", "--format", "oci-archive", "-o", tarfn, "alpine"})
@@ -316,7 +316,7 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull from local directory", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		podmanTest.RestoreArtifact(ALPINE)
 		dirpath := filepath.Join(podmanTest.TempDir, "alpine")
 		os.MkdirAll(dirpath, os.ModePerm)
@@ -341,7 +341,7 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull from local OCI directory", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		podmanTest.RestoreArtifact(ALPINE)
 		dirpath := filepath.Join(podmanTest.TempDir, "alpine")
 		os.MkdirAll(dirpath, os.ModePerm)

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Podman rm", func() {
 	})
 
 	It("podman rm invalid --latest and --cidfile and --all", func() {
-		SkipIfRemote() // Verifying --latest flag
+		SkipIfRemote("Verifying --latest flag")
 
 		result := podmanTest.Podman([]string{"rm", "--cidfile", "foobar", "--latest"})
 		result.WaitWithDefaultTimeout()

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -185,7 +185,7 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi with cached images", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -255,7 +255,7 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi -a with parent|child images", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		dockerfile := `FROM docker.io/library/alpine:latest AS base
 RUN touch /1
 ENV LOCAL=/1

--- a/test/e2e/run_cleanup_test.go
+++ b/test/e2e/run_cleanup_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Podman run exit", func() {
 	})
 
 	It("podman run -d mount cleanup test", func() {
-		SkipIfRemote() // podman-remote does not support mount
+		SkipIfRemote("podman-remote does not support mount")
 		SkipIfRootless()
 
 		result := podmanTest.Podman([]string{"run", "-dt", ALPINE, "top"})

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -90,7 +90,7 @@ ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
 	})
 
 	It("podman run user entrypoint overrides image entrypoint and image cmd", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		dockerfile := `FROM docker.io/library/alpine:latest
 CMD ["-i"]
 ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]

--- a/test/e2e/run_env_test.go
+++ b/test/e2e/run_env_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run --env-host environment test", func() {
-		SkipIfRemote() // FIXME, We should check that --env-host reports correct error on podman-remote
+		SkipIfRemote("FIXME, We should check that --env-host reports correct error on podman-remote")
 		env := append(os.Environ(), "FOO=BAR")
 		session := podmanTest.PodmanAsUser([]string{"run", "--rm", "--env-host", ALPINE, "/bin/printenv", "FOO"}, 0, 0, "", env)
 
@@ -108,7 +108,7 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run --http-proxy test", func() {
-		SkipIfRemote() // FIXME: Should report proper error when http-proxy is not supported
+		SkipIfRemote("FIXME: Should report proper error when http-proxy is not supported")
 		os.Setenv("http_proxy", "1.2.3.4")
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv", "http_proxy"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/run_restart_test.go
+++ b/test/e2e/run_restart_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Podman run restart containers", func() {
 	})
 
 	It("Podman start after successful run", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.Podman([]string{"run", "--name", "test", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/run_security_labels.go
+++ b/test/e2e/run_security_labels.go
@@ -127,7 +127,7 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman container runlabel (podman --version)", func() {
-		SkipIfRemote() // runlabel not supported on podman-remote
+		SkipIfRemote("runlabel not supported on podman-remote")
 		PodmanDockerfile := `
 FROM  alpine:latest
 LABEL io.containers.capabilities=chown,mknod`

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run --signature-policy", func() {
-		SkipIfRemote() // SigPolicy not handled by remote
+		SkipIfRemote("SigPolicy not handled by remote")
 		session := podmanTest.Podman([]string{"run", "--pull=always", "--signature-policy", "/no/such/file", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
@@ -295,7 +295,7 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run user capabilities test with image", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		dockerfile := `FROM busybox
 USER bin`
 		podmanTest.BuildImage(dockerfile, "test", "false")
@@ -343,7 +343,7 @@ USER bin`
 	})
 
 	It("podman run limits host test", func() {
-		SkipIfRemote() // This can only be used for local tests
+		SkipIfRemote("This can only be used for local tests")
 
 		var l syscall.Rlimit
 
@@ -486,7 +486,7 @@ USER bin`
 	})
 
 	It("podman run notify_socket", func() {
-		SkipIfRemote() // This can only be used for local tests
+		SkipIfRemote("This can only be used for local tests")
 
 		host := GetHostDistributionInfo()
 		if host.Distribution != "rhel" && host.Distribution != "centos" && host.Distribution != "fedora" {
@@ -546,7 +546,7 @@ USER bin`
 	})
 
 	It("podman run with secrets", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		containersDir := filepath.Join(podmanTest.TempDir, "containers")
 		err := os.MkdirAll(containersDir, 0755)
 		Expect(err).To(BeNil())
@@ -711,7 +711,7 @@ USER bin`
 	})
 
 	It("podman run with built-in volume image", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.Podman([]string{"run", "--rm", redis, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -1028,7 +1028,7 @@ USER mail`
 	})
 
 	It("podman run with restart-policy always restarts containers", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		testDir := filepath.Join(podmanTest.RunRoot, "restart-test")
 		err := os.MkdirAll(testDir, 0755)
 		Expect(err).To(BeNil())

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman run with volumes and suid/dev/exec options", func() {
-		SkipIfRemote() // podman-remote does not support --volumes
+		SkipIfRemote("podman-remote does not support --volumes")
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
 		os.Mkdir(mountPath, 0755)
 
@@ -227,7 +227,7 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman run with tmpfs named volume mounts and unmounts", func() {
-		SkipIfRemote() // podman-remote does not support --volumes this test could be simplified to be tested on Remote.
+		SkipIfRemote("podman-remote does not support --volumes this test could be simplified to be tested on Remote.")
 		SkipIfRootless()
 		volName := "testvol"
 		mkVolume := podmanTest.Podman([]string{"volume", "create", "--opt", "type=tmpfs", "--opt", "device=tmpfs", "--opt", "o=nodev", "testvol"})
@@ -453,7 +453,7 @@ VOLUME /test/`
 	})
 
 	It("podman run with overlay volume flag", func() {
-		SkipIfRemote() // Overlay volumes only work locally
+		SkipIfRemote("Overlay volumes only work locally")
 		if os.Getenv("container") != "" {
 			Skip("Overlay mounts not supported when running in a container")
 		}

--- a/test/e2e/run_working_dir.go
+++ b/test/e2e/run_working_dir.go
@@ -50,7 +50,7 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run a container on an image with a workdir", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		dockerfile := `FROM alpine
 RUN  mkdir -p /home/foobar
 WORKDIR  /etc/foobar`

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -29,7 +29,7 @@ var _ = Describe("podman container runlabel", func() {
 	)
 
 	BeforeEach(func() {
-		SkipIfRemote() // runlabel is not supported for remote connections
+		SkipIfRemote("runlabel is not supported for remote connections")
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -237,7 +237,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search attempts HTTP if registry is in registries.insecure and force secure is false", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
@@ -278,7 +278,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search doesn't attempt HTTP if force secure is true", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
@@ -317,7 +317,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search doesn't attempt HTTP if registry is not listed as insecure", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
@@ -356,7 +356,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search doesn't attempt HTTP if one registry is not listed as insecure", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Podman stop", func() {
 	})
 
 	It("podman stop latest containers", func() {
-		SkipIfRemote() // Testing --latest
+		SkipIfRemote("--latest flag n/a")
 		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -289,7 +289,7 @@ var _ = Describe("Podman stop", func() {
 	})
 
 	It("podman stop invalid --latest and --cidfile and --all", func() {
-		SkipIfRemote() // testing --latest
+		SkipIfRemote("--latest flag n/a")
 
 		result := podmanTest.Podman([]string{"stop", "--cidfile", "foobar", "--latest"})
 		result.WaitWithDefaultTimeout()

--- a/test/e2e/system_df_test.go
+++ b/test/e2e/system_df_test.go
@@ -35,7 +35,7 @@ var _ = Describe("podman system df", func() {
 	})
 
 	It("podman system df", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.Podman([]string{"create", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/system_reset_test.go
+++ b/test/e2e/system_reset_test.go
@@ -34,7 +34,7 @@ var _ = Describe("podman system reset", func() {
 	})
 
 	It("podman system reset", func() {
-		SkipIfRemote() // system reset not supported on podman --remote
+		SkipIfRemote("system reset not supported on podman --remote")
 		// system reset will not remove additional store images, so need to grab length
 
 		session := podmanTest.Podman([]string{"rmi", "--force", "--all"})

--- a/test/e2e/unshare_test.go
+++ b/test/e2e/unshare_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Podman unshare", func() {
 		podmanTest *PodmanTestIntegration
 	)
 	BeforeEach(func() {
-		SkipIfRemote() // podman-remote unshare is not supported
+		SkipIfRemote("podman-remote unshare is not supported")
 		if _, err := os.Stat("/proc/self/uid_map"); err != nil {
 			Skip("User namespaces not supported.")
 		}

--- a/test/e2e/untag_test.go
+++ b/test/e2e/untag_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Podman untag", func() {
 	})
 
 	It("podman untag all", func() {
-		SkipIfRemote() // FIXME This should work on podman-remote
+		SkipIfRemote("FIXME This should work on podman-remote")
 		setup := podmanTest.PodmanNoCache([]string{"pull", ALPINE})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))


### PR DESCRIPTION
Now that Dan has added helpful comments to each SkipIfRemote,
let's take the next step and include those messages in the
Skip() output so someone viewing test results can easily
see if a remote test is skipped for a real reason or for
a FIXME.

This commit is the result of a simple:

   perl -pi -e 's;(SkipIfRemote)\(\)(\s+//\s+(.*))?;$1("$3");' *.go

in the test/e2e directory, with a few minor (manual) changes
in wording.

Signed-off-by: Ed Santiago <santiago@redhat.com>