### PR TITLE
Fix a bug where log-driver json-file was made no logs

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1330,10 +1330,10 @@ func (r *ConmonOCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, p
 	switch logDriver {
 	case define.JournaldLogging:
 		logDriverArg = define.JournaldLogging
-	case define.JSONLogging:
-		fallthrough
 	case define.NoLogging:
 		logDriverArg = define.NoLogging
+	case define.JSONLogging:
+		fallthrough
 	default: //nolint-stylecheck
 		// No case here should happen except JSONLogging, but keep this here in case the options are extended
 		logrus.Errorf("%s logging specified but not supported. Choosing k8s-file logging instead", ctr.LogDriver())


### PR DESCRIPTION
When we added the None log driver, it was accidentally added in the middle of a set of Fallthrough stanzas which all should have
led to k8s-file, so that JSON file logging accidentally caused no logging to be selected instead of k8s-file.
