### PR TITLE
Allow filtering on pod label values

### DIFF
--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -73,7 +73,7 @@ func pods(cmd *cobra.Command, _ []string) error {
 	if cmd.Flag("filter").Changed {
 		psInput.Filters = make(map[string][]string)
 		for _, f := range inputFilters {
-			split := strings.Split(f, "=")
+			split := strings.SplitN(f, "=", 2)
 			if len(split) < 2 {
 				return errors.Errorf("filter input must be in the form of filter=value: %s is invalid", f)
 			}

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -212,17 +212,17 @@ var _ = Describe("Podman ps", func() {
 		Expect(ec).To(Equal(0))
 
 		_, ec, podid2 := podmanTest.CreatePodWithLabels("", map[string]string{
-			"io.podman.test.label": "value1",
-			"io.podman.test.key":   "irrelevant-value",
+			"app":                "myapp",
+			"io.podman.test.key": "irrelevant-value",
 		})
 		Expect(ec).To(Equal(0))
 
 		_, ec, podid3 := podmanTest.CreatePodWithLabels("", map[string]string{
-			"io.podman.test.label": "value2",
+			"app": "test",
 		})
 		Expect(ec).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"pod", "ps", "--no-trunc", "--filter", "label=io.podman.test.key", "--filter", "label=io.podman.test.label=value1"})
+		session := podmanTest.Podman([]string{"pod", "ps", "--no-trunc", "--filter", "label=app", "--filter", "label=app=myapp"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Not(ContainSubstring(podid1)))


### PR DESCRIPTION
Before this PR, filters of the form `podman pod ps --filter label=app=myapp` were not working. The results would include all pods that contained the `app` label with any value. Looking at the code, this makes sense. It appears that the second `=` and everything after it were getting truncated.

The strange part is that there was a test for this that was passing even before my change. However, when I changed the test to look exactly like my usecase, it did fail until I applied my patch. I haven't yet figured out why this is. If anyone can figure it out, let me know.