### PR TITLE
set interactive mode with compat create endpoint

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -210,7 +210,7 @@ func makeCreateConfig(ctx context.Context, containerConfig *config.Config, input
 		ImageID:           newImage.ID(),
 		BuiltinImgVolumes: nil, // podman
 		ImageVolumeType:   "",  // podman
-		Interactive:       false,
+		Interactive:       input.OpenStdin,
 		// IpcMode:           input.HostConfig.IpcMode,
 		Labels:    input.Labels,
 		LogDriver: input.HostConfig.LogConfig.Type, // is this correct


### PR DESCRIPTION
when creating a container using the compat endpoint, the interactive bool was being hard set to false and ignoring the user's input.

Signed-off-by: baude <bbaude@redhat.com>