### PR TITLE
system tests: helpers: safer parse_table

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -19,8 +19,8 @@ graphRoot:
 graphStatus:
 imageStore:\\\s\\\+number: 1
 runRoot:
-cgroupManager:
-cgroupVersion: v
+cgroupManager: \\\(systemd\\\|cgroupfs\\\)
+cgroupVersion: v[12]
 "
     while read expect; do
         is "$output" ".*$expect" "output includes '$expect'"
@@ -36,6 +36,8 @@ cgroupVersion: v
     tests="
 host.buildahVersion       | [0-9.]
 host.conmon.path          | $expr_path
+host.cgroupManager        | \\\(systemd\\\|cgroupfs\\\)
+host.cgroupVersion        | v[12]
 host.ociRuntime.path      | $expr_path
 store.configFile          | $expr_path
 store.graphDriverName     | [a-z0-9]\\\+\\\$

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -376,7 +376,12 @@ function parse_table() {
         while read col; do
             dprint "col=<<$col>>"
             row+=("$col")
-        done <  <(echo "$line" | tr '|' '\012' | sed -e 's/^ *//' -e 's/\\/\\\\/g')
+        done <  <(echo "$line" | sed -E -e 's/(^|\s)\|(\s|$)/\n /g' | sed -e 's/^ *//' -e 's/\\/\\\\/g')
+        # the above seds:
+        #   1) Convert '|' to newline, but only if bracketed by spaces or
+        #      at beginning/end of line (this allows 'foo|bar' in tests);
+        #   2) then remove leading whitespace;
+        #   3) then double-escape all backslashes
 
         printf "%q " "${row[@]}"
         printf "\n"

--- a/test/system/helpers.t
+++ b/test/system/helpers.t
@@ -85,7 +85,7 @@ while read x y z; do
     check_result "$x" "''" "empty string - left-hand"
     check_result "$y" "''" "empty string - middle"
     check_result "$z" "''" "empty string - right"
-done < <(parse_table " | |")
+done < <(parse_table "  |  |")
 
 # Quotes
 while read x y z;do
@@ -107,6 +107,13 @@ while read x y z;do
     check_result "$2" "e f"   "double quotes - token split - 2"
     check_result "$3" "g"     "double quotes - token split - 3"
 done < <(parse_table "a 'b c' | d \"e f\" g | h")
+
+# Split on '|' only when bracketed by spaces or at beginning/end of line
+while read x y z;do
+    check_result "$x" "|x"    "pipe in strings - pipe at start"
+    check_result "$y" "y|y1"  "pipe in strings - pipe in middle"
+    check_result "$z" "z|"    "pipe in strings - pipe at end"
+done < <(parse_table "|x | y|y1 | z|")
 
 # END   test the parse_table helper
 ###############################################################################


### PR DESCRIPTION
The parse_table() helper has until now dumbly split lines
on every single '|' character. This prevents us from running
simple tests such as 'cgroupManager: (systemd|cgroupfs)'.

We now use an ugly but robust sed expression to split
on '|' but *only* when surrounded by spaces and/or beginning
or end of line. This is safe because, for readability, all
tables already keep the '|' symbols well separated from
table content.

Add tests. And, the whole reason behind this, add
an actual real test for cgroupManager and cgroupVersion.

Signed-off-by: Ed Santiago <santiago@redhat.com>