### PR TITLE
remote load of dir not supported

### DIFF
--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -188,6 +188,13 @@ func (ir *ImageEngine) Inspect(ctx context.Context, namesOrIDs []string, opts en
 }
 
 func (ir *ImageEngine) Load(ctx context.Context, opts entities.ImageLoadOptions) (*entities.ImageLoadReport, error) {
+	pathInfo, err := os.Stat(opts.Input)
+	if err != nil {
+		return nil, err
+	}
+	if pathInfo.IsDir() {
+		return nil, errors.New("remote client cannot load from a directory. use an OCI or Docker archive file instead")
+	}
 	f, err := os.Open(opts.Input)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
we do not support loading an image from a directory with the remote client.  Error message has been added to ensure that is communicated to users clearly.  also added descriptions to Skips for tests.  updated documentation which didnt mention loading from a directory at all.

Fixes: #7723

Signed-off-by: baude <bbaude@redhat.com>