### PR TITLE
Convert Split() calls with an equal sign to SplitN()

### DIFF
--- a/cmd/podman/common/volumes.go
+++ b/cmd/podman/common/volumes.go
@@ -238,7 +238,7 @@ func getBindMount(args []string) (spec.Mount, error) {
 	var setSource, setDest, setRORW, setSuid, setDev, setExec, setRelabel bool
 
 	for _, val := range args {
-		kv := strings.Split(val, "=")
+		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {
 		case "bind-nonrecursive":
 			newMount.Options = append(newMount.Options, "bind")
@@ -366,7 +366,7 @@ func getTmpfsMount(args []string) (spec.Mount, error) {
 	var setDest, setRORW, setSuid, setDev, setExec, setTmpcopyup bool
 
 	for _, val := range args {
-		kv := strings.Split(val, "=")
+		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {
 		case "tmpcopyup", "notmpcopyup":
 			if setTmpcopyup {
@@ -441,7 +441,7 @@ func getDevptsMount(args []string) (spec.Mount, error) {
 	var setDest bool
 
 	for _, val := range args {
-		kv := strings.Split(val, "=")
+		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {
 		case "target", "dst", "destination":
 			if len(kv) == 1 {
@@ -473,7 +473,7 @@ func getNamedVolume(args []string) (*specgen.NamedVolume, error) {
 	var setSource, setDest, setRORW, setSuid, setDev, setExec bool
 
 	for _, val := range args {
-		kv := strings.Split(val, "=")
+		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {
 		case "ro", "rw":
 			if setRORW {

--- a/libpod/image/filters.go
+++ b/libpod/image/filters.go
@@ -82,7 +82,7 @@ func LabelFilter(ctx context.Context, labelfilter string) ResultFilter {
 	// We need to handle both label=key and label=key=value
 	return func(i *Image) bool {
 		var value string
-		splitFilter := strings.Split(labelfilter, "=")
+		splitFilter := strings.SplitN(labelfilter, "=", 2)
 		key := splitFilter[0]
 		if len(splitFilter) > 1 {
 			value = splitFilter[1]
@@ -157,7 +157,7 @@ func (ir *Runtime) createFilterFuncs(filters []string, img *Image) ([]ResultFilt
 	var filterFuncs []ResultFilter
 	ctx := context.Background()
 	for _, filter := range filters {
-		splitFilter := strings.Split(filter, "=")
+		splitFilter := strings.SplitN(filter, "=", 2)
 		if len(splitFilter) < 2 {
 			return nil, errors.Errorf("invalid filter syntax %s", filter)
 		}

--- a/libpod/image/search.go
+++ b/libpod/image/search.go
@@ -263,7 +263,7 @@ func searchRepositoryTags(registry, term string, sc *types.SystemContext, option
 func ParseSearchFilter(filter []string) (*SearchFilter, error) {
 	sFilter := new(SearchFilter)
 	for _, f := range filter {
-		arr := strings.Split(f, "=")
+		arr := strings.SplitN(f, "=", 2)
 		switch arr[0] {
 		case "stars":
 			if len(arr) < 2 {

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -254,9 +254,11 @@ func (r *Runtime) setupSlirp4netns(ctr *Container) error {
 	if ctr.config.NetworkOptions != nil {
 		slirpOptions := ctr.config.NetworkOptions["slirp4netns"]
 		for _, o := range slirpOptions {
-			parts := strings.Split(o, "=")
+			parts := strings.SplitN(o, "=", 2)
+			if len(parts) < 2 {
+				return errors.Errorf("unknown option for slirp4netns: %q", o)
+			}
 			option, value := parts[0], parts[1]
-
 			switch option {
 			case "cidr":
 				ipv4, _, err := net.ParseCIDR(value)

--- a/pkg/spec/security.go
+++ b/pkg/spec/security.go
@@ -178,7 +178,7 @@ func (c *SecurityConfig) ConfigureGenerator(g *generate.Generator, user *UserCon
 
 	for _, opt := range c.SecurityOpts {
 		// Split on both : and =
-		splitOpt := strings.Split(opt, "=")
+		splitOpt := strings.SplitN(opt, "=", 2)
 		if len(splitOpt) == 1 {
 			splitOpt = strings.Split(opt, ":")
 		}

--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -394,7 +394,7 @@ func getBindMount(args []string) (spec.Mount, error) {
 	var setSource, setDest, setRORW, setSuid, setDev, setExec, setRelabel bool
 
 	for _, val := range args {
-		kv := strings.Split(val, "=")
+		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {
 		case "bind-nonrecursive":
 			newMount.Options = append(newMount.Options, "bind")
@@ -517,7 +517,7 @@ func getTmpfsMount(args []string) (spec.Mount, error) {
 	var setDest, setRORW, setSuid, setDev, setExec, setTmpcopyup bool
 
 	for _, val := range args {
-		kv := strings.Split(val, "=")
+		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {
 		case "tmpcopyup", "notmpcopyup":
 			if setTmpcopyup {
@@ -591,7 +591,7 @@ func getNamedVolume(args []string) (*libpod.ContainerNamedVolume, error) {
 	var setSource, setDest, setRORW, setSuid, setDev, setExec bool
 
 	for _, val := range args {
-		kv := strings.Split(val, "=")
+		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {
 		case "ro", "rw":
 			if setRORW {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -474,8 +474,8 @@ func getTomlStorage(storeOptions *storage.StoreOptions) *tomlConfig {
 	config.Storage.RunRoot = storeOptions.RunRoot
 	config.Storage.GraphRoot = storeOptions.GraphRoot
 	for _, i := range storeOptions.GraphDriverOptions {
-		s := strings.Split(i, "=")
-		if s[0] == "overlay.mount_program" {
+		s := strings.SplitN(i, "=", 2)
+		if s[0] == "overlay.mount_program" && len(s) == 2 {
 			config.Storage.Options.MountProgram = s[1]
 		}
 	}


### PR DESCRIPTION
After seeing #7759, I decided to look at the calls in
Podman and Buildah to see if we had issues with strings.Split()
calls where an "=" (equals) sign was in play and we expected
to split on only the first one.

There were only one or two that I found in here that I think
might have been troubling, the remainder are just adding
some extra safety.

I also had another half dozen or so that were checking length
expectations appropriately, those I left alone.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>