### PR TITLE
Fix podman network rm --force when network is used by a pod

### DIFF
--- a/pkg/bindings/network/network.go
+++ b/pkg/bindings/network/network.go
@@ -60,7 +60,7 @@ func Remove(ctx context.Context, nameOrID string, force *bool) ([]*entities.Netw
 	}
 	params := url.Values{}
 	if force != nil {
-		params.Set("size", strconv.FormatBool(*force))
+		params.Set("force", strconv.FormatBool(*force))
 	}
 	response, err := conn.DoRequest(nil, http.MethodDelete, "/networks/%s", params, nil, nameOrID)
 	if err != nil {

--- a/pkg/domain/infra/tunnel/network.go
+++ b/pkg/domain/infra/tunnel/network.go
@@ -26,11 +26,16 @@ func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []stri
 func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, options entities.NetworkRmOptions) ([]*entities.NetworkRmReport, error) {
 	reports := make([]*entities.NetworkRmReport, 0, len(namesOrIds))
 	for _, name := range namesOrIds {
-		report, err := network.Remove(ic.ClientCxt, name, &options.Force)
+		response, err := network.Remove(ic.ClientCxt, name, &options.Force)
 		if err != nil {
-			report[0].Err = err
+			report := &entities.NetworkRmReport{
+				Name: name,
+				Err:  err,
+			}
+			reports = append(reports, report)
+		} else {
+			reports = append(reports, response...)
 		}
-		reports = append(reports, report...)
 	}
 	return reports, nil
 }

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -294,4 +294,23 @@ var _ = Describe("Podman network", func() {
 		Expect(session.ExitCode()).To(BeZero())
 		Expect(session.OutputToString()).To(Not(ContainSubstring(netName)))
 	})
+
+	It("podman network remove with two networks", func() {
+		netName1 := "net1"
+		session := podmanTest.Podman([]string{"network", "create", netName1})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+
+		netName2 := "net2"
+		session = podmanTest.Podman([]string{"network", "create", netName2})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+
+		session = podmanTest.Podman([]string{"network", "rm", netName1, netName2})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		lines := session.OutputToStringArray()
+		Expect(lines[0]).To(Equal(netName1))
+		Expect(lines[1]).To(Equal(netName2))
+	})
 })

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -263,4 +263,35 @@ var _ = Describe("Podman network", func() {
 		rmAll.WaitWithDefaultTimeout()
 		Expect(rmAll.ExitCode()).To(BeZero())
 	})
+
+	It("podman network remove --force with pod", func() {
+		netName := "testnet"
+		session := podmanTest.Podman([]string{"network", "create", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+
+		session = podmanTest.Podman([]string{"pod", "create", "--network", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		podID := session.OutputToString()
+
+		session = podmanTest.Podman([]string{"create", "--pod", podID, ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+
+		session = podmanTest.Podman([]string{"network", "rm", "--force", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+
+		// check if pod is deleted
+		session = podmanTest.Podman([]string{"pod", "exists", podID})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(1))
+
+		// check if net is deleted
+		session = podmanTest.Podman([]string{"network", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		Expect(session.OutputToString()).To(Not(ContainSubstring(netName)))
+	})
 })


### PR DESCRIPTION
I added a test to prevent a future regression.

Fixes #7791 