### PR TITLE
Use local image if input image is a manifest list

### DIFF
--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -609,4 +609,21 @@ var _ = Describe("Podman create", func() {
 		Expect(session.ExitCode()).ToNot(BeZero())
 	})
 
+	It("create use local store image if input image contains a manifest list", func() {
+		session := podmanTest.Podman([]string{"pull", BB})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+
+		session = podmanTest.Podman([]string{"manifest", "create", "mylist"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"manifest", "add", "--all", "mylist", BB})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+
+		session = podmanTest.Podman([]string{"create", "mylist"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+	})
 })


### PR DESCRIPTION
If run&create image returns error: image contains manifest list, not a runnable image, find the local image that has digest matching the digest from the list and use the image from local storage for the command.

close #7233

Signed-off-by: Qi Wang <qiwan@redhat.com>