### PR TITLE
System tests: reenable some skipped tests

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -132,8 +132,6 @@ echo $rand        |   0 | $rand
 }
 
 @test "podman run --pull" {
-    skip_if_remote "podman-remote does not emit 'Trying to pull' msgs"
-
     run_podman run --pull=missing $IMAGE true
     is "$output" "" "--pull=missing [present]: no output"
 
@@ -267,8 +265,6 @@ echo $rand        |   0 | $rand
 # symptom only manifests on a fedora container image -- we have no
 # reproducer on alpine. Checking directory ownership is good enough.
 @test "podman run : user namespace preserved root ownership" {
-    skip_if_remote "FIXME: pending #7195"
-
     for priv in "" "--privileged"; do
         for user in "--user=0" "--user=100"; do
             for keepid in "" "--userns=keep-id"; do
@@ -286,8 +282,6 @@ echo $rand        |   0 | $rand
 
 # #6829 : add username to /etc/passwd inside container if --userns=keep-id
 @test "podman run : add username to /etc/passwd if --userns=keep-id" {
-    skip_if_remote "FIXME: pending #7195"
-
     # Default: always run as root
     run_podman run --rm $IMAGE id -un
     is "$output" "root" "id -un on regular container"
@@ -310,8 +304,6 @@ echo $rand        |   0 | $rand
 
 # #6991 : /etc/passwd is modifiable
 @test "podman run : --userns=keep-id: passwd file is modifiable" {
-    skip_if_remote "FIXME: pending #7195"
-
     run_podman run -d --userns=keep-id $IMAGE sh -c 'while ! test -e /stop; do sleep 0.1; done'
     cid="$output"
 

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -268,6 +268,14 @@ Labels.$label_name | $label_value
     is "${lines[-1]}" "...  ID: [0-9a-f]\{12\} Size: .* Top Layer of: \[localhost/build_test:latest]" \
        "image tree: last layer line"
 
+    # FIXME: 'image tree --whatrequires' does not work via remote
+    if ! is_remote; then
+        run_podman image tree --whatrequires $IMAGE
+        is "${lines[-1]}" \
+           ".*ID: .* Top Layer of: \\[localhost/build_test:latest\\]" \
+           "'image tree --whatrequires' shows our built image"
+    fi
+
     # Clean up
     run_podman rmi -f build_test
 }

--- a/test/system/080-pause.bats
+++ b/test/system/080-pause.bats
@@ -6,7 +6,9 @@
 load helpers
 
 @test "podman pause/unpause" {
-    skip_if_rootless "pause does not work rootless"
+    if is_rootless && ! is_cgroupsv2; then
+        skip "'podman pause' (rootless) only works with cgroups v2"
+    fi
 
     cname=$(random_string 10)
     run_podman run -d --name $cname $IMAGE \

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -186,7 +186,6 @@ EOF
 # Confirm that container sees the correct id
 @test "podman volume with --userns=keep-id" {
     is_rootless || skip "only meaningful when run rootless"
-    skip_if_remote "FIXME: pending #7195"
 
     myvoldir=${PODMAN_TMPDIR}/volume_$(random_string)
     mkdir $myvoldir

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -240,6 +240,16 @@ function is_remote() {
     [[ "$PODMAN" =~ -remote ]]
 }
 
+function is_cgroupsv1() {
+    # WARNING: This will break if there's ever a cgroups v3
+    ! is_cgroupsv2
+}
+
+function is_cgroupsv2() {
+    cgroup_type=$(stat -f -c %T /sys/fs/cgroup)
+    test "$cgroup_type" = "cgroupfs"
+}
+
 ###########################
 #  _add_label_if_missing  #  make sure skip messages include rootless/remote
 ###########################


### PR DESCRIPTION
 - pause test: enable when rootless + cgroups v2
   (was previously disabled for all rootless)

 - run --pull: now works with podman-remote
   (in #7647, thank you @jwhonce)

 - various other run/volumes tests: try reenabling
   It looks like #7195 was fixed (by #7451? I'm not
   sure if I'm reading the conversation correctly).
   Anyway, remove all the skip()s on 7195. Only time
   will tell if it's really fixed)

Also:

 - new test for podman image tree --whatrequires
   (because TIL). Doesn't work with podman-remote.

Signed-off-by: Ed Santiago <santiago@redhat.com>