### PR TITLE
fix for compatibility volume creation

### DIFF
--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -154,7 +154,9 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// parameters:
 	//  - in: body
 	//    name: create
-	//    description: attributes for creating a container
+	//    description: |
+	//      attributes for creating a container.
+	//      Note: If a volume by the same name exists, a 201 response with that volume's information will be generated.
 	//    schema:
 	//      $ref: "#/definitions/DockerVolumeCreate"
 	// produces:


### PR DESCRIPTION
in the compatibility layer, creating a volume with a name that already does not result in an error.  instead a 201 response with the existing volume's information is returned. while it seems like a bug on the part of docker and they agree, no attempt has been made to fix it in five years.  See https://github.com/moby/moby/issues/16068

Fixes: #7740

Signed-off-by: baude <bbaude@redhat.com>