### PR TITLE
Ignore containers.conf sysctl when namespaces set to host

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -448,7 +448,7 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 
 	createFlags.StringSliceVar(
 		&cf.Sysctl,
-		"sysctl", containerConfig.Sysctls(),
+		"sysctl", []string{},
 		"Sysctl options",
 	)
 	createFlags.StringVar(

--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -179,6 +179,12 @@ var _ = Describe("Podman run", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("1000"))
+
+		// Ignore containers.conf setting if --net=host
+		session = podmanTest.Podman([]string{"run", "--rm", "--net", "host", fedoraMinimal, "cat", "/proc/sys/net/ipv4/ping_group_range"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).ToNot((ContainSubstring("1000")))
 	})
 
 	It("podman run containers.conf search domain", func() {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -373,6 +373,11 @@ USER bin`
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("net.core.somaxconn = 65535"))
+
+		// network sysctls should fail if --net=host is set
+		session = podmanTest.Podman([]string{"run", "--net", "host", "--rm", "--sysctl", "net.core.somaxconn=65535", ALPINE, "sysctl", "net.core.somaxconn"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
 	})
 
 	It("podman run blkio-weight test", func() {


### PR DESCRIPTION
If user sets namespace to host, then default sysctls need to be ignored
that are specific to that namespace.

--net=host ignore sysctls that begin with net.
--ipc=host ignore fs.mqueue
--uts=host ignore kernel.domainname and kernel.hostname

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>