### PR TITLE
capabilities: always set ambient and inheritable

### DIFF
--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -131,12 +131,13 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 	}
 
 	configSpec := g.Config
+	configSpec.Process.Capabilities.Ambient = []string{}
 	configSpec.Process.Capabilities.Bounding = caplist
+	configSpec.Process.Capabilities.Inheritable = caplist
 
 	if s.User == "" || s.User == "root" || s.User == "0" {
 		configSpec.Process.Capabilities.Effective = caplist
 		configSpec.Process.Capabilities.Permitted = caplist
-		configSpec.Process.Capabilities.Inheritable = caplist
 	} else {
 		userCaps, err := capabilities.NormalizeCapabilities(s.CapAdd)
 		if err != nil {

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -269,11 +269,11 @@ var _ = Describe("Podman cp", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"exec", "-u", "testuser", "testctr", "touch", "testfile"})
+		session = podmanTest.Podman([]string{"exec", "-u", "testuser", "testctr", "touch", "/tmp/testfile"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"cp", "--pause=false", "testctr:testfile", "testfile1"})
+		session = podmanTest.Podman([]string{"cp", "--pause=false", "testctr:/tmp/testfile", "testfile1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -304,7 +304,7 @@ echo $rand        |   0 | $rand
 
 # #6991 : /etc/passwd is modifiable
 @test "podman run : --userns=keep-id: passwd file is modifiable" {
-    run_podman run -d --userns=keep-id $IMAGE sh -c 'while ! test -e /stop; do sleep 0.1; done'
+    run_podman run -d --userns=keep-id --cap-add=dac_override $IMAGE sh -c 'while ! test -e /tmp/stop; do sleep 0.1; done'
     cid="$output"
 
     # Assign a UID that is (a) not in our image /etc/passwd and (b) not
@@ -325,7 +325,7 @@ echo $rand        |   0 | $rand
     is "$output" "newuser3:x:$uid:999:$gecos:/home/newuser3:/bin/sh" \
        "newuser3 added to /etc/passwd in container"
 
-    run_podman exec $cid touch /stop
+    run_podman exec $cid touch /tmp/stop
     run_podman wait $cid
 }
 

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -92,14 +92,14 @@ load helpers
 # #6829 : add username to /etc/passwd inside container if --userns=keep-id
 @test "podman exec - with keep-id" {
     run_podman run -d --userns=keep-id $IMAGE sh -c \
-               "echo READY;while [ ! -f /stop ]; do sleep 1; done"
+               "echo READY;while [ ! -f /tmp/stop ]; do sleep 1; done"
     cid="$output"
     wait_for_ready $cid
 
     run_podman exec $cid id -un
     is "$output" "$(id -un)" "container is running as current user"
 
-    run_podman exec --user=$(id -un) $cid touch /stop
+    run_podman exec --user=$(id -un) $cid touch /tmp/stop
     run_podman wait $cid
     run_podman rm $cid
 }


### PR DESCRIPTION
change capabilities handling to reflect what docker does.

Bounding: set to caplist
Inheritable: set to caplist
Effective: if uid != 0 then clear; else set to caplist
Permitted: if uid != 0 then clear; else set to caplist
Ambient: clear

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>