### PR TITLE
image look up: consult registries.conf

### DIFF
--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -1,5 +1,10 @@
 package registries
 
+// TODO: this package should not exist anymore.  Users should either use
+// c/image's `sysregistriesv2` package directly OR, even better, we cache a
+// config in libpod's image runtime so we don't need to parse the
+// registries.conf files redundantly.
+
 import (
 	"os"
 	"path/filepath"

--- a/test/registries.conf
+++ b/test/registries.conf
@@ -1,3 +1,4 @@
+# Note that changing the order here may break tests.
 [registries.search]
 registries = ['docker.io', 'quay.io', 'registry.fedoraproject.org']
 


### PR DESCRIPTION
When looking up local images, take the unqualified-serach registries of
the registries.conf into account (on top of "localhost/").

Also extend the integration tests to prevent future regressions.

Fixes: #6381
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>