### PR TITLE
DO NOT MERGE! Revert "Properly handle podman run --pull command"

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -363,7 +363,7 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 	)
 	createFlags.StringVar(
 		&cf.Pull,
-		"pull", containerConfig.Engine.PullPolicy,
+		"pull", "missing",
 		`Pull image before creating ("always"|"missing"|"never")`,
 	)
 	createFlags.BoolVarP(

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -261,7 +261,6 @@ func pullImage(imageName string) (string, error) {
 			OverrideOS:      cliVals.OverrideOS,
 			OverrideVariant: cliVals.OverrideVariant,
 			SignaturePolicy: cliVals.SignaturePolicy,
-			PullPolicy:      pullPolicy,
 		})
 		if pullErr != nil {
 			return "", pullErr

--- a/libpod/image/utils.go
+++ b/libpod/image/utils.go
@@ -33,7 +33,7 @@ func findImageInRepotags(search imageParts, images []*Image) (*storage.Image, er
 				continue
 			}
 			// account for registry:/somedir/image
-			if strings.HasSuffix(dName, "/"+searchName) && dSuspiciousTagValueForSearch == searchSuspiciousTagValueForSearch {
+			if strings.HasSuffix(dName, searchName) && dSuspiciousTagValueForSearch == searchSuspiciousTagValueForSearch {
 				results = append(results, image.image)
 				continue
 			}

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/containers/buildah"
-	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/podman/v2/libpod"
 	image2 "github.com/containers/podman/v2/libpod/image"
@@ -18,6 +17,7 @@ import (
 	"github.com/containers/podman/v2/pkg/api/handlers/utils"
 	"github.com/containers/podman/v2/pkg/auth"
 	"github.com/containers/podman/v2/pkg/domain/entities"
+	"github.com/containers/podman/v2/pkg/util"
 	"github.com/docker/docker/api/types"
 	"github.com/gorilla/schema"
 	"github.com/pkg/errors"
@@ -268,16 +268,6 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 	if sys := runtime.SystemContext(); sys != nil {
 		registryOpts.DockerCertPath = sys.DockerCertPath
 	}
-	rtc, err := runtime.GetConfig()
-	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
-		return
-	}
-	pullPolicy, err := config.ValidatePullPolicy(rtc.Engine.PullPolicy)
-	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
-		return
-	}
 	img, err := runtime.ImageRuntime().New(r.Context(),
 		fromImage,
 		"", // signature policy
@@ -286,7 +276,7 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 		&registryOpts,
 		image2.SigningOptions{},
 		nil, // label
-		pullPolicy,
+		util.PullImageMissing,
 	)
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -3,7 +3,6 @@ package entities
 import (
 	"time"
 
-	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v2/pkg/inspect"
@@ -120,8 +119,8 @@ type ImageHistoryReport struct {
 
 // ImagePullOptions are the arguments for pulling images.
 type ImagePullOptions struct {
-	// AllTags can be specified to pull all tags of an image. Note
-	// that this only works if the image does not include a tag.
+	// AllTags can be specified to pull all tags of the spiecifed image. Note
+	// that this only works if the specified image does not include a tag.
 	AllTags bool
 	// Authfile is the path to the authentication file. Ignored for remote
 	// calls.
@@ -147,8 +146,6 @@ type ImagePullOptions struct {
 	SignaturePolicy string
 	// SkipTLSVerify to skip HTTPS and certificate verification.
 	SkipTLSVerify types.OptionalBool
-	// PullPolicy whether to pull new image
-	PullPolicy config.PullPolicy
 }
 
 // ImagePullReport is the response from pulling one or more images.

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -255,7 +255,7 @@ func pull(ctx context.Context, runtime *image.Runtime, rawImage string, options 
 	}
 
 	if !options.AllTags {
-		newImage, err := runtime.New(ctx, rawImage, options.SignaturePolicy, options.Authfile, writer, &dockerRegistryOptions, image.SigningOptions{}, label, options.PullPolicy)
+		newImage, err := runtime.New(ctx, rawImage, options.SignaturePolicy, options.Authfile, writer, &dockerRegistryOptions, image.SigningOptions{}, label, util.PullImageAlways)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
DO NOT MERGE! This is a dummy PR for the sole purpose of
running CI tests.

I really need to understand why my system tests did not catch
the "podman run --pull" problem addressed by #7770. So this
commit leaves the new tests in place, but reverts the code
changes. That should make these tests fail, and I will be
better able to understand why my tests failed to catch it.

I thought I had ginkgo working on my laptop, but running:

   ginkgo -trace -debug -r -focus 'with --pull' test/e2e

...only yields success. I suspect there's something deeper
going on here but can only find out by running the full CI
test suite. Sorry to be wasting cycles.

This reverts commit 1b5853e64794403d80c4d339c97b61dd63dd093a.

Signed-off-by: Ed Santiago <santiago@redhat.com>