### PR TITLE
healthchecks: return systemd-run error

### DIFF
--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -35,9 +35,8 @@ func (c *Container) createTimer() error {
 	conn.Close()
 	logrus.Debugf("creating systemd-transient files: %s %s", "systemd-run", cmd)
 	systemdRun := exec.Command("systemd-run", cmd...)
-	_, err = systemdRun.CombinedOutput()
-	if err != nil {
-		return err
+	if output, err := systemdRun.CombinedOutput(); err != nil {
+		return errors.Errorf("%s", output)
 	}
 	return nil
 }


### PR DESCRIPTION
In case `systemd-run` errors when creating transient unit files (and
timers), create an error based on the combined output from stdout and
stderr.  Using the error from `exec.Command` contains the exit code
only which is not useful to debug (see #7484).

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>