### PR TITLE
Don't disable Go modules when generating varlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -643,7 +643,7 @@ install.libseccomp.sudo:
 pkg/varlink/iopodman.go: .gopathok pkg/varlink/io.podman.varlink
 ifneq (,$(findstring Linux,$(shell uname -s)))
 	# Only generate the varlink code on Linux (see issue #4814).
-	GO111MODULE=off $(GO) generate ./pkg/varlink/...
+	$(GO) generate ./pkg/varlink/...
 endif
 
 API.md: pkg/varlink/io.podman.varlink


### PR DESCRIPTION
From a fresh install of Fedora 33 Beta and a fresh clone of the repo, `make` fails with the following error when Go modules are disabled:

    # Only generate the varlink code on Linux (see issue #4814).
    GO111MODULE=off go generate ./pkg/varlink/...
    ../../vendor/github.com/varlink/go/cmd/varlink-go-interface-generator/main.go:12:2: cannot find package "github.com/varlink/go/varlink/idl" in any of:
    	/usr/lib/golang/src/github.com/varlink/go/varlink/idl (from $GOROOT)
    	/home/test/src/podman/_output/src/github.com/varlink/go/varlink/idl (from $GOPATH)
    pkg/varlink/generate.go:3: running "go": exit status 1
    make: *** [Makefile:646: pkg/varlink/iopodman.go] Error 1