### PR TITLE
fix remote untag

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -1175,7 +1175,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images
 	// summary: Untag an image
-	// description: Untag an image
+	// description: Untag an image. If not repo and tag are specified, all tags are removed from the image.
 	// parameters:
 	//  - in: path
 	//    name: name:.*

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/docker/reference"
-	"github.com/containers/podman/v2/pkg/bindings"
 	images "github.com/containers/podman/v2/pkg/bindings/images"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/domain/utils"
@@ -139,13 +138,8 @@ func (ir *ImageEngine) Tag(ctx context.Context, nameOrID string, tags []string, 
 }
 
 func (ir *ImageEngine) Untag(ctx context.Context, nameOrID string, tags []string, options entities.ImageUntagOptions) error {
-	// Remove all tags if none are provided
 	if len(tags) == 0 {
-		newImage, err := images.GetImage(ir.ClientCxt, nameOrID, bindings.PFalse)
-		if err != nil {
-			return err
-		}
-		tags = newImage.NamesHistory
+		return images.Untag(ir.ClientCxt, nameOrID, "", "")
 	}
 
 	for _, newTag := range tags {

--- a/test/e2e/untag_test.go
+++ b/test/e2e/untag_test.go
@@ -33,7 +33,6 @@ var _ = Describe("Podman untag", func() {
 	})
 
 	It("podman untag all", func() {
-		SkipIfRemote("FIXME This should work on podman-remote")
 		setup := podmanTest.PodmanNoCache([]string{"pull", ALPINE})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))


### PR DESCRIPTION
Fix the remote client to untag all tags of the specified image.
Instead of querying the image on the client side, support the
case where both, repo and tag, are empty and remove all tags.

Reuse the ABI implementation where possible.  In retrospective,
the libpod untag endpoint should support a slice of strings to
batch remove tags rather than reaching out for each tag individually.

Enable the skipped test.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>