### PR TITLE
Make the e2e test network cleanup more robust.

### DIFF
--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -58,7 +58,7 @@ func genericPluginsToPortMap(plugins interface{}, pluginType string) (network.Po
 func (p *PodmanTestIntegration) removeCNINetwork(name string) {
 	session := p.Podman([]string{"network", "rm", "-f", name})
 	session.WaitWithDefaultTimeout()
-	Expect(session.ExitCode()).To(BeZero())
+	Expect(session.ExitCode()).To(BeNumerically("<=", 1))
 }
 
 func removeNetworkDevice(name string) {

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -135,7 +135,6 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network rm", func() {
-		SkipIfRootless("FIXME: This one is definitely broken in rootless mode")
 		// Setup, use uuid to prevent conflict with other tests
 		uuid := stringid.GenerateNonCryptoID()
 		secondPath := filepath.Join(podmanTest.CNIConfigDir, fmt.Sprintf("%s.conflist", uuid))
@@ -276,6 +275,7 @@ var _ = Describe("Podman network", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
 
 		session = podmanTest.Podman([]string{"pod", "create", "--network", netName})
 		session.WaitWithDefaultTimeout()
@@ -311,11 +311,13 @@ var _ = Describe("Podman network", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName1)
 
 		netName2 := "net2"
 		session = podmanTest.Podman([]string{"network", "create", netName2})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName2)
 
 		session = podmanTest.Podman([]string{"network", "rm", netName1, netName2})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
We need to handle removal of non existing network.

This allows the `removeCNINetwork` function
always to be called. This is needed by tests which are trying
to remove the network manually in order to prevent flakes.

Fixes #7809

Signed-off-by: Paul Holzinger <paul.holzinger@web.de>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>