### PR TITLE
[WIP]use imagecache when building images

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -37,7 +37,7 @@ var (
 	INTEGRATION_ROOT   string
 	CGROUP_MANAGER     = "systemd"
 	ARTIFACT_DIR       = "/tmp/.artifacts"
-	RESTORE_IMAGES     = []string{ALPINE, BB, nginx}
+	RESTORE_IMAGES     = []string{ALPINE, BB, nginx, fedoraMinimal}
 	defaultWaitTimeout = 90
 	CGROUPSV2, _       = cgroups.IsCgroup2UnifiedMode()
 )
@@ -424,7 +424,7 @@ func (p *PodmanTestIntegration) BuildImage(dockerfile, imageName string, layers 
 	dockerfilePath := filepath.Join(p.TempDir, "Dockerfile")
 	err := ioutil.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
 	Expect(err).To(BeNil())
-	session := p.PodmanNoCache([]string{"build", "--layers=" + layers, "-t", imageName, "--file", dockerfilePath, p.TempDir})
+	session := p.Podman([]string{"build", "--layers=" + layers, "-t", imageName, "--file", dockerfilePath, p.TempDir})
 	session.Wait(120)
 	Expect(session).Should(Exit(0), fmt.Sprintf("BuildImage session output: %q", session.OutputToString()))
 }

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -206,39 +206,40 @@ var _ = Describe("Podman rmi", func() {
 		`
 		podmanTest.BuildImage(dockerfile, "test2", "true")
 
-		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
+		session = podmanTest.Podman([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		numOfImages := len(session.OutputToStringArray())
 
-		session = podmanTest.PodmanNoCache([]string{"rmi", "test2"})
+		session = podmanTest.Podman([]string{"rmi", "test2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
+		session = podmanTest.Podman([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(numOfImages - len(session.OutputToStringArray())).To(Equal(2))
 
-		session = podmanTest.PodmanNoCache([]string{"rmi", "test"})
+		session = podmanTest.Podman([]string{"rmi", "test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
+		// NoCache is used here because we are counting the number of images
+		// in the main store.
+		session = podmanTest.PodmanNoCache([]string{"images", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
+		fmt.Println(session.OutputToString())
 		Expect(len(session.OutputToStringArray())).To(Equal(1))
 
 		podmanTest.BuildImage(dockerfile, "test3", "true")
 
-		session = podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
+		session = podmanTest.Podman([]string{"rmi", "test3"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.PodmanNoCache([]string{"rmi", "test3"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-
+		// NoCache is used here because we are counting the number of images
+		// in the main store.
 		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -53,10 +53,6 @@ var _ = Describe("podman container runlabel", func() {
 		result := podmanTest.Podman([]string{"container", "runlabel", "RUN", image})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
-
-		result = podmanTest.Podman([]string{"rmi", image})
-		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(0))
 	})
 
 	It("podman container runlabel (ls -la)", func() {
@@ -64,10 +60,6 @@ var _ = Describe("podman container runlabel", func() {
 		podmanTest.BuildImage(LsDockerfile, image, "false")
 
 		result := podmanTest.Podman([]string{"container", "runlabel", "RUN", image})
-		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(0))
-
-		result = podmanTest.Podman([]string{"rmi", image})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 	})
@@ -79,10 +71,6 @@ var _ = Describe("podman container runlabel", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(result.OutputToString()).To(ContainSubstring(podmanTest.PodmanBinary + " -la"))
-
-		result = podmanTest.Podman([]string{"rmi", image})
-		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(0))
 	})
 	It("podman container runlabel bogus label should result in non-zero exit code", func() {
 		result := podmanTest.Podman([]string{"container", "runlabel", "RUN", ALPINE})
@@ -122,9 +110,5 @@ var _ = Describe("podman container runlabel", func() {
 		result := podmanTest.Podman([]string{"container", "runlabel", "--authfile", "/tmp/nonexist", "RUN", image})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Not(Equal(0)))
-
-		result = podmanTest.Podman([]string{"rmi", image})
-		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(0))
 	})
 })


### PR DESCRIPTION
in the integration tests, podmanNoCache is being used which means that we will pull all images needed for build.  this is not necessary and adds time to the intergration tests.

Signed-off-by: baude <bbaude@redhat.com>