### PR TITLE
Add support for resource limits to play kube

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -612,6 +612,15 @@ func SkipIfRootlessCgroupsV1(reason string) {
 	}
 }
 
+func SkipIfUnprevilegedCPULimits() {
+	info := GetHostDistributionInfo()
+	if isRootless() &&
+		info.Distribution == "fedora" &&
+		(info.Version == "31" || info.Version == "32") {
+		ginkgo.Skip("Rootless Fedora doesn't have permission to set CPU limits before version 33")
+	}
+}
+
 func SkipIfRootless(reason string) {
 	checkReason(reason)
 	if os.Geteuid() != 0 {


### PR DESCRIPTION
Notes:

* MemoryReservation seems like a rough equivalent to requests.memory.
* I don't know of any equivalent to requests.cpu. I'm not sure if this makes sense in a single-node cluster anyway.