### PR TITLE
Makefile: Fix condition for varlink_generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -620,7 +620,7 @@ endef
 
 # $BUILD_TAGS variable is used in hack/golangci-lint.sh
 .PHONY: varlink_generate
-ifneq (or $(findstring varlink,$(BUILDTAGS)),$(findstring varlink,$(BUILD_TAGS)))
+ifneq (,$(or $(findstring varlink,$(BUILDTAGS)),$(findstring varlink,$(BUILD_TAGS))))
 varlink_generate: .gopathok pkg/varlink/iopodman.go ## Generate varlink
 else
 varlink_generate:


### PR DESCRIPTION
This should fix the call to the `or` function. Previously the condition
always evaluated to the empty string independed of the BULILDTAGS.
So `go generate varlink` was allways called.

Signed-off-by: Ralf Haferkamp <rhafer@suse.com>