### PR TITLE
podman-remote does not support most of the global flags

### DIFF
--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -160,6 +160,14 @@ Print the version
 
 Podman can set up environment variables from env of [engine] table in containers.conf. These variables can be overridden by passing  environment variables before the `podman` commands.
 
+## Remote Access
+
+The Podman command can be used with remote services using the `--remote` flag. Connections can
+be made using local unix domain sockets, ssh or directly to tcp sockets. When specifying the
+podman --remote flag, only the global options `--url`, `--identity`, `--log-level`, `--connection` are used.
+
+Connection information can also be managed using the containers.conf file.
+
 ## Exit Status
 
 The exit code from `podman` gives information about why the container

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -61,7 +61,7 @@ function setup() {
     is "$output" ".*Server:" "podman --remote: contacts server"
 
     # This was failing: "podman --foo --bar --remote".
-    PODMAN="${podman_non_remote} --tmpdir /var/tmp --log-level=error ${podman_args[@]} --remote" run_podman version
+    PODMAN="${podman_non_remote} --log-level=error ${podman_args[@]} --remote" run_podman version
     is "$output" ".*Server:" "podman [flags] --remote: contacts server"
 
     # ...but no matter what, --remote is never allowed after subcommand


### PR DESCRIPTION
podman-remote --help is showing a bunch of global flags that it
does not support

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>