### PR TITLE
Support --http-proxy for remote builds

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -70,37 +70,38 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	query := struct {
-		Dockerfile  string   `schema:"dockerfile"`
-		Tag         []string `schema:"t"`
-		ExtraHosts  string   `schema:"extrahosts"`
-		Remote      string   `schema:"remote"`
-		Quiet       bool     `schema:"q"`
-		NoCache     bool     `schema:"nocache"`
+		BuildArgs   string   `schema:"buildargs"`
 		CacheFrom   string   `schema:"cachefrom"`
-		Pull        bool     `schema:"pull"`
-		Rm          bool     `schema:"rm"`
-		ForceRm     bool     `schema:"forcerm"`
-		Memory      int64    `schema:"memory"`
-		MemSwap     int64    `schema:"memswap"`
-		CpuShares   uint64   `schema:"cpushares"`  // nolint
-		CpuSetCpus  string   `schema:"cpusetcpus"` // nolint
 		CpuPeriod   uint64   `schema:"cpuperiod"`  // nolint
 		CpuQuota    int64    `schema:"cpuquota"`   // nolint
-		BuildArgs   string   `schema:"buildargs"`
+		CpuSetCpus  string   `schema:"cpusetcpus"` // nolint
+		CpuShares   uint64   `schema:"cpushares"`  // nolint
+		Dockerfile  string   `schema:"dockerfile"`
+		ExtraHosts  string   `schema:"extrahosts"`
+		ForceRm     bool     `schema:"forcerm"`
+		HTTPProxy   bool     `schema:"httpproxy"`
+		Labels      string   `schema:"labels"`
+		MemSwap     int64    `schema:"memswap"`
+		Memory      int64    `schema:"memory"`
+		NetworkMode string   `schema:"networkmode"`
+		NoCache     bool     `schema:"nocache"`
+		Outputs     string   `schema:"outputs"`
+		Platform    string   `schema:"platform"`
+		Pull        bool     `schema:"pull"`
+		Quiet       bool     `schema:"q"`
+		Registry    string   `schema:"registry"`
+		Remote      string   `schema:"remote"`
+		Rm          bool     `schema:"rm"`
 		ShmSize     int      `schema:"shmsize"`
 		Squash      bool     `schema:"squash"`
-		Labels      string   `schema:"labels"`
-		NetworkMode string   `schema:"networkmode"`
-		Platform    string   `schema:"platform"`
+		Tag         []string `schema:"t"`
 		Target      string   `schema:"target"`
-		Outputs     string   `schema:"outputs"`
-		Registry    string   `schema:"registry"`
 	}{
 		Dockerfile: "Dockerfile",
-		Tag:        []string{},
+		Registry:   "docker.io",
 		Rm:         true,
 		ShmSize:    64 * 1024 * 1024,
-		Registry:   "docker.io",
+		Tag:        []string{},
 	}
 
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
@@ -184,6 +185,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			CPUQuota:   query.CpuQuota,
 			CPUShares:  query.CpuShares,
 			CPUSetCPUs: query.CpuSetCpus,
+			HTTPProxy:  query.HTTPProxy,
 			Memory:     query.Memory,
 			MemorySwap: query.MemSwap,
 			ShmSize:    strconv.Itoa(query.ShmSize),

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -1423,6 +1423,13 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    description: |
 	//      output configuration TBD
 	//      (As of version 1.xx)
+	//  - in: query
+	//    name: httpproxy
+	//    type: boolean
+	//    default:
+	//    description: |
+	//      Inject http proxy environment variables into container
+	//      (As of version 2.0.0)
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -60,7 +60,7 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		params.Set("cpushares", strconv.Itoa(int(cpuShares)))
 	}
 	if cpuSetCpus := options.CommonBuildOpts.CPUSetCPUs; len(cpuSetCpus) > 0 {
-		params.Set("cpusetcpues", cpuSetCpus)
+		params.Set("cpusetcpus", cpuSetCpus)
 	}
 	if cpuPeriod := options.CommonBuildOpts.CPUPeriod; cpuPeriod > 0 {
 		params.Set("cpuperiod", strconv.Itoa(int(cpuPeriod)))
@@ -91,6 +91,9 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 			return nil, err
 		}
 		params.Set("labels", l)
+	}
+	if options.CommonBuildOpts.HTTPProxy {
+		params.Set("httpproxy", "1")
 	}
 
 	stdout := io.Writer(os.Stdout)


### PR DESCRIPTION
 * Fix misspelled parameter
 * Add http-proxy support for builds
 * Sorted fields in query struct to aid in visual scan of fields

http_proxy must be set in the podman.service unit file, for example
Environment=http_proxy=<value>

Signed-off-by: Jhon Honce <jhonce@redhat.com>