### PR TITLE
Volume prune should not pass down the force flag

### DIFF
--- a/cmd/podman/volumes/prune.go
+++ b/cmd/podman/volumes/prune.go
@@ -29,10 +29,6 @@ var (
 	}
 )
 
-var (
-	pruneOptions entities.VolumePruneOptions
-)
-
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
@@ -40,12 +36,16 @@ func init() {
 		Parent:  volumeCmd,
 	})
 	flags := pruneCommand.Flags()
-	flags.BoolVarP(&pruneOptions.Force, "force", "f", false, "Do not prompt for confirmation")
+	flags.BoolP("force", "f", false, "Do not prompt for confirmation")
 }
 
 func prune(cmd *cobra.Command, args []string) error {
 	// Prompt for confirmation if --force is not set
-	if !pruneOptions.Force {
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return err
+	}
+	if !force {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Println("WARNING! This will remove all volumes not used by at least one container.")
 		fmt.Print("Are you sure you want to continue? [y/N] ")
@@ -57,7 +57,7 @@ func prune(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 	}
-	responses, err := registry.ContainerEngine().VolumePrune(context.Background(), pruneOptions)
+	responses, err := registry.ContainerEngine().VolumePrune(context.Background())
 	if err != nil {
 		return err
 	}

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -78,6 +78,6 @@ type ContainerEngine interface {
 	VolumeCreate(ctx context.Context, opts VolumeCreateOptions) (*IDOrNameResponse, error)
 	VolumeInspect(ctx context.Context, namesOrIds []string, opts VolumeInspectOptions) ([]*VolumeInspectReport, error)
 	VolumeList(ctx context.Context, opts VolumeListOptions) ([]*VolumeListReport, error)
-	VolumePrune(ctx context.Context, opts VolumePruneOptions) ([]*VolumePruneReport, error)
+	VolumePrune(ctx context.Context) ([]*VolumePruneReport, error)
 	VolumeRm(ctx context.Context, namesOrIds []string, opts VolumeRmOptions) ([]*VolumeRmReport, error)
 }

--- a/pkg/domain/entities/volumes.go
+++ b/pkg/domain/entities/volumes.go
@@ -113,10 +113,6 @@ type VolumeInspectReport struct {
 	*VolumeConfigResponse
 }
 
-type VolumePruneOptions struct {
-	Force bool
-}
-
 type VolumePruneReport struct {
 	Err error
 	Id  string //nolint

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -120,7 +120,7 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 	return reports, nil
 }
 
-func (ic *ContainerEngine) VolumePrune(ctx context.Context, opts entities.VolumePruneOptions) ([]*entities.VolumePruneReport, error) {
+func (ic *ContainerEngine) VolumePrune(ctx context.Context) ([]*entities.VolumePruneReport, error) {
 	return ic.pruneVolumesHelper(ctx)
 }
 

--- a/pkg/domain/infra/tunnel/volumes.go
+++ b/pkg/domain/infra/tunnel/volumes.go
@@ -56,7 +56,7 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 	return reports, nil
 }
 
-func (ic *ContainerEngine) VolumePrune(ctx context.Context, opts entities.VolumePruneOptions) ([]*entities.VolumePruneReport, error) {
+func (ic *ContainerEngine) VolumePrune(ctx context.Context) ([]*entities.VolumePruneReport, error) {
 	return volumes.Prune(ic.ClientCxt)
 }
 


### PR DESCRIPTION
podman volume prune -f

Should just tell the prune command to not prompt for confirmation.
It should not be passing the prune flag into the API.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>