### PR TITLE
[CI:DOCS] Update rootless_tutorial.md

### DIFF
--- a/docs/tutorials/rootless_tutorial.md
+++ b/docs/tutorials/rootless_tutorial.md
@@ -95,7 +95,7 @@ If this is required, the administrator must verify that the UID of the user is p
 
 To change its value the administrator can use a call similar to: `sysctl -w "net.ipv4.ping_group_range=0 2000000"`.
 
-To make the change persistent, the administrator will need to add a file in `/etc/sysctl.d` that contains `net.ipv4.ping_group_range=0 $MAX_UID`.
+To make the change persist, the administrator will need to add a file with the `.conf` file extension in `/etc/sysctl.d` that contains `net.ipv4.ping_group_range=0 $MAX_GID`, where `$MAX_GID` is the highest assignable GID of the user running the container.
 
 
 ## User Actions


### PR DESCRIPTION
add clarifications in persistently setting unprivileged ping permissions
Signed-off-by: fuzxi <opuspam@posteo.de>

Replaces: https://github.com/containers/podman/pull/7500

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>