### PR TITLE
Add additionalGIDs from users in rootless mode

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -415,8 +415,9 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 	}
 
 	// Look up and add groups the user belongs to, if a group wasn't directly specified
-	if !rootless.IsRootless() && !strings.Contains(c.config.User, ":") {
+	if !strings.Contains(c.config.User, ":") {
 		for _, gid := range execUser.Sgids {
+			// FIXME: We need to add a flag to containers.conf to not add these for HPC Users.
 			g.AddProcessAdditionalGid(uint32(gid))
 		}
 	}


### PR DESCRIPTION
There is a risk here, that if the GID does not exists
within the User Namespace the container will fail to start.

This is only likely to happen in HPC Envioronments, and I think
we should add a field to disable it for this environment,
Added a FIXME for this issue.

We currently have this problem with running a rootfull container within
a user namespace, it will fail if the GID is not available.

I looked at potentially checking the usernamespace that you are assigned
to, but I believe this will be very difficult to code up and to figure out.

Fixes https://github.com/containers/podman/issues/7782

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>