### PR TITLE
logformatter: add Synopsis at top of each page

### DIFF
--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -31,6 +31,12 @@ our $CSS = <<'END_CSS';
 /* wrap long lines - don't require user to scroll right */
 pre        { line-break: normal; overflow-wrap: normal; white-space: pre-wrap; }
 
+/* synopsis table at top */
+table.synopsis { border: none; border-collapse: collapse; margin-left: 2em; margin-top: 2ex; }
+.synopsis th   { font-weight: normal; font-size: 110%; text-align: right; }
+.synopsis td   { font-weight: bold;   font-size: 120%; font-family: monospace; }
+
+/* test results */
 .boring    { color: #999; }
 .timestamp { color: #999; }
 .log-debug { color: #999; }
@@ -171,8 +177,19 @@ window.addEventListener("load", scrollToBottom, false);
 </script>
 </head>
 <body>
-<pre> <!-- begin processed output -->
 END_HTML
+
+    # Synopsis of this job: show job environment, links to PR and Cirrus
+    print { $out_fh } "<h2>Synopsis</h2>\n<hr/>\n",
+        job_synopsis($test_name), "<hr/>\n";
+
+    # FOR DEBUGGING: dump environment, but in HTML comments to not clutter
+    print { $out_fh } "<!-- Environment: -->\n";
+    for my $e (sort keys %ENV) {
+        my $val = escapeHTML($ENV{$e});
+        $val =~ s/--/-&#x002D;/g;       # double dash not valid in comments
+        printf { $out_fh } "<!--  %-20s %s -->\n", $e, $val;
+    }
 
     # State variables
     my $previous_timestamp = '';  # timestamp of previous line
@@ -184,6 +201,8 @@ END_HTML
     my $current_output;           # for removing duplication
     my $looks_like_bats;          # binary flag: for detecting BATS results
     my %bats_count;               # For summary line: count of pass/fail/skip
+
+    print { $out_fh } "<pre> <!-- begin processed output -->\n";
 
     # Main loop: read input, one line at a time, and write out reformatted
   LINE:
@@ -232,8 +251,9 @@ END_HTML
             my $css;
 
             # Readability: /long/path/to/podman -> podman (hover for full path)
-            $line =~ s{^(#\s+(#|\$)\s+)(\S+/)(podman\S*)\s}
-                      {$1<span title="$3$4">$4</span> };
+            # Also make it boldface, to make commands stand out
+            $line =~ s{^(#\s+(#|\$)\s+)(\S+/)(podman\S*)(\s.*)}
+                      {$1<b><span title="$3$4">$4</span>$5</b>};
 
             if    ($line =~ /^ok\s.*\s# skip/) { $css = 'skipped' }
             elsif ($line =~ /^ok\s/)           { $css = 'passed'  }
@@ -470,6 +490,83 @@ sub make_id {
 }
 
 
+###############################################################################
+# BEGIN job_synopsis and related helpers
+
+##################
+#  job_synopsis  #  Job details, links to github/cirrus
+##################
+sub job_synopsis {
+    my $subtest_name = shift;           # e.g. integration_test
+
+    my $s = <<"END_SYNOPSIS";
+<table class="synopsis">
+END_SYNOPSIS
+
+    # PR 1234 - title of the pr
+    my $pr_title = escapeHTML(_env_replace("{CIRRUS_CHANGE_TITLE}"));
+    $s .= _tr("Github PR", sprintf("%s - %s",
+                                   _a("{CIRRUS_PR}", "https://{CIRRUS_REPO_CLONE_HOST}/{CIRRUS_REPO_FULL_NAME}/pull/{CIRRUS_PR}"),
+                                   $pr_title));
+
+    # PR author, if signed-off-by
+    if (my $msg = _env_replace("{CIRRUS_COMMIT_MESSAGE}")) {
+        while ($msg =~ /^Signed-off-by:\s+(\S.*\S)$/gmi) {
+            $s .= _tr("Author", escapeHTML($1));
+        }
+    }
+
+    # eg "test fedora", "special_testing_rootless"
+    my $test_name = _env_replace("{CIRRUS_TASK_NAME}");
+    if (my $rcli = $ENV{RCLI}) {
+        $test_name .= " [remote]" if $rcli eq 'true';
+    }
+    else {
+        $test_name .= " [no RCLI; cannot determine remote/local]";
+    }
+    $s .= _tr("Test name", $test_name);
+
+    # Subtest, e.g. system_test
+    $s .= _tr("Subtest", $subtest_name);
+
+    # Link to further Cirrus results, e.g. other runs.
+    # Build is mostly boring, it's usually TASK that we want to see.
+    $s .= _tr("Cirrus Build ID", "<small>" . _a("{CIRRUS_BUILD_ID}", "https://cirrus-ci.com/build/{CIRRUS_BUILD_ID}") . "</small>");
+    $s .= _tr("Cirrus <b>Task</b> ID", _a("{CIRRUS_TASK_ID}", "https://cirrus-ci.com/task/{CIRRUS_TASK_ID}"));
+
+    # "none", "rootless"
+    $s .= _tr("Special mode", _env_replace("{SPECIALMODE}"));
+
+    $s .= "</table>\n";
+    return $s;
+}
+
+
+sub _tr {
+    my ($th, $td) = @_;
+    return "<tr><th>$th:</th><td>$td</td></tr>\n";
+}
+
+sub _a {
+    my ($name, $href) = map { _env_replace($_) } @_;
+
+    if ($href =~ /UNDEFINED/) {
+        return "$name ($href)";
+    }
+    return "<a href='$href'>$name</a>";
+}
+
+sub _env_replace {
+    my $s_in = shift;
+
+    $s_in =~ s[\{(.*?)\}][$ENV{$1} || "[$1 UNDEFINED]"]ge;
+
+    return $s_in;
+}
+
+# END   job_synopsis and related helpers
+###############################################################################
+# BEGIN html-formatting helpers
 
 sub escapeHTML {
     my $s = shift;
@@ -492,5 +589,7 @@ sub unescapeHTML {
     return $s;
 }
 
+# END   html-formatting helpers
+###############################################################################
 
 1;

--- a/contrib/cirrus/logformatter.t
+++ b/contrib/cirrus/logformatter.t
@@ -96,7 +96,7 @@ ok 4 blah
 <span class='bats-passed'><a name='t--00001'>ok 1 hi</a></span>
 <span class='bats-skipped'><a name='t--00002'>ok 2 bye # skip no reason</a></span>
 <span class='bats-failed'><a name='t--00003'>not ok 3 fail</a></span>
-<span class='bats-log'># $ <span title="/path/to/podman">podman</span> foo -bar</span>
+<span class='bats-log'># $ <b><span title="/path/to/podman">podman</span> foo -bar</b></span>
 <span class='bats-log-esm'># #| FAIL: exit code is 123; expected 321</span>
 <span class='bats-passed'><a name='t--00004'>ok 4 blah</a></span>
 <hr/><span class='bats-summary'>Summary: <span class='bats-passed'>2 Passed</span>, <span class='bats-failed'>1 Failed</span>, <span class='bats-skipped'>1 Skipped</span>. Total tests: 4</span>
@@ -147,11 +147,11 @@ $SCRIPT_BASE/integration_test.sh |&amp; ${TIMESTAMP}
 <pre>
 <span class="timestamp">[+0103s] </span>Podman pod restart
 <span class="timestamp">         </span><a name='t--podman-pod-restart-single-empty-pod--1'><h2>  podman pod restart single empty pod</h2></a>
-<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L41'>/containers/libpod/test/e2e/pod_restart_test.go:41</a>
+<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L41'>/containers/podman/test/e2e/pod_restart_test.go:41</a>
 <span class="timestamp">         </span>[BeforeEach] Podman pod restart
-<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L18'>/containers/libpod/test/e2e/pod_restart_test.go:18</a>
+<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L18'>/containers/podman/test/e2e/pod_restart_test.go:18</a>
 <span class="timestamp">         </span>[It] podman pod restart single empty pod
-<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L41'>/containers/libpod/test/e2e/pod_restart_test.go:41</a>
+<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L41'>/containers/podman/test/e2e/pod_restart_test.go:41</a>
 <span class="timestamp">         </span>Running: <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/podman/imagecachedir
 --root /tmp/podman_test553496330/crio
 --runroot /tmp/podman_test553496330/crio-run
@@ -176,7 +176,7 @@ $SCRIPT_BASE/integration_test.sh |&amp; ${TIMESTAMP}
 <span class="timestamp">         </span><span class='log-warn'>Error: no containers in pod 4810be0cfbd42241e349dbe7d50fbc54405cd320a6637c65fd5323f34d64af89 have no dependencies, cannot start pod: no such container</span>
 <span class="timestamp">         </span>output:
 <span class="timestamp">         </span>[AfterEach] Podman pod restart
-<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L28'>/containers/libpod/test/e2e/pod_restart_test.go:28</a>
+<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L28'>/containers/podman/test/e2e/pod_restart_test.go:28</a>
 <span class="timestamp">         </span>Running: <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/podman/imagecachedir
 --root /tmp/podman_test553496330/crio
 --runroot /tmp/podman_test553496330/crio-run

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -82,6 +82,8 @@ load helpers
 
 # "network create" now works rootless, with the help of a special container
 @test "podman network create" {
+    skip_if_remote "FIXME: pending #7808"
+
     local mynetname=testnet-$(random_string 10)
     local mysubnet=$(random_rfc1918_subnet)
 


### PR DESCRIPTION
At the top of each generated page, add a Synopsis table with:

      PR number/name, and link to github
      Author name(s)
      Test name (fedora/ubuntu, rootless, etc)
      Cirrus task ID, and link to Cirrus
      The value of $SPECIALMODE

This is all we can get from the Cirrus environment in
which logformatter runs; we can't get things like
cgroup manager or username that the test runs under.

Note that the table is at the top, which is usually
invisible because we autoscroll to the bottom on
page load. I tentatively think that top is a more
natural place for this info than bottom, but am
willing to listen to arguments against.

Also, one minor tweak: highlight podman commands in
the BATS output. The idea is to make it easier for the eye
to spot those, then copy/paste them to find a reproducer.

Signed-off-by: Ed Santiago <santiago@redhat.com>
