### PR TITLE
Podman containers/pods prune should throw an error if user adds args

### DIFF
--- a/cmd/podman/containers/prune.go
+++ b/cmd/podman/containers/prune.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/cmd/podman/utils"
+	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -25,6 +26,7 @@ var (
 		Long:    pruneDescription,
 		RunE:    prune,
 		Example: `podman container prune`,
+		Args:    validate.NoArgs,
 	}
 	force  bool
 	filter = []string{}
@@ -45,9 +47,6 @@ func prune(cmd *cobra.Command, args []string) error {
 	var (
 		pruneOptions = entities.ContainerPruneOptions{}
 	)
-	if len(args) > 0 {
-		return errors.Errorf("`%s` takes no arguments", cmd.CommandPath())
-	}
 	if !force {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Println("WARNING! This will remove all non running containers.")

--- a/cmd/podman/pods/prune.go
+++ b/cmd/podman/pods/prune.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/cmd/podman/utils"
+	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -23,6 +24,7 @@ var (
 
 	pruneCommand = &cobra.Command{
 		Use:     "prune [flags]",
+		Args:    validate.NoArgs,
 		Short:   "Remove all stopped pods and their containers",
 		Long:    pruneDescription,
 		RunE:    prune,
@@ -41,9 +43,6 @@ func init() {
 }
 
 func prune(cmd *cobra.Command, args []string) error {
-	if len(args) > 0 {
-		return errors.Errorf("`%s` takes no arguments", cmd.CommandPath())
-	}
 	if !pruneOptions.Force {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Println("WARNING! This will remove all stopped/exited pods..")


### PR DESCRIPTION
We are not currently checking if a user accidently adds an argument to
all podman * prune commands.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>