### PR TITLE
fix compat api privileged and entrypoint code

### DIFF
--- a/pkg/spec/config_linux.go
+++ b/pkg/spec/config_linux.go
@@ -200,6 +200,9 @@ func getDevices(path string) ([]*configs.Device, error) {
 			}
 		case f.Name() == "console":
 			continue
+		case f.Mode()&os.ModeSymlink != 0:
+			// do not add symlink'd devices to privileged devices
+			continue
 		}
 		device, err := devices.DeviceFromPath(filepath.Join(path, f.Name()), "rwm")
 		if err != nil {


### PR DESCRIPTION
when adding /dev to a privileged container using the compatibility API, we need to make sure we dont pass on devices that are simply symlinks.  this was already being done by specgen but not on the compat. side.

the entrypoint code that was recently rewritten for the compatibility layer was also failing due to the odd inputs that docker is willing to accept in its json, specifically [] vs "".  in the case of the latter, this was being made into a []string with a len of one but no content.  this would then be used to prefix the command to run in the container and would fail.  For example " ls" vs "ls".

Signed-off-by: baude <bbaude@redhat.com>