### PR TITLE
libpod: check there are enough gids before adding them

### DIFF
--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/containers/storage"
+	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/pkg/errors"
 )
 
@@ -45,4 +46,18 @@ func TryJoinPauseProcess(pausePidPath string) (bool, int, error) {
 		return false, -1, nil
 	}
 	return became, ret, err
+}
+
+// GetAvailableGids returns how many GIDs are available in the
+// current user namespace.
+func GetAvailableGids() (int64, error) {
+	idMap, err := user.ParseIDMapFile("/proc/self/gid_map")
+	if err != nil {
+		return 0, err
+	}
+	count := int64(0)
+	for _, r := range idMap {
+		count += r.Count
+	}
+	return count, nil
 }

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/podman/v2/libpod/image"
 	"github.com/containers/podman/v2/pkg/rootless"
 	"github.com/containers/podman/v2/pkg/specgen"
-	"github.com/opencontainers/runc/libcontainer/user"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/pkg/errors"
@@ -200,7 +199,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 	gid5Available := true
 	if isRootless {
-		nGids, err := GetAvailableGids()
+		nGids, err := rootless.GetAvailableGids()
 		if err != nil {
 			return nil, err
 		}
@@ -359,16 +358,4 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	setProcOpts(s, &g)
 
 	return configSpec, nil
-}
-
-func GetAvailableGids() (int64, error) {
-	idMap, err := user.ParseIDMapFile("/proc/self/gid_map")
-	if err != nil {
-		return 0, err
-	}
-	count := int64(0)
-	for _, r := range idMap {
-		count += r.Count
-	}
-	return count, nil
 }


### PR DESCRIPTION
when running rootless, check there are enough gids in the current user namespace before adding supplementary gids from /etc/group.

Follow-up for baede7cd2776b1f722dcbb65cff6228eeab5db44

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
