### PR TITLE
This PR allows users to remove external containers directly

### DIFF
--- a/docs/source/markdown/podman-rm.1.md
+++ b/docs/source/markdown/podman-rm.1.md
@@ -43,13 +43,6 @@ to run containers such as CRI-O, the last started container could be from either
 
 The latest option is not supported on the remote client.
 
-**--storage**
-
-Remove external containers from the storage library.
-This is only possible with containers that are not present in libpod can be seen by **podman ps --all --storage**).
-It is used to remove external containers from **podman build** and **buildah**, and orphan containers which were only partially removed by **podman rm**.
-The storage option conflicts with the **--all**, **--latest**, and **--volumes** options.
-
 **--volumes**, **-v**
 
 Remove anonymous volumes associated with the container. This does not include named volumes
@@ -96,7 +89,7 @@ $ podman rm -f --latest
   **125** The command fails for any other reason
 
 ## SEE ALSO
-podman(1), podman-image-rm(1), podman-ps(1), podman-build(1)
+podman(1), podman-image-rm(1), podman-ps(1), podman-build(1), buildah(1), cri-o(1)
 
 ## HISTORY
 August 2017, Originally compiled by Ryan Cole <rycole@redhat.com>

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -131,7 +131,6 @@ type RmOptions struct {
 	Force    bool
 	Ignore   bool
 	Latest   bool
-	Storage  bool
 	Volumes  bool
 }
 

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -206,7 +206,7 @@ t POST containers/${cid_top}/stop "" 204
 t DELETE containers/$cid 204
 t DELETE containers/$cid_top 204
 
-# test the apiv2 create, should't ignore the ENV and WORKDIR from the image
+# test the apiv2 create, shouldn't ignore the ENV and WORKDIR from the image
 t POST containers/create '"Image":"'$ENV_WORKDIR_IMG'","Env":["testKey1"]' 201 \
   .Id~[0-9a-f]\\{64\\}
 cid=$(jq -r '.Id' <<<"$output")

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -28,7 +28,7 @@ func removeConf(confPath string) {
 // generateNetworkConfig generates a cni config with a random name
 // it returns the network name and the filepath
 func generateNetworkConfig(p *PodmanTestIntegration) (string, string) {
-	// generate a random name to preven conflicts with other tests
+	// generate a random name to prevent conflicts with other tests
 	name := "net" + stringid.GenerateNonCryptoID()
 	path := filepath.Join(p.CNIConfigDir, fmt.Sprintf("%s.conflist", name))
 	conf := fmt.Sprintf(`{

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -665,7 +665,7 @@ var _ = Describe("Podman generate kube", func() {
 	It("podman play kube test restartPolicy", func() {
 		// podName,  set,  expect
 		testSli := [][]string{
-			{"testPod1", "", "always"}, // Default eqaul to always
+			{"testPod1", "", "always"}, // Default equal to always
 			{"testPod2", "Always", "always"},
 			{"testPod3", "OnFailure", "on-failure"},
 			{"testPod4", "Never", "no"},

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -236,7 +236,6 @@ var _ = Describe("Podman rm", func() {
 	})
 
 	It("podman rm --ignore bogus container and a running container", func() {
-
 		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -394,7 +394,7 @@ USER bin`
 	})
 
 	It("podman run sysctl test", func() {
-		SkipIfRootless("Network sysctls are not avalable root rootless")
+		SkipIfRootless("Network sysctls are not available root rootless")
 		session := podmanTest.Podman([]string{"run", "--rm", "--sysctl", "net.core.somaxconn=65535", ALPINE, "sysctl", "net.core.somaxconn"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -33,6 +33,21 @@ load helpers
     run_podman rm -f $cid
 }
 
+@test "podman rm container from storage" {
+    if is_remote; then
+        skip "only applicable for local podman"
+    fi
+    rand=$(random_string 30)
+    run_podman create --name $rand $IMAGE /bin/true
+
+    # Create a container that podman does not know about
+    run buildah from $IMAGE
+    cid="$output"
+
+    # rm should succeed
+    run_podman rm $rand $cid
+}
+
 # I'm sorry! This test takes 13 seconds. There's not much I can do about it,
 # please know that I think it's justified: podman 1.5.0 had a strange bug
 # in with exit status was not preserved on some code paths with 'rm -f'


### PR DESCRIPTION
Currenly if a user specifies the name or ID of an external storage
container, we report an error to them.

buildah from scratch
working-container-2
podman rm working-container-2
Error: no container with name or ID working-container-2 found: no such container

Since the user specified the correct name and the container is in storage we
force them to specify --storage to remove it. This is a bad experience for the
user.

This change will just remove the container from storage.  If the container
is known by libpod, it will remove the container from libpod as well.

If the user species the --storage option, and the container is known to libpod
the command will fail.

Also cleaned documented options that are not available to podman-remote.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>