### PR TITLE
Fix Podman logs reading journald

### DIFF
--- a/libpod/container_log_linux.go
+++ b/libpod/container_log_linux.go
@@ -33,7 +33,7 @@ const (
 func (c *Container) readFromJournal(ctx context.Context, options *logs.LogOptions, logChannel chan *logs.LogLine) error {
 	var config journal.JournalReaderConfig
 	if options.Tail < 0 {
-		config.NumFromTail = math.MaxUint64
+		config.NumFromTail = 0
 	} else {
 		config.NumFromTail = uint64(options.Tail)
 	}

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -203,6 +203,7 @@ var _ = Describe("Podman logs", func() {
 		results.WaitWithDefaultTimeout()
 		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(3))
+		Expect(results.OutputToString()).To(Equal("podman podman podman"))
 	})
 
 	It("using journald tail two lines", func() {

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -50,4 +50,15 @@ ${cid[1]} c
 ${cid[0]} d"   "Sequential output from logs"
 }
 
+@test "podman logs over journald" {
+    msg=$(random_string 20)
+
+    run_podman run --name myctr --log-driver journald $IMAGE echo $msg
+
+    run_podman logs myctr
+    is "$output" "$msg" "check that log output equals the container output"
+
+    run_podman rm myctr
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
A podman could not read logs written to journald properly, due to a tail config bug. Also, turned on some journald logging tests that let this regression to occur.

Fixes: #7476, Bugzilla 1873204

Signed-off-by: Ashley Cui <acui@redhat.com>