### PR TITLE
WIP: Get safe subnets for integration testing

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -81,13 +81,13 @@ func GetFreeNetwork(config *config.Config) (*net.IPNet, error) {
 			return nil, err
 		}
 		logrus.Debugf("checking if network %s intersects with other cni networks", nextNetwork.String())
-		if intersectsConfig, _ := networkIntersectsWithNetworks(newNetwork, allocatorToIPNets(networks)); intersectsConfig {
+		if intersectsConfig, _ := IntersectsWithNetworks(newNetwork, allocatorToIPNets(networks)); intersectsConfig {
 			logrus.Debugf("network %s is already being used by a cni configuration", nextNetwork.String())
 			nextNetwork = newNetwork
 			continue
 		}
 		logrus.Debugf("checking if network %s intersects with any network interfaces", nextNetwork.String())
-		if intersectsLive, _ := networkIntersectsWithNetworks(newNetwork, liveNetworks); !intersectsLive {
+		if intersectsLive, _ := IntersectsWithNetworks(newNetwork, liveNetworks); !intersectsLive {
 			break
 		}
 		logrus.Debugf("network %s is being used by a network interface", nextNetwork.String())
@@ -121,7 +121,7 @@ func newIPNetFromSubnet(subnet types.IPNet) *net.IPNet {
 	return &n
 }
 
-func networkIntersectsWithNetworks(n *net.IPNet, networklist []*net.IPNet) (bool, *net.IPNet) {
+func IntersectsWithNetworks(n *net.IPNet, networklist []*net.IPNet) (bool, *net.IPNet) {
 	for _, nw := range networklist {
 		if networkIntersect(n, nw) {
 			return true, nw
@@ -155,11 +155,11 @@ func ValidateUserNetworkIsAvailable(config *config.Config, userNet *net.IPNet) e
 		return err
 	}
 	logrus.Debugf("checking if network %s exists in cni networks", userNet.String())
-	if intersectsConfig, _ := networkIntersectsWithNetworks(userNet, allocatorToIPNets(networks)); intersectsConfig {
+	if intersectsConfig, _ := IntersectsWithNetworks(userNet, allocatorToIPNets(networks)); intersectsConfig {
 		return errors.Errorf("network %s is already being used by a cni configuration", userNet.String())
 	}
 	logrus.Debugf("checking if network %s exists in any network interfaces", userNet.String())
-	if intersectsLive, _ := networkIntersectsWithNetworks(userNet, liveNetworks); intersectsLive {
+	if intersectsLive, _ := IntersectsWithNetworks(userNet, liveNetworks); intersectsLive {
 		return errors.Errorf("network %s is being used by a network interface", userNet.String())
 	}
 	return nil

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -15,7 +15,7 @@ import (
 
 func getRunString(input []string) []string {
 	// CRIU does not work with seccomp correctly on RHEL7 : seccomp=unconfined
-	runString := []string{"run", "-it", "--security-opt", "seccomp=unconfined", "-d", "--ip", GetRandomIPAddress()}
+	runString := []string{"run", "-it", "--security-opt", "seccomp=unconfined", "-d", "--ip", GetRandomIPv4InSubnet("10.88.0.0/16")}
 	return append(runString, input...)
 }
 

--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 	})
 
 	It("Podman create with specified static IP has correct IP", func() {
-		ip := GetRandomIPAddress()
+		ip := GetRandomIPv4InSubnet("10.88.0.0/16")
 		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
 		// Rootless static ip assignment should error
@@ -82,7 +82,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 
 	It("Podman create two containers with the same IP", func() {
 		SkipIfRootless("--ip not supported in rootless mode")
-		ip := GetRandomIPAddress()
+		ip := GetRandomIPv4InSubnet("10.88.0.0/16")
 		result := podmanTest.Podman([]string{"create", "--name", "test1", "--ip", ip, ALPINE, "sleep", "999"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -141,7 +141,8 @@ var _ = Describe("Podman network create", func() {
 		var (
 			results []network.NcList
 		)
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "newnetwork"})
+		safeNet := podmanTest.GetSafeIPv4Subnet()
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", safeNet, "newnetwork"})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc.ExitCode()).To(BeZero())
 
@@ -168,7 +169,7 @@ var _ = Describe("Podman network create", func() {
 		try := podmanTest.Podman([]string{"run", "-it", "--rm", "--network", "newnetwork", ALPINE, "sh", "-c", "ip addr show eth0 |  awk ' /inet / {print $2}'"})
 		try.WaitWithDefaultTimeout()
 
-		_, subnet, err := net.ParseCIDR("10.11.12.0/24")
+		_, subnet, err := net.ParseCIDR(safeNet)
 		Expect(err).To(BeNil())
 		// Note this is an IPv4 test only!
 		containerIP, _, err := net.ParseCIDR(try.OutputToString())
@@ -232,7 +233,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with invalid gateway for subnet", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--gateway", "192.168.1.1", "fail"})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", podmanTest.GetSafeIPv4Subnet(), "--gateway", "192.168.1.1", "fail"})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -230,7 +230,7 @@ var _ = Describe("Podman pod create", func() {
 
 	It("podman create pod with IP address", func() {
 		name := "test"
-		ip := GetRandomIPAddress()
+		ip := GetRandomIPv4InSubnet("10.88.0.0/16")
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--ip", ip, "--name", name})
 		podCreate.WaitWithDefaultTimeout()
 		// Rootless should error
@@ -247,7 +247,7 @@ var _ = Describe("Podman pod create", func() {
 
 	It("podman create pod with IP address and no infra should fail", func() {
 		name := "test"
-		ip := GetRandomIPAddress()
+		ip := GetRandomIPv4InSubnet("10.88.0.0/16")
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--ip", ip, "--name", name, "--infra=false"})
 		podCreate.WaitWithDefaultTimeout()
 		Expect(podCreate.ExitCode()).To(Equal(125))

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -529,8 +529,9 @@ var _ = Describe("Podman run networking", func() {
 	It("podman run in custom CNI network with --static-ip", func() {
 		SkipIfRootless("Rootless mode does not support --ip")
 		netName := "podmantestnetwork"
-		ipAddr := "10.25.30.128"
-		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.30.0/24", netName})
+		subnet := podmanTest.GetSafeIPv4Subnet()
+		ipAddr := GetRandomIPv4InSubnet(subnet)
+		create := podmanTest.Podman([]string{"network", "create", "--subnet", subnet, netName})
 		create.WaitWithDefaultTimeout()
 		Expect(create.ExitCode()).To(BeZero())
 		defer podmanTest.removeCNINetwork(netName)
@@ -544,9 +545,10 @@ var _ = Describe("Podman run networking", func() {
 	It("podman run with new:pod and static-ip", func() {
 		SkipIfRootless("Rootless does not support --ip")
 		netName := "podmantestnetwork2"
-		ipAddr := "10.25.40.128"
+		subnet := podmanTest.GetSafeIPv4Subnet()
+		ipAddr := GetRandomIPv4InSubnet(subnet)
 		podname := "testpod"
-		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.40.0/24", netName})
+		create := podmanTest.Podman([]string{"network", "create", "--subnet", subnet, netName})
 		create.WaitWithDefaultTimeout()
 		Expect(create.ExitCode()).To(BeZero())
 		defer podmanTest.removeCNINetwork(netName)

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 	})
 
 	It("Podman run with specified static IP has correct IP", func() {
-		ip := GetRandomIPAddress()
+		ip := GetRandomIPv4InSubnet("10.88.0.0/16")
 		result := podmanTest.Podman([]string{"run", "-ti", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
@@ -65,7 +65,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 	})
 
 	It("Podman run two containers with the same IP", func() {
-		ip := GetRandomIPAddress()
+		ip := GetRandomIPv4InSubnet("10.88.0.0/16")
 		result := podmanTest.Podman([]string{"run", "-dt", "--ip", ip, nginx})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/containers/storage/pkg/parsers/kernel"
@@ -44,6 +46,11 @@ type PodmanTest struct {
 	RemoteCommand      *exec.Cmd
 	ImageCacheDir      string
 	ImageCacheFS       string
+	Netlock            sync.Mutex
+	SafeIPv4Subnet     net.IPNet
+	// a list of networks which should not be used in the tests
+	// this list gets populated during test setup
+	SkipNetworks []*net.IPNet
 }
 
 // PodmanSession wraps the gexec.session so we can extend it


### PR DESCRIPTION
Currently if someone needs to add a network test with a
specific subnet they have to choose one manually and have
to make sure that this network is not already used. This
is error prone.

Even if the CI passes this can still lead to flakes since
the tests are run parallel and networks could intercept
each other. The proper solution for this is to make sure
that each test uses a globally unique subnet.

This commit implements a GetSafeIPv4Subnet function which
should be used to get a custom subnet for your tests.
The function ensures that the generated subnet is globally
unique across the ginkgo test nodes.

In order for this to work each test which uses a custom
subnet has to use this function. It's up to the maintainers
to make sure new test will use this function.