### PR TITLE
compat: images/create: fix tag parsing

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -39,7 +39,11 @@ t GET images/$iid/json 200 \
   .Id=sha256:$iid \
   .RepoTags[0]=$IMAGE
 
-#t POST images/create fromImage=alpine 201 foo
+t POST "images/create?fromImage=alpine" '' 200
+
+t POST "images/create?fromImage=alpine&tag=latest" '' 200
+
+t POST "images/create?fromImage=docker.io/library/alpine&tag=sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f" '' 200
 
 # Display the image history
 t GET libpod/images/nonesuch/history 404


### PR DESCRIPTION
The `tag` parameter of the compat `images/create` endpoint can be both,
a tag and a digest.  Fix parsing of the parameter to detect digests and
use the appropriate `@` separator.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>