### PR TITLE
Add SELinux support for pods

### DIFF
--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -327,3 +327,21 @@ func (p *Pod) GetPodStats(previousContainerStats map[string]*define.ContainerSta
 	}
 	return newContainerStats, nil
 }
+
+// ProcessLabel returns the SELinux label associated with the pod
+func (p *Pod) ProcessLabel() (string, error) {
+	if !p.HasInfraContainer() {
+		return "", nil
+	}
+
+	id, err := p.InfraContainerID()
+	if err != nil {
+		return "", err
+	}
+
+	ctr, err := p.runtime.state.Container(id)
+	if err != nil {
+		return "", err
+	}
+	return ctr.ProcessLabel(), nil
+}


### PR DESCRIPTION
All containers within a Pod need to run with the same SELinux
label, unless overwritten by the user.

Also added a bunch of SELinux tests to make sure selinux labels
are correct on namespaces.

Fixes: https://github.com/containers/podman/issues/7886

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>