### PR TITLE
Fixes remote attach and exec to signal IdleTracker

### DIFF
--- a/pkg/api/server/idle/tracker.go
+++ b/pkg/api/server/idle/tracker.go
@@ -61,10 +61,14 @@ func (t *Tracker) ConnState(conn net.Conn, state http.ConnState) {
 		oldActive := t.ActiveConnections()
 
 		// Either the server or a hijacking handler has closed the http connection to a client
-		if _, found := t.managed[conn]; found {
-			delete(t.managed, conn)
-		} else {
+		if conn == nil {
 			t.hijacked-- // guarded by t.mux above
+		} else {
+			if _, found := t.managed[conn]; found {
+				delete(t.managed, conn)
+			} else {
+				logrus.Warnf("IdleTracker %p: StateClosed transition by un-managed connection", conn)
+			}
 		}
 
 		// Transitioned from any "active" connection to no connections


### PR DESCRIPTION
 - Fixes issue where remote attach and exec only signaled the IdleTracker
   on errors. Needs to done anytime after connection has been hijacked
 - Fixes trying to send multiple http status codes to client
 - Changes pprof and API server shutdowns to run in parallel
 - Changes shutdown to run in sync.Once block

Fixes #7905 

Signed-off-by: Jhon Honce <jhonce@redhat.com>