### PR TITLE
Fix podman-remote ps --ns broken

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -240,7 +240,7 @@ func ps(cmd *cobra.Command, args []string) error {
 func createPsOut() (string, string) {
 	var row string
 	if listOpts.Namespace {
-		headers := "CONTAINER ID\tNAMES\tPID\tCGROUPNS\tIPC\tMNT\tNET\tPIDN\tUSERNS\tUTS\n"
+		headers := "CONTAINER ID\tNAMES\tPID\tCGROUPNS\tIPC\tMNT\tNET\tPIDNS\tUSERNS\tUTS\n"
 		row := "{{.ID}}\t{{.Names}}\t{{.Pid}}\t{{.Namespaces.Cgroup}}\t{{.Namespaces.IPC}}\t{{.Namespaces.MNT}}\t{{.Namespaces.NET}}\t{{.Namespaces.PIDNS}}\t{{.Namespaces.User}}\t{{.Namespaces.UTS}}\n"
 		return headers, row
 	}

--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -25,7 +25,7 @@ var (
 // the most recent number of containers.  The pod and size booleans indicate that pod information and rootfs
 // size information should also be included.  Finally, the sync bool synchronizes the OCI runtime and
 // container state.
-func List(ctx context.Context, filters map[string][]string, all *bool, last *int, size, sync *bool) ([]entities.ListContainer, error) { // nolint:typecheck
+func List(ctx context.Context, filters map[string][]string, all *bool, last *int, namespace, size, sync *bool) ([]entities.ListContainer, error) { // nolint:typecheck
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return nil, err
@@ -43,6 +43,9 @@ func List(ctx context.Context, filters map[string][]string, all *bool, last *int
 	}
 	if sync != nil {
 		params.Set("sync", strconv.FormatBool(*sync))
+	}
+	if namespace != nil {
+		params.Set("namespace", strconv.FormatBool(*namespace))
 	}
 	if filters != nil {
 		filterString, err := bindings.FiltersToString(filters)

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -499,7 +499,7 @@ var _ = Describe("Podman containers ", func() {
 		Expect(err).To(BeNil())
 		_, err = bt.RunTopContainer(&name2, bindings.PFalse, nil)
 		Expect(err).To(BeNil())
-		containerLatestList, err := containers.List(bt.conn, nil, nil, &latestContainers, nil, nil)
+		containerLatestList, err := containers.List(bt.conn, nil, nil, &latestContainers, nil, nil, nil)
 		Expect(err).To(BeNil())
 		err = containers.Kill(bt.conn, containerLatestList[0].Names[0], "SIGTERM")
 		Expect(err).To(BeNil())
@@ -744,7 +744,7 @@ var _ = Describe("Podman containers ", func() {
 		// Validate list container with id filter
 		filters := make(map[string][]string)
 		filters["id"] = []string{cid}
-		c, err := containers.List(bt.conn, filters, bindings.PTrue, nil, nil, nil)
+		c, err := containers.List(bt.conn, filters, bindings.PTrue, nil, nil, nil, nil)
 		Expect(err).To(BeNil())
 		Expect(len(c)).To(Equal(1))
 	})
@@ -758,7 +758,7 @@ var _ = Describe("Podman containers ", func() {
 
 		lastNum := 1
 
-		c, err := containers.List(bt.conn, nil, bindings.PTrue, &lastNum, nil, nil)
+		c, err := containers.List(bt.conn, nil, bindings.PTrue, &lastNum, nil, nil, nil)
 		Expect(err).To(BeNil())
 		Expect(len(c)).To(Equal(1))
 		Expect(c[0].PodName).To(Equal(podName))

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -548,7 +548,7 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 }
 
 func (ic *ContainerEngine) ContainerList(ctx context.Context, options entities.ContainerListOptions) ([]entities.ListContainer, error) {
-	return containers.List(ic.ClientCxt, options.Filters, &options.All, &options.Last, &options.Size, &options.Sync)
+	return containers.List(ic.ClientCxt, options.Filters, &options.All, &options.Last, &options.Namespace, &options.Size, &options.Sync)
 }
 
 func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.ContainerRunOptions) (*entities.ContainerRunReport, error) {

--- a/pkg/domain/infra/tunnel/helpers.go
+++ b/pkg/domain/infra/tunnel/helpers.go
@@ -19,7 +19,7 @@ func getContainersByContext(contextWithConnection context.Context, all, ignore b
 		return nil, errors.New("cannot lookup containers and all")
 	}
 
-	allContainers, err := containers.List(contextWithConnection, nil, bindings.PTrue, nil, nil, bindings.PTrue)
+	allContainers, err := containers.List(contextWithConnection, nil, bindings.PTrue, nil, nil, nil, bindings.PTrue)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -134,15 +134,16 @@ func ListContainerBatch(rt *libpod.Runtime, ctr *libpod.Container, opts entities
 			logrus.Errorf("error getting exited time for %q: %v", c.ID(), err)
 		}
 
+		pid, err = c.PID()
+		if err != nil {
+			return errors.Wrapf(err, "unable to obtain container pid")
+		}
+
 		if !opts.Size && !opts.Namespace {
 			return nil
 		}
 
 		if opts.Namespace {
-			pid, err = c.PID()
-			if err != nil {
-				return errors.Wrapf(err, "unable to obtain container pid")
-			}
 			ctrPID := strconv.Itoa(pid)
 			cgroup, _ = getNamespaceInfo(filepath.Join("/proc", ctrPID, "ns", "cgroup"))
 			ipc, _ = getNamespaceInfo(filepath.Join("/proc", ctrPID, "ns", "ipc"))

--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -225,7 +225,6 @@ var _ = Describe("Podman pod create", func() {
 	})
 
 	It("podman pod container can override pod pid NS", func() {
-		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.Podman([]string{"pod", "create", "--share", "pid"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -257,7 +256,6 @@ var _ = Describe("Podman pod create", func() {
 	})
 
 	It("podman pod container can override pod not sharing pid", func() {
-		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.Podman([]string{"pod", "create", "--share", "net"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -283,7 +281,6 @@ var _ = Describe("Podman pod create", func() {
 	})
 
 	It("podman pod container can override pod ipc NS", func() {
-		SkipIfRemote("FIXME This should work on podman-remote")
 		session := podmanTest.Podman([]string{"pod", "create", "--share", "ipc"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -173,6 +173,18 @@ var _ = Describe("Podman ps", func() {
 		Expect(len(result.OutputToStringArray())).Should(BeNumerically(">", 0))
 	})
 
+	It("podman ps namespace flag even for remote", func() {
+		session := podmanTest.RunTopContainer("test1")
+		session.WaitWithDefaultTimeout()
+
+		result := podmanTest.Podman([]string{"ps", "-a", "--namespace", "--format",
+			"{{with .Namespaces}}{{.Cgroup}}:{{.IPC}}:{{.MNT}}:{{.NET}}:{{.PIDNS}}:{{.User}}:{{.UTS}}{{end}}"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		// it must contains `::` when some ns is null. If it works normally, it should be "$num1:$num2:$num3"
+		Expect(result.OutputToString()).To(Not(ContainSubstring(`::`)))
+	})
+
 	It("podman ps with no containers is valid json format", func() {
 		result := podmanTest.Podman([]string{"ps", "--format", "json"})
 		result.WaitWithDefaultTimeout()


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/7903
before
```
$ podman-remote  --url tcp://localhost:8081 ps  --ns --format \
    '{{with .Namespaces}}{{.Cgroup}}:{{.IPC}}:{{.MNT}}:{{.NET}}:{{.PIDNS}}:{{.User}}:{{.UTS}}{{end}}'
::::::
```
after
```
$ ./bin/podman-remote  --url tcp://localhost:8081 ps  --ns --format \
    '{{with .Namespaces}}{{.Cgroup}}:{{.IPC}}:{{.MNT}}:{{.NET}}:{{.PIDNS}}:{{.User}}:{{.UTS}}{{end}}'
4026531835:4026532341:4026532339:4026532278:4026532342:4026531837:4026532340
```

Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>