### PR TITLE
Enable k8s configmaps as flags for play kube

### DIFF
--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -60,6 +60,7 @@ func init() {
 		flags.BoolVar(&kubeOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 		flags.StringVar(&kubeOptions.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
 		flags.StringVar(&kubeOptions.SeccompProfileRoot, "seccomp-profile-root", defaultSeccompRoot, "Directory path for seccomp profiles")
+		flags.StringSliceVar(&kubeOptions.ConfigMaps, "configmap", []string{}, "`Pathname` of a YAML file containing a kubernetes configmap")
 	}
 	_ = flags.MarkHidden("signature-policy")
 }

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -30,6 +30,12 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
 Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
 
+**--configmap**=*path*
+
+Use Kubernetes configmap YAML at path to provide a source for environment variable values within the containers of the pod.
+
+Note: The *--configmap* option can be used multiple times or a comma-separated list of paths can be used to pass multiple Kubernetes configmap YAMLs.
+
 **--creds**
 
 The [username[:password]] to use to authenticate with the registry if required.
@@ -63,6 +69,15 @@ Print usage statement
 Recreate the pod and containers as described in a file called `demo.yml`
 ```
 $ podman play kube demo.yml
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+```
+
+Provide `configmap-foo.yml` and `configmap-bar.yml` as sources for environment variables within the containers.
+```
+$ podman play kube demo.yml --configmap configmap-foo.yml,configmap-bar.yml
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+
+$ podman play kube demo.yml --configmap configmap-foo.yml --configmap configmap-bar.yml
 52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
 ```
 

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -24,6 +24,8 @@ type PlayKubeOptions struct {
 	// SeccompProfileRoot - path to a directory containing seccomp
 	// profiles.
 	SeccompProfileRoot string
+	// ConfigMaps - slice of pathnames to kubernetes configmap YAMLs.
+	ConfigMaps []string
 }
 
 // PlayKubePod represents a single pod and associated containers created by play kube

--- a/pkg/domain/infra/abi/play_test.go
+++ b/pkg/domain/infra/abi/play_test.go
@@ -1,0 +1,254 @@
+package abi
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var configMapList = []v1.ConfigMap{
+	{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bar",
+		},
+		Data: map[string]string{
+			"myvar": "bar",
+		},
+	},
+	{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Data: map[string]string{
+			"myvar": "foo",
+		},
+	},
+}
+
+func TestReadConfigMapFromFile(t *testing.T) {
+	tests := []struct {
+		name             string
+		configMapContent string
+		expectError      bool
+		expectedErrorMsg string
+		expected         v1.ConfigMap
+	}{
+		{
+			"ValidConfigMap",
+			`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+data:
+  myvar: foo
+`,
+			false,
+			"",
+			v1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Data: map[string]string{
+					"myvar": "foo",
+				},
+			},
+		},
+		{
+			"InvalidYAML",
+			`
+Invalid YAML
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+data:
+  myvar: foo
+`,
+			true,
+			"unable to read YAML as Kube ConfigMap",
+			v1.ConfigMap{},
+		},
+		{
+			"InvalidKind",
+			`
+apiVersion: v1
+kind: InvalidKind
+metadata:
+  name: foo
+data:
+  myvar: foo
+`,
+			true,
+			"invalid YAML kind",
+			v1.ConfigMap{},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			buf := bytes.NewBufferString(test.configMapContent)
+			cm, err := readConfigMapFromFile(buf)
+
+			if test.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.expectedErrorMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, cm)
+			}
+		})
+	}
+}
+
+func TestEnvVarsFromConfigMap(t *testing.T) {
+	tests := []struct {
+		name          string
+		envFrom       v1.EnvFromSource
+		configMapList []v1.ConfigMap
+		expected      map[string]string
+	}{
+		{
+			"ConfigMapExists",
+			v1.EnvFromSource{
+				ConfigMapRef: &v1.ConfigMapEnvSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "foo",
+					},
+				},
+			},
+			configMapList,
+			map[string]string{
+				"myvar": "foo",
+			},
+		},
+		{
+			"ConfigMapDoesNotExist",
+			v1.EnvFromSource{
+				ConfigMapRef: &v1.ConfigMapEnvSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "doesnotexist",
+					},
+				},
+			},
+			configMapList,
+			map[string]string{},
+		},
+		{
+			"EmptyConfigMapList",
+			v1.EnvFromSource{
+				ConfigMapRef: &v1.ConfigMapEnvSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "foo",
+					},
+				},
+			},
+			[]v1.ConfigMap{},
+			map[string]string{},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			result := envVarsFromConfigMap(test.envFrom, test.configMapList)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestEnvVarValue(t *testing.T) {
+	tests := []struct {
+		name          string
+		envVar        v1.EnvVar
+		configMapList []v1.ConfigMap
+		expected      string
+	}{
+		{
+			"ConfigMapExists",
+			v1.EnvVar{
+				Name: "FOO",
+				ValueFrom: &v1.EnvVarSource{
+					ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: "foo",
+						},
+						Key: "myvar",
+					},
+				},
+			},
+			configMapList,
+			"foo",
+		},
+		{
+			"ContainerKeyDoesNotExistInConfigMap",
+			v1.EnvVar{
+				Name: "FOO",
+				ValueFrom: &v1.EnvVarSource{
+					ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: "foo",
+						},
+						Key: "doesnotexist",
+					},
+				},
+			},
+			configMapList,
+			"",
+		},
+		{
+			"ConfigMapDoesNotExist",
+			v1.EnvVar{
+				Name: "FOO",
+				ValueFrom: &v1.EnvVarSource{
+					ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: "doesnotexist",
+						},
+						Key: "myvar",
+					},
+				},
+			},
+			configMapList,
+			"",
+		},
+		{
+			"EmptyConfigMapList",
+			v1.EnvVar{
+				Name: "FOO",
+				ValueFrom: &v1.EnvVarSource{
+					ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: "foo",
+						},
+						Key: "myvar",
+					},
+				},
+			},
+			[]v1.ConfigMap{},
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			result := envVarValue(test.envVar, test.configMapList)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
This will permit podman play kube to obtain container env vars from configmaps. By passing the --configmap flag with a valid configmap.yaml, it will search for the pod.container.env and pod.container.envFrom settings to validate if a configmap has been conigured as the source.

Examples:
podman play kube [pod|deploy].yaml --configmap myconfigmap.yaml
podman play kube [pod|deploy].yaml --configmap myconfigmap1.yaml --configmap myconfigmap2.yaml 

Fixes: #7567 

Signed-off-by: Eduardo Vega <edvegavalerio@gmail.com>