### PR TITLE
Fix usage of rootless_storage_path from system storage.conf file

### DIFF
--- a/vendor/github.com/containers/storage/utils.go
+++ b/vendor/github.com/containers/storage/utils.go
@@ -206,11 +206,10 @@ func getRootlessStorageOpts(rootlessUID int, systemOpts StoreOptions) (StoreOpti
 		return opts, err
 	}
 	opts.RunRoot = rootlessRuntime
-	opts.GraphRoot = filepath.Join(dataDir, "containers", "storage")
 	if systemOpts.RootlessStoragePath != "" {
-		opts.RootlessStoragePath = systemOpts.RootlessStoragePath
+		opts.GraphRoot = systemOpts.RootlessStoragePath
 	} else {
-		opts.RootlessStoragePath = opts.GraphRoot
+		opts.GraphRoot = filepath.Join(dataDir, "containers", "storage")
 	}
 	if path, err := exec.LookPath("fuse-overlayfs"); err == nil {
 		opts.GraphDriverName = "overlay"

--- a/vendor/github.com/containers/storage/utils.go
+++ b/vendor/github.com/containers/storage/utils.go
@@ -292,13 +292,6 @@ func defaultStoreOptionsIsolated(rootless bool, rootlessUID int, storageConf str
 			if storageOpts.GraphRoot == "" {
 				storageOpts.GraphRoot = defaultRootlessGraphRoot
 			}
-			if storageOpts.RootlessStoragePath != "" {
-				rootlessStoragePath, err := expandEnvPath(storageOpts.RootlessStoragePath, rootlessUID)
-				if err != nil {
-					return storageOpts, err
-				}
-				storageOpts.GraphRoot = rootlessStoragePath
-			}
 		}
 	}
 	return storageOpts, nil


### PR DESCRIPTION
Fixes #7876 
It makes `rootless_storage_path` working from `/etc/containers/storage.conf`.
Further it makes the same option useless from `~/.config/containers/storage.conf`, so it makes it reserved only for admin use: only `graphroot` is meaningfull from user configuration.
This makes the option consistent with the definition in man page:
```
  rootless_storage_path="$HOME/.local/share/containers/storage"
     Storage path for  rootless  users.  By  default  the  graphroot  for  rootless  users  is  set  to
  $XDG_DATA_HOME/containers/storage,  if  XDG_DATA_HOME is set.  Otherwise $HOME/.local/share/contain‐
  ers/storage is used.  This field can be used if administrators need to change the  storage  location
   for all users.
```