### PR TITLE
Add support for resource memory limit to generate kube

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -303,11 +303,22 @@ func containerToV1Container(c *Container) (v1.Container, []v1.Volume, error) {
 	// This should not be applicable
 	//container.EnvFromSource =
 	kubeContainer.Env = envVariables
-	// TODO enable resources when we can support naming conventions
-	//container.Resources
 	kubeContainer.SecurityContext = kubeSec
 	kubeContainer.StdinOnce = false
 	kubeContainer.TTY = c.config.Spec.Process.Terminal
+
+	if c.config.Spec.Linux != nil &&
+		c.config.Spec.Linux.Resources != nil &&
+		c.config.Spec.Linux.Resources.Memory != nil &&
+		c.config.Spec.Linux.Resources.Memory.Limit != nil {
+		if kubeContainer.Resources.Limits == nil {
+			kubeContainer.Resources.Limits = v1.ResourceList{}
+		}
+
+		qty := kubeContainer.Resources.Limits.Memory()
+		qty.Set(*c.config.Spec.Linux.Resources.Memory.Limit)
+		kubeContainer.Resources.Limits[v1.ResourceMemory] = *qty
+	}
 
 	return kubeContainer, kubeVolumes, nil
 }

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -307,6 +307,7 @@ func containerToV1Container(c *Container) (v1.Container, []v1.Volume, error) {
 	kubeContainer.StdinOnce = false
 	kubeContainer.TTY = c.config.Spec.Process.Terminal
 
+	// TODO add CPU limit support.
 	if c.config.Spec.Linux != nil &&
 		c.config.Spec.Linux.Resources != nil &&
 		c.config.Spec.Linux.Resources.Memory != nil &&


### PR DESCRIPTION
Addresses #7855

Steps to run:
```
podman container create --name test1 --memory 10Mi alpine
podman generate kube test1
```

Output (see the comment / note in the generated yaml):
```
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2020-10-04T14:20:48Z"
  labels:
    app: test1
  name: test1
spec:
  containers:
  - command:
    - /bin/sh
    env:
    - name: PATH
      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
    - name: TERM
      value: xterm
    - name: container
      value: podman
    - name: HOSTNAME
    image: docker.io/library/alpine:latest
    name: test1
    resources:
      limits:
        memory: 10Mi          # <<<-- This PR adds this
```