### PR TITLE
[v2.0.5-rhel] compat: images/create: fix tag parsing

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -20,8 +20,24 @@ import (
 	"github.com/containers/libpod/v2/pkg/util"
 	"github.com/docker/docker/api/types"
 	"github.com/gorilla/schema"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
+
+// mergeNameAndTagOrDigest creates an image reference as string from the
+// provided image name and tagOrDigest which can be a tag, a digest or empty.
+func mergeNameAndTagOrDigest(name, tagOrDigest string) string {
+	if len(tagOrDigest) == 0 {
+		return name
+	}
+
+	separator := ":" // default to tag
+	if _, err := digest.Parse(tagOrDigest); err == nil {
+		// We have a digest, so let's change the separator.
+		separator = "@"
+	}
+	return fmt.Sprintf("%s%s%s", name, separator, tagOrDigest)
+}
 
 func ExportImage(w http.ResponseWriter, r *http.Request) {
 	// 200 ok
@@ -252,10 +268,7 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fromImage := query.FromImage
-	if len(query.Tag) >= 1 {
-		fromImage = fmt.Sprintf("%s:%s", fromImage, query.Tag)
-	}
+	fromImage := mergeNameAndTagOrDigest(query.FromImage, query.Tag)
 
 	authConf, authfile, err := auth.GetCredentials(r)
 	if err != nil {

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -31,7 +31,11 @@ t GET images/$iid/json 200 \
   .Id=sha256:$iid \
   .RepoTags[0]=$IMAGE
 
-#t POST images/create fromImage=alpine 201 foo
+t POST "images/create?fromImage=alpine" '' 200
+
+t POST "images/create?fromImage=alpine&tag=latest" '' 200
+
+t POST "images/create?fromImage=docker.io/library/alpine&tag=sha256:acd3ca9941a85e8ed16515bfc5328e4e2f8c128caa72959a58a127b7801ee01f" '' 200
 
 # Display the image history
 t GET libpod/images/nonesuch/history 404


### PR DESCRIPTION
The `tag` parameter of the compat `images/create` endpoint can be both,
a tag and a digest.  Fix parsing of the parameter to detect digests and
use the appropriate `@` separator.

Backport of commit 6a291942c253fcb13fc2ee0990f2137ca3584270.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>