### PR TITLE
Cirrus: Fix branch-validation failure

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -76,11 +76,12 @@ CIRRUS_CI="${CIRRUS_CI:-false}"
 DEST_BRANCH="${DEST_BRANCH:-master}"
 CONTINUOUS_INTEGRATION="${CONTINUOUS_INTEGRATION:-false}"
 CIRRUS_REPO_NAME=${CIRRUS_REPO_NAME:-podman}
-CIRRUS_BASE_SHA=${CIRRUS_BASE_SHA:-unknown$(date +%s)}  # difficult to reliably discover
+# N/B: CIRRUS_BASE_SHA is empty on branch and tag push.
+CIRRUS_BASE_SHA=${CIRRUS_BASE_SHA:-${CIRRUS_LAST_GREEN_CHANGE:-YOU_FOUND_A_BUG}}
 CIRRUS_BUILD_ID=${CIRRUS_BUILD_ID:-$RANDOM$(date +%s)}  # must be short and unique
 
-# Needed for linting and code validation
-EPOCH_TEST_COMMIT=${CIRRUS_BASE_SHA:-$CIRRUS_LAST_GREEN_CHANGE}
+# The starting place for linting and code validation
+EPOCH_TEST_COMMIT="$CIRRUS_BASE_SHA"
 
 # Regex of env. vars. to explicitly pass when executing tests
 # inside a container or as a rootless user

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -179,7 +179,13 @@ case "$TEST_FLAVOR" in
     ext_svc) $SCRIPT_BASE/ext_svc_check.sh ;;
     smoke)
         make gofmt
-        make .gitvalidation
+        # There is little value to validating commits after tag-push
+        # and it's very difficult to automatically determine a starting commit.
+        # $CIRRUS_TAG is only non-empty when executing due to a tag-push
+        # shellcheck disable=SC2154
+        if [[ -z "$CIRRUS_TAG" ]]; then
+            make .gitvalidation
+        fi
         ;;
     automation)
         $SCRIPT_BASE/cirrus_yaml_test.py


### PR DESCRIPTION
When validating code on a branch, determining a starting commit to check
from isn't as straightforward as it would seem.  Default to using the
SHA from last time CI was green.  If for some reason that isn't
available, use an obviously wrong value to cause an intentional
failure.

Signed-off-by: Chris Evich <cevich@redhat.com>