### PR TITLE
Nits

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -210,7 +210,7 @@ func build(cmd *cobra.Command, args []string) error {
 	if cmd.Flag("logfile").Changed {
 		logfile, err := os.OpenFile(buildOpts.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 		if err != nil {
-			return errors.Errorf("error opening logfile %q: %v", buildOpts.Logfile, err)
+			return err
 		}
 		defer logfile.Close()
 	}

--- a/cmd/podman/images/history.go
+++ b/cmd/podman/images/history.go
@@ -132,7 +132,7 @@ func history(cmd *cobra.Command, args []string) error {
 	w := tabwriter.NewWriter(os.Stdout, 8, 2, 2, ' ', 0)
 	err = tmpl.Execute(w, hr)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Failed to print report"))
+		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "failed to print report"))
 	}
 	w.Flush()
 	return nil

--- a/cmd/podman/system/connection/add.go
+++ b/cmd/podman/system/connection/add.go
@@ -166,7 +166,7 @@ func getUDS(cmd *cobra.Command, uri *url.URL) (string, error) {
 		value := cmd.Flag("identity").Value.String()
 		auth, err := terminal.PublicKey(value, []byte(passwd))
 		if err != nil {
-			return "", errors.Wrapf(err, "Failed to read identity %q", value)
+			return "", errors.Wrapf(err, "failed to read identity %q", value)
 		}
 		authMethods = append(authMethods, auth)
 	}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -496,7 +496,7 @@ func (c *Container) setupStorage(ctx context.Context) error {
 
 	artifacts := filepath.Join(c.config.StaticDir, artifactsDir)
 	if err := os.MkdirAll(artifacts, 0755); err != nil {
-		return errors.Wrapf(err, "error creating artifacts directory %q", artifacts)
+		return errors.Wrap(err, "error creating artifacts directory")
 	}
 
 	return nil
@@ -1820,7 +1820,7 @@ func (c *Container) appendStringToRundir(destFile, output string) (string, error
 
 	f, err := os.OpenFile(destFileName, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to open %s", destFileName)
+		return "", err
 	}
 	defer f.Close()
 

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -835,13 +835,13 @@ func (c *Container) checkpointRestoreLabelLog(fileName string) error {
 
 	logFile, err := os.OpenFile(dumpLog, os.O_CREATE, 0600)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create CRIU log file %q", dumpLog)
+		return errors.Wrap(err, "failed to create CRIU log file")
 	}
 	if err := logFile.Close(); err != nil {
-		logrus.Errorf("unable to close log file: %q", err)
+		logrus.Error(err)
 	}
 	if err = label.SetFileLabel(dumpLog, c.MountLabel()); err != nil {
-		return errors.Wrapf(err, "failed to label CRIU log file %q", dumpLog)
+		return err
 	}
 	return nil
 }
@@ -919,7 +919,7 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 func (c *Container) importCheckpoint(input string) error {
 	archiveFile, err := os.Open(input)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to open checkpoint archive %s for import", input)
+		return errors.Wrap(err, "Failed to open checkpoint archive for import")
 	}
 
 	defer archiveFile.Close()
@@ -1116,7 +1116,7 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 			// Only do this if a rootfs-diff.tar actually exists
 			rootfsDiffFile, err := os.Open(rootfsDiffPath)
 			if err != nil {
-				return errors.Wrapf(err, "Failed to open root file-system diff file %s", rootfsDiffPath)
+				return errors.Wrap(err, "Failed to open root file-system diff file")
 			}
 			defer rootfsDiffFile.Close()
 			if err := c.runtime.ApplyDiffTarStream(c.ID(), rootfsDiffFile); err != nil {
@@ -1125,16 +1125,10 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 		}
 		deletedFilesPath := filepath.Join(c.bundlePath(), "deleted.files")
 		if _, err := os.Stat(deletedFilesPath); err == nil {
-			deletedFilesFile, err := os.Open(deletedFilesPath)
-			if err != nil {
-				return errors.Wrapf(err, "Failed to open deleted files file %s", deletedFilesPath)
-			}
-			defer deletedFilesFile.Close()
-
 			var deletedFiles []string
-			deletedFilesJSON, err := ioutil.ReadAll(deletedFilesFile)
+			deletedFilesJSON, err := ioutil.ReadFile(deletedFilesPath)
 			if err != nil {
-				return errors.Wrapf(err, "Failed to read deleted files file %s", deletedFilesPath)
+				return errors.Wrapf(err, "Failed to read deleted files file")
 			}
 			if err := json.Unmarshal(deletedFilesJSON, &deletedFiles); err != nil {
 				return errors.Wrapf(err, "Failed to read deleted files file %s", deletedFilesPath)

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -919,7 +919,7 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 func (c *Container) importCheckpoint(input string) error {
 	archiveFile, err := os.Open(input)
 	if err != nil {
-		return errors.Wrap(err, "Failed to open checkpoint archive for import")
+		return errors.Wrap(err, "failed to open checkpoint archive for import")
 	}
 
 	defer archiveFile.Close()
@@ -1116,11 +1116,11 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 			// Only do this if a rootfs-diff.tar actually exists
 			rootfsDiffFile, err := os.Open(rootfsDiffPath)
 			if err != nil {
-				return errors.Wrap(err, "Failed to open root file-system diff file")
+				return errors.Wrap(err, "failed to open root file-system diff file")
 			}
 			defer rootfsDiffFile.Close()
 			if err := c.runtime.ApplyDiffTarStream(c.ID(), rootfsDiffFile); err != nil {
-				return errors.Wrapf(err, "Failed to apply root file-system diff file %s", rootfsDiffPath)
+				return errors.Wrapf(err, "failed to apply root file-system diff file %s", rootfsDiffPath)
 			}
 		}
 		deletedFilesPath := filepath.Join(c.bundlePath(), "deleted.files")
@@ -1128,17 +1128,17 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 			var deletedFiles []string
 			deletedFilesJSON, err := ioutil.ReadFile(deletedFilesPath)
 			if err != nil {
-				return errors.Wrapf(err, "Failed to read deleted files file")
+				return errors.Wrapf(err, "failed to read deleted files file")
 			}
 			if err := json.Unmarshal(deletedFilesJSON, &deletedFiles); err != nil {
-				return errors.Wrapf(err, "Failed to read deleted files file %s", deletedFilesPath)
+				return errors.Wrapf(err, "failed to read deleted files file %s", deletedFilesPath)
 			}
 			for _, deleteFile := range deletedFiles {
 				// Using RemoveAll as deletedFiles, which is generated from 'podman diff'
 				// lists completely deleted directories as a single entry: 'D /root'.
 				err = os.RemoveAll(filepath.Join(c.state.Mountpoint, deleteFile))
 				if err != nil {
-					return errors.Wrapf(err, "Failed to delete file %s from container %s during restore", deletedFilesPath, c.ID())
+					return errors.Wrapf(err, "failed to delete file %s from container %s during restore", deletedFilesPath, c.ID())
 				}
 			}
 		}

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -867,7 +867,7 @@ func (i *Image) PushImageToReference(ctx context.Context, dest types.ImageRefere
 	// Copy the image to the remote destination
 	manifestBytes, err := cp.Image(ctx, policyContext, dest, src, copyOptions)
 	if err != nil {
-		return errors.Wrapf(err, "Error copying image to the remote destination")
+		return errors.Wrapf(err, "error copying image to the remote destination")
 	}
 	digest, err := manifest.Digest(manifestBytes)
 	if err != nil {

--- a/libpod/lock/file/file_lock.go
+++ b/libpod/lock/file/file_lock.go
@@ -26,7 +26,7 @@ func CreateFileLock(path string) (*FileLocks, error) {
 		return nil, errors.Wrapf(syscall.EEXIST, "directory %s exists", path)
 	}
 	if err := os.MkdirAll(path, 0711); err != nil {
-		return nil, errors.Wrapf(err, "cannot create %s", path)
+		return nil, err
 	}
 
 	locks := new(FileLocks)
@@ -40,7 +40,7 @@ func CreateFileLock(path string) (*FileLocks, error) {
 func OpenFileLock(path string) (*FileLocks, error) {
 	_, err := os.Stat(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "accessing directory %s", path)
+		return nil, err
 	}
 
 	locks := new(FileLocks)
@@ -84,7 +84,7 @@ func (locks *FileLocks) AllocateLock() (uint32, error) {
 			if os.IsExist(err) {
 				continue
 			}
-			return 0, errors.Wrapf(err, "creating lock file")
+			return 0, errors.Wrap(err, "creating lock file")
 		}
 		f.Close()
 		break

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -662,12 +662,12 @@ func (r *Runtime) setupNetNS(ctr *Container) error {
 	nsPath := fmt.Sprintf("/var/run/netns/cni-%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 
 	if err := os.MkdirAll(filepath.Dir(nsPath), 0711); err != nil {
-		return errors.Wrapf(err, "cannot create %s", filepath.Dir(nsPath))
+		return err
 	}
 
 	mountPointFd, err := os.Create(nsPath)
 	if err != nil {
-		return errors.Wrapf(err, "cannot open %s", nsPath)
+		return err
 	}
 	if err := mountPointFd.Close(); err != nil {
 		return err

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1390,12 +1390,12 @@ func startCommandGivenSelinux(cmd *exec.Cmd) error {
 	)
 	plabel, err = selinux.CurrentLabel()
 	if err != nil {
-		return errors.Wrapf(err, "Failed to get current SELinux label")
+		return errors.Wrapf(err, "failed to get current SELinux label")
 	}
 
 	con, err = selinux.NewContext(plabel)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to get new context from SELinux label")
+		return errors.Wrapf(err, "failed to get new context from SELinux label")
 	}
 
 	runtime.LockOSThread()

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -157,15 +157,13 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 	if err := os.MkdirAll(runtime.exitsDir, 0750); err != nil {
 		// The directory is allowed to exist
 		if !os.IsExist(err) {
-			return nil, errors.Wrapf(err, "error creating OCI runtime exit files directory %s",
-				runtime.exitsDir)
+			return nil, errors.Wrapf(err, "error creating OCI runtime exit files directory")
 		}
 	}
 	if err := os.MkdirAll(runtime.socketsDir, 0750); err != nil {
 		// The directory is allowed to exist
 		if !os.IsExist(err) {
-			return nil, errors.Wrapf(err, "error creating OCI runtime attach sockets directory %s",
-				runtime.socketsDir)
+			return nil, errors.Wrap(err, "error creating OCI runtime attach sockets directory")
 		}
 	}
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -251,8 +251,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	if err := os.MkdirAll(runtime.config.Engine.StaticDir, 0700); err != nil {
 		// The directory is allowed to exist
 		if !os.IsExist(err) {
-			return errors.Wrapf(err, "error creating runtime static files directory %s",
-				runtime.config.Engine.StaticDir)
+			return errors.Wrap(err, "error creating runtime static files directory")
 		}
 	}
 
@@ -348,7 +347,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	if err := os.MkdirAll(runtime.config.Engine.TmpDir, 0751); err != nil {
 		// The directory is allowed to exist
 		if !os.IsExist(err) {
-			return errors.Wrapf(err, "error creating tmpdir %s", runtime.config.Engine.TmpDir)
+			return errors.Wrap(err, "error creating tmpdir")
 		}
 	}
 
@@ -356,7 +355,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	if err := os.MkdirAll(filepath.Dir(runtime.config.Engine.EventsLogFilePath), 0700); err != nil {
 		// The directory is allowed to exist
 		if !os.IsExist(err) {
-			return errors.Wrapf(err, "error creating events dirs %s", filepath.Dir(runtime.config.Engine.EventsLogFilePath))
+			return errors.Wrap(err, "error creating events dirs")
 		}
 	}
 
@@ -416,8 +415,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	if err := os.MkdirAll(runtime.config.Engine.TmpDir, 0755); err != nil {
 		// The directory is allowed to exist
 		if !os.IsExist(err) {
-			return errors.Wrapf(err, "error creating runtime temporary files directory %s",
-				runtime.config.Engine.TmpDir)
+			return errors.Wrapf(err, "error creating runtime temporary files directory")
 		}
 	}
 
@@ -649,7 +647,7 @@ func (r *Runtime) refresh(alivePath string) error {
 	// Create a file indicating the runtime is alive and ready
 	file, err := os.OpenFile(alivePath, os.O_RDONLY|os.O_CREATE, 0644)
 	if err != nil {
-		return errors.Wrapf(err, "error creating runtime status file %s", alivePath)
+		return errors.Wrap(err, "error creating runtime status file")
 	}
 	defer file.Close()
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -582,7 +582,7 @@ func (r *Runtime) Shutdown(force bool) error {
 	// attempt to shut it down
 	if r.store != nil {
 		if _, err := r.store.Shutdown(force); err != nil {
-			lastError = errors.Wrapf(err, "Error shutting down container storage")
+			lastError = errors.Wrapf(err, "error shutting down container storage")
 		}
 	}
 	if err := r.state.Close(); err != nil {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -620,7 +620,7 @@ func (r *Runtime) evictContainer(ctx context.Context, idOrName string, removeVol
 
 	id, err := r.state.LookupContainerID(idOrName)
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to find container %q in state", idOrName)
+		return "", errors.Wrapf(err, "failed to find container %q in state", idOrName)
 	}
 
 	// Begin by trying a normal removal. Valid containers will be removed normally.
@@ -650,7 +650,7 @@ func (r *Runtime) evictContainer(ctx context.Context, idOrName string, removeVol
 		return id, err
 	}
 	if !exists {
-		return id, errors.Wrapf(err, "Failed to find container ID %q for eviction", id)
+		return id, errors.Wrapf(err, "failed to find container ID %q for eviction", id)
 	}
 
 	// Re-create a container struct for removal purposes

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -331,7 +331,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		ctr.config.ShmDir = filepath.Join(ctr.bundlePath(), "shm")
 		if err := os.MkdirAll(ctr.config.ShmDir, 0700); err != nil {
 			if !os.IsExist(err) {
-				return nil, errors.Wrapf(err, "unable to create shm %q dir", ctr.config.ShmDir)
+				return nil, errors.Wrap(err, "unable to create shm dir")
 			}
 		}
 		ctr.config.Mounts = append(ctr.config.Mounts, ctr.config.ShmDir)

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -32,7 +32,7 @@ func RemoveContainer(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -59,7 +59,7 @@ func RemoveContainer(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}
-			logrus.Warn(errors.Wrapf(err, "Failed to evict container: %q", name))
+			logrus.Warn(errors.Wrapf(err, "failed to evict container: %q", name))
 			utils.InternalServerError(w, err)
 			return
 		}
@@ -91,7 +91,7 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	if query.All {
@@ -132,7 +132,7 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -160,7 +160,7 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 		Signal: "KILL",
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -33,7 +33,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {

--- a/pkg/api/handlers/compat/containers_logs.go
+++ b/pkg/api/handlers/compat/containers_logs.go
@@ -35,7 +35,7 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 		Tail: "all",
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -93,7 +93,7 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 
 	logChannel := make(chan *logs.LogLine, tail+1)
 	if err := runtime.Log(r.Context(), []*libpod.Container{ctnr}, options, logChannel); err != nil {
-		utils.InternalServerError(w, errors.Wrapf(err, "Failed to obtain logs for Container '%s'", name))
+		utils.InternalServerError(w, errors.Wrapf(err, "failed to obtain logs for Container '%s'", name))
 		return
 	}
 	go func() {
@@ -111,7 +111,7 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 	if !utils.IsLibpodRequest(r) {
 		inspectData, err := ctnr.Inspect(false)
 		if err != nil {
-			utils.InternalServerError(w, errors.Wrapf(err, "Failed to obtain logs for Container '%s'", name))
+			utils.InternalServerError(w, errors.Wrapf(err, "failed to obtain logs for Container '%s'", name))
 			return
 		}
 		writeHeader = !inspectData.Config.Tty

--- a/pkg/api/handlers/compat/containers_prune.go
+++ b/pkg/api/handlers/compat/containers_prune.go
@@ -25,7 +25,7 @@ func PruneContainers(w http.ResponseWriter, r *http.Request) {
 		Filters map[string][]string `schema:"filters"`
 	}{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	for k, v := range query.Filters {

--- a/pkg/api/handlers/compat/containers_restart.go
+++ b/pkg/api/handlers/compat/containers_restart.go
@@ -19,7 +19,7 @@ func RestartContainer(w http.ResponseWriter, r *http.Request) {
 		// Override golang default values for types
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.BadRequest(w, "url", r.URL.String(), errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.BadRequest(w, "url", r.URL.String(), errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_stats.go
+++ b/pkg/api/handlers/compat/containers_stats.go
@@ -27,7 +27,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		Stream: true,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -52,7 +52,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 
 	stats, err := ctnr.GetContainerStats(&define.ContainerStats{})
 	if err != nil {
-		utils.InternalServerError(w, errors.Wrapf(err, "Failed to obtain Container %s stats", name))
+		utils.InternalServerError(w, errors.Wrapf(err, "failed to obtain Container %s stats", name))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_stop.go
+++ b/pkg/api/handlers/compat/containers_stop.go
@@ -22,7 +22,7 @@ func StopContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_top.go
+++ b/pkg/api/handlers/compat/containers_top.go
@@ -26,7 +26,7 @@ func TopContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/events.go
+++ b/pkg/api/handlers/compat/events.go
@@ -82,7 +82,7 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 		Stream: true,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Failed to parse parameters", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "failed to parse parameters", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -92,7 +92,7 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 
 	libpodFilters, err := filtersFromRequest(r)
 	if err != nil {
-		utils.Error(w, "Failed to parse parameters", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "failed to parse parameters", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -47,7 +47,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	newImage, err := runtime.ImageRuntime().NewFromLocal(name)
 	if err != nil {
-		utils.ImageNotFound(w, name, errors.Wrapf(err, "Failed to find image %s", name))
+		utils.ImageNotFound(w, name, errors.Wrapf(err, "failed to find image %s", name))
 		return
 	}
 	tmpfile, err := ioutil.TempFile("", "api.tar")
@@ -88,7 +88,7 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -138,7 +138,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	rtc, err := runtime.GetConfig()
@@ -205,7 +205,7 @@ func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	// fromSrc – Source to import. The value may be a URL from which the image can be retrieved or - to read the image from the request body. This parameter may only be used when importing an image.
@@ -264,7 +264,7 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -272,7 +272,7 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 
 	authConf, authfile, key, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "Failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)
@@ -327,12 +327,12 @@ func GetImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	newImage, err := utils.GetImage(r, name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "Failed to find image %s", name))
+		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
 		return
 	}
 	inspect, err := handlers.ImageDataToImageInspect(r.Context(), newImage)
 	if err != nil {
-		utils.Error(w, "Server error", http.StatusInternalServerError, errors.Wrapf(err, "Failed to convert ImageData to ImageInspect '%s'", inspect.ID))
+		utils.Error(w, "Server error", http.StatusInternalServerError, errors.Wrapf(err, "failed to convert ImageData to ImageInspect '%s'", inspect.ID))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, inspect)
@@ -370,7 +370,7 @@ func LoadImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/images_history.go
+++ b/pkg/api/handlers/compat/images_history.go
@@ -15,7 +15,7 @@ func HistoryImage(w http.ResponseWriter, r *http.Request) {
 
 	newImage, err := runtime.ImageRuntime().NewFromLocal(name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "Failed to find image %s", name))
+		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
 		return
 
 	}

--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -26,7 +26,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -45,13 +45,13 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 
 	newImage, err := runtime.ImageRuntime().NewFromLocal(imageName)
 	if err != nil {
-		utils.ImageNotFound(w, imageName, errors.Wrapf(err, "Failed to find image %s", imageName))
+		utils.ImageNotFound(w, imageName, errors.Wrapf(err, "failed to find image %s", imageName))
 		return
 	}
 
 	authConf, authfile, key, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)
@@ -76,7 +76,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		nil, // additional tags
 	)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Error pushing image %q", imageName))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "error pushing image %q", imageName))
 		return
 	}
 

--- a/pkg/api/handlers/compat/images_remove.go
+++ b/pkg/api/handlers/compat/images_remove.go
@@ -21,7 +21,7 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	if _, found := r.URL.Query()["noprune"]; found {
@@ -32,7 +32,7 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	newImage, err := runtime.ImageRuntime().NewFromLocal(name)
 	if err != nil {
-		utils.ImageNotFound(w, name, errors.Wrapf(err, "Failed to find image %s", name))
+		utils.ImageNotFound(w, name, errors.Wrapf(err, "failed to find image %s", name))
 		return
 	}
 

--- a/pkg/api/handlers/compat/images_search.go
+++ b/pkg/api/handlers/compat/images_search.go
@@ -22,7 +22,7 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/images_tag.go
+++ b/pkg/api/handlers/compat/images_tag.go
@@ -16,7 +16,7 @@ func TagImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	newImage, err := runtime.ImageRuntime().NewFromLocal(name)
 	if err != nil {
-		utils.ImageNotFound(w, name, errors.Wrapf(err, "Failed to find image %s", name))
+		utils.ImageNotFound(w, name, errors.Wrapf(err, "failed to find image %s", name))
 		return
 	}
 	tag := "latest"

--- a/pkg/api/handlers/compat/info.go
+++ b/pkg/api/handlers/compat/info.go
@@ -30,18 +30,18 @@ func GetInfo(w http.ResponseWriter, r *http.Request) {
 
 	infoData, err := runtime.Info()
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "Failed to obtain system memory info"))
+		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain system memory info"))
 		return
 	}
 
 	configInfo, err := runtime.GetConfig()
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "Failed to obtain runtime config"))
+		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain runtime config"))
 		return
 	}
 	versionInfo, err := define.GetVersion()
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "Failed to obtain podman versions"))
+		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain podman versions"))
 		return
 	}
 	stateInfo := getContainersState(runtime)

--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -35,7 +35,7 @@ func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 	//}
 	//decoder := r.Context().Value("decoder").(*schema.Decoder)
 	//if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-	//	utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+	//	utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 	//	return
 	//}
 	config, err := runtime.GetConfig()
@@ -170,7 +170,7 @@ func ListNetworks(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	config, err := runtime.GetConfig()

--- a/pkg/api/handlers/compat/resize.go
+++ b/pkg/api/handlers/compat/resize.go
@@ -28,7 +28,7 @@ func ResizeTTY(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/version.go
+++ b/pkg/api/handlers/compat/version.go
@@ -27,7 +27,7 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 
 	infoData, err := runtime.Info()
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "Failed to obtain system memory info"))
+		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain system memory info"))
 		return
 	}
 

--- a/pkg/api/handlers/compat/volumes.go
+++ b/pkg/api/handlers/compat/volumes.go
@@ -29,7 +29,7 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -83,7 +83,7 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 	query := struct{}{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	// decode params from body
@@ -196,7 +196,7 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -251,7 +251,7 @@ func PruneVolumes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	// TODO: We have no ability to pass pruning filters to `PruneVolumes()` so

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -49,7 +49,7 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -96,7 +96,7 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
@@ -188,7 +188,7 @@ func Checkpoint(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	name := utils.GetName(r)
@@ -256,7 +256,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	name := utils.GetName(r)

--- a/pkg/api/handlers/libpod/containers_stats.go
+++ b/pkg/api/handlers/libpod/containers_stats.go
@@ -27,7 +27,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		Stream: true,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -46,7 +46,7 @@ func ImageExists(w http.ResponseWriter, r *http.Request) {
 
 	_, err := runtime.ImageRuntime().NewFromLocal(name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "Failed to find image %s", name))
+		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
 		return
 	}
 	utils.WriteResponse(w, http.StatusNoContent, "")
@@ -71,7 +71,7 @@ func ImageTree(w http.ResponseWriter, r *http.Request) {
 	report, err := ir.Tree(r.Context(), name, options)
 	if err != nil {
 		if errors.Cause(err) == define.ErrNoSuchImage {
-			utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "Failed to find image %s", name))
+			utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
 			return
 		}
 		utils.Error(w, "Server error", http.StatusInternalServerError, errors.Wrapf(err, "failed to generate image tree for %s", name))
@@ -84,7 +84,7 @@ func GetImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	newImage, err := utils.GetImage(r, name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "Failed to find image %s", name))
+		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
 		return
 	}
 	inspect, err := newImage.Inspect(r.Context())
@@ -130,7 +130,7 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -174,7 +174,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	name := utils.GetName(r)
@@ -247,7 +247,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -410,7 +410,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -434,13 +434,13 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 
 	newImage, err := runtime.ImageRuntime().NewFromLocal(source)
 	if err != nil {
-		utils.ImageNotFound(w, source, errors.Wrapf(err, "Failed to find image %s", source))
+		utils.ImageNotFound(w, source, errors.Wrapf(err, "failed to find image %s", source))
 		return
 	}
 
 	authConf, authfile, key, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "Failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)
@@ -471,7 +471,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		nil, // additional tags
 	)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Error pushing image %q", destination))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "error pushing image %q", destination))
 		return
 	}
 
@@ -500,7 +500,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	rtc, err := runtime.GetConfig()
@@ -591,7 +591,7 @@ func UntagImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	if err := imageEngine.Untag(r.Context(), name, tags, opts); err != nil {
 		if errors.Cause(err) == define.ErrNoSuchImage {
-			utils.ImageNotFound(w, name, errors.Wrapf(err, "Failed to find image %s", name))
+			utils.ImageNotFound(w, name, errors.Wrapf(err, "failed to find image %s", name))
 		} else {
 			utils.Error(w, "failed to untag", http.StatusInternalServerError, err)
 		}
@@ -613,7 +613,7 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -628,7 +628,7 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 	if _, found := r.URL.Query()["filters"]; found {
 		filter, err := image.ParseSearchFilter(query.Filters)
 		if err != nil {
-			utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse filters parameter for %s", r.URL.String()))
+			utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse filters parameter for %s", r.URL.String()))
 			return
 		}
 		options.Filter = *filter

--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -76,7 +76,7 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 
 	authConf, authfile, key, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "Failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)

--- a/pkg/api/handlers/libpod/networks.go
+++ b/pkg/api/handlers/libpod/networks.go
@@ -28,7 +28,7 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	ic := abi.ContainerEngine{Libpod: runtime}
@@ -50,7 +50,7 @@ func ListNetworks(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -76,7 +76,7 @@ func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	name := utils.GetName(r)
@@ -109,7 +109,7 @@ func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	name := utils.GetName(r)

--- a/pkg/api/handlers/libpod/play.go
+++ b/pkg/api/handlers/libpod/play.go
@@ -50,7 +50,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	}
 	authConf, authfile, key, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "Failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -27,7 +27,7 @@ func PodCreate(w http.ResponseWriter, r *http.Request) {
 	)
 	var psg specgen.PodSpecGenerator
 	if err := json.NewDecoder(r.Body).Decode(&psg); err != nil {
-		utils.Error(w, "Failed to decode specgen", http.StatusInternalServerError, errors.Wrap(err, "failed to decode specgen"))
+		utils.Error(w, "failed to decode specgen", http.StatusInternalServerError, errors.Wrap(err, "failed to decode specgen"))
 		return
 	}
 	pod, err := generate.MakePod(&psg, runtime)
@@ -51,7 +51,7 @@ func Pods(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -98,7 +98,7 @@ func PodStop(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	name := utils.GetName(r)
@@ -191,7 +191,7 @@ func PodDelete(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	name := utils.GetName(r)
@@ -320,7 +320,7 @@ func PodTop(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -365,7 +365,7 @@ func PodKill(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	if _, found := r.URL.Query()["signal"]; found {
@@ -443,7 +443,7 @@ func PodStats(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/system.go
+++ b/pkg/api/handlers/libpod/system.go
@@ -26,7 +26,7 @@ func SystemPrune(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -27,7 +27,7 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 	input := entities.VolumeCreateOptions{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	// decode params from body
@@ -124,7 +124,7 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -207,7 +207,7 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	name := utils.GetName(r)

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -178,29 +178,29 @@ type ExecStartConfig struct {
 func ImageToImageSummary(l *libpodImage.Image) (*entities.ImageSummary, error) {
 	containers, err := l.Containers()
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to obtain Containers for image %s", l.ID())
+		return nil, errors.Wrapf(err, "failed to obtain Containers for image %s", l.ID())
 	}
 	containerCount := len(containers)
 
 	// FIXME: GetParent() panics
 	// parent, err := l.GetParent(context.TODO())
 	// if err != nil {
-	// 	return nil, errors.Wrapf(err, "Failed to obtain ParentID for image %s", l.ID())
+	// 	return nil, errors.Wrapf(err, "failed to obtain ParentID for image %s", l.ID())
 	// }
 
 	labels, err := l.Labels(context.TODO())
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to obtain Labels for image %s", l.ID())
+		return nil, errors.Wrapf(err, "failed to obtain Labels for image %s", l.ID())
 	}
 
 	size, err := l.Size(context.TODO())
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to obtain Size for image %s", l.ID())
+		return nil, errors.Wrapf(err, "failed to obtain Size for image %s", l.ID())
 	}
 
 	repoTags, err := l.RepoTags()
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to obtain RepoTags for image %s", l.ID())
+		return nil, errors.Wrapf(err, "failed to obtain RepoTags for image %s", l.ID())
 	}
 
 	digests := make([]string, len(l.Digests()))

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -27,7 +27,7 @@ func WaitContainer(w http.ResponseWriter, r *http.Request) (int32, error) {
 		// Override golang default values for types
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return 0, err
 	}
 	if _, found := r.URL.Query()["interval"]; found {

--- a/pkg/api/handlers/utils/errors.go
+++ b/pkg/api/handlers/utils/errors.go
@@ -90,7 +90,7 @@ func InternalServerError(w http.ResponseWriter, err error) {
 }
 
 func BadRequest(w http.ResponseWriter, key string, value string, err error) {
-	e := errors.Wrapf(err, "Failed to parse query parameter '%s': %q", key, value)
+	e := errors.Wrapf(err, "failed to parse query parameter '%s': %q", key, value)
 	Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, e)
 }
 

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -119,7 +119,7 @@ func NewConnectionWithIdentity(ctx context.Context, uri string, identity string)
 		return nil, errors.Errorf("unable to create connection. %q is not a supported schema", _url.Scheme)
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to create %sClient", _url.Scheme)
+		return nil, errors.Wrapf(err, "failed to create %sClient", _url.Scheme)
 	}
 
 	ctx = context.WithValue(ctx, clientKey, &connection)

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -131,7 +131,7 @@ func getAvailableControllers(exclude map[string]controllerHandler, cgroup2 bool)
 
 	infos, err := ioutil.ReadDir(cgroupRoot)
 	if err != nil {
-		return nil, errors.Wrapf(err, "read directory %s", cgroupRoot)
+		return nil, err
 	}
 	controllers := []controller{}
 	for _, i := range infos {
@@ -157,7 +157,7 @@ func (c *CgroupControl) getCgroupv1Path(name string) string {
 func createCgroupv2Path(path string) (deferredError error) {
 	content, err := ioutil.ReadFile("/sys/fs/cgroup/cgroup.controllers")
 	if err != nil {
-		return errors.Wrapf(err, "read /sys/fs/cgroup/cgroup.controllers")
+		return err
 	}
 	if !strings.HasPrefix(path, "/sys/fs/cgroup/") {
 		return fmt.Errorf("invalid cgroup path %s", path)
@@ -180,7 +180,7 @@ func createCgroupv2Path(path string) (deferredError error) {
 		if i > 0 {
 			if err := os.Mkdir(current, 0755); err != nil {
 				if !os.IsExist(err) {
-					return errors.Wrapf(err, "mkdir %s", path)
+					return err
 				}
 			} else {
 				// If the directory was created, be sure it is not left around on errors.
@@ -237,7 +237,7 @@ func (c *CgroupControl) initialize() (err error) {
 			}
 			path := c.getCgroupv1Path(ctr.name)
 			if err := os.MkdirAll(path, 0755); err != nil {
-				return errors.Wrapf(err, "error creating cgroup path %s for %s", path, ctr.name)
+				return errors.Wrapf(err, "error creating cgroup path for %s", ctr.name)
 			}
 		}
 	}
@@ -265,7 +265,7 @@ func (c *CgroupControl) createCgroupDirectory(controller string) (bool, error) {
 func readFileAsUint64(path string) (uint64, error) {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return 0, errors.Wrapf(err, "open %s", path)
+		return 0, err
 	}
 	v := cleanString(string(data))
 	if v == "max" {
@@ -425,7 +425,7 @@ func rmDirRecursively(path string) error {
 	}
 	entries, err := ioutil.ReadDir(path)
 	if err != nil {
-		return errors.Wrapf(err, "read %s", path)
+		return err
 	}
 	for _, i := range entries {
 		if i.IsDir() {

--- a/pkg/cgroups/cgroups_supported.go
+++ b/pkg/cgroups/cgroups_supported.go
@@ -46,7 +46,7 @@ func UserOwnsCurrentSystemdCgroup() (bool, error) {
 
 	f, err := os.Open("/proc/self/cgroup")
 	if err != nil {
-		return false, errors.Wrapf(err, "open file /proc/self/cgroup")
+		return false, err
 	}
 	defer f.Close()
 

--- a/pkg/cgroups/cpu.go
+++ b/pkg/cgroups/cpu.go
@@ -134,7 +134,7 @@ func GetSystemCPUUsage() (uint64, error) {
 
 	files, err := ioutil.ReadDir(cgroupRoot)
 	if err != nil {
-		return 0, errors.Wrapf(err, "read directory %q", cgroupRoot)
+		return 0, err
 	}
 	var total uint64
 	for _, file := range files {

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -24,11 +24,11 @@ import (
 func crImportFromJSON(filePath string, v interface{}) error {
 	content, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return errors.Wrap(err, "Failed to read container definition for restore")
+		return errors.Wrap(err, "failed to read container definition for restore")
 	}
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(content, v); err != nil {
-		return errors.Wrapf(err, "Failed to unmarshal container definition %s for restore", filePath)
+		return errors.Wrapf(err, "failed to unmarshal container definition %s for restore", filePath)
 	}
 
 	return nil
@@ -41,7 +41,7 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, input stri
 	// tarball to a temporary directory
 	archiveFile, err := os.Open(input)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to open checkpoint archive for import")
+		return nil, errors.Wrap(err, "failed to open checkpoint archive for import")
 	}
 	defer errorhandling.CloseQuiet(archiveFile)
 	options := &archive.TarOptions{

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -22,15 +22,9 @@ import (
 // crImportFromJSON imports the JSON files stored in the exported
 // checkpoint tarball
 func crImportFromJSON(filePath string, v interface{}) error {
-	jsonFile, err := os.Open(filePath)
+	content, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to open container definition %s for restore", filePath)
-	}
-	defer errorhandling.CloseQuiet(jsonFile)
-
-	content, err := ioutil.ReadAll(jsonFile)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to read container definition %s for restore", filePath)
+		return errors.Wrap(err, "Failed to read container definition for restore")
 	}
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(content, v); err != nil {
@@ -47,7 +41,7 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, input stri
 	// tarball to a temporary directory
 	archiveFile, err := os.Open(input)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to open checkpoint archive %s for import", input)
+		return nil, errors.Wrap(err, "Failed to open checkpoint archive for import")
 	}
 	defer errorhandling.CloseQuiet(archiveFile)
 	options := &archive.TarOptions{

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -312,7 +312,7 @@ func (ic *ContainerEngine) ContainerRm(ctx context.Context, namesOrIds []string,
 					reports = append(reports, &report)
 					continue
 				}
-				report.Err = errors.Wrapf(err, "Failed to evict container: %q", id)
+				report.Err = errors.Wrapf(err, "failed to evict container: %q", id)
 				reports = append(reports, &report)
 				continue
 			}

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -604,7 +604,7 @@ func checkExecPreserveFDs(options entities.ExecOptions) error {
 	if options.PreserveFDs > 0 {
 		entries, err := ioutil.ReadDir("/proc/self/fd")
 		if err != nil {
-			return errors.Wrapf(err, "unable to read /proc/self/fd")
+			return err
 		}
 
 		m := make(map[int]bool)

--- a/pkg/domain/infra/abi/cp.go
+++ b/pkg/domain/infra/abi/cp.go
@@ -115,7 +115,7 @@ func (ic *ContainerEngine) ContainerCp(ctx context.Context, source, dest string,
 				return nil, err
 			}
 			if err = idtools.MkdirAllAndChownNew(ctrWorkDir, 0755, hostOwner); err != nil {
-				return nil, errors.Wrapf(err, "error creating directory %q", destPath)
+				return nil, err
 			}
 			cleanedPath, err := securejoin.SecureJoin(mountPoint, filepath.Join(ctr.WorkingDir(), destPath))
 			if err != nil {
@@ -249,7 +249,7 @@ func containerCopy(srcPath, destPath, src, dest string, idMappingOpts storage.ID
 	}
 	destDirIsExist := err == nil
 	if err = os.MkdirAll(destdir, 0755); err != nil {
-		return errors.Wrapf(err, "error creating directory %q", destdir)
+		return err
 	}
 
 	// return functions for copying items
@@ -351,7 +351,7 @@ func streamFileToStdout(srcPath string, srcfi os.FileInfo) error {
 
 	file, err := os.Open(srcPath)
 	if err != nil {
-		return errors.Wrapf(err, "error opening file %s", srcPath)
+		return err
 	}
 	defer file.Close()
 	if !archive.IsArchivePath(srcPath) {

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -770,7 +770,7 @@ func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entitie
 		if err := os.MkdirAll(signatureDir, 0751); err != nil {
 			// The directory is allowed to exist
 			if !os.IsExist(err) {
-				logrus.Errorf("error creating directory %s: %s", signatureDir, err)
+				logrus.Error(err)
 				continue
 			}
 		}

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -100,7 +100,7 @@ func (ic *ContainerEngine) playKubeDeployment(ctx context.Context, deploymentYAM
 		podName := fmt.Sprintf("%s-pod-%d", deploymentName, i)
 		podReport, err := ic.playKubePod(ctx, podName, &podSpec, options)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Error encountered while bringing up pod %s", podName)
+			return nil, errors.Wrapf(err, "error encountered while bringing up pod %s", podName)
 		}
 		report.Pods = append(report.Pods, podReport.Pods...)
 	}
@@ -248,18 +248,18 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			case v1.HostPathDirectoryOrCreate:
 				if _, err := os.Stat(hostPath.Path); os.IsNotExist(err) {
 					if err := os.Mkdir(hostPath.Path, kubeDirectoryPermission); err != nil {
-						return nil, errors.Errorf("Error creating HostPath %s", volume.Name)
+						return nil, errors.Errorf("error creating HostPath %s", volume.Name)
 					}
 				}
 				// Label a newly created volume
 				if err := libpod.LabelVolumePath(hostPath.Path); err != nil {
-					return nil, errors.Wrapf(err, "Error giving %s a label", hostPath.Path)
+					return nil, errors.Wrapf(err, "error giving %s a label", hostPath.Path)
 				}
 			case v1.HostPathFileOrCreate:
 				if _, err := os.Stat(hostPath.Path); os.IsNotExist(err) {
 					f, err := os.OpenFile(hostPath.Path, os.O_RDONLY|os.O_CREATE, kubeFilePermission)
 					if err != nil {
-						return nil, errors.Errorf("Error creating HostPath %s", volume.Name)
+						return nil, errors.Errorf("error creating HostPath %s", volume.Name)
 					}
 					if err := f.Close(); err != nil {
 						logrus.Warnf("Error in closing newly created HostPath file: %v", err)
@@ -267,15 +267,15 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 				}
 				// unconditionally label a newly created volume
 				if err := libpod.LabelVolumePath(hostPath.Path); err != nil {
-					return nil, errors.Wrapf(err, "Error giving %s a label", hostPath.Path)
+					return nil, errors.Wrapf(err, "error giving %s a label", hostPath.Path)
 				}
 			case v1.HostPathSocket:
 				st, err := os.Stat(hostPath.Path)
 				if err != nil {
-					return nil, errors.Wrap(err, "Error checking HostPathSocket")
+					return nil, errors.Wrap(err, "error checking HostPathSocket")
 				}
 				if st.Mode()&os.ModeSocket != os.ModeSocket {
-					return nil, errors.Errorf("Error checking HostPathSocket: path %s is not a socket", hostPath.Path)
+					return nil, errors.Errorf("error checking HostPathSocket: path %s is not a socket", hostPath.Path)
 				}
 
 			case v1.HostPathDirectory:
@@ -289,7 +289,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		}
 
 		if err := parse.ValidateVolumeHostDir(hostPath.Path); err != nil {
-			return nil, errors.Wrapf(err, "Error in parsing HostPath in YAML")
+			return nil, errors.Wrapf(err, "error in parsing HostPath in YAML")
 		}
 		volumes[volume.Name] = hostPath.Path
 	}

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -248,7 +248,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			case v1.HostPathDirectoryOrCreate:
 				if _, err := os.Stat(hostPath.Path); os.IsNotExist(err) {
 					if err := os.Mkdir(hostPath.Path, kubeDirectoryPermission); err != nil {
-						return nil, errors.Errorf("Error creating HostPath %s at %s", volume.Name, hostPath.Path)
+						return nil, errors.Errorf("Error creating HostPath %s", volume.Name)
 					}
 				}
 				// Label a newly created volume
@@ -259,7 +259,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 				if _, err := os.Stat(hostPath.Path); os.IsNotExist(err) {
 					f, err := os.OpenFile(hostPath.Path, os.O_RDONLY|os.O_CREATE, kubeFilePermission)
 					if err != nil {
-						return nil, errors.Errorf("Error creating HostPath %s at %s", volume.Name, hostPath.Path)
+						return nil, errors.Errorf("Error creating HostPath %s", volume.Name)
 					}
 					if err := f.Close(); err != nil {
 						logrus.Warnf("Error in closing newly created HostPath file: %v", err)
@@ -272,7 +272,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			case v1.HostPathSocket:
 				st, err := os.Stat(hostPath.Path)
 				if err != nil {
-					return nil, errors.Wrapf(err, "Error checking HostPathSocket")
+					return nil, errors.Wrap(err, "Error checking HostPathSocket")
 				}
 				if st.Mode()&os.ModeSocket != os.ModeSocket {
 					return nil, errors.Errorf("Error checking HostPathSocket: path %s is not a socket", hostPath.Path)

--- a/pkg/domain/infra/abi/trust.go
+++ b/pkg/domain/infra/abi/trust.go
@@ -24,7 +24,7 @@ func (ir *ImageEngine) ShowTrust(ctx context.Context, args []string, options ent
 	}
 	report.Raw, err = ioutil.ReadFile(policyPath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to read %s", policyPath)
+		return nil, err
 	}
 	if options.Raw {
 		return &report, nil
@@ -67,7 +67,7 @@ func (ir *ImageEngine) SetTrust(ctx context.Context, args []string, options enti
 	if !os.IsNotExist(err) {
 		policyContent, err := ioutil.ReadFile(policyPath)
 		if err != nil {
-			return errors.Wrapf(err, "unable to read %s", policyPath)
+			return err
 		}
 		if err := json.Unmarshal(policyContent, &policyContentStruct); err != nil {
 			return errors.Errorf("could not read trust policies")

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -84,7 +84,7 @@ func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []strin
 	for _, cidFile := range options.CIDFiles {
 		content, err := ioutil.ReadFile(cidFile)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error reading CIDFile %s", cidFile)
+			return nil, errors.Wrap(err, "error reading CIDFile")
 		}
 		id := strings.Split(string(content), "\n")[0]
 		namesOrIds = append(namesOrIds, id)
@@ -164,7 +164,7 @@ func (ic *ContainerEngine) ContainerRm(ctx context.Context, namesOrIds []string,
 	for _, cidFile := range options.CIDFiles {
 		content, err := ioutil.ReadFile(cidFile)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error reading CIDFile %s", cidFile)
+			return nil, errors.Wrap(err, "error reading CIDFile")
 		}
 		id := strings.Split(string(content), "\n")[0]
 		namesOrIds = append(namesOrIds, id)

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -453,7 +453,7 @@ func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []st
 func ReadMappingsProc(path string) ([]idtools.IDMap, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot open %s", path)
+		return nil, err
 	}
 	defer file.Close()
 

--- a/pkg/spec/config_linux_cgo.go
+++ b/pkg/spec/config_linux_cgo.go
@@ -29,7 +29,7 @@ func getSeccompConfig(config *SecurityConfig, configSpec *spec.Spec) (*spec.Linu
 		logrus.Debugf("Loading seccomp profile from %q", config.SeccompProfilePath)
 		seccompProfile, err := ioutil.ReadFile(config.SeccompProfilePath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "opening seccomp profile (%s) failed", config.SeccompProfilePath)
+			return nil, errors.Wrap(err, "opening seccomp profile failed")
 		}
 		seccompConfig, err = goSeccomp.LoadProfile(string(seccompProfile), configSpec)
 		if err != nil {

--- a/pkg/specgen/generate/config_linux_cgo.go
+++ b/pkg/specgen/generate/config_linux_cgo.go
@@ -47,7 +47,7 @@ func getSeccompConfig(s *specgen.SpecGenerator, configSpec *spec.Spec, img *imag
 		logrus.Debugf("Loading seccomp profile from %q", s.SeccompProfilePath)
 		seccompProfile, err := ioutil.ReadFile(s.SeccompProfilePath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "opening seccomp profile (%s) failed", s.SeccompProfilePath)
+			return nil, errors.Wrap(err, "opening seccomp profile failed")
 		}
 		seccompConfig, err = goSeccomp.LoadProfile(string(seccompProfile), configSpec)
 		if err != nil {

--- a/pkg/trust/trust.go
+++ b/pkg/trust/trust.go
@@ -226,10 +226,10 @@ func GetPolicy(policyPath string) (PolicyContent, error) {
 	var policyContentStruct PolicyContent
 	policyContent, err := ioutil.ReadFile(policyPath)
 	if err != nil {
-		return policyContentStruct, errors.Wrapf(err, "unable to read policy file %s", policyPath)
+		return policyContentStruct, errors.Wrap(err, "unable to read policy file")
 	}
 	if err := json.Unmarshal(policyContent, &policyContentStruct); err != nil {
-		return policyContentStruct, errors.Wrapf(err, "could not parse trust policies")
+		return policyContentStruct, errors.Wrapf(err, "could not parse trust policies from %s", policyPath)
 	}
 	return policyContentStruct, nil
 }

--- a/pkg/trust/trust.go
+++ b/pkg/trust/trust.go
@@ -117,7 +117,7 @@ func LoadAndMergeConfig(dirPath string) (*RegistryConfiguration, error) {
 		var config RegistryConfiguration
 		err = yaml.Unmarshal(configBytes, &config)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Error parsing %s", configPath)
+			return nil, errors.Wrapf(err, "error parsing %s", configPath)
 		}
 		if config.DefaultDocker != nil {
 			if mergedConfig.DefaultDocker != nil {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -490,14 +490,14 @@ func WriteStorageConfigFile(storageOpts *storage.StoreOptions, storageConf strin
 	}
 	storageFile, err := os.OpenFile(storageConf, os.O_RDWR|os.O_TRUNC, 0600)
 	if err != nil {
-		return errors.Wrapf(err, "cannot open %s", storageConf)
+		return err
 	}
 	tomlConfiguration := getTomlStorage(storageOpts)
 	defer errorhandling.CloseQuiet(storageFile)
 	enc := toml.NewEncoder(storageFile)
 	if err := enc.Encode(tomlConfiguration); err != nil {
 		if err := os.Remove(storageConf); err != nil {
-			logrus.Errorf("unable to remove file %s", storageConf)
+			logrus.Error(err)
 		}
 		return err
 	}

--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -30,7 +30,7 @@ func GetRuntimeDir() (string, error) {
 		if runtimeDir == "" {
 			tmpDir := filepath.Join("/run", "user", uid)
 			if err := os.MkdirAll(tmpDir, 0700); err != nil {
-				logrus.Debugf("unable to make temp dir %s", tmpDir)
+				logrus.Debug(err)
 			}
 			st, err := os.Stat(tmpDir)
 			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && (st.Mode().Perm()&0700 == 0700) {
@@ -40,7 +40,7 @@ func GetRuntimeDir() (string, error) {
 		if runtimeDir == "" {
 			tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("run-%s", uid))
 			if err := os.MkdirAll(tmpDir, 0700); err != nil {
-				logrus.Debugf("unable to make temp dir %s", tmpDir)
+				logrus.Debug(err)
 			}
 			st, err := os.Stat(tmpDir)
 			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && (st.Mode().Perm()&0700 == 0700) {

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -155,7 +155,7 @@ func (i *VarlinkAPI) BuildImage(call iopodman.VarlinkCall, config iopodman.Build
 
 	reader, err := os.Open(contextDir)
 	if err != nil {
-		logrus.Errorf("failed to open the context dir tar file %s", contextDir)
+		logrus.Errorf("failed to open the context dir tar file")
 		return call.ReplyErrorOccurred(fmt.Sprintf("unable to open context dir tar file %s", contextDir))
 	}
 	defer reader.Close()
@@ -166,7 +166,7 @@ func (i *VarlinkAPI) BuildImage(call iopodman.VarlinkCall, config iopodman.Build
 	logrus.Debugf("untar of %s successful", contextDir)
 	defer func() {
 		if err := os.Remove(contextDir); err != nil {
-			logrus.Errorf("unable to delete file '%s': %q", contextDir, err)
+			logrus.Error(err)
 		}
 		if err := os.RemoveAll(newContextDir); err != nil {
 			logrus.Errorf("unable to delete directory '%s': %q", newContextDir, err)

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -56,7 +56,7 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 func getCgroupProcess(procFile string) (string, error) {
 	f, err := os.Open(procFile)
 	if err != nil {
-		return "", errors.Wrapf(err, "open file %q", procFile)
+		return "", err
 	}
 	defer f.Close()
 
@@ -104,7 +104,7 @@ func MoveUnderCgroupSubtree(subtree string) error {
 	procFile := "/proc/self/cgroup"
 	f, err := os.Open(procFile)
 	if err != nil {
-		return errors.Wrapf(err, "open file %q", procFile)
+		return err
 	}
 	defer f.Close()
 


### PR DESCRIPTION
Lots of small changes, needs a careful review...

### 1. pkg/cgroups/createCgroupv2Path: nits
    
1. Check the path validity before trying to read the cgroup.controllers.  
2. Do not hardcode "/sys/fs/cgroup".
3. Simplify creating the "+this +that" string.
4. Do not wrap ioutil.WriteFile error.

### 2. Remove excessive error wrapping

In case os.Open[File], os.Mkdir[All], ioutil.ReadFile and the like
fails, the error message already contains the file name and the
operation that fails, so there is no need to wrap the error with
something like "open %s failed".
    
While at it
    
- replace a few places with os.Open, ioutil.ReadAll with
ioutil.ReadFile.
    
- replace errors.Wrapf with errors.Wrap for cases where there
are no %-style arguments.
    
