### PR TITLE
add prerequisite section before building binaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,17 @@ Makefile allow you to install needed tools:
 $ make install.tools
 ```
 
+### Prerequisite before build
+
+You need install some dependencies before building a binary..
+
+#### Fedora
+
+  ```shell
+  $ sudo dnf install gpgme-devel libseccomp-devel.x86_64 libseccomp-devel.x86_64
+  $ export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
+  ```
+  
 ### Building binaries and test your changes
 
 To test your changes do `make binaries` to generate your binaries.


### PR DESCRIPTION
Hi people,
I started using Podman some times ago, and like it. Also I'm looking for a OSS project where I can stay longer.
So... I went through CONTRIBUTING.md, but I couldn't run make binaries. I missed some libs/PATH, resolving this issue taken some time. Maybe this section will be helpful for newcomers like me.

Signed-off-by: 3sky <3sky@protonmail.com>