### PR TITLE
Populate /etc/hosts file when run in a user namespace

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1543,10 +1543,7 @@ func (c *Container) getHosts() string {
 		// When using slirp4netns, the interface gets a static IP
 		hosts += fmt.Sprintf("# used by slirp4netns\n%s\t%s %s\n", "10.0.2.100", c.Hostname(), c.Config().Name)
 	}
-	if len(c.state.NetworkStatus) > 0 && len(c.state.NetworkStatus[0].IPs) > 0 {
-		ipAddress := strings.Split(c.state.NetworkStatus[0].IPs[0].Address.String(), "/")[0]
-		hosts += fmt.Sprintf("%s\t%s %s\n", ipAddress, c.Hostname(), c.Config().Name)
-	}
+	hosts += c.cniHosts()
 	return hosts
 }
 

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -477,6 +477,17 @@ var _ = Describe("Podman run networking", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman run --uidmap /etc/hosts contains --hostname", func() {
+		SkipIfRootless("uidmap population of cninetworks not supported for rootless users")
+		session := podmanTest.Podman([]string{"run", "--uidmap", "0:100000:1000", "--rm", "--hostname", "foohostname", ALPINE, "grep", "foohostname", "/etc/hosts"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"run", "--uidmap", "0:100000:1000", "--rm", "--hostname", "foohostname", "-v", "/etc/hosts:/etc/hosts", ALPINE, "grep", "foohostname", "/etc/hosts"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(1))
+	})
+
 	It("podman run network in user created network namespace", func() {
 		SkipIfRootless("ip netns is not supported for rootless users")
 		if Containerized() {


### PR DESCRIPTION
We do not populate the hostname field with the IP Address
when running within a user namespace.

Fixes https://github.com/containers/podman/issues/7490

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>