### PR TITLE
Cirrus: Fix obtaining a CI VM

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,7 +47,7 @@ env:
     TEST_ENVIRON: host       # 'host' or 'container'
     PODBIN_NAME: podman      # 'podman' or 'remote'
     PRIV_NAME: root          # 'root' or 'rootless'
-    DISTRO_NV: $FEDORA_NAME  # any {PRIOR_,}{FEDORA,UBUNTU}_NAME value
+    DISTRO_NV:               # any {PRIOR_,}{FEDORA,UBUNTU}_NAME value
     VM_IMAGE_NAME:           # One of the "Google-cloud VM Images" (above)
     CTR_FQIN:                # One of the "Container FQIN's" (above)
 

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -45,6 +45,9 @@ OS_RELEASE_ID="$(source /etc/os-release; echo $ID)"
 OS_RELEASE_VER="$(source /etc/os-release; echo $VERSION_ID | cut -d '.' -f 1)"
 # Combined to ease soe usage
 OS_REL_VER="${OS_RELEASE_ID}-${OS_RELEASE_VER}"
+# This is normally set from .cirrus.yml but default is necessary when
+# running under hack/get_ci_vm.sh since it cannot infer the value.
+DISTRO_NV="${DISTRO_NV:-$OS_REL_VER}"
 
 # Essential default paths, many are overridden when executing under Cirrus-CI
 GOPATH="${GOPATH:-/var/tmp/go}"

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -6,18 +6,20 @@
 # BEGIN Global export of all variables
 set -a
 
-# Due to differences across platforms and runtime execution environments,
-# handling of the (otherwise) default shell setup is non-uniform.  Rather
-# than attempt to workaround differences, simply force-load/set required
-# items every time this library is utilized.
-source /etc/profile
-source /etc/environment
-USER="$(whoami)"
-HOME="$(getent passwd $USER | cut -d : -f 6)"
-# Some platforms set and make this read-only
-[[ -n "$UID" ]] || \
-    UID=$(getent passwd $USER | cut -d : -f 3)
-GID=$(getent passwd $USER | cut -d : -f 4)
+if [[ "$CI" == "true" ]]; then
+    # Due to differences across platforms and runtime execution environments,
+    # handling of the (otherwise) default shell setup is non-uniform.  Rather
+    # than attempt to workaround differences, simply force-load/set required
+    # items every time this library is utilized.
+    source /etc/profile
+    source /etc/environment
+    USER="$(whoami)"
+    HOME="$(getent passwd $USER | cut -d : -f 6)"
+    # Some platforms set and make this read-only
+    [[ -n "$UID" ]] || \
+        UID=$(getent passwd $USER | cut -d : -f 3)
+    GID=$(getent passwd $USER | cut -d : -f 4)
+fi
 
 # During VM Image build, the 'containers/automation' installation
 # was performed.  The final step of that installation sets the

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -139,6 +139,9 @@ function _run_vendor() {
 }
 
 function _run_build() {
+    # Ensure always start from clean-slate with all vendor modules downloaded
+    make clean
+    make vendor
     make podman-release
     make podman-remote-linux-release
 }

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -67,9 +67,8 @@ case "$CG_FS_TYPE" in
     *) die_unknown CG_FS_TYPE
 esac
 
-# Required to be defined by caller: Which distribution are we testing on
-# shellcheck disable=SC2154
-case "$DISTRO_NV" in
+# Which distribution are we testing on.
+case "$OS_RELEASE_ID" in
     ubuntu*) ;;
     fedora*)
         if ((CONTAINER==0)); then  # Not yet running inside a container
@@ -83,7 +82,7 @@ case "$DISTRO_NV" in
             setsebool container_manage_cgroup true
         fi
         ;;
-    *) die_unknown DISTRO_NV
+    *) die_unknown OS_RELEASE_ID
 esac
 
 # Required to be defined by caller: The environment where primary testing happens

--- a/contrib/cirrus/shellcheck.sh
+++ b/contrib/cirrus/shellcheck.sh
@@ -11,6 +11,6 @@ shellcheck --color=always --format=tty \
     --enable add-default-case,avoid-nullary-conditions,check-unassigned-uppercase \
     --exclude SC2046,SC2034,SC2090,SC2064 \
     --wiki-link-count=0 --severity=warning \
-    $SCRIPT_BASE/*.sh
+    $SCRIPT_BASE/*.sh hack/get_ci_vm.sh
 
 echo "Shellcheck: PASS"


### PR DESCRIPTION
Also removed automatic exection of setup_environment.sh since most
people using this script are podman developers (not automation/CI
folks).  If executing the automation scripts is necessary, manual
attendance to required variables like `$TEST_FLAVOR` is mandatory.