### PR TITLE
system tests: cleanup, and add more tests

### DIFF
--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -43,6 +43,11 @@ load helpers
     # Start with clean slate
     run_podman image umount -a
 
+    # Get full image ID, to verify umount
+    run_podman image inspect --format '{{.ID}}' $IMAGE
+    iid="$output"
+
+    # Mount, and make sure the mount point exists
     run_podman image mount $IMAGE
     mount_path="$output"
 
@@ -60,6 +65,14 @@ load helpers
 
     # Clean up
     run_podman image umount $IMAGE
+    is "$output" "$iid" "podman image umount: image ID of what was umounted"
+
+    run_podman image umount $IMAGE
+    is "$output" "" "podman image umount: does not re-umount"
+
+    run_podman 125 image umount no-such-container
+    is "$output" "Error: unable to find a name and tag match for no-such-container in repotags: no such image" \
+       "error message from image umount no-such-container"
 
     run_podman image mount
     is "$output" "" "podman image mount, no args, after umount"

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -7,9 +7,7 @@ load helpers
 
 
 function check_label() {
-    if [ ! -e /usr/sbin/selinuxenabled ] || ! /usr/sbin/selinuxenabled; then
-        skip "selinux disabled or not available"
-    fi
+    skip_if_no_selinux
 
     local args="$1"; shift        # command-line args for run
 
@@ -52,15 +50,33 @@ function check_label() {
     check_label "--privileged --userns=host" "spc_t"
 }
 
+@test "podman selinux: pid=host" {
+    # FIXME FIXME FIXME: Remove these lines once all VMs have >= 2.146.0
+    # (this is ugly, but better than an unconditional skip)
+    skip_if_no_selinux
+    if is_rootless; then
+        if [ -x /usr/bin/rpm ]; then
+            cs_version=$(rpm -q --qf '%{version}' container-selinux)
+        else
+            # SELinux not enabled on Ubuntu, so we should never get here
+            die "WHOA! SELinux enabled, but no /usr/bin/rpm!"
+        fi
+        if [[ "$cs_version" < "2.146" ]]; then
+            skip "FIXME: #7939: requires container-selinux-2.146.0 (currently installed: $cs_version)"
+        fi
+    fi
+    # FIXME FIXME FIXME: delete up to here, leaving just check_label
+
+    check_label "--pid=host" "spc_t"
+}
+
 @test "podman selinux: container with overridden range" {
     check_label "--security-opt label=level:s0:c1,c2" "container_t" "s0:c1,c2"
 }
 
 # pr #6752
 @test "podman selinux: inspect multiple labels" {
-    if [ ! -e /usr/sbin/selinuxenabled ] || ! /usr/sbin/selinuxenabled; then
-        skip "selinux disabled or not available"
-    fi
+    skip_if_no_selinux
 
     run_podman run -d --name myc \
                --security-opt seccomp=unconfined \
@@ -73,6 +89,86 @@ function check_label() {
 
     run_podman exec myc touch /stop
     run_podman rm -f myc
+}
+
+# Sharing context between two containers not in a pod
+# These tests were piggybacked in with #7902, but are not actually related
+@test "podman selinux: shared context in (some) namespaces" {
+    skip_if_no_selinux
+
+    run_podman run -d --name myctr $IMAGE top
+    run_podman exec myctr cat -v /proc/self/attr/current
+    context_c1="$output"
+
+    # --ipc container
+    run_podman run --name myctr2 --ipc container:myctr $IMAGE cat -v /proc/self/attr/current
+    is "$output" "$context_c1" "new container, run with ipc of existing one "
+
+    # --pid container
+    run_podman run --rm --pid container:myctr $IMAGE cat -v /proc/self/attr/current
+    is "$output" "$context_c1" "new container, run with --pid of existing one "
+
+    # net NS: do not share context
+    run_podman run --rm --net container:myctr $IMAGE cat -v /proc/self/attr/current
+    if [[ "$output" = "$context_c1" ]]; then
+        die "run --net : context ($output) is same as running container (it should not be)"
+    fi
+
+    # The 'myctr2' above was not run with --rm, so it still exists, and
+    # we can't remove the original container until this one is gone.
+    run_podman stop -t 0 myctr
+    run_podman 125 rm myctr
+    is "$output" "Error: container .* has dependent containers"
+
+    # We have to do this in two steps: even if ordered as 'myctr2 myctr',
+    # podman will try the removes in random order, which fails if it
+    # tries myctr first.
+    run_podman rm myctr2
+    run_podman rm myctr
+}
+
+# pr #7902 - containers in pods should all run under same context
+@test "podman selinux: containers in pods share full context" {
+    skip_if_no_selinux
+
+    # We don't need a fullblown pause container; avoid pulling the k8s one
+    run_podman pod create --name myselinuxpod \
+               --infra-image $IMAGE \
+               --infra-command /home/podman/pause
+
+    # Get baseline
+    run_podman run --rm --pod myselinuxpod $IMAGE cat -v /proc/self/attr/current
+    context_c1="$output"
+
+    # Prior to #7902, the labels (':c123,c456') would be different
+    run_podman run --rm --pod myselinuxpod $IMAGE cat -v /proc/self/attr/current
+    is "$output" "$context_c1" "SELinux context of 2nd container matches 1st"
+
+    # What the heck. Try a third time just for extra confidence
+    run_podman run --rm --pod myselinuxpod $IMAGE cat -v /proc/self/attr/current
+    is "$output" "$context_c1" "SELinux context of 3rd container matches 1st"
+
+    run_podman pod rm myselinuxpod
+}
+
+# more pr #7902
+@test "podman selinux: containers in --no-infra pods do not share context" {
+    skip_if_no_selinux
+
+    # We don't need a fullblown pause container; avoid pulling the k8s one
+    run_podman pod create --name myselinuxpod --infra=false
+
+    # Get baseline
+    run_podman run --rm --pod myselinuxpod $IMAGE cat -v /proc/self/attr/current
+    context_c1="$output"
+
+    # Even after #7902, labels (':c123,c456') should be different
+    run_podman run --rm --pod myselinuxpod $IMAGE cat -v /proc/self/attr/current
+    if [[ "$output" = "$context_c1" ]]; then
+        die "context ($output) is the same on two separate containers, it should have been different"
+    fi
+
+    run_podman pod rm myselinuxpod
 }
 
 # vim: filetype=sh

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -286,6 +286,17 @@ function skip_if_remote() {
     fi
 }
 
+########################
+#  skip_if_no_selinux  #
+########################
+function skip_if_no_selinux() {
+    if [ ! -e /usr/sbin/selinuxenabled ]; then
+        skip "selinux not available"
+    elif ! /usr/sbin/selinuxenabled; then
+        skip "selinux disabled"
+    fi
+}
+
 #########
 #  die  #  Abort with helpful message
 #########


### PR DESCRIPTION
 - images test: add test for 'table' and '\t' formatting

 - image mount test: check output from 'umount', test
   repeat umount (NOP), and test invalid-umount

 - kill test: remove kludgy workaround for crun signal bug
   ref: #5004 -- code is no longer needed (fingers crossed),
   and the workaround involved pulling an expensive image.

 - selinux test: add new tests for shared context in:
   * pods , w/ and w/o infra container (ref: #7902)
   * containers with namespace sharing: --ipc, --pid, --net

 - selinux test: new test for --pid=host (disabled pending
   propagation of container-selinux-2.146, ref: #7939)

Signed-off-by: Ed Santiago <santiago@redhat.com>