### PR TITLE
Ports given only by number should have random host port

### DIFF
--- a/cmd/podman/common/util.go
+++ b/cmd/podman/common/util.go
@@ -200,8 +200,6 @@ func parseSplitPort(hostIP, hostPort *string, ctrPort string, protocol *string) 
 			}
 			newPort.HostPort = hostStart
 		}
-	} else {
-		newPort.HostPort = newPort.ContainerPort
 	}
 
 	hport := newPort.HostPort

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Podman run networking", func() {
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports["80/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("80"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Not(Equal("80")))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal(""))
 	})
 
@@ -111,7 +111,7 @@ var _ = Describe("Podman run networking", func() {
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports["80/udp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["80/udp"][0].HostPort).To(Equal("80"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/udp"][0].HostPort).To(Not(Equal("80")))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/udp"][0].HostIP).To(Equal(""))
 	})
 
@@ -195,7 +195,7 @@ var _ = Describe("Podman run networking", func() {
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports["80/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("80"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Not(Equal("80")))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal(""))
 	})
 


### PR DESCRIPTION
In Podman 1.9.3, `podman run -p 80` would assign port 80 in the container to a random port on the host. In Podman 2.0 and up, it assigned Port 80 in the container to Port 80 on the host. This is an easy fix, fortunately - just need to remove the bit that assumed host port, if not given, should be set to container port.

We also had a test for the bad behavior, so fix it to test for the correct way of doing things.

Fixes #7947
