### PR TITLE
Container detach message (Docker Consistency)

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -588,6 +588,9 @@ func (ic *ContainerEngine) ContainerAttach(ctx context.Context, nameOrID string,
 	if err != nil && errors.Cause(err) != define.ErrDetach {
 		return errors.Wrapf(err, "error attaching to container %s", ctr.ID())
 	}
+	// This write maintains compatibility with Docker on <ctrl+p> <ctrl+q> detach:
+	// 'run -it x' does not newline but 'attach x' prints this message and newlines
+	os.Stdout.WriteString("read escape sequence\n")
 	return nil
 }
 


### PR DESCRIPTION
For https://github.com/containers/podman/issues/7751

After a 'docker attach', <ctrl+p> <ctrl+q> detaches with message 'read escape sequence'. This was not occurring for me on 'docker run -it' or 'podman run -it' so I modified the podman behavior so this occurs only on attach as well.