### PR TITLE
Cirrus: rootless system tests: local, not remote

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -539,12 +539,12 @@ rootless_system_test_task:
     alias: rootless_system_test
     depends_on:
       - rootless_integration_test
-    matrix: *fedora_vm_axis
+    matrix: *platform_axis
     gce_instance: *standardvm
     env:
         TEST_FLAVOR: sys
         PRIV_NAME: rootless
-        PODBIN_NAME: remote
+        PODBIN_NAME: podman
     clone_script: *noop  # Comes from cache
     gopath_cache: *ro_gopath_cache
     setup_script: *setup

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -247,6 +247,9 @@ dotest() {
 }
 
 msg "************************************************************"
+# BEFORE DOING ANYTHING AT ALL: make sure we have the env. needed for our job
+load_cirrus_task_environment
+
 # Required to be defined by caller
 # shellcheck disable=SC2154
 msg "Runner executing $TEST_FLAVOR $PODBIN_NAME-tests as $PRIV_NAME on $DISTRO_NV($OS_REL_VER)"


### PR DESCRIPTION
The new CI setup (accidentally?) ran rootless system tests
with podman-remote instead of local, and only on fedora.
This PR runs rootless system tests using podman local,
and on all four flavors (fedora + ubuntu).

Signed-off-by: Ed Santiago <santiago@redhat.com>