### PR TITLE
Cirrus: Use google mirror for docker.io

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -208,6 +208,7 @@ install_test_configs() {
     # as the default).  This config prevents allocation of network address space used
     # by default in google cloud.  https://cloud.google.com/vpc/docs/vpc#ip-ranges
     install -v -D -m 644 $SCRIPT_BASE/99-do-not-use-google-subnets.conflist /etc/cni/net.d/
+
     install -v -D -m 644 ./test/registries.conf /etc/containers/
 }
 

--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -45,8 +45,10 @@ case $1 in
                     containernetworking-plugins \
                     containers-common \
                     criu \
+                    crun \
                     golang \
                     podman \
+                    runc \
                     skopeo \
                     slirp4netns \
         )
@@ -56,9 +58,7 @@ case $1 in
                 PKG_LST_CMD='rpm -q --qf=%{N}-%{V}-%{R}-%{ARCH}\n'
                 PKG_NAMES+=(\
                     container-selinux \
-                    crun \
                     libseccomp \
-                    runc \
                 )
                 ;;
             ubuntu*)

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -178,6 +178,8 @@ case "$TEST_FLAVOR" in
             remove_packaged_podman_files
             make install PREFIX=/usr ETCDIR=/etc
         fi
+
+        install_test_configs
         ;;
     vendor) make clean ;;
     release) ;;

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -51,11 +51,13 @@ var _ = Describe("Podman manifest", func() {
 	})
 
 	It("podman manifest inspect", func() {
-		session := podmanTest.Podman([]string{"manifest", "inspect", BB})
+		// Something NOT on docker hub
+		fqin := "k8s.gcr.io/pause@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea"
+		session := podmanTest.Podman([]string{"manifest", "inspect", fqin})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.PodmanNoCache([]string{"manifest", "inspect", "docker.io/library/busybox"})
+		session = podmanTest.PodmanNoCache([]string{"manifest", "inspect", fqin})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})

--- a/test/registries.conf
+++ b/test/registries.conf
@@ -1,10 +1,10 @@
 # Note that changing the order here may break tests.
-[registries.search]
-registries = ['docker.io', 'quay.io', 'registry.fedoraproject.org']
+unqualified-search-registries = ['docker.io', 'quay.io', 'registry.fedoraproject.org']
 
-[registries.insecure]
-registries = []
-
-#blocked (docker only)
-[registries.block]
-registries = []
+[[registry]]
+# In Nov. 2020, Docker rate-limits image pulling.  To avoid hitting these
+# limits while testing, always use the google mirror for qualified and
+# unqualified `docker.io` images.
+# Ref: https://cloud.google.com/container-registry/docs/pulling-cached-images
+prefix="docker.io"
+location="mirror.gcr.io"


### PR DESCRIPTION
In Nov. 2020 Docker inc. will be limiting (in some unknown way) the rate of image pulls.  In order for this limit to not randomly break automated testing, or require extensive code changes, we need to introduce a transparent mirror.  Fortunately Google provides a transparent mirror of the docker hub, and we're already using GCP for all our test-VMs and containers.  Unfortunately, measuring the use/non-use of the mirror is very difficult w/o achieve without test-breaking operational changes.  However, based on test-failures discovered in the making of this PR, the mirror does appear to be in-use and transparent to (most) tests.