### PR TITLE
add compatibility endpoint for exporting multiple images

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -275,6 +275,31 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}/get"), s.APIHandler(compat.ExportImage)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}/get", s.APIHandler(compat.ExportImage)).Methods(http.MethodGet)
+	// swagger:operation GET /images/get compat get
+	// ---
+	// tags:
+	//  - images (compat)
+	// summary: Export several images
+	// description: Get a tarball containing all images and metadata for several image repositories
+	// parameters:
+	//  - in:  query
+	//    name:  names
+	//    type: string
+	//    required: true
+	//    description: one or more image names or IDs comma separated
+	// produces:
+	//  - application/json
+	// responses:
+	//   200:
+	//     description: no error
+	//     schema:
+	//      type: string
+	//      format: binary
+	//   500:
+	//     $ref: '#/responses/InternalError'
+	r.Handle(VersionedPath("/images/get"), s.APIHandler(compat.ExportImages)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/get", s.APIHandler(compat.ExportImages)).Methods(http.MethodGet)
 	// swagger:operation GET /images/{name:.*}/history compat imageHistory
 	// ---
 	// tags:

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -68,4 +68,7 @@ for i in $iid ${iid:0:12} $PODMAN_TEST_IMAGE_NAME; do
   t GET "libpod/images/$i/get?compress=false" 200 '[POSIX tar archive]'
 done
 
+# Export more than one image
+t GET images/get?names=alpine,busybox 200 '[POSIX tar archive]'
+
 # vim: filetype=sh


### PR DESCRIPTION
with the recent inclusion of dealing with multiple images in a tar archive, we can now add a compatibility endpoint that was missing images/get?names=one,two.

Fixes: #7950

Signed-off-by: baude <bbaude@redhat.com>