### PR TITLE
Print the correct underlying cause for OCI errors

### DIFF
--- a/cmd/podman/root_test.go
+++ b/cmd/podman/root_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/containers/podman/v2/libpod/define"
+	"github.com/pkg/errors"
+)
+
+func TestFormatError(t *testing.T) {
+	err := errors.New("unknown error")
+	output := formatError(err)
+	expected := fmt.Sprintf("Error: %v", err)
+
+	if output != expected {
+		t.Errorf("Expected \"%s\" to equal \"%s\"", output, err.Error())
+	}
+}
+
+func TestFormatOCIError(t *testing.T) {
+	expectedPrefix := "Error: "
+	expectedSuffix := "OCI runtime output"
+	err := errors.Wrap(define.ErrOCIRuntime, expectedSuffix)
+	output := formatError(err)
+
+	if !strings.HasPrefix(output, expectedPrefix) {
+		t.Errorf("Expected \"%s\" to start with \"%s\"", output, expectedPrefix)
+	}
+	if !strings.HasSuffix(output, expectedSuffix) {
+		t.Errorf("Expected \"%s\" to end with \"%s\"", output, expectedSuffix)
+	}
+}


### PR DESCRIPTION
Previously, the order of OCI error messages was reversed, so that the
type of error was listed as the cause. For example:

    Error: writing file `cpu.cfs_quota_us`: Invalid argument: OCI runtime error

This error message makes it seem like "OCI runtime error" is the
argument that was invalid. In fact, "OCI runtime error" is the error and
"writing file ..." is the cause. With this change, the above message
reads:

    Error: writing file `cpu.cfs_quota_us`: Invalid argument

Signed-off-by: Jordan Christiansen <xordspar0@gmail.com>