### PR TITLE
BlobInfoCacheDir is set incorrectly when copying images

### DIFF
--- a/libpod/image/docker_registry_options.go
+++ b/libpod/image/docker_registry_options.go
@@ -55,6 +55,7 @@ func (o DockerRegistryOptions) GetSystemContext(parent *types.SystemContext, add
 		sc.DockerRegistryUserAgent = parent.DockerRegistryUserAgent
 		sc.OSChoice = parent.OSChoice
 		sc.ArchitectureChoice = parent.ArchitectureChoice
+		sc.BlobInfoCacheDir = parent.BlobInfoCacheDir
 	}
 	return sc
 }


### PR DESCRIPTION
It is not set based on the root image directory, and always
points at the defaults.  This change will get it to follow
filepath.Join(ir.store.GraphRoot(), "cache") set from libpod.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>