### PR TITLE
Resolve #7860 - add time.RFC3339 format 

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/containers/podman/v2/libpod"
 	"github.com/containers/podman/v2/libpod/define"
@@ -316,7 +317,7 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 
 	cb := types.ContainerJSONBase{
 		ID:              l.ID(),
-		Created:         l.CreatedTime().String(),
+		Created:         l.CreatedTime().Format(time.RFC3339Nano),
 		Path:            "",
 		Args:            nil,
 		State:           &state,


### PR DESCRIPTION
I can't find any other usage of this type, also no unit-tests for that. Sample validation below: 
```bash
# before
$ podman system service -t 5000 &
$ podman run -d -p 8080:8080 localhost/hello-world
$ curl -s --unix-socket /$XDG_RUNTIME_DIR/podman/podman.sock http://localhost/containers/$(podman ps -q)/json | jq .Created
"2020-10-09 16:24:07.309694324 +0200 CEST"

# after
$ make binaries
$ bin/podman system service -t 5000 &
$ bin/podman run -d -p 8080:8080 localhost/hello-world
$ curl -s --unix-socket /$XDG_RUNTIME_DIR/podman/podman.sock http://localhost/containers/$(podman ps -q)/json | jq .Created
"2020-10-09T16:30:58+02:00"
```

Signed-off-by: 3sky <3sky@protonmail.com>