### PR TITLE
Include CNI networks in inspect output when not running

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -828,6 +828,17 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 
 	// We can't do more if the network is down.
 	if c.state.NetNS == nil {
+		// We still want to make dummy configurations for each CNI net
+		// the container joined.
+		if len(c.config.Networks) > 0 {
+			settings.Networks = make(map[string]*define.InspectAdditionalNetwork, len(c.config.Networks))
+			for _, net := range c.config.Networks {
+				cniNet := new(define.InspectAdditionalNetwork)
+				cniNet.NetworkID = net
+				settings.Networks[net] = cniNet
+			}
+		}
+
 		return settings, nil
 	}
 

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -211,6 +211,43 @@ var _ = Describe("Podman network", func() {
 		Expect(rmAll.ExitCode()).To(BeZero())
 	})
 
+	It("podman inspect container two CNI networks (container not running)", func() {
+		netName1 := "testNetThreeCNI1"
+		network1 := podmanTest.Podman([]string{"network", "create", netName1})
+		network1.WaitWithDefaultTimeout()
+		Expect(network1.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName1)
+
+		netName2 := "testNetThreeCNI2"
+		network2 := podmanTest.Podman([]string{"network", "create", netName2})
+		network2.WaitWithDefaultTimeout()
+		Expect(network2.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName2)
+
+		ctrName := "testCtr"
+		container := podmanTest.Podman([]string{"create", "--network", fmt.Sprintf("%s,%s", netName1, netName2), "--name", ctrName, ALPINE, "top"})
+		container.WaitWithDefaultTimeout()
+		Expect(container.ExitCode()).To(BeZero())
+
+		inspect := podmanTest.Podman([]string{"inspect", ctrName})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(BeZero())
+		conData := inspect.InspectContainerToJSON()
+		Expect(len(conData)).To(Equal(1))
+		Expect(len(conData[0].NetworkSettings.Networks)).To(Equal(2))
+		net1, ok := conData[0].NetworkSettings.Networks[netName1]
+		Expect(ok).To(BeTrue())
+		Expect(net1.NetworkID).To(Equal(netName1))
+		net2, ok := conData[0].NetworkSettings.Networks[netName2]
+		Expect(ok).To(BeTrue())
+		Expect(net2.NetworkID).To(Equal(netName2))
+
+		// Necessary to ensure the CNI network is removed cleanly
+		rmAll := podmanTest.Podman([]string{"rm", "-f", ctrName})
+		rmAll.WaitWithDefaultTimeout()
+		Expect(rmAll.ExitCode()).To(BeZero())
+	})
+
 	It("podman inspect container two CNI networks", func() {
 		netName1 := "testNetTwoCNI1"
 		network1 := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.51.0/25", netName1})


### PR DESCRIPTION
We were only including the CNI Network fields in the output of `podman inspect` when the container was not running. It's simple enough to fix (populate with empty structs, since we can't fill anything without a CNI response to get IP address assigned, etc).

This is necessary for Docker compatibility.
