### PR TITLE
pkg/spec: fix a confusing error message

### DIFF
--- a/pkg/spec/config_linux_cgo.go
+++ b/pkg/spec/config_linux_cgo.go
@@ -39,7 +39,7 @@ func getSeccompConfig(config *SecurityConfig, configSpec *spec.Spec) (*spec.Linu
 		logrus.Debug("Loading default seccomp profile")
 		seccompConfig, err = goSeccomp.GetDefaultProfile(configSpec)
 		if err != nil {
-			return nil, errors.Wrapf(err, "loading seccomp profile (%s) failed", config.SeccompProfilePath)
+			return nil, errors.Wrapf(err, "loading default seccomp profile failed")
 		}
 	}
 


### PR DESCRIPTION
When we try, but fail, to load the default seccomp profile, say that, instead of suggesting that we tried to load a profile with no name.
