### PR TITLE
System tests: run with local podman, not remote

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -544,7 +544,6 @@ rootless_system_test_task:
     env:
         TEST_FLAVOR: sys
         PRIV_NAME: rootless
-        PODBIN_NAME: remote
     clone_script: *noop  # Comes from cache
     gopath_cache: *ro_gopath_cache
     setup_script: *setup


### PR DESCRIPTION
Initially filed as #7967 but that has run into huge complicated
snags related to Ubuntu and environment.

It is crucial to get system tests working with podman-local.
It is less important to get them on Ubuntu. Let's please
expedite this PR while we settle the Ubuntu stuff in #7967

Signed-off-by: Ed Santiago <santiago@redhat.com>