### PR TITLE
Add a shutdown signal handler

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/podman/v2/libpod/events"
 	"github.com/containers/podman/v2/libpod/image"
 	"github.com/containers/podman/v2/libpod/lock"
+	"github.com/containers/podman/v2/libpod/shutdown"
 	"github.com/containers/podman/v2/pkg/cgroups"
 	"github.com/containers/podman/v2/pkg/registries"
 	"github.com/containers/podman/v2/pkg/rootless"
@@ -174,9 +175,21 @@ func newRuntimeFromConfig(ctx context.Context, conf *config.Config, options ...R
 		}
 	}
 
+	if err := shutdown.Start(); err != nil {
+		return nil, errors.Wrapf(err, "error starting shutdown signal handler")
+	}
+
 	if err := makeRuntime(ctx, runtime); err != nil {
 		return nil, err
 	}
+
+	if err := shutdown.Register("libpod", func() error {
+		os.Exit(1)
+		return nil
+	}); err != nil {
+		logrus.Errorf("Error registering shutdown handler for libpod: %v", err)
+	}
+
 	return runtime, nil
 }
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -183,7 +183,7 @@ func newRuntimeFromConfig(ctx context.Context, conf *config.Config, options ...R
 		return nil, err
 	}
 
-	if err := shutdown.Register("libpod", func() error {
+	if err := shutdown.Register("libpod", func(sig os.Signal) error {
 		os.Exit(1)
 		return nil
 	}); err != nil {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/libpod/events"
+	"github.com/containers/podman/v2/libpod/shutdown"
 	"github.com/containers/podman/v2/pkg/cgroups"
 	"github.com/containers/podman/v2/pkg/rootless"
 	"github.com/containers/storage"
@@ -148,6 +149,10 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 	if err := ctr.validate(); err != nil {
 		return nil, err
 	}
+
+	// Inhibit shutdown until creation succeeds
+	shutdown.Inhibit()
+	defer shutdown.Uninhibit()
 
 	// Allocate a lock for the container
 	lock, err := r.lockManager.AllocateLock()

--- a/libpod/shutdown/handler.go
+++ b/libpod/shutdown/handler.go
@@ -1,0 +1,105 @@
+package shutdown
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	stopped         bool
+	sigChan         chan os.Signal
+	cancelChan      chan bool
+	handlers        map[string]func() error
+	shutdownInhibit sync.RWMutex
+)
+
+// Start begins handling SIGTERM and SIGINT and will run the given on-signal
+// handlers when one is called. This can be cancelled by calling Stop().
+func Start() error {
+	if sigChan != nil && !stopped {
+		// Already running, do nothing.
+		return nil
+	}
+
+	sigChan = make(chan os.Signal, 1)
+	cancelChan = make(chan bool, 1)
+	stopped = false
+
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		select {
+		case <-cancelChan:
+			signal.Stop(sigChan)
+			close(sigChan)
+			close(cancelChan)
+			stopped = true
+			return
+		case sig := <-sigChan:
+			logrus.Infof("Received shutdown signal %v, terminating!", sig)
+			shutdownInhibit.Lock()
+			for name, handler := range handlers {
+				logrus.Infof("Invoking shutdown handler %s", name)
+				if err := handler(); err != nil {
+					logrus.Errorf("Error running shutdown handler %s: %v", name, err)
+				}
+			}
+			shutdownInhibit.Unlock()
+			return
+		}
+	}()
+
+	return nil
+}
+
+// Stop the shutdown signal handler.
+func Stop() error {
+	if cancelChan == nil {
+		return errors.New("shutdown signal handler has not yet been started")
+	}
+	if stopped {
+		return nil
+	}
+
+	cancelChan <- true
+
+	return nil
+}
+
+// Temporarily inhibit signals from shutting down Libpod.
+func Inhibit() {
+	shutdownInhibit.RLock()
+}
+
+// Stop inhibiting signals from shutting down Libpod.
+func Uninhibit() {
+	shutdownInhibit.RUnlock()
+}
+
+// Register registers a function that will be executed when Podman is terminated
+// by a signal.
+func Register(name string, handler func() error) error {
+	if _, ok := handlers[name]; ok {
+		return errors.Errorf("handler with name %s already exists", name)
+	}
+
+	handlers[name] = handler
+
+	return nil
+}
+
+// Unregister un-registers a given shutdown handler.
+func Unregister(name string) error {
+	if _, ok := handlers[name]; !ok {
+		return errors.Errorf("no handler with name %s found", name)
+	}
+
+	delete(handlers, name)
+
+	return nil
+}

--- a/libpod/shutdown/handler.go
+++ b/libpod/shutdown/handler.go
@@ -84,6 +84,10 @@ func Uninhibit() {
 // Register registers a function that will be executed when Podman is terminated
 // by a signal.
 func Register(name string, handler func() error) error {
+	if handlers == nil {
+		handlers = make(map[string]func() error)
+	}
+
 	if _, ok := handlers[name]; ok {
 		return errors.Errorf("handler with name %s already exists", name)
 	}
@@ -95,6 +99,10 @@ func Register(name string, handler func() error) error {
 
 // Unregister un-registers a given shutdown handler.
 func Unregister(name string) error {
+	if handlers == nil {
+		handlers = make(map[string]func() error)
+	}
+
 	if _, ok := handlers[name]; !ok {
 		return errors.Errorf("no handler with name %s found", name)
 	}

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -190,6 +190,9 @@ func (s *APIServer) Serve() error {
 	}); err != nil {
 		return err
 	}
+	// Unregister the libpod handler, which just calls exit(1).
+	// Ignore errors if it doesn't exist.
+	_ = shutdown.Unregister("libpod")
 
 	errChan := make(chan error, 1)
 
@@ -226,12 +229,7 @@ func (s *APIServer) Serve() error {
 		errChan <- nil
 	}()
 
-	select {
-	case err := <-errChan:
-		return err
-	}
-
-	return nil
+	return <-errChan
 }
 
 // Shutdown is a clean shutdown waiting on existing clients

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -185,14 +185,11 @@ func (s *APIServer) Serve() error {
 	if err := shutdown.Start(); err != nil {
 		return err
 	}
-	if err := shutdown.Register("server", func() error {
+	if err := shutdown.Register("server", func(sig os.Signal) error {
 		return s.Shutdown()
 	}); err != nil {
 		return err
 	}
-	// Unregister the libpod handler, which just calls exit(1).
-	// Ignore errors if it doesn't exist.
-	_ = shutdown.Unregister("libpod")
 
 	errChan := make(chan error, 1)
 

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/signal"
 	goRuntime "runtime"
 	"strings"
 	"sync"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"github.com/containers/podman/v2/libpod"
+	"github.com/containers/podman/v2/libpod/shutdown"
 	"github.com/containers/podman/v2/pkg/api/handlers"
 	"github.com/containers/podman/v2/pkg/api/server/idle"
 	"github.com/coreos/go-systemd/v22/activation"
@@ -180,8 +180,17 @@ func setupSystemd() {
 // Serve starts responding to HTTP requests.
 func (s *APIServer) Serve() error {
 	setupSystemd()
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// Start the shutdown signal handler.
+	if err := shutdown.Start(); err != nil {
+		return err
+	}
+	if err := shutdown.Register("server", func() error {
+		return s.Shutdown()
+	}); err != nil {
+		return err
+	}
+
 	errChan := make(chan error, 1)
 
 	go func() {
@@ -220,8 +229,6 @@ func (s *APIServer) Serve() error {
 	select {
 	case err := <-errChan:
 		return err
-	case sig := <-sigChan:
-		logrus.Infof("APIServer terminated by signal %v", sig)
 	}
 
 	return nil

--- a/pkg/domain/infra/abi/terminal/sigproxy_linux.go
+++ b/pkg/domain/infra/abi/terminal/sigproxy_linux.go
@@ -5,12 +5,17 @@ import (
 	"syscall"
 
 	"github.com/containers/podman/v2/libpod"
+	"github.com/containers/podman/v2/libpod/shutdown"
 	"github.com/containers/podman/v2/pkg/signal"
 	"github.com/sirupsen/logrus"
 )
 
 // ProxySignals ...
 func ProxySignals(ctr *libpod.Container) {
+	// Stop catching the shutdown signals (SIGINT, SIGTERM) - they're going
+	// to the container now.
+	shutdown.Stop()
+
 	sigBuffer := make(chan os.Signal, 128)
 	signal.CatchAll(sigBuffer)
 


### PR DESCRIPTION
We need a unified package for handling signals that shut down Libpod and Podman. We need to be able to do different things on receiving such a signal (`system service` wants to shut down the service gracefully, while most other commands just want to exit) and we need to be able to inhibit this shutdown signal while we are waiting for some critical operations (e.g. creating a container) to finish. We also want to turn off this handling when `--sig-proxy` is active.

Fixes #7941 

