### PR TITLE
networks/list.go updates for --format

### DIFF
--- a/cmd/podman/networks/network.go
+++ b/cmd/podman/networks/network.go
@@ -8,6 +8,9 @@ import (
 )
 
 var (
+	// Pull in configured json library
+	json = registry.JSONLibrary()
+
 	// Command: podman _network_
 	networkCmd = &cobra.Command{
 		Use:   "network",

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.0
 	github.com/containers/buildah v1.19.6
-	github.com/containers/common v0.34.3-0.20210208115708-8668c76dd577
+	github.com/containers/common v0.35.0
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.10.2
 	github.com/containers/ocicrypt v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/containernetworking/plugins v0.9.0/go.mod h1:dbWv4dI0QrBGuVgj+TuVQ6wJ
 github.com/containers/buildah v1.19.6 h1:8mPysB7QzHxX9okR+Bwq/lsKAZA/FjDcqB+vebgwI1g=
 github.com/containers/buildah v1.19.6/go.mod h1:VnyHWgNmfR1d89/zJ/F4cbwOzaQS+6sBky46W7dCo3E=
 github.com/containers/common v0.33.4/go.mod h1:PhgL71XuC4jJ/1BIqeP7doke3aMFkCP90YBXwDeUr9g=
-github.com/containers/common v0.34.3-0.20210208115708-8668c76dd577 h1:tUJcLouJ1bC3w9gdqgKqZBsj2uCuM8D8jSR592lxbhE=
-github.com/containers/common v0.34.3-0.20210208115708-8668c76dd577/go.mod h1:mwZ9H8sK4+dtWxsnVLyWcjxK/gEQClrLsXsqLvbEKbI=
+github.com/containers/common v0.35.0 h1:1OLZ2v+Tj/CN9BTQkKZ5VOriOiArJedinMMqfJRUI38=
+github.com/containers/common v0.35.0/go.mod h1:gs1th7XFTOvVUl4LDPdQjOfOeNiVRDbQ7CNrZ0wS6F8=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.10.1 h1:tHhGQ8RCMxJfJLD/PEW1qrOKX8nndledW9qz6UiAxns=

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -150,6 +150,13 @@ var _ = Describe("Podman network", func() {
 		defer podmanTest.removeCNINetwork(net)
 		Expect(session.ExitCode()).To(BeZero())
 
+		// Tests Default Table Output
+		session = podmanTest.Podman([]string{"network", "ls", "--filter", "id=" + netID})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		expectedTable := "NETWORK ID NAME VERSION PLUGINS"
+		Expect(session.OutputToString()).To(ContainSubstring(expectedTable))
+
 		session = podmanTest.Podman([]string{"network", "ls", "--format", "{{.Name}} {{.ID}}", "--filter", "id=" + netID})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(BeZero())

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -73,7 +73,6 @@ default_capabilities = [
     "SYS_CHROOT"
 ]
 
-
 # A list of sysctls to be set in containers by default,
 # specified as "name=value",
 # for example:"net.ipv4.ping_group_range = 0 0".
@@ -241,6 +240,9 @@ default_sysctls = [
 #
 # cni_plugin_dirs = ["/usr/libexec/cni"]
 
+# The network name of the default CNI network to attach pods to.
+# default_network = "podman"
+
 # Path to the directory where CNI configuration files are located.
 #
 # network_config_dir = "/etc/cni/net.d/"
@@ -324,7 +326,7 @@ default_sysctls = [
 # associated with the  pod.  This container does nothing other then sleep,
 # reserving the pods resources for the lifetime of the pod.
 #
-# infra_image = "k8s.gcr.io/pause:3.2"
+# infra_image = "k8s.gcr.io/pause:3.4.1"
 
 # Specify the locking mechanism to use; valid values are "shm" and "file".
 # Change the default only if you are sure of what you are doing, in general

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -45,7 +45,7 @@ var (
 	// DefaultInitPath is the default path to the container-init binary
 	DefaultInitPath = "/usr/libexec/podman/catatonit"
 	// DefaultInfraImage to use for infra container
-	DefaultInfraImage = "k8s.gcr.io/pause:3.2"
+	DefaultInfraImage = "k8s.gcr.io/pause:3.4.1"
 	// DefaultRootlessSHMLockPath is the default path for rootless SHM locks
 	DefaultRootlessSHMLockPath = "/libpod_rootless_lock"
 	// DefaultDetachKeys is the default keys sequence for detaching a

--- a/vendor/github.com/containers/common/pkg/report/template.go
+++ b/vendor/github.com/containers/common/pkg/report/template.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"reflect"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -154,4 +155,19 @@ func (t *Template) Funcs(funcMap FuncMap) *Template {
 // IsTable returns true if format string defines a "table"
 func (t *Template) IsTable() bool {
 	return t.isTable
+}
+
+var rangeRegex = regexp.MustCompile(`{{\s*range\s*\.\s*}}.*{{\s*end\s*}}`)
+
+// EnforceRange ensures that the format string contains a range
+func EnforceRange(format string) string {
+	if !rangeRegex.MatchString(format) {
+		return "{{range .}}" + format + "{{end}}"
+	}
+	return format
+}
+
+// HasTable returns whether the format is a table
+func HasTable(format string) bool {
+	return strings.HasPrefix(format, "table ")
 }

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.34.3-dev"
+const Version = "0.35.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -89,7 +89,7 @@ github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/supplemented
 github.com/containers/buildah/util
-# github.com/containers/common v0.34.3-0.20210208115708-8668c76dd577
+# github.com/containers/common v0.35.0
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/apparmor/internal/supported
 github.com/containers/common/pkg/auth


### PR DESCRIPTION
Podman Network ls --format changes

https://docs.google.com/document/d/1YwNkk7t9o-MUbIDcvSMFXkWlnKR-OlGjwD_L5axKx50

Has an issue with 'make validate':

cmd/podman/networks/list.go:97:3: ineffectual assignment to `format` (ineffassign)
		format = report.NormalizeFormat(networkListOptions.Format)
		^
cmd/podman/networks/list.go:99:12: ineffectual assignment to `format` (ineffassign)
		headers, format = createListOut()

However I was following another file (https://github.com/containers/podman/pull/7973/commits/e9b667bb5f9c72fd9903bfa5efd081ad24a2482b podman containers ps) which does not receive this problem
Also - this does not use networkListOptions in createListOut, does it need to?

Signed-off-by: Parker Van Roy <pvanroy@redhat.com>