### PR TITLE
Restore indent on JSON from `podman inspect`

### DIFF
--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -167,6 +167,7 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 
 func printJSON(data []interface{}) error {
 	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "     ")
 	return enc.Encode(data)
 }
 


### PR DESCRIPTION
I don't know when this was disabled, but it's very hard to read without it.
