### PR TITLE
Setup HOME environment when using --userns=keep-id

### DIFF
--- a/test/e2e/toolbox_test.go
+++ b/test/e2e/toolbox_test.go
@@ -365,4 +365,16 @@ var _ = Describe("Toolbox-specific testing", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("READY"))
 	})
+
+	It("podman run --userns=keep-id check $HOME", func() {
+		var session *PodmanSessionIntegration
+
+		currentUser, err := user.Current()
+		Expect(err).To(BeNil())
+		session = podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:%s", currentUser.HomeDir, currentUser.HomeDir), "--userns=keep-id", fedoraToolbox, "sh", "-c", "echo $HOME"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(currentUser.HomeDir))
+	})
+
 })


### PR DESCRIPTION
Currently the HOME environment is set to /root if
the user does not override it.

Also walk the parent directories of users homedir
to see if it is volume mounted into the container,
if yes, then set it correctly.

Fixes: https://github.com/containers/podman/issues/8004

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>