### PR TITLE
Fix indentation for `podman pod inspect`

### DIFF
--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -64,6 +64,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 
 	if parse.MatchesJSONFormat(inspectOptions.Format) {
 		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "     ")
 		return enc.Encode(responses)
 	}
 


### PR DESCRIPTION
I fixed `podman inspect` in another PR, but it looks like `podman pod inspect` was also affected.

I did verify `podman network inspect` and `podman volume inspect` and both of those are still fine, though.