### PR TITLE
Bats

### DIFF
--- a/test/e2e/toolbox_test.go
+++ b/test/e2e/toolbox_test.go
@@ -365,4 +365,16 @@ var _ = Describe("Toolbox-specific testing", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("READY"))
 	})
+
+	It("podman run --userns=keep-id check $HOME", func() {
+		var session *PodmanSessionIntegration
+
+		currentUser, err := user.Current()
+		Expect(err).To(BeNil())
+		session = podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:%s", currentUser.HomeDir, currentUser.HomeDir), "--userns=keep-id", fedoraToolbox, "sh", "-c", "echo $HOME"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(currentUser.HomeDir))
+	})
+
 })

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -224,6 +224,12 @@ EOF
     # Confirm that 'podman inspect' shows the expected values
     # FIXME: can we rely on .Env[0] being PATH, and the rest being in order??
     run_podman image inspect build_test
+
+    # (Assert that output is formatted, not a one-line blob: #8011)
+    if [[ "${#lines[*]}" -lt 10 ]]; then
+        die "Output from 'image inspect' is only ${#lines[*]} lines; see #8011"
+    fi
+
     tests="
 Env[1]             | MYENV1=$s_env1
 Env[2]             | MYENV2=this-should-be-overridden-by-env-host

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -213,6 +213,12 @@ EOF
         run_podman volume create $vol
     done
 
+    # (Assert that output is formatted, not a one-line blob: #8011)
+    run_podman volume inspect ${v[1]}
+    if [[ "${#lines[*]}" -lt 10 ]]; then
+        die "Output from 'volume inspect' is only ${#lines[*]} lines; see #8011"
+    fi
+
     # Run two containers: one mounting v1, one mounting v2 & v3
     run_podman run --name c1 --volume ${v[1]}:/vol1 $IMAGE date
     run_podman run --name c2 --volume ${v[2]}:/vol2 -v ${v[3]}:/vol3 \

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -66,6 +66,12 @@ function teardown() {
     run_podman pod exists $podname
     run_podman pod exists $podid
 
+    # (Assert that output is formatted, not a one-line blob: #8021)
+    run_podman pod inspect $podname
+    if [[ "${#lines[*]}" -lt 10 ]]; then
+        die "Output from 'pod inspect' is only ${#lines[*]} lines; see #8011"
+    fi
+
     # Randomly-assigned port in the 5xxx range
     for port in $(shuf -i 5000-5999);do
         if ! { exec 3<> /dev/tcp/127.0.0.1/$port; } &>/dev/null; then

--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -12,8 +12,6 @@ _SOCAT_LOG=
 function setup() {
     skip_if_remote "systemd tests are meaningless over remote"
 
-    skip "FIXME FIXME FIXME, is this what's causing the CI hang???"
-
     # Skip if systemd is not running
     systemctl list-units &>/dev/null || skip "systemd not available"
 

--- a/test/system/420-cgroups.bats
+++ b/test/system/420-cgroups.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# cgroups-related tests
+#
+
+load helpers
+
+@test "podman run, preserves initial --cgroup-manager" {
+    skip_if_remote "podman-remote does not support --cgroup-manager"
+
+    if is_rootless && is_cgroupsv1; then
+        skip "not supported as rootless under cgroups v1"
+    fi
+
+    # Find out our default cgroup manager, and from that, get the non-default
+    run_podman info --format '{{.Host.CgroupManager}}'
+    case "$output" in
+        systemd)  other="cgroupfs" ;;
+        cgroupfs) other="systemd"  ;;
+        *)        die "Unknown CgroupManager '$output'" ;;
+    esac
+
+    run_podman --cgroup-manager=$other run --name myc $IMAGE true
+    run_podman container inspect --format '{{.HostConfig.CgroupManager}}' myc
+    is "$output" "$other" "podman preserved .HostConfig.CgroupManager"
+
+    # Restart the container, without --cgroup-manager option (ie use default)
+    # Prior to #7970, this would fail with an OCI runtime error
+    run_podman start myc
+
+    run_podman rm myc
+}
+
+# vim: filetype=sh

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -90,7 +90,12 @@ load helpers
     run_podman network create --subnet "${mysubnet}.0/24" $mynetname
     is "$output" ".*/cni/net.d/$mynetname.conflist" "output of 'network create'"
 
-    # WARNING: this pulls a ~100MB image from quay.io, hence is slow/flaky
+    # (Assert that output is formatted, not a one-line blob: #8011)
+    run_podman network inspect $mynetname
+    if [[ "${#lines[*]}" -lt 5 ]]; then
+        die "Output from 'pod inspect' is only ${#lines[*]} lines; see #8011"
+    fi
+
     run_podman run --rm --network $mynetname $IMAGE ip a
     is "$output" ".* inet ${mysubnet}\.2/24 brd ${mysubnet}\.255 " \
        "sdfsdf"

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -247,7 +247,7 @@ function is_cgroupsv1() {
 
 function is_cgroupsv2() {
     cgroup_type=$(stat -f -c %T /sys/fs/cgroup)
-    test "$cgroup_type" = "cgroupfs"
+    test "$cgroup_type" = "cgroup2fs"
 }
 
 ###########################


### PR DESCRIPTION
System test additions

 - run --userns=keep-id: confirm that $HOME gets set (#8013)

 - inspect: confirm that JSON output is a sane number of
   lines (10 or more), not an unreadable one-liner (#8011
   and #8021). Do so with image, pod, network, volume
   because the code paths might be different.

 - cgroups: confirm that 'run' preserves cgroup manager (#7970)

 - sdnotify: reenable tests, and hope CI doesn't hang. This
   test was disabled on August 18 because CI jobs were hanging
   and timing out. My suspicion was that it was #7316, which
   in turn seems to have hinged on conmon #182. The latter
   was merged on Sep 16, so let's cross our fingers and see
   what happens.

Also: remove inaccurate warning from a networking test.

And, wow, fix is_cgroupsv2(), it has never actually worked.

Signed-off-by: Ed Santiago <santiago@redhat.com>
