### PR TITLE
Switch help messages from using [flags] to [options]

### DIFF
--- a/cmd/podman/auto-update.go
+++ b/cmd/podman/auto-update.go
@@ -20,7 +20,7 @@ var (
   or similar units that create new containers in order to run the updated images.
   Note that this command is experimental. Please refer to the podman-auto-update(1) man page for details.`
 	autoUpdateCommand = &cobra.Command{
-		Use:   "auto-update [flags]",
+		Use:   "auto-update [options]",
 		Short: "Auto update containers according to their auto-update policy",
 		Long:  autoUpdateDescription,
 		RunE:  autoUpdate,

--- a/cmd/podman/containers/attach.go
+++ b/cmd/podman/containers/attach.go
@@ -14,7 +14,7 @@ import (
 var (
 	attachDescription = "The podman attach command allows you to attach to a running container using the container's ID or name, either to view its ongoing output or to control it interactively."
 	attachCommand     = &cobra.Command{
-		Use:   "attach [flags] CONTAINER",
+		Use:   "attach [options] CONTAINER",
 		Short: "Attach to a running container",
 		Long:  attachDescription,
 		RunE:  attach,

--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -20,7 +20,7 @@ var (
    Checkpoints one or more running containers. The container name or ID can be used.
 `
 	checkpointCommand = &cobra.Command{
-		Use:   "checkpoint [flags] CONTAINER [CONTAINER...]",
+		Use:   "checkpoint [options] CONTAINER [CONTAINER...]",
 		Short: "Checkpoints one or more containers",
 		Long:  checkpointDescription,
 		RunE:  checkpoint,

--- a/cmd/podman/containers/cleanup.go
+++ b/cmd/podman/containers/cleanup.go
@@ -19,7 +19,7 @@ var (
    Cleans up mount points and network stacks on one or more containers from the host. The container name or ID can be used. This command is used internally when running containers, but can also be used if container cleanup has failed when a container exits.
 `
 	cleanupCommand = &cobra.Command{
-		Use:   "cleanup [flags] CONTAINER [CONTAINER...]",
+		Use:   "cleanup [options] CONTAINER [CONTAINER...]",
 		Short: "Cleanup network and mountpoints of one or more containers",
 		Long:  cleanupDescription,
 		RunE:  cleanup,

--- a/cmd/podman/containers/commit.go
+++ b/cmd/podman/containers/commit.go
@@ -18,7 +18,7 @@ var (
 	commitDescription = `Create an image from a container's changes. Optionally tag the image created, set the author with the --author flag, set the commit message with the --message flag, and make changes to the instructions with the --change flag.`
 
 	commitCommand = &cobra.Command{
-		Use:   "commit [flags] CONTAINER [IMAGE]",
+		Use:   "commit [options] CONTAINER [IMAGE]",
 		Short: "Create new image based on the changed container",
 		Long:  commitDescription,
 		RunE:  commit,

--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -16,7 +16,7 @@ var (
   You can copy from the container's file system to the local machine or the reverse, from the local filesystem to the container. If "-" is specified for either the SRC_PATH or DEST_PATH, you can also stream a tar archive from STDIN or to STDOUT. The CONTAINER can be a running or stopped container.  The SRC_PATH or DEST_PATH can be a file or directory.
 `
 	cpCommand = &cobra.Command{
-		Use:     "cp [flags] SRC_PATH DEST_PATH",
+		Use:     "cp [options] SRC_PATH DEST_PATH",
 		Short:   "Copy files/folders between a container and the local filesystem",
 		Long:    cpDescription,
 		Args:    cobra.ExactArgs(2),

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -29,7 +29,7 @@ var (
 
   The container ID is then printed to stdout. You can then start it at any time with the podman start <container_id> command. The container will be created with the initial state 'created'.`
 	createCommand = &cobra.Command{
-		Use:   "create [flags] IMAGE [COMMAND [ARG...]]",
+		Use:   "create [options] IMAGE [COMMAND [ARG...]]",
 		Short: "Create but do not start a container",
 		Long:  createDescription,
 		RunE:  create,

--- a/cmd/podman/containers/diff.go
+++ b/cmd/podman/containers/diff.go
@@ -13,7 +13,7 @@ import (
 var (
 	// podman container _diff_
 	diffCmd = &cobra.Command{
-		Use:   "diff [flags] CONTAINER",
+		Use:   "diff [options] CONTAINER",
 		Args:  validate.IDOrLatestArgs,
 		Short: "Inspect changes to the container's file systems",
 		Long:  `Displays changes to the container filesystem's'.  The container will be compared to its parent layer.`,

--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -20,7 +20,7 @@ var (
 	execDescription = `Execute the specified command inside a running container.
 `
 	execCommand = &cobra.Command{
-		Use:                   "exec [flags] CONTAINER [COMMAND [ARG...]]",
+		Use:                   "exec [options] CONTAINER [COMMAND [ARG...]]",
 		Short:                 "Run a process in a running container",
 		Long:                  execDescription,
 		RunE:                  exec,

--- a/cmd/podman/containers/exists.go
+++ b/cmd/podman/containers/exists.go
@@ -12,7 +12,7 @@ var (
 	containerExistsDescription = `If the named container exists in local storage, podman container exists exits with 0, otherwise the exit code will be 1.`
 
 	existsCommand = &cobra.Command{
-		Use:   "exists [flags] CONTAINER",
+		Use:   "exists [options] CONTAINER",
 		Short: "Check if a container exists in local storage",
 		Long:  containerExistsDescription,
 		Example: `podman container exists --external containerID

--- a/cmd/podman/containers/export.go
+++ b/cmd/podman/containers/export.go
@@ -18,7 +18,7 @@ var (
 		" and saves it on the local machine."
 
 	exportCommand = &cobra.Command{
-		Use:   "export [flags] CONTAINER",
+		Use:   "export [options] CONTAINER",
 		Short: "Export container's filesystem contents as a tar archive",
 		Long:  exportDescription,
 		RunE:  export,

--- a/cmd/podman/containers/init.go
+++ b/cmd/podman/containers/init.go
@@ -15,7 +15,7 @@ var (
 	initDescription = `Initialize one or more containers, creating the OCI spec and mounts for inspection. Container names or IDs can be used.`
 
 	initCommand = &cobra.Command{
-		Use:   "init [flags] CONTAINER [CONTAINER...]",
+		Use:   "init [options] CONTAINER [CONTAINER...]",
 		Short: "Initialize one or more containers",
 		Long:  initDescription,
 		RunE:  initContainer,

--- a/cmd/podman/containers/inspect.go
+++ b/cmd/podman/containers/inspect.go
@@ -11,7 +11,7 @@ import (
 var (
 	// podman container _inspect_
 	inspectCmd = &cobra.Command{
-		Use:   "inspect [flags] CONTAINER [CONTAINER...]",
+		Use:   "inspect [options] CONTAINER [CONTAINER...]",
 		Short: "Display the configuration of a container",
 		Long:  `Displays the low-level information on a container identified by name or ID.`,
 		RunE:  inspectExec,

--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -17,7 +17,7 @@ import (
 var (
 	killDescription = "The main process inside each container specified will be sent SIGKILL, or any signal specified with option --signal."
 	killCommand     = &cobra.Command{
-		Use:   "kill [flags] CONTAINER [CONTAINER...]",
+		Use:   "kill [options] CONTAINER [CONTAINER...]",
 		Short: "Kill one or more running containers with a specific signal",
 		Long:  killDescription,
 		RunE:  kill,

--- a/cmd/podman/containers/list.go
+++ b/cmd/podman/containers/list.go
@@ -10,7 +10,7 @@ import (
 var (
 	// podman container _list_
 	listCmd = &cobra.Command{
-		Use:     "list",
+		Use:     "list [options]",
 		Aliases: []string{"ls"},
 		Args:    validate.NoArgs,
 		Short:   "List containers",

--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -27,7 +27,7 @@ var (
   This does not guarantee execution order when combined with podman run (i.e., your run may not have generated any logs at the time you execute podman logs).
 `
 	logsCommand = &cobra.Command{
-		Use:   "logs [flags] CONTAINER [CONTAINER...]",
+		Use:   "logs [options] CONTAINER [CONTAINER...]",
 		Short: "Fetch the logs of one or more containers",
 		Long:  logsDescription,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -25,7 +25,7 @@ var (
 `
 
 	mountCommand = &cobra.Command{
-		Use:   "mount [flags] [CONTAINER...]",
+		Use:   "mount [options] [CONTAINER...]",
 		Short: "Mount a working container's root filesystem",
 		Long:  mountDescription,
 		RunE:  mount,

--- a/cmd/podman/containers/pause.go
+++ b/cmd/podman/containers/pause.go
@@ -17,7 +17,7 @@ import (
 var (
 	pauseDescription = `Pauses one or more running containers.  The container name or ID can be used.`
 	pauseCommand     = &cobra.Command{
-		Use:   "pause [flags] CONTAINER [CONTAINER...]",
+		Use:   "pause [options] CONTAINER [CONTAINER...]",
 		Short: "Pause all the processes in one or more containers",
 		Long:  pauseDescription,
 		RunE:  pause,

--- a/cmd/podman/containers/port.go
+++ b/cmd/podman/containers/port.go
@@ -18,7 +18,7 @@ var (
 	portDescription = `List port mappings for the CONTAINER, or lookup the public-facing port that is NAT-ed to the PRIVATE_PORT
 `
 	portCommand = &cobra.Command{
-		Use:   "port [flags] CONTAINER [PORT]",
+		Use:   "port [options] CONTAINER [PORT]",
 		Short: "List port mappings or a specific mapping for the container",
 		Long:  portDescription,
 		RunE:  port,
@@ -31,7 +31,7 @@ var (
 	}
 
 	containerPortCommand = &cobra.Command{
-		Use:   "port [flags] CONTAINER [PORT]",
+		Use:   "port [options] CONTAINER [PORT]",
 		Short: portCommand.Short,
 		Long:  portDescription,
 		RunE:  portCommand.RunE,

--- a/cmd/podman/containers/prune.go
+++ b/cmd/podman/containers/prune.go
@@ -21,7 +21,7 @@ var (
 
 	Removes all non running containers`)
 	pruneCommand = &cobra.Command{
-		Use:     "prune [flags]",
+		Use:     "prune [options]",
 		Short:   "Remove all non running containers",
 		Long:    pruneDescription,
 		RunE:    prune,

--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -27,7 +27,7 @@ import (
 var (
 	psDescription = "Prints out information about the containers"
 	psCommand     = &cobra.Command{
-		Use:   "ps",
+		Use:   "ps [options]",
 		Args:  validate.NoArgs,
 		Short: "List containers",
 		Long:  psDescription,

--- a/cmd/podman/containers/restart.go
+++ b/cmd/podman/containers/restart.go
@@ -20,7 +20,7 @@ var (
   A timeout before forcibly stopping can be set, but defaults to %d seconds.`, containerConfig.Engine.StopTimeout)
 
 	restartCommand = &cobra.Command{
-		Use:   "restart [flags] CONTAINER [CONTAINER...]",
+		Use:   "restart [options] CONTAINER [CONTAINER...]",
 		Short: "Restart one or more containers",
 		Long:  restartDescription,
 		RunE:  restart,

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -20,7 +20,7 @@ var (
    Restores a container from a checkpoint. The container name or ID can be used.
 `
 	restoreCommand = &cobra.Command{
-		Use:   "restore [flags] CONTAINER [CONTAINER...]",
+		Use:   "restore [options] CONTAINER [CONTAINER...]",
 		Short: "Restores one or more containers from a checkpoint",
 		Long:  restoreDescription,
 		RunE:  restore,

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -21,7 +21,7 @@ var (
 
   Command does not remove images. Running or unusable containers will not be removed without the -f option.`
 	rmCommand = &cobra.Command{
-		Use:   "rm [flags] CONTAINER [CONTAINER...]",
+		Use:   "rm [options] CONTAINER [CONTAINER...]",
 		Short: "Remove one or more containers",
 		Long:  rmDescription,
 		RunE:  rm,

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -25,7 +25,7 @@ var (
 	runDescription = "Runs a command in a new container from the given image"
 	runCommand     = &cobra.Command{
 		Args:  cobra.MinimumNArgs(1),
-		Use:   "run [flags] IMAGE [COMMAND [ARG...]]",
+		Use:   "run [options] IMAGE [COMMAND [ARG...]]",
 		Short: "Run a command in a new container",
 		Long:  runDescription,
 		RunE:  run,

--- a/cmd/podman/containers/runlabel.go
+++ b/cmd/podman/containers/runlabel.go
@@ -24,7 +24,7 @@ var (
 	runlabelOptions     = runlabelOptionsWrapper{}
 	runlabelDescription = "Executes a command as described by a container image label."
 	runlabelCommand     = &cobra.Command{
-		Use:   "runlabel [flags] LABEL IMAGE [ARG...]",
+		Use:   "runlabel [options] LABEL IMAGE [ARG...]",
 		Short: "Execute the command described by an image label",
 		Long:  runlabelDescription,
 		RunE:  runlabel,

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -17,7 +17,7 @@ import (
 var (
 	startDescription = `Starts one or more containers.  The container name or ID can be used.`
 	startCommand     = &cobra.Command{
-		Use:   "start [flags] CONTAINER [CONTAINER...]",
+		Use:   "start [options] CONTAINER [CONTAINER...]",
 		Short: "Start one or more containers",
 		Long:  startDescription,
 		RunE:  start,

--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -26,7 +26,7 @@ import (
 var (
 	statsDescription = "Display percentage of CPU, memory, network I/O, block I/O and PIDs for one or more containers."
 	statsCommand     = &cobra.Command{
-		Use:   "stats [flags] [CONTAINER...]",
+		Use:   "stats [options] [CONTAINER...]",
 		Short: "Display a live stream of container resource usage statistics",
 		Long:  statsDescription,
 		RunE:  stats,

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -17,7 +17,7 @@ var (
 
   A timeout to forcibly stop the container can also be set but defaults to %d seconds otherwise.`, containerConfig.Engine.StopTimeout)
 	stopCommand = &cobra.Command{
-		Use:   "stop [flags] CONTAINER [CONTAINER...]",
+		Use:   "stop [options] CONTAINER [CONTAINER...]",
 		Short: "Stop one or more containers",
 		Long:  stopDescription,
 		RunE:  stop,

--- a/cmd/podman/containers/top.go
+++ b/cmd/podman/containers/top.go
@@ -26,7 +26,7 @@ var (
 	topOptions = entities.TopOptions{}
 
 	topCommand = &cobra.Command{
-		Use:   "top [flags] CONTAINER [FORMAT-DESCRIPTORS|ARGS...]",
+		Use:   "top [options] CONTAINER [FORMAT-DESCRIPTORS|ARGS...]",
 		Short: "Display the running processes of a container",
 		Long:  topDescription,
 		RunE:  top,

--- a/cmd/podman/containers/unmount.go
+++ b/cmd/podman/containers/unmount.go
@@ -19,7 +19,7 @@ var (
   An unmount can be forced with the --force flag.
 `
 	unmountCommand = &cobra.Command{
-		Use:     "unmount [flags] CONTAINER [CONTAINER...]",
+		Use:     "unmount [options] CONTAINER [CONTAINER...]",
 		Aliases: []string{"umount"},
 		Short:   "Unmounts working container's root filesystem",
 		Long:    description,

--- a/cmd/podman/containers/unpause.go
+++ b/cmd/podman/containers/unpause.go
@@ -17,7 +17,7 @@ import (
 var (
 	unpauseDescription = `Unpauses one or more previously paused containers.  The container name or ID can be used.`
 	unpauseCommand     = &cobra.Command{
-		Use:   "unpause [flags] CONTAINER [CONTAINER...]",
+		Use:   "unpause [options] CONTAINER [CONTAINER...]",
 		Short: "Unpause the processes in one or more containers",
 		Long:  unpauseDescription,
 		RunE:  unpause,

--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -19,7 +19,7 @@ var (
 	waitDescription = `Block until one or more containers stop and then print their exit codes.
 `
 	waitCommand = &cobra.Command{
-		Use:   "wait [flags] CONTAINER [CONTAINER...]",
+		Use:   "wait [options] CONTAINER [CONTAINER...]",
 		Short: "Block on one or more containers",
 		Long:  waitDescription,
 		RunE:  wait,

--- a/cmd/podman/diff.go
+++ b/cmd/podman/diff.go
@@ -17,7 +17,7 @@ var (
 	// Command: podman _diff_ Object_ID
 	diffDescription = `Displays changes on a container or image's filesystem.  The container or image will be compared to its parent layer.`
 	diffCmd         = &cobra.Command{
-		Use:   "diff [flags] {CONTAINER_ID | IMAGE_ID}",
+		Use:   "diff [options] {CONTAINER_ID | IMAGE_ID}",
 		Args:  validate.IDOrLatestArgs,
 		Short: "Display the changes to the object's file system",
 		Long:  diffDescription,

--- a/cmd/podman/generate/kube.go
+++ b/cmd/podman/generate/kube.go
@@ -20,7 +20,7 @@ var (
 Whether the input is for a container or pod, Podman will always generate the specification as a pod.`
 
 	kubeCmd = &cobra.Command{
-		Use:   "kube [flags] CONTAINER | POD",
+		Use:   "kube [options] CONTAINER | POD",
 		Short: "Generate Kubernetes YAML from a container or pod.",
 		Long:  kubeDescription,
 		RunE:  kube,

--- a/cmd/podman/generate/systemd.go
+++ b/cmd/podman/generate/systemd.go
@@ -24,7 +24,7 @@ var (
   The generated units can later be controlled via systemctl(1).`
 
 	systemdCmd = &cobra.Command{
-		Use:   "systemd [flags] CTR|POD",
+		Use:   "systemd [options] CTR|POD",
 		Short: "Generate systemd units.",
 		Long:  systemdDescription,
 		RunE:  systemd,

--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -40,7 +40,7 @@ var (
 	// Command: podman _diff_ Object_ID
 	buildDescription = "Builds an OCI or Docker image using instructions from one or more Containerfiles and a specified build context directory."
 	buildCmd         = &cobra.Command{
-		Use:   "build [flags] [CONTEXT]",
+		Use:   "build [options] [CONTEXT]",
 		Short: "Build an image using instructions from Containerfiles",
 		Long:  buildDescription,
 		Args:  cobra.MaximumNArgs(1),

--- a/cmd/podman/images/diff.go
+++ b/cmd/podman/images/diff.go
@@ -13,7 +13,7 @@ import (
 var (
 	// podman container _inspect_
 	diffCmd = &cobra.Command{
-		Use:   "diff [flags] IMAGE",
+		Use:   "diff [options] IMAGE",
 		Args:  cobra.ExactArgs(1),
 		Short: "Inspect changes to the image's file systems",
 		Long:  `Displays changes to the image's filesystem.  The image will be compared to its parent layer.`,

--- a/cmd/podman/images/history.go
+++ b/cmd/podman/images/history.go
@@ -27,7 +27,7 @@ var (
 
 	// podman _history_
 	historyCmd = &cobra.Command{
-		Use:     "history [flags] IMAGE",
+		Use:     "history [options] IMAGE",
 		Short:   "Show history of a specified image",
 		Long:    long,
 		Args:    cobra.ExactArgs(1),

--- a/cmd/podman/images/import.go
+++ b/cmd/podman/images/import.go
@@ -19,7 +19,7 @@ var (
   Note remote tar balls can be specified, via web address.
   Optionally tag the image. You can specify the instructions using the --change option.`
 	importCommand = &cobra.Command{
-		Use:   "import [flags] PATH [REFERENCE]",
+		Use:   "import [options] PATH [REFERENCE]",
 		Short: "Import a tarball to create a filesystem image",
 		Long:  importDescription,
 		RunE:  importCon,

--- a/cmd/podman/images/inspect.go
+++ b/cmd/podman/images/inspect.go
@@ -10,7 +10,7 @@ import (
 var (
 	// Command: podman image _inspect_
 	inspectCmd = &cobra.Command{
-		Use:   "inspect [flags] IMAGE [IMAGE...]",
+		Use:   "inspect [options] IMAGE [IMAGE...]",
 		Short: "Display the configuration of an image",
 		Long:  `Displays the low-level information of an image identified by name or ID.`,
 		RunE:  inspectExec,

--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -35,7 +35,7 @@ type listFlagType struct {
 var (
 	// Command: podman image _list_
 	listCmd = &cobra.Command{
-		Use:     "list [flags] [IMAGE]",
+		Use:     "list [options] [IMAGE]",
 		Aliases: []string{"ls"},
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "List images in local storage",

--- a/cmd/podman/images/load.go
+++ b/cmd/podman/images/load.go
@@ -22,7 +22,7 @@ import (
 var (
 	loadDescription = "Loads an image from a locally stored archive (tar file) into container storage."
 	loadCommand     = &cobra.Command{
-		Use:   "load [flags] [NAME[:TAG]]",
+		Use:   "load [options] [NAME[:TAG]]",
 		Short: "Load an image from container archive",
 		Long:  loadDescription,
 		RunE:  load,

--- a/cmd/podman/images/mount.go
+++ b/cmd/podman/images/mount.go
@@ -24,7 +24,7 @@ var (
 `
 
 	mountCommand = &cobra.Command{
-		Use:   "mount [flags] [IMAGE...]",
+		Use:   "mount [options] [IMAGE...]",
 		Short: "Mount an image's root filesystem",
 		Long:  mountDescription,
 		RunE:  mount,

--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -19,7 +19,7 @@ var (
 
   If an image is not being used by a container, it will be removed from the system.`
 	pruneCmd = &cobra.Command{
-		Use:     "prune",
+		Use:     "prune [options]",
 		Args:    validate.NoArgs,
 		Short:   "Remove unused images",
 		Long:    pruneDescription,

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -30,7 +30,7 @@ var (
 
 	// Command: podman pull
 	pullCmd = &cobra.Command{
-		Use:   "pull [flags] IMAGE",
+		Use:   "pull [options] IMAGE",
 		Args:  cobra.ExactArgs(1),
 		Short: "Pull an image from a registry",
 		Long:  pullDescription,

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -29,7 +29,7 @@ var (
 
 	// Command: podman push
 	pushCmd = &cobra.Command{
-		Use:   "push [flags] SOURCE [DESTINATION]",
+		Use:   "push [options] SOURCE [DESTINATION]",
 		Short: "Push an image to a specified destination",
 		Long:  pushDescription,
 		RunE:  imagePush,

--- a/cmd/podman/images/rm.go
+++ b/cmd/podman/images/rm.go
@@ -14,7 +14,7 @@ import (
 var (
 	rmDescription = "Removes one or more previously pulled or locally created images."
 	rmCmd         = &cobra.Command{
-		Use:   "rm [flags] IMAGE [IMAGE...]",
+		Use:   "rm [options] IMAGE [IMAGE...]",
 		Short: "Removes one or more images from local storage",
 		Long:  rmDescription,
 		RunE:  rm,

--- a/cmd/podman/images/save.go
+++ b/cmd/podman/images/save.go
@@ -25,7 +25,7 @@ var (
 	saveDescription = `Save an image to docker-archive or oci-archive on the local machine. Default is docker-archive.`
 
 	saveCommand = &cobra.Command{
-		Use:   "save [flags] IMAGE [IMAGE...]",
+		Use:   "save [options] IMAGE [IMAGE...]",
 		Short: "Save image(s) to an archive",
 		Long:  saveDescription,
 		RunE:  save,

--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -32,7 +32,7 @@ var (
 
 	// Command: podman search
 	searchCmd = &cobra.Command{
-		Use:   "search [flags] TERM",
+		Use:   "search [options] TERM",
 		Short: "Search registry for image",
 		Long:  searchDescription,
 		RunE:  imageSearch,

--- a/cmd/podman/images/sign.go
+++ b/cmd/podman/images/sign.go
@@ -12,7 +12,7 @@ import (
 var (
 	signDescription = "Create a signature file that can be used later to verify the image."
 	signCommand     = &cobra.Command{
-		Use:   "sign [flags] IMAGE [IMAGE...]",
+		Use:   "sign [options] IMAGE [IMAGE...]",
 		Short: "Sign an image",
 		Long:  signDescription,
 		RunE:  sign,

--- a/cmd/podman/images/tree.go
+++ b/cmd/podman/images/tree.go
@@ -11,7 +11,7 @@ import (
 var (
 	treeDescription = "Prints layer hierarchy of an image in a tree format"
 	treeCmd         = &cobra.Command{
-		Use:     "tree [flags] IMAGE",
+		Use:     "tree [options] IMAGE",
 		Args:    cobra.ExactArgs(1),
 		Short:   treeDescription,
 		Long:    treeDescription,

--- a/cmd/podman/images/trust_set.go
+++ b/cmd/podman/images/trust_set.go
@@ -12,7 +12,7 @@ import (
 var (
 	setTrustDescription = "Set default trust policy or add a new trust policy for a registry"
 	setTrustCommand     = &cobra.Command{
-		Use:     "set [flags] REGISTRY",
+		Use:     "set [options] REGISTRY",
 		Short:   "Set default trust policy or a new trust policy for a registry",
 		Long:    setTrustDescription,
 		Example: "",

--- a/cmd/podman/images/trust_show.go
+++ b/cmd/podman/images/trust_show.go
@@ -14,7 +14,7 @@ import (
 var (
 	showTrustDescription = "Display trust policy for the system"
 	showTrustCommand     = &cobra.Command{
-		Use:     "show [flags] [REGISTRY]",
+		Use:     "show [options] [REGISTRY]",
 		Short:   "Display trust policy for the system",
 		Long:    showTrustDescription,
 		RunE:    showTrust,

--- a/cmd/podman/images/unmount.go
+++ b/cmd/podman/images/unmount.go
@@ -19,7 +19,7 @@ var (
   An unmount can be forced with the --force flag.
 `
 	unmountCommand = &cobra.Command{
-		Use:     "unmount [flags] IMAGE [IMAGE...]",
+		Use:     "unmount [options] IMAGE [IMAGE...]",
 		Aliases: []string{"umount"},
 		Short:   "Unmount an image's root filesystem",
 		Long:    description,

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -19,7 +19,7 @@ var (
 
 	// Command: podman _inspect_ Object_ID
 	inspectCmd = &cobra.Command{
-		Use:              "inspect [flags] {CONTAINER_ID | IMAGE_ID} [...]",
+		Use:              "inspect [options] {CONTAINER_ID | IMAGE_ID} [...]",
 		Short:            "Display the configuration of object denoted by ID",
 		RunE:             inspectExec,
 		Long:             inspectDescription,

--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -20,7 +20,7 @@ type loginOptionsWrapper struct {
 var (
 	loginOptions = loginOptionsWrapper{}
 	loginCommand = &cobra.Command{
-		Use:   "login [flags] [REGISTRY]",
+		Use:   "login [options] [REGISTRY]",
 		Short: "Login to a container registry",
 		Long:  "Login to a container registry on a specified server.",
 		RunE:  login,

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -14,7 +14,7 @@ import (
 var (
 	logoutOptions = auth.LogoutOptions{}
 	logoutCommand = &cobra.Command{
-		Use:   "logout [flags] [REGISTRY]",
+		Use:   "logout [options] [REGISTRY]",
 		Short: "Logout of a container registry",
 		Long:  "Remove the cached username and password for the registry.",
 		RunE:  logout,

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -66,6 +66,7 @@ func main() {
 				// - rootCmd uses cobra default template not ours
 				c.Command.SetHelpTemplate(helpTemplate)
 				c.Command.SetUsageTemplate(usageTemplate)
+				c.Command.DisableFlagsInUseLine = true
 			}
 		}
 	}

--- a/cmd/podman/manifest/add.go
+++ b/cmd/podman/manifest/add.go
@@ -25,7 +25,7 @@ type manifestAddOptsWrapper struct {
 var (
 	manifestAddOpts = manifestAddOptsWrapper{}
 	addCmd          = &cobra.Command{
-		Use:   "add [flags] LIST LIST",
+		Use:   "add [options] LIST LIST",
 		Short: "Add images to a manifest list or image index",
 		Long:  "Adds an image to a manifest list or image index.",
 		RunE:  add,

--- a/cmd/podman/manifest/annotate.go
+++ b/cmd/podman/manifest/annotate.go
@@ -13,7 +13,7 @@ import (
 var (
 	manifestAnnotateOpts = entities.ManifestAnnotateOptions{}
 	annotateCmd          = &cobra.Command{
-		Use:     "annotate [flags] LIST IMAGE",
+		Use:     "annotate [options] LIST IMAGE",
 		Short:   "Add or update information about an entry in a manifest list or image index",
 		Long:    "Adds or updates information about an entry in a manifest list or image index.",
 		RunE:    annotate,

--- a/cmd/podman/manifest/create.go
+++ b/cmd/podman/manifest/create.go
@@ -13,7 +13,7 @@ import (
 var (
 	manifestCreateOpts = entities.ManifestCreateOptions{}
 	createCmd          = &cobra.Command{
-		Use:   "create [flags] LIST [IMAGE]",
+		Use:   "create [options] LIST [IMAGE]",
 		Short: "Create manifest list or image index",
 		Long:  "Creates manifest lists or image indexes.",
 		RunE:  create,

--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -22,7 +22,7 @@ type manifestPushOptsWrapper struct {
 var (
 	manifestPushOpts = manifestPushOptsWrapper{}
 	pushCmd          = &cobra.Command{
-		Use:     "push [flags] SOURCE DESTINATION",
+		Use:     "push [options] SOURCE DESTINATION",
 		Short:   "Push a manifest list or image index to a registry",
 		Long:    "Pushes manifest lists and image indexes to registries.",
 		RunE:    push,

--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -14,7 +14,7 @@ import (
 var (
 	networkCreateDescription = `create CNI networks for containers and pods`
 	networkCreateCommand     = &cobra.Command{
-		Use:     "create [flags] [NETWORK]",
+		Use:     "create [options] [NETWORK]",
 		Short:   "network create",
 		Long:    networkCreateDescription,
 		RunE:    networkCreate,

--- a/cmd/podman/networks/inspect.go
+++ b/cmd/podman/networks/inspect.go
@@ -17,7 +17,7 @@ import (
 var (
 	networkinspectDescription = `Inspect network`
 	networkinspectCommand     = &cobra.Command{
-		Use:     "inspect [flags] NETWORK [NETWORK...]",
+		Use:     "inspect [options] NETWORK [NETWORK...]",
 		Short:   "network inspect",
 		Long:    networkinspectDescription,
 		RunE:    networkInspect,

--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -19,7 +19,7 @@ import (
 var (
 	networklistDescription = `List networks`
 	networklistCommand     = &cobra.Command{
-		Use:     "ls",
+		Use:     "ls [options]",
 		Args:    validate.NoArgs,
 		Short:   "network list",
 		Long:    networklistDescription,

--- a/cmd/podman/networks/rm.go
+++ b/cmd/podman/networks/rm.go
@@ -16,7 +16,7 @@ import (
 var (
 	networkrmDescription = `Remove networks`
 	networkrmCommand     = &cobra.Command{
-		Use:     "rm [flags] NETWORK [NETWORK...]",
+		Use:     "rm [options] NETWORK [NETWORK...]",
 		Short:   "network rm",
 		Long:    networkrmDescription,
 		RunE:    networkRm,

--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -32,7 +32,7 @@ var (
   It creates the pod and containers described in the YAML.  The containers within the pod are then started and the ID of the new Pod is output.`
 
 	kubeCmd = &cobra.Command{
-		Use:   "kube [flags] KUBEFILE",
+		Use:   "kube [options] KUBEFILE",
 		Short: "Play a pod based on Kubernetes YAML.",
 		Long:  kubeDescription,
 		RunE:  kube,

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -27,7 +27,7 @@ var (
   You can then start it at any time with the  podman pod start <pod_id> command. The pod will be created with the initial state 'created'.`
 
 	createCommand = &cobra.Command{
-		Use:   "create",
+		Use:   "create [options]",
 		Args:  validate.NoArgs,
 		Short: "Create a new empty pod",
 		Long:  podCreateDescription,

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -26,7 +26,7 @@ var (
 	By default, this will render all results in a JSON array.`)
 
 	inspectCmd = &cobra.Command{
-		Use:     "inspect [flags] POD [POD...]",
+		Use:     "inspect [options] POD [POD...]",
 		Short:   "Displays a pod configuration",
 		Long:    inspectDescription,
 		RunE:    inspect,

--- a/cmd/podman/pods/kill.go
+++ b/cmd/podman/pods/kill.go
@@ -16,7 +16,7 @@ var (
 
   The default signal is SIGKILL, or any signal specified with option --signal.`
 	killCommand = &cobra.Command{
-		Use:   "kill [flags] POD [POD...]",
+		Use:   "kill [options] POD [POD...]",
 		Short: "Send the specified signal or SIGKILL to containers in pod",
 		Long:  podKillDescription,
 		RunE:  kill,

--- a/cmd/podman/pods/pause.go
+++ b/cmd/podman/pods/pause.go
@@ -16,7 +16,7 @@ var (
 
   All running containers within each specified pod will then be paused.`
 	pauseCommand = &cobra.Command{
-		Use:   "pause [flags] POD [POD...]",
+		Use:   "pause [options] POD [POD...]",
 		Short: "Pause one or more pods",
 		Long:  podPauseDescription,
 		RunE:  pause,

--- a/cmd/podman/pods/prune.go
+++ b/cmd/podman/pods/prune.go
@@ -23,7 +23,7 @@ var (
 	pruneDescription = fmt.Sprintf(`podman pod prune Removes all exited pods`)
 
 	pruneCommand = &cobra.Command{
-		Use:     "prune [flags]",
+		Use:     "prune [options]",
 		Args:    validate.NoArgs,
 		Short:   "Remove all stopped pods and their containers",
 		Long:    pruneDescription,

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -25,7 +25,7 @@ var (
 
 	// Command: podman pod _ps_
 	psCmd = &cobra.Command{
-		Use:     "ps",
+		Use:     "ps  [options]",
 		Aliases: []string{"ls", "list"},
 		Short:   "List pods",
 		Long:    psDescription,

--- a/cmd/podman/pods/restart.go
+++ b/cmd/podman/pods/restart.go
@@ -16,7 +16,7 @@ var (
 
   All of the containers within each of the specified pods will be restarted. If a container in a pod is not currently running it will be started.`
 	restartCommand = &cobra.Command{
-		Use:   "restart [flags] POD [POD...]",
+		Use:   "restart [options] POD [POD...]",
 		Short: "Restart one or more pods",
 		Long:  podRestartDescription,
 		RunE:  restart,

--- a/cmd/podman/pods/rm.go
+++ b/cmd/podman/pods/rm.go
@@ -28,7 +28,7 @@ var (
 
   The pod name or ID can be used.  A pod with containers will not be removed without --force. If --force is specified, all containers will be stopped, then removed.`)
 	rmCommand = &cobra.Command{
-		Use:   "rm [flags] POD [POD...]",
+		Use:   "rm [options] POD [POD...]",
 		Short: "Remove one or more pods",
 		Long:  podRmDescription,
 		RunE:  rm,

--- a/cmd/podman/pods/start.go
+++ b/cmd/podman/pods/start.go
@@ -24,7 +24,7 @@ var (
 
   All containers defined in the pod will be started.`
 	startCommand = &cobra.Command{
-		Use:   "start [flags] POD [POD...]",
+		Use:   "start [options] POD [POD...]",
 		Short: "Start one or more pods",
 		Long:  podStartDescription,
 		RunE:  start,

--- a/cmd/podman/pods/stats.go
+++ b/cmd/podman/pods/stats.go
@@ -33,7 +33,7 @@ var (
 	statsDescription = `Display the containers' resource-usage statistics of one or more running pod`
 	// Command: podman pod _pod_
 	statsCmd = &cobra.Command{
-		Use:   "stats [flags] [POD...]",
+		Use:   "stats [options] [POD...]",
 		Short: "Display a live stream of resource usage statistics for the containers in one or more pods",
 		Long:  statsDescription,
 		RunE:  stats,

--- a/cmd/podman/pods/stop.go
+++ b/cmd/podman/pods/stop.go
@@ -29,7 +29,7 @@ var (
   This command will stop all running containers in each of the specified pods.`
 
 	stopCommand = &cobra.Command{
-		Use:   "stop [flags] POD [POD...]",
+		Use:   "stop [options] POD [POD...]",
 		Short: "Stop one or more pods",
 		Long:  podStopDescription,
 		RunE:  stop,

--- a/cmd/podman/pods/top.go
+++ b/cmd/podman/pods/top.go
@@ -23,7 +23,7 @@ var (
 	topOptions = entities.PodTopOptions{}
 
 	topCommand = &cobra.Command{
-		Use:   "top [flags] POD [FORMAT-DESCRIPTORS|ARGS...]",
+		Use:   "top [options] POD [FORMAT-DESCRIPTORS|ARGS...]",
 		Short: "Display the running processes of containers in a pod",
 		Long:  topDescription,
 		RunE:  top,

--- a/cmd/podman/pods/unpause.go
+++ b/cmd/podman/pods/unpause.go
@@ -16,7 +16,7 @@ var (
 
   The pod name or ID can be used.`
 	unpauseCommand = &cobra.Command{
-		Use:   "unpause [flags] POD [POD...]",
+		Use:   "unpause [options] POD [POD...]",
 		Short: "Unpause one or more pods",
 		Long:  podUnpauseDescription,
 		RunE:  unpause,

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -38,7 +38,7 @@ Description:
 // command should not use this.
 const usageTemplate = `Usage:{{if (and .Runnable (not .HasAvailableSubCommands))}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+  {{.UseLine}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
@@ -49,24 +49,24 @@ Examples:
 Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
-Flags:
+Options:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 {{end}}
 `
 
 var (
 	rootCmd = &cobra.Command{
-		Use:                path.Base(os.Args[0]),
-		Long:               "Manage pods, containers and images",
-		SilenceUsage:       true,
-		SilenceErrors:      true,
-		TraverseChildren:   true,
-		PersistentPreRunE:  persistentPreRunE,
-		RunE:               validate.SubCommandExists,
-		PersistentPostRunE: persistentPostRunE,
-		Version:            version.Version.String(),
+		Use:                   path.Base(os.Args[0]) + " [options]",
+		Long:                  "Manage pods, containers and images",
+		SilenceUsage:          true,
+		SilenceErrors:         true,
+		TraverseChildren:      true,
+		PersistentPreRunE:     persistentPreRunE,
+		RunE:                  validate.SubCommandExists,
+		PersistentPostRunE:    persistentPostRunE,
+		Version:               version.Version.String(),
+		DisableFlagsInUseLine: true,
 	}
-
 	logLevels = []string{"debug", "info", "warn", "error", "fatal", "panic"}
 	logLevel  = "error"
 	useSyslog bool
@@ -81,6 +81,7 @@ func init() {
 	)
 
 	rootFlags(rootCmd, registry.PodmanConfig())
+	rootCmd.SetUsageTemplate(usageTemplate)
 }
 
 func Execute() {

--- a/cmd/podman/system/connection/add.go
+++ b/cmd/podman/system/connection/add.go
@@ -27,7 +27,7 @@ const schemaPattern = "^[A-Za-z][A-Za-z0-9+.-]*:"
 
 var (
 	addCmd = &cobra.Command{
-		Use:   "add [flags] NAME DESTINATION",
+		Use:   "add [options] NAME DESTINATION",
 		Args:  cobra.ExactArgs(2),
 		Short: "Record destination for the Podman service",
 		Long: `Add destination to podman configuration.

--- a/cmd/podman/system/df.go
+++ b/cmd/podman/system/df.go
@@ -23,7 +23,7 @@ var (
 	Show podman disk usage
 	`
 	dfSystemCommand = &cobra.Command{
-		Use:   "df",
+		Use:   "df [options]",
 		Args:  validate.NoArgs,
 		Short: "Show podman disk usage",
 		Long:  dfSystemDescription,

--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -20,7 +20,7 @@ var (
 
   By default, streaming mode is used, printing new events as they occur.  Previous events can be listed via --since and --until.`
 	eventsCommand = &cobra.Command{
-		Use:   "events",
+		Use:   "events [options]",
 		Args:  validate.NoArgs,
 		Short: "Show podman events",
 		Long:  eventsDescription,

--- a/cmd/podman/system/info.go
+++ b/cmd/podman/system/info.go
@@ -20,7 +20,7 @@ var (
   Useful for the user and when reporting issues.
 `
 	infoCommand = &cobra.Command{
-		Use:     "info",
+		Use:     "info [options]",
 		Args:    validate.NoArgs,
 		Long:    infoDescription,
 		Short:   "Display podman system information",

--- a/cmd/podman/system/migrate.go
+++ b/cmd/podman/system/migrate.go
@@ -21,7 +21,7 @@ var (
 `
 
 	migrateCommand = &cobra.Command{
-		Use:   "migrate",
+		Use:   "migrate [options]",
 		Args:  validate.NoArgs,
 		Short: "Migrate containers",
 		Long:  migrateDescription,

--- a/cmd/podman/system/prune.go
+++ b/cmd/podman/system/prune.go
@@ -25,7 +25,7 @@ var (
 `)
 
 	pruneCommand = &cobra.Command{
-		Use:     "prune [flags]",
+		Use:     "prune [options]",
 		Short:   "Remove unused data",
 		Args:    validate.NoArgs,
 		Long:    pruneDescription,

--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -22,7 +22,7 @@ var (
   All containers will be stopped and removed, and all images, volumes and container content will be removed.
 `
 	systemResetCommand = &cobra.Command{
-		Use:   "reset",
+		Use:   "reset [options]",
 		Args:  validate.NoArgs,
 		Short: "Reset podman storage",
 		Long:  systemResetDescription,

--- a/cmd/podman/system/service.go
+++ b/cmd/podman/system/service.go
@@ -26,7 +26,7 @@ Enable a listening service for API access to Podman commands.
 `
 
 	srvCmd = &cobra.Command{
-		Use:     "service [flags] [URI]",
+		Use:     "service [options] [URI]",
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Run API service",
 		Long:    srvDescription,

--- a/cmd/podman/system/varlink.go
+++ b/cmd/podman/system/varlink.go
@@ -16,7 +16,7 @@ var (
   Tools speaking varlink protocol can remotely manage pods, containers and images.
 `
 	varlinkCmd = &cobra.Command{
-		Use:        "varlink [flags] [URI]",
+		Use:        "varlink [options] [URI]",
 		Args:       cobra.MinimumNArgs(1),
 		Short:      "Run varlink interface",
 		Long:       varlinkDescription,

--- a/cmd/podman/system/version.go
+++ b/cmd/podman/system/version.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	versionCommand = &cobra.Command{
-		Use:   "version",
+		Use:   "version [options]",
 		Args:  validate.NoArgs,
 		Short: "Display the Podman Version Information",
 		RunE:  version,

--- a/cmd/podman/volumes/create.go
+++ b/cmd/podman/volumes/create.go
@@ -15,7 +15,7 @@ var (
 	createDescription = `If using the default driver, "local", the volume will be created on the host in the volumes directory under container storage.`
 
 	createCommand = &cobra.Command{
-		Use:   "create [flags] [NAME]",
+		Use:   "create [options] [NAME]",
 		Short: "Create a new volume",
 		Long:  createDescription,
 		RunE:  create,

--- a/cmd/podman/volumes/inspect.go
+++ b/cmd/podman/volumes/inspect.go
@@ -19,7 +19,7 @@ var (
 
   Use a Go template to change the format from JSON.`
 	inspectCommand = &cobra.Command{
-		Use:   "inspect [flags] VOLUME [VOLUME...]",
+		Use:   "inspect [options] VOLUME [VOLUME...]",
 		Short: "Display detailed information on one or more volumes",
 		Long:  volumeInspectDescription,
 		RunE:  inspect,

--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -24,7 +24,7 @@ podman volume ls
 List all available volumes. The output of the volumes can be filtered
 and the output format can be changed to JSON or a user specified Go template.`
 	lsCommand = &cobra.Command{
-		Use:     "ls",
+		Use:     "ls [options]",
 		Aliases: []string{"list"},
 		Args:    validate.NoArgs,
 		Short:   "List volumes",

--- a/cmd/podman/volumes/prune.go
+++ b/cmd/podman/volumes/prune.go
@@ -21,7 +21,7 @@ var (
   The command prompts for confirmation which can be overridden with the --force flag.
   Note all data will be destroyed.`
 	pruneCommand = &cobra.Command{
-		Use:   "prune",
+		Use:   "prune [options]",
 		Args:  validate.NoArgs,
 		Short: "Remove all unused volumes",
 		Long:  volumePruneDescription,

--- a/cmd/podman/volumes/rm.go
+++ b/cmd/podman/volumes/rm.go
@@ -18,7 +18,7 @@ var (
 
   By default only volumes that are not being used by any containers will be removed. To remove the volumes anyways, use the --force flag.`
 	rmCommand = &cobra.Command{
-		Use:     "rm [flags] VOLUME [VOLUME...]",
+		Use:     "rm [options] VOLUME [VOLUME...]",
 		Aliases: []string{"remove"},
 		Short:   "Remove one or more volumes",
 		Long:    volumeRmDescription,

--- a/completions/zsh/_podman
+++ b/completions/zsh/_podman
@@ -31,48 +31,48 @@ _read_podman_commands() {
     eval "$_var_ref=(\$_podman_commands)"
 }
 
-# Run 'podman XX --help', set _podman_flag_list to a formatted list
-# of flag options for XX
-_read_podman_flags() {
+# Run 'podman XX --help', set _podman_option_list to a formatted list
+# of option options for XX
+_read_podman_options() {
     local line
 
-    local _var_ref=_podman_flags_"${*// /_}"
+    local _var_ref=_podman_options_"${*// /_}"
     eval "typeset -ga ${_var_ref}"
-    typeset -ga _podman_flag_list
-    _podman_flag_list=(${(P)_var_ref})
-    (( $#_podman_flag_list )) && return
+    typeset -ga _podman_option_list
+    _podman_option_list=(${(P)_var_ref})
+    (( $#_podman_option_list )) && return
 
-    # Extract the Flags; strip leading whitespace; pack '-f, --foo'
+    # Extract the Options; strip leading whitespace; pack '-f, --foo'
     # as '-f,--foo' (no space); then add '=' to '--foo string'.
     # The result will be, e.g. '-f,--foo=string  Description of Option'
     _call_program podman podman "$@" --help |\
-        sed -n -e '0,/^Flags:/d' -e '/^$/q;p' |\
+        sed -n -e '0,/^Options:/d' -e '/^$/q;p' |\
         grep '^ \+-' |\
         sed -e 's/^ *//' -e 's/^\(-.,\) --/\1--/' |\
         sed -e 's/^\(-[^ ]\+\) \([^ ]\+\)  /\1=\2  /' |\
-        while read flags desc;do
-            # flags like --foo=string: split into --foo & string
+        while read options desc;do
+            # options like --foo=string: split into --foo & string
             local -a tmpa
             local optval=
-            tmpa=(${(s.=.)flags})
+            tmpa=(${(s.=.)options})
             if [ -n "$tmpa[2]" ]; then
-                flags=$tmpa[1]
+                options=$tmpa[1]
                 optval=$tmpa[2]
             fi
 
             # 'podman attach --detach-keys' includes ']' in help msg
             desc=${desc//\]/\\]}
 
-            for flag in ${(s:,:)flags}; do
+            for option in ${(s:,:)options}; do
                 if [ -n "$optval" ]; then
-                    _podman_flag_list+=("${flag}[$desc]:$(_podman_find_helper ${flags} ${optval} ${desc})")
+                    _podman_option_list+=("${option}[$desc]:$(_podman_find_helper ${options} ${optval} ${desc})")
                 else
-                    _podman_flag_list+=("${flag}[$desc]")
+                    _podman_option_list+=("${option}[$desc]")
                 fi
             done
         done
 
-    eval "typeset -ga $_var_ref=(\$_podman_flag_list)"
+    eval "typeset -ga $_var_ref=(\$_podman_option_list)"
 }
 
 # Run 'podman XXX --help', set _podman_usage to the line after "Usage:"
@@ -95,9 +95,9 @@ _read_podman_usage() {
 ###############################################################################
 # BEGIN custom helpers for individual option arguments
 
-# Find a zsh helper for a given flag or command-line option
+# Find a zsh helper for a given option or command-line option
 _podman_find_helper() {
-    local flags=$1
+    local options=$1
     local optval=$2
     local desc=$3
     local helper=
@@ -113,7 +113,7 @@ _podman_find_helper() {
         helper=_files
     # For messages like 'restart policy ("always"|"no"|"on-failure")
     elif optlist=$(expr "$desc" : '.*(\(\"[^\\)]\+|[^\\)]\+\"\))' 2>/dev/null); then
-        optval=${${flags##--}//-/ }       # "--log-level" => "log level"
+        optval=${${options##--}//-/ }       # "--log-level" => "log level"
         optlist=${optlist//\"/}           # "a"|"b"|"c"   => a|b|c
         optlist=${optlist//\|/ }          # a|b|c         => a b c
         # FIXME: how to present values _in order_, not sorted alphabetically?
@@ -205,8 +205,8 @@ _set_up_podman_args() {
     _read_podman_usage "$@"
 
     typeset -ga _podman_args=()
-    # E.g. 'podman exec [flags] CONTAINER [...' -> 'CONTAINER [....'
-    local usage_rhs=$(expr "$_podman_usage" : ".*\[flags\] \+\(.*\)")
+    # E.g. 'podman exec [options] CONTAINER [...' -> 'CONTAINER [....'
+    local usage_rhs=$(expr "$_podman_usage" : ".*\[options\] \+\(.*\)")
 
     # e.g. podman pod ps which takes no further args
     if [ -z "$usage_rhs" ]; then
@@ -290,14 +290,14 @@ _set_up_podman_args() {
 # For an endpoint command, i.e. not a subcommand.
 _podman_terminus() {
     typeset -A opt_args
-    typeset -ga _podman_flag_list
+    typeset -ga _podman_option_list
     typeset -ga _podman_args
     integer ret=1
 
     # Find out what args it takes (e.g. image(s), container(s)) and see
     # if we have helpers for them.
     _set_up_podman_args "$@"
-    _arguments -C $_podman_flag_list $_podman_args && ret=0
+    _arguments -C $_podman_option_list $_podman_args && ret=0
 
     return ret
 }
@@ -319,7 +319,7 @@ _podman_terminus() {
 # zsh first calls us with words=(podman container mount) but we don't
 # want all that full context yet! We want to go a piece at a time,
 # handling 'container' first, then 'mount'; ending up with our
-# final 'podman container mount --help' giving us suitable flags
+# final 'podman container mount --help' giving us suitable options
 # and no subcommands; from which we determine that it's a terminus
 # and jump to a function that handles non-subcommand arguments.
 #
@@ -333,15 +333,15 @@ _podman_subcommand() {
 
     # Run 'podman --help' / 'podman system --help' for our context (initially
     # empty, then possibly under subcommands); from those, get a list of
-    # flags appropriate for this context and, if applicable, subcommands.
-    _read_podman_flags "$@"
+    # options appropriate for this context and, if applicable, subcommands.
+    _read_podman_options "$@"
     _read_podman_commands "$@"
 
     # Now, is this a sub-subcommand, or does it have args?
     if (( $#_podman_commands )); then
         # Subcommands required (podman, podman system, etc)
         local cmd=${words// /_}
-        _arguments -C $_podman_flag_list \
+        _arguments -C $_podman_option_list \
                    "(-): :->command" \
                    "(-)*:: :->option-or-argument" \
             && ret=0

--- a/docs/remote-docs.sh
+++ b/docs/remote-docs.sh
@@ -78,7 +78,7 @@ function html_fn() {
 # the command name but not its description.
 function podman_commands() {
     $PODMAN help "$@" |\
-        awk '/^Available Commands:/{ok=1;next}/^Flags:/{ok=0}ok { print $1 }' |\
+        awk '/^Available Commands:/{ok=1;next}/^Options:/{ok=0}ok { print $1 }' |\
         grep .
 }
 

--- a/docs/source/markdown/podman-pod-top.1.md
+++ b/docs/source/markdown/podman-pod-top.1.md
@@ -7,7 +7,7 @@ podman\-pod\-top - Display the running processes of containers in a pod
 **podman pod top** [*options*] *pod* [*format-descriptors*]
 
 ## DESCRIPTION
-Display the running processes of containers in a pod. The *format-descriptors* are ps (1) compatible AIX format descriptors but extended to print additional information, such as the seccomp mode or the effective capabilities of a given process. The descriptors can either be passed as separated arguments or as a single comma-separated argument. Note that you can also specify options and or flags of ps(1); in this case, Podman will fallback to executing ps with the specified arguments and flags in the container.
+Display the running processes of containers in a pod. The *format-descriptors* are ps (1) compatible AIX format descriptors but extended to print additional information, such as the seccomp mode or the effective capabilities of a given process. The descriptors can either be passed as separated arguments or as a single comma-separated argument. Note that you can specify options and/or additionally options of ps(1); in this case, Podman will fallback to executing ps with the specified arguments and options in the container.
 
 ## OPTIONS
 

--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -92,10 +92,10 @@ function compare_usage() {
     # man page lists 'foo [*options*]', help msg shows 'foo [flags]'.
     # Make sure if one has it, the other does too.
     if expr "$from_man" : "\[\*options\*\]" >/dev/null; then
-        if expr "$from_help" : "\[flags\]" >/dev/null; then
+        if expr "$from_help" : "\[options\]" >/dev/null; then
             :
         else
-            echo "WARNING: $cmd: man page shows '[*options*]', help does not show [flags]"
+            echo "WARNING: $cmd: man page shows '[*options*]', help does not show [options]"
             rc=1
        fi
     elif expr "$from_help" : "\[flags\]" >/dev/null; then

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -228,14 +228,14 @@ sub podman_help {
         #    Usage: ...
         #    Available Commands:
         #       ....
-        #    Flags:
+        #    Options:
         #       ....
         #
         # Start by identifying the section we're in...
         if ($line =~ /^Available\s+(Commands):/) {
             $section = lc $1;
         }
-        elsif ($line =~ /^(Flags):/) {
+        elsif ($line =~ /^(Options):/) {
             $section = lc $1;
         }
 
@@ -320,7 +320,7 @@ sub podman_man {
             }
         }
 
-        # Flags should always be of the form '**-f**' or '**--flag**',
+        # Options should always be of the form '**-f**' or '**--flag**',
         # possibly separated by comma-space.
         elsif ($section eq 'flags') {
             # e.g. 'podman run --ip6', documented in man page, but nonexistent

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -6,7 +6,7 @@
 # provides its own --help output. If the usage message ends in '[command]',
 # treat it as a subcommand, and recurse into its own list of sub-subcommands.
 #
-# Any usage message that ends in '[flags]' is interpreted as a command
+# Any usage message that ends in '[options]' is interpreted as a command
 # that takes no further arguments; we confirm by running with 'invalid-arg'
 # and confirming that it exits with error status and message.
 #
@@ -17,7 +17,7 @@ load helpers
 function podman_commands() {
     dprint "$@"
     run_podman help "$@" |\
-        awk '/^Available Commands:/{ok=1;next}/^Flags:/{ok=0}ok { print $1 }' |\
+        awk '/^Available Commands:/{ok=1;next}/^Options:/{ok=0}ok { print $1 }' |\
         grep .
     "$output"
 }
@@ -42,7 +42,7 @@ function check_help() {
 
         # e.g. 'podman ps' should not show 'podman container ps' in usage
         # Trailing space in usage handles 'podman system renumber' which
-        # has no ' [flags]'
+        # has no ' [options]'
         is "$usage " "  $command_string .*" "Usage string matches command"
 
         # If usage ends in '[command]', recurse into subcommands
@@ -52,25 +52,25 @@ function check_help() {
             continue
         fi
 
-        # We had someone write upper-case '[FLAGS]' once. Prevent it.
-        if expr "$usage" : '.*\[FLAG' >/dev/null; then
-            die "'flags' string must be lower-case in usage: $usage"
+        # We had someone write upper-case '[OPTIONS]' once. Prevent it.
+        if expr "$usage" : '.*\[OPTION' >/dev/null; then
+            die "'options' string must be lower-case in usage: $usage"
         fi
 
-        # We had someone do 'podman foo ARG [flags]' one time. Yeah, no.
-        if expr "$usage" : '.*[A-Z].*\[flag' >/dev/null; then
-            die "'flags' must precede arguments in usage: $usage"
+        # We had someone do 'podman foo ARG [options]' one time. Yeah, no.
+        if expr "$usage" : '.*[A-Z].*\[option' >/dev/null; then
+            die "'options' must precede arguments in usage: $usage"
         fi
 
-        # Cross-check: if usage includes '[flags]', there must be a
-        # longer 'Flags:' section in the full --help output; vice-versa,
-        # if 'Flags:' is in full output, usage line must have '[flags]'.
-        if expr "$usage" : '.*\[flag' >/dev/null; then
-            if ! expr "$full_help" : ".*Flags:" >/dev/null; then
-                die "$command_string: Usage includes '[flags]' but has no 'Flags:' subsection"
+        # Cross-check: if usage includes '[options]', there must be a
+        # longer 'Options:' section in the full --help output; vice-versa,
+        # if 'Options:' is in full output, usage line must have '[options]'.
+        if expr "$usage" : '.*\[option' >/dev/null; then
+            if ! expr "$full_help" : ".*Options:" >/dev/null; then
+                die "$command_string: Usage includes '[options]' but has no 'Options:' subsection"
             fi
-        elif expr "$full_help" : ".*Flags:" >/dev/null; then
-            die "$command_string: --help has 'Flags:' section but no '[flags]' in synopsis"
+        elif expr "$full_help" : ".*Options:" >/dev/null; then
+            die "$command_string: --help has 'Options:' section but no '[options]' in synopsis"
         fi
 
         # If usage lists no arguments (strings in ALL CAPS), confirm
@@ -102,7 +102,7 @@ function check_help() {
 
         # If usage has required arguments, try running without them.
         # The expression here is 'first capital letter is not in [BRACKETS]'.
-        # It is intended to handle 'podman foo [flags] ARG' but not ' [ARG]'.
+        # It is intended to handle 'podman foo [options] ARG' but not ' [ARG]'.
         if expr "$usage" : '[^A-Z]\+ [A-Z]' >/dev/null; then
             # Exceptions: these commands don't work rootless
             if is_rootless; then


### PR DESCRIPTION
Want to have man pages match commands, since we have lots of printed
man pages with using Options, we will change the command line to use
Options in --help.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

