### PR TITLE
Fix podman-run man page heading

### DIFF
--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1234,7 +1234,7 @@ you'd like to connect instead, as in:
 $ podman run -a stdin -a stdout -i -t fedora /bin/bash
 ```
 
-## Sharing IPC between containers
+### Sharing IPC between containers
 
 Using **shm_server.c** available here: https://www.cs.cf.ac.uk/Dave/C/node27.html
 


### PR DESCRIPTION
Sharing IPC is meant to be an example under the Examples heading, not a
new section.

Signed-off-by: Jordan Christiansen <xordspar0@gmail.com>