### PR TITLE
Make Podman-managed bind mounts unbindable

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -343,7 +343,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 			Type:        "bind",
 			Source:      srcPath,
 			Destination: dstPath,
-			Options:     []string{"bind", "private"},
+			Options:     []string{"bind", "unbindable"},
 		}
 		if c.IsReadOnly() && dstPath != "/dev/shm" {
 			newMount.Options = append(newMount.Options, "ro", "nosuid", "noexec", "nodev")


### PR DESCRIPTION
This helps prevent potential mount loops when a user bind-mounts a large portion of the host (including bits that Podman uses) into a container using a shared mount propagation.
