### PR TITLE
--tls-verify and --authfile should work for all remote commands

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -63,7 +63,6 @@ func createFlags(flags *pflag.FlagSet) {
 
 	_ = flags.MarkHidden("signature-policy")
 	if registry.IsRemote() {
-		_ = flags.MarkHidden("authfile")
 		_ = flags.MarkHidden("http-proxy")
 	}
 }

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -66,7 +66,6 @@ func runFlags(flags *pflag.FlagSet) {
 
 	_ = flags.MarkHidden("signature-policy")
 	if registry.IsRemote() {
-		_ = flags.MarkHidden("authfile")
 		_ = flags.MarkHidden("http-proxy")
 		_ = flags.MarkHidden("preserve-fds")
 	}

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -84,11 +84,11 @@ func pullFlags(flags *pflag.FlagSet) {
 	flags.Bool("disable-content-trust", false, "This is a Docker specific option and is a NOOP")
 	flags.BoolVarP(&pullOptions.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
 	flags.StringVar(&pullOptions.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
+	flags.BoolVar(&pullOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+	flags.StringVar(&pullOptions.Authfile, "authfile", auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 
 	if !registry.IsRemote() {
-		flags.StringVar(&pullOptions.Authfile, "authfile", auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 		flags.StringVar(&pullOptions.CertDir, "cert-dir", "", "`Pathname` of a directory containing TLS certificates and keys")
-		flags.BoolVar(&pullOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 	}
 	_ = flags.MarkHidden("signature-policy")
 }

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -88,11 +88,9 @@ func pushFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&pushOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 
 	if registry.IsRemote() {
-		_ = flags.MarkHidden("authfile")
 		_ = flags.MarkHidden("cert-dir")
 		_ = flags.MarkHidden("compress")
 		_ = flags.MarkHidden("quiet")
-		_ = flags.MarkHidden("tls-verify")
 	}
 	_ = flags.MarkHidden("signature-policy")
 }

--- a/cmd/podman/manifest/add.go
+++ b/cmd/podman/manifest/add.go
@@ -56,9 +56,7 @@ func init() {
 	flags.StringVar(&manifestAddOpts.Variant, "variant", "", "override the `Variant` of the specified image")
 
 	if registry.IsRemote() {
-		_ = flags.MarkHidden("authfile")
 		_ = flags.MarkHidden("cert-dir")
-		_ = flags.MarkHidden("tls-verify")
 	}
 }
 

--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -51,9 +51,7 @@ func init() {
 	flags.BoolVarP(&manifestPushOpts.Quiet, "quiet", "q", false, "don't output progress information when pushing lists")
 
 	if registry.IsRemote() {
-		_ = flags.MarkHidden("authfile")
 		_ = flags.MarkHidden("cert-dir")
-		_ = flags.MarkHidden("tls-verify")
 	}
 }
 

--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -54,10 +54,10 @@ func init() {
 	flags.StringVar(&kubeOptions.CredentialsCLI, "creds", "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
 	flags.StringVar(&kubeOptions.Network, "network", "", "Connect pod to CNI network(s)")
 	flags.BoolVarP(&kubeOptions.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
+	flags.BoolVar(&kubeOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+	flags.StringVar(&kubeOptions.Authfile, "authfile", auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	if !registry.IsRemote() {
-		flags.StringVar(&kubeOptions.Authfile, "authfile", auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 		flags.StringVar(&kubeOptions.CertDir, "cert-dir", "", "`Pathname` of a directory containing TLS certificates and keys")
-		flags.BoolVar(&kubeOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 		flags.StringVar(&kubeOptions.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
 		flags.StringVar(&kubeOptions.SeccompProfileRoot, "seccomp-profile-root", defaultSeccompRoot, "Directory path for seccomp profiles")
 		flags.StringSliceVar(&kubeOptions.ConfigMaps, "configmap", []string{}, "`Pathname` of a YAML file containing a kubernetes configmap")

--- a/docs/source/markdown/podman-auto-update.1.md
+++ b/docs/source/markdown/podman-auto-update.1.md
@@ -31,7 +31,7 @@ Systemd units that start and stop a container cannot run a new image.
 **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -46,7 +46,7 @@ Set the ARCH of the image to the provided value instead of the architecture of t
 **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -470,7 +470,7 @@ When --timestamp is set, the created timestamp is always set to the time specifi
 
 **--tls-verify**=*true|false*
 
-Require HTTPS and verify certificates when talking to container registries (defaults to true). (Not available for remote commands)
+Require HTTPS and verify certificates when talking to container registries (defaults to true).
 
 **--ulimit**=*type*=*soft-limit*[:*hard-limit*]
 

--- a/docs/source/markdown/podman-container-runlabel.1.md
+++ b/docs/source/markdown/podman-container-runlabel.1.md
@@ -44,7 +44,7 @@ Any additional arguments will be appended to the command.
 **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -85,7 +85,7 @@ created from this image.
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
-TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf (Not available for remote commands)
+TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
 ## EXAMPLES
 

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -47,7 +47,7 @@ each of stdin, stdout, and stderr.
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
-environment variable. `export REGISTRY_AUTH_FILE=path` (Not available for remote commands)
+environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--blkio-weight**=*weight*
 

--- a/docs/source/markdown/podman-login.1.md
+++ b/docs/source/markdown/podman-login.1.md
@@ -42,7 +42,7 @@ Username for registry
 
 **--authfile**=*path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json (Not available for remote commands)
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -60,7 +60,7 @@ Default certificates directory is _/etc/containers/certs.d_. (Not available for 
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
-TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf. (Not available for remote commands)
+TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
 **--help**, **-h**
 

--- a/docs/source/markdown/podman-logout.1.md
+++ b/docs/source/markdown/podman-logout.1.md
@@ -23,7 +23,7 @@ All the cached credentials can be removed by setting the **all** flag.
 
 **--authfile**=*path*
 
-Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json (Not available for remote commands)
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`

--- a/docs/source/markdown/podman-manifest-add.1.md
+++ b/docs/source/markdown/podman-manifest-add.1.md
@@ -36,7 +36,7 @@ retrieved from the image's configuration information.
 **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -71,7 +71,7 @@ image.  This option is rarely used.
 
 **--tls-verify**
 
-Require HTTPS and verify certificates when talking to container registries (defaults to true). (Not available for remote commands)
+Require HTTPS and verify certificates when talking to container registries (defaults to true).
 
 **--variant**
 

--- a/docs/source/markdown/podman-manifest-push.1.md
+++ b/docs/source/markdown/podman-manifest-push.1.md
@@ -22,7 +22,7 @@ the list or index itself.
 **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -64,7 +64,7 @@ Sign the pushed images using the GPG key that matches the specified fingerprint.
 
 **--tls-verify**
 
-Require HTTPS and verify certificates when talking to container registries (defaults to true) (Not available for remote commands)
+Require HTTPS and verify certificates when talking to container registries. (defaults to true)
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -20,7 +20,7 @@ Note: HostPath volume types created by play kube will be given an SELinux privat
 **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -58,7 +58,7 @@ Directory path for seccomp profiles (default: "/var/lib/kubelet/seccomp"). (Not 
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
-TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf. (Not available for remote commands)
+TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
 **--help**, **-h**
 

--- a/docs/source/markdown/podman-pull.1.md
+++ b/docs/source/markdown/podman-pull.1.md
@@ -57,7 +57,7 @@ Note: When using the all-tags flag, Podman will not iterate over the search regi
 **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -97,7 +97,7 @@ Suppress output information when pulling images
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
-TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf. (Not available for remote commands)
+TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
 **--help**, **-h**
 

--- a/docs/source/markdown/podman-push.1.md
+++ b/docs/source/markdown/podman-push.1.md
@@ -46,7 +46,7 @@ Images are pushed from those stored in local image storage.
 **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -98,7 +98,7 @@ Add a signature at the destination using the specified key
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
-TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf. (Not available for remote commands)
+TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -57,7 +57,7 @@ each of **stdin**, **stdout**, and **stderr**.
 
 **--authfile**[=*path*]
 
-Path to the authentication file. Default is *${XDG_RUNTIME_DIR}/containers/auth.json*. (Not available for remote commands)
+Path to the authentication file. Default is *${XDG_RUNTIME_DIR}/containers/auth.json*.
 
 Note: You can also override the default path of the authentication file by setting the **REGISTRY_AUTH_FILE**
 environment variable.

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -636,6 +636,14 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 		options.Filter = *filter
 	}
 
+	_, authfile, key, err := auth.GetCredentials(r)
+	if err != nil {
+		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
+		return
+	}
+	defer auth.RemoveAuthfile(authfile)
+	options.Authfile = authfile
+
 	searchResults, err := image.SearchImages(query.Term, options)
 	if err != nil {
 		utils.BadRequest(w, "term", query.Term, err)

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -673,3 +673,9 @@ func (p *PodmanTestIntegration) PodmanAsUser(args []string, uid, gid uint32, cwd
 	podmanSession := p.PodmanAsUserBase(args, uid, gid, cwd, env, false, false, nil)
 	return &PodmanSessionIntegration{podmanSession}
 }
+
+// We don't support running Varlink when local
+func (p *PodmanTestIntegration) RestartRemoteService() {
+	p.StopRemoteService()
+	p.StartRemoteService()
+}

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -237,7 +237,6 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search attempts HTTP if registry is in registries.insecure and force secure is false", func() {
-		SkipIfRemote("--tls-verify is not supported on podman-remote search")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
@@ -264,6 +263,10 @@ registries = ['{{.Host}}:{{.Port}}']`
 		registryFileTmpl.Execute(&buffer, registryEndpoints[4])
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
 		ioutil.WriteFile(fmt.Sprintf("%s/registry4.conf", tempdir), buffer.Bytes(), 0644)
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+			defer podmanTest.RestartRemoteService()
+		}
 
 		search := podmanTest.PodmanNoCache([]string{"search", image})
 		search.WaitWithDefaultTimeout()
@@ -278,7 +281,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search doesn't attempt HTTP if force secure is true", func() {
-		SkipIfRemote("--tls-verify is not supported on podman-remote search")
+		SkipIfRemote("FIXME This should work on podman-remote")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
@@ -303,6 +306,10 @@ registries = ['{{.Host}}:{{.Port}}']`
 		registryFileTmpl.Execute(&buffer, registryEndpoints[5])
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
 		ioutil.WriteFile(fmt.Sprintf("%s/registry5.conf", tempdir), buffer.Bytes(), 0644)
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+			defer podmanTest.RestartRemoteService()
+		}
 
 		search := podmanTest.PodmanNoCache([]string{"search", image, "--tls-verify=true"})
 		search.WaitWithDefaultTimeout()
@@ -317,7 +324,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search doesn't attempt HTTP if registry is not listed as insecure", func() {
-		SkipIfRemote("--tls-verify is not supported on podman-remote search")
+		SkipIfRemote("FIXME This should work on podman-remote")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
@@ -342,6 +349,11 @@ registries = ['{{.Host}}:{{.Port}}']`
 		registryFileBadTmpl.Execute(&buffer, registryEndpoints[6])
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
 		ioutil.WriteFile(fmt.Sprintf("%s/registry6.conf", tempdir), buffer.Bytes(), 0644)
+
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+			defer podmanTest.RestartRemoteService()
+		}
 
 		search := podmanTest.PodmanNoCache([]string{"search", image})
 		search.WaitWithDefaultTimeout()
@@ -392,6 +404,11 @@ registries = ['{{.Host}}:{{.Port}}']`
 		registryFileTwoTmpl.Execute(&buffer, registryEndpoints[8])
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
 		ioutil.WriteFile(fmt.Sprintf("%s/registry8.conf", tempdir), buffer.Bytes(), 0644)
+
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+			defer podmanTest.RestartRemoteService()
+		}
 
 		search := podmanTest.PodmanNoCache([]string{"search", "my-alpine"})
 		search.WaitWithDefaultTimeout()


### PR DESCRIPTION
These options are now fully supported in the remote API and should no
longer be hidden and/or documented as non supported.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>