### PR TITLE
Update podman-remote run and start to handle detach keys

### DIFF
--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -500,7 +500,6 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 			if err == define.ErrDetach {
 				// User manually detached
 				// Exit cleanly immediately
-				report.Err = err
 				reports = append(reports, &report)
 				return reports, nil
 			}

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -573,6 +573,10 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 
 	// Attach
 	if err := startAndAttach(ic, con.ID, &opts.DetachKeys, opts.InputStream, opts.OutputStream, opts.ErrorStream); err != nil {
+		if err == define.ErrDetach {
+			return &report, nil
+		}
+
 		report.ExitCode = define.ExitCode(err)
 		if opts.Rm {
 			if rmErr := containers.Remove(ic.ClientCxt, con.ID, bindings.PFalse, bindings.PTrue); rmErr != nil {


### PR DESCRIPTION
As described in the issue #7979, `podman-remote run` and `podman-remote start --attach` currently do not handle detach keys. This PR fixes the issue by handling the detach keys and exit cleanly with status 0.