### PR TITLE
podman create doesn't support creating detached containers

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -115,16 +115,6 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 		"cpuset-mems", "",
 		"Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.",
 	)
-	createFlags.BoolVarP(
-		&cf.Detach,
-		"detach", "d", false,
-		"Run container in background and print container ID",
-	)
-	createFlags.StringVar(
-		&cf.DetachKeys,
-		"detach-keys", containerConfig.DetachKeys(),
-		"Override the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-cf`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`",
-	)
 	createFlags.StringSliceVar(
 		&cf.Devices,
 		"device", containerConfig.Devices(),

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -32,8 +32,6 @@ type ContainerCLIOpts struct {
 	CPUS              float64
 	CPUSetCPUs        string
 	CPUSetMems        string
-	Detach            bool
-	DetachKeys        string
 	Devices           []string
 	DeviceCGroupRule  []string
 	DeviceReadBPs     []string

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -63,6 +63,8 @@ func runFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&runOpts.SigProxy, "sig-proxy", true, "Proxy received signals to the process")
 	flags.BoolVar(&runRmi, "rmi", false, "Remove container image unless used by other containers")
 	flags.UintVar(&runOpts.PreserveFDs, "preserve-fds", 0, "Pass a number of additional file descriptors into the container")
+	flags.BoolVarP(&runOpts.Detach, "detach", "d", false, "Run container in background and print container ID")
+	flags.StringVar(&runOpts.DetachKeys, "detach-keys", containerConfig.DetachKeys(), "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-cf`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 
 	_ = flags.MarkHidden("signature-policy")
 	if registry.IsRemote() {
@@ -171,8 +173,6 @@ func run(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
-	runOpts.Detach = cliVals.Detach
-	runOpts.DetachKeys = cliVals.DetachKeys
 	cliVals.PreserveFDs = runOpts.PreserveFDs
 	s := specgen.NewSpecGenerator(imageName, cliVals.RootFS)
 	if err := common.FillOutSpecGen(s, &cliVals, args); err != nil {
@@ -200,7 +200,7 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if cliVals.Detach {
+	if runOpts.Detach {
 		fmt.Println(report.Id)
 		return nil
 	}

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -183,23 +183,6 @@ If you have four memory nodes on your system (0-3), use `--cpuset-mems=0,1`
 then processes in your container will only use memory from the first
 two memory nodes.
 
-**--detach**, **-d**=*true|false*
-
-Detached mode: run the container in the background and print the new container ID. The default is *false*.
-
-At any time you can run **podman ps** in
-the other shell to view a list of the running containers. You can reattach to a
-detached container with **podman attach**.
-
-When attached in the tty mode, you can detach from the container (and leave it
-running) using a configurable key sequence. The default sequence is `ctrl-p,ctrl-q`.
-Configure the keys sequence using the **--detach-keys** option, or specifying
-it in the **containers.conf** file: see **containers.conf(5)** for more information.
-
-**--detach-keys**=*sequence*
-
-Specify the key sequence for detaching a container. Format is a single character `[a-Z]` or one or more `ctrl-<value>` characters where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`. Specifying "" will disable this feature. The default is *ctrl-p,ctrl-q*.
-
 **--device**=_host-device_[**:**_container-device_][**:**_permissions_]
 
 Add a host device to the container. Optional *permissions* parameter

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -197,20 +197,20 @@ to only use memory from the first two memory nodes.
 
 **--detach**, **-d**=**true**|**false**
 
-Detached mode: run the container in the background and print the new container ID. The default is **false**.
+Detached mode: run the container in the background and print the new container ID. The default is *false*.
 
 At any time you can run **podman ps** in
 the other shell to view a list of the running containers. You can reattach to a
 detached container with **podman attach**.
 
 When attached in the tty mode, you can detach from the container (and leave it
-running) using a configurable key sequence.
+running) using a configurable key sequence. The default sequence is `ctrl-p,ctrl-q`.
+Configure the keys sequence using the **--detach-keys** option, or specifying
+it in the **containers.conf** file: see **containers.conf(5)** for more information.
 
-**--detach-keys**=_sequence_
+**--detach-keys**=*sequence*
 
-Specify the key sequence for detaching a container; _sequence_ is a comma-delimited set
-in which each item can be a single character from the [a-Z] range,
-or **ctrl**-_value_, where _value_ is one of: **a-z** or **@^[,_**.
+Specify the key sequence for detaching a container. Format is a single character `[a-Z]` or one or more `ctrl-<value>` characters where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`. Specifying "" will disable this feature. The default is *ctrl-p,ctrl-q*.
 
 This option can also be set in **containers.conf**(5) file.
 

--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman attach to non-running container", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test1", "-d", "-i", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--name", "test1", "-i", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -50,7 +50,7 @@ var _ = Describe("Podman attach", func() {
 	})
 
 	It("podman container attach to non-running container", func() {
-		session := podmanTest.Podman([]string{"container", "create", "--name", "test1", "-d", "-i", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"container", "create", "--name", "test1", "-i", ALPINE, "ls"})
 
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -626,4 +626,22 @@ var _ = Describe("Podman create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(BeZero())
 	})
+
+	It("podman create -d should fail, can not detach create containers", func() {
+		session := podmanTest.Podman([]string{"create", "-d", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session.ErrorToString()).To(ContainSubstring("unknown shorthand flag"))
+
+		session = podmanTest.Podman([]string{"create", "--detach", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session.ErrorToString()).To(ContainSubstring("unknown flag"))
+
+		session = podmanTest.Podman([]string{"create", "--detach-keys", "ctrl-x", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session.ErrorToString()).To(ContainSubstring("unknown flag"))
+	})
+
 })

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Podman generate systemd", func() {
 	})
 
 	It("podman generate systemd --new with explicit detaching param in middle", func() {
-		n := podmanTest.Podman([]string{"create", "--name", "foo", "-d", "alpine", "top"})
+		n := podmanTest.Podman([]string{"create", "--name", "foo", "alpine", "top"})
 		n.WaitWithDefaultTimeout()
 		Expect(n.ExitCode()).To(Equal(0))
 
@@ -253,7 +253,7 @@ var _ = Describe("Podman generate systemd", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 
 		// Grepping the output (in addition to unit tests)
-		found, _ := session.GrepString("--name foo -d alpine top")
+		found, _ := session.GrepString("--name foo alpine top")
 		Expect(found).To(BeTrue())
 	})
 

--- a/test/e2e/init_test.go
+++ b/test/e2e/init_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Podman init", func() {
 	})
 
 	It("podman init single container by ID", func() {
-		session := podmanTest.Podman([]string{"create", "-d", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -61,7 +61,7 @@ var _ = Describe("Podman init", func() {
 
 	It("podman init single container by name", func() {
 		name := "test1"
-		session := podmanTest.Podman([]string{"create", "--name", name, "-d", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--name", name, ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		init := podmanTest.Podman([]string{"init", name})
@@ -76,7 +76,7 @@ var _ = Describe("Podman init", func() {
 
 	It("podman init latest container", func() {
 		SkipIfRemote("--latest flag n/a")
-		session := podmanTest.Podman([]string{"create", "-d", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		init := podmanTest.Podman([]string{"init", "--latest"})
@@ -90,10 +90,10 @@ var _ = Describe("Podman init", func() {
 	})
 
 	It("podman init all three containers, one running", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test1", "-d", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--name", "test1", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session2 := podmanTest.Podman([]string{"create", "--name", "test2", "-d", ALPINE, "ls"})
+		session2 := podmanTest.Podman([]string{"create", "--name", "test2", ALPINE, "ls"})
 		session2.WaitWithDefaultTimeout()
 		Expect(session2.ExitCode()).To(Equal(0))
 		session3 := podmanTest.Podman([]string{"run", "--name", "test3", "-d", ALPINE, "top"})

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Podman logs", func() {
 	})
 
 	It("podman logs on a created container should result in 0 exit code", func() {
-		session := podmanTest.Podman([]string{"create", "-dt", "--name", "log", ALPINE})
+		session := podmanTest.Podman([]string{"create", "-t", "--name", "log", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(Exit(0))
 

--- a/test/e2e/pod_rm_test.go
+++ b/test/e2e/pod_rm_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Podman pod rm", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"create", "-d", "--pod", podid1, ALPINE, "ls"})
+		session = podmanTest.Podman([]string{"create", "--pod", podid1, ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -324,7 +324,7 @@ var _ = Describe("Podman ps", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"create", "-dt", ALPINE, "top"})
+		session = podmanTest.Podman([]string{"create", "-t", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Podman restart", func() {
 	})
 
 	It("Podman restart stopped container by ID", func() {
-		session := podmanTest.Podman([]string{"create", "-d", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -357,7 +357,7 @@ var _ = Describe("Podman run networking", func() {
 	})
 
 	It("podman run network expose ports in image metadata", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test", "-dt", "-P", nginx})
+		session := podmanTest.Podman([]string{"create", "--name", "test", "-t", "-P", nginx})
 		session.Wait(90)
 		Expect(session.ExitCode()).To(Equal(0))
 		results := podmanTest.Podman([]string{"inspect", "test"})

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -489,7 +489,7 @@ VOLUME /test/`
 		Expect(err).To(Not(BeNil()))
 
 		// Make sure modifications in container disappear when container is stopped
-		session = podmanTest.Podman([]string{"create", "-d", "-v", fmt.Sprintf("%s:/run/test:O", mountPath), ALPINE, "top"})
+		session = podmanTest.Podman([]string{"create", "-v", fmt.Sprintf("%s:/run/test:O", mountPath), ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"start", "-l"})

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Podman start", func() {
 	})
 
 	It("podman start single container by id", func() {
-		session := podmanTest.Podman([]string{"create", "-d", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -50,7 +50,7 @@ var _ = Describe("Podman start", func() {
 	})
 
 	It("podman container start single container by id", func() {
-		session := podmanTest.Podman([]string{"container", "create", "-d", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"container", "create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -61,7 +61,7 @@ var _ = Describe("Podman start", func() {
 	})
 
 	It("podman container start single container by short id", func() {
-		session := podmanTest.Podman([]string{"container", "create", "-d", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"container", "create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToString()
@@ -74,7 +74,7 @@ var _ = Describe("Podman start", func() {
 
 	It("podman start single container by name", func() {
 		name := "foobar99"
-		session := podmanTest.Podman([]string{"create", "-d", "--name", name, ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--name", name, ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"start", name})
@@ -98,10 +98,10 @@ var _ = Describe("Podman start", func() {
 	})
 
 	It("podman start multiple containers", func() {
-		session := podmanTest.Podman([]string{"create", "-d", "--name", "foobar99", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--name", "foobar99", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		cid1 := session.OutputToString()
-		session2 := podmanTest.Podman([]string{"create", "-d", "--name", "foobar100", ALPINE, "ls"})
+		session2 := podmanTest.Podman([]string{"create", "--name", "foobar100", ALPINE, "ls"})
 		session2.WaitWithDefaultTimeout()
 		cid2 := session2.OutputToString()
 		session = podmanTest.Podman([]string{"start", cid1, cid2})
@@ -110,7 +110,7 @@ var _ = Describe("Podman start", func() {
 	})
 
 	It("podman start multiple containers with bogus", func() {
-		session := podmanTest.Podman([]string{"create", "-d", "--name", "foobar99", ALPINE, "ls"})
+		session := podmanTest.Podman([]string{"create", "--name", "foobar99", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		cid1 := session.OutputToString()
 		session = podmanTest.Podman([]string{"start", cid1, "doesnotexist"})

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Podman stop", func() {
 
 		defer os.RemoveAll(tmpDir)
 
-		session := podmanTest.Podman([]string{"create", "--cidfile", tmpFile, "-d", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--cidfile", tmpFile, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		cid := session.OutputToStringArray()[0]

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -59,7 +59,7 @@ WantedBy=multi-user.target
 			Expect(stop.ExitCode()).To(Equal(0))
 		}()
 
-		create := podmanTest.Podman([]string{"create", "-d", "--name", "redis", "redis"})
+		create := podmanTest.Podman([]string{"create", "--name", "redis", "redis"})
 		create.WaitWithDefaultTimeout()
 		Expect(create.ExitCode()).To(Equal(0))
 

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -42,7 +42,7 @@ function teardown() {
 
     cname=$(random_string)
     # See #7407 for --pull=always.
-    run_podman create --pull=always --name $cname --label "io.containers.autoupdate=image" --detach $IMAGE top
+    run_podman create --pull=always --name $cname --label "io.containers.autoupdate=image" $IMAGE top
 
     run_podman generate systemd --new $cname
     echo "$output" > "$UNIT_FILE"


### PR DESCRIPTION
Detached containers and detach keys are only created with the podman run, i
exec, and start commands.  We do not store the detach key sequence or the
detach flags in the database, nor does Docker. The current code was ignoreing
these fields but documenting that they can be used.

Fix podman create man page and --help output to no longer indicate that
--detach and --detach-keys works.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>