### PR TITLE
Make invalid image name error more specific

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -341,7 +341,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		}
 		named, err := reference.ParseNormalizedNamed(container.Image)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "Failed to parse image %q", container.Image)
 		}
 		// In kube, if the image is tagged with latest, it should always pull
 		if tagged, isTagged := named.(reference.NamedTagged); isTagged {

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1447,4 +1447,23 @@ MemoryReservation: {{ .HostConfig.MemoryReservation }}`})
 			Expect(inspect.OutputToString()).To(ContainSubstring("Memory: " + expectedMemoryLimit))
 		}
 	})
+
+	It("podman play kube reports invalid image name", func() {
+		invalidImageName := "./myimage"
+
+		pod := getPod(
+			withCtr(
+				getCtr(
+					withImage(invalidImageName),
+				),
+			),
+		)
+		err := generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).To(BeNil())
+
+		kube := podmanTest.Podman([]string{"play", "kube", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube.ExitCode()).To(Equal(125))
+		Expect(kube.ErrorToString()).To(ContainSubstring(invalidImageName))
+	})
 })


### PR DESCRIPTION
Previously, using an invalid image name would produce an error like
this:

    Error: error encountered while bringing up pod test-pod-0: invalid reference format

This message didn't specify that there was an problem with an image
name, and it didn't specify which image name had a problem if there were
multiple. Now the error reads:

    Error: error encountered while bringing up pod test-pod-0: Failed to parse image "./myimage": invalid reference format

Signed-off-by: Jordan Christiansen <xordspar0@gmail.com>