### PR TITLE
System tests: remove some misleading 'run's

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -460,24 +460,4 @@ json-file | f
     is "$output" "$expect" "podman run with --tz=local, matches host"
 }
 
-@test "podman container exists" {
-    rand=$(random_string 30)
-    run_podman 1 container exists myctr
-
-    run_podman create --name myctr $IMAGE /bin/true
-    run_podman container exists myctr
-
-    # Create a container that podman does not know about
-    run buildah from $IMAGE
-    cid="$output"
-
-    # exists should fail
-    run_podman 1 container exists $cid
-
-    # exists should succeed
-    run_podman container exists --external $cid
-
-    run buildah rm $cid
-}
-
 # vim: filetype=sh

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -41,11 +41,14 @@ load helpers
     run_podman create --name $rand $IMAGE /bin/true
 
     # Create a container that podman does not know about
-    run buildah from $IMAGE
-    cid="$output"
+    external_cid=$(buildah from $IMAGE)
+
+    # Plain 'exists' should fail, but should succeed with --external
+    run_podman 1 container exists $external_cid
+    run_podman container exists --external $external_cid
 
     # rm should succeed
-    run_podman rm $rand $cid
+    run_podman rm $rand $external_cid
 }
 
 # I'm sorry! This test takes 13 seconds. There's not much I can do about it,

--- a/test/system/140-diff.bats
+++ b/test/system/140-diff.bats
@@ -34,8 +34,8 @@ load helpers
 
 @test "podman diff with buildah container " {
     rand_file=$(random_string 10)
-    run buildah from --name buildahctr $IMAGE
-    run buildah run buildahctr sh -c "touch /$rand_file;rm /etc/services"
+    buildah from --name buildahctr $IMAGE
+    buildah run buildahctr sh -c "touch /$rand_file;rm /etc/services"
 
     run_podman diff --format json buildahctr
 
@@ -51,7 +51,7 @@ load helpers
         is "$result" "${expect[$field]}" "$field"
     done
 
-    run buildah rm buildahctr
+    buildah rm buildahctr
 }
 
 # vim: filetype=sh

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -34,6 +34,14 @@ function basic_setup() {
     # Clean up all containers
     run_podman rm --all --force
 
+    # ...including external (buildah) ones
+    run_podman ps --all --external --format '{{.ID}} {{.Names}}'
+    for line in "${lines[@]}"; do
+        set $line
+        echo "# setup(): removing stray external container $1 ($2)" >&3
+        run_podman rm $1
+    done
+
     # Clean up all images except those desired
     found_needed_image=
     run_podman images --all --format '{{.Repository}}:{{.Tag}} {{.ID}}'


### PR DESCRIPTION
The BATS 'run' directive is really quite obnoxious; for the
most part we really don't want to use it. Remove some uses
that snuck in last week, and remove one test (exists) that
can more naturally be piggybacked into an rm test.

While we're at it: in setup(), look for and delete stray
external (buildah) containers. This will be important if
any of the external-container tests fails; this way we
don't leave behind a state that causes subsequent tests
to fail.

Signed-off-by: Ed Santiago <santiago@redhat.com>