### PR TITLE
Ensure that hostname is added to hosts with net=host

### DIFF
--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -342,7 +342,7 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 				return errors.Wrapf(err, "error looking up container to share uts namespace with")
 			}
 			hostname = utsCtr.Hostname()
-		case s.NetNS.NSMode == specgen.Host || s.UtsNS.NSMode == specgen.Host:
+		case (s.NetNS.NSMode == specgen.Host && hostname == "") || s.UtsNS.NSMode == specgen.Host:
 			tmpHostname, err := os.Hostname()
 			if err != nil {
 				return errors.Wrap(err, "unable to retrieve hostname of the host")

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -571,4 +571,19 @@ var _ = Describe("Podman run networking", func() {
 		podrm.WaitWithDefaultTimeout()
 		Expect(podrm.ExitCode()).To(BeZero())
 	})
+
+	It("podman run net=host adds entry to /etc/hosts", func() {
+		run := podmanTest.Podman([]string{"run", "--net=host", ALPINE, "cat", "/etc/hosts"})
+		run.WaitWithDefaultTimeout()
+		Expect(run.ExitCode()).To(BeZero())
+		Expect(strings.Contains(run.OutputToString(), "127.0.1.1")).To(BeTrue())
+	})
+
+	It("podman run with --net=host and --hostname sets correct hostname", func() {
+		hostname := "testctr"
+		run := podmanTest.Podman([]string{"run", "--net=host", "--hostname", hostname, ALPINE, "hostname"})
+		run.WaitWithDefaultTimeout()
+		Expect(run.ExitCode()).To(BeZero())
+		Expect(strings.Contains(run.OutputToString(), "testctr")).To(BeTrue())
+	})
 })


### PR DESCRIPTION
When a container uses --net=host the default hostname is set to the host's hostname. However, we were not creating any entries in `/etc/hosts` despite having a hostname, which is incorrect.

Fixes #8054
