### PR TITLE
fix: neutral value for MemorySwappiness

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -238,7 +238,7 @@ func makeCreateConfig(ctx context.Context, containerConfig *config.Config, input
 		Pod:           "",    // podman
 		PodmanPath:    "",    // podman
 		Quiet:         false, // front-end only
-		Resources:     createconfig.CreateResourceConfig{},
+		Resources:     createconfig.CreateResourceConfig{MemorySwappiness: -1},
 		RestartPolicy: input.HostConfig.RestartPolicy.Name,
 		Rm:            input.HostConfig.AutoRemove,
 		StopSignal:    stopSignal,


### PR DESCRIPTION
Setting MemorySwappiness to -1, since that value is interpreted as "not set".

Otherwise there is issue if not running with cgroups v2 (invalid configuration, cannot specify resource limits without cgroups v2 and --cgroup-manager=systemd).