### PR TITLE
Retrieve network inspect info from dependency container

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -823,6 +823,20 @@ func getContainerNetIO(ctr *Container) (*netlink.LinkStatistics, error) {
 // Produce an InspectNetworkSettings containing information on the container
 // network.
 func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, error) {
+	if c.config.NetNsCtr != "" {
+		netNsCtr, err := c.runtime.GetContainer(c.config.NetNsCtr)
+		if err != nil {
+			return nil, err
+		}
+		// Have to sync to ensure that state is populated
+		if err := netNsCtr.syncContainer(); err != nil {
+			return nil, err
+		}
+		logrus.Debugf("Container %s shares network namespace, retrieving network info of container %s", c.ID(), c.config.NetNsCtr)
+
+		return netNsCtr.getContainerNetworkInfo()
+	}
+
 	settings := new(define.InspectNetworkSettings)
 	settings.Ports = makeInspectPortBindings(c.config.PortMappings)
 


### PR DESCRIPTION
When a container either joins a pod that shares the network namespace or uses `--net=container:` to share the network namespace of another container, it does not have its own copy of the CNI results used to generate `podman inspect` output. As such, to inspect these containers, we should be going to the container we share the namespace with for network info.

Fixes #8073
