### PR TITLE
Add a Degraded state to pods

### DIFF
--- a/libpod/define/podstate.go
+++ b/libpod/define/podstate.go
@@ -10,9 +10,12 @@ const (
 	PodStateExited = "Exited"
 	// PodStatePaused indicates the pod has been paused
 	PodStatePaused = "Paused"
-	// PodStateRunning indicates that one or more of the containers in
-	// the pod is running
+	// PodStateRunning indicates that all of the containers in the pod are
+	// running.
 	PodStateRunning = "Running"
+	// PodStateDegraded indicates that at least one, but not all, of the
+	// containers in the pod are running.
+	PodStateDegraded = "Degraded"
 	// PodStateStopped indicates all of the containers belonging to the pod
 	// are stopped.
 	PodStateStopped = "Stopped"

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -506,7 +506,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		})
 		ctrStatuses[c.ID()] = c.state.State
 	}
-	podState, err := CreatePodStatusResults(ctrStatuses)
+	podState, err := createPodStatusResults(ctrStatuses)
 	if err != nil {
 		return nil, err
 	}

--- a/libpod/pod_status.go
+++ b/libpod/pod_status.go
@@ -10,10 +10,10 @@ func (p *Pod) GetPodStatus() (string, error) {
 	if err != nil {
 		return define.PodStateErrored, err
 	}
-	return CreatePodStatusResults(ctrStatuses)
+	return createPodStatusResults(ctrStatuses)
 }
 
-func CreatePodStatusResults(ctrStatuses map[string]define.ContainerStatus) (string, error) {
+func createPodStatusResults(ctrStatuses map[string]define.ContainerStatus) (string, error) {
 	ctrNum := len(ctrStatuses)
 	if ctrNum == 0 {
 		return define.PodStateCreated, nil
@@ -43,8 +43,10 @@ func CreatePodStatusResults(ctrStatuses map[string]define.ContainerStatus) (stri
 	}
 
 	switch {
-	case statuses[define.PodStateRunning] > 0:
+	case statuses[define.PodStateRunning] == ctrNum:
 		return define.PodStateRunning, nil
+	case statuses[define.PodStateRunning] > 0:
+		return define.PodStateDegraded, nil
 	case statuses[define.PodStatePaused] == ctrNum:
 		return define.PodStatePaused, nil
 	case statuses[define.PodStateStopped] == ctrNum:

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -428,4 +428,34 @@ entrypoint ["/fromimage"]
 		Expect(check.ExitCode()).To(Equal(0))
 		Expect(check.OutputToString()).To(Equal("[port_handler=slirp4netns]"))
 	})
+
+	It("podman pod status test", func() {
+		podName := "testpod"
+		create := podmanTest.Podman([]string{"pod", "create", "--name", podName})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(Equal(0))
+
+		status1 := podmanTest.Podman([]string{"pod", "inspect", "--format", "{{ .State }}", podName})
+		status1.WaitWithDefaultTimeout()
+		Expect(status1.ExitCode()).To(Equal(0))
+		Expect(strings.Contains(status1.OutputToString(), "Created")).To(BeTrue())
+
+		ctr1 := podmanTest.Podman([]string{"run", "--pod", podName, "-d", ALPINE, "top"})
+		ctr1.WaitWithDefaultTimeout()
+		Expect(ctr1.ExitCode()).To(Equal(0))
+
+		status2 := podmanTest.Podman([]string{"pod", "inspect", "--format", "{{ .State }}", podName})
+		status2.WaitWithDefaultTimeout()
+		Expect(status2.ExitCode()).To(Equal(0))
+		Expect(strings.Contains(status2.OutputToString(), "Running")).To(BeTrue())
+
+		ctr2 := podmanTest.Podman([]string{"create", "--pod", podName, ALPINE, "top"})
+		ctr2.WaitWithDefaultTimeout()
+		Expect(ctr2.ExitCode()).To(Equal(0))
+
+		status3 := podmanTest.Podman([]string{"pod", "inspect", "--format", "{{ .State }}", podName})
+		status3.WaitWithDefaultTimeout()
+		Expect(status3.ExitCode()).To(Equal(0))
+		Expect(strings.Contains(status3.OutputToString(), "Degraded")).To(BeTrue())
+	})
 })


### PR DESCRIPTION
Make a distinction between pods that are completely running (all containers running) and those that have some containers going, but not all, by introducing an intermediate state between Stopped and Running called Degraded. A Degraded pod has at least one, but not all, containers running; a Running pod has all containers running.

First step to a solution for #7213.
