### PR TITLE
Add EOL to compat container logs

### DIFF
--- a/pkg/api/handlers/compat/containers_logs.go
+++ b/pkg/api/handlers/compat/containers_logs.go
@@ -148,7 +148,13 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 			frame.WriteString(line.Time.Format(time.RFC3339))
 			frame.WriteString(" ")
 		}
+
 		frame.WriteString(line.Msg)
+		// Log lines in the compat layer require adding EOL
+		// https://github.com/containers/podman/issues/8058
+		if !utils.IsLibpodRequest(r) {
+			frame.WriteString("\n")
+		}
 
 		if writeHeader {
 			binary.BigEndian.PutUint32(header[4:], uint32(frame.Len()))


### PR DESCRIPTION
Per request of @rhatdan I created the change mentioned by @psakar in https://github.com/containers/podman/issues/8058 as a pull request.

It fixes the problem that container logs provided by REST API do not contain an EOL (\n)