### PR TITLE
Fix pull method selection

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -240,12 +240,16 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		}
 	}
 
-	pullPolicy := imagebuildah.PullNever
-	if flags.Pull {
+	pullPolicy := imagebuildah.PullIfNewer
+	if c.Flags().Changed("pull") && !flags.Pull {
 		pullPolicy = imagebuildah.PullIfMissing
 	}
 	if flags.PullAlways {
 		pullPolicy = imagebuildah.PullAlways
+	}
+
+	if flags.PullNever {
+		pullPolicy = imagebuildah.PullNever
 	}
 
 	args := make(map[string]string)


### PR DESCRIPTION
When using 'podman build --pull=true', the image was not pulled
if the image being pulled was present locally, but a newer version
was in the repository.  It was only pulled if there was no image
in local storage.

In addition, the pull-never option was ignored.  The line
`if flags.Pull{` at line 244 was always returning true
negating the default pullPolicy of PullNever.

Reworked the algorthim for the selection process.  Now
PullIfNewer is set to the default, and then we set the
pullPolicy appropriately based on the other flags
passed into this routine.

As an FYI, logic run in the calling functions ensures
that we have only one pull flag in the command.

Addresses: #8024

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>