### PR TITLE
Podman build should default to not usins stdin

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -282,8 +282,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		flags.Layers = false
 	}
 
-	var stdin, stdout, stderr, reporter *os.File
-	stdin = os.Stdin
+	var stdout, stderr, reporter *os.File
 	stdout = os.Stdout
 	stderr = os.Stderr
 	reporter = os.Stderr
@@ -422,7 +421,6 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		ForceRmIntermediateCtrs: flags.ForceRm,
 		IDMappingOptions:        idmappingOptions,
 		IIDFile:                 flags.Iidfile,
-		In:                      stdin,
 		Isolation:               isolation,
 		Labels:                  flags.Label,
 		Layers:                  flags.Layers,


### PR DESCRIPTION
Currently we leak stdin into podman builds, which can lead
to issues like run commands inside of the container waiting for
user input.

We should not take input from users other then if the user specifies
podman build -f - or podman build -, which are taken care of in other code.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>