### PR TITLE
Fix handling and documentation of podman wait --interval

### DIFF
--- a/docs/source/markdown/podman-wait.1.md
+++ b/docs/source/markdown/podman-wait.1.md
@@ -23,8 +23,8 @@ Condition to wait on (default "stopped")
 
  Print usage statement
 
-**--interval**, **-i**=*microseconds*
-  Microseconds to wait before polling for completion
+**--interval**, **-i**=*duration*
+  Time interval to wait before polling for completion. A duration string is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Time unit defaults to "ms".
 
 **--latest**, **-l**
 
@@ -40,6 +40,9 @@ $ podman wait mywebserver
 0
 
 $ podman wait --latest
+0
+
+$ podman wait --interval 2s
 0
 
 $ podman wait 860a4b23


### PR DESCRIPTION
In older versions of podman, we supported decimal numbers defaulting
to microseconds.  This PR fixes to allow users to continue to specify
only digits.

Also cleaned up documentation to fully describe what input for --interval flag.

Finally improved testing on podman wait to actually make sure the command succeeded.
Fixed tests to work on podman-remote.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>