### PR TITLE
The cidfile should be created when the container is created

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -111,15 +111,8 @@ func run(cmd *cobra.Command, args []string) error {
 			return errors.Wrapf(err, "error checking authfile path %s", af)
 		}
 	}
-	cidFile, err := openCidFile(cliVals.CIDFile)
-	if err != nil {
-		return err
-	}
 
-	if cidFile != nil {
-		defer errorhandling.CloseQuiet(cidFile)
-		defer errorhandling.SyncQuiet(cidFile)
-	}
+	runOpts.CIDFile = cliVals.CIDFile
 	runOpts.Rm = cliVals.Rm
 	if err := createInit(cmd); err != nil {
 		return err
@@ -192,12 +185,6 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	if err != nil {
 		return err
-	}
-	if cidFile != nil {
-		_, err = cidFile.WriteString(report.Id)
-		if err != nil {
-			logrus.Error(err)
-		}
 	}
 
 	if runOpts.Detach {

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -294,6 +294,7 @@ type ContainerListOptions struct {
 // ContainerRunOptions describes the options needed
 // to run a container from the CLI
 type ContainerRunOptions struct {
+	CIDFile      string
 	Detach       bool
 	DetachKeys   string
 	ErrorStream  *os.File

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containers/podman/v2/pkg/signal"
 	"github.com/containers/podman/v2/pkg/specgen"
 	"github.com/containers/podman/v2/pkg/specgen/generate"
+	"github.com/containers/podman/v2/pkg/util"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -844,6 +845,12 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 	ctr, err := generate.MakeContainer(ctx, ic.Libpod, opts.Spec)
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.CIDFile != "" {
+		if err := util.CreateCidFile(opts.CIDFile, ctr.ID()); err != nil {
+			return nil, err
+		}
 	}
 
 	var joinPod bool

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/errorhandling"
 	"github.com/containers/podman/v2/pkg/specgen"
+	"github.com/containers/podman/v2/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -557,6 +558,11 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 	}
 	for _, w := range con.Warnings {
 		fmt.Fprintf(os.Stderr, "%s\n", w)
+	}
+	if opts.CIDFile != "" {
+		if err := util.CreateCidFile(opts.CIDFile, con.ID); err != nil {
+			return nil, err
+		}
 	}
 
 	report := entities.ContainerRunReport{Id: con.ID}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -638,3 +638,18 @@ func ValidateSysctls(strSlice []string) (map[string]string, error) {
 func DefaultContainerConfig() *config.Config {
 	return containerConfig
 }
+
+func CreateCidFile(cidfile string, id string) error {
+	cidFile, err := OpenExclusiveFile(cidfile)
+	if err != nil {
+		if os.IsExist(err) {
+			return errors.Errorf("container id file exists. Ensure another container is not using it or delete %s", cidfile)
+		}
+		return errors.Errorf("error opening cidfile %s", cidfile)
+	}
+	if _, err = cidFile.WriteString(id); err != nil {
+		logrus.Error(err)
+	}
+	cidFile.Close()
+	return nil
+}


### PR DESCRIPTION
Currently if you run an interactive session of podman run and
specifiy the --cidfile option, the cidfile will not get created
until the container finishes running.  If you run a detached
container, it will get created right away.  This Patch creates
the cidfile as soon as the container is created.  This could allow
other tools to use the cidefile on all running containers.

Fixes: https://github.com/containers/podman/issues/8091

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>