### PR TITLE
container create: record correct image name

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -469,7 +469,7 @@ func (ir *Runtime) getLocalImage(inputName string) (string, *storage.Image, erro
 		if err != nil {
 			return "", nil, err
 		}
-		img, err := ir.store.Image(ref.String())
+		img, err := ir.store.Image(reference.TagNameOnly(ref).String())
 		if err == nil {
 			return ref.String(), img, nil
 		}

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -473,4 +473,23 @@ json-file | f
     run_podman kill $cid
 }
 
+# Regression test for issue #8082
+@test "podman run : look up correct image name" {
+	# Create a 2nd tag for the local image.
+	local name="localhost/foo/bar"
+	run_podman tag $IMAGE $name
+
+	# Create a container with the 2nd tag and make sure that it's being
+	# used.  #8082 always inaccurately used the 1st tag.
+	run_podman create $name
+	cid="$output"
+
+	run_podman inspect --format "{{.ImageName}}" $cid
+	is "$output" "$name"
+
+	# Clean up.
+	run_podman rm $cid
+	run_podman untag $IMAGE $name
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Record the correct image name when creating a container by using the
resolved image name if present.  Otherwise, default to using the first
available name or an empty string in which case the image must have been
referenced by ID.

Fixes: #8082
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>