### PR TITLE
manifest list inspect single image

### DIFF
--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -58,6 +58,11 @@ var _ = Describe("Podman manifest", func() {
 		session = podmanTest.PodmanNoCache([]string{"manifest", "inspect", "quay.io/libpod/busybox"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
+
+		// inspect manifest of single image
+		session = podmanTest.PodmanNoCache([]string{"manifest", "inspect", "quay.io/libpod/busybox@sha256:6655df04a3df853b029a5fac8836035ac4fab117800c9a6c4b69341bb5306c3d"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
 	})
 
 	It("podman manifest add", func() {


### PR DESCRIPTION
If the image name not a manifest list type, enable `manifest inspect` to return manifest of single image with manifest type `application/vnd.docker.distribution.manifest.v2+json` 
close #8023

Signed-off-by: Qi Wang <qiwan@redhat.com>