### PR TITLE
Add hostname to /etc/hosts for --net=none

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1550,9 +1550,13 @@ func (c *Container) getHosts() string {
 			hosts += fmt.Sprintf("# used by slirp4netns\n%s\t%s %s\n", "10.0.2.100", c.Hostname(), c.config.Name)
 		} else {
 			hasNetNS := false
+			netNone := false
 			for _, ns := range c.config.Spec.Linux.Namespaces {
 				if ns.Type == spec.NetworkNamespace {
 					hasNetNS = true
+					if ns.Path == "" && !c.config.CreateNetNS {
+						netNone = true
+					}
 					break
 				}
 			}
@@ -1563,6 +1567,9 @@ func (c *Container) getHosts() string {
 					osHostname = c.Hostname()
 				}
 				hosts += fmt.Sprintf("127.0.1.1 %s\n", osHostname)
+			}
+			if netNone {
+				hosts += fmt.Sprintf("127.0.1.1 %s\n", c.Hostname())
 			}
 		}
 	}

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -584,6 +584,14 @@ var _ = Describe("Podman run networking", func() {
 		run := podmanTest.Podman([]string{"run", "--net=host", "--hostname", hostname, ALPINE, "hostname"})
 		run.WaitWithDefaultTimeout()
 		Expect(run.ExitCode()).To(BeZero())
-		Expect(strings.Contains(run.OutputToString(), "testctr")).To(BeTrue())
+		Expect(strings.Contains(run.OutputToString(), hostname)).To(BeTrue())
+	})
+
+	It("podman run with --net=none adds hostname to /etc/hosts", func() {
+		hostname := "testctr"
+		run := podmanTest.Podman([]string{"run", "--net=none", "--hostname", hostname, ALPINE, "hostname"})
+		run.WaitWithDefaultTimeout()
+		Expect(run.ExitCode()).To(BeZero())
+		Expect(strings.Contains(run.OutputToString(), hostname)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
This does not match Docker, which does not add hostname in this case, but it seems harmless enough.

Fixes #8095
