### PR TITLE
Add pod, volume, network to inspect package

### DIFF
--- a/cmd/podman/networks/inspect.go
+++ b/cmd/podman/networks/inspect.go
@@ -1,13 +1,7 @@
 package network
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"text/tabwriter"
-	"text/template"
-
-	"github.com/containers/common/pkg/report"
+	"github.com/containers/podman/v2/cmd/podman/inspect"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/spf13/cobra"
@@ -23,10 +17,7 @@ var (
 		Example: `podman network inspect podman`,
 		Args:    cobra.MinimumNArgs(1),
 	}
-)
-
-var (
-	networkInspectOptions entities.NetworkInspectOptions
+	inspectOpts *entities.InspectOptions
 )
 
 func init() {
@@ -35,36 +26,13 @@ func init() {
 		Command: networkinspectCommand,
 		Parent:  networkCmd,
 	})
+	inspectOpts = new(entities.InspectOptions)
 	flags := networkinspectCommand.Flags()
-	flags.StringVarP(&networkInspectOptions.Format, "format", "f", "", "Pretty-print network to JSON or using a Go template")
+	flags.StringVarP(&inspectOpts.Format, "format", "f", "", "Pretty-print network to JSON or using a Go template")
 }
 
 func networkInspect(_ *cobra.Command, args []string) error {
-	responses, err := registry.ContainerEngine().NetworkInspect(registry.Context(), args, entities.NetworkInspectOptions{})
-	if err != nil {
-		return err
-	}
+	inspectOpts.Type = inspect.NetworkType
+	return inspect.Inspect(args, *inspectOpts)
 
-	switch {
-	case report.IsJSON(networkInspectOptions.Format) || networkInspectOptions.Format == "":
-		b, err := json.MarshalIndent(responses, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(b))
-	default:
-		row := report.NormalizeFormat(networkInspectOptions.Format)
-		// There can be more than 1 in the inspect output.
-		row = "{{range . }}" + row + "{{end}}"
-		tmpl, err := template.New("inspectNetworks").Parse(row)
-		if err != nil {
-			return err
-		}
-
-		w := tabwriter.NewWriter(os.Stdout, 8, 2, 0, ' ', 0)
-		defer w.Flush()
-
-		return tmpl.Execute(w, responses)
-	}
-	return nil
 }

--- a/cmd/podman/volumes/inspect.go
+++ b/cmd/podman/volumes/inspect.go
@@ -1,16 +1,11 @@
 package volumes
 
 import (
-	"fmt"
-	"os"
-	"text/template"
-
-	"github.com/containers/common/pkg/report"
+	"github.com/containers/podman/v2/cmd/podman/inspect"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 var (
@@ -21,7 +16,7 @@ var (
 		Use:   "inspect [options] VOLUME [VOLUME...]",
 		Short: "Display detailed information on one or more volumes",
 		Long:  volumeInspectDescription,
-		RunE:  inspect,
+		RunE:  volumeInspect,
 		Example: `podman volume inspect myvol
   podman volume inspect --all
   podman volume inspect --format "{{.Driver}} {{.Scope}}" myvol`,
@@ -29,8 +24,7 @@ var (
 )
 
 var (
-	inspectOpts   = entities.VolumeInspectOptions{}
-	inspectFormat string
+	inspectOpts *entities.InspectOptions
 )
 
 func init() {
@@ -39,34 +33,16 @@ func init() {
 		Command: inspectCommand,
 		Parent:  volumeCmd,
 	})
+	inspectOpts = new(entities.InspectOptions)
 	flags := inspectCommand.Flags()
 	flags.BoolVarP(&inspectOpts.All, "all", "a", false, "Inspect all volumes")
-	flags.StringVarP(&inspectFormat, "format", "f", "json", "Format volume output using Go template")
+	flags.StringVarP(&inspectOpts.Format, "format", "f", "json", "Format volume output using Go template")
 }
 
-func inspect(cmd *cobra.Command, args []string) error {
+func volumeInspect(cmd *cobra.Command, args []string) error {
 	if (inspectOpts.All && len(args) > 0) || (!inspectOpts.All && len(args) < 1) {
 		return errors.New("provide one or more volume names or use --all")
 	}
-	responses, err := registry.ContainerEngine().VolumeInspect(context.Background(), args, inspectOpts)
-	if err != nil {
-		return err
-	}
-
-	switch {
-	case report.IsJSON(inspectFormat), inspectFormat == "":
-		jsonOut, err := json.MarshalIndent(responses, "", "     ")
-		if err != nil {
-			return errors.Wrapf(err, "error marshalling inspect JSON")
-		}
-		fmt.Println(string(jsonOut))
-	default:
-		row := "{{range . }}" + report.NormalizeFormat(inspectFormat) + "{{end}}"
-		tmpl, err := template.New("volumeInspect").Parse(row)
-		if err != nil {
-			return err
-		}
-		return tmpl.Execute(os.Stdout, responses)
-	}
-	return nil
+	inspectOpts.Type = inspect.VolumeType
+	return inspect.Inspect(args, *inspectOpts)
 }

--- a/docs/source/markdown/podman-inspect.1.md
+++ b/docs/source/markdown/podman-inspect.1.md
@@ -1,7 +1,7 @@
 % podman-inspect(1)
 
 ## NAME
-podman\-inspect - Display a container or image's configuration
+podman\-inspect - Display a container, image, volume, network, or pod's configuration
 
 ## SYNOPSIS
 **podman inspect** [*options*] *name* [...]
@@ -9,8 +9,9 @@ podman\-inspect - Display a container or image's configuration
 ## DESCRIPTION
 
 This displays the low-level information on containers and images identified by name or ID. By default, this will render
-all results in a JSON array. If the container and image have the same name, this will return container JSON for
-unspecified type. If a format is specified, the given template will be executed for each result.
+all results in a JSON array. If the inspect type is all, the order of inspection is: containers, images, volumes, network, pods.
+ So, if a container has the same name as an image, then the container JSON will be returned, and so on.
+ If a format is specified, the given template will be executed for each result.
 
 For more inspection options, see:
 
@@ -25,7 +26,7 @@ For more inspection options, see:
 
 **--type**, **-t**=*type*
 
-Return JSON for the specified type.  Type can be 'container', 'image' or 'all' (default: all)
+Return JSON for the specified type.  Type can be 'container', 'image', 'volume', 'network', 'pod', or 'all' (default: all)
 (Only meaningful when invoked as *podman inspect*)
 
 **--format**, **-f**=*format*
@@ -37,6 +38,8 @@ The keys of the returned JSON can be used as the values for the --format flag (s
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods.
+
+This option can be used to inspect the latest pod created when used with --type pod
 
 The latest option is not supported on the remote client or when invoked as *podman image inspect*.
 
@@ -146,6 +149,20 @@ size:   4405240
 ```
 podman container inspect --latest --format {{.EffectiveCaps}}
 [CAP_CHOWN CAP_DAC_OVERRIDE CAP_FSETID CAP_FOWNER CAP_MKNOD CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SETFCAP CAP_SETPCAP CAP_NET_BIND_SERVICE CAP_SYS_CHROOT CAP_KILL CAP_AUDIT_WRITE]
+```
+
+```
+# podman inspect myPod --type pod --format "{{.Name}}"
+myPod
+```
+```
+# podman inspect myVolume --type volume --format "{{.Name}}"
+myVolume
+```
+
+```
+# podman inspect nyNetwork --type network --format "{{.name}}"
+myNetwork
 ```
 
 ## SEE ALSO

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -220,7 +220,7 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-import(1)](podman-import.1.md)           | Import a tarball and save it as a filesystem image.                         |
 | [podman-info(1)](podman-info.1.md)               | Displays Podman related system information.                                 |
 | [podman-init(1)](podman-init.1.md)               | Initialize one or more containers                                           |
-| [podman-inspect(1)](podman-inspect.1.md)         | Display a container or image's configuration.                               |
+| [podman-inspect(1)](podman-inspect.1.md)         | Display a container, image, volume, network, or pod's configuration.        |
 | [podman-kill(1)](podman-kill.1.md)               | Kill the main process in one or more containers.                            |
 | [podman-load(1)](podman-load.1.md)               | Load an image from a container image archive into container storage.        |
 | [podman-login(1)](podman-login.1.md)             | Login to a container registry.                                              |

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,6 @@ require (
 	github.com/vishvananda/netlink v1.1.0
 	go.etcd.io/bbolt v1.3.5
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
-	golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f

--- a/pkg/api/handlers/libpod/networks.go
+++ b/pkg/api/handlers/libpod/networks.go
@@ -113,15 +113,15 @@ func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	name := utils.GetName(r)
-	options := entities.NetworkInspectOptions{}
+	options := entities.InspectOptions{}
 	ic := abi.ContainerEngine{Libpod: runtime}
-	reports, err := ic.NetworkInspect(r.Context(), []string{name}, options)
+	reports, errs, err := ic.NetworkInspect(r.Context(), []string{name}, options)
+	// If the network cannot be found, we return a 404.
+	if len(errs) > 0 {
+		utils.Error(w, "Something went wrong", http.StatusNotFound, define.ErrNoSuchNetwork)
+		return
+	}
 	if err != nil {
-		// If the network cannot be found, we return a 404.
-		if errors.Cause(err) == define.ErrNoSuchNetwork {
-			utils.Error(w, "Something went wrong", http.StatusNotFound, err)
-			return
-		}
 		utils.InternalServerError(w, err)
 		return
 	}

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -51,7 +51,7 @@ type ContainerEngine interface {
 	HealthCheckRun(ctx context.Context, nameOrID string, options HealthCheckOptions) (*define.HealthCheckResults, error)
 	Info(ctx context.Context) (*define.Info, error)
 	NetworkCreate(ctx context.Context, name string, options NetworkCreateOptions) (*NetworkCreateReport, error)
-	NetworkInspect(ctx context.Context, namesOrIds []string, options NetworkInspectOptions) ([]NetworkInspectReport, error)
+	NetworkInspect(ctx context.Context, namesOrIds []string, options InspectOptions) ([]NetworkInspectReport, []error, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) ([]*NetworkListReport, error)
 	NetworkRm(ctx context.Context, namesOrIds []string, options NetworkRmOptions) ([]*NetworkRmReport, error)
 	PlayKube(ctx context.Context, path string, opts PlayKubeOptions) (*PlayKubeReport, error)
@@ -76,7 +76,7 @@ type ContainerEngine interface {
 	VarlinkService(ctx context.Context, opts ServiceOptions) error
 	Version(ctx context.Context) (*SystemVersionReport, error)
 	VolumeCreate(ctx context.Context, opts VolumeCreateOptions) (*IDOrNameResponse, error)
-	VolumeInspect(ctx context.Context, namesOrIds []string, opts VolumeInspectOptions) ([]*VolumeInspectReport, error)
+	VolumeInspect(ctx context.Context, namesOrIds []string, opts InspectOptions) ([]*VolumeInspectReport, []error, error)
 	VolumeList(ctx context.Context, opts VolumeListOptions) ([]*VolumeListReport, error)
 	VolumePrune(ctx context.Context) ([]*VolumePruneReport, error)
 	VolumeRm(ctx context.Context, namesOrIds []string, opts VolumeRmOptions) ([]*VolumeRmReport, error)

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -18,11 +18,6 @@ type NetworkListReport struct {
 	*libcni.NetworkConfigList
 }
 
-// NetworkInspectOptions describes options for inspect networks
-type NetworkInspectOptions struct {
-	Format string
-}
-
 // NetworkInspectReport describes the results from inspect networks
 type NetworkInspectReport map[string]interface{}
 

--- a/pkg/domain/entities/types.go
+++ b/pkg/domain/entities/types.go
@@ -56,6 +56,8 @@ type InspectOptions struct {
 	Size bool `json:",omitempty"`
 	// Type -- return JSON for specified type.
 	Type string `json:",omitempty"`
+	// All -- inspect all
+	All bool `json:",omitempty"`
 }
 
 // All API and CLI diff commands and diff sub-commands use the same options

--- a/pkg/domain/entities/volumes.go
+++ b/pkg/domain/entities/volumes.go
@@ -105,10 +105,6 @@ type VolumeRmReport struct {
 	Id  string //nolint
 }
 
-type VolumeInspectOptions struct {
-	All bool
-}
-
 type VolumeInspectReport struct {
 	*VolumeConfigResponse
 }

--- a/pkg/domain/infra/tunnel/volumes.go
+++ b/pkg/domain/infra/tunnel/volumes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/containers/podman/v2/pkg/bindings/volumes"
 	"github.com/containers/podman/v2/pkg/domain/entities"
+	"github.com/pkg/errors"
 )
 
 func (ic *ContainerEngine) VolumeCreate(ctx context.Context, opts entities.VolumeCreateOptions) (*entities.IDOrNameResponse, error) {
@@ -35,25 +36,36 @@ func (ic *ContainerEngine) VolumeRm(ctx context.Context, namesOrIds []string, op
 	return reports, nil
 }
 
-func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []string, opts entities.VolumeInspectOptions) ([]*entities.VolumeInspectReport, error) {
+func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []string, opts entities.InspectOptions) ([]*entities.VolumeInspectReport, []error, error) {
+	var (
+		reports = make([]*entities.VolumeInspectReport, 0, len(namesOrIds))
+		errs    = []error{}
+	)
 	if opts.All {
 		vols, err := volumes.List(ic.ClientCxt, nil)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		for _, v := range vols {
 			namesOrIds = append(namesOrIds, v.Name)
 		}
 	}
-	reports := make([]*entities.VolumeInspectReport, 0, len(namesOrIds))
 	for _, id := range namesOrIds {
 		data, err := volumes.Inspect(ic.ClientCxt, id)
 		if err != nil {
-			return nil, err
+			errModel, ok := err.(entities.ErrorModel)
+			if !ok {
+				return nil, nil, err
+			}
+			if errModel.ResponseCode == 404 {
+				errs = append(errs, errors.Errorf("no such volume %q", id))
+				continue
+			}
+			return nil, nil, err
 		}
 		reports = append(reports, &entities.VolumeInspectReport{VolumeConfigResponse: data})
 	}
-	return reports, nil
+	return reports, errs, nil
 }
 
 func (ic *ContainerEngine) VolumePrune(ctx context.Context) ([]*entities.VolumePruneReport, error) {

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -515,6 +515,14 @@ func (s *PodmanSessionIntegration) InspectPodToJSON() define.InspectPodData {
 	return i
 }
 
+// InspectPodToJSON takes the sessions output from an inspect and returns json
+func (s *PodmanSessionIntegration) InspectPodArrToJSON() []define.InspectPodData {
+	var i []define.InspectPodData
+	err := jsoniter.Unmarshal(s.Out.Contents(), &i)
+	Expect(err).To(BeNil())
+	return i
+}
+
 // CreatePod creates a pod with no infra container
 // it optionally takes a pod name
 func (p *PodmanTestIntegration) CreatePod(name string) (*PodmanSessionIntegration, int, string) {


### PR DESCRIPTION
podman inspect only had the capabilities to inspect containers and images. if a user wanted to inspect a pod, volume, or network, they would have to use `podman network inspect`, `podman pod inspect` etc. Docker's cli allowed users to inspect both volumes and networks using regular inspect, so this commit gives the user the functionality

If the inspect type is not specified using --type, the order of inspection is:

containers
images
volumes
networks
pods

meaning if container that has the same name as an image, podman inspect would return the container inspect.

To avoid duplicate code, podman network inspect and podman volume inspect now use the inspect package as well. Podman pod inspect does not because podman pod inspect returns a single json object while podman inspect can return multiple)

Closes #6757 

Signed-off-by: Ashley Cui <acui@redhat.com>