### PR TITLE
set compat network driver default

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -231,6 +231,9 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 	if len(networkCreate.Name) > 0 {
 		name = networkCreate.Name
 	}
+	if len(networkCreate.Driver) < 1 {
+		networkCreate.Driver = network.DefaultNetworkDriver
+	}
 	// At present I think we should just support the bridge driver
 	// and allow demand to make us consider more
 	if networkCreate.Driver != network.DefaultNetworkDriver {


### PR DESCRIPTION
when using the compatibility endpoint for creating a network, if the driver is not provided, we need to set it to the default network driver ... which is bridge.

Signed-off-by: baude <bbaude@redhat.com>