### PR TITLE
add GitHub action to add non-main branch to PR title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,16 @@
+# Upstream: github.com/tzkhan/pr-update-action
+
+name: "PR title check"
+
+on: pull_request_target
+
+jobs:
+  update_pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: tzkhan/pr-update-action@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        base-branch-regex: '^(?!master).*$'
+        title-template: '[%basebranch%]'
+        title-prefix-space: true


### PR DESCRIPTION
Add a GitHub action to add the name of the target branch as prefix to
the title of a pull request.  It is easy to miss the target of a given
pull request which has already caused issues of commits going into
non-main branches without intention.

We have already used this action on the `v2.0.5-rhel` branch with
limited success.  Fortunately, the upstream implemented our feature
request to support adding the _target_ branch name (rather than the
source) to the PR title, which is what we need.

Any non-main branch from this commit forward will now be clearly marked.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>