### PR TITLE
Add support for host keys for non-22 ports (v2.1)

### DIFF
--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -214,17 +214,21 @@ func sshClient(_url *url.URL, secure bool, passPhrase string, identity string) (
 		authMethods = append(authMethods, ssh.Password(string(pass)))
 	}
 
-	callback := ssh.InsecureIgnoreHostKey()
-	if secure {
-		key := terminal.HostKey(_url.Hostname())
-		if key != nil {
-			callback = ssh.FixedHostKey(key)
-		}
-	}
-
 	port := _url.Port()
 	if port == "" {
 		port = "22"
+	}
+
+	callback := ssh.InsecureIgnoreHostKey()
+	if secure {
+		host := _url.Hostname()
+		if port != "22" {
+			host = fmt.Sprintf("[%s]:%s", host, port)
+		}
+		key := terminal.HostKey(host)
+		if key != nil {
+			callback = ssh.FixedHostKey(key)
+		}
 	}
 
 	bastion, err := ssh.Dial("tcp",


### PR DESCRIPTION
For #8139

Patch against release version (2.1.1), can be rebased against master.