### PR TITLE
Fix "Error: no such container"

### DIFF
--- a/docs/tutorials/podman_tutorial.md
+++ b/docs/tutorials/podman_tutorial.md
@@ -60,7 +60,7 @@ curl http://<IP_address>:8080
 ### Viewing the container's logs
 You can view the container's logs with Podman as well:
 ```console
-$ sudo podman logs --latest
+$ podman logs --latest
 10.88.0.1 - - [07/Feb/2018:15:22:11 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
 10.88.0.1 - - [07/Feb/2018:15:22:30 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"
 10.88.0.1 - - [07/Feb/2018:15:22:30 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.55.1" "-"


### PR DESCRIPTION
When executing podman logs as root, I get only "Error: no such container".

```bash
$ sudo podman logs --latest
Error: no such container
$ podman logs --latest
(snip)
[Sun Oct 25 16:38:59.076398 2020] [ssl:warn] [pid 1:tid 140704353533312] AH01882: Init: this version of mod_ssl was compiled against a newer library (OpenSSL 1.1.1b FIPS  26 Feb 2019, version currently loaded is OpenSSL 1.1.1 FIPS  11 Sep 2018) - may result in undefined or erroneous behavior
(snip)
```