### PR TITLE
pr update action: fix errors on master branch

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,6 +3,8 @@
 name: "PR title check"
 
 on: pull_request_target
+  branches:
+    - "!master"  # don't run it on master to prevent errors
 
 jobs:
   update_pr:


### PR DESCRIPTION
The action fails on the master branch as the regex does not match.
The error in this scenario is unfortunate and not of much value as
we do not want to change PR titles on the master branch.

To fix it, entirely disable the action on the master branch which
in restrospective may be a better approach as we do not fire off the
action.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>