### PR TITLE
Yet another iteration on PR title plugin

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,9 +2,10 @@
 
 name: "PR title check"
 
-on: pull_request_target
-  branches:
-    - "!master"  # don't run it on master to prevent errors
+on:
+  pull_request_target:
+    branches:
+      - "!master"   # causes errors; reason unknown
 
 jobs:
   update_pr:


### PR DESCRIPTION
PR #8147 made things worse: it's not valid YAML. This at
least is valid YAML. I have no idea if it yields the
desired result, and we won't even know until it gets
merged, but at least it won't cause fatal syntax errors.

Signed-off-by: Ed Santiago <santiago@redhat.com>