### PR TITLE
Add network aliases for containers to DB

### DIFF
--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -239,6 +239,15 @@ type ContainerNetworkConfig struct {
 	NetMode namespaces.NetworkMode `json:"networkMode,omitempty"`
 	// NetworkOptions are additional options for each network
 	NetworkOptions map[string][]string `json:"network_options,omitempty"`
+	// NetworkAliases are aliases that will be added to each network.
+	// These are additional names that this container can be accessed as via
+	// DNS when the CNI dnsname plugin is in use.
+	// Please note that these can be altered at runtime. As such, the actual
+	// list is stored in the database and should be retrieved from there;
+	// this is only the set of aliases the container was *created with*.
+	// Formatted as map of network name to aliases. All network names must
+	// be present in the Networks list above.
+	NetworkAliases map[string][]string `json:"network_alises,omitempty"`
 }
 
 // ContainerImageConfig is an embedded sub-config providing image configuration

--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -107,5 +107,16 @@ func (c *Container) validate() error {
 		destinations[vol.Dest] = true
 	}
 
+	// Check that networks and network aliases match up.
+	ctrNets := make(map[string]bool)
+	for _, net := range c.config.Networks {
+		ctrNets[net] = true
+	}
+	for net := range c.config.NetworkAliases {
+		if _, ok := ctrNets[net]; !ok {
+			return errors.Wrapf(define.ErrNoSuchNetwork, "container tried to set network aliases for network %s but is not connected to the network", net)
+		}
+	}
+
 	return nil
 }

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -27,6 +27,13 @@ var (
 	// not exist.
 	ErrNoSuchExecSession = errors.New("no such exec session")
 
+	// ErrNoAliases indicates that the container does not have any network
+	// aliases.
+	ErrNoAliases = errors.New("no aliases for container")
+	// ErrNoAliasesForNetwork indicates that the container has no aliases
+	// for a specific network.
+	ErrNoAliasesForNetwork = errors.New("no aliases for network")
+
 	// ErrCtrExists indicates a container with the same name or ID already
 	// exists
 	ErrCtrExists = errors.New("container already exists")
@@ -39,6 +46,9 @@ var (
 	// ErrExecSessionExists indicates an exec session with the same ID
 	// already exists.
 	ErrExecSessionExists = errors.New("exec session already exists")
+	// ErrAliasExists indicates that a network alias with the same name
+	// already exists in the network.
+	ErrAliasExists = errors.New("alias already exists")
 
 	// ErrCtrStateInvalid indicates a container is in an improper state for
 	// the requested operation

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -31,6 +31,10 @@ type InMemoryState struct {
 	ctrExecSessions map[string][]string
 	// Maps pod ID to a map of container ID to container struct.
 	podContainers map[string]map[string]*Container
+	// Maps network name to alias to container ID
+	networkAliases map[string]map[string]string
+	// Maps container ID to network name to list of aliases.
+	ctrNetworkAliases map[string]map[string][]string
 	// Global name registry - ensures name uniqueness and performs lookups.
 	nameIndex *registrar.Registrar
 	// Global ID registry - ensures ID uniqueness and performs lookups.
@@ -64,6 +68,9 @@ func NewInMemoryState() (State, error) {
 	state.ctrExecSessions = make(map[string][]string)
 
 	state.podContainers = make(map[string]map[string]*Container)
+
+	state.networkAliases = make(map[string]map[string]string)
+	state.ctrNetworkAliases = make(map[string]map[string][]string)
 
 	state.nameIndex = registrar.NewRegistrar()
 	state.idIndex = truncindex.NewTruncIndex([]string{})
@@ -278,6 +285,29 @@ func (s *InMemoryState) AddContainer(ctr *Container) error {
 		return err
 	}
 
+	// Check network aliases
+	for network, aliases := range ctr.config.NetworkAliases {
+		inNet := false
+		for _, net := range ctr.config.Networks {
+			if net == network {
+				inNet = true
+				break
+			}
+		}
+		if !inNet {
+			return errors.Wrapf(define.ErrInvalidArg, "container %s has network aliases for network %q but is not joined to network", ctr.ID(), network)
+		}
+
+		allNetAliases, ok := s.networkAliases[network]
+		if ok {
+			for _, alias := range aliases {
+				if _, ok := allNetAliases[alias]; ok {
+					return define.ErrAliasExists
+				}
+			}
+		}
+	}
+
 	// There are potential race conditions with this
 	// But in-memory state is intended purely for testing and not production
 	// use, so this should be fine.
@@ -333,6 +363,20 @@ func (s *InMemoryState) AddContainer(ctr *Container) error {
 	for _, vol := range ctr.config.NamedVolumes {
 		s.addCtrToVolDependsMap(ctr.ID(), vol.Name)
 	}
+
+	// Add network aliases
+	for network, aliases := range ctr.config.NetworkAliases {
+		allNetAliases, ok := s.networkAliases[network]
+		if !ok {
+			allNetAliases = make(map[string]string)
+			s.networkAliases[network] = allNetAliases
+		}
+
+		for _, alias := range aliases {
+			allNetAliases[alias] = ctr.ID()
+		}
+	}
+	s.ctrNetworkAliases[ctr.ID()] = ctr.config.NetworkAliases
 
 	return nil
 }
@@ -394,6 +438,20 @@ func (s *InMemoryState) RemoveContainer(ctr *Container) error {
 	// Remove this container from volume dependencies
 	for _, vol := range ctr.config.NamedVolumes {
 		s.removeCtrFromVolDependsMap(ctr.ID(), vol.Name)
+	}
+
+	// Remove our network aliases
+	ctrAliases, ok := s.ctrNetworkAliases[ctr.ID()]
+	if ok {
+		for network, aliases := range ctrAliases {
+			netAliases, ok := s.networkAliases[network]
+			if ok {
+				for _, alias := range aliases {
+					delete(netAliases, alias)
+				}
+			}
+		}
+		delete(s.ctrNetworkAliases, ctr.ID())
 	}
 
 	return nil
@@ -470,6 +528,153 @@ func (s *InMemoryState) AllContainers() ([]*Container, error) {
 	}
 
 	return ctrs, nil
+}
+
+// GetNetworkAliases returns network aliases for the given container in the
+// given network.
+func (s *InMemoryState) GetNetworkAliases(ctr *Container, network string) ([]string, error) {
+	if !ctr.valid {
+		return nil, define.ErrCtrRemoved
+	}
+
+	if network == "" {
+		return nil, errors.Wrapf(define.ErrInvalidArg, "network names must not be empty")
+	}
+
+	ctr, ok := s.containers[ctr.ID()]
+	if !ok {
+		return nil, define.ErrNoSuchCtr
+	}
+
+	inNet := false
+	for _, net := range ctr.config.Networks {
+		if net == network {
+			inNet = true
+		}
+	}
+	if !inNet {
+		return nil, define.ErrInvalidArg
+	}
+
+	ctrAliases, ok := s.ctrNetworkAliases[ctr.ID()]
+	if !ok {
+		return []string{}, nil
+	}
+	netAliases, ok := ctrAliases[network]
+	if !ok {
+		return []string{}, nil
+	}
+
+	return netAliases, nil
+}
+
+// SetNetworkAliases sets network aliases for the given container in the given
+// network.
+func (s *InMemoryState) SetNetworkAliases(ctr *Container, network string, aliases []string) error {
+	if !ctr.valid {
+		return define.ErrCtrRemoved
+	}
+
+	if network == "" {
+		return errors.Wrapf(define.ErrInvalidArg, "network names must not be empty")
+	}
+
+	ctr, ok := s.containers[ctr.ID()]
+	if !ok {
+		return define.ErrNoSuchCtr
+	}
+
+	inNet := false
+	for _, net := range ctr.config.Networks {
+		if net == network {
+			inNet = true
+		}
+	}
+	if !inNet {
+		return define.ErrInvalidArg
+	}
+
+	ctrAliases, ok := s.ctrNetworkAliases[ctr.ID()]
+	if !ok {
+		ctrAliases = make(map[string][]string)
+		s.ctrNetworkAliases[ctr.ID()] = ctrAliases
+	}
+	netAliases, ok := ctrAliases[network]
+	if !ok {
+		netAliases = []string{}
+		ctrAliases[network] = netAliases
+	}
+
+	allAliases, ok := s.networkAliases[network]
+	if !ok {
+		allAliases = make(map[string]string)
+		s.networkAliases[network] = allAliases
+	}
+
+	for _, alias := range netAliases {
+		delete(allAliases, alias)
+	}
+
+	for _, newAlias := range aliases {
+		if _, ok := allAliases[newAlias]; ok {
+			return define.ErrAliasExists
+		}
+		allAliases[newAlias] = ctr.ID()
+	}
+
+	ctrAliases[network] = aliases
+
+	return nil
+}
+
+// RemoveNetworkAliases removes network aliases from the given container in the
+// given network.
+func (s *InMemoryState) RemoveNetworkAliases(ctr *Container, network string) error {
+	if !ctr.valid {
+		return define.ErrCtrRemoved
+	}
+
+	if network == "" {
+		return errors.Wrapf(define.ErrInvalidArg, "network names must not be empty")
+	}
+
+	ctr, ok := s.containers[ctr.ID()]
+	if !ok {
+		return define.ErrNoSuchCtr
+	}
+
+	inNet := false
+	for _, net := range ctr.config.Networks {
+		if net == network {
+			inNet = true
+		}
+	}
+	if !inNet {
+		return define.ErrInvalidArg
+	}
+
+	ctrAliases, ok := s.ctrNetworkAliases[ctr.ID()]
+	if !ok {
+		ctrAliases = make(map[string][]string)
+		s.ctrNetworkAliases[ctr.ID()] = ctrAliases
+	}
+	netAliases, ok := ctrAliases[network]
+	if !ok {
+		netAliases = []string{}
+		ctrAliases[network] = netAliases
+	}
+
+	allAliases, ok := s.networkAliases[network]
+	if !ok {
+		allAliases = make(map[string]string)
+		s.networkAliases[network] = allAliases
+	}
+
+	for _, alias := range netAliases {
+		delete(allAliases, alias)
+	}
+
+	return nil
 }
 
 // GetContainerConfig returns a container config from the database by full ID
@@ -1116,6 +1321,29 @@ func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 		return err
 	}
 
+	// Check network aliases
+	for network, aliases := range ctr.config.NetworkAliases {
+		inNet := false
+		for _, net := range ctr.config.Networks {
+			if net == network {
+				inNet = true
+				break
+			}
+		}
+		if !inNet {
+			return errors.Wrapf(define.ErrInvalidArg, "container %s has network aliases for network %q but is not joined to network", ctr.ID(), network)
+		}
+
+		allNetAliases, ok := s.networkAliases[network]
+		if ok {
+			for _, alias := range aliases {
+				if _, ok := allNetAliases[alias]; ok {
+					return define.ErrAliasExists
+				}
+			}
+		}
+	}
+
 	// Retrieve pod containers list
 	podCtrs, ok := s.podContainers[pod.ID()]
 	if !ok {
@@ -1187,6 +1415,25 @@ func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 	for _, depCtr := range depCtrs {
 		s.addCtrToDependsMap(ctr.ID(), depCtr)
 	}
+
+	// Add container to volume dependencies
+	for _, vol := range ctr.config.NamedVolumes {
+		s.addCtrToVolDependsMap(ctr.ID(), vol.Name)
+	}
+
+	// Add network aliases
+	for network, aliases := range ctr.config.NetworkAliases {
+		allNetAliases, ok := s.networkAliases[network]
+		if !ok {
+			allNetAliases = make(map[string]string)
+			s.networkAliases[network] = allNetAliases
+		}
+
+		for _, alias := range aliases {
+			allNetAliases[alias] = ctr.ID()
+		}
+	}
+	s.ctrNetworkAliases[ctr.ID()] = ctr.config.NetworkAliases
 
 	return nil
 }
@@ -1266,6 +1513,20 @@ func (s *InMemoryState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 	depCtrs := ctr.Dependencies()
 	for _, depCtr := range depCtrs {
 		s.removeCtrFromDependsMap(ctr.ID(), depCtr)
+	}
+
+	// Remove our network aliases
+	ctrAliases, ok := s.ctrNetworkAliases[ctr.ID()]
+	if ok {
+		for network, aliases := range ctrAliases {
+			netAliases, ok := s.networkAliases[network]
+			if ok {
+				for _, alias := range aliases {
+					delete(netAliases, alias)
+				}
+			}
+		}
+		delete(s.ctrNetworkAliases, ctr.ID())
 	}
 
 	return nil

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -568,6 +568,25 @@ func (s *InMemoryState) GetNetworkAliases(ctr *Container, network string) ([]str
 	return netAliases, nil
 }
 
+// GetAllNetworkAliases gets all network aliases for the given container.
+func (s *InMemoryState) GetAllNetworkAliases(ctr *Container) (map[string][]string, error) {
+	if !ctr.valid {
+		return nil, define.ErrCtrRemoved
+	}
+
+	ctr, ok := s.containers[ctr.ID()]
+	if !ok {
+		return nil, define.ErrNoSuchCtr
+	}
+
+	ctrAliases, ok := s.ctrNetworkAliases[ctr.ID()]
+	if !ok {
+		return map[string][]string{}, nil
+	}
+
+	return ctrAliases, nil
+}
+
 // SetNetworkAliases sets network aliases for the given container in the given
 // network.
 func (s *InMemoryState) SetNetworkAliases(ctr *Container, network string, aliases []string) error {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1487,6 +1487,20 @@ func WithCreateWorkingDir() CtrCreateOption {
 	}
 }
 
+// WithNetworkAliases sets network aliases for the container.
+// Accepts a map of network name to aliases.
+func WithNetworkAliases(aliases map[string][]string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.NetworkAliases = aliases
+
+		return nil
+	}
+}
+
 // Volume Creation Options
 
 // WithVolumeName sets the name of the volume.

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -98,6 +98,13 @@ type State interface {
 	// returned.
 	AllContainers() ([]*Container, error)
 
+	// Get network aliases for the given container in the given network.
+	GetNetworkAliases(ctr *Container, network string) ([]string, error)
+	// Set network aliases for the given container in the given network.
+	SetNetworkAliases(ctr *Container, network string, aliases []string) error
+	// Remove network aliases for the given container in the given network.
+	RemoveNetworkAliases(ctr *Container, network string) error
+
 	// Return a container config from the database by full ID
 	GetContainerConfig(id string) (*ContainerConfig, error)
 

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -106,6 +106,12 @@ type State interface {
 	SetNetworkAliases(ctr *Container, network string, aliases []string) error
 	// Remove network aliases for the given container in the given network.
 	RemoveNetworkAliases(ctr *Container, network string) error
+	// GetAllAliasesForNetwork returns all the aliases for a given
+	// network. Returns a map of alias to container ID.
+	GetAllAliasesForNetwork(network string) (map[string]string, error)
+	// RemoveAllAliasesForNetwork removes all the aliases for a given
+	// network.
+	RemoveAllAliasesForNetwork(network string) error
 
 	// Return a container config from the database by full ID
 	GetContainerConfig(id string) (*ContainerConfig, error)

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -100,6 +100,8 @@ type State interface {
 
 	// Get network aliases for the given container in the given network.
 	GetNetworkAliases(ctr *Container, network string) ([]string, error)
+	// Get all network aliases for the given container.
+	GetAllNetworkAliases(ctr *Container) (map[string][]string, error)
 	// Set network aliases for the given container in the given network.
 	SetNetworkAliases(ctr *Container, network string, aliases []string) error
 	// Remove network aliases for the given container in the given network.


### PR DESCRIPTION
This adds the database backend for network aliases. Aliases are additional names for a container that are used with the CNI dnsname plugin - the container will be accessible by these names in addition to its name. Aliases are allowed to change over time as the container connects to and disconnects from networks.

Aliases are implemented as another bucket in the database to register all aliases, plus two buckets for each container (one to hold connected CNI networks, a second to hold its aliases). The aliases are only unique per-network, to the global and per-container aliases buckets have a sub-bucket for each CNI network that has aliases, and the aliases are stored within that sub-bucket. Aliases are formatted as alias (key) to container ID (value) in both cases.

Three DB functions are defined for aliases: retrieving current aliases for a given network, setting aliases for a given network, and removing all aliases for a given network.

This is still only partially done. Remaining work:
- Implement the remove aliases function for BoltDB
- Implement aliases in the in-memory state
- Add unit testing for the new aliases functionality in the DB
- Add accessors to Container to get aliases
- Add an accessor to get the container's IP for a specific CNI network