### PR TITLE
libpod: clean paths before check

### DIFF
--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -104,25 +105,25 @@ func checkRuntimeConfig(db *bolt.DB, rt *Runtime) error {
 		},
 		{
 			"libpod root directory (staticdir)",
-			rt.config.Engine.StaticDir,
+			filepath.Clean(rt.config.Engine.StaticDir),
 			staticDirKey,
 			"",
 		},
 		{
 			"libpod temporary files directory (tmpdir)",
-			rt.config.Engine.TmpDir,
+			filepath.Clean(rt.config.Engine.TmpDir),
 			tmpDirKey,
 			"",
 		},
 		{
 			"storage temporary directory (runroot)",
-			rt.StorageConfig().RunRoot,
+			filepath.Clean(rt.StorageConfig().RunRoot),
 			runRootKey,
 			storeOpts.RunRoot,
 		},
 		{
 			"storage graph root directory (graphroot)",
-			rt.StorageConfig().GraphRoot,
+			filepath.Clean(rt.StorageConfig().GraphRoot),
 			graphRootKey,
 			storeOpts.GraphRoot,
 		},


### PR DESCRIPTION
clean the paths before checking whether its value is different than
what is stored in the db.

Closes: https://github.com/containers/podman/issues/8160

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>