### PR TITLE
Improve the journal event reading

### DIFF
--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -69,35 +69,39 @@ func (e EventJournalD) Read(ctx context.Context, options ReadOptions) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate event options")
 	}
-	j, err := sdjournal.NewJournal() //nolint
+	j, err := sdjournal.NewJournal()
 	if err != nil {
 		return err
 	}
-	// TODO AddMatch and Seek seem to conflict
-	// Issue filed upstream -> https://github.com/coreos/go-systemd/issues/315
-	// Leaving commented code in case upstream fixes things
-	//podmanJournal := sdjournal.Match{Field: "SYSLOG_IDENTIFIER", Value: "podman"} //nolint
-	//if err := j.AddMatch(podmanJournal.String()); err != nil {
-	//	return errors.Wrap(err, "failed to add filter for event log")
-	//}
+
+	// match only podman journal entries
+	podmanJournal := sdjournal.Match{Field: "SYSLOG_IDENTIFIER", Value: "podman"}
+	if err := j.AddMatch(podmanJournal.String()); err != nil {
+		return errors.Wrap(err, "failed to add journal filter for event log")
+	}
+
 	if len(options.Since) == 0 && len(options.Until) == 0 && options.Stream {
 		if err := j.SeekTail(); err != nil {
 			return errors.Wrap(err, "failed to seek end of journal")
 		}
-	} else {
-		podmanJournal := sdjournal.Match{Field: "SYSLOG_IDENTIFIER", Value: "podman"} //nolint
-		if err := j.AddMatch(podmanJournal.String()); err != nil {
-			return errors.Wrap(err, "failed to add filter for event log")
+		// After SeekTail calling Next moves to a random entry.
+		// To prevent this we have to call Previous first.
+		// see: https://bugs.freedesktop.org/show_bug.cgi?id=64614
+		if _, err := j.Previous(); err != nil {
+			return errors.Wrap(err, "failed to move journal cursor to previous entry")
 		}
 	}
+
 	// the api requires a next|prev before getting a cursor
 	if _, err := j.Next(); err != nil {
-		return err
+		return errors.Wrap(err, "failed to move journal cursor to next entry")
 	}
+
 	prevCursor, err := j.GetCursor()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get journal cursor")
 	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -106,30 +110,26 @@ func (e EventJournalD) Read(ctx context.Context, options ReadOptions) error {
 		default:
 			// fallthrough
 		}
+
 		if _, err := j.Next(); err != nil {
-			return err
+			return errors.Wrap(err, "failed to move journal cursor to next entry")
 		}
 		newCursor, err := j.GetCursor()
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to get journal cursor")
 		}
 		if prevCursor == newCursor {
 			if len(options.Until) > 0 || !options.Stream {
 				break
 			}
-			_ = j.Wait(sdjournal.IndefiniteWait) //nolint
+			_ = j.Wait(sdjournal.IndefiniteWait)
 			continue
 		}
 		prevCursor = newCursor
+
 		entry, err := j.GetEntry()
 		if err != nil {
-			return err
-		}
-		// TODO this keeps us from feeding the podman event parser with
-		// with regular journal content; it can be removed if the above
-		// problem with AddMatch is resolved.
-		if entry.Fields["PODMAN_EVENT"] == "" {
-			continue
+			return errors.Wrap(err, "failed to read journal entry")
 		}
 		newEvent, err := newEventFromJournalEntry(entry)
 		if err != nil {


### PR DESCRIPTION
Fix the AddMatch/SeekTail conflict. This prevents reading
unnecessary journal entries which could cause errors.

Also wrap the sdjournal errors to provide better error messages.

Fixes #8125