### PR TITLE
Allow users to mount with unbindable flag

### DIFF
--- a/cmd/podman/common/volumes.go
+++ b/cmd/podman/common/volumes.go
@@ -313,7 +313,7 @@ func getBindMount(args []string) (spec.Mount, error) {
 			}
 			setExec = true
 			newMount.Options = append(newMount.Options, kv[0])
-		case "shared", "rshared", "private", "rprivate", "slave", "rslave", "Z", "z":
+		case "shared", "rshared", "private", "rprivate", "slave", "rslave", "unbindable", "runbindable", "Z", "z":
 			newMount.Options = append(newMount.Options, kv[0])
 		case "bind-propagation":
 			if len(kv) == 1 {

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -541,7 +541,7 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      · ro, readonly: true or false (default).
 
-	      · bind-propagation: shared, slave, private, rshared, rslave, or rprivate(default). See also mount(2).
+	      · bind-propagation: shared, slave, private, unbindable, rshared, rslave, runbindable, or rprivate(default). See also mount(2).
 
 	      . bind-nonrecursive: do not setup a recursive bind mount.  By default it is recursive.
 
@@ -962,7 +962,7 @@ The _options_ is a comma delimited list and can be:
 
 * **rw**|**ro**
 * **z**|**Z**
-* [**r**]**shared**|[**r**]**slave**|[**r**]**private**
+* [**r**]**shared**|[**r**]**slave**|[**r**]**private**[**r**]**unbindable**
 * [**r**]**bind**
 * [**no**]**exec**
 * [**no**]**dev**
@@ -1048,13 +1048,14 @@ visible on host and vice versa. Making a volume `slave` enables only one
 way mount propagation and that is mounts done on host under that volume
 will be visible inside container but not the other way around. <sup>[[1]](#Footnote1)</sup>
 
-To control mount propagation property of volume one can use `:[r]shared`,
-`:[r]slave` or `:[r]private` propagation flag. Propagation property can
-be specified only for bind mounted volumes and not for internal volumes or
-named volumes. For mount propagation to work source mount point (mount point
-where source dir is mounted on) has to have right propagation properties. For
-shared volumes, source mount point has to be shared. And for slave volumes,
-source mount has to be either shared or slave. <sup>[[1]](#Footnote1)</sup>
+To control mount propagation property of a volume one can use the [**r**]**shared**,
+[**r**]**slave**, [**r**]**private** or the [**r**]**unbindable** propagation flag.
+Propagation property can be specified only for bind mounted volumes and not for
+internal volumes or named volumes. For mount propagation to work the source mount
+point (the mount point where source dir is mounted on) has to have the right propagation
+properties. For shared volumes, the source mount point has to be shared. And for
+slave volumes, the source mount point has to be either shared or slave.
+<sup>[[1]](#Footnote1)</sup>
 
 If you want to recursively mount a volume and all of its submounts into a
 container, then you can use the `rbind` option.  By default the bind option is

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -567,7 +567,7 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      · ro, readonly: true or false (default).
 
-	      · bind-propagation: shared, slave, private, rshared, rslave, or rprivate(default). See also mount(2).
+	      · bind-propagation: shared, slave, private, unbindable, rshared, rslave, runbindable, or rprivate(default). See also mount(2).
 
 	      . bind-nonrecursive: do not setup a recursive bind mount.  By default it is recursive.
 
@@ -1015,7 +1015,7 @@ The _options_ is a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
 
 * **rw**|**ro**
 * **z**|**Z**
-* [**r**]**shared**|[**r**]**slave**|[**r**]**private**
+* [**r**]**shared**|[**r**]**slave**|[**r**]**private**[**r**]**unbindable**
 * [**r**]**bind**
 * [**no**]**exec**
 * [**no**]**dev**
@@ -1099,12 +1099,13 @@ way mount propagation and that is mounts done on host under that volume
 will be visible inside container but not the other way around. <sup>[[1]](#Footnote1)</sup>
 
 To control mount propagation property of volume one can use [**r**]**shared**,
-[**r**]**slave** or [**r**]**private** propagation flag. Propagation property can
-be specified only for bind mounted volumes and not for internal volumes or
-named volumes. For mount propagation to work source mount point (mount point
-where source dir is mounted on) has to have right propagation properties. For
-shared volumes, source mount point has to be shared. And for slave volumes,
-source mount has to be either shared or slave. <sup>[[1]](#Footnote1)</sup>
+[**r**]**slave**, [**r**]**private** or [**r**]**unbindable** propagation flag.
+Propagation property can be specified only for bind mounted volumes and not for
+internal volumes or named volumes. For mount propagation to work source mount
+point (mount point where source dir is mounted on) has to have right propagation
+properties. For shared volumes, source mount point has to be shared. And for
+slave volumes, source mount has to be either shared or slave.
+<sup>[[1]](#Footnote1)</sup>
 
 If you want to recursively mount a volume and all of its submounts into a
 container, then you can use the **rbind** option.  By default the bind option is

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -270,7 +270,7 @@ func parseMountOptionsForInspect(options []string, mount *define.InspectMount) {
 			isRW = false
 		case "rw":
 			// Do nothing, silently discard
-		case "shared", "slave", "private", "rshared", "rslave", "rprivate":
+		case "shared", "slave", "private", "rshared", "rslave", "rprivate", "unbindable", "runbindable":
 			mountProp = opt
 		case "z", "Z":
 			zZ = opt

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -344,7 +344,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 			Type:        "bind",
 			Source:      srcPath,
 			Destination: dstPath,
-			Options:     []string{"bind", "private"},
+			Options:     []string{"bind", "rprivate"},
 		}
 		if c.IsReadOnly() && dstPath != "/dev/shm" {
 			newMount.Options = append(newMount.Options, "ro", "nosuid", "noexec", "nodev")

--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -445,7 +445,7 @@ func getBindMount(args []string) (spec.Mount, error) {
 			}
 			setExec = true
 			newMount.Options = append(newMount.Options, kv[0])
-		case "shared", "rshared", "private", "rprivate", "slave", "rslave", "Z", "z":
+		case "shared", "rshared", "private", "rprivate", "slave", "rslave", "unbindable", "runbindable", "Z", "z":
 			newMount.Options = append(newMount.Options, kv[0])
 		case "bind-propagation":
 			if len(kv) == 1 {

--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -57,7 +57,7 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 				return nil, errors.Wrapf(ErrDupeMntOption, "only one of 'rw' and 'ro' can be used")
 			}
 			foundWrite = true
-		case "private", "rprivate", "slave", "rslave", "shared", "rshared":
+		case "private", "rprivate", "slave", "rslave", "shared", "rshared", "unbindable", "runbindable":
 			if foundProp {
 				return nil, errors.Wrapf(ErrDupeMntOption, "only one root propagation mode can be used")
 			}


### PR DESCRIPTION
Allow users to specify unbindable on volume command line

Switch internal mounts to rprivate to help prevent leaks.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>