### PR TITLE
Remove build \!remote flags from test

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (
@@ -27,6 +25,7 @@ var _ = Describe("Podman checkpoint", func() {
 	)
 
 	BeforeEach(func() {
+		SkipIfRemote("checkpoint not supported in remote mode")
 		SkipIfRootless("checkpoint not supported in rootless mode")
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {

--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (
@@ -31,6 +29,10 @@ var _ = Describe("Podman run", func() {
 		podmanTest.Setup()
 		podmanTest.SeedImages()
 		os.Setenv("CONTAINERS_CONF", "config/containers.conf")
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+		}
+
 	})
 
 	AfterEach(func() {
@@ -80,12 +82,14 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman Capabilities in containers.conf", func() {
-		os.Setenv("CONTAINERS_CONF", "config/containers.conf")
 		cap := podmanTest.Podman([]string{"run", ALPINE, "grep", "CapEff", "/proc/self/status"})
 		cap.WaitWithDefaultTimeout()
 		Expect(cap.ExitCode()).To(Equal(0))
 
 		os.Setenv("CONTAINERS_CONF", "config/containers-ns.conf")
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+		}
 		session := podmanTest.Podman([]string{"run", "busybox", "grep", "CapEff", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -93,7 +97,6 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman Regular capabilities", func() {
-		os.Setenv("CONTAINERS_CONF", "config/containers.conf")
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		result := podmanTest.Podman([]string{"top", "test1", "capeff"})
@@ -105,6 +108,9 @@ var _ = Describe("Podman run", func() {
 
 	It("podman drop capabilities", func() {
 		os.Setenv("CONTAINERS_CONF", "config/containers-caps.conf")
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+		}
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		result := podmanTest.Podman([]string{"container", "top", "test1", "capeff"})
@@ -116,6 +122,9 @@ var _ = Describe("Podman run", func() {
 
 	verifyNSHandling := func(nspath, option string) {
 		os.Setenv("CONTAINERS_CONF", "config/containers-ns.conf")
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+		}
 		//containers.conf default ipcns to default to host
 		session := podmanTest.Podman([]string{"run", ALPINE, "ls", "-l", nspath})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (
@@ -22,6 +20,7 @@ var _ = Describe("Podman cp", func() {
 	)
 
 	BeforeEach(func() {
+		SkipIfRemote("FIXME: Podman-remote cp needs to work")
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)

--- a/test/e2e/image_sign_test.go
+++ b/test/e2e/image_sign_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (
@@ -21,6 +19,7 @@ var _ = Describe("Podman image sign", func() {
 	)
 
 	BeforeEach(func() {
+		SkipIfRemote("podman-remote image sign is not supported")
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)

--- a/test/e2e/import_test.go
+++ b/test/e2e/import_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (
@@ -19,6 +17,7 @@ var _ = Describe("Podman import", func() {
 	)
 
 	BeforeEach(func() {
+		SkipIfRemote("FIXME: These look like it is supposed to work in remote")
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)

--- a/test/e2e/mount_rootless_test.go
+++ b/test/e2e/mount_rootless_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (
@@ -18,9 +16,8 @@ var _ = Describe("Podman mount", func() {
 	)
 
 	BeforeEach(func() {
-		if os.Geteuid() == 0 {
-			Skip("This function is not enabled for rootfull podman")
-		}
+		SkipIfNotRootless("This function is not enabled for rootfull podman")
+		SkipIfRemote("Podman mount not supported for remote connections")
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
Add some more tests, document cases where remote will not work
Add FIXMEs for tests that should work on podman-remote but currently
do not.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>