### PR TITLE
[NO TESTS NEEDED] allow the removal of storage images

### DIFF
--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -325,6 +325,15 @@ func (r *Runtime) LoadImageFromSingleImageArchive(ctx context.Context, writer io
 	return "", errors.Wrapf(saveErr, "error pulling image")
 }
 
+// RemoveImageFromStorage goes directly to storage and attempts to remove
+// the specified image. This is dangerous and should only be done if libpod
+// reports that image is not known. This call is useful if you have a corrupted
+// image that was never fully added to the libpod database.
+func (r *Runtime) RemoveImageFromStorage(id string) error {
+	_, err := r.store.DeleteImage(id, true)
+	return err
+}
+
 func getImageNames(images []*image.Image) string {
 	var names string
 	for i := range images {

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -640,6 +640,10 @@ func (ir *ImageEngine) Remove(ctx context.Context, images []string, opts entitie
 	for _, id := range images {
 		img, err := ir.Libpod.ImageRuntime().NewFromLocal(id)
 		if err != nil {
+			// attempt to remove image from storage
+			if forceErr := ir.Libpod.RemoveImageFromStorage(id); forceErr == nil {
+				continue
+			}
 			rmErrors = append(rmErrors, err)
 			continue
 		}


### PR DESCRIPTION
Sometimes if the system crashes while an image is being pulled
containers/storage can get into a bad state.  This PR allows the
user to call into container storage to remove the image.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>