### PR TITLE
rootless: improve error message if cannot join namespaces

### DIFF
--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -123,7 +123,7 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command) 
 		}
 	}
 	if err != nil {
-		logrus.Error(err)
+		logrus.Error(errors.Wrapf(err, "invalid internal status, try resetting the pause process with %q", os.Args[0]+" system migrate"))
 		os.Exit(1)
 	}
 	if became {


### PR DESCRIPTION
if podman failed to join the rootless namespaces, give users a better
errror message and possible solution.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1891220

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>