### PR TITLE
Podman often reports OCI Runtime does not exist, even if it does

### DIFF
--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -138,15 +138,15 @@ var (
 
 	// ErrOCIRuntimePermissionDenied indicates the OCI runtime attempted to invoke a command that returned
 	// a permission denied error
-	ErrOCIRuntimePermissionDenied = errors.New("OCI runtime permission denied error")
+	ErrOCIRuntimePermissionDenied = errors.New("OCI permission denied")
 
 	// ErrOCIRuntimeNotFound indicates the OCI runtime attempted to invoke a command
 	// that was not found
-	ErrOCIRuntimeNotFound = errors.New("OCI runtime command not found error")
+	ErrOCIRuntimeNotFound = errors.New("OCI not found")
 
 	// ErrOCIRuntimeUnavailable indicates that the OCI runtime associated to a container
 	// could not be found in the configuration
-	ErrOCIRuntimeUnavailable = errors.New("OCI runtime not available in the current configuration")
+	ErrOCIRuntimeUnavailable = errors.New("OCI unavailable")
 
 	// ErrConmonOutdated indicates the version of conmon found (whether via the configuration or $PATH)
 	// is out of date for the current podman version

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -14,8 +14,8 @@ load helpers
     # ...but check the configured runtime engine, and switch to crun as needed
     run_podman info --format '{{ .Host.OCIRuntime.Path }}'
     if expr "$output" : ".*/crun"; then
-        err_no_such_cmd="Error: executable file.* not found in \$PATH: No such file or directory: OCI runtime command not found error"
-        err_no_exec_dir="Error: open executable: Operation not permitted: OCI runtime permission denied error"
+        err_no_such_cmd="Error: executable file.* not found in \$PATH: No such file or directory: OCI not found"
+        err_no_exec_dir="Error: open executable: Operation not permitted: OCI permission denied"
     fi
 
     tests="

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -119,7 +119,7 @@ EOF
     # noexec option. This should fail.
     # ARGH. Unfortunately, runc (used for cgroups v1) produces a different error
     local expect_rc=126
-    local expect_msg='.* OCI runtime permission denied.*'
+    local expect_msg='.* OCI permission denied.*'
     run_podman info --format '{{ .Host.OCIRuntime.Path }}'
     if expr "$output" : ".*/runc"; then
         expect_rc=1


### PR DESCRIPTION
When the OCI Runtime tries to set certain settings in cgroups
it can get the error "no such file or directory",  the wrapper
ends up reporting a bogus error like:

```
 Request Failed(Internal Server Error): open io.max: No such file or directory: OCI runtime command not found error
{"cause":"OCI runtime command not found error","message":"open io.max: No such file or directory: OCI runtime command not found error","response":500}
```

On first reading of this, you would think the OCI Runtime (crun or runc) were not found.  But the error is actually reporting

message":"open io.max: No such file or directory

Which is what we want the user to concentrate on.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>