### PR TITLE
Ensure that attach ready channel does not block

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -249,7 +249,7 @@ func (c *Container) Attach(streams *define.AttachStreams, keys string, resize <-
 	// attaching, and I really do not want to do that right now.
 	// Send a SIGWINCH after attach succeeds so that most programs will
 	// redraw the screen for the new attach session.
-	attachRdy := make(chan bool)
+	attachRdy := make(chan bool, 1)
 	if c.config.Spec.Process != nil && c.config.Spec.Process.Terminal {
 		go func() {
 			<-attachRdy


### PR DESCRIPTION
We only use this channel in terminal attach, and it was not a buffered channel originally, so it would block on trying to send unless a receiver was ready. In the non-terminal case, there was no receiver, so attach blocked forever. Buffer the channel for a single bool so that it will never block, even if unused.

Fixes #8154
