### PR TITLE
Stop excessive wrapping of errors

### DIFF
--- a/cmd/podman/containers/commit.go
+++ b/cmd/podman/containers/commit.go
@@ -95,7 +95,7 @@ func commit(cmd *cobra.Command, args []string) error {
 	}
 	if len(iidFile) > 0 {
 		if err = ioutil.WriteFile(iidFile, []byte(response.Id), 0644); err != nil {
-			return errors.Wrapf(err, "failed to write image ID to file %q", iidFile)
+			return errors.Wrap(err, "failed to write image ID")
 		}
 	}
 	fmt.Println(response.Id)

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -108,7 +108,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	if af := cliVals.Authfile; len(af) > 0 {
 		if _, err := os.Stat(af); err != nil {
-			return errors.Wrapf(err, "error checking authfile path %s", af)
+			return err
 		}
 	}
 

--- a/cmd/podman/containers/runlabel.go
+++ b/cmd/podman/containers/runlabel.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -75,7 +74,7 @@ func runlabel(cmd *cobra.Command, args []string) error {
 	}
 	if runlabelOptions.Authfile != "" {
 		if _, err := os.Stat(runlabelOptions.Authfile); err != nil {
-			return errors.Wrapf(err, "error getting authfile %s", runlabelOptions.Authfile)
+			return err
 		}
 	}
 	return registry.ContainerEngine().ContainerRunlabel(context.Background(), args[0], args[1], args[2:], runlabelOptions.ContainerRunlabelOptions)

--- a/cmd/podman/generate/kube.go
+++ b/cmd/podman/generate/kube.go
@@ -55,7 +55,7 @@ func kube(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flags().Changed("filename") {
 		if _, err := os.Stat(kubeFile); err == nil {
-			return errors.Errorf("cannot write to %q", kubeFile)
+			return errors.Errorf("cannot write to %q; file exists", kubeFile)
 		}
 		if err := ioutil.WriteFile(kubeFile, content, 0644); err != nil {
 			return errors.Wrapf(err, "cannot write to %q", kubeFile)

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -104,7 +103,7 @@ func imagePull(cmd *cobra.Command, args []string) error {
 	}
 	if pullOptions.Authfile != "" {
 		if _, err := os.Stat(pullOptions.Authfile); err != nil {
-			return errors.Wrapf(err, "error getting authfile %s", pullOptions.Authfile)
+			return err
 		}
 	}
 

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -110,7 +109,7 @@ func imagePush(cmd *cobra.Command, args []string) error {
 
 	if pushOptions.Authfile != "" {
 		if _, err := os.Stat(pushOptions.Authfile); err != nil {
-			return errors.Wrapf(err, "error getting authfile %s", pushOptions.Authfile)
+			return err
 		}
 	}
 

--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -116,7 +116,7 @@ func imageSearch(cmd *cobra.Command, args []string) error {
 
 	if searchOptions.Authfile != "" {
 		if _, err := os.Stat(searchOptions.Authfile); err != nil {
-			return errors.Wrapf(err, "error getting authfile %s", searchOptions.Authfile)
+			return err
 		}
 	}
 

--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/utils"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -75,7 +74,7 @@ func kube(cmd *cobra.Command, args []string) error {
 	}
 	if kubeOptions.Authfile != "" {
 		if _, err := os.Stat(kubeOptions.Authfile); err != nil {
-			return errors.Wrapf(err, "error getting authfile %s", kubeOptions.Authfile)
+			return err
 		}
 	}
 	if kubeOptions.CredentialsCLI != "" {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -578,10 +578,10 @@ func (c *Container) refresh() error {
 	if len(c.config.IDMappings.UIDMap) != 0 || len(c.config.IDMappings.GIDMap) != 0 {
 		info, err := os.Stat(c.runtime.config.Engine.TmpDir)
 		if err != nil {
-			return errors.Wrapf(err, "cannot stat `%s`", c.runtime.config.Engine.TmpDir)
+			return err
 		}
 		if err := os.Chmod(c.runtime.config.Engine.TmpDir, info.Mode()|0111); err != nil {
-			return errors.Wrapf(err, "cannot chmod `%s`", c.runtime.config.Engine.TmpDir)
+			return err
 		}
 		root := filepath.Join(c.runtime.config.Engine.TmpDir, "containers-root", c.ID())
 		if err := os.MkdirAll(root, 0755); err != nil {

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -309,7 +309,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 				fallthrough
 			case "Z":
 				if err := label.Relabel(m.Source, c.MountLabel(), label.IsShared(o)); err != nil {
-					return nil, errors.Wrapf(err, "relabel failed %q", m.Source)
+					return nil, err
 				}
 
 			default:
@@ -360,11 +360,11 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 	for _, overlayVol := range c.config.OverlayVolumes {
 		contentDir, err := overlay.TempDir(c.config.StaticDir, c.RootUID(), c.RootGID())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create TempDir in the %s directory", c.config.StaticDir)
+			return nil, err
 		}
 		overlayMount, err := overlay.Mount(contentDir, overlayVol.Source, overlayVol.Dest, c.RootUID(), c.RootGID(), c.runtime.store.GraphOptions())
 		if err != nil {
-			return nil, errors.Wrapf(err, "creating overlay failed %q", overlayVol.Source)
+			return nil, errors.Wrapf(err, "mounting overlay failed %q", overlayVol.Source)
 		}
 		g.AddMount(overlayMount)
 	}
@@ -811,7 +811,7 @@ func (c *Container) exportCheckpoint(dest string, ignoreRootfs bool) error {
 				return errors.Wrapf(err, "error creating delete files list file %q", deleteFilesList)
 			}
 			if err := ioutil.WriteFile(deleteFilesList, formatJSON, 0600); err != nil {
-				return errors.Wrapf(err, "error creating delete files list file %q", deleteFilesList)
+				return errors.Wrap(err, "error creating delete files list file")
 			}
 
 			includeFiles = append(includeFiles, "deleted.files")
@@ -835,7 +835,7 @@ func (c *Container) exportCheckpoint(dest string, ignoreRootfs bool) error {
 	defer outFile.Close()
 
 	if err := os.Chmod(dest, 0600); err != nil {
-		return errors.Wrapf(err, "cannot chmod %q", dest)
+		return err
 	}
 
 	_, err = io.Copy(outFile, input)
@@ -1059,7 +1059,7 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 					if n.Sandbox != "" {
 						MAC, err = net.ParseMAC(n.Mac)
 						if err != nil {
-							return errors.Wrapf(err, "failed to parse MAC %v", n.Mac)
+							return err
 						}
 						break
 					}
@@ -1163,14 +1163,14 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 				return errors.Wrapf(err, "failed to read deleted files file")
 			}
 			if err := json.Unmarshal(deletedFilesJSON, &deletedFiles); err != nil {
-				return errors.Wrapf(err, "failed to read deleted files file %s", deletedFilesPath)
+				return errors.Wrapf(err, "failed to unmarshal deleted files file %s", deletedFilesPath)
 			}
 			for _, deleteFile := range deletedFiles {
 				// Using RemoveAll as deletedFiles, which is generated from 'podman diff'
 				// lists completely deleted directories as a single entry: 'D /root'.
 				err = os.RemoveAll(filepath.Join(c.state.Mountpoint, deleteFile))
 				if err != nil {
-					return errors.Wrapf(err, "failed to delete file %s from container %s during restore", deletedFilesPath, c.ID())
+					return errors.Wrapf(err, "failed to delete files from container %s during restore", c.ID())
 				}
 			}
 		}
@@ -1209,7 +1209,7 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 // Make standard bind mounts to include in the container
 func (c *Container) makeBindMounts() error {
 	if err := os.Chown(c.state.RunDir, c.RootUID(), c.RootGID()); err != nil {
-		return errors.Wrapf(err, "cannot chown run directory %s", c.state.RunDir)
+		return errors.Wrap(err, "cannot chown run directory")
 	}
 
 	if c.state.BindMounts == nil {
@@ -1227,13 +1227,13 @@ func (c *Container) makeBindMounts() error {
 		if c.config.NetNsCtr == "" {
 			if resolvePath, ok := c.state.BindMounts["/etc/resolv.conf"]; ok {
 				if err := os.Remove(resolvePath); err != nil && !os.IsNotExist(err) {
-					return errors.Wrapf(err, "error removing container %s resolv.conf", c.ID())
+					return errors.Wrapf(err, "container %s", c.ID())
 				}
 				delete(c.state.BindMounts, "/etc/resolv.conf")
 			}
 			if hostsPath, ok := c.state.BindMounts["/etc/hosts"]; ok {
 				if err := os.Remove(hostsPath); err != nil && !os.IsNotExist(err) {
-					return errors.Wrapf(err, "error removing container %s hosts", c.ID())
+					return errors.Wrapf(err, "container %s", c.ID())
 				}
 				delete(c.state.BindMounts, "/etc/hosts")
 			}
@@ -1433,7 +1433,7 @@ func (c *Container) generateResolvConf() (string, error) {
 				if err == nil {
 					resolvConf = definedPath
 				} else if !os.IsNotExist(err) {
-					return "", errors.Wrapf(err, "failed to stat %s", definedPath)
+					return "", err
 				}
 			}
 			break
@@ -1455,7 +1455,7 @@ func (c *Container) generateResolvConf() (string, error) {
 	contents, err := ioutil.ReadFile(resolvPath)
 	// resolv.conf doesn't have to exists
 	if err != nil && !os.IsNotExist(err) {
-		return "", errors.Wrapf(err, "unable to read %s", resolvPath)
+		return "", err
 	}
 
 	// Ensure that the container's /etc/resolv.conf is compatible with its
@@ -1524,7 +1524,7 @@ func (c *Container) generateResolvConf() (string, error) {
 	destPath := filepath.Join(c.state.RunDir, "resolv.conf")
 
 	if err := os.Remove(destPath); err != nil && !os.IsNotExist(err) {
-		return "", errors.Wrapf(err, "error removing resolv.conf for container %s", c.ID())
+		return "", errors.Wrapf(err, "container %s", c.ID())
 	}
 
 	// Build resolv.conf
@@ -1544,7 +1544,7 @@ func (c *Container) generateResolvConf() (string, error) {
 func (c *Container) generateHosts(path string) (string, error) {
 	orig, err := ioutil.ReadFile(path)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to read %s", path)
+		return "", err
 	}
 	hosts := string(orig)
 	hosts += c.getHosts()
@@ -1947,7 +1947,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 			}
 			orig, err := ioutil.ReadFile(originPasswdFile)
 			if err != nil && !os.IsNotExist(err) {
-				return "", "", errors.Wrapf(err, "unable to read passwd file %s", originPasswdFile)
+				return "", "", err
 			}
 			passwdFile, err := c.writeStringToStaticDir("passwd", string(orig)+passwdEntry)
 			if err != nil {
@@ -1966,7 +1966,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 
 			f, err := os.OpenFile(containerPasswd, os.O_APPEND|os.O_WRONLY, 0600)
 			if err != nil {
-				return "", "", errors.Wrapf(err, "error opening container %s /etc/passwd", c.ID())
+				return "", "", errors.Wrapf(err, "container %s", c.ID())
 			}
 			defer f.Close()
 
@@ -1993,7 +1993,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 			}
 			orig, err := ioutil.ReadFile(originGroupFile)
 			if err != nil && !os.IsNotExist(err) {
-				return "", "", errors.Wrapf(err, "unable to read group file %s", originGroupFile)
+				return "", "", err
 			}
 			groupFile, err := c.writeStringToStaticDir("group", string(orig)+groupEntry)
 			if err != nil {
@@ -2012,7 +2012,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 
 			f, err := os.OpenFile(containerGroup, os.O_APPEND|os.O_WRONLY, 0600)
 			if err != nil {
-				return "", "", errors.Wrapf(err, "error opening container %s /etc/group", c.ID())
+				return "", "", errors.Wrapf(err, "container %s", c.ID())
 			}
 			defer f.Close()
 
@@ -2033,13 +2033,13 @@ func (c *Container) copyOwnerAndPerms(source, dest string) error {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return errors.Wrapf(err, "cannot stat `%s`", dest)
+		return err
 	}
 	if err := os.Chmod(dest, info.Mode()); err != nil {
-		return errors.Wrapf(err, "cannot chmod `%s`", dest)
+		return err
 	}
 	if err := os.Chown(dest, int(info.Sys().(*syscall.Stat_t).Uid), int(info.Sys().(*syscall.Stat_t).Gid)); err != nil {
-		return errors.Wrapf(err, "cannot chown `%s`", dest)
+		return err
 	}
 	return nil
 }
@@ -2130,7 +2130,7 @@ func (c *Container) checkFileExistsInRootfs(file string) (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return false, errors.Wrapf(err, "error accessing container %s file %q", c.ID(), file)
+		return false, errors.Wrapf(err, "container %s", c.ID())
 	}
 	if stat.IsDir() {
 		return false, nil

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -223,7 +223,7 @@ func (c *Container) GetHealthCheckLog() (define.HealthCheckResults, error) {
 	}
 	b, err := ioutil.ReadFile(c.healthCheckLogPath())
 	if err != nil {
-		return healthCheck, errors.Wrapf(err, "failed to read health check log file %s", c.healthCheckLogPath())
+		return healthCheck, errors.Wrap(err, "failed to read health check log file")
 	}
 	if err := json.Unmarshal(b, &healthCheck); err != nil {
 		return healthCheck, errors.Wrapf(err, "failed to unmarshal existing healthcheck results in %s", c.healthCheckLogPath())

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -120,7 +120,7 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 			if os.IsNotExist(err) {
 				continue
 			}
-			return nil, errors.Wrapf(err, "cannot stat OCI runtime %s path %q", name, path)
+			return nil, errors.Wrapf(err, "cannot stat OCI runtime %s path", name)
 		}
 		if !stat.Mode().IsRegular() {
 			continue

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1296,7 +1296,7 @@ func WithRootFS(rootfs string) CtrCreateOption {
 			return define.ErrCtrFinalized
 		}
 		if _, err := os.Stat(rootfs); err != nil {
-			return errors.Wrapf(err, "error checking path %q", rootfs)
+			return err
 		}
 		ctr.config.Rootfs = rootfs
 		return nil

--- a/libpod/runtime_migrate.go
+++ b/libpod/runtime_migrate.go
@@ -29,7 +29,7 @@ func stopPauseProcess() error {
 			if os.IsNotExist(err) {
 				return nil
 			}
-			return errors.Wrapf(err, "cannot read pause process pid file %s", pausePidPath)
+			return errors.Wrap(err, "cannot read pause process pid file")
 		}
 		pausePid, err := strconv.Atoi(string(data))
 		if err != nil {

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -74,7 +74,7 @@ func WaitForFile(path string, chWait chan error, timeout time.Duration) (bool, e
 				return false, nil
 			}
 			if !os.IsNotExist(err) {
-				return false, errors.Wrapf(err, "checking file %s", path)
+				return false, err
 			}
 		case <-time.After(25 * time.Millisecond):
 			// Check periodically for the file existence.  It is needed
@@ -86,7 +86,7 @@ func WaitForFile(path string, chWait chan error, timeout time.Duration) (bool, e
 				return false, nil
 			}
 			if !os.IsNotExist(err) {
-				return false, errors.Wrapf(err, "checking file %s", path)
+				return false, err
 			}
 		case <-timeoutChan:
 			return false, errors.Wrapf(define.ErrInternal, "timed out waiting for file %s", path)
@@ -184,11 +184,11 @@ func DefaultSeccompPath() (string, error) {
 		return config.SeccompOverridePath, nil
 	}
 	if !os.IsNotExist(err) {
-		return "", errors.Wrapf(err, "can't check if %q exists", config.SeccompOverridePath)
+		return "", err
 	}
 	if _, err := os.Stat(config.SeccompDefaultPath); err != nil {
 		if !os.IsNotExist(err) {
-			return "", errors.Wrapf(err, "can't check if %q exists", config.SeccompDefaultPath)
+			return "", err
 		}
 		return "", nil
 	}

--- a/pkg/domain/infra/abi/cp.go
+++ b/pkg/domain/infra/abi/cp.go
@@ -214,7 +214,7 @@ func getPathInfo(path string) (string, os.FileInfo, error) {
 	}
 	srcfi, err := os.Stat(path)
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "error reading path %q", path)
+		return "", nil, err
 	}
 	return path, srcfi, nil
 }
@@ -245,7 +245,7 @@ func containerCopy(srcPath, destPath, src, dest string, idMappingOpts storage.ID
 	}
 	_, err = os.Stat(destdir)
 	if err != nil && !os.IsNotExist(err) {
-		return errors.Wrapf(err, "error checking directory %q", destdir)
+		return err
 	}
 	destDirIsExist := err == nil
 	if err = os.MkdirAll(destdir, 0755); err != nil {
@@ -292,7 +292,7 @@ func containerCopy(srcPath, destPath, src, dest string, idMappingOpts storage.ID
 	destfi, err := os.Stat(destPath)
 	if err != nil {
 		if !os.IsNotExist(err) || strings.HasSuffix(dest, string(os.PathSeparator)) {
-			return errors.Wrapf(err, "failed to get stat of dest path %s", destPath)
+			return err
 		}
 	}
 	if destfi != nil && destfi.IsDir() {

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -251,7 +251,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			case v1.HostPathDirectoryOrCreate:
 				if _, err := os.Stat(hostPath.Path); os.IsNotExist(err) {
 					if err := os.Mkdir(hostPath.Path, kubeDirectoryPermission); err != nil {
-						return nil, errors.Errorf("error creating HostPath %s", volume.Name)
+						return nil, err
 					}
 				}
 				// Label a newly created volume
@@ -262,7 +262,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 				if _, err := os.Stat(hostPath.Path); os.IsNotExist(err) {
 					f, err := os.OpenFile(hostPath.Path, os.O_RDONLY|os.O_CREATE, kubeFilePermission)
 					if err != nil {
-						return nil, errors.Errorf("error creating HostPath %s", volume.Name)
+						return nil, errors.Wrap(err, "error creating HostPath")
 					}
 					if err := f.Close(); err != nil {
 						logrus.Warnf("Error in closing newly created HostPath file: %v", err)

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -52,7 +52,7 @@ func addPrivilegedDevices(g *generate.Generator) error {
 				if err == unix.EPERM {
 					continue
 				}
-				return errors.Wrapf(err, "stat %s", d.Path)
+				return err
 			}
 			// Skip devices that the user has not access to.
 			if st.Mode()&0007 == 0 {
@@ -90,7 +90,7 @@ func DevicesFromPath(g *generate.Generator, devicePath string) error {
 	}
 	st, err := os.Stat(resolvedDevicePath)
 	if err != nil {
-		return errors.Wrapf(err, "cannot stat device path %s", devicePath)
+		return err
 	}
 	if st.IsDir() {
 		found := false
@@ -231,10 +231,7 @@ func addDevice(g *generate.Generator, device string) error {
 	}
 	if rootless.IsRootless() {
 		if _, err := os.Stat(src); err != nil {
-			if os.IsNotExist(err) {
-				return errors.Wrapf(err, "the specified device %s doesn't exist", src)
-			}
-			return errors.Wrapf(err, "stat device %s exist", src)
+			return err
 		}
 		perm := "ro"
 		if strings.Contains(permissions, "w") {

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -278,7 +278,7 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	switch s.PidNS.NSMode {
 	case specgen.Path:
 		if _, err := os.Stat(s.PidNS.Value); err != nil {
-			return errors.Wrapf(err, "cannot find specified PID namespace path %q", s.PidNS.Value)
+			return errors.Wrap(err, "cannot find specified PID namespace path")
 		}
 		if err := g.AddOrReplaceLinuxNamespace(string(spec.PIDNamespace), s.PidNS.Value); err != nil {
 			return err
@@ -297,7 +297,7 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	switch s.IpcNS.NSMode {
 	case specgen.Path:
 		if _, err := os.Stat(s.IpcNS.Value); err != nil {
-			return errors.Wrapf(err, "cannot find specified IPC namespace path %q", s.IpcNS.Value)
+			return errors.Wrap(err, "cannot find specified IPC namespace path")
 		}
 		if err := g.AddOrReplaceLinuxNamespace(string(spec.IPCNamespace), s.IpcNS.Value); err != nil {
 			return err
@@ -316,7 +316,7 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	switch s.UtsNS.NSMode {
 	case specgen.Path:
 		if _, err := os.Stat(s.UtsNS.Value); err != nil {
-			return errors.Wrapf(err, "cannot find specified UTS namespace path %q", s.UtsNS.Value)
+			return errors.Wrap(err, "cannot find specified UTS namespace path")
 		}
 		if err := g.AddOrReplaceLinuxNamespace(string(spec.UTSNamespace), s.UtsNS.Value); err != nil {
 			return err
@@ -367,7 +367,7 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	switch s.UserNS.NSMode {
 	case specgen.Path:
 		if _, err := os.Stat(s.UserNS.Value); err != nil {
-			return errors.Wrapf(err, "cannot find specified user namespace path %s", s.UserNS.Value)
+			return errors.Wrap(err, "cannot find specified user namespace path")
 		}
 		if err := g.AddOrReplaceLinuxNamespace(string(spec.UserNamespace), s.UserNS.Value); err != nil {
 			return err
@@ -410,7 +410,7 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	switch s.CgroupNS.NSMode {
 	case specgen.Path:
 		if _, err := os.Stat(s.CgroupNS.Value); err != nil {
-			return errors.Wrapf(err, "cannot find specified cgroup namespace path %s", s.CgroupNS.Value)
+			return errors.Wrap(err, "cannot find specified cgroup namespace path")
 		}
 		if err := g.AddOrReplaceLinuxNamespace(string(spec.CgroupNamespace), s.CgroupNS.Value); err != nil {
 			return err
@@ -429,7 +429,7 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	switch s.NetNS.NSMode {
 	case specgen.Path:
 		if _, err := os.Stat(s.NetNS.Value); err != nil {
-			return errors.Wrapf(err, "cannot find specified network namespace path %s", s.NetNS.Value)
+			return errors.Wrap(err, "cannot find specified network namespace path")
 		}
 		if err := g.AddOrReplaceLinuxNamespace(string(spec.NetworkNamespace), s.NetNS.Value); err != nil {
 			return err

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -148,7 +148,7 @@ load helpers
     is "$output" "" "output from podman cp 1"
 
     run_podman 125 cp --pause=false $srcdir/$rand_filename2 cpcontainer:/tmp/d2/x/
-    is "$output" "Error: failed to get stat of dest path .*stat.* no such file or directory" "cp will not create nonexistent destination directory"
+    is "$output" ".*stat.* no such file or directory" "cp will not create nonexistent destination directory"
 
     run_podman cp --pause=false $srcdir/$rand_filename3 cpcontainer:/tmp/d3/x
     is "$output" "" "output from podman cp 3"


### PR DESCRIPTION
Most of the builtin golang functions like os.Stat and
os.Open report errors including the file system object
path. We should not wrap these errors and put the file path
in a second time, causing stuttering of errors when they
get presented to the user.

This patch tries to cleanup a bunch of these errors.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>