### PR TITLE
Add support for mounting external containers

### DIFF
--- a/docs/source/markdown/podman-mount.1.md
+++ b/docs/source/markdown/podman-mount.1.md
@@ -13,7 +13,9 @@ Mounts the specified containers' root file system in a location which can be
 accessed from the host, and returns its location.
 
 If you execute the command without any arguments, Podman will list all of the
-currently mounted containers.
+currently mounted containers, including external containers. External containers are
+containers in container/storage by tools other then Podman. For example Buildah and
+CRI-O.
 
 Rootless mode only supports mounting VFS driver, unless you enter the user namespace
 via the `podman unshare` command. All other storage drivers will fail to mount.
@@ -26,7 +28,7 @@ returned.
 
 **--all**, **-a**
 
-Mount all containers.
+Mount all podman containers. (External containers will not be mounted)
 
 **--format**=*format*
 

--- a/docs/source/markdown/podman-unmount.1.md
+++ b/docs/source/markdown/podman-unmount.1.md
@@ -22,6 +22,10 @@ container's root filesystem is physically unmounted only when the mount
 counter reaches zero indicating no other processes are using the mount.
 An unmount can be forced with the --force flag.
 
+Note: Podman can be used to unmount Podman containers as well as external containers.
+External containers are containers created in container/storage by other tools like
+Buildah and CRI-O.
+
 ## OPTIONS
 **--all**, **-a**
 


### PR DESCRIPTION
Continue progress on use of external containers.

This PR adds the ability to mount, umount and list the
storage containers whether they are in libpod or not.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>