### PR TITLE
Restore --format table header support

### DIFF
--- a/cmd/podman/images/history.go
+++ b/cmd/podman/images/history.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/containers/common/pkg/report"
+	"github.com/containers/podman/v2/cmd/podman/parse"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/docker/go-units"
@@ -119,7 +120,7 @@ func history(cmd *cobra.Command, args []string) error {
 	case opts.quiet:
 		row = "{{.ID}}\n"
 	}
-	format := "{{range . }}" + row + "{{end}}"
+	format := parse.EnforceRange(row)
 
 	tmpl, err := template.New("report").Parse(format)
 	if err != nil {

--- a/cmd/podman/parse/template.go
+++ b/cmd/podman/parse/template.go
@@ -1,0 +1,22 @@
+package parse
+
+import (
+	"regexp"
+	"strings"
+)
+
+var rangeRegex = regexp.MustCompile(`{{\s*range\s*\.\s*}}.*{{\s*end\s*}}`)
+
+// TODO move to github.com/containers/common/pkg/report
+// EnforceRange ensures that the format string contains a range
+func EnforceRange(format string) string {
+	if !rangeRegex.MatchString(format) {
+		return "{{range .}}" + format + "{{end}}"
+	}
+	return format
+}
+
+// EnforceRange ensures that the format string contains a range
+func HasTable(format string) bool {
+	return strings.HasPrefix(format, "table ")
+}

--- a/cmd/podman/parse/template_test.go
+++ b/cmd/podman/parse/template_test.go
@@ -1,0 +1,30 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnforceRange(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"{{range .}}{{.ID}}{{end}}", "{{range .}}{{.ID}}{{end}}"},
+		{"{{.ID}}", "{{range .}}{{.ID}}{{end}}"},
+		{"{{ range . }}{{ .ID }}{{ end }}", "{{ range . }}{{ .ID }}{{ end }}"},
+		// EnforceRange does not verify syntax or semantics, that will happen later
+		{"{{range .}}{{.ID}}", "{{range .}}{{range .}}{{.ID}}{{end}}"},
+		{".ID", "{{range .}}.ID{{end}}"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		label := "TestEnforceRange_" + tc.input
+		t.Run(label, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, EnforceRange(tc.input))
+		})
+	}
+}

--- a/cmd/podman/pods/stats.go
+++ b/cmd/podman/pods/stats.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buger/goterm"
 	"github.com/containers/common/pkg/report"
+	"github.com/containers/podman/v2/cmd/podman/parse"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
@@ -135,7 +136,7 @@ func printFormattedPodStatsLines(headerNames []map[string]string, row string, st
 		return nil
 	}
 
-	row = "{{range .}}" + row + "{{end}}"
+	row = parse.EnforceRange(row)
 
 	tmpl, err := template.New("pod stats").Parse(row)
 	if err != nil {

--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/containers/common/pkg/report"
+	"github.com/containers/podman/v2/cmd/podman/parse"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
@@ -91,9 +92,9 @@ func outputTemplate(cmd *cobra.Command, responses []*entities.VolumeListReport) 
 	if cliOpts.Quiet {
 		row = "{{.Name}}\n"
 	}
-	row = "{{range . }}" + row + "{{end}}"
+	format := parse.EnforceRange(row)
 
-	tmpl, err := template.New("list volume").Parse(row)
+	tmpl, err := template.New("list volume").Parse(format)
 	if err != nil {
 		return err
 	}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containers/storage/pkg/parsers/kernel"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var (
@@ -48,7 +48,7 @@ type PodmanTest struct {
 
 // PodmanSession wraps the gexec.session so we can extend it
 type PodmanSession struct {
-	*gexec.Session
+	*Session
 }
 
 // HostOS is a simple struct for the test os
@@ -96,7 +96,7 @@ func (p *PodmanTest) PodmanAsUserBase(args []string, uid, gid uint32, cwd string
 
 	command.ExtraFiles = extraFiles
 
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+	session, err := Start(command, GinkgoWriter, GinkgoWriter)
 	if err != nil {
 		Fail(fmt.Sprintf("unable to run podman command: %s\n%v", strings.Join(podmanOptions, " "), err))
 	}
@@ -125,7 +125,7 @@ func (p *PodmanTest) NumberOfContainersRunning() int {
 	var containers []string
 	ps := p.PodmanBase([]string{"ps", "-q"}, false, true)
 	ps.WaitWithDefaultTimeout()
-	Expect(ps.ExitCode()).To(Equal(0))
+	Expect(ps).Should(Exit(0))
 	for _, i := range ps.OutputToStringArray() {
 		if i != "" {
 			containers = append(containers, i)
@@ -318,7 +318,7 @@ func (s *PodmanSession) IsJSONOutputValid() bool {
 
 // WaitWithDefaultTimeout waits for process finished with defaultWaitTimeout
 func (s *PodmanSession) WaitWithDefaultTimeout() {
-	Eventually(s, defaultWaitTimeout).Should(gexec.Exit())
+	Eventually(s, defaultWaitTimeout).Should(Exit())
 	os.Stdout.Sync()
 	os.Stderr.Sync()
 	fmt.Println("output:", s.OutputToString())
@@ -332,7 +332,7 @@ func CreateTempDirInTempDir() (string, error) {
 // SystemExec is used to exec a system command to check its exit code or output
 func SystemExec(command string, args []string) *PodmanSession {
 	c := exec.Command(command, args...)
-	session, err := gexec.Start(c, GinkgoWriter, GinkgoWriter)
+	session, err := Start(c, GinkgoWriter, GinkgoWriter)
 	if err != nil {
 		Fail(fmt.Sprintf("unable to run command: %s %s", command, strings.Join(args, " ")))
 	}
@@ -343,7 +343,7 @@ func SystemExec(command string, args []string) *PodmanSession {
 // StartSystemExec is used to start exec a system command
 func StartSystemExec(command string, args []string) *PodmanSession {
 	c := exec.Command(command, args...)
-	session, err := gexec.Start(c, GinkgoWriter, GinkgoWriter)
+	session, err := Start(c, GinkgoWriter, GinkgoWriter)
 	if err != nil {
 		Fail(fmt.Sprintf("unable to run command: %s %s", command, strings.Join(args, " ")))
 	}


### PR DESCRIPTION
Restore V1 `--format table... ` header support 

The orIginal code was not always consistent on when headers should be rendered, I followed the tests and v1.9 code here.

Signed-off-by: Jhon Honce <jhonce@redhat.com>