### PR TITLE
Fix the `--pull` flag to `podman build` to match Docker

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -241,8 +241,12 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 	}
 
 	pullPolicy := imagebuildah.PullIfNewer
-	if c.Flags().Changed("pull") && !flags.Pull {
-		pullPolicy = imagebuildah.PullIfMissing
+	if c.Flags().Changed("pull") {
+		if flags.Pull {
+			pullPolicy = imagebuildah.PullAlways
+		} else {
+			pullPolicy = imagebuildah.PullNever
+		}
 	}
 	if flags.PullAlways {
 		pullPolicy = imagebuildah.PullAlways


### PR DESCRIPTION
The behavior should be as follows: Unset, pull if missing by default, obey the `--pull-never` and `--pull-always` flags. Set to false, pull never. Set to true, pull always.
