### PR TITLE
Pod's that share the IPC Namespace need to share /dev/shm

### DIFF
--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -131,6 +131,7 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, rawIm
 
 	logrus.Debugf("Using %q as infra container entrypoint", entryCmd)
 
+	g.RemoveMount("/dev/shm")
 	if isRootless {
 		g.RemoveMount("/dev/pts")
 		devPts := spec.Mount{

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -127,6 +127,7 @@ func namespaceOptions(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.
 			return nil, errNoInfra
 		}
 		toReturn = append(toReturn, libpod.WithIPCNSFrom(infraCtr))
+		toReturn = append(toReturn, libpod.WithShmDir(infraCtr.ShmDir()))
 	case specgen.FromContainer:
 		ipcCtr, err := rt.LookupContainer(s.IpcNS.Value)
 		if err != nil {

--- a/test/e2e/pod_pod_namespaces.go
+++ b/test/e2e/pod_pod_namespaces.go
@@ -60,6 +60,25 @@ var _ = Describe("Podman pod create", func() {
 		Expect(NAMESPACE1).To(Equal(NAMESPACE2))
 	})
 
+	It("podman pod container share ipc && /dev/shm ", func() {
+		session := podmanTest.Podman([]string{"pod", "create"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		podID := session.OutputToString()
+
+		session = podmanTest.Podman([]string{"pod", "start", podID})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"run", "--rm", "--pod", podID, ALPINE, "touch", "/dev/shm/test"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"run", "--rm", "--pod", podID, ALPINE, "ls", "/dev/shm/test"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman pod container dontshare PIDNS", func() {
 		session := podmanTest.Podman([]string{"pod", "create"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Containers that share IPC Namespaces share each others
/dev/shm, which means a private /dev/shm needs to be setup
for the infra container.

Added a system test and an e2e test to make sure the
/dev/shm is shared.

Fixes: https://github.com/containers/podman/issues/8181

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>