### PR TITLE
Static IP and MAC addresses are allowed in rootless CNI

### DIFF
--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -28,7 +28,7 @@ func exclusiveOptions(opt1, opt2 string) error {
 // input for creating a container.
 func (s *SpecGenerator) Validate() error {
 
-	if rootless.IsRootless() {
+	if rootless.IsRootless() && len(s.CNINetworks) == 0 {
 		if s.StaticIP != nil || s.StaticIPv6 != nil {
 			return ErrNoStaticIPRootless
 		}


### PR DESCRIPTION
Loosen some restrictions within specgen around rootlesscontainers - they can now set static IP and MAC addresses as long  as they are in a CNI network.

Fixes #7842
