### PR TITLE
Remove search limit since pagination support

### DIFF
--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -98,10 +98,6 @@ func imageSearch(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("search requires exactly one argument")
 	}
 
-	if searchOptions.Limit > 100 {
-		return errors.Errorf("Limit %d is outside the range of [1, 100]", searchOptions.Limit)
-	}
-
 	if searchOptions.ListTags && len(searchOptions.Filters) != 0 {
 		return errors.Errorf("filters are not applicable to list tags result")
 	}

--- a/docs/source/markdown/podman-search.1.md
+++ b/docs/source/markdown/podman-search.1.md
@@ -62,7 +62,7 @@ Note: use .Tag only if the --list-tags is set.
 
 **--limit**=*limit*
 
-Limit the number of results. This value can be in the range between 1 and 100. The default number of results is 25.
+Limit the number of results (default 25).
 Note: The results from each registry will be limited to this value.
 Example if limit is 10 and two registries are being searched, the total
 number of results will be 20, 10 from each (if there are at least 10 matches in each).

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -460,4 +460,11 @@ registries = ['{{.Host}}:{{.Port}}']`
 		search.WaitWithDefaultTimeout()
 		Expect(len(search.OutputToStringArray()) == 0).To(BeTrue())
 	})
+
+	It("podman search with limit over 100", func() {
+		search := podmanTest.Podman([]string{"search", "--limit", "130", "registry.redhat.io/rhel"})
+		search.WaitWithDefaultTimeout()
+		Expect(search.ExitCode()).To(Equal(0))
+		Expect(len(search.OutputToStringArray())).To(Equal(131))
+	})
 })


### PR DESCRIPTION
Remove the search limit check since the c/image v5.6.0 supports pagination and can give result over 100 entries.
The same change of code has been in the v2.0 branch. https://github.com/containers/podman/pull/7356
Signed-off-by: Qi Wang <qiwan@redhat.com>