### PR TITLE
Fix dnsname when joining a different network namespace in a pod

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -102,17 +102,7 @@ func (r *Runtime) configureNetNS(ctr *Container, ctrNS ns.NetNS) ([]*cnitypes.Re
 		requestedMAC = ctr.config.StaticMAC
 	}
 
-	// If we are in a pod use the pod name for the network, otherwise the container name
-	var podName string
-	if ctr.PodID() != "" {
-		pod, err := r.GetPod(ctr.PodID())
-		if err == nil {
-			podName = pod.Name()
-		}
-	}
-	if podName == "" {
-		podName = ctr.Name()
-	}
+	podName := getCNIPodName(ctr)
 
 	podNetwork := r.getPodNetwork(ctr.ID(), podName, ctrNS.Path(), ctr.config.Networks, ctr.config.PortMappings, requestedIP, requestedMAC)
 


### PR DESCRIPTION
When creating a container in a pod the podname was always set as
the dns entry. This is incorrect when the container is not part
of the pods network namespace. This happend both rootful and
rootless. To fix this check if we are part of the pods network
namespace and if not use the container name as dns entry.

Fixes #8194 