### PR TITLE
Only use container/storage/pkg/unshare.HomeDir()

### DIFF
--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -444,10 +444,7 @@ func (r *ConmonOCIRuntime) startExec(c *Container, sessionID string, options *Ex
 	// 	}
 	// }
 
-	conmonEnv, extraFiles, err := r.configureConmonEnv(c, runtimeDir)
-	if err != nil {
-		return nil, nil, err
-	}
+	conmonEnv, extraFiles := r.configureConmonEnv(c, runtimeDir)
 
 	var filesToClose []*os.File
 	if options.PreserveFDs > 0 {


### PR DESCRIPTION
We are resolving the homedir of the user in many different
places.  This Patch consolodates them to use container/storage
version.

This PR also fixes a failure mode when the homedir does not
exists, and the user sets a root path.  In this situation
podman should continue to work. Podman does not require a users
homedir to exist in order to run.

Fixes: https://github.com/containers/podman/issues/8131

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>