### PR TITLE
Centralize cores and period/quota conversion code

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -25,11 +25,8 @@ func getCPULimits(c *ContainerCLIOpts) *specs.LinuxCPU {
 	cpu := &specs.LinuxCPU{}
 	hasLimits := false
 
-	const cpuPeriod = 100000
-
 	if c.CPUS > 0 {
-		quota := int64(c.CPUS * cpuPeriod)
-		period := uint64(cpuPeriod)
+		period, quota := util.CoresToPeriodAndQuota(c.CPUS)
 
 		cpu.Period = &period
 		cpu.Quota = &quota

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -327,7 +327,7 @@ func containerToV1Container(c *Container) (v1.Container, []v1.Volume, error) {
 			period := *c.config.Spec.Linux.Resources.CPU.Period
 
 			if quota > 0 && period > 0 {
-				cpuLimitMilli := int64(1000 * float64(quota) / float64(period))
+				cpuLimitMilli := int64(1000 * util.PeriodAndQuotaToCores(period, quota))
 
 				// Kubernetes: precision finer than 1m is not allowed
 				if cpuLimitMilli >= 1 {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -653,3 +653,26 @@ func CreateCidFile(cidfile string, id string) error {
 	cidFile.Close()
 	return nil
 }
+
+// DefaultCPUPeriod is the default CPU period is 100us, which is the same default
+// as Kubernetes.
+const DefaultCPUPeriod uint64 = 100000
+
+// CoresToPeriodAndQuota converts a fraction of cores to the equivalent
+// Completely Fair Scheduler (CFS) parameters period and quota.
+//
+// Cores is a fraction of the CFS period that a container may use. Period and
+// Quota are in microseconds.
+func CoresToPeriodAndQuota(cores float64) (uint64, int64) {
+	return DefaultCPUPeriod, int64(cores * float64(DefaultCPUPeriod))
+}
+
+// PeriodAndQuotaToCores takes the CFS parameters period and quota and returns
+// a fraction that represents the limit to the number of cores that can be
+// utilized over the scheduling period.
+//
+// Cores is a fraction of the CFS period that a container may use. Period and
+// Quota are in microseconds.
+func PeriodAndQuotaToCores(period uint64, quota int64) float64 {
+	return float64(quota) / float64(period)
+}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -257,3 +257,23 @@ func TestValidateSysctlBadSysctl(t *testing.T) {
 	_, err := ValidateSysctls(strSlice)
 	assert.Error(t, err)
 }
+
+func TestCoresToPeriodAndQuota(t *testing.T) {
+	cores := 1.0
+	expectedPeriod := DefaultCPUPeriod
+	expectedQuota := int64(DefaultCPUPeriod)
+
+	actualPeriod, actualQuota := CoresToPeriodAndQuota(cores)
+	assert.Equal(t, actualPeriod, expectedPeriod, "Period does not match")
+	assert.Equal(t, actualQuota, expectedQuota, "Quota does not match")
+}
+
+func TestPeriodAndQuotaToCores(t *testing.T) {
+	var (
+		period        uint64 = 100000
+		quota         int64  = 50000
+		expectedCores        = 0.5
+	)
+
+	assert.Equal(t, PeriodAndQuotaToCores(period, quota), expectedCores)
+}


### PR DESCRIPTION
Fixes #8113.

This first draft is functional, but I would like feedback on the interface of the functions I wrote. Returning two related integers leaves too many opportunities for the caller to make a mistake. The two integers are different types. Maybe that means the compiler will catch mistakes, but most likely it will produce confusing error messages.

```go
func CoresToPeriodAndQuota(cores float64) (uint64, int64)
func PeriodAndQuotaToCores(period uint64, quota int64) float64
```

An alternative I considered is only returning the quota. The default period would have to be looked up in a const value. I'm not satisfied with this because it means the value returned by CoresToQuota is meaningless until the user looks up the period. This also wouldn't improve the PeriodAndQuotaToCores function.

```go
const DefaultCPUPeriod uint64 = 100000
func CoresToQuota(cores float64) int64
func PeriodAndQuotaToCores(period uint64, quota int64) float64
```

Finally, I also considered using a custom struct. This would give the caller named fields instead of anonymous return values. However, this seems overly complicated to implement for what are basically one-line functions.

```go
type CFSParams struct {
	Period uint64
	Quota int64
}

func CoresToPeriodAndQuota(cores float64) CFSParams
func (c *CFSParams) ToCores() float64
```