### PR TITLE
Change http ConnState actions between new and active

### DIFF
--- a/pkg/api/server/idle/tracker.go
+++ b/pkg/api/server/idle/tracker.go
@@ -41,11 +41,12 @@ func (t *Tracker) ConnState(conn net.Conn, state http.ConnState) {
 
 	logrus.Debugf("IdleTracker %p:%v %dm+%dh/%dt connection(s)", conn, state, len(t.managed), t.hijacked, t.TotalConnections())
 	switch state {
-	case http.StateNew, http.StateActive:
+	case http.StateNew:
+		t.total++
+	case http.StateActive:
 		// stop the API timer when the server transitions any connection to an "active" state
 		t.managed[conn] = struct{}{}
 		t.timer.Stop()
-		t.total++
 	case http.StateHijacked:
 		// hijacked connections should call Close() when finished.
 		// Note: If a handler hijack's a connection and then doesn't Close() it,


### PR DESCRIPTION
Currently it double counts connections because it's incrementing the
total for both the new and active states. Based on the comments, we
should only count new connections for the total count and perform the
timer stop actions when the connection has transitioned to an active
state.

Closes #8208