### PR TITLE
Match build pull functionality with Docker's

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -240,13 +240,9 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		}
 	}
 
-	pullPolicy := imagebuildah.PullIfNewer
-	if c.Flags().Changed("pull") {
-		if flags.Pull {
-			pullPolicy = imagebuildah.PullAlways
-		} else {
-			pullPolicy = imagebuildah.PullNever
-		}
+	pullPolicy := imagebuildah.PullIfMissing
+	if c.Flags().Changed("pull") && flags.Pull {
+		pullPolicy = imagebuildah.PullAlways
 	}
 	if flags.PullAlways {
 		pullPolicy = imagebuildah.PullAlways

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -384,16 +384,13 @@ not required for Buildah as it supports only Linux.
 
 **--pull**
 
-When the flag is enabled, attempt to pull the latest image from the registries
-listed in registries.conf if a local image does not exist or the image is newer
-than the one in storage. Raise an error if the image is not in any listed
-registry and is not present locally.
+When the option is specified or set to "true", pull the image from the first registry
+it is found in as listed in registries.conf.  Raise an error if not found in the
+registries, even if the image is present locally.
 
-If the flag is disabled (with *--pull=false*), do not pull the image from the
-registry, unless there is no local image. Raise an error if the image is not
-in any registry and is not present locally.
-
-Defaults to *true*.
+If the option is disabled (with *--pull=false*), or not specified, pull the image
+from the registry only if the image is not present locally. Raise an error if the image
+is not found in the registries.
 
 **--pull-always**
 


### PR DESCRIPTION
This is a continuation of #8189 and #8085.

When doing a `docker build` command, if the `--pull` command is not specified
or set to `false` the pullOption used is `PullifMissing`.  This causes the
build to pull the image only if it is not present in local storage.  It also will
raise an error if the image is not found in the registry (or the registry is down),
even if the image is present in local storage.

If the `--pull` command IS specified or specified with an argument of `true`, the
build will always pull the image from the registries.  This uses the pullOption
`PullAlways`.  It also will raise an error if the image is not found in the registry,
even if the image is present in local storage.

These changes now brings the pull functionality for `podman build` into line
with `docker build`.

However, I consider this to be a breaking change.  Previously if you did
`podman build --pull`, `podman build` or `podman build --pull = true`, then
the image would be pulled from the registry if there was not an image in
local storage or if the image in the registry was newer than the one in
local storage.  An error would *NOT* be raised if there was not an image in
the registry or the registry was down as long as there was a copy in the local
storage.  An error would be raised if the image could not be retrieved from
both the registry and local storage.  This is the PullOption `PullIfNewer`.

I believe this also differs from what Buildah does at this time but I'm too
beat to chase that down at the moment.

Personally I'd like to use the `PullIfNewer` for at least `--pull` and
`--pull=true` so that you don't get an error if the registry has a network
hiccup and the image is already stored locally.  But this differs from Docker.

I'd like to post scrum about this at our next stand up to make sure we're
all on the same page about the ramifications of this change.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>