### PR TITLE
Reinstate skipped shortname test

### DIFF
--- a/test/e2e/exists_test.go
+++ b/test/e2e/exists_test.go
@@ -39,7 +39,6 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session).Should(Exit(0))
 	})
 	It("podman image exists in local storage by short name", func() {
-		Skip("FIXME-8165: shortnames don't seem to work with quay (#8176)")
 		session := podmanTest.Podman([]string{"image", "exists", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))


### PR DESCRIPTION
PR #8178 fixed #8176 but didn't remove the Skip(). This
reinstates the test.

Signed-off-by: Ed Santiago <santiago@redhat.com>