### PR TITLE
specgen: add support for ambient capabilities

### DIFF
--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -350,3 +350,8 @@ func deviceFromPath(path string) (*spec.LinuxDevice, error) {
 		Minor:    int64(unix.Minor(devNumber)),
 	}, nil
 }
+
+func supportAmbientCapabilities() bool {
+	err := unix.Prctl(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_IS_SET, 0, 0, 0)
+	return err == nil
+}

--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -135,7 +135,9 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 	configSpec.Process.Capabilities.Bounding = caplist
 	configSpec.Process.Capabilities.Inheritable = caplist
 
-	if s.User == "" || s.User == "root" || s.User == "0" {
+	user := strings.Split(s.User, ":")[0]
+
+	if user == "" || user == "root" || user == "0" {
 		configSpec.Process.Capabilities.Effective = caplist
 		configSpec.Process.Capabilities.Permitted = caplist
 	} else {

--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -137,7 +137,7 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 
 	user := strings.Split(s.User, ":")[0]
 
-	if user == "" || user == "root" || user == "0" {
+	if (user == "" && s.UserNS.NSMode != specgen.KeepID) || user == "root" || user == "0" {
 		configSpec.Process.Capabilities.Effective = caplist
 		configSpec.Process.Capabilities.Permitted = caplist
 	} else {

--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -145,6 +145,12 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 		}
 		configSpec.Process.Capabilities.Effective = userCaps
 		configSpec.Process.Capabilities.Permitted = userCaps
+
+		// Ambient capabilities were added to Linux 4.3.  Set ambient
+		// capabilities only when the kernel supports them.
+		if supportAmbientCapabilities() {
+			configSpec.Process.Capabilities.Ambient = userCaps
+		}
 	}
 
 	g.SetProcessNoNewPrivileges(s.NoNewPrivileges)

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -315,6 +315,21 @@ var _ = Describe("Podman run", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("00000000a80425fb"))
+
+		session = podmanTest.Podman([]string{"run", "--user=1000:1000", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapAmb", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("0000000000000002"))
+
+		session = podmanTest.Podman([]string{"run", "--user=1000:1000", "--rm", ALPINE, "grep", "CapAmb", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
+
+		session = podmanTest.Podman([]string{"run", "--user=0", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapAmb", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 	})
 
 	It("podman run user capabilities test with image", func() {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -330,6 +330,11 @@ var _ = Describe("Podman run", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
+
+		session = podmanTest.Podman([]string{"run", "--user=0:0", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapAmb", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 	})
 
 	It("podman run user capabilities test with image", func() {


### PR DESCRIPTION
if the kernel supports ambient capabilities (Linux 4.3+), also set them when running with euid != 0.

This is different that what Moby does, as ambient capabilities are never set.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
