### PR TITLE
pull: account for platform

### DIFF
--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -22,6 +22,7 @@ type ImageData struct {
 	Version      string                        `json:"Version"`
 	Author       string                        `json:"Author"`
 	Architecture string                        `json:"Architecture"`
+	Variant      string                        `json:"Variant"`
 	Os           string                        `json:"Os"`
 	Size         int64                         `json:"Size"`
 	VirtualSize  int64                         `json:"VirtualSize"`

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -88,7 +88,7 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 	if s.Rootfs != "" {
 		options = append(options, libpod.WithRootFS(s.Rootfs))
 	} else {
-		newImage, err = rt.ImageRuntime().NewFromLocal(s.Image)
+		newImage, err = rt.ImageRuntime().NewFromLocal(s.RawImageName)
 		if err != nil {
 			return nil, err
 		}
@@ -97,7 +97,7 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		// defaulting to the first name or an empty one if no names are
 		// present.
 		imgName := newImage.InputName
-		if s.Image == newImage.InputName && strings.HasPrefix(newImage.ID(), s.Image) {
+		if strings.HasPrefix(newImage.ID(), s.RawImageName) {
 			imgName = ""
 			names := newImage.Names()
 			if len(names) > 0 {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -14,6 +15,7 @@ import (
 	. "github.com/containers/podman/v2/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/mrunalp/fileutils"
+	"github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -45,6 +47,22 @@ var _ = Describe("Podman run", func() {
 		session := podmanTest.Podman([]string{"run", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+	})
+
+	It("podman run a container based on local image but with --override-arch", func() {
+		if runtime.GOARCH == "arm64" {
+			ginkgo.Skip("test does not run on arm64")
+		}
+		session := podmanTest.Podman([]string{"run", "--override-arch", "arm64", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(1))
+	})
+
+	It("podman run a container based on local image but with --override-os", func() {
+		session := podmanTest.Podman([]string{"run", "--override-os", "bogus", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session.ErrorToString()).To(ContainSubstring("Error choosing an image from manifest list"))
 	})
 
 	It("podman run a container based on a complex local image name", func() {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -142,7 +142,7 @@ echo $rand        |   0 | $rand
     NONLOCAL_IMAGE="$PODMAN_TEST_IMAGE_REGISTRY/$PODMAN_TEST_IMAGE_USER/$PODMAN_TEST_IMAGE_NAME:00000000"
 
     run_podman 125 run --pull=never $NONLOCAL_IMAGE true
-    is "$output" "Error: unable to find a name and tag match for $NONLOCAL_IMAGE in repotags: no such image" "--pull=never [with image not present]: error"
+    is "$output" "Error: unable to find $NONLOCAL_IMAGE in local storage: no such image" "--pull=never [with image not present]: error"
 
     run_podman run --pull=missing $NONLOCAL_IMAGE true
     is "$output" "Trying to pull .*" "--pull=missing [with image NOT PRESENT]: fetches"


### PR DESCRIPTION
When pulling an image, account for the specified OS and architecture
when looking up local images.  While a local image may be found based
on the specified name, the platform may be different from what the
user desires.  In that case, do not use the local image but continue
pulling.

Also remove pull-policy logic from the client.  That'll reduce one
roundtrip for the remote client and reduces code scattering.  The
backend should be the single source of truth for pull-policy handling.

Fixes: #8001
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>