### PR TITLE
[CI:DOCS] add a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+<!--
+Thanks for sending a pull request!
+
+Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).
+
+In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,10 @@ when the PR is merged.
 
 PRs will be approved by an [approver][owners] listed in [`OWNERS`](OWNERS).
 
+In case you're only changing docs, make sure to prefix the PR title with
+"[CI:DOCS]".  That will prevent functional tests from running and save time and
+energy.
+
 ### Describe your Changes in Commit Messages
 
 Describe your problem. Whether your patch is a one-line bug fix or 5000 lines


### PR DESCRIPTION
Add a pull-request template that points to the section in the
contributing guidelines and to remind users to use the `[CI:DOCS]`
prefix if applicable.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>