### PR TITLE
Ensure that --net=host/pod/container conflicts with -p

### DIFF
--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -27,19 +27,25 @@ const (
 	// Private indicates the namespace is private
 	Private NamespaceMode = "private"
 	// NoNetwork indicates no network namespace should
-	// be joined.  loopback should still exists
+	// be joined.  loopback should still exists.
+	// Only used with the network namespace, invalid otherwise.
 	NoNetwork NamespaceMode = "none"
 	// Bridge indicates that a CNI network stack
-	// should be used
+	// should be used.
+	// Only used with the network namespace, invalid otherwise.
 	Bridge NamespaceMode = "bridge"
 	// Slirp indicates that a slirp4netns network stack should
-	// be used
+	// be used.
+	// Only used with the network namespace, invalid otherwise.
 	Slirp NamespaceMode = "slirp4netns"
 	// KeepId indicates a user namespace to keep the owner uid inside
-	// of the namespace itself
+	// of the namespace itself.
+	// Only used with the user namespace, invalid otherwise.
 	KeepID NamespaceMode = "keep-id"
-	// KeepId indicates to automatically create a user namespace
+	// Auto indicates to automatically create a user namespace.
+	// Only used with the user namespace, invalid otherwise.
 	Auto NamespaceMode = "auto"
+
 	// DefaultKernelNamespaces is a comma-separated list of default kernel
 	// namespaces.
 	DefaultKernelNamespaces = "cgroup,ipc,net,uts"

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -522,4 +522,9 @@ json-file | f
     run_podman untag $IMAGE $newtag $newtag2
 }
 
+@test "podman run with --net=host and --port prints warning" {
+    run_podman run -d --rm -p 8080 --net=host $IMAGE ls > /dev/null
+    is "$output" ".*Port mappings have been discarded as one of the Host, Container, Pod, and None network modes are in use"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Setting port mappings only works when CNI is configuring our network (or slirp4netns, in the rootless case). This is not the case with `--net=host`, `--net=container:`, and joining the network namespace of the pod we are part of. Instead of allowing users to do these things and then be confused why they do nothing, let's actually return an error.
