### PR TITLE
fedora rootless cpu settings

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -613,12 +613,10 @@ func SkipIfRootlessCgroupsV1(reason string) {
 	}
 }
 
-func SkipIfUnprevilegedCPULimits() {
+func SkipIfUnprivilegedCPULimits() {
 	info := GetHostDistributionInfo()
-	if isRootless() &&
-		info.Distribution == "fedora" &&
-		(info.Version == "31" || info.Version == "32") {
-		ginkgo.Skip("Rootless Fedora doesn't have permission to set CPU limits before version 33")
+	if isRootless() && info.Distribution == "fedora" {
+		ginkgo.Skip("Rootless Fedora doesn't have permission to set CPU limits")
 	}
 }
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1406,7 +1406,7 @@ spec:
 	It("podman play kube allows setting resource limits", func() {
 		SkipIfContainerized("Resource limits require a running systemd")
 		SkipIfRootlessCgroupsV1("Limits require root or cgroups v2")
-		SkipIfUnprevilegedCPULimits()
+		SkipIfUnprivilegedCPULimits()
 		podmanTest.CgroupManager = "systemd"
 
 		var (


### PR DESCRIPTION
fedora does not have the the ability in rootless to set cpu limits.
this requires a simple fix for fedora 33 to pass ci tests.

Signed-off-by: baude <bbaude@redhat.com>