### PR TITLE
Use regex for "pod ps" name filter to match "ps" behavior

### DIFF
--- a/libpod/filters/pods.go
+++ b/libpod/filters/pods.go
@@ -1,6 +1,7 @@
 package lpfilters
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -78,7 +79,11 @@ func GeneratePodFilterFunc(filter, filterValue string) (
 		}, nil
 	case "name":
 		return func(p *libpod.Pod) bool {
-			return strings.Contains(p.Name(), filterValue)
+			match, err := regexp.MatchString(filterValue, p.Name())
+			if err != nil {
+				return false
+			}
+			return match
 		}, nil
 	case "status":
 		if !util.StringInSlice(filterValue, []string{"stopped", "running", "paused", "exited", "dead", "created"}) {

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -107,6 +107,28 @@ var _ = Describe("Podman ps", func() {
 		Expect(result.ExitCode()).To(Equal(0))
 	})
 
+	It("podman pod ps filter name regexp", func() {
+		_, ec, podid := podmanTest.CreatePod("mypod")
+		Expect(ec).To(Equal(0))
+		_, ec2, _ := podmanTest.CreatePod("mypod1")
+		Expect(ec2).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"pod", "ps", "-q", "--no-trunc", "--filter", "name=mypod"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		output := result.OutputToStringArray()
+		Expect(len(output)).To(Equal(2))
+
+		result = podmanTest.Podman([]string{"pod", "ps", "-q", "--no-trunc", "--filter", "name=mypod$"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		output = result.OutputToStringArray()
+		Expect(len(output)).To(Equal(1))
+		Expect(output[0]).To(Equal(podid))
+	})
+
 	It("podman pod ps mutually exclusive flags", func() {
 		session := podmanTest.Podman([]string{"pod", "ps", "-q", "--format", "{{.ID}}"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
`podman ps --filter name=containername` supports specifying a regular expression as the container name. This provides flexibility to match exact names using `^` and `$` to anchor the string. For example, a filter of `name=hello` would match containers `hello` and `othello`, but a filter of `name=^hello$` will only match a container named `hello`. This is a good and useful feature.

By contrast, `podman pod ps --filter name=podname` does not use regular expressions. Instead, it matches any pod name which contains the filter string.  As a result, there is no way to filter on `hello` without also matching `othello`.

This patch makes the behavior consistent across `podman ps` and `podman pod ps`.