### PR TITLE
Use /tmp/podman-run-* for backup XDG_RUNTIME_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,6 +493,8 @@ install.bin-nobuild:
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 bin/podman $(DESTDIR)$(BINDIR)/podman
 	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(DESTDIR)$(BINDIR)/podman bin/podman
+	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${TMPFILESDIR}
+	install ${SELINUXOPT} -m 644 contrib/tmpfile/podman.conf ${DESTDIR}${TMPFILESDIR}/podman.conf
 
 .PHONY: install.bin
 install.bin: podman install.bin-nobuild
@@ -531,14 +533,13 @@ install.docker: docker-docs
 .PHONY: install.varlink
 ifneq (,$(findstring varlink,$(BUILDTAGS)))
 install.varlink:
-	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR}  ${DESTDIR}${USERSYSTEMDDIR} ${DESTDIR}${TMPFILESDIR}
+	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR}  ${DESTDIR}${USERSYSTEMDDIR}
 	install ${SELINUXOPT} -m 644 contrib/varlink/io.podman.socket ${DESTDIR}${SYSTEMDDIR}/io.podman.socket
 	install ${SELINUXOPT} -m 644 contrib/varlink/io.podman.socket ${DESTDIR}${USERSYSTEMDDIR}/io.podman.socket
 	install ${SELINUXOPT} -m 644 contrib/varlink/io.podman.service ${DESTDIR}${SYSTEMDDIR}/io.podman.service
 	# User units are ordered differently, we can't make the *system* multi-user.target depend on a user unit.
 	# For user units the default.target that's the default is fine.
 	sed -e 's,^WantedBy=.*,WantedBy=default.target,' < contrib/varlink/io.podman.service > ${DESTDIR}${USERSYSTEMDDIR}/io.podman.service
-	install ${SELINUXOPT} -m 644 contrib/varlink/podman.conf ${DESTDIR}${TMPFILESDIR}/podman.conf
 else
 install.varlink:
 endif

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -509,6 +509,7 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/vendor:%{gopath}
 %{_usr}/lib/systemd/user/podman.socket
 %{_usr}/lib/systemd/user/podman-auto-update.service
 %{_usr}/lib/systemd/user/podman-auto-update.timer
+%{_usr}/lib/tmpfiles.d/podman.conf
 
 %if 0%{?with_devel}
 %files -n libpod-devel -f devel.file-list

--- a/contrib/tmpfile/podman.conf
+++ b/contrib/tmpfile/podman.conf
@@ -1,0 +1,4 @@
+# /tmp/podman-run-* directory can contain content for Podman containers that have run
+# for many days. This following line prevents systemd from removing this content.
+x /tmp/podman-run-.*
+d /run/podman 0700 root root

--- a/contrib/varlink/podman.conf
+++ b/contrib/varlink/podman.conf
@@ -1,1 +1,0 @@
-d /run/podman 0700 root root

--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -38,7 +38,7 @@ func GetRuntimeDir() (string, error) {
 			}
 		}
 		if runtimeDir == "" {
-			tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("run-%s", uid))
+			tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("podman-run-%s", uid))
 			if err := os.MkdirAll(tmpDir, 0700); err != nil {
 				logrus.Debug(err)
 			}


### PR DESCRIPTION
We need to block systemd from cleaning up this directory
by dropping a /usr/lib/tmpfiles.d/podman.conf file in place.

Fixes: https://github.com/containers/podman/issues/7852

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
