### PR TITLE
[CI:DOCS] fix: podman-system-service doc time is seconds

### DIFF
--- a/docs/source/markdown/podman-system-service.1.md
+++ b/docs/source/markdown/podman-system-service.1.md
@@ -21,8 +21,8 @@ Both APIs are versioned, but the server will not reject requests with an unsuppo
 
 **--time**, **-t**
 
-The time until the session expires in _milliseconds_. The default is 1
-second. A value of `0` means no timeout and the session will not expire.
+The time until the session expires in _seconds_. The default is 5
+seconds. A value of `0` means no timeout and the session will not expire.
 
 **--help**, **-h**
 


### PR DESCRIPTION
Podman man page states --time argument is in milliseconds, however it behaves as seconds.

https://github.com/containers/podman/blob/cdc50e9d195f8081d3a5dc69cc65ddd3f050497c/cmd/podman/system/service.go#L51