### PR TITLE
[ci:docs] Fix link to point at correct content

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Release notes for recent Podman versions.
 **[Contributing](CONTRIBUTING.md)**
 Information about contributing to this project.
 
-[spec-hooks]: https://github.com/opencontainers/runtime-spec/blob/v2.0.1/config.md#posix-platform-hooks
+[spec-hooks]: https://github.com/opencontainers/runtime-spec/blob/v1.0.2/config.md#posix-platform-hooks
 
 ## Buildah and Podman relationship
 


### PR DESCRIPTION
Version of runtime.spec was incorrect.

Fixes: https://github.com/containers/podman/issues/8244

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
