### PR TITLE
Use CPP, CC and flags in dep check scripts

### DIFF
--- a/hack/btrfs_installed_tag.sh
+++ b/hack/btrfs_installed_tag.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-cc -E - > /dev/null 2> /dev/null << EOF
+${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
 #include <btrfs/ioctl.h>
 EOF
 if test $? -ne 0 ; then

--- a/hack/btrfs_tag.sh
+++ b/hack/btrfs_tag.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-cc -E - > /dev/null 2> /dev/null << EOF
+${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
 #include <btrfs/version.h>
 EOF
 if test $? -ne 0 ; then

--- a/hack/libdm_tag.sh
+++ b/hack/libdm_tag.sh
@@ -2,7 +2,7 @@
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT
-cc -o "$tmpdir"/libdm_tag -ldevmapper -x c - > /dev/null 2> /dev/null << EOF
+${CC:-cc} ${CFLAGS} ${CPPFLAGS} ${LDFLAGS} -o "$tmpdir"/libdm_tag -x c - -ldevmapper > /dev/null 2> /dev/null << EOF
 #include <libdevmapper.h>
 int main() {
 	struct dm_task *task;

--- a/hack/systemd_tag.sh
+++ b/hack/systemd_tag.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-cc -E - > /dev/null 2> /dev/null << EOF
+${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
 #include <systemd/sd-daemon.h>
 EOF
 if test $? -eq 0 ; then


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
Similar to https://github.com/containers/buildah/pull/2751:

#### What this PR does / why we need it:

Allow build system without standard `cc` to successfully run the dependency checking helper scripts from the Makefile.
This supports custom compilers specified by the common `CC` environment variable, preprocessors given as `CPP` and additional preprocessor flags from `CPPFLAGS`.
Additionally, additional flags from `CFLAGS` and `LDFLAGS` are considered for compiling/linking.
Overall, this facilitates cross-compilation and similar setups (e.g., for building Conda packages at https://gitub.com/conda-forge).

#### How to verify it

Temporarily remove `cc` from `PATH` and point `CC`/`CPP` to a different compiler.
Install header files, e.g., `btrfs/ioctl.h`, in a custom location and set `CPPFLAGS=-I/custom/location`.
Add `-Wl,--as-needed` to `LDFLAGS` (which makes library order important (again) while linking) to confirm the order of the inputs `-` and `-ldevmapper` is correct in `libdm_tag.sh`.
