### PR TITLE
Show error on bad name filter in podman ps

### DIFF
--- a/libpod/filters/containers.go
+++ b/libpod/filters/containers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/podman/v2/pkg/timetype"
 	"github.com/containers/podman/v2/pkg/util"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // GenerateContainerFilterFuncs return ContainerFilter functions based of filter.
@@ -40,6 +41,7 @@ func GenerateContainerFilterFuncs(filter, filterValue string, r *libpod.Runtime)
 		return func(c *libpod.Container) bool {
 			match, err := regexp.MatchString(filterValue, c.Name())
 			if err != nil {
+				logrus.Errorf("Failed to compile regex for 'name' filter: %v", err)
 				return false
 			}
 			return match

--- a/libpod/filters/pods.go
+++ b/libpod/filters/pods.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/pkg/util"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // GeneratePodFilterFunc takes a filter and filtervalue (key, value)
@@ -81,6 +82,7 @@ func GeneratePodFilterFunc(filter, filterValue string) (
 		return func(p *libpod.Pod) bool {
 			match, err := regexp.MatchString(filterValue, p.Name())
 			if err != nil {
+				logrus.Errorf("Failed to compile regex for 'name' filter: %v", err)
 				return false
 			}
 			return match


### PR DESCRIPTION
See comments in #8238 where it was decided that a message should be logged when a bad name regex is used for filtering for `podman ps` and `podman pod ps`.



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->