### PR TITLE
Add --log-driver to play kube

### DIFF
--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -52,6 +52,7 @@ func init() {
 	flags.SetNormalizeFunc(utils.AliasFlags)
 	flags.StringVar(&kubeOptions.CredentialsCLI, "creds", "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
 	flags.StringVar(&kubeOptions.Network, "network", "", "Connect pod to CNI network(s)")
+	flags.StringVar(&kubeOptions.LogDriver, "log-driver", "", "Logging driver for the container")
 	flags.BoolVarP(&kubeOptions.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
 	flags.BoolVar(&kubeOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 	flags.StringVar(&kubeOptions.Authfile, "authfile", auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")

--- a/pkg/api/handlers/libpod/play.go
+++ b/pkg/api/handlers/libpod/play.go
@@ -22,6 +22,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	query := struct {
 		Network   string `schema:"reference"`
 		TLSVerify bool   `schema:"tlsVerify"`
+		LogDriver string `schema:"logDriver"`
 	}{
 		TLSVerify: true,
 	}
@@ -62,11 +63,12 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 	options := entities.PlayKubeOptions{
-		Authfile: authfile,
-		Username: username,
-		Password: password,
-		Network:  query.Network,
-		Quiet:    true,
+		Authfile:  authfile,
+		Username:  username,
+		Password:  password,
+		Network:   query.Network,
+		Quiet:     true,
+		LogDriver: query.LogDriver,
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)

--- a/pkg/api/server/register_play.go
+++ b/pkg/api/server/register_play.go
@@ -25,6 +25,10 @@ func (s *APIServer) registerPlayHandlers(r *mux.Router) error {
 	//    type: boolean
 	//    default: true
 	//    description: Require HTTPS and verify signatures when contacting registries.
+	//  - in: query
+	//    name: logDriver
+	//    type: string
+	//    description: Logging driver for the containers in the pod.
 	//  - in: body
 	//    name: request
 	//    description: Kubernetes YAML file.

--- a/pkg/bindings/play/play.go
+++ b/pkg/bindings/play/play.go
@@ -28,6 +28,7 @@ func Kube(ctx context.Context, path string, options entities.PlayKubeOptions) (*
 
 	params := url.Values{}
 	params.Set("network", options.Network)
+	params.Set("logDriver", options.LogDriver)
 	if options.SkipTLSVerify != types.OptionalBoolUndefined {
 		params.Set("tlsVerify", strconv.FormatBool(options.SkipTLSVerify == types.OptionalBoolTrue))
 	}

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -26,6 +26,8 @@ type PlayKubeOptions struct {
 	SeccompProfileRoot string
 	// ConfigMaps - slice of pathnames to kubernetes configmap YAMLs.
 	ConfigMaps []string
+	// LogDriver for the container. For example: journald
+	LogDriver string
 }
 
 // PlayKubePod represents a single pod and associated containers created by play kube

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -351,7 +351,8 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		if err != nil {
 			return nil, err
 		}
-		conf, err := kubeContainerToCreateConfig(ctx, container, newImage, namespaces, volumes, pod.ID(), podName, podInfraID, configMaps, seccompPaths)
+
+		conf, err := kubeContainerToCreateConfig(ctx, container, newImage, namespaces, volumes, pod.ID(), podName, podInfraID, configMaps, seccompPaths, options.LogDriver)
 		if err != nil {
 			return nil, err
 		}
@@ -464,7 +465,7 @@ func setupSecurityContext(securityConfig *createconfig.SecurityConfig, userConfi
 }
 
 // kubeContainerToCreateConfig takes a v1.Container and returns a createconfig describing a container
-func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container, newImage *image.Image, namespaces map[string]string, volumes map[string]string, podID, podName, infraID string, configMaps []v1.ConfigMap, seccompPaths *kubeSeccompPaths) (*createconfig.CreateConfig, error) {
+func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container, newImage *image.Image, namespaces map[string]string, volumes map[string]string, podID, podName, infraID string, configMaps []v1.ConfigMap, seccompPaths *kubeSeccompPaths, logDriver string) (*createconfig.CreateConfig, error) {
 	var (
 		containerConfig createconfig.CreateConfig
 		pidConfig       createconfig.PidConfig
@@ -592,6 +593,10 @@ func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container
 	containerConfig.Cgroup = cgroupConfig
 	containerConfig.User = userConfig
 	containerConfig.Security = securityConfig
+
+	if logDriver != "" {
+		containerConfig.LogDriver = logDriver
+	}
 
 	annotations := make(map[string]string)
 	if infraID != "" {

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1466,4 +1466,20 @@ MemoryReservation: {{ .HostConfig.MemoryReservation }}`})
 		Expect(kube.ExitCode()).To(Equal(125))
 		Expect(kube.ErrorToString()).To(ContainSubstring(invalidImageName))
 	})
+
+	It("podman play kube applies log driver to containers", func() {
+		Skip("need to verify images have correct packages for journald")
+		pod := getPod()
+		err := generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).To(BeNil())
+
+		kube := podmanTest.Podman([]string{"play", "kube", "--log-driver", "journald", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", getCtrNameInPod(pod), "--format", "'{{ .HostConfig.LogConfig.Type }}'"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(Equal(0))
+		Expect(inspect.OutputToString()).To(ContainSubstring("journald"))
+	})
 })


### PR DESCRIPTION
To integrate container/pod logs into systemd service and journalctl, we can use `--log-driver=journald` on `podman create` and `podman run`. However `play kube` doesn't have the option yet. So, this PR adds it to `play kube`.

Addresses #6604 



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
