### PR TITLE
Stop binding layer from changing line endings

### DIFF
--- a/pkg/bindings/containers/logs.go
+++ b/pkg/bindings/containers/logs.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -64,7 +63,6 @@ func Logs(ctx context.Context, nameOrID string, opts LogOptions, stdoutChan, std
 		if err != nil {
 			return err
 		}
-		frame = bytes.Replace(frame[0:l], []byte{13}, []byte{10}, -1)
 
 		switch fd {
 		case 0:


### PR DESCRIPTION
The binding layer attempted to help the CLI, which just made things
worse.

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
