### PR TITLE
system tests: skip journald tests on RHEL8

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -436,6 +436,16 @@ json-file | f
 @test "podman run --log-driver journald" {
     skip_if_remote "We cannot read journalctl over remote."
 
+    # We can't use journald on RHEL as rootless, either: rhbz#1895105
+    if is_rootless; then
+        run journalctl -n 1
+        if [[ $status -ne 0 ]]; then
+            if [[ $output =~ permission ]]; then
+                skip "Cannot use rootless journald on this system"
+            fi
+        fi
+    fi
+
     msg=$(random_string 20)
     pidfile="${PODMAN_TMPDIR}/$(random_string 20)"
 

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -51,6 +51,16 @@ ${cid[0]} d"   "Sequential output from logs"
 }
 
 @test "podman logs over journald" {
+    # We can't use journald on RHEL as rootless: rhbz#1895105
+    if is_rootless; then
+        run journalctl -n 1
+        if [[ $status -ne 0 ]]; then
+            if [[ $output =~ permission ]]; then
+                skip "Cannot use rootless journald on this system"
+            fi
+        fi
+    fi
+
     msg=$(random_string 20)
 
     run_podman run --name myctr --log-driver journald $IMAGE echo $msg


### PR DESCRIPTION
(actually, on any system exhibiting the symptom wherein
journalctl --user fails due to insufficient permissions,
which for all practical purposes means only RHEL8)

Signed-off-by: Ed Santiago <santiago@redhat.com>
