### PR TITLE
make network name uniq for dnsname tests

### DIFF
--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	. "github.com/containers/podman/v2/test/utils"
+	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/uber/jaeger-client-go/utils"
@@ -601,11 +602,11 @@ var _ = Describe("Podman run networking", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(BeZero())
 
-		net := "dnsNetTest"
+		net := "IntTest" + stringid.GenerateNonCryptoID()
 		session = podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(BeZero())
 		defer podmanTest.removeCNINetwork(net)
+		Expect(session.ExitCode()).To(BeZero())
 
 		pod2 := "testpod2"
 		session = podmanTest.Podman([]string{"pod", "create", "--network", net, "--name", pod2})


### PR DESCRIPTION
ed identified that the dnsname integration test does not use a unique
name and therefore cannot be cleaned up.  this was made worse by a
improper defer statement to remove the network should the test fail.

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
