### PR TITLE
Add podman(1) to the list of man pages on docs.podman.io

### DIFF
--- a/docs/source/Commands.rst
+++ b/docs/source/Commands.rst
@@ -3,6 +3,7 @@
 Commands
 ========
 
+:doc:`Podman <markdown/podman.1>` (Pod Manager) Global Options
 
 :doc:`attach <markdown/podman-attach.1>` Attach to a running container
 


### PR DESCRIPTION
As the title says.

Addresses: #7219

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
