### PR TITLE
Change podman build --pull=true to PullIfMissing

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -249,7 +249,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 	}
 
 	if flags.PullNever {
-		pullPolicy = imagebuildah.PullNever
+		pullPolicy = imagebuildah.PullIfMissing
 	}
 
 	args := make(map[string]string)

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -438,9 +438,9 @@ When the option is specified or set to "true", pull the image from the first
 registry it is found in as listed in registries.conf.  Raise an error if not
 found in the registries, even if the image is present locally.
 
-If the option is disabled (with *--pull=false*), or not specified, pull the
+If the option is disabled (with *--pull=false*) or not specified, pull the
 image from the registry only if the image is not present locally. Raise an
-error if the image is not found in the registries.
+error if the image is not found in the registries and is not present locally.
 
 #### **--pull-always**
 


### PR DESCRIPTION
One last tweak to the man page for 'build --pull' and after
further testing against Docker, one slight change to the
pull policy.  First I changed `--pull=false` from PullNever
to PullIfMissing.  This matches Docker and will pull the
image if it's not present rather than erroring.  We've
the `--pull-never` option if someone wants the pull to
not do an actual pull and to error if the image isn't
local.

Then for the man page, I'd a much bigger change, in the
initial PR, I've backed most of that out and just
added a tweak.
Hopefully, this puts this portion of the pull work behind
us for a while.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
