### PR TITLE
Cleanup error reporting

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -556,7 +556,7 @@ func (r *Runtime) setupRootlessPortMappingViaRLK(ctr *Container, netnsPath strin
 		if stdoutStr != "" {
 			// err contains full debug log and too verbose, so return stdoutStr
 			logrus.Debug(err)
-			return errors.Errorf("failed to expose ports via rootlessport: %q", stdoutStr)
+			return errors.Errorf("rootlessport " + strings.TrimSuffix(stdoutStr, "\n"))
 		}
 		return err
 	}


### PR DESCRIPTION
The error message reported is overlay complicated and the added test does not
really help the user.

Currently the error looks like:

podman run -p 80:80 fedora echo hello
Error: failed to expose ports via rootlessport: "cannot expose privileged port 80, you might need to add "net.ipv4.ip_unprivileged_port_start=0" (currently 1024) to /etc/sysctl.conf, or choose a larger port number (>= 1024): listen tcp 0.0.0.0:80: bind: permission denied\n"

After this change

./bin/podman run -p 80:80 fedora echo hello
Error: cannot expose privileged port 80, you might need to add "net.ipv4.ip_unprivileged_port_start=0" (currently 1024) to /etc/sysctl.conf, or choose a larger port number (>= 1024): listen tcp 0.0.0.0:80: bind: permission denied

Control chars have been eliminated.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
