### PR TITLE
Refactor to use DockerClient vs APIClient

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,9 +17,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'Podman'
-copyright = '2019, team'
-author = 'team'
+project = "Podman"
+copyright = "2019, team"
+author = "team"
 
 
 # -- General configuration ---------------------------------------------------
@@ -28,33 +28,33 @@ author = 'team'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'recommonmark',
+    "recommonmark",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
-master_doc = 'index'
+master_doc = "index"
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 html_css_files = [
-    'custom.css',
+    "custom.css",
 ]
 
 # -- Extension configuration -------------------------------------------------

--- a/test/apiv2/rest_api/test_rest_v2_0_0.py
+++ b/test/apiv2/rest_api/test_rest_v2_0_0.py
@@ -165,11 +165,34 @@ class TestApi(unittest.TestCase):
         r = requests.get(_url(ctnr("/containers/{}/logs?stdout=true")))
         self.assertEqual(r.status_code, 200, r.text)
 
-    def test_post_create(self):
-        self.skipTest("TODO: create request body")
-        r = requests.post(_url("/containers/create?args=True"))
-        self.assertEqual(r.status_code, 200, r.text)
-        json.loads(r.text)
+    def test_post_create_compat(self):
+        """Create network and container then connect to network"""
+        net = requests.post(
+            PODMAN_URL + "/v1.40/networks/create", json={"Name": "TestNetwork"}
+        )
+        self.assertEqual(net.status_code, 201, net.text)
+
+        create = requests.post(
+            PODMAN_URL + "/v1.40/containers/create?name=postCreate",
+            json={
+                "Cmd": ["date"],
+                "Image": "alpine:latest",
+                "NetworkDisabled": False,
+                "NetworkConfig": {
+                    "EndpointConfig": {"TestNetwork": {"Aliases": ["test_post_create"]}}
+                },
+            },
+        )
+        self.assertEqual(create.status_code, 201, create.text)
+        payload = json.loads(create.text)
+        self.assertIsNotNone(payload["Id"])
+
+        connect = requests.post(
+            PODMAN_URL + "/v1.40/networks/TestNetwork/connect",
+            json={"Container": payload["Id"]},
+        )
+        self.assertEqual(connect.status_code, 200, create.text)
+        self.assertEqual(connect.text, "OK\n")
 
     def test_commit(self):
         r = requests.post(_url(ctnr("/commit?container={}")))

--- a/test/python/docker/common.py
+++ b/test/python/docker/common.py
@@ -1,21 +1,23 @@
-from docker import APIClient
+from docker import DockerClient
 
 from test.python.docker import constant
 
 
-def run_top_container(client: APIClient):
-    c = client.create_container(
+def run_top_container(client: DockerClient):
+    c = client.containers.create(
         constant.ALPINE, command="top", detach=True, tty=True, name="top"
     )
-    client.start(c.get("Id"))
-    return c.get("Id")
+    c.start()
+    return c.id
 
 
-def remove_all_containers(client: APIClient):
-    for ctnr in client.containers(quiet=True):
-        client.remove_container(ctnr, force=True)
+def remove_all_containers(client: DockerClient):
+    for ctnr in client.containers.list(all=True):
+        ctnr.remove(force=True)
 
 
-def remove_all_images(client: APIClient):
-    for image in client.images(quiet=True):
-        client.remove_image(image, force=True)
+def remove_all_images(client: DockerClient):
+    for img in client.images.list():
+        # FIXME should DELETE /images accept the sha256: prefix?
+        id_ = img.id.removeprefix("sha256:")
+        client.images.remove(id_, force=True)

--- a/test/python/docker/test_containers.py
+++ b/test/python/docker/test_containers.py
@@ -3,7 +3,7 @@ import sys
 import time
 import unittest
 
-from docker import APIClient, errors
+from docker import DockerClient, errors
 
 from test.python.docker import Podman, common, constant
 
@@ -15,7 +15,7 @@ class TestContainers(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client = APIClient(base_url="tcp://127.0.0.1:8080", timeout=15)
+        self.client = DockerClient(base_url="tcp://127.0.0.1:8080", timeout=15)
         TestContainers.podman.restore_image_from_cache(self.client)
         TestContainers.topContainerId = common.run_top_container(self.client)
         self.assertIsNotNone(TestContainers.topContainerId)
@@ -52,146 +52,115 @@ class TestContainers(unittest.TestCase):
         TestContainers.podman.tear_down()
         return super().tearDownClass()
 
-    def test_inspect_container(self):
-        # Inspect bogus container
-        with self.assertRaises(errors.NotFound) as error:
-            self.client.inspect_container("dummy")
-        self.assertEqual(error.exception.response.status_code, 404)
-
-        # Inspect valid container by Id
-        container = self.client.inspect_container(TestContainers.topContainerId)
-        self.assertIn("top", container["Name"])
-
-        # Inspect valid container by name
-        container = self.client.inspect_container("top")
-        self.assertIn(TestContainers.topContainerId, container["Id"])
-
     def test_create_container(self):
         # Run a container with detach mode
-        container = self.client.create_container(image="alpine", detach=True)
-        self.assertEqual(len(container), 2)
+        self.client.containers.create(image="alpine", detach=True)
+        self.assertEqual(len(self.client.containers.list(all=True)), 2)
+
+    def test_create_network(self):
+        net = self.client.networks.create("testNetwork", driver="bridge")
+        ctnr = self.client.containers.create(image="alpine", detach=True)
+        net.connect(ctnr)
+
+        nets = self.client.networks.list(greedy=True)
+        self.assertGreaterEqual(len(nets), 1)
+
+        # TODO fix endpoint to include containers
+        # for n in nets:
+        #     if n.id == "testNetwork":
+        #         self.assertEqual(ctnr.id, n.containers)
+        # self.assertTrue(False, "testNetwork not found")
 
     def test_start_container(self):
-        # Start bogus container
-        with self.assertRaises(errors.NotFound) as error:
-            self.client.start("dummy")
-        self.assertEqual(error.exception.response.status_code, 404)
-
         # Podman docs says it should give a 304 but returns with no response
         # # Start a already started container should return 304
-        # response = self.client.start(container=TestContainers.topContainerId)
+        # response = self.client.api.start(container=TestContainers.topContainerId)
         # self.assertEqual(error.exception.response.status_code, 304)
 
         # Create a new container and validate the count
-        self.client.create_container(image=constant.ALPINE, name="container2")
-        containers = self.client.containers(quiet=True, all=True)
+        self.client.containers.create(image=constant.ALPINE, name="container2")
+        containers = self.client.containers.list(all=True)
         self.assertEqual(len(containers), 2)
 
     def test_stop_container(self):
-        # Stop bogus container
-        with self.assertRaises(errors.NotFound) as error:
-            self.client.stop("dummy")
-        self.assertEqual(error.exception.response.status_code, 404)
-
-        # Validate the container state
-        container = self.client.inspect_container("top")
-        self.assertEqual(container["State"]["Status"], "running")
+        top = self.client.containers.get("top")
+        self.assertEqual(top.status, "running")
 
         # Stop a running container and validate the state
-        self.client.stop(TestContainers.topContainerId)
-        container = self.client.inspect_container("top")
-        self.assertIn(
-            container["State"]["Status"],
-            "stopped exited",
-        )
+        top.stop()
+        top.reload()
+        self.assertIn(top.status, ("stopped", "exited"))
 
     def test_restart_container(self):
-        # Restart bogus container
-        with self.assertRaises(errors.NotFound) as error:
-            self.client.restart("dummy")
-        self.assertEqual(error.exception.response.status_code, 404)
-
         # Validate the container state
-        self.client.stop(TestContainers.topContainerId)
-        container = self.client.inspect_container("top")
-        self.assertEqual(container["State"]["Status"], "stopped")
+        top = self.client.containers.get(TestContainers.topContainerId)
+        top.stop()
+        top.reload()
+        self.assertIn(top.status, ("stopped", "exited"))
 
         # restart a running container and validate the state
-        self.client.restart(TestContainers.topContainerId)
-        container = self.client.inspect_container("top")
-        self.assertEqual(container["State"]["Status"], "running")
+        top.restart()
+        top.reload()
+        self.assertEqual(top.status, "running")
 
     def test_remove_container(self):
-        # Remove bogus container
-        with self.assertRaises(errors.NotFound) as error:
-            self.client.remove_container("dummy")
-        self.assertEqual(error.exception.response.status_code, 404)
-
         # Remove container by ID with force
-        self.client.remove_container(TestContainers.topContainerId, force=True)
-        containers = self.client.containers()
-        self.assertEqual(len(containers), 0)
+        top = self.client.containers.get(TestContainers.topContainerId)
+        top.remove(force=True)
+        self.assertEqual(len(self.client.containers.list()), 0)
 
     def test_remove_container_without_force(self):
         # Validate current container count
-        containers = self.client.containers()
-        self.assertTrue(len(containers), 1)
+        self.assertTrue(len(self.client.containers.list()), 1)
 
         # Remove running container should throw error
+        top = self.client.containers.get(TestContainers.topContainerId)
         with self.assertRaises(errors.APIError) as error:
-            self.client.remove_container(TestContainers.topContainerId)
+            top.remove()
         self.assertEqual(error.exception.response.status_code, 500)
 
-        # Remove container by ID with force
-        self.client.stop(TestContainers.topContainerId)
-        self.client.remove_container(TestContainers.topContainerId)
-        containers = self.client.containers()
-        self.assertEqual(len(containers), 0)
+        # Remove container by ID without force
+        top.stop()
+        top.remove()
+        self.assertEqual(len(self.client.containers.list()), 0)
 
     def test_pause_container(self):
-        # Pause bogus container
-        with self.assertRaises(errors.NotFound) as error:
-            self.client.pause("dummy")
-        self.assertEqual(error.exception.response.status_code, 404)
-
         # Validate the container state
-        container = self.client.inspect_container("top")
-        self.assertEqual(container["State"]["Status"], "running")
+        top = self.client.containers.get(TestContainers.topContainerId)
+        self.assertEqual(top.status, "running")
 
         # Pause a running container and validate the state
-        self.client.pause(container["Id"])
-        container = self.client.inspect_container("top")
-        self.assertEqual(container["State"]["Status"], "paused")
+        top.pause()
+        top.reload()
+        self.assertEqual(top.status, "paused")
 
     def test_pause_stopped_container(self):
         # Stop the container
-        self.client.stop(TestContainers.topContainerId)
+        top = self.client.containers.get(TestContainers.topContainerId)
+        top.stop()
 
         # Pause exited container should trow error
         with self.assertRaises(errors.APIError) as error:
-            self.client.pause(TestContainers.topContainerId)
+            top.pause()
         self.assertEqual(error.exception.response.status_code, 500)
 
     def test_unpause_container(self):
-        # Unpause bogus container
-        with self.assertRaises(errors.NotFound) as error:
-            self.client.unpause("dummy")
-        self.assertEqual(error.exception.response.status_code, 404)
+        top = self.client.containers.get(TestContainers.topContainerId)
 
         # Validate the container state
-        self.client.pause(TestContainers.topContainerId)
-        container = self.client.inspect_container("top")
-        self.assertEqual(container["State"]["Status"], "paused")
+        top.pause()
+        top.reload()
+        self.assertEqual(top.status, "paused")
 
         # Pause a running container and validate the state
-        self.client.unpause(TestContainers.topContainerId)
-        container = self.client.inspect_container("top")
-        self.assertEqual(container["State"]["Status"], "running")
+        top.unpause()
+        top.reload()
+        self.assertEqual(top.status, "running")
 
     def test_list_container(self):
         # Add container and validate the count
-        self.client.create_container(image="alpine", detach=True)
-        containers = self.client.containers(all=True)
+        self.client.containers.create(image="alpine", detach=True)
+        containers = self.client.containers.list(all=True)
         self.assertEqual(len(containers), 2)
 
     def test_filters(self):
@@ -199,16 +168,18 @@ class TestContainers(unittest.TestCase):
 
         # List container with filter by id
         filters = {"id": TestContainers.topContainerId}
-        ctnrs = self.client.containers(all=True, filters=filters)
+        ctnrs = self.client.containers.list(all=True, filters=filters)
         self.assertEqual(len(ctnrs), 1)
 
         # List container with filter by name
         filters = {"name": "top"}
-        ctnrs = self.client.containers(all=True, filters=filters)
+        ctnrs = self.client.containers.list(all=True, filters=filters)
         self.assertEqual(len(ctnrs), 1)
 
     def test_rename_container(self):
+        top = self.client.containers.get(TestContainers.topContainerId)
+
         # rename bogus container
         with self.assertRaises(errors.APIError) as error:
-            self.client.rename(container="dummy", name="newname")
+            top.rename(name="newname")
         self.assertEqual(error.exception.response.status_code, 404)

--- a/test/python/docker/test_system.py
+++ b/test/python/docker/test_system.py
@@ -3,7 +3,7 @@ import sys
 import time
 import unittest
 
-from docker import APIClient
+from docker import DockerClient
 
 from test.python.docker import Podman, common, constant
 
@@ -15,7 +15,7 @@ class TestSystem(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client = APIClient(base_url="tcp://127.0.0.1:8080", timeout=15)
+        self.client = DockerClient(base_url="tcp://127.0.0.1:8080", timeout=15)
 
         TestSystem.podman.restore_image_from_cache(self.client)
         TestSystem.topContainerId = common.run_top_container(self.client)
@@ -58,9 +58,10 @@ class TestSystem(unittest.TestCase):
     def test_info_container_details(self):
         info = self.client.info()
         self.assertEqual(info["Containers"], 1)
-        self.client.create_container(image=constant.ALPINE)
+        self.client.containers.create(image=constant.ALPINE)
         info = self.client.info()
         self.assertEqual(info["Containers"], 2)
 
     def test_version(self):
-        self.assertIsNotNone(self.client.version())
+        version = self.client.version()
+        self.assertIsNotNone(version["Platform"]["Name"])


### PR DESCRIPTION
* Update tests and framework
* remove tests for APIClient methods

Moving to a higher level abstraction.

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
