### PR TITLE
system tests: various

### DIFF
--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -3,10 +3,18 @@
 load helpers
 
 @test "podman images - basic output" {
-    run_podman images -a
+    headings="REPOSITORY *TAG *IMAGE ID *CREATED *SIZE"
 
-    is "${lines[0]}" "REPOSITORY *TAG *IMAGE ID *CREATED *SIZE" "header line"
+    run_podman images -a
+    is "${lines[0]}" "$headings" "header line"
     is "${lines[1]}" "$PODMAN_TEST_IMAGE_REGISTRY/$PODMAN_TEST_IMAGE_USER/$PODMAN_TEST_IMAGE_NAME *$PODMAN_TEST_IMAGE_TAG *[0-9a-f]\+" "podman images output"
+
+    # 'podman images' should emit headings even if there are no images
+    # (but --root only works locally)
+    if ! is_remote; then
+        run_podman --root ${PODMAN_TMPDIR}/nothing-here-move-along images
+        is "$output" "$headings" "'podman images' emits headings even w/o images"
+    fi
 }
 
 @test "podman images - custom formats" {

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -162,7 +162,8 @@ EOF
     myvol=myvol$(random_string)
     rand=$(random_string)
 
-    run_podman run --rm -v $myvol:/myvol:z $IMAGE \
+    # Duplicate "-v" confirms #8307, fix for double-lock on same volume
+    run_podman run --rm -v $myvol:/myvol:z -v $myvol:/myvol2:z $IMAGE \
                sh -c "echo $rand >/myvol/myfile"
     run_podman volume ls -q
     is "$output" "$myvol" "autocreated named container persists"


### PR DESCRIPTION
- images: confirm that 'podman images' emits headings
  even if there are no images present. Intended to
  replace e2e test which is difficult to get working
  under podman-remote.

- build: add test for #8092, podman-build gobbling stdin.

- volumes: add test for #8307, double-lock on same volume

Signed-off-by: Ed Santiago <santiago@redhat.com>