### PR TITLE
Fix namespace flag parsing for podman build

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/utils"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/docker/go-units"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -315,20 +314,9 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		}
 	}
 
-	nsValues, err := getNsValues(flags)
+	nsValues, networkPolicy, err := parse.NamespaceOptions(c)
 	if err != nil {
 		return nil, err
-	}
-
-	networkPolicy := buildah.NetworkDefault
-	for _, ns := range nsValues {
-		if ns.Name == "none" {
-			networkPolicy = buildah.NetworkDisabled
-			break
-		} else if !filepath.IsAbs(ns.Path) {
-			networkPolicy = buildah.NetworkEnabled
-			break
-		}
 	}
 
 	// `buildah bud --layers=false` acts like `docker build --squash` does.
@@ -450,29 +438,4 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 	}
 
 	return &entities.BuildOptions{BuildOptions: opts}, nil
-}
-
-func getNsValues(flags *buildFlagsWrapper) ([]buildah.NamespaceOption, error) {
-	var ret []buildah.NamespaceOption
-	if flags.Network != "" {
-		switch {
-		case flags.Network == "host":
-			ret = append(ret, buildah.NamespaceOption{
-				Name: string(specs.NetworkNamespace),
-				Host: true,
-			})
-		case flags.Network == "container":
-			ret = append(ret, buildah.NamespaceOption{
-				Name: string(specs.NetworkNamespace),
-			})
-		case flags.Network[0] == '/':
-			ret = append(ret, buildah.NamespaceOption{
-				Name: string(specs.NetworkNamespace),
-				Path: flags.Network,
-			})
-		default:
-			return nil, errors.Errorf("unsupported configuration network=%s", flags.Network)
-		}
-	}
-	return ret, nil
 }

--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -128,6 +128,7 @@ func buildFlags(flags *pflag.FlagSet) {
 	}
 	flags.AddFlagSet(&fromAndBudFlags)
 	_ = flags.MarkHidden("signature-policy")
+	flags.SetNormalizeFunc(buildahCLI.AliasFlags)
 }
 
 // build executes the build command.

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -394,7 +394,7 @@ The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kilobytes), `m` (megabytes), or `g` (gigabytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
-#### **--network**=*mode*
+#### **--network**=*mode*, **--net**
 
 Sets the configuration for network namespaces when handling `RUN` instructions.
 


### PR DESCRIPTION
The namespace options for pid,ipc,uts were completely ignored.
The network namespace did not accept `none`.

This commit fixes these issues simply by calling `parse.NamespaceOptions`
from buildah instead of implementing our own logic.

Also add podman build `--net` alias for `--network`

Fixes #8322

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
