### PR TITLE
test for buildah version in container images.

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/containers/buildah"
 	. "github.com/containers/podman/v2/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -238,5 +239,17 @@ RUN printenv http_proxy`
 		ok, _ := session.GrepString("1.2.3.4")
 		Expect(ok).To(BeTrue())
 		os.Unsetenv("http_proxy")
+	})
+
+	It("podman build and check identity", func() {
+		session := podmanTest.Podman([]string{"build", "-f", "Containerfile.path", "--no-cache", "-t", "test", "build/basicalpine"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		// Verify that OS and Arch are being set
+		inspect := podmanTest.PodmanNoCache([]string{"image", "inspect", "--format", "{{ index .Config.Labels }}", "test"})
+		inspect.WaitWithDefaultTimeout()
+		data := inspect.OutputToString()
+		Expect(data).To(ContainSubstring(buildah.Version))
 	})
 })

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -198,7 +198,7 @@ WORKDIR /test
 		Expect(result.OutputToString()).To(Equal("/test"))
 	})
 
-	It("podman images filter after image", func() {
+	It("podman images filter since image", func() {
 		podmanTest.RestoreAllArtifacts()
 		rmi := podmanTest.PodmanNoCache([]string{"rmi", "busybox"})
 		rmi.WaitWithDefaultTimeout()
@@ -207,7 +207,7 @@ WORKDIR /test
 		dockerfile := `FROM quay.io/libpod/alpine:latest
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
-		result := podmanTest.PodmanNoCache([]string{"images", "-q", "-f", "after=quay.io/libpod/alpine:latest"})
+		result := podmanTest.PodmanNoCache([]string{"images", "-q", "-f", "since=quay.io/libpod/alpine:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
 		Expect(len(result.OutputToStringArray())).To(Equal(0))

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -221,6 +221,11 @@ EOF
     run_podman run --rm build_test pwd
     is "$output" "$workdir" "pwd command in container"
 
+    # Determine buildah version, so we can confirm it gets into Labels
+    run_podman info --format '{{ .Host.BuildahVersion }}'
+    is "$output" "[1-9][0-9.-]\+" ".Host.BuildahVersion is reasonable"
+    buildah_version=$output
+
     # Confirm that 'podman inspect' shows the expected values
     # FIXME: can we rely on .Env[0] being PATH, and the rest being in order??
     run_podman image inspect build_test
@@ -239,6 +244,7 @@ Cmd[0]             | /bin/mydefaultcmd
 Cmd[1]             | $s_echo
 WorkingDir         | $workdir
 Labels.$label_name | $label_value
+Labels.\"io.buildah.version\" | $buildah_version
 "
 
     parse_table "$tests" | while read field expect; do


### PR DESCRIPTION
Check to see if we are recording the version of buildah
used to build the image as a label in the image.

Also we should make sure the filter "since" works.
We are only testing "after", which we don't document.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
