### PR TITLE
[CI:DOCS] Add missing --now in systemctl start command

### DIFF
--- a/docs/tutorials/mac_win_client.md
+++ b/docs/tutorials/mac_win_client.md
@@ -29,9 +29,9 @@ $ brew install podman
 
 ### Enable the Podman service on the server machine.
 
-Before performing any  Podman client commands, you must enable the podman.sock SystemD service on the Linux server.  In these examples, we are running Podman as a normal, unprivileged user, also known as a rootless user.  By default, the rootless socket listens at  `/run/user/${UID}/podman/podman.sock`.  You can enable this socket, permanently using the following command:
+Before performing any  Podman client commands, you must enable the podman.sock SystemD service on the Linux server.  In these examples, we are running Podman as a normal, unprivileged user, also known as a rootless user.  By default, the rootless socket listens at  `/run/user/${UID}/podman/podman.sock`.  You can enable and start this socket permanently, using the following commands:
 ```
-$ systemctl --user enable podman.socket
+$ systemctl --user enable --now podman.socket
 ```
 You will need to enable linger for this user in order for the socket to work when the user is not logged in.
 


### PR DESCRIPTION
If you don't use --now or also run systemctl --user start podman.socket
then the socket won't start until a reboot.  Much easier to just start
the socket at the same time as enabling it.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
