### PR TITLE
Podman-remote build is getting ID twice

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -272,15 +272,13 @@ loop:
 			flush()
 		case <-runCtx.Done():
 			if !failed {
-				if utils.IsLibpodRequest(r) {
-					m.Stream = imageID
-				} else {
+				if !utils.IsLibpodRequest(r) {
 					m.Stream = fmt.Sprintf("Successfully built %12.12s\n", imageID)
+					if err := enc.Encode(m); err != nil {
+						logrus.Warnf("Failed to json encode error %q", err.Error())
+					}
+					flush()
 				}
-				if err := enc.Encode(m); err != nil {
-					logrus.Warnf("Failed to json encode error %q", err.Error())
-				}
-				flush()
 			}
 			break loop
 		}

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -187,7 +187,7 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		case s.Stream != "":
 			stdout.Write([]byte(s.Stream))
 			if re.Match([]byte(s.Stream)) {
-				id = s.Stream
+				id = strings.TrimSuffix(s.Stream, "\n")
 			}
 		case s.Error != "":
 			return nil, errors.New(s.Error)


### PR DESCRIPTION
This PR eliminates the second sending of the image id to the
podman-remote client.

Fixes: https://github.com/containers/podman/issues/8332

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
