### PR TITLE
Set podman-auto-update.service Type=oneshot

### DIFF
--- a/contrib/systemd/auto-update/podman-auto-update.service
+++ b/contrib/systemd/auto-update/podman-auto-update.service
@@ -5,6 +5,7 @@ Wants=network.target
 After=network-online.target
 
 [Service]
+Type=oneshot
 ExecStart=/usr/bin/podman auto-update
 
 [Install]


### PR DESCRIPTION
This allows a user to easily crate a `container-prune.service` that runs after `podman-auto-update.service` and cleans up any left over images.

Without this change one has to sleep the prune service or run it on a separate timer since they would start at the same time.

Example service utilizing this change:
```
[Unit]
After=podman-auto-update.service

[Service]
ExecStart=podman image prune --force

[Install]
WantedBy=podman-auto-update.service
```