### PR TITLE
[CI:DOCS] Touch up Podman description in man page menu

### DIFF
--- a/docs/source/Commands.rst
+++ b/docs/source/Commands.rst
@@ -3,7 +3,7 @@
 Commands
 ========
 
-:doc:`Podman <markdown/podman.1>` (Pod Manager) Global Options
+:doc:`Podman <markdown/podman.1>` (Pod Manager) Global Options, Environment Variables, Exit Codes, Configuration Files, and more
 
 :doc:`attach <markdown/podman-attach.1>` Attach to a running container
 

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -168,7 +168,7 @@ podman --remote flag, only the global options `--url`, `--identity`, `--log-leve
 
 Connection information can also be managed using the containers.conf file.
 
-## Exit Status
+## Exit Codes
 
 The exit code from `podman` gives information about why the container
 failed to run or why it exited.  When `podman` commands exit with a non-zero code,
@@ -257,7 +257,7 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-volume(1)](podman-volume.1.md)           | Simple management tool for volumes.                                         |
 | [podman-wait(1)](podman-wait.1.md)               | Wait on one or more containers to stop and print their exit codes.          |
 
-## FILES
+## CONFIGURATION FILES
 
 **containers.conf** (`/usr/share/containers/containers.conf`, `/etc/containers/containers.conf`, `$HOME/.config/containers/containers.conf`)
 


### PR DESCRIPTION
The title for the Podman man page on the commands menu was a little
light, adding a few more words to it.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
