### PR TITLE
Cirrus: Invalidate static cache on VM image update

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -362,7 +362,8 @@ static_alt_build_task:
     # this cache ensures only the static podman binary is built.
     nix_cache:
         folder: '/var/cache/nix'
-        fingerprint_script: cat nix/*
+        # Cirrus will calculate/use sha of this output as the cache key
+        fingerprint_script: echo "${IMAGE_SUFFIX}" && cat nix/*
     setup_script: *setup
     main_script: *main
     always: *binary_artifacts


### PR DESCRIPTION
Fixes: #8313

It's important to periodically update the nix cache (about 1GB in size).
If not, it can grow stale and has been observed causing task failures.
Associating the nix cache update with a VM/Container image update,
ensures it happens first in PRs where environment-related failures
are less surprising.

Signed-off-by: Chris Evich <cevich@redhat.com>
