### PR TITLE
Add support for volume ls --filter label=key=value

### DIFF
--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -73,11 +73,11 @@ func list(cmd *cobra.Command, args []string) error {
 		lsOpts.Filter = make(map[string][]string)
 	}
 	for _, f := range cliOpts.Filter {
-		filterSplit := strings.Split(f, "=")
+		filterSplit := strings.SplitN(f, "=", 2)
 		if len(filterSplit) < 2 {
 			return errors.Errorf("filter input must be in the form of filter=value: %s is invalid", f)
 		}
-		lsOpts.Filter[filterSplit[0]] = append(lsOpts.Filter[filterSplit[0]], filterSplit[1:]...)
+		lsOpts.Filter[filterSplit[0]] = append(lsOpts.Filter[filterSplit[0]], filterSplit[1])
 	}
 	responses, err := registry.ContainerEngine().VolumeList(context.Background(), lsOpts)
 	if err != nil {

--- a/docs/source/markdown/podman-volume-ls.1.md
+++ b/docs/source/markdown/podman-volume-ls.1.md
@@ -40,6 +40,8 @@ $ podman volume ls --format json
 $ podman volume ls --format "{{.Driver}} {{.Scope}}"
 
 $ podman volume ls --filter name=foo,label=blue
+
+$ podman volume ls --filter label=key=value
 ```
 
 ## SEE ALSO

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -83,6 +83,22 @@ var _ = Describe("Podman volume ls", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(2))
 		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName))
+
+		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=foo=foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=foo=bar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(2))
+		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName))
+
+		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=foo=baz"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(0))
 	})
 
 	It("podman volume ls with --filter dangling", func() {
@@ -132,5 +148,11 @@ var _ = Describe("Podman volume ls", func() {
 		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName))
 		Expect(session.OutputToStringArray()[2]).To(ContainSubstring(anotherVol))
 
+		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=foo=bar", "--filter", "label=foo2=bar2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(3))
+		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName))
+		Expect(session.OutputToStringArray()[2]).To(ContainSubstring(anotherVol))
 	})
 })


### PR DESCRIPTION
Supposed to be able to search for labels with a given value.

Previously it meant searching for label key and label value:

--filter label=key --filter label=value

Add some documentation and integration tests for it as well.

Fixes: #8341