### PR TITLE
Improve the shell completion api

### DIFF
--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -21,6 +21,7 @@ var (
 		Short:             "Start one or more containers",
 		Long:              startDescription,
 		RunE:              start,
+		Args:              validateStart,
 		ValidArgsFunction: common.AutocompleteContainersStartable,
 		Example: `podman start --latest
   podman start 860a4b231279 5421ab43b45
@@ -32,6 +33,7 @@ var (
 		Short:             startCommand.Short,
 		Long:              startCommand.Long,
 		RunE:              startCommand.RunE,
+		Args:              startCommand.Args,
 		ValidArgsFunction: startCommand.ValidArgsFunction,
 		Example: `podman container start --latest
   podman container start 860a4b231279 5421ab43b45
@@ -76,8 +78,7 @@ func init() {
 	validate.AddLatestFlag(containerStartCommand, &startOptions.Latest)
 }
 
-func start(cmd *cobra.Command, args []string) error {
-	var errs utils.OutputErrors
+func validateStart(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 && !startOptions.Latest {
 		return errors.New("start requires at least one argument")
 	}
@@ -87,7 +88,11 @@ func start(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 && startOptions.Attach {
 		return errors.Errorf("you cannot start and attach multiple containers at once")
 	}
+	return nil
+}
 
+func start(cmd *cobra.Command, args []string) error {
+	var errs utils.OutputErrors
 	sigProxy := startOptions.SigProxy || startOptions.Attach
 	if cmd.Flag("sig-proxy").Changed {
 		sigProxy = startOptions.SigProxy

--- a/libpod/filters/pods.go
+++ b/libpod/filters/pods.go
@@ -88,7 +88,7 @@ func GeneratePodFilterFunc(filter, filterValue string) (
 			return match
 		}, nil
 	case "status":
-		if !util.StringInSlice(filterValue, []string{"stopped", "running", "paused", "exited", "dead", "created"}) {
+		if !util.StringInSlice(filterValue, []string{"stopped", "running", "paused", "exited", "dead", "created", "degraded"}) {
 			return nil, errors.Errorf("%s is not a valid pod status", filterValue)
 		}
 		return func(p *libpod.Pod) bool {


### PR DESCRIPTION
One main advantage of the new shell completion logic is that
we can easly parse flags and adjust based on the given flags
the suggestions. For example some commands accept the
`--latest` flag only if no arguments are given.

This commit implements this logic in a simple maintainable way
since it reuses the already existing `Args` function in the
cmd struct.

I also refactored the `getXXX` function to match based on the
namei/id which could speed up the shell completion with many
containers, images, etc...

I also added the degraded status to the valid pod status
filters which was implemented in #8081.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
