### PR TITLE
[WIP] Add pre-dump support for checkpoint

### DIFF
--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -47,6 +47,8 @@ func init() {
 	flags.BoolVarP(&checkpointOptions.Keep, "keep", "k", false, "Keep all temporary checkpoint files")
 	flags.BoolVarP(&checkpointOptions.LeaveRunning, "leave-running", "R", false, "Leave the container running after writing checkpoint to disk")
 	flags.BoolVar(&checkpointOptions.TCPEstablished, "tcp-established", false, "Checkpoint a container with established TCP connections")
+	flags.BoolVar(&checkpointOptions.PreDump, "pre-dump", false, "Dump container's memory information only, leave the container running after this")
+	flags.BoolVar(&checkpointOptions.WithPrevious, "with-parent", false, "Checkout container with pre-dump images")
 	flags.BoolVarP(&checkpointOptions.All, "all", "a", false, "Checkpoint all running containers")
 	flags.StringVarP(&checkpointOptions.Export, "export", "e", "", "Export the checkpoint image to a tar.gz")
 	flags.BoolVar(&checkpointOptions.IgnoreRootFS, "ignore-rootfs", false, "Do not include root file-system changes when exporting")

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -677,6 +677,10 @@ type ContainerCheckpointOptions struct {
 	// important to be able to restore a container multiple
 	// times with '--import --name'.
 	IgnoreStaticMAC bool
+	// Pre dump the container
+	PreDump bool
+	// dump container with Pre-dump images
+	WithPrevious bool
 }
 
 // Checkpoint checkpoints a container
@@ -685,6 +689,12 @@ func (c *Container) Checkpoint(ctx context.Context, options ContainerCheckpointO
 
 	if options.TargetFile != "" {
 		if err := c.prepareCheckpointExport(); err != nil {
+			return err
+		}
+	}
+
+	if options.WithPrevious {
+		if err := c.canWithPrevious(); err != nil {
 			return err
 		}
 	}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -134,6 +134,11 @@ func (c *Container) CheckpointPath() string {
 	return filepath.Join(c.bundlePath(), "checkpoint")
 }
 
+// CheckpointPath returns the path to the directory containing the checkpoint
+func (c *Container) PreDumpPath() string {
+	return filepath.Join(c.bundlePath(), "pre-dump")
+}
+
 // AttachSocketPath retrieves the path of the container's attach socket
 func (c *Container) AttachSocketPath() (string, error) {
 	return c.ociRuntime.AttachSocketPath(c)
@@ -2055,6 +2060,11 @@ func (c *Container) prepareCheckpointExport() error {
 	}
 
 	return nil
+}
+
+func (c *Container) canWithPrevious() error {
+	_, err := os.Stat(c.PreDumpPath())
+	return err
 }
 
 // sortUserVolumes sorts the volumes specified for a container

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -938,7 +938,7 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 
 	logrus.Debugf("Checkpointed container %s", c.ID())
 
-	if !options.KeepRunning {
+	if !options.KeepRunning && !options.PreDump {
 		c.state.State = define.ContainerStateStopped
 
 		// Cleanup Storage and Network
@@ -947,7 +947,7 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 		}
 	}
 
-	if !options.Keep {
+	if !options.Keep && !options.PreDump {
 		cleanup := []string{
 			"dump.log",
 			"stats-dump",

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -171,6 +171,8 @@ type CheckpointOptions struct {
 	Latest         bool
 	LeaveRunning   bool
 	TCPEstablished bool
+	PreDump        bool
+	WithPrevious   bool
 }
 
 type CheckpointReport struct {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -492,6 +492,8 @@ func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds [
 		TargetFile:     options.Export,
 		IgnoreRootfs:   options.IgnoreRootFS,
 		KeepRunning:    options.LeaveRunning,
+		PreDump:        options.PreDump,
+		WithPrevious:   options.WithPrevious,
 	}
 
 	if options.All {


### PR DESCRIPTION
We can migrate container to other machine with less downtime if we can migrate container with two step, first migrating the most memory images, the second migrating the left.
For this purpose, we push the new pr.