### PR TITLE
Add U volume flag to chown source volumes

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1036,6 +1036,7 @@ The _options_ is a comma delimited list and can be:
 * [**no**]**dev**
 * [**no**]**suid**
 * [**O**]
+* [**U**]
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The volume
 will be mounted into the container at this directory.
@@ -1064,6 +1065,14 @@ container.
 You can add `:ro` or `:rw` suffix to a volume to mount it read-only or
 read-write mode, respectively. By default, the volumes are mounted read-write.
 See examples.
+
+  `Chowning Volume Mounts`
+
+By default, Podman does not change the owner and group of source volume directories mounted into containers. If a container is created in a new user namespace, the UID and GID in the container may correspond to another UID and GID on the host.
+
+The `:U` suffix tells Podman to use the correct host UID and GID based on the UID and GID within the container, to change recursively the owner and group of the source volume.
+
+**Warning** use with caution since this will modify the host filesystem.
 
   `Labeling Volume Mounts`
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1111,6 +1111,7 @@ The _options_ is a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
 * [**no**]**dev**
 * [**no**]**suid**
 * [**O**]
+* [**U**]
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The volume
 will be mounted into the container at this directory.
@@ -1138,6 +1139,14 @@ container.
 
 You can add **:ro** or **:rw** option to mount a volume in read-only or
 read-write mode, respectively. By default, the volumes are mounted read-write.
+
+  `Chowning Volume Mounts`
+
+By default, Podman does not change the owner and group of source volume directories mounted into containers. If a container is created in a new user namespace, the UID and GID in the container may correspond to another UID and GID on the host.
+
+The `:U` suffix tells Podman to use the correct host UID and GID based on the UID and GID within the container, to change recursively the owner and group of the source volume.
+
+**Warning** use with caution since this will modify the host filesystem.
 
   `Labeling Volume Mounts`
 
@@ -1450,6 +1459,8 @@ $ podman run -v /var/db:/data1 -i -t fedora bash
 $ podman run -v data:/data2 -i -t fedora bash
 
 $ podman run -v /var/cache/dnf:/var/cache/dnf:O -ti fedora dnf -y update
+
+$ podman run -d -e MYSQL_ROOT_PASSWORD=root --user mysql --userns=keep-id -v ~/data:/var/lib/mysql:z,U mariadb
 ```
 
 Using **--mount** flags to mount a host directory as a container folder, specify

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -236,6 +236,8 @@ type ContainerOverlayVolume struct {
 	Dest string `json:"dest"`
 	// Source specifies the source path of the mount.
 	Source string `json:"source,omitempty"`
+	// Options holds overlay volume options.
+	Options []string `json:"options,omitempty"`
 }
 
 // ContainerImageVolume is a volume based on a container image.  The container

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1429,8 +1429,9 @@ func WithOverlayVolumes(volumes []*ContainerOverlayVolume) CtrCreateOption {
 
 		for _, vol := range volumes {
 			ctr.config.OverlayVolumes = append(ctr.config.OverlayVolumes, &ContainerOverlayVolume{
-				Dest:   vol.Dest,
-				Source: vol.Source,
+				Dest:    vol.Dest,
+				Source:  vol.Source,
+				Options: vol.Options,
 			})
 		}
 

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -247,8 +247,9 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 		var vols []*libpod.ContainerOverlayVolume
 		for _, v := range overlays {
 			vols = append(vols, &libpod.ContainerOverlayVolume{
-				Dest:   v.Destination,
-				Source: v.Source,
+				Dest:    v.Destination,
+				Source:  v.Source,
+				Options: v.Options,
 			})
 		}
 		options = append(options, libpod.WithOverlayVolumes(vols))

--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -25,7 +25,7 @@ type defaultMountOptions struct {
 // The sourcePath variable, if not empty, contains a bind mount source.
 func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string, error) {
 	var (
-		foundWrite, foundSize, foundProp, foundMode, foundExec, foundSuid, foundDev, foundCopyUp, foundBind, foundZ bool
+		foundWrite, foundSize, foundProp, foundMode, foundExec, foundSuid, foundDev, foundCopyUp, foundBind, foundZ, foundU bool
 	)
 
 	newOptions := make([]string, 0, len(options))
@@ -116,6 +116,11 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 				return nil, errors.Wrapf(ErrDupeMntOption, "only one of 'z' and 'Z' can be used")
 			}
 			foundZ = true
+		case "U":
+			if foundU {
+				return nil, errors.Wrapf(ErrDupeMntOption, "the 'U' option can only be set once")
+			}
+			foundU = true
 		default:
 			return nil, errors.Wrapf(ErrBadMntOption, "unknown mount option %q", opt)
 		}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/terminal"
@@ -691,4 +692,17 @@ func CoresToPeriodAndQuota(cores float64) (uint64, int64) {
 // Quota are in microseconds.
 func PeriodAndQuotaToCores(period uint64, quota int64) float64 {
 	return float64(quota) / float64(period)
+}
+
+// IDtoolsToRuntimeSpec converts idtools ID mapping to the one of the runtime spec.
+func IDtoolsToRuntimeSpec(idMaps []idtools.IDMap) (convertedIDMap []specs.LinuxIDMapping) {
+	for _, idmap := range idMaps {
+		tempIDMap := specs.LinuxIDMapping{
+			ContainerID: uint32(idmap.ContainerID),
+			HostID:      uint32(idmap.HostID),
+			Size:        uint32(idmap.Size),
+		}
+		convertedIDMap = append(convertedIDMap, tempIDMap)
+	}
+	return convertedIDMap
 }

--- a/vendor/github.com/containers/common/pkg/chown/chown.go
+++ b/vendor/github.com/containers/common/pkg/chown/chown.go
@@ -1,0 +1,122 @@
+package chown
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"syscall"
+
+	"github.com/containers/storage/pkg/homedir"
+	"github.com/pkg/errors"
+)
+
+// DangerousHostPath validates if a host path is dangerous and should not be modified
+func DangerousHostPath(path string) (bool, error) {
+	excludePaths := map[string]bool{
+		"/":           true,
+		"/bin":        true,
+		"/boot":       true,
+		"/dev":        true,
+		"/etc":        true,
+		"/etc/passwd": true,
+		"/etc/pki":    true,
+		"/etc/shadow": true,
+		"/home":       true,
+		"/lib":        true,
+		"/lib64":      true,
+		"/media":      true,
+		"/opt":        true,
+		"/proc":       true,
+		"/root":       true,
+		"/run":        true,
+		"/sbin":       true,
+		"/srv":        true,
+		"/sys":        true,
+		"/tmp":        true,
+		"/usr":        true,
+		"/var":        true,
+		"/var/lib":    true,
+		"/var/log":    true,
+	}
+
+	if home := homedir.Get(); home != "" {
+		excludePaths[home] = true
+	}
+
+	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+		if usr, err := user.Lookup(sudoUser); err == nil {
+			excludePaths[usr.HomeDir] = true
+		}
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return true, err
+	}
+
+	realPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return true, err
+	}
+
+	if excludePaths[realPath] {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// ChangeHostPathOwnership changes the uid and gid ownership of a directory or file within the host.
+// This is used by the volume U flag to change source volumes ownership
+func ChangeHostPathOwnership(path string, recursive bool, uid, gid int) error {
+	// Validate if host path can be chowned
+	isDangerous, err := DangerousHostPath(path)
+	if err != nil {
+		return errors.Wrapf(err, "failed to validate if host path is dangerous")
+	}
+
+	if isDangerous {
+		return errors.Errorf("chowning host path %q is not allowed. You can manually `chown -R %d:%d %s`", path, uid, gid, path)
+	}
+
+	// Chown host path
+	if recursive {
+		err := filepath.Walk(path, func(filePath string, f os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// Get current ownership
+			currentUID := int(f.Sys().(*syscall.Stat_t).Uid)
+			currentGID := int(f.Sys().(*syscall.Stat_t).Gid)
+
+			if uid != currentUID || gid != currentGID {
+				return os.Lchown(filePath, uid, gid)
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return errors.Wrapf(err, "failed to chown recursively host path")
+		}
+	} else {
+		// Get host path info
+		f, err := os.Lstat(path)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get host path information")
+		}
+
+		// Get current ownership
+		currentUID := int(f.Sys().(*syscall.Stat_t).Uid)
+		currentGID := int(f.Sys().(*syscall.Stat_t).Gid)
+
+		if uid != currentUID || gid != currentGID {
+			if err := os.Lchown(path, uid, gid); err != nil {
+				return errors.Wrapf(err, "failed to chown host path")
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -95,6 +95,7 @@ github.com/containers/common/pkg/apparmor/internal/supported
 github.com/containers/common/pkg/auth
 github.com/containers/common/pkg/capabilities
 github.com/containers/common/pkg/cgroupv2
+github.com/containers/common/pkg/chown
 github.com/containers/common/pkg/completion
 github.com/containers/common/pkg/config
 github.com/containers/common/pkg/parse


### PR DESCRIPTION
This will ensure that the uid,gid will be the same between the containers and volumes. The source volume will be chowned if the flag is specified to match the uid, gid of the container.

Fixes #7778 

Signed-off-by: Eduardo Vega <edvegavalerio@gmail.com>
