### PR TITLE
Add API for communicating with Docker volume plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v17.12.0-ce-rc1.0.20201020191947-73dc6a680cdd+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-plugins-helpers v0.0.0-20200102110956-c9a8a2d92ccc
 	github.com/docker/go-units v0.4.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
+github.com/docker/go-plugins-helpers v0.0.0-20200102110956-c9a8a2d92ccc h1:/A+mPcpajLsWiX9gSnzdVKM/IzZoYiNqXHe83z50k2c=
+github.com/docker/go-plugins-helpers v0.0.0-20200102110956-c9a8a2d92ccc/go.mod h1:LFyLie6XcDbyKGeVK6bHe+9aJTYCxWLBg5IrJZOaXKA=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libnetwork v0.8.0-dev.2.0.20190625141545-5a177b73e316 h1:moehPjPiGUaWdwgOl92xRyFHJyaqXDHcCyW9M6nmCK4=

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1547,12 +1547,19 @@ func WithVolumeDriver(driver string) VolumeCreateOption {
 		if volume.valid {
 			return define.ErrVolumeFinalized
 		}
-		// only local driver is possible rn
+
+		// Uncomment when volume plugins are ready for use.
+		// if driver != define.VolumeDriverLocal {
+		// 	if _, err := plugin.GetVolumePlugin(driver); err != nil {
+		// 		return err
+		// 	}
+		// }
+
 		if driver != define.VolumeDriverLocal {
 			return define.ErrNotImplemented
-
 		}
-		volume.config.Driver = define.VolumeDriverLocal
+
+		volume.config.Driver = driver
 		return nil
 	}
 }

--- a/libpod/plugin/volume_api.go
+++ b/libpod/plugin/volume_api.go
@@ -1,0 +1,454 @@
+package plugin
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/containers/podman/v2/libpod/define"
+	"github.com/docker/go-plugins-helpers/sdk"
+	"github.com/docker/go-plugins-helpers/volume"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+// TODO: We should add syntax for specifying plugins to containers.conf, and
+// support for loading based on that.
+
+// Copied from docker/go-plugins-helpers/volume/api.go - not exported, so we
+// need to do this to get at them.
+// These are well-established paths that should not change unless the plugin API
+// version changes.
+var (
+	activatePath    = "/Plugin.Activate"
+	createPath      = "/VolumeDriver.Create"
+	getPath         = "/VolumeDriver.Get"
+	listPath        = "/VolumeDriver.List"
+	removePath      = "/VolumeDriver.Remove"
+	hostVirtualPath = "/VolumeDriver.Path"
+	mountPath       = "/VolumeDriver.Mount"
+	unmountPath     = "/VolumeDriver.Unmount"
+	// nolint
+	capabilitiesPath = "/VolumeDriver.Capabilities"
+)
+
+const (
+	defaultTimeout   = 5 * time.Second
+	defaultPath      = "/run/docker/plugins"
+	volumePluginType = "VolumeDriver"
+)
+
+var (
+	ErrNotPlugin       = errors.New("target does not appear to be a valid plugin")
+	ErrNotVolumePlugin = errors.New("plugin is not a volume plugin")
+	ErrPluginRemoved   = errors.New("plugin is no longer available (shut down?)")
+
+	// This stores available, initialized volume plugins.
+	pluginsLock sync.Mutex
+	plugins     map[string]*VolumePlugin
+)
+
+// VolumePlugin is a single volume plugin.
+type VolumePlugin struct {
+	// Name is the name of the volume plugin. This will be used to refer to
+	// it.
+	Name string
+	// SocketPath is the unix socket at which the plugin is accessed.
+	SocketPath string
+}
+
+// This is the response from the activate endpoint of the API.
+type activateResponse struct {
+	Implements []string
+}
+
+// Validate that the given plugin is good to use.
+// Add it to available plugins if so.
+func validatePlugin(newPlugin *VolumePlugin) error {
+	// It's a socket. Is it a plugin?
+	// Hit the Activate endpoint to find out if it is, and if so what kind
+	req, err := http.NewRequest("POST", activatePath, nil)
+	if err != nil {
+		return errors.Wrapf(err, "error making request to volume plugin %s activation endpoint", newPlugin.Name)
+	}
+
+	req.Header.Set("Host", newPlugin.getURI())
+	req.Header.Set("Content-Type", sdk.DefaultContentTypeV1_1)
+
+	client := new(http.Client)
+	client.Timeout = defaultTimeout
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrapf(err, "error sending request to plugin %s activation endpoint", newPlugin.Name)
+	}
+	defer resp.Body.Close()
+
+	// Response code MUST be 200. Anything else, we have to assume it's not
+	// a valid plugin.
+	if resp.StatusCode != 200 {
+		return errors.Wrapf(ErrNotPlugin, "got status code %d from activation endpoint for plugin %s", resp.StatusCode, newPlugin.Name)
+	}
+
+	// Read and decode the body so we can tell if this is a volume plugin.
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrapf(err, "error reading activation response body from plugin %s", newPlugin.Name)
+	}
+
+	respStruct := new(activateResponse)
+	if err := json.Unmarshal(respBytes, respStruct); err != nil {
+		return errors.Wrapf(err, "error unmarshalling plugin %s activation response", newPlugin.Name)
+	}
+
+	foundVolume := false
+	for _, pluginType := range respStruct.Implements {
+		if pluginType == volumePluginType {
+			foundVolume = true
+			break
+		}
+	}
+
+	if !foundVolume {
+		return errors.Wrapf(ErrNotVolumePlugin, "plugin %s does not implement volume plugin, instead provides %s", newPlugin.Name, strings.Join(respStruct.Implements, ", "))
+	}
+
+	plugins[newPlugin.Name] = newPlugin
+
+	return nil
+}
+
+// GetVolumePlugin gets a single volume plugin by path.
+// TODO: We should not be auto-completing based on a default path; we should
+// require volumes to have been pre-specified in containers.conf (will need a
+// function to pre-populate the plugins list, and we should probably do a lazy
+// initialization there to not slow things down too much).
+func GetVolumePlugin(name string) (*VolumePlugin, error) {
+	pluginsLock.Lock()
+	defer pluginsLock.Unlock()
+
+	plugin, exists := plugins[name]
+	if exists {
+		return plugin, nil
+	}
+
+	// It's not cached. We need to get it.
+
+	newPlugin := new(VolumePlugin)
+	newPlugin.Name = name
+	newPlugin.SocketPath = filepath.Join(defaultPath, fmt.Sprintf("%s.sock", name))
+
+	stat, err := os.Stat(newPlugin.SocketPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot access plugin %s socket %q", name, newPlugin.SocketPath)
+	}
+	if stat.Mode()&os.ModeSocket == 0 {
+		return nil, errors.Wrapf(ErrNotPlugin, "volume %s path %q is not a unix socket", name, newPlugin.SocketPath)
+	}
+
+	if err := validatePlugin(newPlugin); err != nil {
+		return nil, err
+	}
+
+	return newPlugin, nil
+}
+
+func (p *VolumePlugin) getURI() string {
+	return "unix://" + p.SocketPath
+}
+
+// Verify the plugin is still available.
+// TODO: Do we want to ping with an HTTP request? There's no ping endpoint so
+// we'd need to hit Activate or Capabilities?
+func (p *VolumePlugin) verifyReachable() error {
+	if _, err := os.Stat(p.SocketPath); err != nil {
+		if os.IsNotExist(err) {
+			pluginsLock.Lock()
+			defer pluginsLock.Unlock()
+			delete(plugins, p.Name)
+			return errors.Wrapf(ErrPluginRemoved, p.Name)
+		}
+
+		return errors.Wrapf(err, "error accessing plugin %s", p.Name)
+	}
+	return nil
+}
+
+// Send a request to the volume plugin for handling.
+func (p *VolumePlugin) sendRequest(toJSON interface{}, hasBody bool, endpoint string) (*http.Response, error) {
+	var (
+		reqJSON []byte
+		err     error
+	)
+
+	if hasBody {
+		reqJSON, err = json.Marshal(toJSON)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error marshalling request JSON for volume plugin %s endpoint %s", p.Name, endpoint)
+		}
+	}
+
+	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(reqJSON))
+	if err != nil {
+		return nil, errors.Wrapf(err, "error making request to volume plugin %s endpoint %s", p.Name, endpoint)
+	}
+
+	req.Header.Set("Host", p.getURI())
+	req.Header.Set("Content-Type", sdk.DefaultContentTypeV1_1)
+
+	client := new(http.Client)
+	client.Timeout = defaultTimeout
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error sending request to volume plugin %s endpoint %s", p.Name, endpoint)
+	}
+	defer resp.Body.Close()
+
+	return resp, nil
+}
+
+// Turn an error response from a volume plugin into a well-formatted Go error.
+func (p *VolumePlugin) makeErrorResponse(err, endpoint, volName string) error {
+	if err == "" {
+		err = "empty error from plugin"
+	}
+	if volName != "" {
+		return errors.Wrapf(errors.New(err), "error on %s on volume %s in volume plugin %s", endpoint, volName, p.Name)
+	} else {
+		return errors.Wrapf(errors.New(err), "error on %s in volume plugin %s", endpoint, p.Name)
+	}
+}
+
+// Handle error responses from plugin
+func (p *VolumePlugin) handleErrorResponse(resp *http.Response, endpoint, volName string) error {
+	// The official plugin reference implementation uses HTTP 500 for
+	// errors, but I don't think we can guarantee all plugins do that.
+	// Let's interpret anything other than 200 as an error.
+	// If there isn't an error, don't even bother decoding the response.
+	if resp.StatusCode != 200 {
+		errResp, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "error reading response body from volume plugin %s", p.Name)
+		}
+
+		errStruct := new(volume.ErrorResponse)
+		if err := json.Unmarshal(errResp, errStruct); err != nil {
+			return errors.Wrapf(err, "error unmarshalling JSON response from volume plugin %s", p.Name)
+		}
+
+		return p.makeErrorResponse(errStruct.Err, endpoint, volName)
+	}
+
+	return nil
+}
+
+// CreateVolume creates a volume in the plugin.
+func (p *VolumePlugin) CreateVolume(req *volume.CreateRequest) error {
+	if req == nil {
+		return errors.Wrapf(define.ErrInvalidArg, "must provide non-nil request to CreateVolume")
+	}
+
+	if err := p.verifyReachable(); err != nil {
+		return err
+	}
+
+	logrus.Infof("Creating volume %s using plugin %s", req.Name, p.Name)
+
+	resp, err := p.sendRequest(req, true, createPath)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return p.handleErrorResponse(resp, createPath, req.Name)
+}
+
+// ListVolumes lists volumes available in the plugin.
+func (p *VolumePlugin) ListVolumes() ([]*volume.Volume, error) {
+	if err := p.verifyReachable(); err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Listing volumes using plugin %s", p.Name)
+
+	resp, err := p.sendRequest(nil, false, listPath)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := p.handleErrorResponse(resp, listPath, ""); err != nil {
+		return nil, err
+	}
+
+	// TODO: Can probably unify response reading under a helper
+	volumeRespBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading response body from volume plugin %s", p.Name)
+	}
+
+	volumeResp := new(volume.ListResponse)
+	if err := json.Unmarshal(volumeRespBytes, volumeResp); err != nil {
+		return nil, errors.Wrapf(err, "error unmarshalling volume plugin %s list response", p.Name)
+	}
+
+	return volumeResp.Volumes, nil
+}
+
+// GetVolume gets a single volume from the plugin.
+func (p *VolumePlugin) GetVolume(req *volume.GetRequest) (*volume.Volume, error) {
+	if req == nil {
+		return nil, errors.Wrapf(define.ErrInvalidArg, "must provide non-nil request to GetVolume")
+	}
+
+	if err := p.verifyReachable(); err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Getting volume %s using plugin %s", req.Name, p.Name)
+
+	resp, err := p.sendRequest(req, true, getPath)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := p.handleErrorResponse(resp, getPath, req.Name); err != nil {
+		return nil, err
+	}
+
+	getRespBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading response body from volume plugin %s", p.Name)
+	}
+
+	getResp := new(volume.GetResponse)
+	if err := json.Unmarshal(getRespBytes, getResp); err != nil {
+		return nil, errors.Wrapf(err, "error unmarshalling volume plugin %s get response", p.Name)
+	}
+
+	return getResp.Volume, nil
+}
+
+// RemoveVolume removes a single volume from the plugin.
+func (p *VolumePlugin) RemoveVolume(req *volume.RemoveRequest) error {
+	if req == nil {
+		return errors.Wrapf(define.ErrInvalidArg, "must provide non-nil request to RemoveVolume")
+	}
+
+	if err := p.verifyReachable(); err != nil {
+		return err
+	}
+
+	logrus.Infof("Removing volume %s using plugin %s", req.Name, p.Name)
+
+	resp, err := p.sendRequest(req, true, removePath)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return p.handleErrorResponse(resp, removePath, req.Name)
+}
+
+// GetVolumePath gets the path the given volume is mounted at.
+func (p *VolumePlugin) GetVolumePath(req *volume.PathRequest) (string, error) {
+	if req == nil {
+		return "", errors.Wrapf(define.ErrInvalidArg, "must provide non-nil request to GetVolumePath")
+	}
+
+	if err := p.verifyReachable(); err != nil {
+		return "", err
+	}
+
+	logrus.Infof("Getting volume %s path using plugin %s", req.Name, p.Name)
+
+	resp, err := p.sendRequest(req, true, hostVirtualPath)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if err := p.handleErrorResponse(resp, hostVirtualPath, req.Name); err != nil {
+		return "", err
+	}
+
+	pathRespBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrapf(err, "error reading response body from volume plugin %s", p.Name)
+	}
+
+	pathResp := new(volume.PathResponse)
+	if err := json.Unmarshal(pathRespBytes, pathResp); err != nil {
+		return "", errors.Wrapf(err, "error unmarshalling volume plugin %s path response", p.Name)
+	}
+
+	return pathResp.Mountpoint, nil
+}
+
+// MountVolume mounts the given volume. The ID argument is the ID of the
+// mounting container, used for internal record-keeping by the plugin. Returns
+// the path the volume has been mounted at.
+func (p *VolumePlugin) MountVolume(req *volume.MountRequest) (string, error) {
+	if req == nil {
+		return "", errors.Wrapf(define.ErrInvalidArg, "must provide non-nil request to MountVolume")
+	}
+
+	if err := p.verifyReachable(); err != nil {
+		return "", err
+	}
+
+	logrus.Infof("Mounting volume %s using plugin %s for container %s", req.Name, p.Name, req.ID)
+
+	resp, err := p.sendRequest(req, true, mountPath)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if err := p.handleErrorResponse(resp, mountPath, req.Name); err != nil {
+		return "", err
+	}
+
+	mountRespBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrapf(err, "error reading response body from volume plugin %s", p.Name)
+	}
+
+	mountResp := new(volume.MountResponse)
+	if err := json.Unmarshal(mountRespBytes, mountResp); err != nil {
+		return "", errors.Wrapf(err, "error unmarshalling volume plugin %s path response", p.Name)
+	}
+
+	return mountResp.Mountpoint, nil
+}
+
+// UnmountVolume unmounts the given volume. The ID argument is the ID of the
+// container that is unmounting, used for internal record-keeping by the plugin.
+func (p *VolumePlugin) UnmountVolume(req *volume.UnmountRequest) error {
+	if req == nil {
+		return errors.Wrapf(define.ErrInvalidArg, "must provide non-nil request to UnmountVolume")
+	}
+
+	if err := p.verifyReachable(); err != nil {
+		return err
+	}
+
+	logrus.Infof("Unmounting volume %s using plugin %s for container %s", req.Name, p.Name, req.ID)
+
+	resp, err := p.sendRequest(req, true, unmountPath)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return p.handleErrorResponse(resp, unmountPath, req.Name)
+}

--- a/vendor/github.com/coreos/go-systemd/LICENSE
+++ b/vendor/github.com/coreos/go-systemd/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/coreos/go-systemd/NOTICE
+++ b/vendor/github.com/coreos/go-systemd/NOTICE
@@ -1,0 +1,5 @@
+CoreOS Project
+Copyright 2018 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).

--- a/vendor/github.com/coreos/go-systemd/activation/files.go
+++ b/vendor/github.com/coreos/go-systemd/activation/files.go
@@ -1,0 +1,67 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package activation implements primitives for systemd socket activation.
+package activation
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const (
+	// listenFdsStart corresponds to `SD_LISTEN_FDS_START`.
+	listenFdsStart = 3
+)
+
+// Files returns a slice containing a `os.File` object for each
+// file descriptor passed to this process via systemd fd-passing protocol.
+//
+// The order of the file descriptors is preserved in the returned slice.
+// `unsetEnv` is typically set to `true` in order to avoid clashes in
+// fd usage and to avoid leaking environment flags to child processes.
+func Files(unsetEnv bool) []*os.File {
+	if unsetEnv {
+		defer os.Unsetenv("LISTEN_PID")
+		defer os.Unsetenv("LISTEN_FDS")
+		defer os.Unsetenv("LISTEN_FDNAMES")
+	}
+
+	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
+	if err != nil || pid != os.Getpid() {
+		return nil
+	}
+
+	nfds, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
+	if err != nil || nfds == 0 {
+		return nil
+	}
+
+	names := strings.Split(os.Getenv("LISTEN_FDNAMES"), ":")
+
+	files := make([]*os.File, 0, nfds)
+	for fd := listenFdsStart; fd < listenFdsStart+nfds; fd++ {
+		syscall.CloseOnExec(fd)
+		name := "LISTEN_FD_" + strconv.Itoa(fd)
+		offset := fd - listenFdsStart
+		if offset < len(names) && len(names[offset]) > 0 {
+			name = names[offset]
+		}
+		files = append(files, os.NewFile(uintptr(fd), name))
+	}
+
+	return files
+}

--- a/vendor/github.com/coreos/go-systemd/activation/listeners.go
+++ b/vendor/github.com/coreos/go-systemd/activation/listeners.go
@@ -1,0 +1,103 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package activation
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+// Listeners returns a slice containing a net.Listener for each matching socket type
+// passed to this process.
+//
+// The order of the file descriptors is preserved in the returned slice.
+// Nil values are used to fill any gaps. For example if systemd were to return file descriptors
+// corresponding with "udp, tcp, tcp", then the slice would contain {nil, net.Listener, net.Listener}
+func Listeners() ([]net.Listener, error) {
+	files := Files(true)
+	listeners := make([]net.Listener, len(files))
+
+	for i, f := range files {
+		if pc, err := net.FileListener(f); err == nil {
+			listeners[i] = pc
+			f.Close()
+		}
+	}
+	return listeners, nil
+}
+
+// ListenersWithNames maps a listener name to a set of net.Listener instances.
+func ListenersWithNames() (map[string][]net.Listener, error) {
+	files := Files(true)
+	listeners := map[string][]net.Listener{}
+
+	for _, f := range files {
+		if pc, err := net.FileListener(f); err == nil {
+			current, ok := listeners[f.Name()]
+			if !ok {
+				listeners[f.Name()] = []net.Listener{pc}
+			} else {
+				listeners[f.Name()] = append(current, pc)
+			}
+			f.Close()
+		}
+	}
+	return listeners, nil
+}
+
+// TLSListeners returns a slice containing a net.listener for each matching TCP socket type
+// passed to this process.
+// It uses default Listeners func and forces TCP sockets handlers to use TLS based on tlsConfig.
+func TLSListeners(tlsConfig *tls.Config) ([]net.Listener, error) {
+	listeners, err := Listeners()
+
+	if listeners == nil || err != nil {
+		return nil, err
+	}
+
+	if tlsConfig != nil && err == nil {
+		for i, l := range listeners {
+			// Activate TLS only for TCP sockets
+			if l.Addr().Network() == "tcp" {
+				listeners[i] = tls.NewListener(l, tlsConfig)
+			}
+		}
+	}
+
+	return listeners, err
+}
+
+// TLSListenersWithNames maps a listener name to a net.Listener with
+// the associated TLS configuration.
+func TLSListenersWithNames(tlsConfig *tls.Config) (map[string][]net.Listener, error) {
+	listeners, err := ListenersWithNames()
+
+	if listeners == nil || err != nil {
+		return nil, err
+	}
+
+	if tlsConfig != nil && err == nil {
+		for _, ll := range listeners {
+			// Activate TLS only for TCP sockets
+			for i, l := range ll {
+				if l.Addr().Network() == "tcp" {
+					ll[i] = tls.NewListener(l, tlsConfig)
+				}
+			}
+		}
+	}
+
+	return listeners, err
+}

--- a/vendor/github.com/coreos/go-systemd/activation/packetconns.go
+++ b/vendor/github.com/coreos/go-systemd/activation/packetconns.go
@@ -1,0 +1,38 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package activation
+
+import (
+	"net"
+)
+
+// PacketConns returns a slice containing a net.PacketConn for each matching socket type
+// passed to this process.
+//
+// The order of the file descriptors is preserved in the returned slice.
+// Nil values are used to fill any gaps. For example if systemd were to return file descriptors
+// corresponding with "udp, tcp, udp", then the slice would contain {net.PacketConn, nil, net.PacketConn}
+func PacketConns() ([]net.PacketConn, error) {
+	files := Files(true)
+	conns := make([]net.PacketConn, len(files))
+
+	for i, f := range files {
+		if pc, err := net.FilePacketConn(f); err == nil {
+			conns[i] = pc
+			f.Close()
+		}
+	}
+	return conns, nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/LICENSE
+++ b/vendor/github.com/docker/go-plugins-helpers/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/docker/go-plugins-helpers/NOTICE
+++ b/vendor/github.com/docker/go-plugins-helpers/NOTICE
@@ -1,0 +1,19 @@
+Docker
+Copyright 2012-2015 Docker, Inc.
+
+This product includes software developed at Docker, Inc. (https://www.docker.com).
+
+This product contains software (https://github.com/kr/pty) developed
+by Keith Rarick, licensed under the MIT License.
+
+The following is courtesy of our legal counsel:
+
+
+Use and transfer of Docker may be subject to certain restrictions by the
+United States and other governments.
+It is your responsibility to ensure that your use and/or transfer does not
+violate applicable laws.
+
+For more information, please see https://www.bis.doc.gov
+
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/encoder.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/encoder.go
@@ -1,0 +1,37 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// DefaultContentTypeV1_1 is the default content type accepted and sent by the plugins.
+const DefaultContentTypeV1_1 = "application/vnd.docker.plugins.v1.1+json"
+
+// DecodeRequest decodes an http request into a given structure.
+func DecodeRequest(w http.ResponseWriter, r *http.Request, req interface{}) (err error) {
+	if err = json.NewDecoder(r.Body).Decode(req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+	return
+}
+
+// EncodeResponse encodes the given structure into an http response.
+func EncodeResponse(w http.ResponseWriter, res interface{}, err bool) {
+	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+	if err {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	json.NewEncoder(w).Encode(res)
+}
+
+// StreamResponse streams a response object to the client
+func StreamResponse(w http.ResponseWriter, data io.ReadCloser) {
+	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+	if _, err := copyBuf(w, data); err != nil {
+		fmt.Printf("ERROR in stream: %v\n", err)
+	}
+	data.Close()
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/handler.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/handler.go
@@ -1,0 +1,88 @@
+package sdk
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+)
+
+const activatePath = "/Plugin.Activate"
+
+// Handler is the base to create plugin handlers.
+// It initializes connections and sockets to listen to.
+type Handler struct {
+	mux *http.ServeMux
+}
+
+// NewHandler creates a new Handler with an http mux.
+func NewHandler(manifest string) Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(activatePath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+		fmt.Fprintln(w, manifest)
+	})
+
+	return Handler{mux: mux}
+}
+
+// Serve sets up the handler to serve requests on the passed in listener
+func (h Handler) Serve(l net.Listener) error {
+	server := http.Server{
+		Addr:    l.Addr().String(),
+		Handler: h.mux,
+	}
+	return server.Serve(l)
+}
+
+// ServeTCP makes the handler to listen for request in a given TCP address.
+// It also writes the spec file in the right directory for docker to read.
+// Due to constrains for running Docker in Docker on Windows, data-root directory
+// of docker daemon must be provided. To get default directory, use
+// WindowsDefaultDaemonRootDir() function. On Unix, this parameter is ignored.
+func (h Handler) ServeTCP(pluginName, addr, daemonDir string, tlsConfig *tls.Config) error {
+	l, spec, err := newTCPListener(addr, pluginName, daemonDir, tlsConfig)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
+}
+
+// ServeUnix makes the handler to listen for requests in a unix socket.
+// It also creates the socket file in the right directory for docker to read.
+func (h Handler) ServeUnix(addr string, gid int) error {
+	l, spec, err := newUnixListener(addr, gid)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
+}
+
+// ServeWindows makes the handler to listen for request in a Windows named pipe.
+// It also creates the spec file in the right directory for docker to read.
+// Due to constrains for running Docker in Docker on Windows, data-root directory
+// of docker daemon must be provided. To get default directory, use
+// WindowsDefaultDaemonRootDir() function. On Unix, this parameter is ignored.
+func (h Handler) ServeWindows(addr, pluginName, daemonDir string, pipeConfig *WindowsPipeConfig) error {
+	l, spec, err := newWindowsListener(addr, pluginName, daemonDir, pipeConfig)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
+}
+
+// HandleFunc registers a function to handle a request path with.
+func (h Handler) HandleFunc(path string, fn func(w http.ResponseWriter, r *http.Request)) {
+	h.mux.HandleFunc(path, fn)
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/pool.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/pool.go
@@ -1,0 +1,18 @@
+package sdk
+
+import (
+	"io"
+	"sync"
+)
+
+const buffer32K = 32 * 1024
+
+var buffer32KPool = &sync.Pool{New: func() interface{} { return make([]byte, buffer32K) }}
+
+// copyBuf uses a shared buffer pool with io.CopyBuffer
+func copyBuf(w io.Writer, r io.Reader) (int64, error) {
+	buf := buffer32KPool.Get().([]byte)
+	written, err := io.CopyBuffer(w, r, buf)
+	buffer32KPool.Put(buf)
+	return written, err
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/spec_file_generator.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/spec_file_generator.go
@@ -1,0 +1,58 @@
+package sdk
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type protocol string
+
+const (
+	protoTCP       protocol = "tcp"
+	protoNamedPipe protocol = "npipe"
+)
+
+// PluginSpecDir returns plugin spec dir in relation to daemon root directory.
+func PluginSpecDir(daemonRoot string) string {
+	return ([]string{filepath.Join(daemonRoot, "plugins")})[0]
+}
+
+// WindowsDefaultDaemonRootDir returns default data directory of docker daemon on Windows.
+func WindowsDefaultDaemonRootDir() string {
+	return filepath.Join(os.Getenv("programdata"), "docker")
+}
+
+func createPluginSpecDirWindows(name, address, daemonRoot string) (string, error) {
+	_, err := os.Stat(daemonRoot)
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf("Deamon root directory must already exist: %s", err)
+	}
+
+	pluginSpecDir := PluginSpecDir(daemonRoot)
+
+	if err := windowsCreateDirectoryWithACL(pluginSpecDir); err != nil {
+		return "", err
+	}
+	return pluginSpecDir, nil
+}
+
+func createPluginSpecDirUnix(name, address string) (string, error) {
+	pluginSpecDir := PluginSpecDir("/etc/docker")
+	if err := os.MkdirAll(pluginSpecDir, 0755); err != nil {
+		return "", err
+	}
+	return pluginSpecDir, nil
+}
+
+func writeSpecFile(name, address, pluginSpecDir string, proto protocol) (string, error) {
+	specFileDir := filepath.Join(pluginSpecDir, name+".spec")
+
+	url := string(proto) + "://" + address
+	if err := ioutil.WriteFile(specFileDir, []byte(url), 0644); err != nil {
+		return "", err
+	}
+
+	return specFileDir, nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/tcp_listener.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/tcp_listener.go
@@ -1,0 +1,34 @@
+package sdk
+
+import (
+	"crypto/tls"
+	"net"
+	"runtime"
+
+	"github.com/docker/go-connections/sockets"
+)
+
+func newTCPListener(address, pluginName, daemonDir string, tlsConfig *tls.Config) (net.Listener, string, error) {
+	listener, err := sockets.NewTCPSocket(address, tlsConfig)
+	if err != nil {
+		return nil, "", err
+	}
+
+	addr := listener.Addr().String()
+
+	var specDir string
+	if runtime.GOOS == "windows" {
+		specDir, err = createPluginSpecDirWindows(pluginName, addr, daemonDir)
+	} else {
+		specDir, err = createPluginSpecDirUnix(pluginName, addr)
+	}
+	if err != nil {
+		return nil, "", err
+	}
+
+	specFile, err := writeSpecFile(pluginName, addr, specDir, protoTCP)
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, specFile, nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener.go
@@ -1,0 +1,35 @@
+// +build linux freebsd
+
+package sdk
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/go-connections/sockets"
+)
+
+const pluginSockDir = "/run/docker/plugins"
+
+func newUnixListener(pluginName string, gid int) (net.Listener, string, error) {
+	path, err := fullSocketAddress(pluginName)
+	if err != nil {
+		return nil, "", err
+	}
+	listener, err := sockets.NewUnixSocket(path, gid)
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, path, nil
+}
+
+func fullSocketAddress(address string) (string, error) {
+	if err := os.MkdirAll(pluginSockDir, 0755); err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(address) {
+		return address, nil
+	}
+	return filepath.Join(pluginSockDir, address+".sock"), nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_nosystemd.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_nosystemd.go
@@ -1,0 +1,10 @@
+// +build linux freebsd
+// +build nosystemd
+
+package sdk
+
+import "net"
+
+func setupSocketActivation() (net.Listener, error) {
+	return nil, nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_systemd.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_systemd.go
@@ -1,0 +1,45 @@
+// +build linux freebsd
+// +build !nosystemd
+
+package sdk
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/coreos/go-systemd/activation"
+)
+
+// isRunningSystemd checks whether the host was booted with systemd as its init
+// system. This functions similarly to systemd's `sd_booted(3)`: internally, it
+// checks whether /run/systemd/system/ exists and is a directory.
+// http://www.freedesktop.org/software/systemd/man/sd_booted.html
+//
+// Copied from github.com/coreos/go-systemd/util.IsRunningSystemd
+func isRunningSystemd() bool {
+	fi, err := os.Lstat("/run/systemd/system")
+	if err != nil {
+		return false
+	}
+	return fi.IsDir()
+}
+
+func setupSocketActivation() (net.Listener, error) {
+	if !isRunningSystemd() {
+		return nil, nil
+	}
+	listenFds := activation.Files(false)
+	if len(listenFds) > 1 {
+		return nil, fmt.Errorf("expected only one socket from systemd, got %d", len(listenFds))
+	}
+	var listener net.Listener
+	if len(listenFds) == 1 {
+		l, err := net.FileListener(listenFds[0])
+		if err != nil {
+			return nil, err
+		}
+		listener = l
+	}
+	return listener, nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_unsupported.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_unsupported.go
@@ -1,0 +1,16 @@
+// +build !linux,!freebsd
+
+package sdk
+
+import (
+	"errors"
+	"net"
+)
+
+var (
+	errOnlySupportedOnLinuxAndFreeBSD = errors.New("unix socket creation is only supported on Linux and FreeBSD")
+)
+
+func newUnixListener(pluginName string, gid int) (net.Listener, string, error) {
+	return nil, "", errOnlySupportedOnLinuxAndFreeBSD
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener.go
@@ -1,0 +1,70 @@
+// +build windows
+
+package sdk
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// Named pipes use Windows Security Descriptor Definition Language to define ACL. Following are
+// some useful definitions.
+const (
+	// This will set permissions for everyone to have full access
+	AllowEveryone = "S:(ML;;NW;;;LW)D:(A;;0x12019f;;;WD)"
+
+	// This will set permissions for Service, System, Adminstrator group and account to have full access
+	AllowServiceSystemAdmin = "D:(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;FA;;;LA)(A;ID;FA;;;LS)"
+)
+
+func newWindowsListener(address, pluginName, daemonRoot string, pipeConfig *WindowsPipeConfig) (net.Listener, string, error) {
+	winioPipeConfig := winio.PipeConfig{
+		SecurityDescriptor: pipeConfig.SecurityDescriptor,
+		InputBufferSize:    pipeConfig.InBufferSize,
+		OutputBufferSize:   pipeConfig.OutBufferSize,
+	}
+	listener, err := winio.ListenPipe(address, &winioPipeConfig)
+	if err != nil {
+		return nil, "", err
+	}
+
+	addr := listener.Addr().String()
+
+	specDir, err := createPluginSpecDirWindows(pluginName, addr, daemonRoot)
+	if err != nil {
+		return nil, "", err
+	}
+
+	spec, err := writeSpecFile(pluginName, addr, specDir, protoNamedPipe)
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, spec, nil
+}
+
+func windowsCreateDirectoryWithACL(name string) error {
+	sa := syscall.SecurityAttributes{Length: 0}
+	sddl := "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
+	sd, err := winio.SddlToSecurityDescriptor(sddl)
+	if err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+	sa.SecurityDescriptor = uintptr(unsafe.Pointer(&sd[0]))
+
+	namep, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+
+	e := syscall.CreateDirectory(namep, &sa)
+	if e != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: e}
+	}
+	return nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener_unsupported.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener_unsupported.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+package sdk
+
+import (
+	"errors"
+	"net"
+)
+
+var (
+	errOnlySupportedOnWindows = errors.New("named pipe creation is only supported on Windows")
+)
+
+func newWindowsListener(address, pluginName, daemonRoot string, pipeConfig *WindowsPipeConfig) (net.Listener, string, error) {
+	return nil, "", errOnlySupportedOnWindows
+}
+
+func windowsCreateDirectoryWithACL(name string) error {
+	return nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/windows_pipe_config.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/windows_pipe_config.go
@@ -1,0 +1,13 @@
+package sdk
+
+// WindowsPipeConfig is a helper structure for configuring named pipe parameters on Windows.
+type WindowsPipeConfig struct {
+	// SecurityDescriptor contains a Windows security descriptor in SDDL format.
+	SecurityDescriptor string
+
+	// InBufferSize in bytes.
+	InBufferSize int32
+
+	// OutBufferSize in bytes.
+	OutBufferSize int32
+}

--- a/vendor/github.com/docker/go-plugins-helpers/volume/README.md
+++ b/vendor/github.com/docker/go-plugins-helpers/volume/README.md
@@ -1,0 +1,36 @@
+# Docker volume extension api.
+
+Go handler to create external volume extensions for Docker.
+
+## Usage
+
+This library is designed to be integrated in your program.
+
+1. Implement the `volume.Driver` interface.
+2. Initialize a `volume.Handler` with your implementation.
+3. Call either `ServeTCP` or `ServeUnix` from the `volume.Handler`.
+
+### Example using TCP sockets:
+
+```go
+  d := MyVolumeDriver{}
+  h := volume.NewHandler(d)
+  h.ServeTCP("test_volume", ":8080")
+```
+
+### Example using Unix sockets:
+
+```go
+  d := MyVolumeDriver{}
+  h := volume.NewHandler(d)
+  u, _ := user.Lookup("root")
+  gid, _ := strconv.Atoi(u.Gid)
+  h.ServeUnix("test_volume", gid)
+```
+
+## Full example plugins
+
+- https://github.com/calavera/docker-volume-glusterfs
+- https://github.com/calavera/docker-volume-keywhiz
+- https://github.com/quobyte/docker-volume
+- https://github.com/NimbleStorage/Nemo

--- a/vendor/github.com/docker/go-plugins-helpers/volume/api.go
+++ b/vendor/github.com/docker/go-plugins-helpers/volume/api.go
@@ -1,0 +1,230 @@
+package volume
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/docker/go-plugins-helpers/sdk"
+)
+
+const (
+	// DefaultDockerRootDirectory is the default directory where volumes will be created.
+	DefaultDockerRootDirectory = "/var/lib/docker-volumes"
+
+	manifest         = `{"Implements": ["VolumeDriver"]}`
+	createPath       = "/VolumeDriver.Create"
+	getPath          = "/VolumeDriver.Get"
+	listPath         = "/VolumeDriver.List"
+	removePath       = "/VolumeDriver.Remove"
+	hostVirtualPath  = "/VolumeDriver.Path"
+	mountPath        = "/VolumeDriver.Mount"
+	unmountPath      = "/VolumeDriver.Unmount"
+	capabilitiesPath = "/VolumeDriver.Capabilities"
+)
+
+// CreateRequest is the structure that docker's requests are deserialized to.
+type CreateRequest struct {
+	Name    string
+	Options map[string]string `json:"Opts,omitempty"`
+}
+
+// RemoveRequest structure for a volume remove request
+type RemoveRequest struct {
+	Name string
+}
+
+// MountRequest structure for a volume mount request
+type MountRequest struct {
+	Name string
+	ID   string
+}
+
+// MountResponse structure for a volume mount response
+type MountResponse struct {
+	Mountpoint string
+}
+
+// UnmountRequest structure for a volume unmount request
+type UnmountRequest struct {
+	Name string
+	ID   string
+}
+
+// PathRequest structure for a volume path request
+type PathRequest struct {
+	Name string
+}
+
+// PathResponse structure for a volume path response
+type PathResponse struct {
+	Mountpoint string
+}
+
+// GetRequest structure for a volume get request
+type GetRequest struct {
+	Name string
+}
+
+// GetResponse structure for a volume get response
+type GetResponse struct {
+	Volume *Volume
+}
+
+// ListResponse structure for a volume list response
+type ListResponse struct {
+	Volumes []*Volume
+}
+
+// CapabilitiesResponse structure for a volume capability response
+type CapabilitiesResponse struct {
+	Capabilities Capability
+}
+
+// Volume represents a volume object for use with `Get` and `List` requests
+type Volume struct {
+	Name       string
+	Mountpoint string                 `json:",omitempty"`
+	CreatedAt  string                 `json:",omitempty"`
+	Status     map[string]interface{} `json:",omitempty"`
+}
+
+// Capability represents the list of capabilities a volume driver can return
+type Capability struct {
+	Scope string
+}
+
+// ErrorResponse is a formatted error message that docker can understand
+type ErrorResponse struct {
+	Err string
+}
+
+// NewErrorResponse creates an ErrorResponse with the provided message
+func NewErrorResponse(msg string) *ErrorResponse {
+	return &ErrorResponse{Err: msg}
+}
+
+// Driver represent the interface a driver must fulfill.
+type Driver interface {
+	Create(*CreateRequest) error
+	List() (*ListResponse, error)
+	Get(*GetRequest) (*GetResponse, error)
+	Remove(*RemoveRequest) error
+	Path(*PathRequest) (*PathResponse, error)
+	Mount(*MountRequest) (*MountResponse, error)
+	Unmount(*UnmountRequest) error
+	Capabilities() *CapabilitiesResponse
+}
+
+// Handler forwards requests and responses between the docker daemon and the plugin.
+type Handler struct {
+	driver Driver
+	sdk.Handler
+}
+
+// NewHandler initializes the request handler with a driver implementation.
+func NewHandler(driver Driver) *Handler {
+	h := &Handler{driver, sdk.NewHandler(manifest)}
+	h.initMux()
+	return h
+}
+
+func (h *Handler) initMux() {
+	h.HandleFunc(createPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers createPath")
+		req := &CreateRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Create(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, struct{}{}, false)
+	})
+	h.HandleFunc(removePath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers removePath")
+		req := &RemoveRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Remove(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, struct{}{}, false)
+	})
+	h.HandleFunc(mountPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers mountPath")
+		req := &MountRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Mount(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+	h.HandleFunc(hostVirtualPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers hostVirtualPath")
+		req := &PathRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Path(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+	h.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers getPath")
+		req := &GetRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Get(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+	h.HandleFunc(unmountPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers unmountPath")
+		req := &UnmountRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Unmount(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, struct{}{}, false)
+	})
+	h.HandleFunc(listPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers listPath")
+		res, err := h.driver.List()
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+
+	h.HandleFunc(capabilitiesPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers capabilitiesPath")
+		sdk.EncodeResponse(w, h.driver.Capabilities(), false)
+	})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -211,6 +211,8 @@ github.com/containers/storage/pkg/truncindex
 github.com/containers/storage/pkg/unshare
 # github.com/coreos/go-iptables v0.4.5
 github.com/coreos/go-iptables/iptables
+# github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+github.com/coreos/go-systemd/activation
 # github.com/coreos/go-systemd/v22 v22.1.0
 github.com/coreos/go-systemd/v22/activation
 github.com/coreos/go-systemd/v22/daemon
@@ -276,6 +278,9 @@ github.com/docker/go-connections/sockets
 github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-metrics v0.0.1
 github.com/docker/go-metrics
+# github.com/docker/go-plugins-helpers v0.0.0-20200102110956-c9a8a2d92ccc
+github.com/docker/go-plugins-helpers/sdk
+github.com/docker/go-plugins-helpers/volume
 # github.com/docker/go-units v0.4.0
 github.com/docker/go-units
 # github.com/docker/libnetwork v0.8.0-dev.2.0.20190625141545-5a177b73e316


### PR DESCRIPTION
Docker provides extensibility through a plugin system, of which several types are available. This provides an initial library API for communicating with one type of plugins, volume plugins. Volume plugins allow for an external service to create and manage a volume on Podman's behalf.

This does not integrate the plugin system into Libpod or Podman yet; that will come in subsequent pull requests.

This replaces #4548 and will begin the continuation of that work.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
