### PR TITLE
Refactor compat container create endpoint

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -134,7 +134,6 @@ func stringMaptoArray(m map[string]string) []string {
 // a specgen spec.
 func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroupsManager string) (*ContainerCLIOpts, []string, error) {
 	var (
-		aliases    []string
 		capAdd     []string
 		cappDrop   []string
 		entrypoint string
@@ -211,7 +210,7 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		mounts = append(mounts, mount)
 	}
 
-	//volumes
+	// volumes
 	volumes := make([]string, 0, len(cc.Config.Volumes))
 	for v := range cc.Config.Volumes {
 		volumes = append(volumes, v)
@@ -241,16 +240,6 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		}
 	}
 
-	// network names
-	endpointsConfig := cc.NetworkingConfig.EndpointsConfig
-	cniNetworks := make([]string, 0, len(endpointsConfig))
-	for netName, endpoint := range endpointsConfig {
-		cniNetworks = append(cniNetworks, netName)
-		if len(endpoint.Aliases) > 0 {
-			aliases = append(aliases, endpoint.Aliases...)
-		}
-	}
-
 	// netMode
 	nsmode, _, err := specgen.ParseNetworkNamespace(cc.HostConfig.NetworkMode.NetworkName())
 	if err != nil {
@@ -267,8 +256,6 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 	// defined when there is only one network.
 	netInfo := entities.NetOptions{
 		AddHosts:     cc.HostConfig.ExtraHosts,
-		Aliases:      aliases,
-		CNINetworks:  cniNetworks,
 		DNSOptions:   cc.HostConfig.DNSOptions,
 		DNSSearch:    cc.HostConfig.DNSSearch,
 		DNSServers:   dns,
@@ -276,31 +263,58 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		PublishPorts: specPorts,
 	}
 
-	// static IP and MAC
-	if len(endpointsConfig) == 1 {
-		for _, ep := range endpointsConfig {
-			// if IP address is provided
-			if len(ep.IPAddress) > 0 {
-				staticIP := net.ParseIP(ep.IPAddress)
-				netInfo.StaticIP = &staticIP
+	// network names
+	switch {
+	case len(cc.NetworkingConfig.EndpointsConfig) > 0:
+		var aliases []string
+
+		endpointsConfig := cc.NetworkingConfig.EndpointsConfig
+		cniNetworks := make([]string, 0, len(endpointsConfig))
+		for netName, endpoint := range endpointsConfig {
+
+			cniNetworks = append(cniNetworks, netName)
+
+			if endpoint == nil {
+				continue
 			}
-			// If MAC address is provided
-			if len(ep.MacAddress) > 0 {
-				staticMac, err := net.ParseMAC(ep.MacAddress)
-				if err != nil {
-					return nil, nil, err
-				}
-				netInfo.StaticMAC = &staticMac
+			if len(endpoint.Aliases) > 0 {
+				aliases = append(aliases, endpoint.Aliases...)
 			}
-			break
 		}
+
+		// static IP and MAC
+		if len(endpointsConfig) == 1 {
+			for _, ep := range endpointsConfig {
+				if ep == nil {
+					continue
+				}
+				// if IP address is provided
+				if len(ep.IPAddress) > 0 {
+					staticIP := net.ParseIP(ep.IPAddress)
+					netInfo.StaticIP = &staticIP
+				}
+				// If MAC address is provided
+				if len(ep.MacAddress) > 0 {
+					staticMac, err := net.ParseMAC(ep.MacAddress)
+					if err != nil {
+						return nil, nil, err
+					}
+					netInfo.StaticMAC = &staticMac
+				}
+				break
+			}
+		}
+		netInfo.Aliases = aliases
+		netInfo.CNINetworks = cniNetworks
+	case len(cc.HostConfig.NetworkMode) > 0:
+		netInfo.CNINetworks = []string{string(cc.HostConfig.NetworkMode)}
 	}
 
 	// Note: several options here are marked as "don't need". this is based
 	// on speculation by Matt and I. We think that these come into play later
 	// like with start. We believe this is just a difference in podman/compat
 	cliOpts := ContainerCLIOpts{
-		//Attach:            nil, // dont need?
+		// Attach:            nil, // dont need?
 		Authfile:     "",
 		CapAdd:       append(capAdd, cc.HostConfig.CapAdd...),
 		CapDrop:      append(cappDrop, cc.HostConfig.CapDrop...),
@@ -311,11 +325,11 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		CPURTPeriod:  uint64(cc.HostConfig.CPURealtimePeriod),
 		CPURTRuntime: cc.HostConfig.CPURealtimeRuntime,
 		CPUShares:    uint64(cc.HostConfig.CPUShares),
-		//CPUS:              0, // dont need?
+		// CPUS:              0, // dont need?
 		CPUSetCPUs: cc.HostConfig.CpusetCpus,
 		CPUSetMems: cc.HostConfig.CpusetMems,
-		//Detach:            false, // dont need
-		//DetachKeys:        "",    // dont need
+		// Detach:            false, // dont need
+		// DetachKeys:        "",    // dont need
 		Devices:          devices,
 		DeviceCGroupRule: nil,
 		DeviceReadBPs:    readBps,
@@ -437,7 +451,7 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 	}
 
 	// specgen assumes the image name is arg[0]
-	cmd := []string{cc.Image}
+	cmd := []string{cc.Config.Image}
 	cmd = append(cmd, cc.Config.Cmd...)
 	return &cliOpts, cmd, nil
 }

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -900,7 +900,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 	// If we have CNI networks - handle that here
 	if len(networks) > 0 && !isDefault {
 		if len(networks) != len(c.state.NetworkStatus) {
-			return nil, errors.Wrapf(define.ErrInternal, "network inspection mismatch: asked to join %d CNI networks but have information on %d networks", len(networks), len(c.state.NetworkStatus))
+			return nil, errors.Wrapf(define.ErrInternal, "network inspection mismatch: asked to join %d CNI network(s) %v, but have information on %d network(s)", len(networks), networks, len(c.state.NetworkStatus))
 		}
 
 		settings.Networks = make(map[string]*define.InspectAdditionalNetwork)

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -110,11 +110,12 @@ type ContainerWaitOKBody struct {
 	}
 }
 
+// CreateContainerConfig used when compatible endpoint creates a container
 type CreateContainerConfig struct {
-	Name string
-	dockerContainer.Config
-	HostConfig       dockerContainer.HostConfig
-	NetworkingConfig dockerNetwork.NetworkingConfig
+	Name                   string                         // container name
+	dockerContainer.Config                                // desired container configuration
+	HostConfig             dockerContainer.HostConfig     // host dependent configuration for container
+	NetworkingConfig       dockerNetwork.NetworkingConfig // network configuration for container
 }
 
 // swagger:model IDResponse
@@ -253,7 +254,7 @@ func ImageDataToImageInspect(ctx context.Context, l *libpodImage.Image) (*ImageI
 		//	StdinOnce:       false,
 		Env: info.Config.Env,
 		Cmd: info.Config.Cmd,
-		//Healthcheck: l.ImageData.HealthCheck,
+		// Healthcheck: l.ImageData.HealthCheck,
 		//	ArgsEscaped:     false,
 		//	Image:           "",
 		Volumes:    info.Config.Volumes,
@@ -261,7 +262,7 @@ func ImageDataToImageInspect(ctx context.Context, l *libpodImage.Image) (*ImageI
 		Entrypoint: info.Config.Entrypoint,
 		//	NetworkDisabled: false,
 		//	MacAddress:      "",
-		//OnBuild:    info.Config.OnBuild,
+		// OnBuild:    info.Config.OnBuild,
 		Labels:     info.Labels,
 		StopSignal: info.Config.StopSignal,
 		//	StopTimeout:     nil,

--- a/test/apiv2/rest_api/__init__.py
+++ b/test/apiv2/rest_api/__init__.py
@@ -16,19 +16,18 @@ class Podman(object):
         binary = os.getenv("PODMAN", "bin/podman")
         self.cmd = [binary, "--storage-driver=vfs"]
 
-        cgroupfs = os.getenv("CGROUP_MANAGER", "cgroupfs")
+        cgroupfs = os.getenv("CGROUP_MANAGER", "systemd")
         self.cmd.append(f"--cgroup-manager={cgroupfs}")
 
         if os.getenv("DEBUG"):
             self.cmd.append("--log-level=debug")
+            self.cmd.append("--syslog=true")
 
         self.anchor_directory = tempfile.mkdtemp(prefix="podman_restapi_")
         self.cmd.append("--root=" + os.path.join(self.anchor_directory, "crio"))
         self.cmd.append("--runroot=" + os.path.join(self.anchor_directory, "crio-run"))
 
-        os.environ["REGISTRIES_CONFIG_PATH"] = os.path.join(
-            self.anchor_directory, "registry.conf"
-        )
+        os.environ["REGISTRIES_CONFIG_PATH"] = os.path.join(self.anchor_directory, "registry.conf")
         p = configparser.ConfigParser()
         p.read_dict(
             {
@@ -40,14 +39,10 @@ class Podman(object):
         with open(os.environ["REGISTRIES_CONFIG_PATH"], "w") as w:
             p.write(w)
 
-        os.environ["CNI_CONFIG_PATH"] = os.path.join(
-            self.anchor_directory, "cni", "net.d"
-        )
+        os.environ["CNI_CONFIG_PATH"] = os.path.join(self.anchor_directory, "cni", "net.d")
         os.makedirs(os.environ["CNI_CONFIG_PATH"], exist_ok=True)
         self.cmd.append("--cni-config-dir=" + os.environ["CNI_CONFIG_PATH"])
-        cni_cfg = os.path.join(
-            os.environ["CNI_CONFIG_PATH"], "87-podman-bridge.conflist"
-        )
+        cni_cfg = os.path.join(os.environ["CNI_CONFIG_PATH"], "87-podman-bridge.conflist")
         # json decoded and encoded to ensure legal json
         buf = json.loads(
             """

--- a/test/apiv2/rest_api/v1_test_rest_v1_0_0.py
+++ b/test/apiv2/rest_api/v1_test_rest_v1_0_0.py
@@ -84,9 +84,7 @@ class TestApi(unittest.TestCase):
             print("\nService Stderr:\n" + stderr.decode("utf-8"))
 
         if TestApi.podman.returncode > 0:
-            sys.stderr.write(
-                "podman exited with error code {}\n".format(TestApi.podman.returncode)
-            )
+            sys.stderr.write("podman exited with error code {}\n".format(TestApi.podman.returncode))
             sys.exit(2)
 
         return super().tearDownClass()

--- a/test/python/docker/__init__.py
+++ b/test/python/docker/__init__.py
@@ -39,9 +39,7 @@ class Podman(object):
         self.cmd.append("--root=" + os.path.join(self.anchor_directory, "crio"))
         self.cmd.append("--runroot=" + os.path.join(self.anchor_directory, "crio-run"))
 
-        os.environ["REGISTRIES_CONFIG_PATH"] = os.path.join(
-            self.anchor_directory, "registry.conf"
-        )
+        os.environ["REGISTRIES_CONFIG_PATH"] = os.path.join(self.anchor_directory, "registry.conf")
         p = configparser.ConfigParser()
         p.read_dict(
             {
@@ -53,14 +51,10 @@ class Podman(object):
         with open(os.environ["REGISTRIES_CONFIG_PATH"], "w") as w:
             p.write(w)
 
-        os.environ["CNI_CONFIG_PATH"] = os.path.join(
-            self.anchor_directory, "cni", "net.d"
-        )
+        os.environ["CNI_CONFIG_PATH"] = os.path.join(self.anchor_directory, "cni", "net.d")
         os.makedirs(os.environ["CNI_CONFIG_PATH"], exist_ok=True)
         self.cmd.append("--cni-config-dir=" + os.environ["CNI_CONFIG_PATH"])
-        cni_cfg = os.path.join(
-            os.environ["CNI_CONFIG_PATH"], "87-podman-bridge.conflist"
-        )
+        cni_cfg = os.path.join(os.environ["CNI_CONFIG_PATH"], "87-podman-bridge.conflist")
         # json decoded and encoded to ensure legal json
         buf = json.loads(
             """

--- a/test/python/docker/common.py
+++ b/test/python/docker/common.py
@@ -4,9 +4,7 @@ from test.python.docker import constant
 
 
 def run_top_container(client: DockerClient):
-    c = client.containers.create(
-        constant.ALPINE, command="top", detach=True, tty=True, name="top"
-    )
+    c = client.containers.create(constant.ALPINE, command="top", detach=True, tty=True, name="top")
     c.start()
     return c.id
 

--- a/test/python/docker/test_images.py
+++ b/test/python/docker/test_images.py
@@ -78,9 +78,7 @@ class TestImages(unittest.TestCase):
         self.assertEqual(len(self.client.images.list()), 2)
 
         # List images with filter
-        self.assertEqual(
-            len(self.client.images.list(filters={"reference": "alpine"})), 1
-        )
+        self.assertEqual(len(self.client.images.list(filters={"reference": "alpine"})), 1)
 
     def test_search_image(self):
         """Search for image"""


### PR DESCRIPTION
* Make endpoint compatibile with docker-py network expectations
* Update specgen helper when called from compat endpoint
* Update godoc on types
* Add test for network/container create using docker-py method
* Add syslog logging when DEBUG=1 for tests

Fixes #8361

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
