### PR TITLE
Add an option to control if play kube should start the pod

### DIFF
--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -22,6 +22,7 @@ type playKubeOptionsWrapper struct {
 
 	TLSVerifyCLI   bool
 	CredentialsCLI string
+	StartCLI       bool
 }
 
 var (
@@ -68,6 +69,7 @@ func init() {
 
 	flags.BoolVarP(&kubeOptions.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
 	flags.BoolVar(&kubeOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+	flags.BoolVar(&kubeOptions.StartCLI, "start", true, "Start the pod after creating it")
 
 	authfileFlagName := "authfile"
 	flags.StringVar(&kubeOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
@@ -99,6 +101,9 @@ func kube(cmd *cobra.Command, args []string) error {
 	// boolean CLI flags.
 	if cmd.Flags().Changed("tls-verify") {
 		kubeOptions.SkipTLSVerify = types.NewOptionalBool(!kubeOptions.TLSVerifyCLI)
+	}
+	if cmd.Flags().Changed("start") {
+		kubeOptions.Start = types.NewOptionalBool(kubeOptions.StartCLI)
 	}
 	if kubeOptions.Authfile != "" {
 		if _, err := os.Stat(kubeOptions.Authfile); err != nil {

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -58,6 +58,10 @@ Suppress output information when pulling images
 
 Directory path for seccomp profiles (default: "/var/lib/kubelet/seccomp"). (Not available for remote commands)
 
+#### **--start**=*true|false*
+
+Start the pod after creating it, set to false to only create it.
+
 #### **--tls-verify**=*true|false*
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,

--- a/pkg/api/handlers/libpod/play.go
+++ b/pkg/api/handlers/libpod/play.go
@@ -23,8 +23,10 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 		Network   string `schema:"reference"`
 		TLSVerify bool   `schema:"tlsVerify"`
 		LogDriver string `schema:"logDriver"`
+		Start     bool   `schema:"start"`
 	}{
 		TLSVerify: true,
+		Start:     true,
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
@@ -72,6 +74,9 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)
+	}
+	if _, found := r.URL.Query()["start"]; found {
+		options.Start = types.NewOptionalBool(query.Start)
 	}
 
 	report, err := containerEngine.PlayKube(r.Context(), tmpfile.Name(), options)

--- a/pkg/api/server/register_play.go
+++ b/pkg/api/server/register_play.go
@@ -29,6 +29,11 @@ func (s *APIServer) registerPlayHandlers(r *mux.Router) error {
 	//    name: logDriver
 	//    type: string
 	//    description: Logging driver for the containers in the pod.
+	//  - in: query
+	//    name: start
+	//    type: boolean
+	//    default: true
+	//    description: Start the pod after creating it.
 	//  - in: body
 	//    name: request
 	//    description: Kubernetes YAML file.

--- a/pkg/bindings/play/play.go
+++ b/pkg/bindings/play/play.go
@@ -32,6 +32,9 @@ func Kube(ctx context.Context, path string, options entities.PlayKubeOptions) (*
 	if options.SkipTLSVerify != types.OptionalBoolUndefined {
 		params.Set("tlsVerify", strconv.FormatBool(options.SkipTLSVerify == types.OptionalBoolTrue))
 	}
+	if options.Start != types.OptionalBoolUndefined {
+		params.Set("start", strconv.FormatBool(options.Start == types.OptionalBoolTrue))
+	}
 
 	// TODO: have a global system context we can pass around (1st argument)
 	header, err := auth.Header(nil, auth.XRegistryAuthHeader, options.Authfile, options.Username, options.Password)

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -28,6 +28,8 @@ type PlayKubeOptions struct {
 	ConfigMaps []string
 	// LogDriver for the container. For example: journald
 	LogDriver string
+	// Start - don't start the pod if false
+	Start types.OptionalBool
 }
 
 // PlayKubePod represents a single pod and associated containers created by play kube

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -297,20 +297,22 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		containers = append(containers, ctr)
 	}
 
-	//start the containers
-	podStartErrors, err := pod.Start(ctx)
-	if err != nil {
-		return nil, err
-	}
+	if options.Start != types.OptionalBoolFalse {
+		//start the containers
+		podStartErrors, err := pod.Start(ctx)
+		if err != nil {
+			return nil, err
+		}
 
-	// Previous versions of playkube started containers individually and then
-	// looked for errors.  Because we now use the uber-Pod start call, we should
-	// iterate the map of possible errors and return one if there is a problem. This
-	// keeps the behavior the same
+		// Previous versions of playkube started containers individually and then
+		// looked for errors.  Because we now use the uber-Pod start call, we should
+		// iterate the map of possible errors and return one if there is a problem. This
+		// keeps the behavior the same
 
-	for _, e := range podStartErrors {
-		if e != nil {
-			return nil, e
+		for _, e := range podStartErrors {
+			if e != nil {
+				return nil, e
+			}
 		}
 	}
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1482,4 +1482,19 @@ MemoryReservation: {{ .HostConfig.MemoryReservation }}`})
 		Expect(inspect.ExitCode()).To(Equal(0))
 		Expect(inspect.OutputToString()).To(ContainSubstring("journald"))
 	})
+
+	It("podman play kube test only creating the containers", func() {
+		pod := getPod()
+		err := generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).To(BeNil())
+
+		kube := podmanTest.Podman([]string{"play", "kube", "--start=false", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", getCtrNameInPod(pod), "--format", "{{ .State.Running }}"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(Equal(0))
+		Expect(inspect.OutputToString()).To(Equal("false"))
+	})
 })


### PR DESCRIPTION
Having play kube start the pod is not always appropriate, one might
for example like to have the pod running as a set of systemd services.
This new option allow to skip starting the pod.