### PR TITLE
Remove some more excessive wrapping and stuttering

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -592,7 +592,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 		case "max-size":
 			logSize, err := units.FromHumanSize(split[1])
 			if err != nil {
-				return errors.Wrapf(err, "%s is not a valid option", o)
+				return err
 			}
 			s.LogConfiguration.Size = logSize
 		default:
@@ -662,7 +662,7 @@ func makeHealthCheckFromCli(inCmd, interval string, retries uint, timeout, start
 	}
 	intervalDuration, err := time.ParseDuration(interval)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid healthcheck-interval %s ", interval)
+		return nil, errors.Wrapf(err, "invalid healthcheck-interval")
 	}
 
 	hc.Interval = intervalDuration
@@ -673,7 +673,7 @@ func makeHealthCheckFromCli(inCmd, interval string, retries uint, timeout, start
 	hc.Retries = int(retries)
 	timeoutDuration, err := time.ParseDuration(timeout)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid healthcheck-timeout %s", timeout)
+		return nil, errors.Wrapf(err, "invalid healthcheck-timeout")
 	}
 	if timeoutDuration < time.Duration(1) {
 		return nil, errors.New("healthcheck-timeout must be at least 1 second")
@@ -682,7 +682,7 @@ func makeHealthCheckFromCli(inCmd, interval string, retries uint, timeout, start
 
 	startPeriodDuration, err := time.ParseDuration(startPeriod)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid healthcheck-start-period %s", startPeriod)
+		return nil, errors.Wrapf(err, "invalid healthcheck-start-period")
 	}
 	if startPeriodDuration < time.Duration(0) {
 		return nil, errors.New("healthcheck-start-period must be 0 seconds or greater")

--- a/cmd/podman/common/util.go
+++ b/cmd/podman/common/util.go
@@ -250,7 +250,7 @@ func parseAndValidateRange(portRange string) (uint16, uint16, error) {
 func parseAndValidatePort(port string) (uint16, error) {
 	num, err := strconv.Atoi(port)
 	if err != nil {
-		return 0, errors.Wrapf(err, "cannot parse %q as a port number", port)
+		return 0, errors.Wrapf(err, "invalid port number")
 	}
 	if num < 1 || num > 65535 {
 		return 0, errors.Errorf("port numbers must be between 1 and 65535 (inclusive), got %d", num)

--- a/cmd/podman/containers/prune.go
+++ b/cmd/podman/containers/prune.go
@@ -57,7 +57,7 @@ func prune(cmd *cobra.Command, args []string) error {
 		fmt.Print("Are you sure you want to continue? [y/N] ")
 		answer, err := reader.ReadString('\n')
 		if err != nil {
-			return errors.Wrapf(err, "error reading input")
+			return err
 		}
 		if strings.ToLower(answer)[0] != 'y' {
 			return nil

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -205,7 +205,7 @@ func run(cmd *cobra.Command, args []string) error {
 	if runRmi {
 		_, rmErrors := registry.ImageEngine().Remove(registry.GetContext(), []string{imageName}, entities.ImageRemoveOptions{})
 		if len(rmErrors) > 0 {
-			logrus.Errorf("%s", errors.Wrapf(errorhandling.JoinErrors(rmErrors), "failed removing image"))
+			logrus.Errorf("%s", errorhandling.JoinErrors(rmErrors))
 		}
 	}
 	return nil

--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -353,18 +353,18 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 
 	isolation, err := parse.IsolationOption(flags.Isolation)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing ID mapping options")
+		return nil, err
 	}
 
 	usernsOption, idmappingOptions, err := parse.IDMappingOptions(c, isolation)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing ID mapping options")
+		return nil, err
 	}
 	nsValues = append(nsValues, usernsOption...)
 
 	systemContext, err := parse.SystemContextFromOptions(c)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error building system context")
+		return nil, err
 	}
 
 	format := ""

--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/utils"
 	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -60,7 +59,7 @@ WARNING! This will remove all dangling images.
 Are you sure you want to continue? [y/N] `)
 		answer, err := reader.ReadString('\n')
 		if err != nil {
-			return errors.Wrapf(err, "error reading input")
+			return err
 		}
 		if strings.ToLower(answer)[0] != 'y' {
 			return nil

--- a/cmd/podman/images/sign.go
+++ b/cmd/podman/images/sign.go
@@ -58,7 +58,7 @@ func sign(cmd *cobra.Command, args []string) error {
 	if len(signOptions.Directory) > 0 {
 		sigStoreDir = signOptions.Directory
 		if _, err := os.Stat(sigStoreDir); err != nil {
-			return errors.Wrapf(err, "invalid directory %s", sigStoreDir)
+			return err
 		}
 	}
 	_, err := registry.ImageEngine().Sign(registry.Context(), args, signOptions)

--- a/cmd/podman/images/trust_set.go
+++ b/cmd/podman/images/trust_set.go
@@ -55,7 +55,7 @@ func setTrust(cmd *cobra.Command, args []string) error {
 
 	valid, err := image.IsValidImageURI(args[0])
 	if err != nil || !valid {
-		return errors.Wrapf(err, "invalid image uri %s", args[0])
+		return err
 	}
 
 	if !util.StringInSlice(setOptions.Type, validTrustTypes) {

--- a/cmd/podman/manifest/add.go
+++ b/cmd/podman/manifest/add.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -116,7 +115,7 @@ func add(cmd *cobra.Command, args []string) error {
 
 	listID, err := registry.ImageEngine().ManifestAdd(context.Background(), manifestAddOpts.ManifestAddOptions)
 	if err != nil {
-		return errors.Wrapf(err, "error adding to manifest list %s", args[0])
+		return err
 	}
 	fmt.Printf("%s\n", listID)
 	return nil

--- a/cmd/podman/manifest/annotate.go
+++ b/cmd/podman/manifest/annotate.go
@@ -73,7 +73,7 @@ func annotate(cmd *cobra.Command, args []string) error {
 	}
 	updatedListID, err := registry.ImageEngine().ManifestAnnotate(context.Background(), args, manifestAnnotateOpts)
 	if err != nil {
-		return errors.Wrapf(err, "error removing from manifest list %s", listImageSpec)
+		return err
 	}
 	fmt.Printf("%s\n", updatedListID)
 	return nil

--- a/cmd/podman/manifest/create.go
+++ b/cmd/podman/manifest/create.go
@@ -7,7 +7,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/common"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +38,7 @@ func init() {
 func create(cmd *cobra.Command, args []string) error {
 	imageID, err := registry.ImageEngine().ManifestCreate(context.Background(), args[:1], args[1:], manifestCreateOpts)
 	if err != nil {
-		return errors.Wrapf(err, "error creating manifest %s", args[0])
+		return err
 	}
 	fmt.Printf("%s\n", imageID)
 	return nil

--- a/cmd/podman/manifest/inspect.go
+++ b/cmd/podman/manifest/inspect.go
@@ -7,7 +7,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/common"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -35,7 +34,7 @@ func init() {
 func inspect(cmd *cobra.Command, args []string) error {
 	buf, err := registry.ImageEngine().ManifestInspect(context.Background(), args[0])
 	if err != nil {
-		return errors.Wrapf(err, "error inspect manifest %s", args[0])
+		return err
 	}
 	fmt.Printf("%s\n", buf)
 	return nil

--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -108,7 +108,7 @@ func push(cmd *cobra.Command, args []string) error {
 		manifestPushOpts.SkipTLSVerify = types.NewOptionalBool(!manifestPushOpts.TLSVerifyCLI)
 	}
 	if err := registry.ImageEngine().ManifestPush(registry.Context(), args, manifestPushOpts.ManifestPushOptions); err != nil {
-		return errors.Wrapf(err, "error pushing manifest %s to %s", listImageSpec, destSpec)
+		return err
 	}
 	return nil
 }

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -218,7 +218,7 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 	if len(podIDFile) > 0 {
 		if err = ioutil.WriteFile(podIDFile, []byte(response.Id), 0644); err != nil {
-			return errors.Wrapf(err, "failed to write pod ID to file %q", podIDFile)
+			return errors.Wrapf(err, "failed to write pod ID to file")
 		}
 	}
 	fmt.Println(response.Id)

--- a/cmd/podman/pods/prune.go
+++ b/cmd/podman/pods/prune.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/utils"
 	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -51,7 +50,7 @@ func prune(cmd *cobra.Command, args []string) error {
 		fmt.Print("Are you sure you want to continue? [y/N] ")
 		answer, err := reader.ReadString('\n')
 		if err != nil {
-			return errors.Wrapf(err, "error reading input")
+			return err
 		}
 		if strings.ToLower(answer)[0] != 'y' {
 			return nil

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -189,8 +189,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 		if cmd.Flag("cpu-profile").Changed {
 			f, err := os.Create(cfg.CPUProfile)
 			if err != nil {
-				return errors.Wrapf(err, "unable to create cpu profiling file %s",
-					cfg.CPUProfile)
+				return err
 			}
 			if err := pprof.StartCPUProfile(f); err != nil {
 				return err

--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/libpod/events"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -104,7 +103,7 @@ func eventsCmd(cmd *cobra.Command, _ []string) error {
 		case doJSON:
 			jsonStr, err := event.ToJSONString()
 			if err != nil {
-				return errors.Wrapf(err, "unable to format json")
+				return err
 			}
 			fmt.Println(jsonStr)
 		case cmd.Flags().Changed("format"):

--- a/cmd/podman/system/prune.go
+++ b/cmd/podman/system/prune.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/utils"
 	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -68,7 +67,7 @@ WARNING! This will remove:
 Are you sure you want to continue? [y/N] `, volumeString)
 		answer, err := reader.ReadString('\n')
 		if err != nil {
-			return errors.Wrapf(err, "error reading input")
+			return err
 		}
 		if strings.ToLower(answer)[0] != 'y' {
 			return nil

--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -13,7 +13,7 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/domain/infra"
-	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +57,7 @@ WARNING! This will remove:
 Are you sure you want to continue? [y/N] `)
 		answer, err := reader.ReadString('\n')
 		if err != nil {
-			fmt.Println(errors.Wrapf(err, "error reading input"))
+			logrus.Error(err)
 			os.Exit(1)
 		}
 		if strings.ToLower(answer)[0] != 'y' {
@@ -71,13 +71,13 @@ Are you sure you want to continue? [y/N] `)
 
 	engine, err := infra.NewSystemEngine(entities.ResetMode, registry.PodmanConfig())
 	if err != nil {
-		fmt.Println(err)
+		logrus.Error(err)
 		os.Exit(125)
 	}
 	defer engine.Shutdown(registry.Context())
 
 	if err := engine.Reset(registry.Context()); err != nil {
-		fmt.Println(err)
+		logrus.Error(err)
 		os.Exit(125)
 	}
 	os.Exit(0)

--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -33,7 +33,7 @@ func restService(opts entities.ServiceOptions, flags *pflag.FlagSet, cfg *entiti
 		address := strings.Join(fields[1:], ":")
 		l, err := net.Listen(fields[0], address)
 		if err != nil {
-			return errors.Wrapf(err, "unable to create socket %s", opts.URI)
+			return errors.Wrapf(err, "unable to create socket")
 		}
 		listener = &l
 	}

--- a/cmd/podman/volumes/prune.go
+++ b/cmd/podman/volumes/prune.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/utils"
 	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +52,7 @@ func prune(cmd *cobra.Command, args []string) error {
 		fmt.Print("Are you sure you want to continue? [y/N] ")
 		answer, err := reader.ReadString('\n')
 		if err != nil {
-			return errors.Wrapf(err, "error reading input")
+			return err
 		}
 		if strings.ToLower(answer)[0] != 'y' {
 			return nil


### PR DESCRIPTION
Stop over wrapping API Calls

The API calls will return an appropriate error, and this wrapping
just makes the error message look like it is stuttering and a
big mess.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
