### PR TITLE
Align the podman ps --filter behavior with docker

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -98,14 +98,6 @@ func checkFlags(c *cobra.Command) error {
 	if listOpts.Last >= 0 && listOpts.Latest {
 		return errors.Errorf("last and latest are mutually exclusive")
 	}
-	// Filter on status forces all
-	for _, filter := range filters {
-		splitFilter := strings.SplitN(filter, "=", 2)
-		if strings.ToLower(splitFilter[0]) == "status" {
-			listOpts.All = true
-			break
-		}
-	}
 	// Quiet conflicts with size and namespace and is overridden by a Go
 	// template.
 	if listOpts.Quiet {

--- a/libpod/filters/containers.go
+++ b/libpod/filters/containers.go
@@ -1,7 +1,6 @@
 package lpfilters
 
 import (
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -11,64 +10,76 @@ import (
 	"github.com/containers/podman/v2/pkg/timetype"
 	"github.com/containers/podman/v2/pkg/util"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // GenerateContainerFilterFuncs return ContainerFilter functions based of filter.
-func GenerateContainerFilterFuncs(filter, filterValue string, r *libpod.Runtime) (func(container *libpod.Container) bool, error) {
+func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpod.Runtime) (func(container *libpod.Container) bool, error) {
 	switch filter {
 	case "id":
+		// we only have to match one ID
 		return func(c *libpod.Container) bool {
-			return strings.Contains(c.ID(), filterValue)
+			return util.StringMatchRegexSlice(c.ID(), filterValues)
 		}, nil
 	case "label":
-		var filterArray = strings.SplitN(filterValue, "=", 2)
-		var filterKey = filterArray[0]
-		if len(filterArray) > 1 {
-			filterValue = filterArray[1]
-		} else {
-			filterValue = ""
+		// we have to match that all given labels exits on that container
+		return func(c *libpod.Container) bool {
+			labels := c.Labels()
+			for _, filterValue := range filterValues {
+				matched := false
+				filterArray := strings.SplitN(filterValue, "=", 2)
+				filterKey := filterArray[0]
+				if len(filterArray) > 1 {
+					filterValue = filterArray[1]
+				} else {
+					filterValue = ""
+				}
+				for labelKey, labelValue := range labels {
+					if labelKey == filterKey && ("" == filterValue || labelValue == filterValue) {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					return false
+				}
+			}
+			return true
+		}, nil
+	case "name":
+		// we only have to match one name
+		return func(c *libpod.Container) bool {
+			return util.StringMatchRegexSlice(c.Name(), filterValues)
+		}, nil
+	case "exited":
+		var exitCodes []int32
+		for _, exitCode := range filterValues {
+			ec, err := strconv.ParseInt(exitCode, 10, 32)
+			if err != nil {
+				return nil, errors.Wrapf(err, "exited code out of range %q", ec)
+			}
+			exitCodes = append(exitCodes, int32(ec))
 		}
 		return func(c *libpod.Container) bool {
-			for labelKey, labelValue := range c.Labels() {
-				if labelKey == filterKey && ("" == filterValue || labelValue == filterValue) {
-					return true
+			ec, exited, err := c.ExitCode()
+			if err == nil && exited {
+				for _, exitCode := range exitCodes {
+					if ec == exitCode {
+						return true
+					}
 				}
 			}
 			return false
 		}, nil
-	case "name":
-		return func(c *libpod.Container) bool {
-			match, err := regexp.MatchString(filterValue, c.Name())
-			if err != nil {
-				logrus.Errorf("Failed to compile regex for 'name' filter: %v", err)
-				return false
-			}
-			return match
-		}, nil
-	case "exited":
-		exitCode, err := strconv.ParseInt(filterValue, 10, 32)
-		if err != nil {
-			return nil, errors.Wrapf(err, "exited code out of range %q", filterValue)
-		}
-		return func(c *libpod.Container) bool {
-			ec, exited, err := c.ExitCode()
-			if ec == int32(exitCode) && err == nil && exited {
-				return true
-			}
-			return false
-		}, nil
 	case "status":
-		if !util.StringInSlice(filterValue, []string{"created", "running", "paused", "stopped", "exited", "unknown"}) {
-			return nil, errors.Errorf("%s is not a valid status", filterValue)
+		for _, filterValue := range filterValues {
+			if !util.StringInSlice(filterValue, []string{"created", "running", "paused", "stopped", "exited", "unknown"}) {
+				return nil, errors.Errorf("%s is not a valid status", filterValue)
+			}
 		}
 		return func(c *libpod.Container) bool {
 			status, err := c.State()
 			if err != nil {
 				return false
-			}
-			if filterValue == "stopped" {
-				filterValue = "exited"
 			}
 			state := status.String()
 			if status == define.ContainerStateConfigured {
@@ -76,36 +87,56 @@ func GenerateContainerFilterFuncs(filter, filterValue string, r *libpod.Runtime)
 			} else if status == define.ContainerStateStopped {
 				state = "exited"
 			}
-			return state == filterValue
+			for _, filterValue := range filterValues {
+				if filterValue == "stopped" {
+					filterValue = "exited"
+				}
+				if state == filterValue {
+					return true
+				}
+			}
+			return false
 		}, nil
 	case "ancestor":
 		// This needs to refine to match docker
 		// - ancestor=(<image-name>[:tag]|<image-id>| ⟨image@digest⟩) - containers created from an image or a descendant.
 		return func(c *libpod.Container) bool {
-			containerConfig := c.Config()
-			if strings.Contains(containerConfig.RootfsImageID, filterValue) || strings.Contains(containerConfig.RootfsImageName, filterValue) {
-				return true
+			for _, filterValue := range filterValues {
+				containerConfig := c.Config()
+				if strings.Contains(containerConfig.RootfsImageID, filterValue) || strings.Contains(containerConfig.RootfsImageName, filterValue) {
+					return true
+				}
 			}
 			return false
 		}, nil
 	case "before":
-		ctr, err := r.LookupContainer(filterValue)
-		if err != nil {
-			return nil, errors.Errorf("unable to find container by name or id of %s", filterValue)
+		var createTime time.Time
+		for _, filterValue := range filterValues {
+			ctr, err := r.LookupContainer(filterValue)
+			if err != nil {
+				return nil, err
+			}
+			containerConfig := ctr.Config()
+			if createTime.IsZero() || createTime.After(containerConfig.CreatedTime) {
+				createTime = containerConfig.CreatedTime
+			}
 		}
-		containerConfig := ctr.Config()
-		createTime := containerConfig.CreatedTime
 		return func(c *libpod.Container) bool {
 			cc := c.Config()
 			return createTime.After(cc.CreatedTime)
 		}, nil
 	case "since":
-		ctr, err := r.LookupContainer(filterValue)
-		if err != nil {
-			return nil, errors.Errorf("unable to find container by name or id of %s", filterValue)
+		var createTime time.Time
+		for _, filterValue := range filterValues {
+			ctr, err := r.LookupContainer(filterValue)
+			if err != nil {
+				return nil, err
+			}
+			containerConfig := ctr.Config()
+			if createTime.IsZero() || createTime.After(containerConfig.CreatedTime) {
+				createTime = containerConfig.CreatedTime
+			}
 		}
-		containerConfig := ctr.Config()
-		createTime := containerConfig.CreatedTime
 		return func(c *libpod.Container) bool {
 			cc := c.Config()
 			return createTime.Before(cc.CreatedTime)
@@ -115,17 +146,27 @@ func GenerateContainerFilterFuncs(filter, filterValue string, r *libpod.Runtime)
 		return func(c *libpod.Container) bool {
 			containerConfig := c.Config()
 			var dest string
-			arr := strings.Split(filterValue, ":")
-			source := arr[0]
-			if len(arr) == 2 {
-				dest = arr[1]
-			}
-			for _, mount := range containerConfig.Spec.Mounts {
-				if dest != "" && (mount.Source == source && mount.Destination == dest) {
-					return true
+			for _, filterValue := range filterValues {
+				arr := strings.SplitN(filterValue, ":", 2)
+				source := arr[0]
+				if len(arr) == 2 {
+					dest = arr[1]
 				}
-				if dest == "" && mount.Source == source {
-					return true
+				for _, mount := range containerConfig.Spec.Mounts {
+					if dest != "" && (mount.Source == source && mount.Destination == dest) {
+						return true
+					}
+					if dest == "" && mount.Source == source {
+						return true
+					}
+				}
+				for _, vname := range containerConfig.NamedVolumes {
+					if dest != "" && (vname.Name == source && vname.Dest == dest) {
+						return true
+					}
+					if dest == "" && vname.Name == source {
+						return true
+					}
 				}
 			}
 			return false
@@ -136,10 +177,18 @@ func GenerateContainerFilterFuncs(filter, filterValue string, r *libpod.Runtime)
 			if err != nil {
 				return false
 			}
-			return hcStatus == filterValue
+			for _, filterValue := range filterValues {
+				if hcStatus == filterValue {
+					return true
+				}
+			}
+			return false
 		}, nil
 	case "until":
-		ts, err := timetype.GetTimestamp(filterValue, time.Now())
+		if len(filterValues) != 1 {
+			return nil, errors.Errorf("specify exactly one timestamp for %s", filter)
+		}
+		ts, err := timetype.GetTimestamp(filterValues[0], time.Now())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -205,15 +205,13 @@ func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []strin
 }
 
 func (ic *ContainerEngine) ContainerPrune(ctx context.Context, options entities.ContainerPruneOptions) (*entities.ContainerPruneReport, error) {
-	var filterFuncs []libpod.ContainerFilter
+	filterFuncs := make([]libpod.ContainerFilter, 0, len(options.Filters))
 	for k, v := range options.Filters {
-		for _, val := range v {
-			generatedFunc, err := lpfilters.GenerateContainerFilterFuncs(k, val, ic.Libpod)
-			if err != nil {
-				return nil, err
-			}
-			filterFuncs = append(filterFuncs, generatedFunc)
+		generatedFunc, err := lpfilters.GenerateContainerFilterFuncs(k, v, ic.Libpod)
+		if err != nil {
+			return nil, err
 		}
+		filterFuncs = append(filterFuncs, generatedFunc)
 	}
 	return ic.pruneContainersHelper(filterFuncs)
 }

--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -21,19 +21,17 @@ import (
 
 func GetContainerLists(runtime *libpod.Runtime, options entities.ContainerListOptions) ([]entities.ListContainer, error) {
 	var (
-		filterFuncs []libpod.ContainerFilter
-		pss         = []entities.ListContainer{}
+		pss = []entities.ListContainer{}
 	)
+	filterFuncs := make([]libpod.ContainerFilter, 0, len(options.Filters))
 	all := options.All || options.Last > 0
 	if len(options.Filters) > 0 {
 		for k, v := range options.Filters {
-			for _, val := range v {
-				generatedFunc, err := lpfilters.GenerateContainerFilterFuncs(k, val, runtime)
-				if err != nil {
-					return nil, err
-				}
-				filterFuncs = append(filterFuncs, generatedFunc)
+			generatedFunc, err := lpfilters.GenerateContainerFilterFuncs(k, v, runtime)
+			if err != nil {
+				return nil, err
 			}
+			filterFuncs = append(filterFuncs, generatedFunc)
 		}
 	}
 
@@ -43,7 +41,7 @@ func GetContainerLists(runtime *libpod.Runtime, options entities.ContainerListOp
 		all = true
 	}
 	if !all {
-		runningOnly, err := lpfilters.GenerateContainerFilterFuncs("status", define.ContainerStateRunning.String(), runtime)
+		runningOnly, err := lpfilters.GenerateContainerFilterFuncs("status", []string{define.ContainerStateRunning.String()}, runtime)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -78,6 +79,17 @@ func ParseRegistryCreds(creds string) (*types.DockerAuthConfig, error) {
 func StringInSlice(s string, sl []string) bool {
 	for _, i := range sl {
 		if i == s {
+			return true
+		}
+	}
+	return false
+}
+
+// StringMatchRegexSlice determines if a given string matches one of the given regexes, returns bool
+func StringMatchRegexSlice(s string, re []string) bool {
+	for _, r := range re {
+		m, err := regexp.MatchString(r, s)
+		if err == nil && m {
 			return true
 		}
 	}


### PR DESCRIPTION
All of our filters worked exclusive resulting in `--filter status=created --filter status=exited` to return nothing.

In docker filters with the same key work inclusive with the only exception being `label` which is exclusive. Filters with different keys always work exclusive.

This PR aims to match the docker behavior with podman.

Fixes #8344


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
