### PR TITLE
Remove build \!remote flags from test phase 2

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -310,7 +310,11 @@ func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	reports, err := ic.NetworkRm(r.Context(), []string{name}, options)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "remove Network create"))
+		utils.Error(w, "remove Network failed", http.StatusInternalServerError, err)
+		return
+	}
+	if len(reports) == 0 {
+		utils.Error(w, "remove Network failed", http.StatusInternalServerError, errors.Errorf("internal error"))
 		return
 	}
 	report := reports[0]

--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -96,7 +96,7 @@ func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, o
 					if err := ic.Libpod.RemovePod(ctx, pod, true, true); err != nil {
 						return reports, err
 					}
-				} else if err := ic.Libpod.RemoveContainer(ctx, c, true, true); err != nil {
+				} else if err := ic.Libpod.RemoveContainer(ctx, c, true, true); err != nil && errors.Cause(err) != define.ErrNoSuchCtr {
 					return reports, err
 				}
 			}

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (
@@ -18,6 +16,7 @@ var _ = Describe("Podman mount", func() {
 	)
 
 	BeforeEach(func() {
+		SkipIfRemote("Podman mount not supported for remote connections")
 		SkipIfRootless("Podman mount requires podman unshare first to work")
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (
@@ -39,6 +37,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to containers/storage", func() {
+		SkipIfRemote("Remote push does not support containers-storage transport")
 		session := podmanTest.Podman([]string{"push", ALPINE, "containers-storage:busybox:test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -49,6 +48,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to dir", func() {
+		SkipIfRemote("Remote push does not support dir transport")
 		bbdir := filepath.Join(podmanTest.TempDir, "busybox")
 		session := podmanTest.Podman([]string{"push", "--remove-signatures", ALPINE,
 			fmt.Sprintf("dir:%s", bbdir)})
@@ -57,6 +57,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to local registry", func() {
+		SkipIfRemote("FIXME: This should work")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
@@ -87,6 +88,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to local registry with authorization", func() {
+		SkipIfRemote("FIXME: This does not seem to be returning an error")
 		SkipIfRootless("FIXME: Creating content in certs.d we use directories in homedir")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
@@ -163,6 +165,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to docker-archive", func() {
+		SkipIfRemote("Remote push does not support docker-archive transport")
 		tarfn := filepath.Join(podmanTest.TempDir, "alp.tar")
 		session := podmanTest.Podman([]string{"push", ALPINE,
 			fmt.Sprintf("docker-archive:%s:latest", tarfn)})
@@ -171,6 +174,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to docker daemon", func() {
+		SkipIfRemote("Remote push does not support docker-daemon transport")
 		setup := SystemExec("bash", []string{"-c", "systemctl status docker 2>&1"})
 
 		if setup.LineInOutputContains("Active: inactive") {
@@ -196,6 +200,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to oci-archive", func() {
+		SkipIfRemote("Remote push does not support oci-archive transport")
 		tarfn := filepath.Join(podmanTest.TempDir, "alp.tar")
 		session := podmanTest.Podman([]string{"push", ALPINE,
 			fmt.Sprintf("oci-archive:%s:latest", tarfn)})
@@ -204,6 +209,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to docker-archive no reference", func() {
+		SkipIfRemote("Remote push does not support docker-archive transport")
 		tarfn := filepath.Join(podmanTest.TempDir, "alp.tar")
 		session := podmanTest.Podman([]string{"push", ALPINE,
 			fmt.Sprintf("docker-archive:%s", tarfn)})
@@ -212,6 +218,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to oci-archive no reference", func() {
+		SkipIfRemote("Remote push does not support oci-archive transport")
 		ociarc := filepath.Join(podmanTest.TempDir, "alp-oci")
 		session := podmanTest.Podman([]string{"push", ALPINE,
 			fmt.Sprintf("oci-archive:%s", ociarc)})

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (

--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (
@@ -46,6 +44,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 	})
 
 	Specify("signals are forwarded to container using sig-proxy", func() {
+		SkipIfRemote("FIXME: This looks like it is supposed to work in remote")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("Doesn't work on ppc64le")
 		}
@@ -111,6 +110,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 	})
 
 	Specify("signals are not forwarded to container with sig-proxy false", func() {
+		SkipIfRemote("FIXME: This looks like it is supposed to work in remote")
 		signal := syscall.SIGFPE
 		if rootless.IsRootless() {
 			podmanTest.RestoreArtifact(fedoraMinimal)

--- a/test/e2e/trust_test.go
+++ b/test/e2e/trust_test.go
@@ -1,5 +1,3 @@
-// +build !remote
-
 package integration
 
 import (
@@ -21,6 +19,7 @@ var _ = Describe("Podman trust", func() {
 	)
 
 	BeforeEach(func() {
+		SkipIfRemote("podman-remote does not support image trust")
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
Add some more tests, document cases where remote will not work
Add FIXMEs for tests that should work on podman-remote but currently
do not.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
