### PR TITLE
Client call to /play/kube incorrectly set tlsVerify

### DIFF
--- a/pkg/bindings/play/play.go
+++ b/pkg/bindings/play/play.go
@@ -30,7 +30,7 @@ func Kube(ctx context.Context, path string, options entities.PlayKubeOptions) (*
 	params.Set("network", options.Network)
 	params.Set("logDriver", options.LogDriver)
 	if options.SkipTLSVerify != types.OptionalBoolUndefined {
-		params.Set("tlsVerify", strconv.FormatBool(options.SkipTLSVerify == types.OptionalBoolTrue))
+		params.Set("tlsVerify", strconv.FormatBool(options.SkipTLSVerify != types.OptionalBoolTrue))
 	}
 
 	// TODO: have a global system context we can pass around (1st argument)


### PR DESCRIPTION
The API parameter `tlsVerify` should be the invert of the internal option `SkipTLSVerify`, fix this conversion.