### PR TITLE
[CI:DOCS] Fix example for manifest push

### DIFF
--- a/cmd/podman/manifest/manifest.go
+++ b/cmd/podman/manifest/manifest.go
@@ -18,7 +18,7 @@ var (
   podman manifest create localhost/list
   podman manifest inspect localhost/list
   podman manifest annotate --annotation left=right mylist:v1.11 image:v1.11-amd64
-  podman manifest push mylist:v1.11 quay.io/myimagelist
+  podman manifest push mylist:v1.11 docker://quay.io/myuser/image:v1.11
   podman manifest remove mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736`,
 	}
 )

--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -28,7 +28,7 @@ var (
 		Short:             "Push a manifest list or image index to a registry",
 		Long:              "Pushes manifest lists and image indexes to registries.",
 		RunE:              push,
-		Example:           `podman manifest push mylist:v1.11 quay.io/myimagelist`,
+		Example:           `podman manifest push mylist:v1.11 docker://quay.io/myuser/image:v1.11`,
 		Args:              cobra.ExactArgs(2),
 		ValidArgsFunction: common.AutocompleteImages,
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

Updating the "podman manifest push" example to match the required syntax.

If you run the command as stated:
- Error: error pushing manifest multiarch to quay.io/myimagelist: Invalid image name "quay.io/myimagelist", expected colon-separated transport:reference


