### PR TITLE
Fix podman pod inspect show wrong StaticMAC

### DIFF
--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -67,7 +67,7 @@ type InspectPodInfraConfig struct {
 	StaticIP net.IP
 	// StaticMAC is a static MAC address that will be assigned to the infra
 	// container and then used by the pod.
-	StaticMAC net.HardwareAddr
+	StaticMAC string
 	// NoManageResolvConf indicates that the pod will not manage resolv.conf
 	// and instead each container will handle their own.
 	NoManageResolvConf bool

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -535,7 +535,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		infraConfig = new(define.InspectPodInfraConfig)
 		infraConfig.HostNetwork = p.config.InfraContainer.HostNetwork
 		infraConfig.StaticIP = p.config.InfraContainer.StaticIP
-		infraConfig.StaticMAC = p.config.InfraContainer.StaticMAC
+		infraConfig.StaticMAC = p.config.InfraContainer.StaticMAC.String()
 		infraConfig.NoManageResolvConf = p.config.InfraContainer.UseImageResolvConf
 		infraConfig.NoManageHosts = p.config.InfraContainer.UseImageHosts
 


### PR DESCRIPTION
Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>
```
$ podman pod create --name mypod  --mac-address 42:43:44:00:00:01
a5e9fc3aa4bfd859c99e524126bb40d2140cb0eb87707773ba2a98f1038b0d78
$ podman run --rm -d --name test2 --pod mypod $IMG top
ac8e0e389d0b9826a4d296850249e112b23e56a61d4c4bd41d3ec69543eb0c01
$ podman pod inspect mypod | grep MAC
          "StaticMAC": "QkNEAAAB",
```
```
$ ./bin/podman pod inspect mypod | grep MAC
          "StaticMAC": "42:43:44:00:00:01",
```
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
