### PR TITLE
[CI:DOCS] correct numbering typo

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -457,7 +457,7 @@ Attempts to run podman result in
 
 One workaround is to disable Secure Boot in your BIOS.
 
-### 20) error creating libpod runtime: there might not be enough IDs available in the namespace
+### 19) error creating libpod runtime: there might not be enough IDs available in the namespace
 
 Unable to pull images
 


### PR DESCRIPTION
Based on PR from @sethjones.

Replaces: https://github.com/containers/podman/pull/8222

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
