### PR TITLE
add network connect|disconnect compat endpoints

### DIFF
--- a/cmd/podman/networks/connect.go
+++ b/cmd/podman/networks/connect.go
@@ -1,0 +1,47 @@
+package network
+
+import (
+	"github.com/containers/common/pkg/completion"
+	"github.com/containers/podman/v2/cmd/podman/common"
+	"github.com/containers/podman/v2/cmd/podman/registry"
+	"github.com/containers/podman/v2/pkg/domain/entities"
+	"github.com/spf13/cobra"
+)
+
+var (
+	networkConnectDescription = `Add container to a network`
+	networkConnectCommand     = &cobra.Command{
+		Use:               "connect [options] NETWORK CONTAINER",
+		Short:             "network connect",
+		Long:              networkConnectDescription,
+		RunE:              networkConnect,
+		Example:           `podman network connect web secondary`,
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: common.AutocompleteNetworks,
+	}
+)
+
+var (
+	networkConnectOptions entities.NetworkConnectOptions
+)
+
+func networkConnectFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+	aliasFlagName := "alias"
+	flags.StringSliceVar(&networkConnectOptions.Aliases, aliasFlagName, []string{}, "network scoped alias for container")
+	_ = cmd.RegisterFlagCompletionFunc(aliasFlagName, completion.AutocompleteNone)
+}
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: networkConnectCommand,
+		Parent:  networkCmd,
+	})
+	networkConnectFlags(networkConnectCommand)
+}
+
+func networkConnect(cmd *cobra.Command, args []string) error {
+	networkConnectOptions.Container = args[1]
+	return registry.ContainerEngine().NetworkConnect(registry.Context(), args[0], networkConnectOptions)
+}

--- a/cmd/podman/networks/disconnect.go
+++ b/cmd/podman/networks/disconnect.go
@@ -1,0 +1,45 @@
+package network
+
+import (
+	"github.com/containers/podman/v2/cmd/podman/common"
+	"github.com/containers/podman/v2/cmd/podman/registry"
+	"github.com/containers/podman/v2/pkg/domain/entities"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	networkDisconnectDescription = `Remove container from a network`
+	networkDisconnectCommand     = &cobra.Command{
+		Use:               "disconnect [options] NETWORK CONTAINER",
+		Short:             "network rm",
+		Long:              networkDisconnectDescription,
+		RunE:              networkDisconnect,
+		Example:           `podman network disconnect web secondary`,
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: common.AutocompleteNetworks,
+	}
+)
+
+var (
+	networkDisconnectOptions entities.NetworkDisconnectOptions
+)
+
+func networkDisconnectFlags(flags *pflag.FlagSet) {
+	flags.BoolVarP(&networkDisconnectOptions.Force, "force", "f", false, "force removal of container from network")
+}
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: networkDisconnectCommand,
+		Parent:  networkCmd,
+	})
+	flags := networkDisconnectCommand.Flags()
+	networkDisconnectFlags(flags)
+}
+
+func networkDisconnect(cmd *cobra.Command, args []string) error {
+	networkDisconnectOptions.Container = args[1]
+	return registry.ContainerEngine().NetworkDisconnect(registry.Context(), args[0], networkDisconnectOptions)
+}

--- a/commands-demo.md
+++ b/commands-demo.md
@@ -47,6 +47,8 @@
 | [podman-mount(1)](https://podman.readthedocs.io/en/latest/markdown/podman-mount.1.html)                               | Mount a working container's root filesystem                                |
 | [podman-network(1)](https://podman.readthedocs.io/en/latest/network.html)                                             | Manage Podman CNI networks                                                 |
 | [podman-network-create(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-create.1.html)             | Create a CNI network                                                       |
+| [podman-network-connect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-connect.1.html)           | Connect a container to a CNI network                                       |
+| [podman-network-disconnect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-dosconnect.1.html)             | Disconnect a container from a CNI network                                  |
 | [podman-network-inspect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-inspect.1.html)           | Displays the raw CNI network configuration for one or more networks        |
 | [podman-network-ls(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-ls.1.html)                     | Display a summary of CNI networks                                          |
 | [podman-network-rm(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-rm.1.html)                     | Remove one or more CNI networks                                            |

--- a/docs/source/markdown/podman-network-connect.1.md
+++ b/docs/source/markdown/podman-network-connect.1.md
@@ -1,0 +1,34 @@
+% podman-network-connect(1)
+
+## NAME
+podman\-network\-connect - Connect a container to a network
+
+## SYNOPSIS
+**podman network connect** [*options*] network container
+
+## DESCRIPTION
+Connects a container to a network. A container can be connected to a network by name or by ID.
+Once connected, the container can communicate with other containers in the same network.
+
+## OPTIONS
+#### **--alias**
+Add network-scoped alias for the container.  If the network is using the `dnsname` CNI plugin, these aliases
+can be used for name resolution on the given network.  Multiple *--alias* options may be specificed as input.
+
+## EXAMPLE
+
+Connect a container named *web* to a network named *test*
+```
+podman network connect test web
+```
+
+Connect a container name *web* to a network named *test* with two aliases: web1 and web2
+```
+podman network connect --alias web1 --alias web2 test web
+```
+
+## SEE ALSO
+podman(1), podman-network(1), podman-network-disconnect(1), podman-network-inspect(1)
+
+## HISTORY
+November 2020, Originally compiled by Brent Baude <bbaude@redhat.com>

--- a/docs/source/markdown/podman-network-disconnect.1.md
+++ b/docs/source/markdown/podman-network-disconnect.1.md
@@ -1,0 +1,29 @@
+% podman-network-disconnect(1)
+
+## NAME
+podman\-network\-disconnect - Disconnect a container from a network
+
+## SYNOPSIS
+**podman network disconnect** [*options*] network container
+
+## DESCRIPTION
+Disconnects a container from a network.
+
+## OPTIONS
+#### **--force**, **-f**
+
+Force the container to disconnect from a network
+
+## EXAMPLE
+Disconnect a container named *web* from a network called *test*.
+
+```
+podman network disconnect test web
+```
+
+
+## SEE ALSO
+podman(1), podman-network(1), podman-network-connect(1)
+
+## HISTORY
+November 2020, Originally compiled by Brent Baude <bbaude@redhat.com>

--- a/docs/source/markdown/podman-network.1.md
+++ b/docs/source/markdown/podman-network.1.md
@@ -13,7 +13,9 @@ The network command manages CNI networks for Podman. It is not supported for roo
 
 | Command  | Man Page                                            | Description                                                                  |
 | -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
+| connect | [podman-network-connect(1)](podman-network-connect.1.md)| Connect a container to a network|
 | create | [podman-network-create(1)](podman-network-create.1.md)| Create a Podman CNI network|
+| disconnect | [podman-network-disconnect(1)](podman-network-disconnect.1.md)| Disconnect a container from a network|
 | inspect | [podman-network-inspect(1)](podman-network-inspect.1.md)| Displays the raw CNI network configuration for one or more networks|
 | ls | [podman-network-ls(1)](podman-network-ls.1.md)| Display a summary of CNI networks                        |
 | rm | [podman-network-rm(1)](podman-network-rm.1.md)| Remove one or more CNI networks                        |

--- a/docs/source/network.rst
+++ b/docs/source/network.rst
@@ -1,7 +1,11 @@
 Network
 =======
 
+:doc:`connect <markdown/podman-network-connect.1>` network connect
+
 :doc:`create <markdown/podman-network-create.1>` network create
+
+:doc:`disconnect <markdown/podman-network-disconnect.1>` network disconnect
 
 :doc:`inspect <markdown/podman-network-inspect.1>` network inspect
 

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -178,4 +178,7 @@ var (
 	// ErrStoreNotInitialized indicates that the container storage was never
 	// initialized.
 	ErrStoreNotInitialized = errors.New("the container storage was never initialized")
+
+	// ErrNoNetwork indicates that a container has no net namespace, like network=none
+	ErrNoNetwork = errors.New("container has no network namespace")
 )

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -50,6 +50,18 @@ func (c *Container) newContainerExitedEvent(exitCode int32) {
 	}
 }
 
+// netNetworkEvent creates a new event based on a network connect/disconnect
+func (c *Container) newNetworkEvent(status events.Status, netName string) {
+	e := events.NewEvent(status)
+	e.ID = c.ID()
+	e.Name = c.Name()
+	e.Type = events.Network
+	e.Network = netName
+	if err := c.runtime.eventer.Write(e); err != nil {
+		logrus.Errorf("unable to write pod event: %q", err)
+	}
+}
+
 // newPodEvent creates a new event for a libpod pod
 func (p *Pod) newPodEvent(status events.Status) {
 	e := events.NewEvent(status)

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -30,6 +30,8 @@ type Event struct {
 	Image string `json:",omitempty"`
 	// Name where applicable
 	Name string `json:",omitempty"`
+	// Network is the network name in a network event
+	Network string `json:"network,omitempty"`
 	// Status describes the event that occurred
 	Status Status
 	// Time the event occurred
@@ -101,6 +103,8 @@ const (
 	Container Type = "container"
 	// Image - event is related to images
 	Image Type = "image"
+	// Network - event is related to networks
+	Network Type = "network"
 	// Pod - event is related to pods
 	Pod Type = "pod"
 	// System - event is related to Podman whole and not to any specific
@@ -141,6 +145,10 @@ const (
 	LoadFromArchive Status = "loadfromarchive"
 	// Mount ...
 	Mount Status = "mount"
+	// NetworkConnect
+	NetworkConnect Status = "connect"
+	// NetworkDisconnect
+	NetworkDisconnect Status = "disconnect"
 	// Pause ...
 	Pause Status = "pause"
 	// Prune ...

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -77,6 +77,8 @@ func (e *Event) ToHumanReadable() string {
 			}
 		}
 		humanFormat += ")"
+	case Network:
+		humanFormat = fmt.Sprintf("%s %s %s %s (container=%s, name=%s)", e.Time, e.Type, e.Status, e.ID, e.ID, e.Network)
 	case Image:
 		humanFormat = fmt.Sprintf("%s %s %s %s %s", e.Time, e.Type, e.Status, e.ID, e.Name)
 	case System:
@@ -115,6 +117,8 @@ func StringToType(name string) (Type, error) {
 		return Container, nil
 	case Image.String():
 		return Image, nil
+	case Network.String():
+		return Network, nil
 	case Pod.String():
 		return Pod, nil
 	case System.String():
@@ -162,6 +166,10 @@ func StringToStatus(name string) (Status, error) {
 		return LoadFromArchive, nil
 	case Mount.String():
 		return Mount, nil
+	case NetworkConnect.String():
+		return NetworkConnect, nil
+	case NetworkDisconnect.String():
+		return NetworkDisconnect, nil
 	case Pause.String():
 		return Pause, nil
 	case Prune.String():

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -56,6 +56,9 @@ func (e EventJournalD) Write(ee Event) error {
 			}
 			m["PODMAN_LABELS"] = string(b)
 		}
+	case Network:
+		m["PODMAN_ID"] = ee.ID
+		m["PODMAN_NETWORK_NAME"] = ee.Network
 	case Volume:
 		m["PODMAN_NAME"] = ee.Name
 	}
@@ -197,6 +200,9 @@ func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) { /
 				newEvent.Details = Details{Attributes: labels}
 			}
 		}
+	case Network:
+		newEvent.ID = entry.Fields["PODMAN_ID"]
+		newEvent.Network = entry.Fields["PODMAN_NETWORK_NAME"]
 	case Image:
 		newEvent.ID = entry.Fields["PODMAN_ID"]
 	}

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -76,7 +76,7 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 			return err
 		}
 		switch event.Type {
-		case Image, Volume, Pod, System, Container:
+		case Image, Volume, Pod, System, Container, Network:
 		//	no-op
 		default:
 			return errors.Errorf("event type %s is not valid in %s", event.Type.String(), e.options.LogFilePath)

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -253,5 +253,59 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/networks/create"), s.APIHandler(libpod.CreateNetwork)).Methods(http.MethodPost)
+	// swagger:operation POST /libpod/networks/{name}/connect libpod libpodConnectNetwork
+	// ---
+	// tags:
+	//  - networks
+	// summary: Connect container to network
+	// description: Connect a container to a network.
+	// produces:
+	// - application/json
+	// parameters:
+	//  - in: path
+	//    name: name
+	//    type: string
+	//    required: true
+	//    description: the name of the network
+	//  - in: body
+	//    name: create
+	//    description: attributes for connecting a container to a network
+	//    schema:
+	//      $ref: "#/definitions/NetworkConnectRequest"
+	// responses:
+	//   200:
+	//     description: OK
+	//   404:
+	//     $ref: "#/responses/NoSuchNetwork"
+	//   500:
+	//     $ref: "#/responses/InternalError"
+	r.HandleFunc(VersionedPath("/libpod/networks/{name}/connect"), s.APIHandler(libpod.Connect)).Methods(http.MethodPost)
+	// swagger:operation POST /libpod/networks/{name}/disconnect libpod libpodDisconnectNetwork
+	// ---
+	// tags:
+	//  - networks
+	// summary: Disconnect container from network
+	// description: Disconnect a container from a network.
+	// produces:
+	// - application/json
+	// parameters:
+	//  - in: path
+	//    name: name
+	//    type: string
+	//    required: true
+	//    description: the name of the network
+	//  - in: body
+	//    name: create
+	//    description: attributes for disconnecting a container from a network
+	//    schema:
+	//      $ref: "#/definitions/NetworkDisconnectRequest"
+	// responses:
+	//   200:
+	//     description: OK
+	//   404:
+	//     $ref: "#/responses/NoSuchNetwork"
+	//   500:
+	//     $ref: "#/responses/InternalError"
+	r.HandleFunc(VersionedPath("/libpod/networks/{name}/disconnect"), s.APIHandler(compat.Disconnect)).Methods(http.MethodPost)
 	return nil
 }

--- a/pkg/bindings/network/network.go
+++ b/pkg/bindings/network/network.go
@@ -88,3 +88,41 @@ func List(ctx context.Context, options entities.NetworkListOptions) ([]*entities
 	}
 	return netList, response.Process(&netList)
 }
+
+// Disconnect removes a container from a given network
+func Disconnect(ctx context.Context, networkName string, options entities.NetworkDisconnectOptions) error {
+	conn, err := bindings.GetClient(ctx)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	body, err := jsoniter.MarshalToString(options)
+	if err != nil {
+		return err
+	}
+	stringReader := strings.NewReader(body)
+	response, err := conn.DoRequest(stringReader, http.MethodPost, "/networks/%s/disconnect", params, nil, networkName)
+	if err != nil {
+		return err
+	}
+	return response.Process(nil)
+}
+
+// Connect adds a container to a network
+func Connect(ctx context.Context, networkName string, options entities.NetworkConnectOptions) error {
+	conn, err := bindings.GetClient(ctx)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	body, err := jsoniter.MarshalToString(options)
+	if err != nil {
+		return err
+	}
+	stringReader := strings.NewReader(body)
+	response, err := conn.DoRequest(stringReader, http.MethodPost, "/networks/%s/connect", params, nil, networkName)
+	if err != nil {
+		return err
+	}
+	return response.Process(nil)
+}

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -50,7 +50,9 @@ type ContainerEngine interface {
 	SystemPrune(ctx context.Context, options SystemPruneOptions) (*SystemPruneReport, error)
 	HealthCheckRun(ctx context.Context, nameOrID string, options HealthCheckOptions) (*define.HealthCheckResults, error)
 	Info(ctx context.Context) (*define.Info, error)
+	NetworkConnect(ctx context.Context, networkname string, options NetworkConnectOptions) error
 	NetworkCreate(ctx context.Context, name string, options NetworkCreateOptions) (*NetworkCreateReport, error)
+	NetworkDisconnect(ctx context.Context, networkname string, options NetworkDisconnectOptions) error
 	NetworkInspect(ctx context.Context, namesOrIds []string, options InspectOptions) ([]NetworkInspectReport, []error, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) ([]*NetworkListReport, error)
 	NetworkRm(ctx context.Context, namesOrIds []string, options NetworkRmOptions) ([]*NetworkRmReport, error)

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -49,3 +49,17 @@ type NetworkCreateOptions struct {
 type NetworkCreateReport struct {
 	Filename string
 }
+
+// NetworkDisconnectOptions describes options for disconnecting
+// containers from networks
+type NetworkDisconnectOptions struct {
+	Container string
+	Force     bool
+}
+
+// NetworkConnectOptions describes options for connecting
+// a container to a network
+type NetworkConnectOptions struct {
+	Aliases   []string
+	Container string
+}

--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -138,3 +138,12 @@ func ifPassesFilterTest(netconf *libcni.NetworkConfigList, filter []string) bool
 	}
 	return result
 }
+
+// NetworkDisconnect removes a container from a given network
+func (ic *ContainerEngine) NetworkDisconnect(ctx context.Context, networkname string, options entities.NetworkDisconnectOptions) error {
+	return ic.Libpod.DisconnectContainerFromNetwork(options.Container, networkname, options.Force)
+}
+
+func (ic *ContainerEngine) NetworkConnect(ctx context.Context, networkname string, options entities.NetworkConnectOptions) error {
+	return ic.Libpod.ConnectContainerToNetwork(options.Container, networkname, options.Aliases)
+}

--- a/pkg/domain/infra/tunnel/network.go
+++ b/pkg/domain/infra/tunnel/network.go
@@ -55,3 +55,13 @@ func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, o
 func (ic *ContainerEngine) NetworkCreate(ctx context.Context, name string, options entities.NetworkCreateOptions) (*entities.NetworkCreateReport, error) {
 	return network.Create(ic.ClientCxt, options, &name)
 }
+
+// NetworkDisconnect removes a container from a given network
+func (ic *ContainerEngine) NetworkDisconnect(ctx context.Context, networkname string, options entities.NetworkDisconnectOptions) error {
+	return network.Disconnect(ic.ClientCxt, networkname, options)
+}
+
+// NetworkConnect removes a container from a given network
+func (ic *ContainerEngine) NetworkConnect(ctx context.Context, networkname string, options entities.NetworkConnectOptions) error {
+	return network.Connect(ic.ClientCxt, networkname, options)
+}

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -341,4 +341,157 @@ var _ = Describe("Podman network", func() {
 		c3.WaitWithDefaultTimeout()
 		Expect(c3.ExitCode()).To(BeZero())
 	})
+
+	It("bad network name in disconnect should result in error", func() {
+		SkipIfRootless("network connect and disconnect are only rootfull")
+		dis := podmanTest.Podman([]string{"network", "disconnect", "foobar", "test"})
+		dis.WaitWithDefaultTimeout()
+		Expect(dis.ExitCode()).ToNot(BeZero())
+
+	})
+
+	It("bad container name in network disconnect should result in error", func() {
+		SkipIfRootless("network connect and disconnect are only rootfull")
+		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		dis := podmanTest.Podman([]string{"network", "disconnect", netName, "foobar"})
+		dis.WaitWithDefaultTimeout()
+		Expect(dis.ExitCode()).ToNot(BeZero())
+
+	})
+
+	It("podman network disconnect with invalid container state should result in error", func() {
+		SkipIfRootless("network connect and disconnect are only rootfull")
+		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		ctr := podmanTest.Podman([]string{"create", "--name", "test", "--network", netName, ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr.ExitCode()).To(BeZero())
+
+		dis := podmanTest.Podman([]string{"network", "disconnect", netName, "test"})
+		dis.WaitWithDefaultTimeout()
+		Expect(dis.ExitCode()).ToNot(BeZero())
+	})
+
+	It("podman network disconnect", func() {
+		SkipIfRootless("network connect and disconnect are only rootfull")
+		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		ctr := podmanTest.Podman([]string{"run", "-dt", "--name", "test", "--network", netName, ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr.ExitCode()).To(BeZero())
+
+		exec := podmanTest.Podman([]string{"exec", "-it", "test", "ip", "addr", "show", "eth0"})
+		exec.WaitWithDefaultTimeout()
+		Expect(exec.ExitCode()).To(BeZero())
+
+		dis := podmanTest.Podman([]string{"network", "disconnect", netName, "test"})
+		dis.WaitWithDefaultTimeout()
+		Expect(dis.ExitCode()).To(BeZero())
+
+		exec = podmanTest.Podman([]string{"exec", "-it", "test", "ip", "addr", "show", "eth0"})
+		exec.WaitWithDefaultTimeout()
+		Expect(exec.ExitCode()).ToNot(BeZero())
+	})
+
+	It("bad network name in connect should result in error", func() {
+		SkipIfRootless("network connect and disconnect are only rootfull")
+		dis := podmanTest.Podman([]string{"network", "connect", "foobar", "test"})
+		dis.WaitWithDefaultTimeout()
+		Expect(dis.ExitCode()).ToNot(BeZero())
+
+	})
+
+	It("bad container name in network connect should result in error", func() {
+		SkipIfRootless("network connect and disconnect are only rootfull")
+		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		dis := podmanTest.Podman([]string{"network", "connect", netName, "foobar"})
+		dis.WaitWithDefaultTimeout()
+		Expect(dis.ExitCode()).ToNot(BeZero())
+
+	})
+
+	It("podman connect on a container that already is connected to the network should error", func() {
+		SkipIfRootless("network connect and disconnect are only rootfull")
+		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		ctr := podmanTest.Podman([]string{"create", "--name", "test", "--network", netName, ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr.ExitCode()).To(BeZero())
+
+		con := podmanTest.Podman([]string{"network", "connect", netName, "test"})
+		con.WaitWithDefaultTimeout()
+		Expect(con.ExitCode()).ToNot(BeZero())
+	})
+
+	It("podman network connect with invalid container state should result in error", func() {
+		SkipIfRootless("network connect and disconnect are only rootfull")
+		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		ctr := podmanTest.Podman([]string{"create", "--name", "test", "--network", netName, ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr.ExitCode()).To(BeZero())
+
+		dis := podmanTest.Podman([]string{"network", "connect", netName, "test"})
+		dis.WaitWithDefaultTimeout()
+		Expect(dis.ExitCode()).ToNot(BeZero())
+	})
+
+	It("podman network connect", func() {
+		SkipIfRemote("This requires a pending PR to be merged before it will work")
+		SkipIfRootless("network connect and disconnect are only rootfull")
+		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		ctr := podmanTest.Podman([]string{"run", "-dt", "--name", "test", "--network", netName, ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr.ExitCode()).To(BeZero())
+
+		exec := podmanTest.Podman([]string{"exec", "-it", "test", "ip", "addr", "show", "eth0"})
+		exec.WaitWithDefaultTimeout()
+		Expect(exec.ExitCode()).To(BeZero())
+
+		// Create a second network
+		newNetName := "aliasTest" + stringid.GenerateNonCryptoID()
+		session = podmanTest.Podman([]string{"network", "create", newNetName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(newNetName)
+
+		connect := podmanTest.Podman([]string{"network", "connect", newNetName, "test"})
+		connect.WaitWithDefaultTimeout()
+		Expect(connect.ExitCode()).To(BeZero())
+
+		exec = podmanTest.Podman([]string{"exec", "-it", "test", "ip", "addr", "show", "eth1"})
+		exec.WaitWithDefaultTimeout()
+		Expect(exec.ExitCode()).To(BeZero())
+	})
 })


### PR DESCRIPTION
this enables the ability to connect and disconnect a container from a
given network. it is only for the compatibility layer. some code had to
be refactored to avoid circular imports.

additionally, tests are being deferred temporarily due to some
incompatibility/bug in either docker-py or our stack.

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
