### PR TITLE
Fix `podman images...` missing headers in table templates

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -126,8 +126,8 @@ func images(cmd *cobra.Command, args []string) error {
 	case listFlag.quiet:
 		return writeID(imgs)
 	default:
-		if cmd.Flag("format").Changed {
-			listFlag.noHeading = true // V1 compatibility
+		if cmd.Flags().Changed("format") && !parse.HasTable(listFlag.format) {
+			listFlag.noHeading = true
 		}
 		return writeTemplate(imgs)
 	}

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -278,7 +278,7 @@ WORKDIR /test
 	It("podman images sort by values", func() {
 		sortValueTest := func(value string, result int, format string) []string {
 			f := fmt.Sprintf("{{.%s}}", format)
-			session := podmanTest.Podman([]string{"images", "--sort", value, "--format", f})
+			session := podmanTest.Podman([]string{"images", "--noheading", "--sort", value, "--format", f})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(result))
 

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -199,9 +199,16 @@ Labels.created_at | 20[0-9-]\\\+T[0-9:]\\\+Z
         local format=$2
 
         run_podman images --sort repository --format "$format"
-        _check_line 0 ${aaa_name} ${aaa_tag}
-        _check_line 1 "${PODMAN_TEST_IMAGE_REGISTRY}/${PODMAN_TEST_IMAGE_USER}/${PODMAN_TEST_IMAGE_NAME}" "${PODMAN_TEST_IMAGE_TAG}"
-        _check_line 2 ${zzz_name} ${zzz_tag}
+
+        line_no=0
+        if [[ $format == table* ]]; then
+            # skip headers from table command
+            line_no=1
+        fi
+
+        _check_line $line_no ${aaa_name} ${aaa_tag}
+        _check_line $((line_no+1)) "${PODMAN_TEST_IMAGE_REGISTRY}/${PODMAN_TEST_IMAGE_USER}/${PODMAN_TEST_IMAGE_NAME}" "${PODMAN_TEST_IMAGE_TAG}"
+        _check_line $((line_no+2)) ${zzz_name} ${zzz_tag}
     }
 
     # Begin the test: tag $IMAGE with both the given names


### PR DESCRIPTION
Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
