### PR TITLE
Align the podman pod ps --filter behavior with podman ps

### DIFF
--- a/docs/source/markdown/podman-pod-ps.1.md
+++ b/docs/source/markdown/podman-pod-ps.1.md
@@ -80,19 +80,23 @@ Default: created
 
 #### **--filter**, **-f**=*filter*
 
-Filter output based on conditions given
+Filter output based on conditions given.
+Multiple filters can be given with multiple uses of the --filter flag.
+Filters with the same key work inclusive with the only exception being
+`label` which is exclusive. Filters with different keys always work exclusive.
 
 Valid filters are listed below:
 
-| **Filter**      | **Description**                                                     |
-| --------------- | ------------------------------------------------------------------- |
-| id              | [ID] Pod's ID                                                       |
-| name            | [Name] Pod's name                                                   |
-| label           | [Key] or [Key=Value] Label assigned to a container                  |
-| ctr-names       | Container name within the pod                                       |
-| ctr-ids         | Container ID within the pod                                         |
-| ctr-status      | Container status within the pod                                     |
-| ctr-number      | Number of containers in the pod                                     |
+| **Filter** | **Description**                                                                       |
+| ---------- | ------------------------------------------------------------------------------------- |
+| id         | [ID] Pod's ID (accepts regex)                                                         |
+| name       | [Name] Pod's name (accepts regex)                                                     |
+| label      | [Key] or [Key=Value] Label assigned to a container                                    |
+| status     | Pod's status: `stopped`, `running`, `paused`, `exited`, `dead`, `created`, `degraded` |
+| ctr-names  | Container name within the pod (accepts regex)                                         |
+| ctr-ids    | Container ID within the pod (accepts regex)                                           |
+| ctr-status | Container status within the pod                                                       |
+| ctr-number | Number of containers in the pod                                                       |
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -44,15 +44,15 @@ Display external containers that are not controlled by Podman but are stored in 
 
 Filter what containers are shown in the output.
 Multiple filters can be given with multiple uses of the --filter flag.
-If multiple filters are given, only containers which match all of the given filters will be shown.
-Results will be drawn from all containers, regardless of whether --all was given.
+Filters with the same key work inclusive with the only exception being
+`label` which is exclusive. Filters with different keys always work exclusive.
 
 Valid filters are listed below:
 
 | **Filter**      | **Description**                                                                  |
 | --------------- | -------------------------------------------------------------------------------- |
-| id              | [ID] Container's ID                                                              |
-| name            | [Name] Container's name                                                          |
+| id              | [ID] Container's ID (accepts regex)                                              |
+| name            | [Name] Container's name (accepts regex)                                          |
 | label           | [Key] or [Key=Value] Label assigned to a container                               |
 | exited          | [Int] Container's exit code                                                      |
 | status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |

--- a/pkg/api/handlers/utils/pods.go
+++ b/pkg/api/handlers/utils/pods.go
@@ -11,8 +11,7 @@ import (
 
 func GetPods(w http.ResponseWriter, r *http.Request) ([]*entities.ListPodsReport, error) {
 	var (
-		pods    []*libpod.Pod
-		filters []libpod.PodFilter
+		pods []*libpod.Pod
 	)
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
@@ -30,14 +29,13 @@ func GetPods(w http.ResponseWriter, r *http.Request) ([]*entities.ListPodsReport
 		UnSupportedParameter("digests")
 	}
 
+	filters := make([]libpod.PodFilter, 0, len(query.Filters))
 	for k, v := range query.Filters {
-		for _, filter := range v {
-			f, err := lpfilters.GeneratePodFilterFunc(k, filter)
-			if err != nil {
-				return nil, err
-			}
-			filters = append(filters, f)
+		f, err := lpfilters.GeneratePodFilterFunc(k, v)
+		if err != nil {
+			return nil, err
 		}
+		filters = append(filters, f)
 	}
 	pods, err := runtime.Pods(filters...)
 	if err != nil {

--- a/pkg/domain/infra/abi/pods.go
+++ b/pkg/domain/infra/abi/pods.go
@@ -282,20 +282,17 @@ func (ic *ContainerEngine) PodTop(ctx context.Context, options entities.PodTopOp
 
 func (ic *ContainerEngine) PodPs(ctx context.Context, options entities.PodPSOptions) ([]*entities.ListPodsReport, error) {
 	var (
-		err     error
-		filters = []libpod.PodFilter{}
-		pds     = []*libpod.Pod{}
+		err error
+		pds = []*libpod.Pod{}
 	)
 
+	filters := make([]libpod.PodFilter, 0, len(options.Filters))
 	for k, v := range options.Filters {
-		for _, filter := range v {
-			f, err := lpfilters.GeneratePodFilterFunc(k, filter)
-			if err != nil {
-				return nil, err
-			}
-			filters = append(filters, f)
-
+		f, err := lpfilters.GeneratePodFilterFunc(k, v)
+		if err != nil {
+			return nil, err
 		}
+		filters = append(filters, f)
 	}
 	if options.Latest {
 		pod, err := ic.Libpod.GetLatestPod()

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -194,7 +194,19 @@ var _ = Describe("Podman ps", func() {
 		Expect(session.OutputToString()).To(ContainSubstring(podid1))
 		Expect(session.OutputToString()).To(Not(ContainSubstring(podid2)))
 
+		session = podmanTest.Podman([]string{"pod", "ps", "-q", "--no-trunc", "--filter", "ctr-names=test", "--filter", "ctr-status=running"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(podid1))
+		Expect(session.OutputToString()).To(Not(ContainSubstring(podid2)))
+
 		session = podmanTest.Podman([]string{"pod", "ps", "-q", "--no-trunc", "--filter", fmt.Sprintf("ctr-ids=%s", cid)})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(podid2))
+		Expect(session.OutputToString()).To(Not(ContainSubstring(podid1)))
+
+		session = podmanTest.Podman([]string{"pod", "ps", "-q", "--no-trunc", "--filter", "ctr-ids=" + cid[:40], "--filter", "ctr-ids=" + cid + "$"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring(podid2))
@@ -210,6 +222,13 @@ var _ = Describe("Podman ps", func() {
 		Expect(session.OutputToString()).To(ContainSubstring(podid2))
 		Expect(session.OutputToString()).To(Not(ContainSubstring(podid3)))
 
+		session = podmanTest.Podman([]string{"pod", "ps", "-q", "--no-trunc", "--filter", "ctr-number=1", "--filter", "ctr-number=0"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(podid1))
+		Expect(session.OutputToString()).To(ContainSubstring(podid2))
+		Expect(session.OutputToString()).To(ContainSubstring(podid3))
+
 		session = podmanTest.Podman([]string{"pod", "ps", "-q", "--no-trunc", "--filter", "ctr-status=running"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -222,6 +241,13 @@ var _ = Describe("Podman ps", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring(podid2))
 		Expect(session.OutputToString()).To(Not(ContainSubstring(podid1)))
+		Expect(session.OutputToString()).To(Not(ContainSubstring(podid3)))
+
+		session = podmanTest.Podman([]string{"pod", "ps", "-q", "--no-trunc", "--filter", "ctr-status=exited", "--filter", "ctr-status=running"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(podid1))
+		Expect(session.OutputToString()).To(ContainSubstring(podid2))
 		Expect(session.OutputToString()).To(Not(ContainSubstring(podid3)))
 
 		session = podmanTest.Podman([]string{"pod", "ps", "-q", "--no-trunc", "--filter", "ctr-status=created"})


### PR DESCRIPTION
Filters with the same key work inclusive with the only exception being
`label` which is exclusive. Filters with different keys always work exclusive.

Also update the documentation with the new behavior.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
