### PR TITLE
Shell completion for podman ps and podman pod ps --filter

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -64,8 +64,7 @@ func listFlagSet(cmd *cobra.Command) {
 
 	filterFlagName := "filter"
 	flags.StringSliceVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
-	//TODO add custom filter function
-	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, completion.AutocompleteNone)
+	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePsFilters)
 
 	formatFlagName := "format"
 	flags.StringVar(&listOpts.Format, formatFlagName, "", "Pretty-print containers to JSON or using a Go template")

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -57,8 +57,7 @@ func init() {
 
 	filterFlagName := "filter"
 	flags.StringSliceVarP(&inputFilters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
-	//TODO complete filters
-	_ = psCmd.RegisterFlagCompletionFunc(filterFlagName, completion.AutocompleteNone)
+	_ = psCmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePodPsFilters)
 
 	formatFlagName := "format"
 	flags.StringVar(&psInput.Format, formatFlagName, "", "Pretty-print pods to JSON or using a Go template")


### PR DESCRIPTION
Add all available filter options for `podman ps` and `podman
pod ps` to the completions. Refactor the code a bit to make it
easier to handle key value pairs in completions. The `completeKeyValues` function  helps to reduce code duplication.

Also make use of the new filter logic in the completions.