### PR TITLE
Add alias for podman network rm -> remove

### DIFF
--- a/cmd/podman/networks/rm.go
+++ b/cmd/podman/networks/rm.go
@@ -18,6 +18,7 @@ var (
 	networkrmDescription = `Remove networks`
 	networkrmCommand     = &cobra.Command{
 		Use:               "rm [options] NETWORK [NETWORK...]",
+		Aliases:           []string{"remove"},
 		Short:             "network rm",
 		Long:              networkrmDescription,
 		RunE:              networkRm,

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -76,31 +76,36 @@ var _ = Describe("Podman network", func() {
 		Expect(session.LineInOutputContains(name)).To(BeFalse())
 	})
 
-	It("podman network rm no args", func() {
-		session := podmanTest.Podman([]string{"network", "rm"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).ToNot(BeZero())
-	})
+	rm_func := func(rm string) {
+		It(fmt.Sprintf("podman network %s no args", rm), func() {
+			session := podmanTest.Podman([]string{"network", rm})
+			session.WaitWithDefaultTimeout()
+			Expect(session.ExitCode()).ToNot(BeZero())
 
-	It("podman network rm", func() {
-		SkipIfRootless("FIXME: This one is definitely broken in rootless mode")
-		name, path := generateNetworkConfig(podmanTest)
-		defer removeConf(path)
+		})
 
-		session := podmanTest.Podman([]string{"network", "ls", "--quiet"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.LineInOutputContains(name)).To(BeTrue())
+		It(fmt.Sprintf("podman network %s", rm), func() {
+			name, path := generateNetworkConfig(podmanTest)
+			defer removeConf(path)
 
-		rm := podmanTest.Podman([]string{"network", "rm", name})
-		rm.WaitWithDefaultTimeout()
-		Expect(rm.ExitCode()).To(BeZero())
+			session := podmanTest.Podman([]string{"network", "ls", "--quiet"})
+			session.WaitWithDefaultTimeout()
+			Expect(session.ExitCode()).To(Equal(0))
+			Expect(session.LineInOutputContains(name)).To(BeTrue())
 
-		results := podmanTest.Podman([]string{"network", "ls", "--quiet"})
-		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
-		Expect(results.LineInOutputContains(name)).To(BeFalse())
-	})
+			rm := podmanTest.Podman([]string{"network", rm, name})
+			rm.WaitWithDefaultTimeout()
+			Expect(rm.ExitCode()).To(BeZero())
+
+			results := podmanTest.Podman([]string{"network", "ls", "--quiet"})
+			results.WaitWithDefaultTimeout()
+			Expect(results.ExitCode()).To(Equal(0))
+			Expect(results.LineInOutputContains(name)).To(BeFalse())
+		})
+	}
+
+	rm_func("rm")
+	rm_func("remove")
 
 	It("podman network inspect no args", func() {
 		session := podmanTest.Podman([]string{"network", "inspect"})


### PR DESCRIPTION
docker network remove exists and is alias to docker network rm.

Bug for bug compatible.

Fixes: https://github.com/containers/podman/issues/8402

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
