### PR TITLE
Build multi-arch rootless-cni-infra on GitHub Actions

### DIFF
--- a/.github/workflows/rootless-cni-infra.yaml
+++ b/.github/workflows/rootless-cni-infra.yaml
@@ -1,0 +1,36 @@
+name: Build rootless-cni-infra
+on: [push, pull_request]
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: "Register QEMU to /proc/sys/fs/binfmt_misc"
+      run: docker run --privileged --rm tonistiigi/binfmt --install all
+    - name: "Fetch buildx binary"
+      run: |
+        wget -O buildx https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64
+        chmod +x buildx
+    - name: "Initialize buildx"
+      run: |
+        ./buildx create --name cross --platform=amd64,arm,arm64,s390x,ppc64le --use
+        ./buildx inspect --bootstrap
+    - name: "Build rootless-cni-infra.tar.gz (Multi-arch OCI archive)"
+      run: |
+        ./buildx build \
+          --output type=oci,dest=rootless-cni-infra.tar \
+          --platform amd64,arm,arm64,s390x,ppc64le \
+          -f contrib/rootless-cni-infra/Containerfile \
+          contrib/rootless-cni-infra
+        gzip -9 rootless-cni-infra.tar
+    - name: "Print SHA256SUM of rootless-cni-infra.tar.gz"
+      run: |
+        sha256sum rootless-cni-infra.tar.gz
+    - name: "Upload rootless-cni-infra.tar.gz as a GitHub Artifact"
+      uses: actions/upload-artifact@v1
+      with:
+        name: rootless-cni-infra.tar.gz
+        path: rootless-cni-infra.tar.gz
+    - name: "Notice"
+      run: |
+        echo "The image is NOT pushed to quay. To push the image to quay, run skopeo manually with the artifact archive."

--- a/contrib/rootless-cni-infra/Containerfile
+++ b/contrib/rootless-cni-infra/Containerfile
@@ -4,22 +4,22 @@ ARG CNI_VERSION=v0.8.0
 ARG CNI_PLUGINS_VERSION=v0.8.7
 ARG DNSNAME_VESION=v1.0.0
 
-FROM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS golang-base
+FROM --platform=$BUILDPLATFORM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS golang-base
 RUN apk add --no-cache git
 
-FROM golang-base AS cnitool
+FROM --platform=$BUILDPLATFORM golang-base AS cnitool
 RUN git clone https://github.com/containernetworking/cni /go/src/github.com/containernetworking/cni
 WORKDIR /go/src/github.com/containernetworking/cni
 ARG CNI_VERSION
 RUN git checkout ${CNI_VERSION}
-RUN go build -o /cnitool ./cnitool
+RUN GOARCH=$TARGETARCH go build -o /cnitool ./cnitool
 
-FROM golang-base AS dnsname
+FROM --platform=$BUILDPLATFORM golang-base AS dnsname
 RUN git clone https://github.com/containers/dnsname /go/src/github.com/containers/dnsname
 WORKDIR /go/src/github.com/containers/dnsname
 ARG DNSNAME_VERSION
 RUN git checkout ${DNSNAME_VERSION}
-RUN go build -o /dnsname ./plugins/meta/dnsname
+RUN GOARCH=$TARGETARCH go build -o /dnsname ./plugins/meta/dnsname
 
 FROM alpine:${ALPINE_VERSION}
 RUN apk add --no-cache curl dnsmasq iptables ip6tables iproute2
@@ -33,4 +33,4 @@ COPY rootless-cni-infra /usr/local/bin
 ENV CNI_PATH=/opt/cni/bin
 CMD ["sleep", "infinity"]
 
-ENV ROOTLESS_CNI_INFRA_VERSION=3
+ENV ROOTLESS_CNI_INFRA_VERSION=4


### PR DESCRIPTION
The image is built as a multi-arch OCI tar.gz and uploaded as a GitHub Artifact.

The image is NOT pushed to quay automatically.
~~A maintainer can use `skopeo` to push the artifact archive to quay.~~ (**EDIT**: might not be true for multi-arch...)

Relates to #8411

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
