### PR TITLE
more shell completion improvements

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -84,7 +84,7 @@ func getContainers(cmd *cobra.Command, toComplete string, cType completeType, st
 	containers, err := engine.ContainerList(registry.GetContext(), listOpts)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	for _, c := range containers {
@@ -119,7 +119,7 @@ func getPods(cmd *cobra.Command, toComplete string, cType completeType, statuses
 	pods, err := engine.PodPs(registry.GetContext(), listOpts)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	for _, pod := range pods {
@@ -149,7 +149,7 @@ func getVolumes(cmd *cobra.Command, toComplete string) ([]string, cobra.ShellCom
 	volumes, err := engine.VolumeList(registry.GetContext(), lsOpts)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	for _, v := range volumes {
@@ -172,7 +172,7 @@ func getImages(cmd *cobra.Command, toComplete string) ([]string, cobra.ShellComp
 	images, err := engine.List(registry.GetContext(), listOptions)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	for _, image := range images {
@@ -215,7 +215,7 @@ func getRegistries() ([]string, cobra.ShellCompDirective) {
 	regs, err := registries.GetRegistries()
 	if err != nil {
 		cobra.CompErrorln(err.Error())
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	return regs, cobra.ShellCompDirectiveNoFileComp
 }
@@ -232,7 +232,7 @@ func getNetworks(cmd *cobra.Command, toComplete string) ([]string, cobra.ShellCo
 	networks, err := engine.NetworkList(registry.Context(), networkListOptions)
 	if err != nil {
 		cobra.CompErrorln(err.Error())
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	for _, n := range networks {
@@ -485,7 +485,7 @@ func AutocompleteSystemConnections(cmd *cobra.Command, args []string, toComplete
 	cfg, err := config.ReadCustomConfig()
 	if err != nil {
 		cobra.CompErrorln(err.Error())
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	for k, v := range cfg.Engine.ServiceDestinations {
@@ -633,7 +633,8 @@ func AutocompleteUserFlag(cmd *cobra.Command, args []string, toComplete string) 
 		// but at this point we don't know the image.
 		file, err := os.Open("/etc/group")
 		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
+			cobra.CompErrorln(err.Error())
+			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 		defer file.Close()
 
@@ -649,7 +650,8 @@ func AutocompleteUserFlag(cmd *cobra.Command, args []string, toComplete string) 
 			}
 		}
 		if err = scanner.Err(); err != nil {
-			return nil, cobra.ShellCompDirectiveError
+			cobra.CompErrorln(err.Error())
+			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 		return groups, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -658,7 +660,8 @@ func AutocompleteUserFlag(cmd *cobra.Command, args []string, toComplete string) 
 	// but at this point we don't know the image.
 	file, err := os.Open("/etc/passwd")
 	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
+		cobra.CompErrorln(err.Error())
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	defer file.Close()
 
@@ -673,7 +676,7 @@ func AutocompleteUserFlag(cmd *cobra.Command, args []string, toComplete string) 
 		}
 	}
 	if err = scanner.Err(); err != nil {
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	return users, cobra.ShellCompDirectiveNoSpace
 }

--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -464,6 +464,18 @@ func AutocompleteCpCommand(cmd *cobra.Command, args []string, toComplete string)
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
+// AutocompleteNetworkConnectCmd - Autocomplete podman network connect/disconnect command args.
+func AutocompleteNetworkConnectCmd(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return getNetworks(cmd, toComplete)
+	}
+	if len(args) == 1 {
+		return getContainers(cmd, toComplete, completeDefault)
+	}
+	// don't complete more than 2 args
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}
+
 // AutocompleteSystemConnections - Autocomplete system connections.
 func AutocompleteSystemConnections(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if !validCurrentCmdLine(cmd, args, toComplete) {
@@ -695,8 +707,22 @@ func AutocompleteJSONFormat(cmd *cobra.Command, args []string, toComplete string
 // AutocompleteEventFilter - Autocomplete event filter flag options.
 // -> "container=", "event=", "image=", "pod=", "volume=", "type="
 func AutocompleteEventFilter(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	filters := []string{"container=", "event=", "image=", "pod=", "volume=", "type="}
-	return filters, cobra.ShellCompDirectiveNoSpace
+	eventTypes := func(_ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"attach", "checkpoint", "cleanup", "commit", "create", "exec",
+			"export", "import", "init", "kill", "mount", "pause", "prune", "remove",
+			"restart", "restore", "start", "stop", "sync", "unmount", "unpause",
+			"pull", "push", "save", "tag", "untag", "refresh", "renumber",
+		}, cobra.ShellCompDirectiveNoFileComp
+	}
+	kv := keyValueCompletion{
+		"container=": func(s string) ([]string, cobra.ShellCompDirective) { return getContainers(cmd, s, completeDefault) },
+		"image=":     func(s string) ([]string, cobra.ShellCompDirective) { return getImages(cmd, s) },
+		"pod=":       func(s string) ([]string, cobra.ShellCompDirective) { return getPods(cmd, s, completeDefault) },
+		"volume=":    func(s string) ([]string, cobra.ShellCompDirective) { return getVolumes(cmd, s) },
+		"event=":     eventTypes,
+		"type=":      eventTypes,
+	}
+	return completeKeyValues(toComplete, kv)
 }
 
 // AutocompleteSystemdRestartOptions - Autocomplete systemd restart options.
@@ -843,6 +869,50 @@ func AutocompletePodPsFilters(cmd *cobra.Command, args []string, toComplete stri
 			return containerStatuses, cobra.ShellCompDirectiveNoFileComp
 		},
 		"label=": nil,
+	}
+	return completeKeyValues(toComplete, kv)
+}
+
+// AutocompleteImageFilters - Autocomplete image ls --filter options.
+func AutocompleteImageFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	getBool := func(_ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
+	}
+	getImg := func(s string) ([]string, cobra.ShellCompDirective) { return getImages(cmd, s) }
+	kv := keyValueCompletion{
+		"before=":    getImg,
+		"since=":     getImg,
+		"label=":     nil,
+		"reference=": nil,
+		"dangling=":  getBool,
+		"readonly=":  getBool,
+	}
+	return completeKeyValues(toComplete, kv)
+}
+
+// AutocompleteNetworkFilters - Autocomplete network ls --filter options.
+func AutocompleteNetworkFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	kv := keyValueCompletion{
+		"name=":   func(s string) ([]string, cobra.ShellCompDirective) { return getNetworks(cmd, s) },
+		"plugin=": nil,
+	}
+	return completeKeyValues(toComplete, kv)
+}
+
+// AutocompleteVolumeFilters - Autocomplete volume ls --filter options.
+func AutocompleteVolumeFilters(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	local := func(_ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"local"}, cobra.ShellCompDirectiveNoFileComp
+	}
+	kv := keyValueCompletion{
+		"name=":   func(s string) ([]string, cobra.ShellCompDirective) { return getVolumes(cmd, s) },
+		"driver=": local,
+		"scope=":  local,
+		"label=":  nil,
+		"opt=":    nil,
+		"dangling=": func(_ string) ([]string, cobra.ShellCompDirective) {
+			return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 	return completeKeyValues(toComplete, kv)
 }

--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -79,8 +79,7 @@ func imageListFlagSet(cmd *cobra.Command) {
 
 	filterFlagName := "filter"
 	flags.StringSliceVarP(&listOptions.Filter, filterFlagName, "f", []string{}, "Filter output based on conditions provided (default [])")
-	// TODO: add completion function for filters
-	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, completion.AutocompleteNone)
+	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteImageFilters)
 
 	formatFlagName := "format"
 	flags.StringVar(&listFlag.format, formatFlagName, "", "Change the output format to JSON or a Go template")

--- a/cmd/podman/networks/connect.go
+++ b/cmd/podman/networks/connect.go
@@ -17,7 +17,7 @@ var (
 		RunE:              networkConnect,
 		Example:           `podman network connect web secondary`,
 		Args:              cobra.ExactArgs(2),
-		ValidArgsFunction: common.AutocompleteNetworks,
+		ValidArgsFunction: common.AutocompleteNetworkConnectCmd,
 	}
 )
 

--- a/cmd/podman/networks/disconnect.go
+++ b/cmd/podman/networks/disconnect.go
@@ -17,7 +17,7 @@ var (
 		RunE:              networkDisconnect,
 		Example:           `podman network disconnect web secondary`,
 		Args:              cobra.ExactArgs(2),
-		ValidArgsFunction: common.AutocompleteNetworks,
+		ValidArgsFunction: common.AutocompleteNetworkConnectCmd,
 	}
 )
 

--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -46,7 +46,7 @@ func networkListFlags(flags *pflag.FlagSet) {
 
 	filterFlagName := "filter"
 	flags.StringVarP(&networkListOptions.Filter, filterFlagName, "", "", "Provide filter values (e.g. 'name=podman')")
-	_ = networklistCommand.RegisterFlagCompletionFunc(filterFlagName, completion.AutocompleteNone)
+	_ = networklistCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteNetworkFilters)
 
 }
 

--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -56,7 +56,7 @@ func init() {
 
 	filterFlagName := "filter"
 	flags.StringSliceVarP(&cliOpts.Filter, filterFlagName, "f", []string{}, "Filter volume output")
-	_ = lsCommand.RegisterFlagCompletionFunc(filterFlagName, completion.AutocompleteNone)
+	_ = lsCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteVolumeFilters)
 
 	formatFlagName := "format"
 	flags.StringVar(&cliOpts.Format, formatFlagName, "{{.Driver}}\t{{.Name}}\n", "Format volume output using Go template")


### PR DESCRIPTION
* podman image ls --filter
* podman network ls --filter
* podman volume ls --filter
* podman network connect/disconnect
* podman events --filter


If we return `ShellCompDirectiveError` to the shell the shell will
provide path completion. In none of that cases we want path completion
so it will be better to return `ShellCompDirectiveNoFileComp` instead
and log the error in case we need it.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
