### PR TITLE
Handle ps container created field as a time.Time

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -126,7 +126,7 @@ func checkFlags(c *cobra.Command) error {
 func jsonOut(responses []entities.ListContainer) error {
 	r := make([]entities.ListContainer, 0)
 	for _, con := range responses {
-		con.CreatedAt = units.HumanDuration(time.Since(time.Unix(con.Created, 0))) + " ago"
+		con.CreatedAt = units.HumanDuration(time.Since(con.Created)) + " ago"
 		con.Status = psReporter{con}.Status()
 		r = append(r, con)
 	}
@@ -386,12 +386,12 @@ func (l psReporter) Ports() string {
 // CreatedAt returns the container creation time in string format.  podman
 // and docker both return a timestamped value for createdat
 func (l psReporter) CreatedAt() string {
-	return time.Unix(l.Created, 0).String()
+	return l.Created.String()
 }
 
 // CreateHuman allows us to output the created time in human readable format
 func (l psReporter) CreatedHuman() string {
-	return units.HumanDuration(time.Since(time.Unix(l.Created, 0))) + " ago"
+	return units.HumanDuration(time.Since(l.Created)) + " ago"
 }
 
 // Cgroup exposes .Namespaces.Cgroup

--- a/pkg/domain/entities/container_ps.go
+++ b/pkg/domain/entities/container_ps.go
@@ -3,6 +3,7 @@ package entities
 import (
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/containers/podman/v2/pkg/ps/define"
 	"github.com/cri-o/ocicni/pkg/ocicni"
@@ -14,7 +15,7 @@ type ListContainer struct {
 	// Container command
 	Command []string
 	// Container creation time
-	Created int64
+	Created time.Time
 	// Human readable container creation time.
 	CreatedAt string
 	// If container has exited/stopped
@@ -137,7 +138,7 @@ func (a psSortedSize) Less(i, j int) bool {
 type PsSortedCreateTime struct{ SortListContainers }
 
 func (a PsSortedCreateTime) Less(i, j int) bool {
-	return a.SortListContainers[i].Created < a.SortListContainers[j].Created
+	return a.SortListContainers[i].Created.Before(a.SortListContainers[j].Created)
 }
 
 func SortPsOutput(sortBy string, psOutput SortListContainers) (SortListContainers, error) {

--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -180,7 +180,7 @@ func ListContainerBatch(rt *libpod.Runtime, ctr *libpod.Container, opts entities
 
 	ps := entities.ListContainer{
 		Command:   conConfig.Command,
-		Created:   conConfig.CreatedTime.Unix(),
+		Created:   conConfig.CreatedTime,
 		Exited:    exited,
 		ExitCode:  exitCode,
 		ExitedAt:  exitedTime.Unix(),
@@ -231,7 +231,7 @@ func ListStorageContainer(rt *libpod.Runtime, ctr storage.Container, opts entiti
 
 	ps := entities.ListContainer{
 		ID:      ctr.ID,
-		Created: ctr.Created.Unix(),
+		Created: ctr.Created,
 		ImageID: ctr.ImageID,
 		State:   "storage",
 		Names:   []string{name},
@@ -301,5 +301,5 @@ func (a SortPSContainers) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 type SortPSCreateTime struct{ SortPSContainers }
 
 func (a SortPSCreateTime) Less(i, j int) bool {
-	return a.SortPSContainers[i].Created > a.SortPSContainers[j].Created
+	return a.SortPSContainers[i].Created.Before(a.SortPSContainers[j].Created)
 }


### PR DESCRIPTION
In the current code we were translating the created time
from a time.Time to a unix epoch, this was leading to a loss
of precession, and some unexpected results where the sorting
order of containers was misordered because of the precession loss.

Fixes: https://github.com/containers/podman/issues/8414

If we pass around created as time.Time, we do not loose the precission.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
