### PR TITLE
APIv2 - strip CAP_ prefix from capabilities in inspect container json 

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -298,6 +298,9 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 		state.Running = true
 	}
 
+	formatCapabilities(inspect.HostConfig.CapDrop)
+	formatCapabilities(inspect.HostConfig.CapAdd)
+
 	h, err := json.Marshal(inspect.HostConfig)
 	if err != nil {
 		return nil, err
@@ -427,4 +430,10 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 		NetworkSettings:   &networkSettings,
 	}
 	return &c, nil
+}
+
+func formatCapabilities(slice []string) {
+	for i := range slice {
+		slice[i] = strings.TrimPrefix(slice[i], "CAP_")
+	}
 }


### PR DESCRIPTION
CapAdd and CapDrop lists of capabilities in HostConfig element in generated json should not start with CAP_ prefix. Fixes issue originally reported as https://github.com/docker-java/docker-java/issues/1488 or https://github.com/docker-java/docker-java/issues/1500