### PR TITLE
Specify what the replace flag replaces in help text

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -94,7 +94,7 @@ func init() {
 	flags.StringVar(&podIDFile, podIDFileFlagName, "", "Write the pod ID to the file")
 	_ = createCommand.RegisterFlagCompletionFunc(podIDFileFlagName, completion.AutocompleteDefault)
 
-	flags.BoolVar(&replace, "replace", false, "If a pod with the same exists, replace it")
+	flags.BoolVar(&replace, "replace", false, "If a pod with the same name exists, replace it")
 
 	shareFlagName := "share"
 	flags.StringVar(&share, shareFlagName, specgen.DefaultKernelNamespaces, "A comma delimited list of kernel namespaces the pod will share")


### PR DESCRIPTION
The word "name" appears to have been missed in the help output for:

    podman pod create --help

This patch fixes that

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
