### PR TITLE
Set PATH env in systemd timer.

### DIFF
--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -26,6 +26,10 @@ func (c *Container) createTimer() error {
 	if rootless.IsRootless() {
 		cmd = append(cmd, "--user")
 	}
+	path := os.Getenv("PATH")
+	if path != "" {
+		cmd = append(cmd, "--setenv=PATH="+path)
+	}
 	cmd = append(cmd, "--unit", c.ID(), fmt.Sprintf("--on-unit-inactive=%s", c.HealthCheckConfig().Interval.String()), "--timer-property=AccuracySec=1s", podman, "healthcheck", "run", c.ID())
 
 	conn, err := systemd.ConnectToDBUS()


### PR DESCRIPTION
This fixes an issue where binaries that are in the path of the original
podman process are not found in the transient systemd timer for healthchecks.

This showed up for me on a NixOS machine since binaries are not installed
in the usual places.

Signed-off-by: Marco Munizaga <git@marcopolo.io>

---
PS [this section in contributing](https://github.com/containers/podman/blob/b4b4fa07a97560085bfedbf0498a9301eb815435/CONTRIBUTING.md#go-format-and-lint) tells you to run `podman build -t gate -f contrib/gate/Dockerfile .` but that doesn't seem to work in master
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
