### PR TITLE
Add podman container ps command

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -29,14 +29,24 @@ var (
 	psDescription = "Prints out information about the containers"
 	psCommand     = &cobra.Command{
 		Use:               "ps [options]",
-		Args:              validate.NoArgs,
 		Short:             "List containers",
 		Long:              psDescription,
 		RunE:              ps,
+		Args:              validate.NoArgs,
 		ValidArgsFunction: completion.AutocompleteNone,
 		Example: `podman ps -a
   podman ps -a --format "{{.ID}}  {{.Image}}  {{.Labels}}  {{.Mounts}}"
   podman ps --size --sort names`,
+	}
+
+	psContainerCommand = &cobra.Command{
+		Use:               psCommand.Use,
+		Short:             psCommand.Short,
+		Long:              psCommand.Long,
+		RunE:              psCommand.RunE,
+		Args:              psCommand.Args,
+		ValidArgsFunction: psCommand.ValidArgsFunction,
+		Example:           strings.ReplaceAll(psCommand.Example, "podman ps", "podman container ps"),
 	}
 )
 var (
@@ -54,6 +64,14 @@ func init() {
 	})
 	listFlagSet(psCommand)
 	validate.AddLatestFlag(psCommand, &listOpts.Latest)
+
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: psContainerCommand,
+		Parent:  containerCmd,
+	})
+	listFlagSet(psContainerCommand)
+	validate.AddLatestFlag(psContainerCommand, &listOpts.Latest)
 }
 
 func listFlagSet(cmd *cobra.Command) {

--- a/docs/source/managecontainers.rst
+++ b/docs/source/managecontainers.rst
@@ -39,6 +39,8 @@ Manage Containers
 
 :doc:`prune <markdown/podman-container-prune.1>` Remove all stopped containers
 
+:doc:`ps <markdown/podman-ps.1>` List containers
+
 :doc:`restart <markdown/podman-restart.1>` Restart one or more containers
 
 :doc:`restore <markdown/podman-container-restore.1>` Restores one or more containers from a checkpoint

--- a/docs/source/markdown/links/podman-list.1
+++ b/docs/source/markdown/links/podman-list.1
@@ -1,1 +1,0 @@
-.so man1/podman-ps.1

--- a/docs/source/markdown/links/podman-ls.1
+++ b/docs/source/markdown/links/podman-ls.1
@@ -1,1 +1,0 @@
-.so man1/podman-ps.1

--- a/docs/source/markdown/podman-container.1.md
+++ b/docs/source/markdown/podman-container.1.md
@@ -32,6 +32,7 @@ The container command allows you to manage containers
 | pause      | [podman-pause(1)](podman-pause.1.md)                | Pause one or more containers.                                                |
 | port       | [podman-port(1)](podman-port.1.md)                  | List port mappings for the container.                                        |
 | prune      | [podman-container-prune(1)](podman-container-prune.1.md)| Remove all stopped containers from local storage.                        |
+| ps         | [podman-ps(1)](podman-ps.1.md)                      | Prints out information about containers.                                     |
 | restart    | [podman-restart(1)](podman-restart.1.md)            | Restart one or more containers.                                              |
 | restore    | [podman-container-restore(1)](podman-container-restore.1.md)  | Restores one or more containers from a checkpoint.                 |
 | rm         | [podman-rm(1)](podman-rm.1.md)                      | Remove one or more containers.                                               |

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -6,15 +6,11 @@ podman\-ps - Prints out information about containers
 ## SYNOPSIS
 **podman ps** [*options*]
 
+**podman container ps** [*options*]
+
 **podman container list** [*options*]
 
 **podman container ls** [*options*]
-
-**podman container ps** [*options*]
-
-**podman list** [*options*]
-
-**podman ls** [*options*]
 
 ## DESCRIPTION
 **podman ps** lists the running containers on the system. Use the **--all** flag to view

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -44,6 +44,12 @@ var _ = Describe("Podman ps", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman container ps no containers", func() {
+		session := podmanTest.Podman([]string{"container", "ps"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman ps default", func() {
 		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
This command exists in docker and is also in our documentation.

Also remove mentions of `podman ls` or `podman list`. These
commands do not exists in podman or docker.

Fixes #8445 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
