### PR TITLE
Fix ip-range for classless subnet masks

### DIFF
--- a/libpod/network/subnet.go
+++ b/libpod/network/subnet.go
@@ -54,14 +54,10 @@ func LastIPInSubnet(addr *net.IPNet) (net.IP, error) { //nolint:interfacer
 
 	ones, bits := cidr.Mask.Size()
 	if ones == bits {
-		return FirstIPInSubnet(cidr)
+		return cidr.IP, nil
 	}
-	hostStart := ones / 8
-	// Handle the first host byte
-	cidr.IP[hostStart] |= 0xff & cidr.Mask[hostStart]
-	// Fill the rest with ones
-	for i := hostStart; i < len(cidr.IP); i++ {
-		cidr.IP[i] = 0xff
+	for i := range cidr.IP {
+		cidr.IP[i] = cidr.IP[i] | ^cidr.Mask[i]
 	}
 	return cidr.IP, nil
 }
@@ -72,6 +68,10 @@ func FirstIPInSubnet(addr *net.IPNet) (net.IP, error) { //nolint:interfacer
 	_, cidr, err := net.ParseCIDR(addr.String())
 	if err != nil {
 		return nil, err
+	}
+	ones, bits := cidr.Mask.Size()
+	if ones == bits {
+		return cidr.IP, nil
 	}
 	cidr.IP[len(cidr.IP)-1]++
 	return cidr.IP, nil

--- a/libpod/network/subnet_test.go
+++ b/libpod/network/subnet_test.go
@@ -33,3 +33,65 @@ func TestNextSubnet(t *testing.T) {
 		})
 	}
 }
+
+func TestFirstIPInSubnet(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    *net.IPNet
+		want    net.IP
+		wantErr bool
+	}{
+		{"class b", parseCIDR("192.168.0.0/16"), net.ParseIP("192.168.0.1"), false},
+		{"class c", parseCIDR("192.168.1.0/24"), net.ParseIP("192.168.1.1"), false},
+		{"cidr /23", parseCIDR("192.168.0.0/23"), net.ParseIP("192.168.0.1"), false},
+		{"cidr /25", parseCIDR("192.168.1.0/25"), net.ParseIP("192.168.1.1"), false},
+		{"cidr /26", parseCIDR("172.16.1.128/26"), net.ParseIP("172.16.1.129"), false},
+		{"class a", parseCIDR("10.0.0.0/8"), net.ParseIP("10.0.0.1"), false},
+		{"cidr /32", parseCIDR("192.168.255.4/32"), net.ParseIP("192.168.255.4"), false},
+		{"cidr /31", parseCIDR("192.168.255.4/31"), net.ParseIP("192.168.255.5"), false},
+	}
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			got, err := FirstIPInSubnet(test.args)
+			if (err != nil) != test.wantErr {
+				t.Errorf("FirstIPInSubnet() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if !got.Equal(test.want) {
+				t.Errorf("FirstIPInSubnet() got = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestLastIPInSubnet(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    *net.IPNet
+		want    net.IP
+		wantErr bool
+	}{
+		{"class b", parseCIDR("192.168.0.0/16"), net.ParseIP("192.168.255.255"), false},
+		{"class c", parseCIDR("192.168.1.0/24"), net.ParseIP("192.168.1.255"), false},
+		{"cidr /23", parseCIDR("192.168.0.0/23"), net.ParseIP("192.168.1.255"), false},
+		{"cidr /25", parseCIDR("192.168.1.0/25"), net.ParseIP("192.168.1.127"), false},
+		{"cidr /26", parseCIDR("172.16.1.128/26"), net.ParseIP("172.16.1.191"), false},
+		{"class a", parseCIDR("10.0.0.0/8"), net.ParseIP("10.255.255.255"), false},
+		{"cidr /32", parseCIDR("192.168.255.4/32"), net.ParseIP("192.168.255.4"), false},
+		{"cidr /31", parseCIDR("192.168.255.4/31"), net.ParseIP("192.168.255.5"), false},
+	}
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			got, err := LastIPInSubnet(test.args)
+			if (err != nil) != test.wantErr {
+				t.Errorf("LastIPInSubnet() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if !got.Equal(test.want) {
+				t.Errorf("LastIPInSubnet() got = %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `LastIPInSubnet` function worked only for classful subnet
masks (e.g. /8, /16, /24). For non standard subnet masks this
returned the wrong ip address.

This works now for all subnet mask. A unit test is added to
ensure this.

Fixes #8448 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
