### PR TITLE
WIP: Improve the cli args validation

### DIFF
--- a/cmd/podman/containers/attach.go
+++ b/cmd/podman/containers/attach.go
@@ -18,7 +18,7 @@ var (
 		Short:             "Attach to a running container",
 		Long:              attachDescription,
 		RunE:              attach,
-		Args:              validate.IDOrLatestArgs,
+		Args:              validate.OneContainerOrLatestArgs,
 		ValidArgsFunction: common.AutocompleteContainersRunning,
 		Example: `podman attach ctrID
   podman attach 1234
@@ -30,7 +30,7 @@ var (
 		Short:             attachCommand.Short,
 		Long:              attachCommand.Long,
 		RunE:              attachCommand.RunE,
-		Args:              validate.IDOrLatestArgs,
+		Args:              validate.OneContainerOrLatestArgs,
 		ValidArgsFunction: attachCommand.ValidArgsFunction,
 		Example: `podman container attach ctrID
 	podman container attach 1234

--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -27,7 +27,7 @@ var (
 		Long:  checkpointDescription,
 		RunE:  checkpoint,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndCIDFile(cmd, args, true, false)
 		},
 		ValidArgsFunction: common.AutocompleteContainersRunning,
 		Example: `podman container checkpoint --keep ctrID

--- a/cmd/podman/containers/container.go
+++ b/cmd/podman/containers/container.go
@@ -14,11 +14,10 @@ var (
 
 	// Command: podman _container_
 	containerCmd = &cobra.Command{
-		Use:              "container",
-		Short:            "Manage containers",
-		Long:             "Manage containers",
-		TraverseChildren: true,
-		RunE:             validate.SubCommandExists,
+		Use:   "container",
+		Short: "Manage containers",
+		Long:  "Manage containers",
+		RunE:  validate.SubCommandExists,
 	}
 
 	containerConfig = util.DefaultContainerConfig()

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -39,11 +39,11 @@ var (
 	}
 
 	containerCreateCommand = &cobra.Command{
-		Args:              cobra.MinimumNArgs(1),
 		Use:               createCommand.Use,
 		Short:             createCommand.Short,
 		Long:              createCommand.Long,
 		RunE:              createCommand.RunE,
+		Args:              createCommand.Args,
 		ValidArgsFunction: createCommand.ValidArgsFunction,
 		Example: `podman container create alpine ls
   podman container create --annotation HELLO=WORLD alpine ls

--- a/cmd/podman/containers/diff.go
+++ b/cmd/podman/containers/diff.go
@@ -14,7 +14,7 @@ var (
 	// podman container _diff_
 	diffCmd = &cobra.Command{
 		Use:               "diff [options] CONTAINER",
-		Args:              validate.IDOrLatestArgs,
+		Args:              validate.OneContainerOrLatestArgs,
 		Short:             "Inspect changes to the container's file systems",
 		Long:              `Displays changes to the container filesystem's'.  The container will be compared to its parent layer.`,
 		RunE:              diff,

--- a/cmd/podman/containers/exists.go
+++ b/cmd/podman/containers/exists.go
@@ -18,10 +18,9 @@ var (
 		Long:  containerExistsDescription,
 		Example: `podman container exists --external containerID
   podman container exists myctr || podman run --name myctr [etc...]`,
-		RunE:                  exists,
-		Args:                  cobra.ExactArgs(1),
-		DisableFlagsInUseLine: true,
-		ValidArgsFunction:     common.AutocompleteContainers,
+		RunE:              exists,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: common.AutocompleteContainers,
 	}
 )
 

--- a/cmd/podman/containers/export.go
+++ b/cmd/podman/containers/export.go
@@ -30,11 +30,11 @@ var (
 	}
 
 	containerExportCommand = &cobra.Command{
-		Args:              cobra.ExactArgs(1),
 		Use:               exportCommand.Use,
 		Short:             exportCommand.Short,
 		Long:              exportCommand.Long,
 		RunE:              exportCommand.RunE,
+		Args:              exportCommand.Args,
 		ValidArgsFunction: exportCommand.ValidArgsFunction,
 		Example: `podman container export ctrID > myCtr.tar
   podman container export --output="myCtr.tar" ctrID`,

--- a/cmd/podman/containers/inspect.go
+++ b/cmd/podman/containers/inspect.go
@@ -16,6 +16,7 @@ var (
 		Short:             "Display the configuration of a container",
 		Long:              `Displays the low-level information on a container identified by name or ID.`,
 		RunE:              inspectExec,
+		Args:              validate.ContainersOrLatestArgs,
 		ValidArgsFunction: common.AutocompleteContainers,
 		Example: `podman container inspect myCtr
   podman container inspect -l --format '{{.Id}} {{.Config.Labels}}'`,

--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -31,13 +31,11 @@ var (
 	}
 
 	containerKillCommand = &cobra.Command{
-		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
-		},
 		Use:               killCommand.Use,
 		Short:             killCommand.Short,
 		Long:              killCommand.Long,
 		RunE:              killCommand.RunE,
+		Args:              killCommand.Args,
 		ValidArgsFunction: killCommand.ValidArgsFunction,
 		Example: `podman container kill mywebserver
   podman container kill 860a4b23

--- a/cmd/podman/containers/pause.go
+++ b/cmd/podman/containers/pause.go
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	// TODO: make pause support --latest and add Args function
 	pauseDescription = `Pauses one or more running containers.  The container name or ID can be used.`
 	pauseCommand     = &cobra.Command{
 		Use:               "pause [options] CONTAINER [CONTAINER...]",

--- a/cmd/podman/containers/port.go
+++ b/cmd/podman/containers/port.go
@@ -33,13 +33,11 @@ var (
 	}
 
 	containerPortCommand = &cobra.Command{
-		Use:   "port [options] CONTAINER [PORT]",
-		Short: portCommand.Short,
-		Long:  portDescription,
-		RunE:  portCommand.RunE,
-		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, true, false)
-		},
+		Use:               "port [options] CONTAINER [PORT]",
+		Short:             portCommand.Short,
+		Long:              portDescription,
+		RunE:              portCommand.RunE,
+		Args:              portCommand.Args,
 		ValidArgsFunction: portCommand.ValidArgsFunction,
 		Example: `podman container port --all
   podman container port --latest 80`,

--- a/cmd/podman/containers/restart.go
+++ b/cmd/podman/containers/restart.go
@@ -39,6 +39,7 @@ var (
 		Short:             restartCommand.Short,
 		Long:              restartCommand.Long,
 		RunE:              restartCommand.RunE,
+		Args:              restartCommand.Args,
 		ValidArgsFunction: restartCommand.ValidArgsFunction,
 		Example: `podman container restart ctrID
   podman container restart --latest

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -27,7 +27,7 @@ var (
 		Long:  restoreDescription,
 		RunE:  restore,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, true, false)
+			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		ValidArgsFunction: common.AutocompleteContainers,
 		Example: `podman container restore ctrID
@@ -88,12 +88,6 @@ func restore(_ *cobra.Command, args []string) error {
 		if argLen > 0 {
 			return errors.Errorf("Cannot use --import with positional arguments")
 		}
-	}
-	if (restoreOptions.All || restoreOptions.Latest) && argLen > 0 {
-		return errors.Errorf("--all or --latest and containers cannot be used together")
-	}
-	if argLen < 1 && !restoreOptions.All && !restoreOptions.Latest && restoreOptions.Import == "" {
-		return errors.Errorf("you must provide at least one name or id")
 	}
 	responses, err := registry.ContainerEngine().ContainerRestore(context.Background(), args, restoreOptions)
 	if err != nil {

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -37,13 +37,11 @@ var (
 	}
 
 	containerRmCommand = &cobra.Command{
-		Use:   rmCommand.Use,
-		Short: rmCommand.Short,
-		Long:  rmCommand.Long,
-		RunE:  rmCommand.RunE,
-		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, true)
-		},
+		Use:               rmCommand.Use,
+		Short:             rmCommand.Short,
+		Long:              rmCommand.Long,
+		RunE:              rmCommand.RunE,
+		Args:              rmCommand.Args,
 		ValidArgsFunction: rmCommand.ValidArgsFunction,
 		Example: `podman container rm imageID
   podman container rm mywebserver myflaskserver 860a4b23

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -24,11 +24,11 @@ import (
 var (
 	runDescription = "Runs a command in a new container from the given image"
 	runCommand     = &cobra.Command{
-		Args:              cobra.MinimumNArgs(1),
 		Use:               "run [options] IMAGE [COMMAND [ARG...]]",
 		Short:             "Run a command in a new container",
 		Long:              runDescription,
 		RunE:              run,
+		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: common.AutocompleteCreateRun,
 		Example: `podman run imageID ls -alF /etc
   podman run --network=host imageID dnf -y install java
@@ -36,11 +36,11 @@ var (
 	}
 
 	containerRunCommand = &cobra.Command{
-		Args:              cobra.MinimumNArgs(1),
 		Use:               runCommand.Use,
 		Short:             runCommand.Short,
 		Long:              runCommand.Long,
 		RunE:              runCommand.RunE,
+		Args:              runCommand.Args,
 		ValidArgsFunction: runCommand.ValidArgsFunction,
 		Example: `podman container run imageID ls -alF /etc
 	podman container run --network=host imageID dnf -y install java

--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -30,7 +30,7 @@ var (
 		Short:             "Display a live stream of container resource usage statistics",
 		Long:              statsDescription,
 		RunE:              stats,
-		Args:              checkStatOptions,
+		Args:              validate.CheckStatOptions,
 		ValidArgsFunction: common.AutocompleteContainersRunning,
 		Example: `podman stats --all --no-stream
   podman stats ctrID
@@ -42,7 +42,7 @@ var (
 		Short:             statsCommand.Short,
 		Long:              statsCommand.Long,
 		RunE:              statsCommand.RunE,
-		Args:              checkStatOptions,
+		Args:              statsCommand.Args,
 		ValidArgsFunction: statsCommand.ValidArgsFunction,
 		Example: `podman container stats --all --no-stream
   podman container stats ctrID
@@ -92,25 +92,6 @@ func init() {
 	})
 	statFlags(containerStatsCommand)
 	validate.AddLatestFlag(containerStatsCommand, &statsOptions.Latest)
-}
-
-// stats is different in that it will assume running containers if
-// no input is given, so we need to validate differently
-func checkStatOptions(cmd *cobra.Command, args []string) error {
-	opts := 0
-	if statsOptions.All {
-		opts++
-	}
-	if statsOptions.Latest {
-		opts++
-	}
-	if len(args) > 0 {
-		opts++
-	}
-	if opts > 1 {
-		return errors.Errorf("--all, --latest and containers cannot be used together")
-	}
-	return nil
 }
 
 func stats(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -32,13 +32,11 @@ var (
 	}
 
 	containerStopCommand = &cobra.Command{
-		Use:   stopCommand.Use,
-		Short: stopCommand.Short,
-		Long:  stopCommand.Long,
-		RunE:  stopCommand.RunE,
-		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, true)
-		},
+		Use:               stopCommand.Use,
+		Short:             stopCommand.Short,
+		Long:              stopCommand.Long,
+		RunE:              stopCommand.RunE,
+		Args:              stopCommand.Args,
 		ValidArgsFunction: stopCommand.ValidArgsFunction,
 		Example: `podman container stop ctrID
   podman container stop --latest

--- a/cmd/podman/containers/top.go
+++ b/cmd/podman/containers/top.go
@@ -29,7 +29,6 @@ var (
 		Short:             "Display the running processes of a container",
 		Long:              topDescription,
 		RunE:              top,
-		Args:              cobra.ArbitraryArgs,
 		ValidArgsFunction: common.AutocompleteTopCmd,
 		Example: `podman top ctrID
 podman top --latest

--- a/cmd/podman/containers/unmount.go
+++ b/cmd/podman/containers/unmount.go
@@ -35,14 +35,12 @@ var (
 	}
 
 	containerUnmountCommand = &cobra.Command{
-		Use:     unmountCommand.Use,
-		Short:   unmountCommand.Short,
-		Aliases: unmountCommand.Aliases,
-		Long:    unmountCommand.Long,
-		RunE:    unmountCommand.RunE,
-		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
-		},
+		Use:               unmountCommand.Use,
+		Short:             unmountCommand.Short,
+		Aliases:           unmountCommand.Aliases,
+		Long:              unmountCommand.Long,
+		RunE:              unmountCommand.RunE,
+		Args:              unmountCommand.Args,
 		ValidArgsFunction: common.AutocompleteContainers,
 		Example: `podman container unmount ctrID
   podman container unmount ctrID1 ctrID2 ctrID3

--- a/cmd/podman/containers/unpause.go
+++ b/cmd/podman/containers/unpause.go
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	// TODO: make unpause support --latest and add Args function
 	unpauseDescription = `Unpauses one or more previously paused containers.  The container name or ID can be used.`
 	unpauseCommand     = &cobra.Command{
 		Use:               "unpause [options] CONTAINER [CONTAINER...]",

--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +23,7 @@ var (
 		Short:             "Block on one or more containers",
 		Long:              waitDescription,
 		RunE:              wait,
+		Args:              validate.ContainersOrLatestArgs,
 		ValidArgsFunction: common.AutocompleteContainers,
 		Example: `podman wait --interval 5s ctrID
   podman wait ctrID1 ctrID2`,
@@ -34,6 +34,7 @@ var (
 		Short:             waitCommand.Short,
 		Long:              waitCommand.Long,
 		RunE:              waitCommand.RunE,
+		Args:              waitCommand.Args,
 		ValidArgsFunction: waitCommand.ValidArgsFunction,
 		Example: `podman container wait --interval 5s ctrID
   podman container wait ctrID1 ctrID2`,
@@ -86,13 +87,6 @@ func wait(cmd *cobra.Command, args []string) error {
 		if waitOptions.Interval, err1 = time.ParseDuration(waitInterval + "ms"); err1 != nil {
 			return err
 		}
-	}
-
-	if !waitOptions.Latest && len(args) == 0 {
-		return errors.Errorf("%q requires a name, id, or the \"--latest\" flag", cmd.CommandPath())
-	}
-	if waitOptions.Latest && len(args) > 0 {
-		return errors.New("--latest and containers cannot be used together")
 	}
 
 	waitOptions.Condition, err = define.StringToContainerStatus(waitCondition)

--- a/cmd/podman/diff.go
+++ b/cmd/podman/diff.go
@@ -19,7 +19,7 @@ var (
 	diffDescription = `Displays changes on a container or image's filesystem.  The container or image will be compared to its parent layer.`
 	diffCmd         = &cobra.Command{
 		Use:               "diff [options] {CONTAINER_ID | IMAGE_ID}",
-		Args:              validate.IDOrLatestArgs,
+		Args:              validate.OneContainerOrLatestArgs,
 		Short:             "Display the changes to the object's file system",
 		Long:              diffDescription,
 		RunE:              diff,

--- a/cmd/podman/healthcheck/run.go
+++ b/cmd/podman/healthcheck/run.go
@@ -13,14 +13,13 @@ import (
 var (
 	healthcheckRunDescription = "run the health check of a container"
 	healthcheckrunCommand     = &cobra.Command{
-		Use:                   "run CONTAINER",
-		Short:                 "run the health check of a container",
-		Long:                  healthcheckRunDescription,
-		Example:               `podman healthcheck run mywebapp`,
-		RunE:                  run,
-		Args:                  cobra.ExactArgs(1),
-		ValidArgsFunction:     common.AutocompleteContainersRunning,
-		DisableFlagsInUseLine: true,
+		Use:               "run CONTAINER",
+		Short:             "run the health check of a container",
+		Long:              healthcheckRunDescription,
+		Example:           `podman healthcheck run mywebapp`,
+		RunE:              run,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: common.AutocompleteContainersRunning,
 	}
 )
 

--- a/cmd/podman/images/exists.go
+++ b/cmd/podman/images/exists.go
@@ -17,7 +17,6 @@ var (
 		ValidArgsFunction: common.AutocompleteImages,
 		Example: `podman image exists ID
   podman image exists IMAGE && podman pull IMAGE`,
-		DisableFlagsInUseLine: true,
 	}
 )
 

--- a/cmd/podman/images/images.go
+++ b/cmd/podman/images/images.go
@@ -11,14 +11,13 @@ import (
 var (
 	// podman _images_  Alias for podman image _list_
 	imagesCmd = &cobra.Command{
-		Use:                   strings.Replace(listCmd.Use, "list", "images", 1),
-		Args:                  listCmd.Args,
-		Short:                 listCmd.Short,
-		Long:                  listCmd.Long,
-		RunE:                  listCmd.RunE,
-		ValidArgsFunction:     listCmd.ValidArgsFunction,
-		Example:               strings.Replace(listCmd.Example, "podman image list", "podman images", -1),
-		DisableFlagsInUseLine: true,
+		Use:               strings.Replace(listCmd.Use, "list", "images", 1),
+		Args:              listCmd.Args,
+		Short:             listCmd.Short,
+		Long:              listCmd.Long,
+		RunE:              listCmd.RunE,
+		ValidArgsFunction: listCmd.ValidArgsFunction,
+		Example:           strings.Replace(listCmd.Example, "podman image list", "podman images", -1),
 	}
 )
 

--- a/cmd/podman/images/import.go
+++ b/cmd/podman/images/import.go
@@ -25,6 +25,7 @@ var (
 		Short:             "Import a tarball to create a filesystem image",
 		Long:              importDescription,
 		RunE:              importCon,
+		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: completion.AutocompleteDefault,
 		Example: `podman import http://example.com/ctr.tar url-image
   cat ctr.tar | podman -q import --message "importing the ctr.tar tarball" - image-imported
@@ -32,11 +33,11 @@ var (
 	}
 
 	imageImportCommand = &cobra.Command{
-		Args:              cobra.MinimumNArgs(1),
 		Use:               importCommand.Use,
 		Short:             importCommand.Short,
 		Long:              importCommand.Long,
 		RunE:              importCommand.RunE,
+		Args:              importCommand.Args,
 		ValidArgsFunction: importCommand.ValidArgsFunction,
 		Example: `podman image import http://example.com/ctr.tar url-image
   cat ctr.tar | podman -q image import --message "importing the ctr.tar tarball" - image-imported

--- a/cmd/podman/images/inspect.go
+++ b/cmd/podman/images/inspect.go
@@ -15,6 +15,7 @@ var (
 		Short:             "Display the configuration of an image",
 		Long:              `Displays the low-level information of an image identified by name or ID.`,
 		RunE:              inspectExec,
+		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: common.AutocompleteImages,
 		Example: `podman inspect alpine
   podman inspect --format "imageId: {{.Id}} size: {{.Size}}" alpine

--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -46,7 +46,6 @@ var (
 		Example: `podman image list --format json
   podman image list --sort repository --format "table {{.ID}} {{.Repository}} {{.Tag}}"
   podman image list --filter dangling=true`,
-		DisableFlagsInUseLine: true,
 	}
 
 	// Options to pull data

--- a/cmd/podman/images/load.go
+++ b/cmd/podman/images/load.go
@@ -31,12 +31,12 @@ var (
 	}
 
 	imageLoadCommand = &cobra.Command{
-		Args:              loadCommand.Args,
 		Use:               loadCommand.Use,
 		Short:             loadCommand.Short,
 		Long:              loadCommand.Long,
-		ValidArgsFunction: loadCommand.ValidArgsFunction,
 		RunE:              loadCommand.RunE,
+		Args:              loadCommand.Args,
+		ValidArgsFunction: loadCommand.ValidArgsFunction,
 	}
 )
 

--- a/cmd/podman/images/mount.go
+++ b/cmd/podman/images/mount.go
@@ -64,10 +64,6 @@ func init() {
 }
 
 func mount(cmd *cobra.Command, args []string) error {
-	if len(args) > 0 && mountOpts.All {
-		return errors.New("when using the --all switch, you may not pass any image names or IDs")
-	}
-
 	reports, err := registry.ImageEngine().Mount(registry.GetContext(), args, mountOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/images/rm.go
+++ b/cmd/podman/images/rm.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/containers/podman/v2/cmd/podman/common"
 	"github.com/containers/podman/v2/cmd/podman/registry"
+	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/errorhandling"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -19,6 +19,7 @@ var (
 		Short:             "Removes one or more images from local storage",
 		Long:              rmDescription,
 		RunE:              rm,
+		Args:              validate.ImagesOrAllArgs,
 		ValidArgsFunction: common.AutocompleteImages,
 		Example: `podman image rm imageID
   podman image rm --force alpine
@@ -44,13 +45,6 @@ func imageRemoveFlagSet(flags *pflag.FlagSet) {
 }
 
 func rm(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 && !imageOpts.All {
-		return errors.Errorf("image name or ID must be specified")
-	}
-	if len(args) > 0 && imageOpts.All {
-		return errors.Errorf("when using the --all switch, you may not pass any images names or IDs")
-	}
-
 	// Note: certain image-removal errors are non-fatal.  Hence, the report
 	// might be set even if err != nil.
 	report, rmErrors := registry.ImageEngine().Remove(registry.GetContext(), args, imageOpts)

--- a/cmd/podman/images/tag.go
+++ b/cmd/podman/images/tag.go
@@ -10,26 +10,24 @@ import (
 var (
 	tagDescription = "Adds one or more additional names to locally-stored image."
 	tagCommand     = &cobra.Command{
-		Use:                   "tag IMAGE TARGET_NAME [TARGET_NAME...]",
-		Short:                 "Add an additional name to a local image",
-		Long:                  tagDescription,
-		RunE:                  tag,
-		Args:                  cobra.MinimumNArgs(2),
-		DisableFlagsInUseLine: true,
-		ValidArgsFunction:     common.AutocompleteImages,
+		Use:               "tag IMAGE TARGET_NAME [TARGET_NAME...]",
+		Short:             "Add an additional name to a local image",
+		Long:              tagDescription,
+		RunE:              tag,
+		Args:              cobra.MinimumNArgs(2),
+		ValidArgsFunction: common.AutocompleteImages,
 		Example: `podman tag 0e3bbc2 fedora:latest
   podman tag imageID:latest myNewImage:newTag
   podman tag httpd myregistryhost:5000/fedora/httpd:v2`,
 	}
 
 	imageTagCommand = &cobra.Command{
-		Args:                  tagCommand.Args,
-		DisableFlagsInUseLine: true,
-		Use:                   tagCommand.Use,
-		Short:                 tagCommand.Short,
-		Long:                  tagCommand.Long,
-		RunE:                  tagCommand.RunE,
-		ValidArgsFunction:     tagCommand.ValidArgsFunction,
+		Use:               tagCommand.Use,
+		Short:             tagCommand.Short,
+		Long:              tagCommand.Long,
+		RunE:              tagCommand.RunE,
+		Args:              tagCommand.Args,
+		ValidArgsFunction: tagCommand.ValidArgsFunction,
 		Example: `podman image tag 0e3bbc2 fedora:latest
   podman image tag imageID:latest myNewImage:newTag
   podman image tag httpd myregistryhost:5000/fedora/httpd:v2`,

--- a/cmd/podman/images/unmount.go
+++ b/cmd/podman/images/unmount.go
@@ -6,8 +6,8 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/common"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/cmd/podman/utils"
+	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -25,6 +25,7 @@ var (
 		Short:             "Unmount an image's root filesystem",
 		Long:              description,
 		RunE:              unmount,
+		Args:              validate.ImagesOrAllArgs,
 		ValidArgsFunction: common.AutocompleteImages,
 		Example: `podman unmount imgID
   podman unmount imgID1 imgID2 imgID3
@@ -52,12 +53,6 @@ func init() {
 
 func unmount(cmd *cobra.Command, args []string) error {
 	var errs utils.OutputErrors
-	if len(args) < 1 && !unmountOpts.All {
-		return errors.New("image name or ID must be specified")
-	}
-	if len(args) > 0 && unmountOpts.All {
-		return errors.New("when using the --all switch, you may not pass any image names or IDs")
-	}
 	reports, err := registry.ImageEngine().Unmount(registry.GetContext(), args, unmountOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/images/untag.go
+++ b/cmd/podman/images/untag.go
@@ -9,26 +9,24 @@ import (
 
 var (
 	untagCommand = &cobra.Command{
-		Use:                   "untag IMAGE [NAME...]",
-		Short:                 "Remove a name from a local image",
-		Long:                  "Removes one or more names from a locally-stored image.",
-		RunE:                  untag,
-		Args:                  cobra.MinimumNArgs(1),
-		DisableFlagsInUseLine: true,
-		ValidArgsFunction:     common.AutocompleteImages,
+		Use:               "untag IMAGE [NAME...]",
+		Short:             "Remove a name from a local image",
+		Long:              "Removes one or more names from a locally-stored image.",
+		RunE:              untag,
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: common.AutocompleteImages,
 		Example: `podman untag 0e3bbc2
   podman untag imageID:latest otherImageName:latest
   podman untag httpd myregistryhost:5000/fedora/httpd:v2`,
 	}
 
 	imageUntagCommand = &cobra.Command{
-		Args:                  untagCommand.Args,
-		DisableFlagsInUseLine: true,
-		Use:                   untagCommand.Use,
-		Short:                 untagCommand.Short,
-		Long:                  untagCommand.Long,
-		RunE:                  untagCommand.RunE,
-		ValidArgsFunction:     untagCommand.ValidArgsFunction,
+		Args:              untagCommand.Args,
+		Use:               untagCommand.Use,
+		Short:             untagCommand.Short,
+		Long:              untagCommand.Long,
+		RunE:              untagCommand.RunE,
+		ValidArgsFunction: untagCommand.ValidArgsFunction,
 		Example: `podman image untag 0e3bbc2
   podman image untag imageID:latest otherImageName:latest
   podman image untag httpd myregistryhost:5000/fedora/httpd:v2`,

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -4,6 +4,7 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/common"
 	"github.com/containers/podman/v2/cmd/podman/inspect"
 	"github.com/containers/podman/v2/cmd/podman/registry"
+	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/spf13/cobra"
 )
@@ -24,7 +25,7 @@ var (
 		Short:             "Display the configuration of object denoted by ID",
 		RunE:              inspectExec,
 		Long:              inspectDescription,
-		TraverseChildren:  true,
+		Args:              validate.ContainersOrLatestArgs,
 		ValidArgsFunction: common.AutocompleteContainersAndImages,
 		Example: `podman inspect fedora
   podman inspect --type image fedora

--- a/cmd/podman/manifest/inspect.go
+++ b/cmd/podman/manifest/inspect.go
@@ -12,14 +12,13 @@ import (
 
 var (
 	inspectCmd = &cobra.Command{
-		Use:                   "inspect IMAGE",
-		Short:                 "Display the contents of a manifest list or image index",
-		Long:                  "Display the contents of a manifest list or image index.",
-		RunE:                  inspect,
-		ValidArgsFunction:     common.AutocompleteImages,
-		Example:               "podman manifest inspect localhost/list",
-		Args:                  cobra.ExactArgs(1),
-		DisableFlagsInUseLine: true,
+		Use:               "inspect IMAGE",
+		Short:             "Display the contents of a manifest list or image index",
+		Long:              "Display the contents of a manifest list or image index.",
+		RunE:              inspect,
+		ValidArgsFunction: common.AutocompleteImages,
+		Example:           "podman manifest inspect localhost/list",
+		Args:              cobra.ExactArgs(1),
 	}
 )
 

--- a/cmd/podman/manifest/remove.go
+++ b/cmd/podman/manifest/remove.go
@@ -13,14 +13,13 @@ import (
 
 var (
 	removeCmd = &cobra.Command{
-		Use:                   "remove LIST IMAGE",
-		Short:                 "Remove an entry from a manifest list or image index",
-		Long:                  "Removes an image from a manifest list or image index.",
-		RunE:                  remove,
-		ValidArgsFunction:     common.AutocompleteImages,
-		Example:               `podman manifest remove mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736`,
-		Args:                  cobra.ExactArgs(2),
-		DisableFlagsInUseLine: true,
+		Use:               "remove LIST IMAGE",
+		Short:             "Remove an entry from a manifest list or image index",
+		Long:              "Removes an image from a manifest list or image index.",
+		RunE:              remove,
+		ValidArgsFunction: common.AutocompleteImages,
+		Example:           `podman manifest remove mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736`,
+		Args:              cobra.ExactArgs(2),
 	}
 )
 

--- a/cmd/podman/pods/exists.go
+++ b/cmd/podman/pods/exists.go
@@ -21,7 +21,6 @@ var (
 		ValidArgsFunction: common.AutocompletePods,
 		Example: `podman pod exists podID
   podman pod exists mypod || podman pod create --name mypod`,
-		DisableFlagsInUseLine: true,
 	}
 )
 

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +29,7 @@ var (
 		Short:             "Displays a pod configuration",
 		Long:              inspectDescription,
 		RunE:              inspect,
+		Args:              validate.ContainersOrLatestArgs,
 		ValidArgsFunction: common.AutocompletePods,
 		Example:           `podman pod inspect podID`,
 	}
@@ -51,14 +51,6 @@ func init() {
 }
 
 func inspect(cmd *cobra.Command, args []string) error {
-
-	if len(args) < 1 && !inspectOptions.Latest {
-		return errors.Errorf("you must provide the name or id of a running pod")
-	}
-	if len(args) > 0 && inspectOptions.Latest {
-		return errors.Errorf("--latest and containers cannot be used together")
-	}
-
 	if !inspectOptions.Latest {
 		inspectOptions.NameOrID = args[0]
 	}

--- a/cmd/podman/pods/stats.go
+++ b/cmd/podman/pods/stats.go
@@ -38,6 +38,7 @@ var (
 		Short:             "Display a live stream of resource usage statistics for the containers in one or more pods",
 		Long:              statsDescription,
 		RunE:              stats,
+		Args:              validate.CheckStatOptions,
 		ValidArgsFunction: common.AutocompletePodsRunning,
 		Example: `podman pod stats
   podman pod stats a69b23034235 named-pod

--- a/cmd/podman/system/connection.go
+++ b/cmd/podman/system/connection.go
@@ -14,14 +14,12 @@ var (
 	}
 
 	ConnectionCmd = &cobra.Command{
-		Use:                   "connection",
-		Short:                 "Manage remote ssh destinations",
-		Long:                  `Manage ssh destination information in podman configuration`,
-		DisableFlagsInUseLine: true,
-		PersistentPreRunE:     noOp,
-		RunE:                  validate.SubCommandExists,
-		PersistentPostRunE:    noOp,
-		TraverseChildren:      false,
+		Use:                "connection",
+		Short:              "Manage remote ssh destinations",
+		Long:               `Manage ssh destination information in podman configuration`,
+		PersistentPreRunE:  noOp,
+		RunE:               validate.SubCommandExists,
+		PersistentPostRunE: noOp,
 	}
 )
 

--- a/cmd/podman/system/connection/default.go
+++ b/cmd/podman/system/connection/default.go
@@ -14,14 +14,13 @@ import (
 var (
 	// Skip creating engines since this command will obtain connection information to said engines
 	dfltCmd = &cobra.Command{
-		Use:                   "default NAME",
-		Args:                  cobra.ExactArgs(1),
-		Short:                 "Set named destination as default",
-		Long:                  `Set named destination as default for the Podman service`,
-		DisableFlagsInUseLine: true,
-		ValidArgsFunction:     common.AutocompleteSystemConnections,
-		RunE:                  defaultRunE,
-		Example:               `podman system connection default testing`,
+		Use:               "default NAME",
+		Args:              cobra.ExactArgs(1),
+		Short:             "Set named destination as default",
+		Long:              `Set named destination as default for the Podman service`,
+		ValidArgsFunction: common.AutocompleteSystemConnections,
+		RunE:              defaultRunE,
+		Example:           `podman system connection default testing`,
 	}
 )
 

--- a/cmd/podman/system/connection/list.go
+++ b/cmd/podman/system/connection/list.go
@@ -16,17 +16,15 @@ import (
 
 var (
 	listCmd = &cobra.Command{
-		Use:                   "list",
-		Aliases:               []string{"ls"},
-		Args:                  validate.NoArgs,
-		Short:                 "List destination for the Podman service(s)",
-		Long:                  `List destination information for the Podman service(s) in podman configuration`,
-		DisableFlagsInUseLine: true,
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Args:    validate.NoArgs,
+		Short:   "List destination for the Podman service(s)",
+		Long:    `List destination information for the Podman service(s) in podman configuration`,
 		Example: `podman system connection list
   podman system connection ls`,
 		ValidArgsFunction: completion.AutocompleteNone,
 		RunE:              list,
-		TraverseChildren:  false,
 	}
 )
 

--- a/cmd/podman/system/connection/remove.go
+++ b/cmd/podman/system/connection/remove.go
@@ -12,14 +12,13 @@ import (
 var (
 	// Skip creating engines since this command will obtain connection information to said engines
 	rmCmd = &cobra.Command{
-		Use:                   "remove NAME",
-		Args:                  cobra.ExactArgs(1),
-		Aliases:               []string{"rm"},
-		Long:                  `Delete named destination from podman configuration`,
-		Short:                 "Delete named destination",
-		DisableFlagsInUseLine: true,
-		ValidArgsFunction:     common.AutocompleteSystemConnections,
-		RunE:                  rm,
+		Use:               "remove NAME",
+		Args:              cobra.ExactArgs(1),
+		Aliases:           []string{"rm"},
+		Long:              `Delete named destination from podman configuration`,
+		Short:             "Delete named destination",
+		ValidArgsFunction: common.AutocompleteSystemConnections,
+		RunE:              rm,
 		Example: `podman system connection remove devl
   podman system connection rm devl`,
 	}

--- a/cmd/podman/system/connection/rename.go
+++ b/cmd/podman/system/connection/rename.go
@@ -14,14 +14,13 @@ import (
 var (
 	// Skip creating engines since this command will obtain connection information to said engines
 	renameCmd = &cobra.Command{
-		Use:                   "rename OLD NEW",
-		Aliases:               []string{"mv"},
-		Args:                  cobra.ExactArgs(2),
-		Short:                 "Rename \"old\" to \"new\"",
-		Long:                  `Rename destination for the Podman service from "old" to "new"`,
-		DisableFlagsInUseLine: true,
-		ValidArgsFunction:     common.AutocompleteSystemConnections,
-		RunE:                  rename,
+		Use:               "rename OLD NEW",
+		Aliases:           []string{"mv"},
+		Args:              cobra.ExactArgs(2),
+		Short:             "Rename \"old\" to \"new\"",
+		Long:              `Rename destination for the Podman service from "old" to "new"`,
+		ValidArgsFunction: common.AutocompleteSystemConnections,
+		RunE:              rename,
 		Example: `podman system connection rename laptop devl,
   podman system connection mv laptop devl`,
 	}

--- a/cmd/podman/system/renumber.go
+++ b/cmd/podman/system/renumber.go
@@ -23,13 +23,12 @@ var (
 `
 
 	renumberCommand = &cobra.Command{
-		Use:                   "renumber",
-		Args:                  validate.NoArgs,
-		DisableFlagsInUseLine: true,
-		Short:                 "Migrate lock numbers",
-		Long:                  renumberDescription,
-		Run:                   renumber,
-		ValidArgsFunction:     completion.AutocompleteNone,
+		Use:               "renumber",
+		Args:              validate.NoArgs,
+		Short:             "Migrate lock numbers",
+		Long:              renumberDescription,
+		Run:               renumber,
+		ValidArgsFunction: completion.AutocompleteNone,
 	}
 )
 

--- a/cmd/podman/system/unshare.go
+++ b/cmd/podman/system/unshare.go
@@ -14,12 +14,11 @@ import (
 var (
 	unshareDescription = "Runs a command in a modified user namespace."
 	unshareCommand     = &cobra.Command{
-		Use:                   "unshare [COMMAND [ARG ...]]",
-		DisableFlagsInUseLine: true,
-		Short:                 "Run a command in a modified user namespace",
-		Long:                  unshareDescription,
-		RunE:                  unshare,
-		ValidArgsFunction:     completion.AutocompleteDefault,
+		Use:               "unshare [COMMAND [ARG ...]]",
+		Short:             "Run a command in a modified user namespace",
+		Long:              unshareDescription,
+		RunE:              unshare,
+		ValidArgsFunction: completion.AutocompleteDefault,
 		Example: `podman unshare id
   podman unshare cat /proc/self/uid_map,
   podman unshare podman-script.sh`,

--- a/cmd/podman/validate/args.go
+++ b/cmd/podman/validate/args.go
@@ -1,9 +1,6 @@
 package validate
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -12,7 +9,7 @@ import (
 // NoArgs returns an error if any args are included.
 func NoArgs(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
-		return fmt.Errorf("`%s` takes no arguments", cmd.CommandPath())
+		return errors.Errorf("`%s` takes no arguments", cmd.CommandPath())
 	}
 	return nil
 }
@@ -25,114 +22,139 @@ func SubCommandExists(cmd *cobra.Command, args []string) error {
 	return errors.Errorf("missing command '%[1]s COMMAND'\nTry '%[1]s --help' for more information.", cmd.CommandPath())
 }
 
-// IDOrLatestArgs used to validate a nameOrId was provided or the "--latest" flag
-func IDOrLatestArgs(cmd *cobra.Command, args []string) error {
-	if len(args) > 1 {
-		return fmt.Errorf("`%s` accepts at most one argument", cmd.CommandPath())
+// OneContainerOrLatestArgs used to validate if one arg was provided or the "--latest" flag
+func OneContainerOrLatestArgs(cmd *cobra.Command, args []string) error {
+	return checkArgsOrLatest(cmd, args, true)
+}
+
+// ContainersOrLatestArgs used to validate if args are provided or the "--latest" flag
+func ContainersOrLatestArgs(cmd *cobra.Command, args []string) error {
+	return checkArgsOrLatest(cmd, args, false)
+}
+
+func checkArgsOrLatest(cmd *cobra.Command, args []string, singleArg bool) error {
+	if singleArg && len(args) > 1 {
+		return errors.Errorf("`%s` accepts at most one argument", cmd.CommandPath())
+	}
+
+	// This function is used by container and pod commands.
+	// Lets make the error more descriptive by adding the correct noun to the error message.
+	argType := "container"
+	if cmd.Parent().Name() == "pod" {
+		argType = "pod"
 	}
 
 	latest := cmd.Flag("latest")
 	if latest != nil {
-		given, _ := strconv.ParseBool(cmd.Flag("latest").Value.String())
+		given, _ := cmd.Flags().GetBool("latest")
 		if len(args) == 0 && !given {
-			return fmt.Errorf("%q requires a name, id, or the \"--latest\" flag", cmd.CommandPath())
+			return errors.Errorf("%q requires a %s name, id, or the \"--latest\" flag", cmd.CommandPath(), argType)
 		}
 		if len(args) > 0 && given {
-			return fmt.Errorf("--latest and containers cannot be used together")
+			return errors.Errorf("--latest and %ss cannot be used together", argType)
 		}
 	}
 	return nil
 }
 
-// TODO: the two functions CheckAllLatestAndCIDFile and CheckAllLatestAndPodIDFile are almost identical.
-//       It may be worth looking into generalizing the two a bit more and share code but time is scarce and
-//       we only live once.
+// ImagesOrAllArgs used to validate if args are provided or the "--all" flag
+func ImagesOrAllArgs(cmd *cobra.Command, args []string) error {
+	return checkAllArgs(cmd, args, "image")
+}
+
+// VolumesOrAllArgs used to validate if args are provided or the "--all" flag
+func VolumesOrAllArgs(cmd *cobra.Command, args []string) error {
+	return checkAllArgs(cmd, args, "volume")
+}
+
+// checkAllArgs used to validate if args are provided or the "--all" flag
+func checkAllArgs(cmd *cobra.Command, args []string, name string) error {
+	all := cmd.Flag("all")
+	if all != nil {
+		given, _ := cmd.Flags().GetBool("all")
+		if len(args) == 0 && !given {
+			return errors.Errorf("%q requires a %s name, id or the \"--all\" flag", cmd.CommandPath(), name)
+		}
+		if len(args) > 0 && given {
+			return errors.Errorf("--all and %ss cannot be used together", name)
+		}
+	}
+	return nil
+}
+
+// CheckStatOptions stats is different in that it will assume running
+// containers if no input is given, so we need to validate differently
+func CheckStatOptions(cmd *cobra.Command, args []string) error {
+	opts := 0
+	all, err := cmd.Flags().GetBool("all")
+	if err != nil {
+		return err
+	}
+	if all {
+		opts++
+	}
+	if !registry.IsRemote() {
+		latest, err := cmd.Flags().GetBool("latest")
+		if err != nil {
+			return err
+		}
+		if latest {
+			opts++
+		}
+	}
+	if len(args) > 0 {
+		opts++
+	}
+	if opts > 1 {
+		ctype := "container"
+		if cmd.Parent().Name() == "pod" {
+			ctype = "pod"
+		}
+		return errors.Errorf("--all, --latest and %ss cannot be used together", ctype)
+	}
+	return nil
+}
 
 // CheckAllLatestAndCIDFile checks that --all and --latest are used correctly.
 // If cidfile is set, also check for the --cidfile flag.
 func CheckAllLatestAndCIDFile(c *cobra.Command, args []string, ignoreArgLen bool, cidfile bool) error {
-	var specifiedLatest bool
-	argLen := len(args)
-	if !registry.IsRemote() {
-		specifiedLatest, _ = c.Flags().GetBool("latest")
-		if c.Flags().Lookup("all") == nil || c.Flags().Lookup("latest") == nil {
-			if !cidfile {
-				return errors.New("unable to lookup values for 'latest' or 'all'")
-			} else if c.Flags().Lookup("cidfile") == nil {
-				return errors.New("unable to lookup values for 'latest', 'all' or 'cidfile'")
-			}
-		}
-	}
-
-	specifiedAll, _ := c.Flags().GetBool("all")
-	specifiedCIDFile := false
-	if cid, _ := c.Flags().GetStringArray("cidfile"); len(cid) > 0 {
-		specifiedCIDFile = true
-	}
-
-	if specifiedCIDFile && (specifiedAll || specifiedLatest) {
-		return errors.Errorf("--all, --latest and --cidfile cannot be used together")
-	} else if specifiedAll && specifiedLatest {
-		return errors.Errorf("--all and --latest cannot be used together")
-	}
-
-	if (argLen > 0) && specifiedAll {
-		return errors.Errorf("no arguments are needed with --all")
-	}
-
-	if ignoreArgLen {
-		return nil
-	}
-
-	if argLen > 0 {
-		if specifiedLatest {
-			return errors.Errorf("--latest and containers cannot be used together")
-		} else if cidfile && (specifiedLatest || specifiedCIDFile) {
-			return errors.Errorf("no arguments are needed with --latest or --cidfile")
-		}
-	}
-
-	if specifiedCIDFile {
-		return nil
-	}
-
-	if argLen < 1 && !specifiedAll && !specifiedLatest && !specifiedCIDFile {
-		return errors.Errorf("you must provide at least one name or id")
-	}
-	return nil
+	return checkAllLatestAndIDFile(c, args, ignoreArgLen, cidfile, "cidfile")
 }
 
 // CheckAllLatestAndPodIDFile checks that --all and --latest are used correctly.
 // If withIDFile is set, also check for the --pod-id-file flag.
 func CheckAllLatestAndPodIDFile(c *cobra.Command, args []string, ignoreArgLen bool, withIDFile bool) error {
+	return checkAllLatestAndIDFile(c, args, ignoreArgLen, withIDFile, "pod-id-file")
+}
+
+func checkAllLatestAndIDFile(c *cobra.Command, args []string, ignoreArgLen bool, withIDFile bool, idFlagName string) error {
 	var specifiedLatest bool
 	argLen := len(args)
 	if !registry.IsRemote() {
-		// remote clients have no latest flag
 		specifiedLatest, _ = c.Flags().GetBool("latest")
 		if c.Flags().Lookup("all") == nil || c.Flags().Lookup("latest") == nil {
 			if !withIDFile {
 				return errors.New("unable to lookup values for 'latest' or 'all'")
-			} else if c.Flags().Lookup("pod-id-file") == nil {
-				return errors.New("unable to lookup values for 'latest', 'all' or 'pod-id-file'")
+			} else if c.Flags().Lookup(idFlagName) == nil {
+				return errors.Errorf("unable to lookup values for 'latest', 'all' or '%s'", idFlagName)
 			}
 		}
 	}
 
 	specifiedAll, _ := c.Flags().GetBool("all")
-	specifiedPodIDFile := false
-	if pid, _ := c.Flags().GetStringArray("pod-id-file"); len(pid) > 0 {
-		specifiedPodIDFile = true
+	specifiedIDFile := false
+	if cid, _ := c.Flags().GetStringArray(idFlagName); len(cid) > 0 {
+		specifiedIDFile = true
 	}
 
-	if specifiedPodIDFile && (specifiedAll || specifiedLatest) {
-		return errors.Errorf("--all, --latest and --pod-id-file cannot be used together")
+	if specifiedIDFile && (specifiedAll || specifiedLatest) {
+		return errors.Errorf("--all, --latest and --%s cannot be used together", idFlagName)
 	} else if specifiedAll && specifiedLatest {
-		return errors.Errorf("--all and --latest cannot be used together")
+		return errors.New("--all and --latest cannot be used together")
 	}
 
 	if (argLen > 0) && specifiedAll {
-		return errors.Errorf("no arguments are needed with --all")
+		return errors.New("no arguments are needed with --all")
 	}
 
 	if ignoreArgLen {
@@ -141,17 +163,17 @@ func CheckAllLatestAndPodIDFile(c *cobra.Command, args []string, ignoreArgLen bo
 
 	if argLen > 0 {
 		if specifiedLatest {
-			return errors.Errorf("--latest and pods cannot be used together")
-		} else if withIDFile && (specifiedLatest || specifiedPodIDFile) {
-			return errors.Errorf("no arguments are needed with --latest or --pod-id-file")
+			return errors.New("--latest and containers cannot be used together")
+		} else if withIDFile && (specifiedLatest || specifiedIDFile) {
+			return errors.Errorf("no arguments are needed with --latest or --%s", idFlagName)
 		}
 	}
 
-	if specifiedPodIDFile {
+	if specifiedIDFile {
 		return nil
 	}
 
-	if argLen < 1 && !specifiedAll && !specifiedLatest && !specifiedPodIDFile {
+	if argLen < 1 && !specifiedAll && !specifiedLatest && !specifiedIDFile {
 		return errors.Errorf("you must provide at least one name or id")
 	}
 	return nil

--- a/cmd/podman/volumes/create.go
+++ b/cmd/podman/volumes/create.go
@@ -20,6 +20,7 @@ var (
 		Short:             "Create a new volume",
 		Long:              createDescription,
 		RunE:              create,
+		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: completion.AutocompleteNone,
 		Example: `podman volume create myvol
   podman volume create

--- a/cmd/podman/volumes/inspect.go
+++ b/cmd/podman/volumes/inspect.go
@@ -4,8 +4,8 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/common"
 	"github.com/containers/podman/v2/cmd/podman/inspect"
 	"github.com/containers/podman/v2/cmd/podman/registry"
+	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +18,7 @@ var (
 		Short:             "Display detailed information on one or more volumes",
 		Long:              volumeInspectDescription,
 		RunE:              volumeInspect,
+		Args:              validate.VolumesOrAllArgs,
 		ValidArgsFunction: common.AutocompleteVolumes,
 		Example: `podman volume inspect myvol
   podman volume inspect --all
@@ -45,9 +46,6 @@ func init() {
 }
 
 func volumeInspect(cmd *cobra.Command, args []string) error {
-	if (inspectOpts.All && len(args) > 0) || (!inspectOpts.All && len(args) < 1) {
-		return errors.New("provide one or more volume names or use --all")
-	}
 	inspectOpts.Type = inspect.VolumeType
 	return inspect.Inspect(args, *inspectOpts)
 }

--- a/cmd/podman/volumes/rm.go
+++ b/cmd/podman/volumes/rm.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/podman/v2/cmd/podman/common"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/cmd/podman/utils"
+	"github.com/containers/podman/v2/cmd/podman/validate"
 	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/pkg/errors"
@@ -24,6 +25,7 @@ var (
 		Short:             "Remove one or more volumes",
 		Long:              volumeRmDescription,
 		RunE:              rm,
+		Args:              validate.VolumesOrAllArgs,
 		ValidArgsFunction: common.AutocompleteVolumes,
 		Example: `podman volume rm myvol1 myvol2
   podman volume rm --all
@@ -50,9 +52,6 @@ func rm(cmd *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
-	if (len(args) > 0 && rmOptions.All) || (len(args) < 1 && !rmOptions.All) {
-		return errors.New("choose either one or more volumes or all")
-	}
 	responses, err := registry.ContainerEngine().VolumeRm(context.Background(), args, rmOptions)
 	if err != nil {
 		setExitCode(err)

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -273,7 +273,6 @@ RUN find $LOCAL
 		session := podmanTest.Podman([]string{"image", "rm"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(125))
-		match, _ := session.ErrorGrepString("image name or ID must be specified")
-		Expect(match).To(BeTrue())
+		Expect(session.ErrorToString()).To(ContainSubstring(`image rm" requires a image name, id or the "--all" flag`))
 	})
 })


### PR DESCRIPTION
Make use of the cobra `Args` function to validate the cli arguments.
This already exists for most commands. Using the `Args` function has
two advantages. First, it helps to reduce code duplication since most
commands can share the same `Args` function. Second, the shell
completion logic also uses this to provide better completions.
e.g. `podman start --latest [TAB]` should not complete containers

Remove useless definitions of `DisableFlagsInUseLine`. This is already
set for all commands in `cmd/podman/main.go`. Also remove
`TraverseChildren` since this has only affect on the root command.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
