### PR TITLE
Static IP and MAC addresses are allowed in rootless CNI

### DIFF
--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -30,7 +30,7 @@ func exclusiveOptions(opt1, opt2 string) error {
 // input for creating a container.
 func (s *SpecGenerator) Validate() error {
 
-	if rootless.IsRootless() {
+	if rootless.IsRootless() && len(s.CNINetworks) == 0 {
 		if s.StaticIP != nil || s.StaticIPv6 != nil {
 			return ErrNoStaticIPRootless
 		}

--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -49,7 +49,6 @@ var _ = Describe("Podman create with --ip flag", func() {
 	})
 
 	It("Podman create --ip with non-allocatable IP", func() {
-		SkipIfRootless("--ip is not supported in rootless mode")
 		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", "203.0.113.124", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
@@ -81,7 +80,6 @@ var _ = Describe("Podman create with --ip flag", func() {
 	})
 
 	It("Podman create two containers with the same IP", func() {
-		SkipIfRootless("--ip not supported in rootless mode")
 		ip := GetRandomIPAddress()
 		result := podmanTest.Podman([]string{"create", "--name", "test1", "--ip", ip, ALPINE, "sleep", "999"})
 		result.WaitWithDefaultTimeout()

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -539,7 +539,6 @@ var _ = Describe("Podman run networking", func() {
 	})
 
 	It("podman run in custom CNI network with --static-ip", func() {
-		SkipIfRootless("Rootless mode does not support --ip")
 		netName := "podmantestnetwork"
 		ipAddr := "10.25.30.128"
 		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.30.0/24", netName})
@@ -558,7 +557,6 @@ var _ = Describe("Podman run networking", func() {
 	})
 
 	It("podman run with new:pod and static-ip", func() {
-		SkipIfRootless("Rootless does not support --ip")
 		netName := "podmantestnetwork2"
 		ipAddr := "10.25.40.128"
 		podname := "testpod"


### PR DESCRIPTION
    Loosen some restrictions within specgen around rootless
    containers - they can now set static IP and MAC addresses as long
    as they are in a CNI network.
    
    Fixes #7842
    
    Signed-off-by: Matthew Heon <matthew.heon@pm.me>
