### PR TITLE
Fix custom mac address with a custom cni network

### DIFF
--- a/libpod/network/config.go
+++ b/libpod/network/config.go
@@ -129,6 +129,16 @@ func (f FirewallConfig) Bytes() ([]byte, error) {
 	return json.MarshalIndent(f, "", "\t")
 }
 
+// TuningConfig describes the tuning plugin
+type TuningConfig struct {
+	PluginType string `json:"type"`
+}
+
+// Bytes outputs the configuration as []byte
+func (f TuningConfig) Bytes() ([]byte, error) {
+	return json.MarshalIndent(f, "", "\t")
+}
+
 // DNSNameConfig describes the dns container name resolution plugin config
 type DNSNameConfig struct {
 	PluginType   string          `json:"type"`

--- a/libpod/network/create.go
+++ b/libpod/network/create.go
@@ -176,6 +176,7 @@ func createBridge(name string, options entities.NetworkCreateOptions, runtimeCon
 	plugins = append(plugins, bridge)
 	plugins = append(plugins, NewPortMapPlugin())
 	plugins = append(plugins, NewFirewallPlugin())
+	plugins = append(plugins, NewTuningPlugin())
 	// if we find the dnsname plugin or are rootless, we add configuration for it
 	// the rootless-cni-infra container has the dnsname plugin always installed
 	if (HasDNSNamePlugin(runtimeConfig.Network.CNIPluginDirs) || rootless.IsRootless()) && !options.DisableDNS {

--- a/libpod/network/netconflist.go
+++ b/libpod/network/netconflist.go
@@ -119,6 +119,13 @@ func NewFirewallPlugin() FirewallConfig {
 	}
 }
 
+// NewTuningPlugin creates a generic tuning section
+func NewTuningPlugin() TuningConfig {
+	return TuningConfig{
+		PluginType: "tuning",
+	}
+}
+
 // NewDNSNamePlugin creates the dnsname config with a given
 // domainname
 func NewDNSNamePlugin(domainName string) DNSNameConfig {


### PR DESCRIPTION
The cni plugin `tuning` is required to set a custom mac address.
This plugin is configured in the default cni config file which is
packaged with podman but was not included the generated config form
`podman network create`.

Fixes #8385

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
