### PR TITLE
[CI:DOCS] Tutorials:mac-win-client - Fix command ensuring sshd is enabled

### DIFF
--- a/docs/tutorials/mac_win_client.md
+++ b/docs/tutorials/mac_win_client.md
@@ -55,7 +55,7 @@ host:
 
 In order for the client to communicate with the server you need to enable and start the SSH daemon on your Linux machine, if it is not currently enabled.
 ```
-sudo systemctl enable --now -s sshd
+sudo systemctl enable --now sshd
 ```
 
 #### Setting up SSH


### PR DESCRIPTION
`-s, --signal` requires a value and is probably not intended to be here since it would send a signal to the `sshd` process.
