### PR TITLE
[wip] allow static ip and mac with rootless cni network

### DIFF
--- a/contrib/rootless-cni-infra/Containerfile
+++ b/contrib/rootless-cni-infra/Containerfile
@@ -33,4 +33,4 @@ COPY rootless-cni-infra /usr/local/bin
 ENV CNI_PATH=/opt/cni/bin
 CMD ["sleep", "infinity"]
 
-ENV ROOTLESS_CNI_INFRA_VERSION=3
+ENV ROOTLESS_CNI_INFRA_VERSION=4

--- a/contrib/rootless-cni-infra/rootless-cni-infra
+++ b/contrib/rootless-cni-infra/rootless-cni-infra
@@ -21,16 +21,18 @@ wait_unshare_net() {
 	done
 }
 
-# CLI subcommand: "alloc $CONTAINER_ID $NETWORK_NAME $POD_NAME"
+# CLI subcommand: "alloc $CONTAINER_ID $NETWORK_NAME $POD_NAME $IP $MAC"
 cmd_entrypoint_alloc() {
-	if [ "$#" -ne 3 ]; then
-		echo >&2 "Usage: $ARG0 alloc CONTAINER_ID NETWORK_NAME POD_NAME"
+	if [ "$#" -ne 5 ]; then
+		echo >&2 "Usage: $ARG0 alloc CONTAINER_ID NETWORK_NAME POD_NAME IP MAC"
 		exit 1
 	fi
 
 	ID="$1"
 	NET="$2"
 	K8S_POD_NAME="$3"
+	IP="$4"
+	MAC="$5"
 
 	dir="${BASE}/${ID}"
 	mkdir -p "${dir}/attached" "${dir}/attached-args"
@@ -46,6 +48,12 @@ cmd_entrypoint_alloc() {
 		nsenter -t "${pid}" -n ip link set lo up
 	fi
 	CNI_ARGS="IgnoreUnknown=1;K8S_POD_NAME=${K8S_POD_NAME}"
+	if [ "$IP" ]; then
+		CNI_ARGS="$CNI_ARGS;IP=${IP}"
+	fi
+	if [ "$MAC" ]; then
+		CNI_ARGS="$CNI_ARGS;MAC=${MAC}"
+	fi
 	nwcount=$(find "${dir}/attached" -type f | wc -l)
 	CNI_IFNAME="eth${nwcount}"
 	export CNI_ARGS CNI_IFNAME

--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -30,7 +30,7 @@ func exclusiveOptions(opt1, opt2 string) error {
 // input for creating a container.
 func (s *SpecGenerator) Validate() error {
 
-	if rootless.IsRootless() {
+	if rootless.IsRootless() && len(s.CNINetworks) == 0 {
 		if s.StaticIP != nil || s.StaticIPv6 != nil {
 			return ErrNoStaticIPRootless
 		}

--- a/pkg/specgen/pod_validate.go
+++ b/pkg/specgen/pod_validate.go
@@ -20,7 +20,7 @@ func exclusivePodOptions(opt1, opt2 string) error {
 // Validate verifies the input is valid
 func (p *PodSpecGenerator) Validate() error {
 
-	if rootless.IsRootless() {
+	if rootless.IsRootless() && len(p.CNINetworks) == 0 {
 		if p.StaticIP != nil {
 			return ErrNoStaticIPRootless
 		}

--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -49,7 +49,6 @@ var _ = Describe("Podman create with --ip flag", func() {
 	})
 
 	It("Podman create --ip with non-allocatable IP", func() {
-		SkipIfRootless("--ip is not supported in rootless mode")
 		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", "203.0.113.124", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
@@ -63,7 +62,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 		ip := GetRandomIPAddress()
 		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
-		// Rootless static ip assignment should error
+		// Rootless static ip assignment without network should error
 		if rootless.IsRootless() {
 			Expect(result.ExitCode()).To(Equal(125))
 		} else {
@@ -81,7 +80,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 	})
 
 	It("Podman create two containers with the same IP", func() {
-		SkipIfRootless("--ip not supported in rootless mode")
+		SkipIfRootless("--ip not supported without network in rootless mode")
 		ip := GetRandomIPAddress()
 		result := podmanTest.Podman([]string{"create", "--name", "test1", "--ip", ip, ALPINE, "sleep", "999"})
 		result.WaitWithDefaultTimeout()

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -552,7 +552,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("create container in pod with IP should fail", func() {
-		SkipIfRootless("Setting IP not supported in rootless mode")
+		SkipIfRootless("Setting IP not supported in rootless mode without network")
 		name := "createwithstaticip"
 		pod := podmanTest.RunTopContainerInPod("", "new:"+name)
 		pod.WaitWithDefaultTimeout()
@@ -564,7 +564,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("create container in pod with mac should fail", func() {
-		SkipIfRootless("Setting MAC Address not supported in rootless mode")
+		SkipIfRootless("Setting MAC Address not supported in rootless mode without network")
 		name := "createwithstaticmac"
 		pod := podmanTest.RunTopContainerInPod("", "new:"+name)
 		pod.WaitWithDefaultTimeout()

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Podman pod create", func() {
 		ip := GetRandomIPAddress()
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--ip", ip, "--name", name})
 		podCreate.WaitWithDefaultTimeout()
-		// Rootless should error
+		// Rootless should error without network
 		if rootless.IsRootless() {
 			Expect(podCreate.ExitCode()).To(Equal(125))
 		} else {
@@ -247,7 +247,7 @@ var _ = Describe("Podman pod create", func() {
 	})
 
 	It("podman container in pod with IP address shares IP address", func() {
-		SkipIfRootless("Rootless does not support --ip")
+		SkipIfRootless("Rootless does not support --ip without network")
 		podName := "test"
 		ctrName := "testCtr"
 		ip := GetRandomIPAddress()

--- a/test/e2e/pod_inspect_test.go
+++ b/test/e2e/pod_inspect_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Podman pod inspect", func() {
 	})
 
 	It("podman pod inspect outputs show correct MAC", func() {
-		SkipIfRootless("--mac-address is not supported in rootless mode")
+		SkipIfRootless("--mac-address is not supported in rootless mode without network")
 		podName := "testPod"
 		macAddr := "42:43:44:00:00:01"
 		create := podmanTest.Podman([]string{"pod", "create", "--name", podName, "--mac-address", macAddr})

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -539,7 +539,6 @@ var _ = Describe("Podman run networking", func() {
 	})
 
 	It("podman run in custom CNI network with --static-ip", func() {
-		SkipIfRootless("Rootless mode does not support --ip")
 		netName := "podmantestnetwork"
 		ipAddr := "10.25.30.128"
 		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.30.0/24", netName})
@@ -551,14 +550,9 @@ var _ = Describe("Podman run networking", func() {
 		run.WaitWithDefaultTimeout()
 		Expect(run.ExitCode()).To(BeZero())
 		Expect(run.OutputToString()).To(ContainSubstring(ipAddr))
-
-		create = podmanTest.Podman([]string{"network", "rm", netName})
-		create.WaitWithDefaultTimeout()
-		Expect(create.ExitCode()).To(BeZero())
 	})
 
 	It("podman run with new:pod and static-ip", func() {
-		SkipIfRootless("Rootless does not support --ip")
 		netName := "podmantestnetwork2"
 		ipAddr := "10.25.40.128"
 		podname := "testpod"

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 	)
 
 	BeforeEach(func() {
-		SkipIfRootless("rootless does not support --ip")
+		SkipIfRootless("rootless does not support --ip without network")
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
Make sure we pass the ip and mac address as CNI_ARGS to
the cnitool which is executed in the rootless-cni-infra container.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
