### PR TITLE
Drop default log-level from error to warn

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -22,7 +22,7 @@ var (
 	// ChangeCmds is the list of valid Change commands to passed to the Commit call
 	ChangeCmds = []string{"CMD", "ENTRYPOINT", "ENV", "EXPOSE", "LABEL", "ONBUILD", "STOPSIGNAL", "USER", "VOLUME", "WORKDIR"}
 	// LogLevels supported by podman
-	LogLevels = []string{"debug", "info", "warn", "error", "fatal", "panic"}
+	LogLevels = []string{"debug", "info", "warn", "warning", "error", "fatal", "panic"}
 )
 
 type completeType int

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -71,7 +71,7 @@ var (
 		DisableFlagsInUseLine: true,
 	}
 
-	logLevel       = "error"
+	logLevel       = "warn"
 	useSyslog      bool
 	requireCleanup = true
 )

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/containers/psgo v1.5.1
 	github.com/containers/storage v1.24.1
 	github.com/coreos/go-systemd/v22 v22.1.0
-	github.com/cri-o/ocicni v0.2.1-0.20201102180012-75c612fda1a2
+	github.com/cri-o/ocicni v0.2.1-0.20201125151022-df072ea5421c
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.7.1+incompatible
@@ -73,5 +73,3 @@ require (
 	k8s.io/apimachinery v0.19.4
 	k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
 )
-
-replace github.com/cri-o/ocicni => github.com/cri-o/ocicni v0.2.1-0.20201109200316-afdc16ba66df

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cri-o/ocicni v0.2.1-0.20201109200316-afdc16ba66df h1:c35uRFkER07nAkB1X21e+PI5xO21SOyI6G7tdfvz1z4=
-github.com/cri-o/ocicni v0.2.1-0.20201109200316-afdc16ba66df/go.mod h1:vingr1ztOAzP2WyTgGbpMov9dFhbjNxdLtDv0+PhAvY=
+github.com/cri-o/ocicni v0.2.1-0.20201125151022-df072ea5421c h1:iGaCU6d3oVT0pl8tmvyDhoA/vTDL3IX08akfsKZIy9o=
+github.com/cri-o/ocicni v0.2.1-0.20201125151022-df072ea5421c/go.mod h1:vingr1ztOAzP2WyTgGbpMov9dFhbjNxdLtDv0+PhAvY=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -488,7 +488,7 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 					// Weight? For now, ignore anything
 					// without Weight set.
 					if dev.Weight == nil {
-						logrus.Warnf("Ignoring weight device %s as it lacks a weight", key)
+						logrus.Infof("Ignoring weight device %s as it lacks a weight", key)
 						continue
 					}
 					if deviceNodes == nil {
@@ -500,7 +500,7 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 					}
 					path, ok := deviceNodes[key]
 					if !ok {
-						logrus.Warnf("Could not locate weight device %s in system devices", key)
+						logrus.Infof("Could not locate weight device %s in system devices", key)
 						continue
 					}
 					weightDev := define.InspectBlkioWeightDevice{}
@@ -522,7 +522,7 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 						}
 						path, ok := deviceNodes[key]
 						if !ok {
-							logrus.Warnf("Could not locate throttle device %s in system devices", key)
+							logrus.Infof("Could not locate throttle device %s in system devices", key)
 							continue
 						}
 						throttleDev := define.InspectBlkioThrottleDevice{}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -525,7 +525,7 @@ func (c *Container) teardownStorage() error {
 		// Potentially another tool using containers/storage already
 		// removed it?
 		if errors.Cause(err) == storage.ErrNotAContainer || errors.Cause(err) == storage.ErrContainerUnknown {
-			logrus.Warnf("Storage for container %s already removed", c.ID())
+			logrus.Infof("Storage for container %s already removed", c.ID())
 			return nil
 		}
 

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -352,7 +352,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 		if !MountExists(g.Mounts(), dstPath) {
 			g.AddMount(newMount)
 		} else {
-			logrus.Warnf("User mount overriding libpod mount at %q", dstPath)
+			logrus.Infof("User mount overriding libpod mount at %q", dstPath)
 		}
 	}
 

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -117,7 +117,6 @@ func (r *Runtime) hostInfo() (*define.HostInfo, error) {
 
 	if rootless.IsRootless() {
 		if path, err := exec.LookPath("slirp4netns"); err == nil {
-			logrus.Warnf("Failed to retrieve program version for %s: %v", path, err)
 			version, err := programVersion(path)
 			if err != nil {
 				logrus.Warnf("Failed to retrieve program version for %s: %v", path, err)

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -231,7 +231,7 @@ func (r *ConmonOCIRuntime) ExecStopContainer(ctr *Container, sessionID string, t
 
 		// Wait for the PID to stop
 		if err := waitPidStop(pid, time.Duration(timeout)*time.Second); err != nil {
-			logrus.Warnf("Timed out waiting for container %s exec session %s to stop, resorting to SIGKILL", ctr.ID(), sessionID)
+			logrus.Infof("Timed out waiting for container %s exec session %s to stop, resorting to SIGKILL: %v", ctr.ID(), sessionID, err)
 		} else {
 			// No error, container is dead
 			return nil

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -442,7 +442,7 @@ func (r *ConmonOCIRuntime) StopContainer(ctr *Container, timeout uint, all bool)
 		}
 
 		if err := waitContainerStop(ctr, time.Duration(timeout)*time.Second); err != nil {
-			logrus.Warnf("Timed out stopping container %s, resorting to SIGKILL", ctr.ID())
+			logrus.Infof("Timed out stopping container %s, resorting to SIGKILL: %v", ctr.ID(), err)
 		} else {
 			// No error, the container is dead
 			return nil
@@ -1009,7 +1009,7 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 
 	if ctr.config.SdNotifyMode == define.SdNotifyModeIgnore {
 		if err := os.Unsetenv("NOTIFY_SOCKET"); err != nil {
-			logrus.Warnf("Error unsetting NOTIFY_SOCKET %s", err.Error())
+			logrus.Warnf("Error unsetting NOTIFY_SOCKET %v", err)
 		}
 	}
 
@@ -1155,14 +1155,14 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 
 	conmonPID, err := readConmonPidFile(ctr.config.ConmonPidFile)
 	if err != nil {
-		logrus.Warnf("error reading conmon pid file for container %s: %s", ctr.ID(), err.Error())
+		logrus.Warnf("error reading conmon pid file for container %s: %v", ctr.ID(), err)
 	} else if conmonPID > 0 {
 		// conmon not having a pid file is a valid state, so don't set it if we don't have it
 		logrus.Infof("Got Conmon PID as %d", conmonPID)
 		ctr.state.ConmonPID = conmonPID
 		if ctr.config.SdNotifyMode != define.SdNotifyModeIgnore {
 			if sent, err := daemon.SdNotify(false, fmt.Sprintf("MAINPID=%d", conmonPID)); err != nil {
-				logrus.Errorf("Error notifying systemd of Conmon PID: %s", err.Error())
+				logrus.Errorf("Error notifying systemd of Conmon PID: %v", err)
 			} else if sent {
 				logrus.Debugf("Notify MAINPID sent successfully")
 			}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -387,8 +387,8 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 			// Don't fatally error.
 			// This will allow us to ship configs including optional
 			// runtimes that might not be installed (crun, kata).
-			// Only a warnf so default configs don't spec errors.
-			logrus.Warnf("Error initializing configured OCI runtime %s: %v", name, err)
+			// Only a infof so default configs don't spec errors.
+			logrus.Infof("Error initializing configured OCI runtime %s: %v", name, err)
 			continue
 		}
 

--- a/libpod/runtime_cstorage.go
+++ b/libpod/runtime_cstorage.go
@@ -103,7 +103,7 @@ func (r *Runtime) removeStorageContainer(idOrName string, force bool) error {
 			if errors.Cause(err) == storage.ErrContainerUnknown {
 				// Container was removed from under us.
 				// It's gone, so don't bother erroring.
-				logrus.Warnf("Storage for container %s already removed", ctr.ID)
+				logrus.Infof("Storage for container %s already removed", ctr.ID)
 				return nil
 			}
 			return errors.Wrapf(err, "error looking up container %q mounts", idOrName)
@@ -114,7 +114,7 @@ func (r *Runtime) removeStorageContainer(idOrName string, force bool) error {
 	} else if _, err := r.store.Unmount(ctr.ID, true); err != nil {
 		if errors.Cause(err) == storage.ErrContainerUnknown {
 			// Container again gone, no error
-			logrus.Warnf("Storage for container %s already removed", ctr.ID)
+			logrus.Infof("Storage for container %s already removed", ctr.ID)
 			return nil
 		}
 		return errors.Wrapf(err, "error unmounting container %q", idOrName)
@@ -123,7 +123,7 @@ func (r *Runtime) removeStorageContainer(idOrName string, force bool) error {
 	if err := r.store.DeleteContainer(ctr.ID); err != nil {
 		if errors.Cause(err) == storage.ErrContainerUnknown {
 			// Container again gone, no error
-			logrus.Warnf("Storage for container %s already removed", ctr.ID)
+			logrus.Infof("Storage for container %s already removed", ctr.ID)
 			return nil
 		}
 		return errors.Wrapf(err, "error removing storage for container %q", idOrName)

--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -117,7 +117,7 @@ func (r *Runtime) NewPod(ctx context.Context, options ...PodCreateOption) (_ *Po
 		return nil, errors.Errorf("Pods must have an infra container to share namespaces")
 	}
 	if pod.HasInfraContainer() && !pod.SharesNamespaces() {
-		logrus.Warnf("Pod has an infra container, but shares no namespaces")
+		logrus.Infof("Pod has an infra container, but shares no namespaces")
 	}
 
 	if err := r.state.AddPod(pod); err != nil {
@@ -212,7 +212,7 @@ func (r *Runtime) removePod(ctx context.Context, p *Pod, removeCtrs, force bool)
 		// Don't try if we failed to retrieve the cgroup
 		if err == nil {
 			if err := conmonCgroup.Update(resLimits); err != nil {
-				logrus.Warnf("Error updating pod %s conmon cgroup %s PID limit: %v", p.ID(), conmonCgroupPath, err)
+				logrus.Warnf("Error updating pod %s conmon cgroup PID limit: %v", p.ID(), err)
 			}
 		}
 	}

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -263,7 +263,7 @@ loop:
 			failed = true
 			m.Error = string(e)
 			if err := enc.Encode(m); err != nil {
-				logrus.Warnf("Failed to json encode error %q", err.Error())
+				logrus.Warnf("Failed to json encode error %v", err)
 			}
 			flush()
 		case <-runCtx.Done():
@@ -271,7 +271,7 @@ loop:
 				if !utils.IsLibpodRequest(r) {
 					m.Stream = fmt.Sprintf("Successfully built %12.12s\n", imageID)
 					if err := enc.Encode(m); err != nil {
-						logrus.Warnf("Failed to json encode error %q", err.Error())
+						logrus.Warnf("Failed to json encode error %v", err)
 					}
 					flush()
 				}

--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -332,7 +332,7 @@ func attachHandleResize(ctx, winCtx context.Context, winChange chan os.Signal, i
 		case <-winChange:
 			h, w, err := terminal.GetSize(int(file.Fd()))
 			if err != nil {
-				logrus.Warnf("failed to obtain TTY size: " + err.Error())
+				logrus.Warnf("failed to obtain TTY size: %v", err)
 			}
 
 			var resizeErr error
@@ -342,7 +342,7 @@ func attachHandleResize(ctx, winCtx context.Context, winChange chan os.Signal, i
 				resizeErr = ResizeContainerTTY(ctx, id, &h, &w)
 			}
 			if resizeErr != nil {
-				logrus.Warnf("failed to resize TTY: " + resizeErr.Error())
+				logrus.Warnf("failed to resize TTY: %v", err)
 			}
 		}
 	}

--- a/pkg/systemd/generate/pods.go
+++ b/pkg/systemd/generate/pods.go
@@ -224,7 +224,7 @@ func executePodTemplate(info *podInfo, options entities.GenerateSystemdOptions) 
 		executable, err := os.Executable()
 		if err != nil {
 			executable = "/usr/bin/podman"
-			logrus.Warnf("Could not obtain podman executable location, using default %s", executable)
+			logrus.Warnf("Could not obtain podman executable location, using default %s: %v", executable, err)
 		}
 		info.Executable = executable
 	}

--- a/vendor/github.com/cri-o/ocicni/pkg/ocicni/ocicni.go
+++ b/vendor/github.com/cri-o/ocicni/pkg/ocicni/ocicni.go
@@ -149,7 +149,7 @@ func (plugin *cniNetworkPlugin) monitorConfDir(start *sync.WaitGroup) {
 	for {
 		select {
 		case event := <-plugin.watcher.Events:
-			logrus.Warningf("CNI monitoring event %v", event)
+			logrus.Infof("CNI monitoring event %v", event)
 
 			var defaultDeleted bool
 			createWrite := (event.Op&fsnotify.Create == fsnotify.Create ||
@@ -295,7 +295,7 @@ func loadNetworks(confDir string, cni *libcni.CNIConfig) (map[string]*cniNetwork
 			}
 		}
 		if len(confList.Plugins) == 0 {
-			logrus.Warningf("CNI config list %s has no networks, skipping", confFile)
+			logrus.Infof("CNI config list %s has no networks, skipping", confFile)
 			continue
 		}
 
@@ -350,7 +350,7 @@ func (plugin *cniNetworkPlugin) syncNetworkConfig() error {
 		plugin.defaultNetName.name = defaultNetName
 		logrus.Infof("Update default CNI network name to %s", defaultNetName)
 	} else {
-		logrus.Warnf("Default CNI network name %s is unchangeable", plugin.defaultNetName.name)
+		logrus.Debugf("Default CNI network name %s is unchangeable", plugin.defaultNetName.name)
 	}
 
 	plugin.networks = networks

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -220,7 +220,7 @@ github.com/coreos/go-systemd/v22/dbus
 github.com/coreos/go-systemd/v22/internal/dlopen
 github.com/coreos/go-systemd/v22/journal
 github.com/coreos/go-systemd/v22/sdjournal
-# github.com/cri-o/ocicni v0.2.1-0.20201102180012-75c612fda1a2 => github.com/cri-o/ocicni v0.2.1-0.20201109200316-afdc16ba66df
+# github.com/cri-o/ocicni v0.2.1-0.20201125151022-df072ea5421c
 github.com/cri-o/ocicni/pkg/ocicni
 # github.com/cyphar/filepath-securejoin v0.2.2
 github.com/cyphar/filepath-securejoin


### PR DESCRIPTION
Our users are missing certain warning messages that would
make debugging issues with Podman easier.

For example if you do a podman build with a Containerfile
that contains the SHELL directive, the Derective is silently
ignored.

If you run with the log-level warn you get a warning message explainging
what happened.

$ podman build --no-cache -f /tmp/Containerfile1 /tmp/
STEP 1: FROM ubi8
STEP 2: SHELL ["/bin/bash", "-c"]
STEP 3: COMMIT
--> 7a207be102a
7a207be102aa8993eceb32802e6ceb9d2603ceed9dee0fee341df63e6300882e

$ podman --log-level=warn build --no-cache -f /tmp/Containerfile1 /tmp/
STEP 1: FROM ubi8
STEP 2: SHELL ["/bin/bash", "-c"]
STEP 3: COMMIT
WARN[0000] SHELL is not supported for OCI image format, [/bin/bash -c] will be ignored. Must use `docker` format
--> 7bd96fd25b9
7bd96fd25b9f755d8a045e31187e406cf889dcf3799357ec906e90767613e95f

These messages will no longer be lost, when we default to WARNing level.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
