### PR TITLE
Do not validate the volume source path in specgen

### DIFF
--- a/cmd/podman/common/volumes.go
+++ b/cmd/podman/common/volumes.go
@@ -323,8 +323,8 @@ func getBindMount(args []string) (spec.Mount, error) {
 			if len(kv) == 1 {
 				return newMount, errors.Wrapf(optionArgError, kv[0])
 			}
-			if err := parse.ValidateVolumeHostDir(kv[1]); err != nil {
-				return newMount, err
+			if len(kv[1]) == 0 {
+				return newMount, errors.Wrapf(optionArgError, "host directory cannot be empty")
 			}
 			newMount.Source = kv[1]
 			setSource = true

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -84,11 +84,10 @@ func GenVolumeMounts(volumeFlag []string) (map[string]spec.Mount, map[string]*Na
 				return nil, nil, nil, err
 			}
 		}
-
 		// Do not check source dir for anonymous volumes
 		if len(splitVol) > 1 {
-			if err := parse.ValidateVolumeHostDir(src); err != nil {
-				return nil, nil, nil, err
+			if len(src) == 0 {
+				return nil, nil, nil, errors.New("host directory cannot be empty")
 			}
 		}
 		if err := parse.ValidateVolumeCtrDir(dest); err != nil {


### PR DESCRIPTION
The volume src path should not be validated in specgen since
the remote client also uses that part and the path must only
exists on the server. This now fails later and only on the
server and not the client.

I don't think I can add a test for this because the CI runs
server and client always on the same vm.

Fixes #8473

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
