### PR TITLE
REST API v2 - ping - remove newline from response to improve Docker compatibility

### DIFF
--- a/pkg/api/handlers/compat/ping.go
+++ b/pkg/api/handlers/compat/ping.go
@@ -25,5 +25,4 @@ func Ping(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodGet {
 		fmt.Fprint(w, "OK")
 	}
-	fmt.Fprint(w, "\n")
 }


### PR DESCRIPTION
This fixes an APIv2 Docker compatibility issue exposed by running the [docker-py](https://github.com/docker/docker-py) library's API tests against Podman's API service (see https://github.com/containers/podman/issues/5386#issuecomment-733346103).

The `GET /_ping` endpoint appends a superfluous newline character to the end of the response. i.e. it responds with "OK\n" instead of just "OK".

For comparison:
- [case in Docker tests](https://github.com/moby/moby/blob/e1bba7456d9902d04eec8c402f852d0ae17d123c/integration/system/ping_test.go#L34)
- [code in docker-py](https://github.com/docker/docker-py/blob/432819766014ce396e7507c52246ff5c8a11cdbc/docker/api/daemon.py#L166)