### PR TITLE
REST API v2 - ping - fix typo in header

### DIFF
--- a/pkg/api/handlers/compat/ping.go
+++ b/pkg/api/handlers/compat/ping.go
@@ -19,7 +19,7 @@ func Ping(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Pragma", "no-cache")
 
-	w.Header().Set("Libpod-Buildha-Version", buildah.Version)
+	w.Header().Set("Libpod-Buildah-Version", buildah.Version)
 	w.WriteHeader(http.StatusOK)
 
 	if r.Method == http.MethodGet {

--- a/pkg/api/server/register_ping.go
+++ b/pkg/api/server/register_ping.go
@@ -53,7 +53,7 @@ func (s *APIServer) registerPingHandlers(r *mux.Router) error {
 	//             Max Podman API Version the server supports.
 	//             Available if service is backed by Podman, therefore may be used to
 	//             determine if talking to Podman engine or another engine
-	//         Libpod-Buildha-Version:
+	//         Libpod-Buildah-Version:
 	//           type: string
 	//           description: |
 	//             Default version of libpod image builder.


### PR DESCRIPTION
There seems to be a typo in one of the response headers of the `GET /_ping` endpoint. It sets a header named "Libpod-Build**ha**-Version".