### PR TITLE
Add support for --platform

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -513,6 +513,14 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	)
 	_ = cmd.RegisterFlagCompletionFunc(pidsLimitFlagName, completion.AutocompleteNone)
 
+	platformFlagName := "platform"
+	createFlags.StringVar(
+		&cf.Platform,
+		platformFlagName, "",
+		"Specify the platform for selecting the image.  (Conflicts with override-arch and override-os)",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(platformFlagName, completion.AutocompleteNone)
+
 	podFlagName := "pod"
 	createFlags.StringVar(
 		&cf.Pod,

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -78,6 +78,7 @@ type ContainerCLIOpts struct {
 	OverrideVariant   string
 	PID               string
 	PIDsLimit         *int64
+	Platform          string
 	Pod               string
 	PodIDFile         string
 	PreserveFDs       uint

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/podman/v2/pkg/specgen"
 	"github.com/containers/podman/v2/pkg/util"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -234,6 +235,21 @@ func pullImage(imageName string) (string, error) {
 			return "", err
 		}
 		imageMissing = !br.Value
+	}
+
+	if cliVals.Platform != "" {
+		if cliVals.OverrideArch != "" || cliVals.OverrideOS != "" {
+			return "", errors.Errorf("--platform option can not be specified with --overide-arch or --override-os")
+		}
+		split := strings.SplitN(cliVals.Platform, "/", 2)
+		cliVals.OverrideOS = split[0]
+		if len(split) > 1 {
+			cliVals.OverrideArch = split[1]
+		}
+		if pullPolicy != config.PullImageAlways {
+			logrus.Info("--platform causes the pull policy to be \"always\"")
+			pullPolicy = config.PullImageAlways
+		}
 	}
 
 	if imageMissing || pullPolicy == config.PullImageAlways {

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -647,6 +647,11 @@ Default is to create a private PID namespace for the container
 
 Tune the container's pids limit. Set `0` to have unlimited pids for the container. (default "4096" on systems that support PIDS cgroups).
 
+#### **--platform**=*OS/ARCH*
+
+Specify the platform for selecting the image.   (Conflicts with override-arch and override-os)
+The `--platform` option can be used to override the current architecture and operating system.
+
 #### **--pod**=*name*
 
 Run container in an existing pod. If you want Podman to make the pod for you, preference the pod name with `new:`.

--- a/docs/source/markdown/podman-pull.1.md
+++ b/docs/source/markdown/podman-pull.1.md
@@ -89,6 +89,11 @@ Override the OS, defaults to hosts, of the image to be pulled. For example, `win
 
 Use _VARIANT_ instead of the default architecture variant of the container image.  Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
+#### **--platform**=*OS/ARCH*
+
+Specify the platform for selecting the image.  (Conflicts with override-arch and override-os)
+The `--platform` option can be used to override the current architecture and operating system.
+
 #### **--quiet**, **-q**
 
 Suppress output information when pulling images

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -675,6 +675,11 @@ The efault is to create a private PID namespace for the container.
 
 Tune the container's pids limit. Set to **0** to have unlimited pids for the container. The default is **4096** on systems that support "pids" cgroup controller.
 
+#### **--platform**=*OS/ARCH*
+
+Specify the platform for selecting the image.  (Conflicts with override-arch and override-os)
+The `--platform` option can be used to override the current architecture and operating system.
+
 #### **--pod**=*name*
 
 Run container in an existing pod. If you want Podman to make the pod for you, prefix the pod name with **new:**.


### PR DESCRIPTION
For docker compatibility we need to support --platform
flag.

podman create --platform
podman run --platform
podman pull --platform

Since we have --override-os and --override-arch already
this can be done just by modifying the client to split
the --platform call into os and arch and then pass those
options to the server side.

Fixes: https://github.com/containers/podman/issues/6244

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
