### PR TITLE
Fix problems with network remove

### DIFF
--- a/libpod/network/files.go
+++ b/libpod/network/files.go
@@ -14,6 +14,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrNoSuchNetworkInterface indicates that no network interface exists
+var ErrNoSuchNetworkInterface = errors.New("unable to find interface name for network")
+
 // GetCNIConfDir get CNI configuration directory
 func GetCNIConfDir(configArg *config.Config) string {
 	if len(configArg.Network.NetworkConfigDir) < 1 {
@@ -142,7 +145,7 @@ func GetInterfaceNameFromConfig(path string) (string, error) {
 		}
 	}
 	if len(name) == 0 {
-		return "", errors.New("unable to find interface name for network")
+		return "", ErrNoSuchNetworkInterface
 	}
 	return name, nil
 }

--- a/libpod/network/network.go
+++ b/libpod/network/network.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v2/libpod/define"
+	"github.com/containers/podman/v2/pkg/rootless"
 	"github.com/containers/podman/v2/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -181,21 +182,26 @@ func RemoveNetwork(config *config.Config, name string) error {
 	// Before we delete the configuration file, we need to make sure we can read and parse
 	// it to get the network interface name so we can remove that too
 	interfaceName, err := GetInterfaceNameFromConfig(cniPath)
-	if err != nil {
-		return errors.Wrapf(err, "failed to find network interface name in %q", cniPath)
-	}
-	liveNetworkNames, err := GetLiveNetworkNames()
-	if err != nil {
-		return errors.Wrapf(err, "failed to get live network names")
-	}
-	if util.StringInSlice(interfaceName, liveNetworkNames) {
-		if err := RemoveInterface(interfaceName); err != nil {
-			return errors.Wrapf(err, "failed to delete the network interface %q", interfaceName)
+	if err == nil {
+		// Don't try to remove the network interface if we are not root
+		if !rootless.IsRootless() {
+			liveNetworkNames, err := GetLiveNetworkNames()
+			if err != nil {
+				return errors.Wrapf(err, "failed to get live network names")
+			}
+			if util.StringInSlice(interfaceName, liveNetworkNames) {
+				if err := RemoveInterface(interfaceName); err != nil {
+					return errors.Wrapf(err, "failed to delete the network interface %q", interfaceName)
+				}
+			}
 		}
+	} else if err != ErrNoSuchNetworkInterface {
+		// Don't error if we couldn't find the network interface name
+		return err
 	}
 	// Remove the configuration file
 	if err := os.Remove(cniPath); err != nil {
-		return errors.Wrapf(err, "failed to remove network configuration file %q", cniPath)
+		return errors.Wrap(err, "failed to remove network configuration")
 	}
 	return nil
 }

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -499,4 +499,15 @@ var _ = Describe("Podman network", func() {
 		exec.WaitWithDefaultTimeout()
 		Expect(exec.ExitCode()).To(BeZero())
 	})
+
+	It("podman network create/remove macvlan", func() {
+		net := "macvlan" + stringid.GenerateNonCryptoID()
+		nc := podmanTest.Podman([]string{"network", "create", "--macvlan", "lo", net})
+		nc.WaitWithDefaultTimeout()
+		Expect(nc.ExitCode()).To(Equal(0))
+
+		nc = podmanTest.Podman([]string{"network", "rm", net})
+		nc.WaitWithDefaultTimeout()
+		Expect(nc.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
First, make sure we are only trying to remove the network
interface if we are root.
Second, if we cannot get the interface name (e.g macvlan config)
then we should not fail. Just remove the config file.

Fixes #8491 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
