### PR TITLE
runtime: set XDG_* env variables if missing

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -162,6 +162,10 @@ func newRuntimeFromConfig(ctx context.Context, conf *config.Config, options ...R
 
 	runtime.config = conf
 
+	if err := SetXdgDirs(); err != nil {
+		return nil, err
+	}
+
 	storeOpts, err := storage.DefaultStoreOptions(rootless.IsRootless(), rootless.GetRootlessUID())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
regression introduced when moving to Podman 2.0.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1877228

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
