### PR TITLE
podman network label support

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -40,6 +40,10 @@ Restrict external access of this network
 Allocate container IP from a range.  The range must be a complete subnet and in CIDR notation.  The *ip-range* option
 must be used with a *subnet* option.
 
+#### **--label**
+
+Set metadata for a network (e.g., --label mykey=value).
+
 #### **--macvlan**
 
 Create a *Macvlan* based connection rather than a classic bridge.  You must pass an interface name from the host for the

--- a/docs/source/markdown/podman-network-ls.1.md
+++ b/docs/source/markdown/podman-network-ls.1.md
@@ -14,13 +14,25 @@ Displays a list of existing podman networks. This command is not available for r
 
 The `quiet` option will restrict the output to only the network names.
 
-#### **--format**, **-f**
+#### **--format**
 
 Pretty-print networks to JSON or using a Go template.
 
-#### **--filter**
+#### **--filter**, **-f**
 
-Provide filter values (e.g. 'name=podman').
+Filter output based on conditions given.
+Multiple filters can be given with multiple uses of the --filter flag.
+Filters with the same key work inclusive with the only exception being
+`label` which is exclusive. Filters with different keys always work exclusive.
+
+Valid filters are listed below:
+
+| **Filter** | **Description**                                                                       |
+| ---------- | ------------------------------------------------------------------------------------- |
+| name       | [Name] Network name (accepts regex)                                                   |
+| label      | [Key] or [Key=Value] Label assigned to a network                                      |
+| plugin     | [Plugin] CNI plugins included in a network (e.g `bridge`,`portmap`,`firewall`,`tuning`,`dnsname`,`macvlan`) |
+| driver     | [Driver] Only `bridge` is supported                                                   |
 
 ## EXAMPLE
 

--- a/libpod/network/create.go
+++ b/libpod/network/create.go
@@ -169,7 +169,7 @@ func createBridge(name string, options entities.NetworkCreateOptions, runtimeCon
 	}
 
 	// create CNI plugin configuration
-	ncList := NewNcList(name, version.Current())
+	ncList := NewNcList(name, version.Current(), options.Labels)
 	var plugins []CNIPlugins
 	// TODO need to iron out the role of isDefaultGW and IPMasq
 	bridge := NewHostLocalBridge(bridgeDeviceName, isGateway, false, ipMasq, ipamConfig)
@@ -223,7 +223,7 @@ func createMacVLAN(name string, options entities.NetworkCreateOptions, runtimeCo
 			return "", err
 		}
 	}
-	ncList := NewNcList(name, version.Current())
+	ncList := NewNcList(name, version.Current(), options.Labels)
 	macvlan := NewMacVLANPlugin(options.MacVLAN)
 	plugins = append(plugins, macvlan)
 	ncList["plugins"] = plugins

--- a/pkg/api/handlers/libpod/networks.go
+++ b/pkg/api/handlers/libpod/networks.go
@@ -48,7 +48,7 @@ func ListNetworks(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
-		Filter string `schema:"filter"`
+		Filters map[string][]string `schema:"filters"`
 	}{
 		// override any golang type defaults
 	}
@@ -59,7 +59,7 @@ func ListNetworks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	options := entities.NetworkListOptions{
-		Filter: query.Filter,
+		Filters: query.Filters,
 	}
 	ic := abi.ContainerEngine{Libpod: runtime}
 	reports, err := ic.NetworkList(r.Context(), options)

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -65,7 +65,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: filters
 	//    type: string
-	//    description: JSON encoded value of the filters (a map[string][]string) to process on the networks list. Only the name filter is supported.
+	//    description: |
+	//      JSON encoded value of the filters (a map[string][]string) to process on the network list. Currently available filters:
+	//        - name=[name] Matches network name (accepts regex).
+	//        - driver=[driver] Only bridge is supported.
+	//        - label=[key] or label=[key=value] Matches networks based on the presence of a label alone or a label and a value.
 	// produces:
 	// - application/json
 	// responses:
@@ -216,9 +220,14 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// description: Display summary of network configurations
 	// parameters:
 	//  - in: query
-	//    name: filter
+	//    name: filters
 	//    type: string
-	//    description: Provide filter values (e.g. 'name=podman')
+	//    description: |
+	//      JSON encoded value of the filters (a map[string][]string) to process on the network list. Available filters:
+	//        - name=[name] Matches network name (accepts regex).
+	//        - driver=[driver] Only bridge is supported.
+	//        - label=[key] or label=[key=value] Matches networks based on the presence of a label alone or a label and a value.
+	//        - plugin=[plugin] Matches CNI plugins included in a network (e.g `bridge`,`portmap`,`firewall`,`tuning`,`dnsname`,`macvlan`)
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/bindings/network/network.go
+++ b/pkg/bindings/network/network.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -79,8 +80,12 @@ func List(ctx context.Context, options entities.NetworkListOptions) ([]*entities
 		return nil, err
 	}
 	params := url.Values{}
-	if options.Filter != "" {
-		params.Set("filter", options.Filter)
+	if options.Filters != nil {
+		b, err := json.Marshal(options.Filters)
+		if err != nil {
+			return nil, err
+		}
+		params.Set("filters", string(b))
 	}
 	response, err := conn.DoRequest(nil, http.MethodGet, "/networks/json", params, nil)
 	if err != nil {

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -8,14 +8,15 @@ import (
 
 // NetworkListOptions describes options for listing networks in cli
 type NetworkListOptions struct {
-	Format string
-	Quiet  bool
-	Filter string
+	Format  string
+	Quiet   bool
+	Filters map[string][]string
 }
 
 // NetworkListReport describes the results from listing networks
 type NetworkListReport struct {
 	*libcni.NetworkConfigList
+	Labels map[string]string
 }
 
 // NetworkInspectReport describes the results from inspect networks
@@ -39,6 +40,7 @@ type NetworkCreateOptions struct {
 	Driver     string
 	Gateway    net.IP
 	Internal   bool
+	Labels     map[string]string
 	MacVLAN    string
 	Range      net.IPNet
 	Subnet     net.IPNet

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -9,8 +9,8 @@ t GET networks/non-existing-network 404 \
 t POST libpod/networks/create?name=network1 '' 200 \
 .Filename~.*/network1\\.conflist
 
-# --data '{"Subnet":{"IP":"10.10.254.0","Mask":[255,255,255,0]}}'
-t POST libpod/networks/create?name=network2 '"Subnet":{"IP":"10.10.254.0","Mask":[255,255,255,0]}' 200 \
+# --data '{"Subnet":{"IP":"10.10.254.0","Mask":[255,255,255,0]},"Labels":{"abc":"val"}}'
+t POST libpod/networks/create?name=network2 '"Subnet":{"IP":"10.10.254.0","Mask":[255,255,255,0]},"Labels":{"abc":"val"}' 200 \
 .Filename~.*/network2\\.conflist
 
 # test for empty mask
@@ -22,7 +22,8 @@ t POST libpod/networks/create '"Subnet":{"IP":"10.10.1.0","Mask":[0,255,255,0]}'
 
 # network list
 t GET libpod/networks/json 200
-t GET libpod/networks/json?filter=name=network1 200 \
+# filters={"name":["network1"]}
+t GET libpod/networks/json?filters=%7B%22name%22%3A%5B%22network1%22%5D%7D 200 \
 length=1 \
 .[0].Name=network1
 t GET networks 200
@@ -34,12 +35,12 @@ length=2
 #filters={"name":["network"]}
 t GET networks?filters=%7B%22name%22%3A%5B%22network%22%5D%7D 200 \
 length=2
-# invalid filter filters={"label":"abc"}
-t GET networks?filters=%7B%22label%22%3A%5B%22abc%22%5D%7D 500 \
-.cause="only the name filter for listing networks is implemented"
-# invalid filter filters={"label":"abc","name":["network"]}
-t GET networks?filters=%7B%22label%22%3A%22abc%22%2C%22name%22%3A%5B%22network%22%5D%7D 500 \
-.cause="only the name filter for listing networks is implemented"
+# filters={"label":["abc"]}
+t GET networks?filters=%7B%22label%22%3A%5B%22abc%22%5D%7D 200 \
+length=1
+# invalid filter filters={"id":["abc"]}
+t GET networks?filters=%7B%22id%22%3A%5B%22abc%22%5D%7D 500 \
+.cause='invalid filter "id"'
 
 # clean the network
 t DELETE libpod/networks/network1 200 \


### PR DESCRIPTION
Add label support for podman network create. Use the `args`
field in the cni config file to store the podman labels.
Use `podman_labels` as key name and store the labels as
map[string]string.

For reference: https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#args-in-network-config
https://github.com/containernetworking/cni/blob/spec-v0.4.0/SPEC.md#network-configuration

Example snippet:

```
...
"args": {
	"podman_labels": {
		"key1":"value1",
		"key2":"value2"
	}
}
...
```

Make podman network list support several filters. Supported filters are name,
plugin, driver and label. Filters with different keys work exclusive. Several label
filters work exclusive and the other filter keys are working inclusive.

Also adjust the compat api to support labels in network create and list.

Breaking changes:

- podman network ls -f shortform is used for --filter instead --format
This matches docker and other podman commands (container ps, volume ps)

- libpod network list endpoint filter parameter is removed. Instead the
filters paramter should be used as json encoded map[string][]string.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
