### PR TITLE
Revert "Allow multiple --network flags for podman run/create"

### DIFF
--- a/cmd/podman/common/netflags.go
+++ b/cmd/podman/common/netflags.go
@@ -59,8 +59,8 @@ func DefineNetFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(macAddressFlagName, completion.AutocompleteNone)
 
 	networkFlagName := "network"
-	netFlags.StringArray(
-		networkFlagName, []string{containerConfig.NetNS()},
+	netFlags.String(
+		networkFlagName, containerConfig.NetNS(),
 		"Connect a container to a network",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(networkFlagName, AutocompleteNetworks)
@@ -194,29 +194,25 @@ func NetFlagsToNetOptions(cmd *cobra.Command) (*entities.NetOptions, error) {
 	}
 
 	if cmd.Flags().Changed("network") {
-		networks, err := cmd.Flags().GetStringArray("network")
+		network, err := cmd.Flags().GetString("network")
 		if err != nil {
 			return nil, err
 		}
-		for i, network := range networks {
-			parts := strings.SplitN(network, ":", 2)
 
-			ns, cniNets, err := specgen.ParseNetworkNamespace(network)
-			if err != nil {
-				return nil, err
-			}
-			if i > 0 && (len(cniNets) == 0 || len(opts.CNINetworks) == 0) {
-				return nil, errors.Errorf("network conflict between type %s and %s", opts.Network.NSMode, ns.NSMode)
-			}
+		parts := strings.SplitN(network, ":", 2)
 
-			if len(parts) > 1 {
-				opts.NetworkOptions = make(map[string][]string)
-				opts.NetworkOptions[parts[0]] = strings.Split(parts[1], ",")
-				cniNets = nil
-			}
-			opts.Network = ns
-			opts.CNINetworks = append(opts.CNINetworks, cniNets...)
+		ns, cniNets, err := specgen.ParseNetworkNamespace(network)
+		if err != nil {
+			return nil, err
 		}
+
+		if len(parts) > 1 {
+			opts.NetworkOptions = make(map[string][]string)
+			opts.NetworkOptions[parts[0]] = strings.Split(parts[1], ",")
+			cniNets = nil
+		}
+		opts.Network = ns
+		opts.CNINetworks = cniNets
 	}
 
 	aliases, err := cmd.Flags().GetStringSlice("network-alias")

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -588,7 +588,7 @@ Valid _mode_ values are:
 - **none**: no networking;
 - **container:**_id_: reuse another container's network stack;
 - **host**: use the Podman host network stack. Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure;
-- **cni-network**: connect to a user-defined network, multiple networks should be comma-separated or they can be specified with multiple uses of the **--network** option;
+- _network-id_: connect to a user-defined network, multiple networks should be comma separated;
 - **ns:**_path_: path to a network namespace to join;
 - **private**: create a new namespace for the container (default)
 - **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack.  This is the default for rootless containers.  It is possible to specify these additional options:

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -614,7 +614,7 @@ Valid _mode_ values are:
 - **none**: no networking;
 - **container:**_id_: reuse another container's network stack;
 - **host**: use the Podman host network stack. Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure;
-- **cni-network**: connect to a user-defined network, multiple networks should be comma-separated or they can be specified with multiple uses of the **--network** option;
+- _network-id_: connect to a user-defined network, multiple networks should be comma separated;
 - **ns:**_path_: path to a network namespace to join;
 - **private**: create a new namespace for the container (default)
 - **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack.  This is the default for rootless containers.  It is possible to specify these additional options:

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -272,10 +272,16 @@ func ParseNetworkNamespace(ns string) (Namespace, []string, error) {
 		toReturn.NSMode = Private
 	case strings.HasPrefix(ns, "ns:"):
 		split := strings.SplitN(ns, ":", 2)
+		if len(split) != 2 {
+			return toReturn, nil, errors.Errorf("must provide a path to a namespace when specifying ns:")
+		}
 		toReturn.NSMode = Path
 		toReturn.Value = split[1]
 	case strings.HasPrefix(ns, "container:"):
 		split := strings.SplitN(ns, ":", 2)
+		if len(split) != 2 {
+			return toReturn, nil, errors.Errorf("must provide name or ID or a container when specifying container:")
+		}
 		toReturn.NSMode = FromContainer
 		toReturn.Value = split[1]
 	default:

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/containers/podman/v2/pkg/rootless"
 	. "github.com/containers/podman/v2/test/utils"
-	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -476,24 +475,5 @@ entrypoint ["/fromimage"]
 		status3.WaitWithDefaultTimeout()
 		Expect(status3.ExitCode()).To(Equal(0))
 		Expect(strings.Contains(status3.OutputToString(), "Degraded")).To(BeTrue())
-	})
-
-	It("podman create pod invalid network config", func() {
-		net1 := "n1" + stringid.GenerateNonCryptoID()
-		session := podmanTest.Podman([]string{"network", "create", net1})
-		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net1)
-		Expect(session.ExitCode()).To(BeZero())
-
-		session = podmanTest.Podman([]string{"pod", "create", "--network", "host", "--network", net1})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(125))
-		Expect(session.ErrorToString()).To(ContainSubstring("host"))
-		Expect(session.ErrorToString()).To(ContainSubstring("bridge"))
-
-		session = podmanTest.Podman([]string{"pod", "create", "--network", "container:abc"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(125))
-		Expect(session.ErrorToString()).To(ContainSubstring("pods presently do not support network mode container"))
 	})
 })

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -665,33 +665,4 @@ var _ = Describe("Podman run networking", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(BeZero())
 	})
-
-	It("podman run with multiple networks", func() {
-		net1 := "n1" + stringid.GenerateNonCryptoID()
-		session := podmanTest.Podman([]string{"network", "create", net1})
-		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net1)
-		Expect(session.ExitCode()).To(BeZero())
-
-		net2 := "n2" + stringid.GenerateNonCryptoID()
-		session = podmanTest.Podman([]string{"network", "create", net2})
-		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net2)
-		Expect(session.ExitCode()).To(BeZero())
-
-		run := podmanTest.Podman([]string{"run", "--network", net1, "--network", net2, ALPINE, "ip", "-o", "-4", "addr"})
-		run.WaitWithDefaultTimeout()
-		Expect(run.ExitCode()).To(BeZero())
-		Expect(len(run.OutputToStringArray())).To(Equal(3))
-		Expect(run.OutputToString()).To(ContainSubstring("lo"))
-		Expect(run.OutputToString()).To(ContainSubstring("eth0"))
-		Expect(run.OutputToString()).To(ContainSubstring("eth1"))
-
-		//invalid config network host and cni should fail
-		run = podmanTest.Podman([]string{"run", "--network", "host", "--network", net2, ALPINE, "ip", "-o", "-4", "addr"})
-		run.WaitWithDefaultTimeout()
-		Expect(run.ExitCode()).To(Equal(125))
-		Expect(run.ErrorToString()).To(ContainSubstring("host"))
-		Expect(run.ErrorToString()).To(ContainSubstring("bridge"))
-	})
 })


### PR DESCRIPTION
Reverts containers/podman#8410

As described in issue #8507 this commit contains a breaking change which is not wanted in v2.2.

We can discuss later if we want this in 3.0 or not.