### PR TITLE
[CI:DOCS] Fix option names --subuidname and --subgidname

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -946,7 +946,7 @@ Set the user namespace mode for the container.  It defaults to the **PODMAN_USER
 - `ns`: run the container in the given existing user namespace.
 - `private`: create a new namespace for the container (default)
 
-This option is incompatible with --gidmap, --uidmap, --subuid and --subgid
+This option is incompatible with **--gidmap**, **--uidmap**, **--subuidname** and **--subgidname**.
 
 #### **--uts**=*mode*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -999,7 +999,7 @@ Set the user namespace mode for the container.  It defaults to the **PODMAN_USER
 - **private**: create a new namespace for the container.
 - **container**: join the user namespace of the specified container.
 
-This option is incompatible with **--gidmap**, **--uidmap**, **--subuid** and **--subgid**.
+This option is incompatible with **--gidmap**, **--uidmap**, **--subuidname** and **--subgidname**.
 
 #### **--uts**=*mode*
 


### PR DESCRIPTION
Options --subuid and --subgid does not exists

Fixes: https://github.com/containers/podman/issues/8510

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
