### PR TITLE
Bump master to v3.0.0-dev

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -42,7 +42,7 @@ Epoch: 99
 %else
 Epoch: 0
 %endif
-Version: 2.2.0
+Version: 3.0.0
 Release: #COMMITDATE#.git%{shortcommit0}%{?dist}
 Summary: Manage Pods, Containers and Container Images
 License: ASL 2.0

--- a/version/version.go
+++ b/version/version.go
@@ -8,9 +8,9 @@ import (
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-var Version = semver.MustParse("2.2.0-dev")
+var Version = semver.MustParse("3.0.0-dev")
 
 // APIVersion is the version for the remote
 // client API.  It is used to determine compatibility
 // between a remote podman client and its backend
-var APIVersion = semver.MustParse("2.1.0")
+var APIVersion = semver.MustParse("3.0.0")


### PR DESCRIPTION
Now that we have a v2.2.0 branch, it's time to bump master to v3.0 for our big breaking changes (API fixes, varlink removal)