### PR TITLE
Update nix pin with `make nixpkgs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ bin/podman.cross.%: .gopathok
 # Update nix/nixpkgs.json its latest stable commit
 .PHONY: nixpkgs
 nixpkgs:
-	@nix run -f channel:nixos-20.03 nix-prefetch-git -c nix-prefetch-git \
+	@nix run -f channel:nixos-20.09 nix-prefetch-git -c nix-prefetch-git \
 		--no-deepClone https://github.com/nixos/nixpkgs > nix/nixpkgs.json
 
 # Build statically linked binary

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -38,10 +38,10 @@ let
     doCheck = false;
     enableParallelBuilding = true;
     outputs = [ "out" ];
-    nativeBuildInputs = [ bash git go-md2man installShellFiles makeWrapper pkg-config which ];
+    nativeBuildInputs = [ bash gitMinimal go-md2man installShellFiles makeWrapper pkg-config which ];
     buildInputs = [ glibc glibc.static gpgme libassuan libgpgerror libseccomp libapparmor libselinux ];
     prePatch = ''
-      export CFLAGS='-static'
+      export CFLAGS='-static -pthread'
       export LDFLAGS='-s -w -static-libgcc -static'
       export EXTRA_LDFLAGS='-s -w -linkmode external -extldflags "-static -lm"'
       export BUILDTAGS='static netgo osusergo exclude_graphdriver_btrfs exclude_graphdriver_devicemapper seccomp apparmor selinux'

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,10 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "6e089d30148953df7abb3a1167169afc7848499c",
-  "date": "2020-11-05T09:56:30+01:00",
-  "sha256": "0ydqjkz7payl16psx445jwh6dc6lgbvj2w11xin1dqvbpcp03jcy",
-  "fetchSubmodules": false
+  "rev": "6ea2fd15d881006b41ea5bbed0f76bffcd85f9f9",
+  "date": "2020-12-20T13:26:58+10:00",
+  "path": "/nix/store/kyw1ackbp9qh1jzlzwmjvi5i3541ym5z-nixpkgs",
+  "sha256": "0kgqmw4ki10b37530jh912sn49x3gay5cnmfr8yz2yp8nvkrk236",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

Regular monthly update; BTW, it is now failing as below:

```
$ nix build -f nix/
builder for '/nix/store/4dd7a34bv0sx18wa10r1mknjfknabrnb-fontforge-20200314.drv' failed with exit code 2; last 10 log lines:
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../../lib/libfontforge.so.4: undefined reference to `g_variant_type_get_gtype'
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../../lib/libfontforge.so.4: undefined reference to `g_signal_emit_by_name'
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../../lib/libfontforge.so.4: undefined reference to `mnt_new_iter'
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../../lib/libfontforge.so.4: undefined reference to `g_value_get_schar'
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../../lib/libfontforge.so.4: undefined reference to `g_signal_connect_object'
  /nix/store/cqxfi2q7d7k6y0q91wcx2cbkj4xsak63-binutils-2.31.1/bin/ld: ../../lib/libfontforge.so.4: undefined reference to `g_enum_get_value_by_nick'
  collect2: error: ld returned 1 exit status
  make[2]: *** [contrib/fonttools/CMakeFiles/acorn2sfd.dir/build.make:111: bin/acorn2sfd] Error 1
  make[1]: *** [CMakeFiles/Makefile2:647: contrib/fonttools/CMakeFiles/acorn2sfd.dir/all] Error 2
  make: *** [Makefile:171: all] Error 2
cannot build derivation '/nix/store/xyw4lgpcpavwfhq1myaw4mvf7pmvxmd8-dejavu-fonts-full-2.37.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/7lrm28jwxkgdma6ir6i6b1ks7laj900v-dejavu-fonts-minimal-2.37.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/n44c4ncpna4csmvmf6c91dbhl0ck20a5-fontconfig-2.13.92.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/zw3r5raw35p63xwbr7bfxqqf3r0kkcz0-fonts.conf.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/d5nmji8lw80skxz3szd7mrab8aqwpgi6-cairo-1.16.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/jnv8rklccj07w787ir6y658p6c3qgb9v-pango-1.47.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/d6mvckwy2i2gsry6kxnlbxf7qmw21wqm-ruby2.6.6-mathematical-1.6.12.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/4gvrvagafg0y92frjhyrnyh2q6cs24d1-asciidoctor-2.0.10.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/2wj33m7l7gxam92z4prv72q6n9zvr860-asciidoctor-2.0.10.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/z6jc188ckfrfqpqwr8zzg0rpjfhwn2li-git-2.29.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/qcgc87yqrdmyp31k44jgfqnd3b06v4z4-podman.drv': 1 dependencies couldn't be built
[0 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/qcgc87yqrdmyp31k44jgfqnd3b06v4z4-podman.drv' failed
```