### PR TITLE
BATS: add ping test, ps filters, multi-option

### DIFF
--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -59,7 +59,8 @@ Labels.created_at | 20[0-9-]\\\+T[0-9:]\\\+Z
 @test "podman images - history output" {
     # podman history is persistent: it permanently alters our base image.
     # Create a dummy image here so we leave our setup as we found it.
-    run_podman run --name my-container $IMAGE true
+    # Multiple --name options confirm command-line override (last one wins)
+    run_podman run --name ignore-me --name my-container $IMAGE true
     run_podman commit my-container my-test-image
 
     run_podman images my-test-image --format '{{ .History }}'
@@ -87,7 +88,8 @@ Labels.created_at | 20[0-9-]\\\+T[0-9:]\\\+Z
 }
 
 @test "podman images - filter" {
-    run_podman inspect --format '{{.ID}}' $IMAGE
+    # Multiple --format options confirm command-line override (last one wins)
+    run_podman inspect --format '{{.XYZ}}' --format '{{.ID}}' $IMAGE
     iid=$output
 
     run_podman images --noheading --filter=after=$iid

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -91,7 +91,8 @@ load helpers
 
 # #6829 : add username to /etc/passwd inside container if --userns=keep-id
 @test "podman exec - with keep-id" {
-    run_podman run -d --userns=keep-id $IMAGE sh -c \
+    # Multiple --userns options confirm command-line override (last one wins)
+    run_podman run -d --userns=private --userns=keep-id $IMAGE sh -c \
                "echo READY;while [ ! -f /tmp/stop ]; do sleep 1; done"
     cid="$output"
     wait_for_ready $cid

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -286,6 +286,10 @@ EOF
     is "$output" "nc: bind: Address in use" \
        "two containers cannot bind to same port"
 
+    # make sure we can ping; failure here might mean that capabilities are wrong
+    run_podman run --rm --pod mypod $IMAGE ping -c1 127.0.0.1
+    run_podman run --rm --pod mypod $IMAGE ping -c1 $hostname
+
     # While the container is still running, run 'podman ps' (no --format)
     # and confirm that the output includes the published port
     run_podman ps --filter id=$cid


### PR DESCRIPTION
 - run test : tweaks to recently-added network-conflict test:
   * remove "-d" in run
   * confirm exact warning text, and also that container
     runs successfully
   * test multiple --net options (regression #8057)

 - images, run, build, exec tests: add multiple-flag
   testing for various flags, confirming as appropriate
   whether options are overridden or accumulated.

 - ps test : add --filter and --sort tests

 - pod test: run 'ping' inside container (confirms that
   container gets PING capability)

Signed-off-by: Ed Santiago <santiago@redhat.com>