### PR TITLE
compat create should use bindings

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -211,12 +211,6 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		mounts = append(mounts, mount)
 	}
 
-	// volumes
-	volumes := make([]string, 0, len(cc.Config.Volumes))
-	for v := range cc.Config.Volumes {
-		volumes = append(volumes, v)
-	}
-
 	// dns
 	dns := make([]net.IP, 0, len(cc.HostConfig.DNS))
 	for _, d := range cc.HostConfig.DNS {
@@ -373,7 +367,6 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		UserNS:           string(cc.HostConfig.UsernsMode),
 		UTS:              string(cc.HostConfig.UTSMode),
 		Mount:            mounts,
-		Volume:           volumes,
 		VolumesFrom:      cc.HostConfig.VolumesFrom,
 		Workdir:          cc.Config.WorkingDir,
 		Net:              &netInfo,
@@ -388,6 +381,10 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		}
 	}
 
+	// volumes
+	if volumes := cc.HostConfig.Binds; len(volumes) > 0 {
+		cliOpts.Volume = volumes
+	}
 	if len(cc.HostConfig.BlkioWeightDevice) > 0 {
 		devices := make([]string, 0, len(cc.HostConfig.BlkioWeightDevice))
 		for _, d := range cc.HostConfig.BlkioWeightDevice {


### PR DESCRIPTION
the volumes provided is seemingly useless representing what volumes
should be added to a container. instead, the host config bindings should
be used as they acurately describe the src/dest and options for
bindings.

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
