### PR TITLE
Fix potential race condition in testing

### DIFF
--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -290,17 +290,17 @@ var _ = Describe("Podman containers ", func() {
 		Expect(wait).To(BeNil())
 		Expect(exitCode).To(BeNumerically("==", -1))
 
-		errChan = make(chan error)
+		unpauseErrChan := make(chan error)
 		go func() {
 			defer GinkgoRecover()
 
 			_, waitErr := containers.Wait(bt.conn, name, &running)
-			errChan <- waitErr
-			close(errChan)
+			unpauseErrChan <- waitErr
+			close(unpauseErrChan)
 		}()
 		err = containers.Unpause(bt.conn, name)
 		Expect(err).To(BeNil())
-		unPausewait := <-errChan
+		unPausewait := <-unpauseErrChan
 		Expect(unPausewait).To(BeNil())
 		Expect(exitCode).To(BeNumerically("==", -1))
 	})


### PR DESCRIPTION
The It("podman wait to pause|unpause condition"... test is
flaking every so often when a messages is sent in the second
function to a channel.  It is my believe that in between the time
the first function sends a message to the channel and before it closes
the channel the second errChan=make() has happened.  This would mean that
the fist function closes the second errChan, and then when the second
function sends a message to the second errChan, it fails and blows up with
the error you are seeing.

By creating a different variable for the second channel, we eliminate the race.

Fixes: https://github.com/containers/podman/issues/6518

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
