### PR TITLE
Do not use "true" after "syslog" in exit commands

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -388,7 +388,7 @@ func CreateExitCommandArgs(storageConfig storage.StoreOptions, config *config.Co
 	}
 
 	if syslog {
-		command = append(command, "--syslog", "true")
+		command = append(command, "--syslog")
 	}
 	command = append(command, []string{"container", "cleanup"}...)
 


### PR DESCRIPTION
Instead of being interpreted as an argument to the boolean flag, the 'true' is being intepreted as the Podman command to be run - so we're trying to run `podman true`, which does not exist. This causes the cleanup command to fail when `--log-level=debug` is set, so containers are not cleaned up or removed.

Separate, but worth looking into later: the errors we get on trying `podman true` with any flags are terrible - if you just type `podman true` you get a quite sane "Unrecognized command" error, but if you try `podman true --rm` you get an "unknown flag --rm" error - which makes very little sense given the command itself doesn't exist.