### PR TITLE
Add support for network ids

### DIFF
--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -37,6 +37,7 @@ var (
 var (
 	networkListOptions entities.NetworkListOptions
 	filters            []string
+	noTrunc            bool
 )
 
 func networkListFlags(flags *pflag.FlagSet) {
@@ -45,6 +46,7 @@ func networkListFlags(flags *pflag.FlagSet) {
 	_ = networklistCommand.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteJSONFormat)
 
 	flags.BoolVarP(&networkListOptions.Quiet, "quiet", "q", false, "display only names")
+	flags.BoolVar(&noTrunc, "no-trunc", false, "Do not truncate the network ID")
 
 	filterFlagName := "filter"
 	flags.StringArrayVarP(&filters, filterFlagName, "f", nil, "Provide filter values (e.g. 'name=podman')")
@@ -96,6 +98,7 @@ func networkList(cmd *cobra.Command, args []string) error {
 		"Version":    "version",
 		"Plugins":    "plugins",
 		"Labels":     "labels",
+		"ID":         "network id",
 	})
 	renderHeaders := true
 	row := "{{.Name}}\t{{.Version}}\t{{.Plugins}}\n"
@@ -154,4 +157,12 @@ func (n ListPrintReports) Labels() string {
 		list = append(list, k+"="+v)
 	}
 	return strings.Join(list, ",")
+}
+
+func (n ListPrintReports) ID() string {
+	length := 12
+	if noTrunc {
+		length = 64
+	}
+	return network.GetNetworkID(n.Name)[:length]
 }

--- a/docs/source/markdown/podman-network-ls.1.md
+++ b/docs/source/markdown/podman-network-ls.1.md
@@ -10,14 +10,6 @@ podman\-network\-ls - Display a summary of CNI networks
 Displays a list of existing podman networks. This command is not available for rootless users.
 
 ## OPTIONS
-#### **--quiet**, **-q**
-
-The `quiet` option will restrict the output to only the network names.
-
-#### **--format**
-
-Pretty-print networks to JSON or using a Go template.
-
 #### **--filter**, **-f**
 
 Filter output based on conditions given.
@@ -30,9 +22,32 @@ Valid filters are listed below:
 | **Filter** | **Description**                                                                       |
 | ---------- | ------------------------------------------------------------------------------------- |
 | name       | [Name] Network name (accepts regex)                                                   |
+| id         | [ID] Full or partial network ID                                                       |
 | label      | [Key] or [Key=Value] Label assigned to a network                                      |
 | plugin     | [Plugin] CNI plugins included in a network (e.g `bridge`,`portmap`,`firewall`,`tuning`,`dnsname`,`macvlan`) |
 | driver     | [Driver] Only `bridge` is supported                                                   |
+
+#### **--format**
+
+Change the default output format.  This can be of a supported type like 'json'
+or a Go template.
+Valid placeholders for the Go template are listed below:
+
+| **Placeholder** | **Description**                 |
+| --------------- | --------------------------------|
+| .ID             | Network ID                      |
+| .Name           | Network name                    |
+| .Plugins        | Network Plugins                 |
+| .Labels         | Network labels                  |
+| .Version        | CNI Version of the config file	|
+
+#### **--no-trunc**
+
+Do not truncate the network ID. The network ID is not displayed by default and must be specified with **--format**.
+
+#### **--quiet**, **-q**
+
+The `quiet` option will restrict the output to only the network names.
 
 ## EXAMPLE
 

--- a/libpod/network/netconflist.go
+++ b/libpod/network/netconflist.go
@@ -230,8 +230,16 @@ func IfPassesFilter(netconf *libcni.NetworkConfigList, filters map[string][]stri
 				}
 			}
 
+		case "id":
+			// matches part of one id
+			for _, filterValue := range filterValues {
+				if strings.Contains(GetNetworkID(netconf.Name), filterValue) {
+					result = true
+					break
+				}
+			}
+
 		// TODO: add dangling filter
-		// TODO TODO: add id filter if we support ids
 
 		default:
 			return false, errors.Errorf("invalid filter %q", key)

--- a/libpod/network/network.go
+++ b/libpod/network/network.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net"
 	"os"
@@ -175,7 +177,7 @@ func RemoveNetwork(config *config.Config, name string) error {
 		return err
 	}
 	defer l.releaseCNILock()
-	cniPath, err := GetCNIConfigPathByName(config, name)
+	cniPath, err := GetCNIConfigPathByNameOrID(config, name)
 	if err != nil {
 		return err
 	}
@@ -228,4 +230,11 @@ func Exists(config *config.Config, name string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// GetNetworkID return the network ID for a given name.
+// It is just the sha256 hash but this should be good enough.
+func GetNetworkID(name string) string {
+	hash := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(hash[:])
 }

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -68,6 +68,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    description: |
 	//      JSON encoded value of the filters (a map[string][]string) to process on the network list. Currently available filters:
 	//        - name=[name] Matches network name (accepts regex).
+	//        - id=[id] Matches for full or partial ID.
 	//        - driver=[driver] Only bridge is supported.
 	//        - label=[key] or label=[key=value] Matches networks based on the presence of a label alone or a label and a value.
 	// produces:
@@ -225,6 +226,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    description: |
 	//      JSON encoded value of the filters (a map[string][]string) to process on the network list. Available filters:
 	//        - name=[name] Matches network name (accepts regex).
+	//        - id=[id] Matches for full or partial ID.
 	//        - driver=[driver] Only bridge is supported.
 	//        - label=[key] or label=[key=value] Matches networks based on the presence of a label alone or a label and a value.
 	//        - plugin=[plugin] Matches CNI plugins included in a network (e.g `bridge`,`portmap`,`firewall`,`tuning`,`dnsname`,`macvlan`)

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -38,9 +38,19 @@ length=2
 # filters={"label":["abc"]}
 t GET networks?filters=%7B%22label%22%3A%5B%22abc%22%5D%7D 200 \
 length=1
-# invalid filter filters={"id":["abc"]}
-t GET networks?filters=%7B%22id%22%3A%5B%22abc%22%5D%7D 500 \
-.cause='invalid filter "id"'
+# id filter filters={"id":["a7662f44d65029fd4635c91feea3d720a57cef52e2a9fcc7772b69072cc1ccd1"]}
+t GET networks?filters=%7B%22id%22%3A%5B%22a7662f44d65029fd4635c91feea3d720a57cef52e2a9fcc7772b69072cc1ccd1%22%5D%7D 200 \
+length=1 \
+.[0].Name=network1 \
+.[0].Id=a7662f44d65029fd4635c91feea3d720a57cef52e2a9fcc7772b69072cc1ccd1
+# invalid filter filters={"dangling":["1"]}
+t GET networks?filters=%7B%22dangling%22%3A%5B%221%22%5D%7D 500 \
+.cause='invalid filter "dangling"'
+
+# network inspect docker
+t GET networks/a7662f44d65029fd4635c91feea3d720a57cef52e2a9fcc7772b69072cc1ccd1 200 \
+.Name=network1 \
+.Id=a7662f44d65029fd4635c91feea3d720a57cef52e2a9fcc7772b69072cc1ccd1
 
 # clean the network
 t DELETE libpod/networks/network1 200 \


### PR DESCRIPTION
The network ID is not stored. It is just the sha256 hash from
the network name. There is a risk of a potential hash collision.
However it's very unlikely and even if we hit this it will
complain that more than network with this ID exists.

The main benefit is that the compat api can have proper
network ID support. Also this adds the support for
`podman network ls --format "{{.ID}}"` and `--filter id=<ID>`.

It also ensures that we can do network rm \<ID> and network
inspect \<ID>.

Since we use a hash this commit is backwards compatible even for
already existing networks.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
