### PR TITLE
Support --network=default as if it was private

### DIFF
--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -233,6 +233,8 @@ func namespaceOptions(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.
 			val = fmt.Sprintf("slirp4netns:%s", s.NetNS.Value)
 		}
 		toReturn = append(toReturn, libpod.WithNetNS(portMappings, postConfigureNetNS, val, nil))
+	case specgen.Private:
+		fallthrough
 	case specgen.Bridge:
 		portMappings, err := createPortMappings(ctx, s, img)
 		if err != nil {

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -258,24 +258,22 @@ func ParseNetworkNamespace(ns string) (Namespace, []string, error) {
 	var cniNetworks []string
 	// Net defaults to Slirp on rootless
 	switch {
-	case ns == "slirp4netns", strings.HasPrefix(ns, "slirp4netns:"):
+	case ns == string(Slirp), strings.HasPrefix(ns, string(Slirp)+":"):
 		toReturn.NSMode = Slirp
-	case ns == "pod":
+	case ns == string(FromPod):
 		toReturn.NSMode = FromPod
-	case ns == "":
+	case ns == "" || ns == string(Default) || ns == string(Private):
 		if rootless.IsRootless() {
 			toReturn.NSMode = Slirp
 		} else {
 			toReturn.NSMode = Bridge
 		}
-	case ns == "bridge":
+	case ns == string(Bridge):
 		toReturn.NSMode = Bridge
-	case ns == "none":
+	case ns == string(NoNetwork):
 		toReturn.NSMode = NoNetwork
-	case ns == "host":
+	case ns == string(Host):
 		toReturn.NSMode = Host
-	case ns == "private":
-		toReturn.NSMode = Private
 	case strings.HasPrefix(ns, "ns:"):
 		split := strings.SplitN(ns, ":", 2)
 		if len(split) != 2 {
@@ -283,7 +281,7 @@ func ParseNetworkNamespace(ns string) (Namespace, []string, error) {
 		}
 		toReturn.NSMode = Path
 		toReturn.Value = split[1]
-	case strings.HasPrefix(ns, "container:"):
+	case strings.HasPrefix(ns, string(FromContainer)+":"):
 		split := strings.SplitN(ns, ":", 2)
 		if len(split) != 2 {
 			return toReturn, nil, errors.Errorf("must provide name or ID or a container when specifying container:")

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -49,9 +49,28 @@ var _ = Describe("Podman run networking", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman run network connection with default", func() {
+		session := podmanTest.Podman([]string{"run", "--network", "default", ALPINE, "wget", "www.podman.io"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
+	It("podman run network connection with none", func() {
+		session := podmanTest.Podman([]string{"run", "--network", "none", ALPINE, "wget", "www.podman.io"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(1))
+		Expect(session.ErrorToString()).To(ContainSubstring("wget: bad address 'www.podman.io'"))
+	})
+
+	It("podman run network connection with private", func() {
+		session := podmanTest.Podman([]string{"run", "--network", "private", ALPINE, "wget", "www.podman.io"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman run network connection with loopback", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--network", "host", ALPINE, "wget", "www.podman.io"})
-		session.Wait(90)
+		session := podmanTest.Podman([]string{"run", "--network", "host", ALPINE, "wget", "www.podman.io"})
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 


### PR DESCRIPTION
Docker defines an option of "default" which means to
use the default network.  We should support this with
the same code path as --network="".

This is important for compatibility with the Docker API.

Fixes: https://github.com/containers/podman/issues/8544

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
