### PR TITLE
Use Libpod tmpdir for pause path

### DIFF
--- a/libpod/reset.go
+++ b/libpod/reset.go
@@ -46,7 +46,7 @@ func (r *Runtime) Reset(ctx context.Context) error {
 		}
 	}
 
-	if err := stopPauseProcess(); err != nil {
+	if err := r.stopPauseProcess(); err != nil {
 		logrus.Errorf("Error stopping pause process: %v", err)
 	}
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -472,7 +472,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 		// we will need to access the storage.
 		if os.Geteuid() != 0 {
 			aliveLock.Unlock() // Unlock to avoid deadlock as BecomeRootInUserNS will reexec.
-			pausePid, err := util.GetRootlessPauseProcessPidPath()
+			pausePid, err := util.GetRootlessPauseProcessPidPathGivenDir(runtime.config.Engine.TmpDir)
 			if err != nil {
 				return errors.Wrapf(err, "could not get pause process pid file path")
 			}
@@ -536,6 +536,15 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	}
 
 	return nil
+}
+
+// TmpDir gets the current Libpod temporary files directory.
+func (r *Runtime) TmpDir() (string, error) {
+	if !r.valid {
+		return "", define.ErrRuntimeStopped
+	}
+
+	return r.config.Engine.TmpDir, nil
 }
 
 // GetConfig returns a copy of the configuration used by the runtime

--- a/libpod/runtime_migrate.go
+++ b/libpod/runtime_migrate.go
@@ -18,9 +18,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func stopPauseProcess() error {
+func (r *Runtime) stopPauseProcess() error {
 	if rootless.IsRootless() {
-		pausePidPath, err := util.GetRootlessPauseProcessPidPath()
+		pausePidPath, err := util.GetRootlessPauseProcessPidPathGivenDir(r.config.Engine.TmpDir)
 		if err != nil {
 			return errors.Wrapf(err, "could not get pause process pid file path")
 		}
@@ -98,5 +98,5 @@ func (r *Runtime) migrate(ctx context.Context) error {
 		}
 	}
 
-	return stopPauseProcess()
+	return r.stopPauseProcess()
 }

--- a/libpod/runtime_migrate_unsupported.go
+++ b/libpod/runtime_migrate_unsupported.go
@@ -10,6 +10,6 @@ func (r *Runtime) migrate(ctx context.Context) error {
 	return nil
 }
 
-func stopPauseProcess() error {
+func (r *Runtime) stopPauseProcess() error {
 	return nil
 }

--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -99,11 +99,22 @@ func GetRootlessConfigHomeDir() (string, error) {
 }
 
 // GetRootlessPauseProcessPidPath returns the path to the file that holds the pid for
-// the pause process
+// the pause process.
+// DEPRECATED - switch to GetRootlessPauseProcessPidPathGivenDir
 func GetRootlessPauseProcessPidPath() (string, error) {
 	runtimeDir, err := GetRuntimeDir()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(runtimeDir, "libpod", "pause.pid"), nil
+}
+
+// GetRootlessPauseProcessPidPathGivenDir returns the path to the file that
+// holds the PID of the pause process, given the location of Libpod's temporary
+// files.
+func GetRootlessPauseProcessPidPathGivenDir(libpodTmpDir string) (string, error) {
+	if libpodTmpDir == "" {
+		return "", errors.Errorf("must provide non-empty tmporary directory")
+	}
+	return filepath.Join(libpodTmpDir, "pause.pid"), nil
 }

--- a/pkg/util/utils_windows.go
+++ b/pkg/util/utils_windows.go
@@ -25,6 +25,12 @@ func GetRootlessPauseProcessPidPath() (string, error) {
 	return "", errors.Wrap(errNotImplemented, "GetRootlessPauseProcessPidPath")
 }
 
+// GetRootlessPauseProcessPidPath returns the path to the file that holds the pid for
+// the pause process
+func GetRootlessPauseProcessPidPathGivenDir(unused string) (string, error) {
+	return "", errors.Wrap(errNotImplemented, "GetRootlessPauseProcessPidPath")
+}
+
 // GetRuntimeDir returns the runtime directory
 func GetRuntimeDir() (string, error) {
 	return "", errors.New("this function is not implemented for windows")


### PR DESCRIPTION
Previously, we always computed pause path from the Rootless runtime directory. Problem: this does not match the behavior of Libpod when the directory changes. Libpod will continue to use the previous directory, cached in the database; Pause pidfiles will swap to the new path. This is problematic when the directory needs to exist to write the pidfile, and Libpod is what creates the directory.

There are two potential solutions - allow the pause pidfile to move and just make the directory when we want to write it, or use the cached Libpod paths for a guaranteed location. This patch does the second, because it seems safer - we will never miss a previously-existing pidfile because the location is now consistent.

Fixes #8539
