### PR TITLE
Do not mount sysfs as rootless in more cases

### DIFF
--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -165,7 +165,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 			inUserNS = true
 		}
 	}
-	if inUserNS && s.NetNS.IsHost() {
+	if inUserNS && s.NetNS.NSMode != specgen.NoNetwork {
 		canMountSys = false
 	}
 

--- a/test/e2e/run_memory_test.go
+++ b/test/e2e/run_memory_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Podman run memory", func() {
 		var session *PodmanSessionIntegration
 
 		if CGROUPSV2 {
-			session = podmanTest.Podman([]string{"run", "--memory=40m", ALPINE, "sh", "-c", "cat /sys/fs/cgroup/$(sed -e 's|0::||' < /proc/self/cgroup)/memory.max"})
+			session = podmanTest.Podman([]string{"run", "--memory=40m", "--net=none", ALPINE, "sh", "-c", "cat /sys/fs/cgroup/$(sed -e 's|0::||' < /proc/self/cgroup)/memory.max"})
 		} else {
 			session = podmanTest.Podman([]string{"run", "--memory=40m", ALPINE, "cat", "/sys/fs/cgroup/memory/memory.limit_in_bytes"})
 		}
@@ -55,7 +55,7 @@ var _ = Describe("Podman run memory", func() {
 		var session *PodmanSessionIntegration
 
 		if CGROUPSV2 {
-			session = podmanTest.Podman([]string{"run", "--memory-reservation=40m", ALPINE, "sh", "-c", "cat /sys/fs/cgroup/$(sed -e 's|0::||' < /proc/self/cgroup)/memory.low"})
+			session = podmanTest.Podman([]string{"run", "--memory-reservation=40m", "--net=none", ALPINE, "sh", "-c", "cat /sys/fs/cgroup/$(sed -e 's|0::||' < /proc/self/cgroup)/memory.low"})
 		} else {
 			session = podmanTest.Podman([]string{"run", "--memory-reservation=40m", ALPINE, "cat", "/sys/fs/cgroup/memory/memory.soft_limit_in_bytes"})
 		}
@@ -81,7 +81,7 @@ var _ = Describe("Podman run memory", func() {
 		var session *PodmanSessionIntegration
 
 		if CGROUPSV2 {
-			session = podmanTest.Podman([]string{"run", "--memory-reservation=40m", ALPINE, "sh", "-c", "cat /sys/fs/cgroup/$(sed -e 's|0::||' < /proc/self/cgroup)/memory.low"})
+			session = podmanTest.Podman([]string{"run", "--net=none", "--memory-reservation=40m", ALPINE, "sh", "-c", "cat /sys/fs/cgroup/$(sed -e 's|0::||' < /proc/self/cgroup)/memory.low"})
 		} else {
 			session = podmanTest.Podman([]string{"run", "--memory-reservation=40m", ALPINE, "cat", "/sys/fs/cgroup/memory/memory.soft_limit_in_bytes"})
 		}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1267,7 +1267,7 @@ USER mail`
 	It("podman run verify pids-limit", func() {
 		SkipIfCgroupV1("pids-limit not supported on cgroup V1")
 		limit := "4321"
-		session := podmanTest.Podman([]string{"run", "--pids-limit", limit, "--rm", ALPINE, "cat", "/sys/fs/cgroup/pids.max"})
+		session := podmanTest.Podman([]string{"run", "--pids-limit", limit, "--net=none", "--rm", ALPINE, "cat", "/sys/fs/cgroup/pids.max"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring(limit))


### PR DESCRIPTION
We can't mount sysfs as rootless unless we manage the network namespace. Problem: slirp4netns is now creating and managing a network namespace separate from the OCI runtime, so we can't mount sysfs in many circumstances. The `crun` OCI runtime will automatically handle this by falling back to a bind mount, but `runc` will not, so we didn't notice until RHEL gating tests ran on the new branch.
