### PR TITLE
swagger.yaml: fix multi-line string indentation

### DIFF
--- a/vendor/github.com/docker/docker/api/swagger.yaml
+++ b/vendor/github.com/docker/docker/api/swagger.yaml
@@ -1025,7 +1025,7 @@ definitions:
           SecurityOpt:
             type: "array"
             description: "A list of string values to customize labels for MLS
-            systems, such as SELinux."
+              systems, such as SELinux."
             items:
               type: "string"
           StorageOpt:


### PR DESCRIPTION
A tool I ran on the yaml file didn't like the multi-line string wasn't indented.