### PR TITLE
[CI:DOCS] Correct which network commands can be run as rootless

### DIFF
--- a/docs/source/markdown/podman-network-connect.1.md
+++ b/docs/source/markdown/podman-network-connect.1.md
@@ -10,6 +10,8 @@ podman\-network\-connect - Connect a container to a network
 Connects a container to a network. A container can be connected to a network by name or by ID.
 Once connected, the container can communicate with other containers in the same network.
 
+This command is not available for rootless users.
+
 ## OPTIONS
 #### **--alias**
 Add network-scoped alias for the container.  If the network is using the `dnsname` CNI plugin, these aliases

--- a/docs/source/markdown/podman-network-disconnect.1.md
+++ b/docs/source/markdown/podman-network-disconnect.1.md
@@ -9,6 +9,8 @@ podman\-network\-disconnect - Disconnect a container from a network
 ## DESCRIPTION
 Disconnects a container from a network.
 
+This command is not available for rootless users.
+
 ## OPTIONS
 #### **--force**, **-f**
 

--- a/docs/source/markdown/podman-network-inspect.1.md
+++ b/docs/source/markdown/podman-network-inspect.1.md
@@ -7,7 +7,7 @@ podman\-network\-inspect - Displays the raw CNI network configuration for one or
 **podman network inspect** [*options*] [*network* ...]
 
 ## DESCRIPTION
-Display the raw (JSON format) network configuration. This command is not available for rootless users.
+Display the raw (JSON format) network configuration.
 
 ## OPTIONS
 #### **--format**, **-f**

--- a/docs/source/markdown/podman-network-ls.1.md
+++ b/docs/source/markdown/podman-network-ls.1.md
@@ -7,7 +7,7 @@ podman\-network\-ls - Display a summary of CNI networks
 **podman network ls**  [*options*]
 
 ## DESCRIPTION
-Displays a list of existing podman networks. This command is not available for rootless users.
+Displays a list of existing podman networks.
 
 ## OPTIONS
 #### **--filter**, **-f**

--- a/docs/source/markdown/podman-network.1.md
+++ b/docs/source/markdown/podman-network.1.md
@@ -7,7 +7,7 @@ podman\-network - Manage Podman CNI networks
 **podman network** *subcommand*
 
 ## DESCRIPTION
-The network command manages CNI networks for Podman. It is not supported for rootless users.
+The network command manages CNI networks for Podman.
 
 ## COMMANDS
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
