### PR TITLE
generate kube on multiple containers

### DIFF
--- a/cmd/podman/generate/kube.go
+++ b/cmd/podman/generate/kube.go
@@ -17,16 +17,16 @@ import (
 var (
 	kubeOptions     = entities.GenerateKubeOptions{}
 	kubeFile        = ""
-	kubeDescription = `Command generates Kubernetes pod and service YAML (v1 specification) from a Podman container or pod.
+	kubeDescription = `Command generates Kubernetes pod and service YAML (v1 specification) from Podman containers or a pod.
 
 Whether the input is for a container or pod, Podman will always generate the specification as a pod.`
 
 	kubeCmd = &cobra.Command{
-		Use:               "kube [options] CONTAINER | POD",
+		Use:               "kube [options] CONTAINER... | POD",
 		Short:             "Generate Kubernetes YAML from a container or pod.",
 		Long:              kubeDescription,
 		RunE:              kube,
-		Args:              cobra.ExactArgs(1),
+		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: common.AutocompleteContainersAndPods,
 		Example: `podman generate kube ctrID
   podman generate kube podID
@@ -51,7 +51,7 @@ func init() {
 }
 
 func kube(cmd *cobra.Command, args []string) error {
-	report, err := registry.ContainerEngine().GenerateKube(registry.GetContext(), args[0], kubeOptions)
+	report, err := registry.ContainerEngine().GenerateKube(registry.GetContext(), args, kubeOptions)
 	if err != nil {
 		return err
 	}

--- a/docs/source/markdown/podman-generate-kube.1.md
+++ b/docs/source/markdown/podman-generate-kube.1.md
@@ -3,12 +3,12 @@
 podman-generate-kube - Generate Kubernetes YAML based on a pod or container
 
 ## SYNOPSIS
-**podman generate kube** [*options*] *container* | *pod*
+**podman generate kube** [*options*] *container...* | *pod*
 
 ## DESCRIPTION
-**podman generate kube** will generate Kubernetes Pod YAML (v1 specification) from a Podman container or pod. Whether
-the input is for a container or pod, Podman will always generate the specification as a Pod. The input may be in the form
-of a pod or container name or ID.
+**podman generate kube** will generate Kubernetes Pod YAML (v1 specification) from Podman one or more containers or a single pod. Whether
+the input is for containers or a pod, Podman will always generate the specification as a Pod. The input may be in the form
+of a pod or one or more container names or IDs.
 
 Note that the generated Kubernetes YAML file can be used to re-run the deployment via podman-play-kube(1).
 

--- a/pkg/api/handlers/libpod/generate.go
+++ b/pkg/api/handlers/libpod/generate.go
@@ -60,7 +60,8 @@ func GenerateKube(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
-		Service bool `schema:"service"`
+		Names   []string `schema:"names"`
+		Service bool     `schema:"service"`
 	}{
 		// Defaults would go here.
 	}
@@ -73,7 +74,7 @@ func GenerateKube(w http.ResponseWriter, r *http.Request) {
 
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 	options := entities.GenerateKubeOptions{Service: query.Service}
-	report, err := containerEngine.GenerateKube(r.Context(), utils.GetName(r), options)
+	report, err := containerEngine.GenerateKube(r.Context(), query.Names, options)
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error generating YAML"))
 		return

--- a/pkg/api/server/register_generate.go
+++ b/pkg/api/server/register_generate.go
@@ -70,7 +70,7 @@ func (s *APIServer) registerGenerateHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/generate/{name:.*}/systemd"), s.APIHandler(libpod.GenerateSystemd)).Methods(http.MethodGet)
 
-	// swagger:operation GET /libpod/generate/{name:.*}/kube libpod libpodGenerateKube
+	// swagger:operation GET /libpod/generate/kube libpod libpodGenerateKube
 	// ---
 	// tags:
 	//  - containers
@@ -78,9 +78,11 @@ func (s *APIServer) registerGenerateHandlers(r *mux.Router) error {
 	// summary: Generate a Kubernetes YAML file.
 	// description: Generate Kubernetes YAML based on a pod or container.
 	// parameters:
-	//  - in: path
-	//    name: name:.*
-	//    type: string
+	//  - in: query
+	//    name: names
+	//    type: array
+	//    items:
+	//       type: string
 	//    required: true
 	//    description: Name or ID of the container or pod.
 	//  - in: query
@@ -98,6 +100,6 @@ func (s *APIServer) registerGenerateHandlers(r *mux.Router) error {
 	//      format: binary
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/generate/{name:.*}/kube"), s.APIHandler(libpod.GenerateKube)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/libpod/generate/kube"), s.APIHandler(libpod.GenerateKube)).Methods(http.MethodGet)
 	return nil
 }

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -46,7 +46,7 @@ type ContainerEngine interface {
 	ContainerWait(ctx context.Context, namesOrIds []string, options WaitOptions) ([]WaitReport, error)
 	Events(ctx context.Context, opts EventsOptions) error
 	GenerateSystemd(ctx context.Context, nameOrID string, opts GenerateSystemdOptions) (*GenerateSystemdReport, error)
-	GenerateKube(ctx context.Context, nameOrID string, opts GenerateKubeOptions) (*GenerateKubeReport, error)
+	GenerateKube(ctx context.Context, nameOrIDs []string, opts GenerateKubeOptions) (*GenerateKubeReport, error)
 	SystemPrune(ctx context.Context, options SystemPruneOptions) (*SystemPruneReport, error)
 	HealthCheckRun(ctx context.Context, nameOrID string, options HealthCheckOptions) (*define.HealthCheckResults, error)
 	Info(ctx context.Context) (*define.Info, error)

--- a/pkg/domain/infra/tunnel/generate.go
+++ b/pkg/domain/infra/tunnel/generate.go
@@ -11,6 +11,6 @@ func (ic *ContainerEngine) GenerateSystemd(ctx context.Context, nameOrID string,
 	return generate.Systemd(ic.ClientCxt, nameOrID, options)
 }
 
-func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrID string, options entities.GenerateKubeOptions) (*entities.GenerateKubeReport, error) {
-	return generate.Kube(ic.ClientCxt, nameOrID, options)
+func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrIDs []string, options entities.GenerateKubeOptions) (*entities.GenerateKubeReport, error) {
+	return generate.Kube(ic.ClientCxt, nameOrIDs, options)
 }

--- a/test/apiv2/25-containersMore.at
+++ b/test/apiv2/25-containersMore.at
@@ -65,13 +65,13 @@ t GET libpod/containers/json?last=1 200 \
 
 cid=$(jq -r '.[0].Id' <<<"$output")
 
-t GET libpod/generate/$cid/kube 200
+t GET libpod/generate/kube?names=$cid 200
 like "$output" ".*apiVersion:.*" "Check generated kube yaml - apiVersion"
 like "$output" ".*kind:\\sPod.*" "Check generated kube yaml - kind: Pod"
 like "$output" ".*metadata:.*" "Check generated kube yaml - metadata"
 like "$output" ".*spec:.*" "Check generated kube yaml - spec"
 
-t GET libpod/generate/$cid/kube?service=true 200
+t GET "libpod/generate/kube?service=true&names=$cid" 200
 like "$output" ".*apiVersion:.*" "Check generated kube yaml(service=true) - apiVersion"
 like "$output" ".*kind:\\sPod.*" "Check generated kube yaml(service=true) - kind: Pod"
 like "$output" ".*metadata:.*" "Check generated kube yaml(service=true) - metadata"

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -469,4 +469,74 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(inspect.ExitCode()).To(Equal(0))
 		Expect(inspect.OutputToString()).To(ContainSubstring(`"pid"`))
 	})
+
+	It("podman generate kube multiple pods should fail", func() {
+		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", ALPINE, "top"})
+		pod1.WaitWithDefaultTimeout()
+		Expect(pod1.ExitCode()).To(Equal(0))
+
+		pod2 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod2", ALPINE, "top"})
+		pod2.WaitWithDefaultTimeout()
+		Expect(pod2.ExitCode()).To(Equal(0))
+
+		kube := podmanTest.Podman([]string{"generate", "kube", "pod1", "pod2"})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube.ExitCode()).ToNot(Equal(0))
+	})
+
+	It("podman generate kube with pods and containers should fail", func() {
+		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", ALPINE, "top"})
+		pod1.WaitWithDefaultTimeout()
+		Expect(pod1.ExitCode()).To(Equal(0))
+
+		pod2 := podmanTest.Podman([]string{"run", "-dt", "--name", "top", ALPINE, "top"})
+		pod2.WaitWithDefaultTimeout()
+		Expect(pod2.ExitCode()).To(Equal(0))
+
+		kube := podmanTest.Podman([]string{"generate", "kube", "pod1", "top"})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube.ExitCode()).ToNot(Equal(0))
+	})
+
+	It("podman generate kube with containers in a pod should fail", func() {
+		pod1 := podmanTest.Podman([]string{"pod", "create", "--name", "pod1"})
+		pod1.WaitWithDefaultTimeout()
+		Expect(pod1.ExitCode()).To(Equal(0))
+
+		con := podmanTest.Podman([]string{"run", "-dt", "--pod", "pod1", "--name", "top", ALPINE, "top"})
+		con.WaitWithDefaultTimeout()
+		Expect(con.ExitCode()).To(Equal(0))
+
+		kube := podmanTest.Podman([]string{"generate", "kube", "top"})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube.ExitCode()).ToNot(Equal(0))
+	})
+
+	It("podman generate kube with multiple containers", func() {
+		con1 := podmanTest.Podman([]string{"run", "-dt", "--name", "con1", ALPINE, "top"})
+		con1.WaitWithDefaultTimeout()
+		Expect(con1.ExitCode()).To(Equal(0))
+
+		con2 := podmanTest.Podman([]string{"run", "-dt", "--name", "con2", ALPINE, "top"})
+		con2.WaitWithDefaultTimeout()
+		Expect(con2.ExitCode()).To(Equal(0))
+
+		kube := podmanTest.Podman([]string{"generate", "kube", "con1", "con2"})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube.ExitCode()).To(Equal(0))
+	})
+
+	It("podman generate kube with containers in a pod should fail", func() {
+		pod1 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod1", "--name", "top1", ALPINE, "top"})
+		pod1.WaitWithDefaultTimeout()
+		Expect(pod1.ExitCode()).To(Equal(0))
+
+		pod2 := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:pod2", "--name", "top2", ALPINE, "top"})
+		pod2.WaitWithDefaultTimeout()
+		Expect(pod2.ExitCode()).To(Equal(0))
+
+		kube := podmanTest.Podman([]string{"generate", "kube", "pod1", "pod2"})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube.ExitCode()).ToNot(Equal(0))
+	})
 })


### PR DESCRIPTION
add the ability to add multiple containers into a single k8s pod
instead of just one.

also fixed some bugs in the resulting yaml where an empty service
description was being added on error causing the k8s validation to fail.

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
