### PR TITLE
[CI:DOCS] The --net=container flag to Buildah is deprecated

### DIFF
--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -412,7 +412,9 @@ Valid _mode_ values are:
 container full access to local system services such as D-bus and is therefore
 considered insecure.
 - **ns:**_path_: path to a network namespace to join.
-- **private**: create a new namespace for the container (default).
+- **private**: create a new namespace for the container (default). The
+**container** network mode is an alias for **private**, but has been deprecated
+and will be removed in a future release of Podman.
 
 #### **--no-cache**
 


### PR DESCRIPTION
It's very confusing that `podman run --net=container` joins the network namespace of another container - but `podman build --net=container` creates a private network namespace. We've standardized on `--net=private` for this, and will eventually remove `podman build --net=container` as an alias for `--net=private`.
