### PR TITLE
Jira RUN-1106 Image handlers updates

### DIFF
--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -81,5 +81,4 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.WriteResponse(w, http.StatusOK, "")
-
 }

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -145,13 +145,14 @@ type PodCreateConfig struct {
 	Share        string   `json:"share"`
 }
 
+// HistoryResponse provides details on image layers
 type HistoryResponse struct {
-	ID        string   `json:"Id"`
-	Created   int64    `json:"Created"`
-	CreatedBy string   `json:"CreatedBy"`
-	Tags      []string `json:"Tags"`
-	Size      int64    `json:"Size"`
-	Comment   string   `json:"Comment"`
+	ID        string `json:"Id"`
+	Created   int64
+	CreatedBy string
+	Tags      []string
+	Size      int64
+	Comment   string
 }
 
 type ImageLayer struct{}
@@ -213,6 +214,7 @@ func ImageToImageSummary(l *libpodImage.Image) (*entities.ImageSummary, error) {
 		ID:           l.ID(),
 		ParentId:     l.Parent,
 		RepoTags:     repoTags,
+		RepoDigests:  digests,
 		Created:      l.Created().Unix(),
 		Size:         int64(*size),
 		SharedSize:   0,
@@ -223,7 +225,6 @@ func ImageToImageSummary(l *libpodImage.Image) (*entities.ImageSummary, error) {
 		Dangling:     l.Dangling(),
 		Names:        l.Names(),
 		Digest:       string(l.Digest()),
-		Digests:      digests,
 		ConfigDigest: string(l.ConfigDigest),
 		History:      l.NamesHistory(),
 	}
@@ -329,7 +330,6 @@ func ImageDataToImageInspect(ctx context.Context, l *libpodImage.Image) (*ImageI
 		dockerImageInspect.Parent = d.Parent.String()
 	}
 	return &ImageInspect{dockerImageInspect}, nil
-
 }
 
 // portsToPortSet converts libpods exposed ports to dockers structs

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -51,22 +51,22 @@ func (i *Image) Id() string { // nolint
 }
 
 type ImageSummary struct {
-	ID          string   `json:"Id"`
-	ParentId    string   // nolint
-	RepoTags    []string `json:",omitempty"`
+	ID          string `json:"Id"`
+	ParentId    string // nolint
+	RepoTags    []string
+	RepoDigests []string
 	Created     int64
-	Size        int64             `json:",omitempty"`
-	SharedSize  int               `json:",omitempty"`
-	VirtualSize int64             `json:",omitempty"`
-	Labels      map[string]string `json:",omitempty"`
-	Containers  int               `json:",omitempty"`
-	ReadOnly    bool              `json:",omitempty"`
-	Dangling    bool              `json:",omitempty"`
+	Size        int64
+	SharedSize  int
+	VirtualSize int64
+	Labels      map[string]string
+	Containers  int
+	ReadOnly    bool `json:",omitempty"`
+	Dangling    bool `json:",omitempty"`
 
 	// Podman extensions
 	Names        []string `json:",omitempty"`
 	Digest       string   `json:",omitempty"`
-	Digests      []string `json:",omitempty"`
 	ConfigDigest string   `json:",omitempty"`
 	History      []string `json:",omitempty"`
 }

--- a/pkg/domain/infra/abi/images_list.go
+++ b/pkg/domain/infra/abi/images_list.go
@@ -35,7 +35,7 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 			Created:      img.Created().Unix(),
 			Dangling:     img.Dangling(),
 			Digest:       string(img.Digest()),
-			Digests:      digests,
+			RepoDigests:  digests,
 			History:      img.NamesHistory(),
 			Names:        img.Names(),
 			ParentId:     img.Parent,


### PR DESCRIPTION
* Audit and add tests for required fields.
* Added issue for /images/load implementation

Audit:
- GET /images/json GetImages
- POST /build BuildImage
- POST /build/prune 404 not found
- POST /images/create CreateImageFromImage/CreateImageFromSrc
- GET /images/{name}/json GetImage
- GET /images/{name}/history HistoryImage
- POST /images/{name}/push PushImage
- POST /images/{name}/tag TagImage
- DELETE /images/{name} RemoveImage
- POST /images/prune PruneImages
- POST /commit CommitContainer
- GET /images/{name}/get ExportImage
- GET /images/get ExportImages
- POST /images/load LoadImages See https://github.com/containers/podman/issues/8586

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
