### PR TITLE
Support Unix timestamps for `podman logs --since`

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -530,6 +530,11 @@ func ParseInputTime(inputTime string) (time.Time, error) {
 		}
 	}
 
+	unix_timestamp, err := strconv.ParseInt(inputTime, 10, 64)
+	if err == nil {
+		return time.Unix(unix_timestamp, 0), nil
+	}
+
 	// input might be a duration
 	duration, err := time.ParseDuration(inputTime)
 	if err != nil {

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -21,6 +21,9 @@ load helpers
     run_podman logs $cid
     is "$output" "$rand_string" "output from podman-logs after container is run"
 
+    # test --since with Unix timestamps
+    run_podman logs --since 1000 $cid
+
     run_podman rm $cid
 }
 


### PR DESCRIPTION
To match what `podman-logs(1)` describes `--since`: https://github.com/containers/podman/blob/master/docs/source/markdown/podman-logs.1.md#--sincetimestamp.

I discovered this when testing a Python library that uses docker-py to retrieve container logs [1][2]. Under the hood the `/containers/{id}/logs` API is called with since as a UNIX timestamp [3]. Hopefully this fix can help with compatibility between Podman and docker-py [4].

[1] https://github.com/spulec/moto/issues/3276
[2] https://github.com/spulec/moto/blob/b6369d62503651a3c614fb2b3ee08c8013b732fc/moto/batch/models.py#L454-L473
[3] https://docs.docker.com/engine/api/v1.40/#operation/ContainerLogs
[4] https://github.com/containers/podman/issues/5386