### PR TITLE
add @Luap99 to OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
   - TomSweeneyRedHat
   - vrothberg
   - umohnani8
+  - Luap99
 reviewers:
   - baude
   - edsantiago
@@ -20,3 +21,4 @@ reviewers:
   - ashley-cui
   - QiWang19
   - umohnani8
+  - Luap99


### PR DESCRIPTION
@Luap99 is a long-term contributor, does a lot of reviews, contributed
many non-trivial patches, and is very active in the community.

Being in the OWNERS file gives privileges to approve (/approve) and
merge (/lgtm) pull requests.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
