### PR TITLE
Use PasswordCallback instead of Password for ssh

### DIFF
--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -207,11 +207,11 @@ func sshClient(_url *url.URL, secure bool, passPhrase string, identity string) (
 		authMethods = append(authMethods, ssh.Password(pw))
 	}
 	if len(authMethods) == 0 {
-		pass, err := terminal.ReadPassword("Login password:")
-		if err != nil {
-			return Connection{}, err
+		callback := func() (string, error) {
+			pass, err := terminal.ReadPassword("Login password:")
+			return string(pass), err
 		}
-		authMethods = append(authMethods, ssh.Password(string(pass)))
+		authMethods = append(authMethods, ssh.PasswordCallback(callback))
 	}
 
 	port := _url.Port()


### PR DESCRIPTION
Currently asking for login password, even if not supported by
the ssh server. So wait with prompt until actually requested.

Closes #8498