### PR TITLE
Jira RUN-1106 Network handlers updates

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -271,11 +271,16 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	net, err := getNetworkResourceByNameOrID(name, runtime, nil)
+	if err != nil {
+		utils.InternalServerError(w, err)
+		return
+	}
 	body := struct {
 		Id      string
 		Warning []string
 	}{
-		Id: name,
+		Id: net.ID,
 	}
 	utils.WriteResponse(w, http.StatusCreated, body)
 }
@@ -320,7 +325,7 @@ func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	utils.WriteResponse(w, http.StatusNoContent, "")
+	utils.WriteResponse(w, http.StatusNoContent, nil)
 }
 
 // Connect adds a container to a network


### PR DESCRIPTION
* Add network API tests
* Update network create endpoint to return ID not Name

Audit:
- GET /networks ListNetworks
- GET /networks/{id} InspectNetwork
- DELETE /networks/{id} RemoveNetwork
- POST /networks/create CreateNetwork
- POST /networks/prune 405 not implemented

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
