### PR TITLE
Jira RUN-1106 Volumes handlers updates

### DIFF
--- a/pkg/api/handlers/compat/volumes.go
+++ b/pkg/api/handlers/compat/volumes.go
@@ -223,7 +223,7 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 			}
 		} else {
 			// Success
-			utils.WriteResponse(w, http.StatusNoContent, "")
+			utils.WriteResponse(w, http.StatusNoContent, nil)
 		}
 	} else {
 		if !query.Force {
@@ -232,7 +232,7 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 			// Volume does not exist and `force` is truthy - this emulates what
 			// Docker would do when told to `force` removal of a nonextant
 			// volume
-			utils.WriteResponse(w, http.StatusNoContent, "")
+			utils.WriteResponse(w, http.StatusNoContent, nil)
 		}
 	}
 }


### PR DESCRIPTION
* Add tests to verify required fields in responses

Audit:
- GET /volumes ListVolume
- POST /volumes/create CreateVolume
- GET /volumes/{name} InspectVolume
- DELETE /volumes/{name} RemoveVolume
- POST /volumes/prune PruneVolumes

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
