### PR TITLE
Initial implementation of volume plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ release.txt
 /test/checkseccomp/checkseccomp
 /test/copyimg/copyimg
 /test/goecho/goecho
+/test/testvol/testvol
 .vscode*
 result
 # Necessary to prevent hack/tree-status.sh false-positive

--- a/Containerfile-testvol
+++ b/Containerfile-testvol
@@ -1,0 +1,10 @@
+FROM golang:1.15-alpine AS build-img
+COPY ./test/testvol/ /go/src/github.com/containers/podman/cmd/testvol/
+COPY ./vendor /go/src/github.com/containers/podman/vendor/
+WORKDIR /go/src/github.com/containers/podman
+RUN go build -o /testvol ./cmd/testvol
+
+FROM alpine
+COPY --from=build-img /testvol /usr/local/bin
+WORKDIR /
+ENTRYPOINT ["/usr/local/bin/testvol"]

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,14 @@ gofmt: ## Verify the source code gofmt
 test/checkseccomp/checkseccomp: .gopathok $(wildcard test/checkseccomp/*.go)
 	$(GO) build $(BUILDFLAGS) -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS)" -o $@ ./test/checkseccomp
 
+.PHONY: test/testvol/testvol
+test/testvol/testvol: .gopathok $(wildcard test/testvol/*.go)
+	$(GO) build $(BUILDFLAGS) -ldflags '$(LDFLAGS_PODMAN)' -o $@ ./test/testvol
+
+.PHONY: volume-plugin-test-image
+volume-plugin-test-img:
+	podman build -t quay.io/libpod/volume-plugin-test-img -f Containerfile-testvol .
+
 .PHONY: test/goecho/goecho
 test/goecho/goecho: .gopathok $(wildcard test/goecho/*.go)
 	$(GO) build $(BUILDFLAGS) -ldflags '$(LDFLAGS_PODMAN)' -o $@ ./test/goecho

--- a/docs/source/markdown/podman-volume-create.1.md
+++ b/docs/source/markdown/podman-volume-create.1.md
@@ -17,7 +17,7 @@ driver options can be set using the **--opt** flag.
 
 #### **--driver**=*driver*
 
-Specify the volume driver name (default local).
+Specify the volume driver name (default **local**). Setting this to a value other than **local** Podman will attempt to create the volume using a volume plugin with the given name. Such plugins must be defined in the **volume_plugins** section of the **containers.conf**(5) configuration file.
 
 #### **--help**
 
@@ -30,13 +30,14 @@ Set metadata for a volume (e.g., --label mykey=value).
 #### **--opt**=*option*, **-o**
 
 Set driver specific options.
-For the default driver, `local`, this allows a volume to be configured to mount a filesystem on the host.
+For the default driver, **local**, this allows a volume to be configured to mount a filesystem on the host.
 For the `local` driver the following options are supported: `type`, `device`, and `o`.
 The `type` option sets the type of the filesystem to be mounted, and is equivalent to the `-t` flag to **mount(8)**.
 The `device` option sets the device to be mounted, and is equivalent to the `device` argument to **mount(8)**.
 The `o` option sets options for the mount, and is equivalent to the `-o` flag to **mount(8)** with two exceptions.
 The `o` option supports `uid` and `gid` options to set the UID and GID of the created volume that are not normally supported by **mount(8)**.
-Using volume options with the `local` driver requires root privileges.
+Using volume options with the **local** driver requires root privileges.
+When not using the **local** driver, the given options will be passed directly to the volume plugin. In this case, supported options will be dictated by the plugin in question, not Podman.
 
 ## EXAMPLES
 
@@ -53,7 +54,8 @@ $ podman volume create --label foo=bar myvol
 ```
 
 ## SEE ALSO
-podman-volume(1), mount(8)
+**podman-volume**(1), **mount**(8), **containers.conf**(5)
 
 ## HISTORY
+January 2020, updated with information on volume plugins by Matthew Heon <mheon@redhat.com>
 November 2018, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -304,6 +304,7 @@ func (s *BoltState) Refresh() error {
 
 			// Reset mount count to 0
 			oldState.MountCount = 0
+			oldState.MountPoint = ""
 
 			newState, err := json.Marshal(oldState)
 			if err != nil {

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -212,7 +212,12 @@ func (c *Container) getInspectMounts(namedVolumes []*ContainerNamedVolume, image
 			return nil, errors.Wrapf(err, "error looking up volume %s in container %s config", volume.Name, c.ID())
 		}
 		mountStruct.Driver = volFromDB.Driver()
-		mountStruct.Source = volFromDB.MountPoint()
+
+		mountPoint, err := volFromDB.MountPoint()
+		if err != nil {
+			return nil, err
+		}
+		mountStruct.Source = mountPoint
 
 		parseMountOptionsForInspect(volume.Options, &mountStruct)
 

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -35,6 +35,10 @@ var (
 	// aliases.
 	ErrNoAliases = errors.New("no aliases for container")
 
+	// ErrMissingPlugin indicates that the requested operation requires a
+	// plugin that is not present on the system or in the configuration.
+	ErrMissingPlugin = errors.New("required plugin missing")
+
 	// ErrCtrExists indicates a container with the same name or ID already
 	// exists
 	ErrCtrExists = errors.New("container already exists")

--- a/libpod/define/volume_inspect.go
+++ b/libpod/define/volume_inspect.go
@@ -1,0 +1,51 @@
+package define
+
+import (
+	"time"
+)
+
+// InspectVolumeData is the output of Inspect() on a volume. It is matched to
+// the format of 'docker volume inspect'.
+type InspectVolumeData struct {
+	// Name is the name of the volume.
+	Name string `json:"Name"`
+	// Driver is the driver used to create the volume.
+	// If set to "local" or "", the Local driver (Podman built-in code) is
+	// used to service the volume; otherwise, a volume plugin with the given
+	// name is used to mount and manage the volume.
+	Driver string `json:"Driver"`
+	// Mountpoint is the path on the host where the volume is mounted.
+	Mountpoint string `json:"Mountpoint"`
+	// CreatedAt is the date and time the volume was created at. This is not
+	// stored for older Libpod volumes; if so, it will be omitted.
+	CreatedAt time.Time `json:"CreatedAt,omitempty"`
+	// Status is used to return information on the volume's current state,
+	// if the volume was created using a volume plugin (uses a Driver that
+	// is not the local driver).
+	// Status is provided to us by an external program, so no guarantees are
+	// made about its format or contents. Further, it is an optional field,
+	// so it may not be set even in cases where a volume plugin is in use.
+	Status map[string]interface{} `json:"Status,omitempty"`
+	// Labels includes the volume's configured labels, key:value pairs that
+	// can be passed during volume creation to provide information for third
+	// party tools.
+	Labels map[string]string `json:"Labels"`
+	// Scope is unused and provided solely for Docker compatibility. It is
+	// unconditionally set to "local".
+	Scope string `json:"Scope"`
+	// Options is a set of options that were used when creating the volume.
+	// For the Local driver, these are mount options that will be used to
+	// determine how a local filesystem is mounted; they are handled as
+	// parameters to Mount in a manner described in the volume create
+	// manpage.
+	// For non-local drivers, these are passed as-is to the volume plugin.
+	Options map[string]string `json:"Options"`
+	// UID is the UID that the volume was created with.
+	UID int `json:"UID,omitempty"`
+	// GID is the GID that the volume was created with.
+	GID int `json:"GID,omitempty"`
+	// Anonymous indicates that the volume was created as an anonymous
+	// volume for a specific container, and will be be removed when any
+	// container using it is removed.
+	Anonymous bool `json:"Anonymous,omitempty"`
+}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1549,17 +1549,6 @@ func WithVolumeDriver(driver string) VolumeCreateOption {
 			return define.ErrVolumeFinalized
 		}
 
-		// Uncomment when volume plugins are ready for use.
-		// if driver != define.VolumeDriverLocal {
-		// 	if _, err := plugin.GetVolumePlugin(driver); err != nil {
-		// 		return err
-		// 	}
-		// }
-
-		if driver != define.VolumeDriverLocal {
-			return define.ErrNotImplemented
-		}
-
 		volume.config.Driver = driver
 		return nil
 	}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/podman/v2/libpod/events"
 	"github.com/containers/podman/v2/libpod/image"
 	"github.com/containers/podman/v2/libpod/lock"
+	"github.com/containers/podman/v2/libpod/plugin"
 	"github.com/containers/podman/v2/libpod/shutdown"
 	"github.com/containers/podman/v2/pkg/cgroups"
 	"github.com/containers/podman/v2/pkg/registries"
@@ -887,4 +888,19 @@ func (r *Runtime) reloadStorageConf() error {
 	storage.ReloadConfigurationFile(configFile, &r.storageConfig)
 	logrus.Infof("applied new storage configuration: %v", r.storageConfig)
 	return nil
+}
+
+// getVolumePlugin gets a specific volume plugin given its name.
+func (r *Runtime) getVolumePlugin(name string) (*plugin.VolumePlugin, error) {
+	// There is no plugin for local.
+	if name == define.VolumeDriverLocal || name == "" {
+		return nil, nil
+	}
+
+	pluginPath, ok := r.config.Engine.VolumePlugins[name]
+	if !ok {
+		return nil, errors.Wrapf(define.ErrMissingPlugin, "no volume plugin with name %s available", name)
+	}
+
+	return plugin.GetVolumePlugin(name, pluginPath)
 }

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -22,13 +22,24 @@ func newVolume(runtime *Runtime) *Volume {
 
 // teardownStorage deletes the volume from volumePath
 func (v *Volume) teardownStorage() error {
+	if v.UsesVolumeDriver() {
+		return nil
+	}
+
+	// TODO: Should this be converted to use v.config.MountPoint?
 	return os.RemoveAll(filepath.Join(v.runtime.config.Engine.VolumePath, v.Name()))
 }
 
 // Volumes with options set, or a filesystem type, or a device to mount need to
 // be mounted and unmounted.
 func (v *Volume) needsMount() bool {
-	return len(v.config.Options) > 0 && v.config.Driver == define.VolumeDriverLocal
+	// Non-local driver always needs mount
+	if v.UsesVolumeDriver() {
+		return true
+	}
+
+	// Local driver with options needs mount
+	return len(v.config.Options) > 0
 }
 
 // update() updates the volume state from the DB.

--- a/pkg/api/handlers/compat/volumes.go
+++ b/pkg/api/handlers/compat/volumes.go
@@ -58,10 +58,15 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 	}
 	volumeConfigs := make([]*docker_api_types.Volume, 0, len(vols))
 	for _, v := range vols {
+		mp, err := v.MountPoint()
+		if err != nil {
+			utils.InternalServerError(w, err)
+			return
+		}
 		config := docker_api_types.Volume{
 			Name:       v.Name(),
 			Driver:     v.Driver(),
-			Mountpoint: v.MountPoint(),
+			Mountpoint: mp,
 			CreatedAt:  v.CreatedTime().Format(time.RFC3339),
 			Labels:     v.Labels(),
 			Scope:      v.Scope(),
@@ -106,11 +111,16 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 	// if using the compat layer and the volume already exists, we
 	// must return a 201 with the same information as create
 	if existingVolume != nil && !utils.IsLibpodRequest(r) {
+		mp, err := existingVolume.MountPoint()
+		if err != nil {
+			utils.InternalServerError(w, err)
+			return
+		}
 		response := docker_api_types.Volume{
 			CreatedAt:  existingVolume.CreatedTime().Format(time.RFC3339),
 			Driver:     existingVolume.Driver(),
 			Labels:     existingVolume.Labels(),
-			Mountpoint: existingVolume.MountPoint(),
+			Mountpoint: mp,
 			Name:       existingVolume.Name(),
 			Options:    existingVolume.Options(),
 			Scope:      existingVolume.Scope(),
@@ -146,10 +156,15 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
+	mp, err := vol.MountPoint()
+	if err != nil {
+		utils.InternalServerError(w, err)
+		return
+	}
 	volResponse := docker_api_types.Volume{
 		Name:       config.Name,
 		Driver:     config.Driver,
-		Mountpoint: config.MountPoint,
+		Mountpoint: mp,
 		CreatedAt:  config.CreatedTime.Format(time.RFC3339),
 		Labels:     config.Labels,
 		Options:    config.Options,
@@ -173,10 +188,15 @@ func InspectVolume(w http.ResponseWriter, r *http.Request) {
 		utils.VolumeNotFound(w, name, err)
 		return
 	}
+	mp, err := vol.MountPoint()
+	if err != nil {
+		utils.InternalServerError(w, err)
+		return
+	}
 	volResponse := docker_api_types.Volume{
 		Name:       vol.Name(),
 		Driver:     vol.Driver(),
-		Mountpoint: vol.MountPoint(),
+		Mountpoint: mp,
 		CreatedAt:  vol.CreatedTime().Format(time.RFC3339),
 		Labels:     vol.Labels(),
 		Options:    vol.Options(),

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -60,20 +60,13 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
-	config, err := vol.Config()
+	inspectOut, err := vol.Inspect()
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
 	}
 	volResponse := entities.VolumeConfigResponse{
-		Name:       config.Name,
-		Driver:     config.Driver,
-		Mountpoint: config.MountPoint,
-		CreatedAt:  config.CreatedTime,
-		Labels:     config.Labels,
-		Options:    config.Options,
-		UID:        config.UID,
-		GID:        config.GID,
+		InspectVolumeData: *inspectOut,
 	}
 	utils.WriteResponse(w, http.StatusCreated, volResponse)
 }
@@ -88,27 +81,13 @@ func InspectVolume(w http.ResponseWriter, r *http.Request) {
 		utils.VolumeNotFound(w, name, err)
 		return
 	}
-	var uid, gid int
-	uid, err = vol.UID()
+	inspectOut, err := vol.Inspect()
 	if err != nil {
-		utils.Error(w, "Error fetching volume UID", http.StatusInternalServerError, err)
-		return
-	}
-	gid, err = vol.GID()
-	if err != nil {
-		utils.Error(w, "Error fetching volume GID", http.StatusInternalServerError, err)
+		utils.InternalServerError(w, err)
 		return
 	}
 	volResponse := entities.VolumeConfigResponse{
-		Name:       vol.Name(),
-		Driver:     vol.Driver(),
-		Mountpoint: vol.MountPoint(),
-		CreatedAt:  vol.CreatedTime(),
-		Labels:     vol.Labels(),
-		Scope:      vol.Scope(),
-		Options:    vol.Options(),
-		UID:        uid,
-		GID:        gid,
+		InspectVolumeData: *inspectOut,
 	}
 	utils.WriteResponse(w, http.StatusOK, volResponse)
 }
@@ -143,27 +122,13 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 	}
 	volumeConfigs := make([]*entities.VolumeListReport, 0, len(vols))
 	for _, v := range vols {
-		var uid, gid int
-		uid, err = v.UID()
+		inspectOut, err := v.Inspect()
 		if err != nil {
-			utils.Error(w, "Error fetching volume UID", http.StatusInternalServerError, err)
-			return
-		}
-		gid, err = v.GID()
-		if err != nil {
-			utils.Error(w, "Error fetching volume GID", http.StatusInternalServerError, err)
+			utils.InternalServerError(w, err)
 			return
 		}
 		config := entities.VolumeConfigResponse{
-			Name:       v.Name(),
-			Driver:     v.Driver(),
-			Mountpoint: v.MountPoint(),
-			CreatedAt:  v.CreatedTime(),
-			Labels:     v.Labels(),
-			Scope:      v.Scope(),
-			Options:    v.Options(),
-			UID:        uid,
-			GID:        gid,
+			InspectVolumeData: *inspectOut,
 		}
 		volumeConfigs = append(volumeConfigs, &entities.VolumeListReport{VolumeConfigResponse: config})
 	}

--- a/pkg/domain/entities/volumes.go
+++ b/pkg/domain/entities/volumes.go
@@ -2,8 +2,8 @@ package entities
 
 import (
 	"net/url"
-	"time"
 
+	"github.com/containers/podman/v2/libpod/define"
 	docker_api_types "github.com/docker/docker/api/types"
 	docker_api_types_volume "github.com/docker/docker/api/types/volume"
 )
@@ -26,38 +26,7 @@ type IDOrNameResponse struct {
 }
 
 type VolumeConfigResponse struct {
-	// Name is the name of the volume.
-	Name string `json:"Name"`
-	// Driver is the driver used to create the volume.
-	// This will be properly implemented in a future version.
-	Driver string `json:"Driver"`
-	// Mountpoint is the path on the host where the volume is mounted.
-	Mountpoint string `json:"Mountpoint"`
-	// CreatedAt is the date and time the volume was created at. This is not
-	// stored for older Libpod volumes; if so, it will be omitted.
-	CreatedAt time.Time `json:"CreatedAt,omitempty"`
-	// Status is presently unused and provided only for Docker compatibility.
-	// In the future it will be used to return information on the volume's
-	// current state.
-	Status map[string]string `json:"Status,omitempty"`
-	// Labels includes the volume's configured labels, key:value pairs that
-	// can be passed during volume creation to provide information for third
-	// party tools.
-	Labels map[string]string `json:"Labels"`
-	// Scope is unused and provided solely for Docker compatibility. It is
-	// unconditionally set to "local".
-	Scope string `json:"Scope"`
-	// Options is a set of options that were used when creating the volume.
-	// It is presently not used.
-	Options map[string]string `json:"Options"`
-	// UID is the UID that the volume was created with.
-	UID int `json:"UID"`
-	// GID is the GID that the volume was created with.
-	GID int `json:"GID"`
-	// Anonymous indicates that the volume was created as an anonymous
-	// volume for a specific container, and will be be removed when any
-	// container using it is removed.
-	Anonymous bool `json:"Anonymous"`
+	define.InspectVolumeData
 }
 
 // VolumeInfo Volume list response

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -312,7 +312,17 @@ func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.System
 	var reclaimableSize int64
 	for _, v := range vols {
 		var consInUse int
-		volSize, err := sizeOfPath(v.MountPoint())
+		mountPoint, err := v.MountPoint()
+		if err != nil {
+			return nil, err
+		}
+		if mountPoint == "" {
+			// We can't get any info on this volume, as it's not
+			// mounted.
+			// TODO: fix this.
+			continue
+		}
+		volSize, err := sizeOfPath(mountPoint)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -103,25 +103,12 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 	}
 	reports := make([]*entities.VolumeInspectReport, 0, len(vols))
 	for _, v := range vols {
-		var uid, gid int
-		uid, err = v.UID()
-		if err != nil {
-			return nil, nil, err
-		}
-		gid, err = v.GID()
+		inspectOut, err := v.Inspect()
 		if err != nil {
 			return nil, nil, err
 		}
 		config := entities.VolumeConfigResponse{
-			Name:       v.Name(),
-			Driver:     v.Driver(),
-			Mountpoint: v.MountPoint(),
-			CreatedAt:  v.CreatedTime(),
-			Labels:     v.Labels(),
-			Scope:      v.Scope(),
-			Options:    v.Options(),
-			UID:        uid,
-			GID:        gid,
+			InspectVolumeData: *inspectOut,
 		}
 		reports = append(reports, &entities.VolumeInspectReport{VolumeConfigResponse: &config})
 	}
@@ -155,25 +142,12 @@ func (ic *ContainerEngine) VolumeList(ctx context.Context, opts entities.VolumeL
 	}
 	reports := make([]*entities.VolumeListReport, 0, len(vols))
 	for _, v := range vols {
-		var uid, gid int
-		uid, err = v.UID()
-		if err != nil {
-			return nil, err
-		}
-		gid, err = v.GID()
+		inspectOut, err := v.Inspect()
 		if err != nil {
 			return nil, err
 		}
 		config := entities.VolumeConfigResponse{
-			Name:       v.Name(),
-			Driver:     v.Driver(),
-			Mountpoint: v.MountPoint(),
-			CreatedAt:  v.CreatedTime(),
-			Labels:     v.Labels(),
-			Scope:      v.Scope(),
-			Options:    v.Options(),
-			UID:        uid,
-			GID:        gid,
+			InspectVolumeData: *inspectOut,
 		}
 		reports = append(reports, &entities.VolumeListReport{VolumeConfigResponse: config})
 	}

--- a/test/apiv2/30-volumes.at
+++ b/test/apiv2/30-volumes.at
@@ -12,7 +12,7 @@ t POST libpod/volumes/create name=foo1  201 \
     .Mountpoint=$volumepath/foo1/_data \
     .CreatedAt~[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}.* \
     .Labels={} \
-    .Options=null
+    .Options={}
 t POST libpod/volumes/create ''  201
 t POST libpod/volumes/create \
     '"Name":"foo2","Label":{"testlabel":"testonly"},"Options":{"type":"tmpfs","o":"nodev,noexec"}}' 201 \

--- a/test/apiv2/45-system.at
+++ b/test/apiv2/45-system.at
@@ -19,7 +19,7 @@ t POST libpod/volumes/create name=foo1  201 \
     .Mountpoint=$volumepath/foo1/_data \
     .CreatedAt~[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}.* \
     .Labels={} \
-    .Options=null
+    .Options={}
 
 t GET system/df 200 '.Volumes[0].Name=foo1'
 

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -623,7 +623,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result := podmanTest.Podman([]string{"container", "checkpoint", "-l"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).To(ExitWithError())
-		Expect(result.ErrorToString()).To(ContainSubstring("Cannot checkpoint containers that have been started with '--rm'"))
+		Expect(result.ErrorToString()).To(ContainSubstring("cannot checkpoint containers that have been started with '--rm'"))
 
 		// Checkpointing with --export should still work
 		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -122,7 +122,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	}
 
 	// Pull cirros but don't put it into the cache
-	pullImages := []string{cirros, fedoraToolbox}
+	pullImages := []string{cirros, fedoraToolbox, volumeTest}
 	pullImages = append(pullImages, CACHE_IMAGES...)
 	for _, image := range pullImages {
 		podman.createArtifact(image)
@@ -483,13 +483,7 @@ func (p *PodmanTestIntegration) CleanupVolume() {
 	session := p.Podman([]string{"volume", "rm", "-fa"})
 	session.Wait(90)
 
-	// Stop remove service on volume cleanup
-	p.StopRemoteService()
-
-	// Nuke tempdir
-	if err := os.RemoveAll(p.TempDir); err != nil {
-		fmt.Printf("%q\n", err)
-	}
+	p.Cleanup()
 }
 
 // InspectContainerToJSON takes the session output of an inspect

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -15,6 +15,7 @@ var (
 	healthcheck       = "quay.io/libpod/alpine_healthcheck:latest"
 	ImageCacheDir     = "/tmp/podman/imagecachedir"
 	fedoraToolbox     = "registry.fedoraproject.org/f32/fedora-toolbox:latest"
+	volumeTest        = "quay.io/libpod/volume-plugin-test-img:latest"
 
 	// This image has seccomp profiles that blocks all syscalls.
 	// The intention behind blocking all syscalls is to prevent

--- a/test/e2e/config/containers.conf
+++ b/test/e2e/config/containers.conf
@@ -56,3 +56,17 @@ umask = "0002"
 [engine]
 
 network_cmd_options=["allow_host_loopback=true"]
+
+# We need to ensure each test runs on a separate plugin instance...
+# For now, let's just make a bunch of plugin paths and have each test use one.
+[engine.volume_plugins]
+testvol0 = "/run/docker/plugins/testvol0.sock"
+testvol1 = "/run/docker/plugins/testvol1.sock"
+testvol2 = "/run/docker/plugins/testvol2.sock"
+testvol3 = "/run/docker/plugins/testvol3.sock"
+testvol4 = "/run/docker/plugins/testvol4.sock"
+testvol5 = "/run/docker/plugins/testvol5.sock"
+testvol6 = "/run/docker/plugins/testvol6.sock"
+testvol7 = "/run/docker/plugins/testvol7.sock"
+testvol8 = "/run/docker/plugins/testvol8.sock"
+testvol9 = "/run/docker/plugins/testvol9.sock"

--- a/test/e2e/volume_plugin_test.go
+++ b/test/e2e/volume_plugin_test.go
@@ -1,0 +1,184 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/containers/podman/v2/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman volume plugins", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest *PodmanTestIntegration
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanTestCreate(tempdir)
+		podmanTest.Setup()
+		podmanTest.SeedImages()
+		os.Setenv("CONTAINERS_CONF", "config/containers.conf")
+		SkipIfRemote("Volume plugins only supported as local")
+		SkipIfRootless("Root is required for volume plugin testing")
+		os.MkdirAll("/run/docker/plugins", 0755)
+	})
+
+	AfterEach(func() {
+		podmanTest.CleanupVolume()
+		f := CurrentGinkgoTestDescription()
+		processTestResult(f)
+		os.Unsetenv("CONTAINERS_CONF")
+	})
+
+	It("volume create with nonexistent plugin errors", func() {
+		session := podmanTest.Podman([]string{"volume", "create", "--driver", "notexist", "test_volume_name"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+	})
+
+	It("volume create with not-running plugin does not error", func() {
+		session := podmanTest.Podman([]string{"volume", "create", "--driver", "testvol0", "test_volume_name"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+	})
+
+	It("volume create and remove with running plugin succeeds", func() {
+		podmanTest.AddImageToRWStore(volumeTest)
+
+		pluginStatePath := filepath.Join(podmanTest.TempDir, "volumes")
+		os.Mkdir(pluginStatePath, 0755)
+
+		// Keep this distinct within tests to avoid multiple tests using the same plugin.
+		pluginName := "testvol1"
+		plugin := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
+		plugin.WaitWithDefaultTimeout()
+		Expect(plugin.ExitCode()).To(Equal(0))
+
+		volName := "testVolume1"
+		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(Equal(0))
+
+		ls1 := podmanTest.Podman([]string{"volume", "ls", "-q"})
+		ls1.WaitWithDefaultTimeout()
+		Expect(ls1.ExitCode()).To(Equal(0))
+		arrOutput := ls1.OutputToStringArray()
+		Expect(len(arrOutput)).To(Equal(1))
+		Expect(arrOutput[0]).To(ContainSubstring(volName))
+
+		remove := podmanTest.Podman([]string{"volume", "rm", volName})
+		remove.WaitWithDefaultTimeout()
+		Expect(remove.ExitCode()).To(Equal(0))
+
+		ls2 := podmanTest.Podman([]string{"volume", "ls", "-q"})
+		ls2.WaitWithDefaultTimeout()
+		Expect(ls2.ExitCode()).To(Equal(0))
+		Expect(len(ls2.OutputToStringArray())).To(Equal(0))
+	})
+
+	It("volume inspect with running plugin succeeds", func() {
+		podmanTest.AddImageToRWStore(volumeTest)
+
+		pluginStatePath := filepath.Join(podmanTest.TempDir, "volumes")
+		os.Mkdir(pluginStatePath, 0755)
+
+		// Keep this distinct within tests to avoid multiple tests using the same plugin.
+		pluginName := "testvol2"
+		plugin := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
+		plugin.WaitWithDefaultTimeout()
+		Expect(plugin.ExitCode()).To(Equal(0))
+
+		volName := "testVolume1"
+		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(Equal(0))
+
+		volInspect := podmanTest.Podman([]string{"volume", "inspect", "--format", "{{ .Driver }}", volName})
+		volInspect.WaitWithDefaultTimeout()
+		Expect(volInspect.ExitCode()).To(Equal(0))
+		Expect(volInspect.OutputToString()).To(ContainSubstring(pluginName))
+	})
+
+	It("remove plugin with stopped plugin succeeds", func() {
+		podmanTest.AddImageToRWStore(volumeTest)
+
+		pluginStatePath := filepath.Join(podmanTest.TempDir, "volumes")
+		os.Mkdir(pluginStatePath, 0755)
+
+		// Keep this distinct within tests to avoid multiple tests using the same plugin.
+		pluginName := "testvol3"
+		ctrName := "pluginCtr"
+		plugin := podmanTest.Podman([]string{"run", "--name", ctrName, "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
+		plugin.WaitWithDefaultTimeout()
+		Expect(plugin.ExitCode()).To(Equal(0))
+
+		volName := "testVolume1"
+		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(Equal(0))
+
+		ls1 := podmanTest.Podman([]string{"volume", "ls", "-q"})
+		ls1.WaitWithDefaultTimeout()
+		Expect(ls1.ExitCode()).To(Equal(0))
+		arrOutput := ls1.OutputToStringArray()
+		Expect(len(arrOutput)).To(Equal(1))
+		Expect(arrOutput[0]).To(ContainSubstring(volName))
+
+		stop := podmanTest.Podman([]string{"stop", "--timeout", "0", ctrName})
+		stop.WaitWithDefaultTimeout()
+		Expect(stop.ExitCode()).To(Equal(0))
+
+		// Remove should exit non-zero because missing plugin
+		remove := podmanTest.Podman([]string{"volume", "rm", volName})
+		remove.WaitWithDefaultTimeout()
+		Expect(remove.ExitCode()).To(Not(Equal(0)))
+
+		// But the volume should still be gone
+		ls2 := podmanTest.Podman([]string{"volume", "ls", "-q"})
+		ls2.WaitWithDefaultTimeout()
+		Expect(ls2.ExitCode()).To(Equal(0))
+		Expect(len(ls2.OutputToStringArray())).To(Equal(0))
+	})
+
+	It("use plugin in containers", func() {
+		podmanTest.AddImageToRWStore(volumeTest)
+
+		pluginStatePath := filepath.Join(podmanTest.TempDir, "volumes")
+		os.Mkdir(pluginStatePath, 0755)
+
+		// Keep this distinct within tests to avoid multiple tests using the same plugin.
+		pluginName := "testvol4"
+		plugin := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", "/run/docker/plugins:/run/docker/plugins", "-v", fmt.Sprintf("%v:%v", pluginStatePath, pluginStatePath), "-d", volumeTest, "--sock-name", pluginName, "--path", pluginStatePath})
+		plugin.WaitWithDefaultTimeout()
+		Expect(plugin.ExitCode()).To(Equal(0))
+
+		volName := "testVolume1"
+		create := podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, volName})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(Equal(0))
+
+		ctr1 := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", fmt.Sprintf("%v:/test", volName), ALPINE, "sh", "-c", "touch /test/testfile && echo helloworld > /test/testfile"})
+		ctr1.WaitWithDefaultTimeout()
+		Expect(ctr1.ExitCode()).To(Equal(0))
+
+		ctr2 := podmanTest.Podman([]string{"run", "--security-opt", "label=disable", "-v", fmt.Sprintf("%v:/test", volName), ALPINE, "cat", "/test/testfile"})
+		ctr2.WaitWithDefaultTimeout()
+		Expect(ctr2.ExitCode()).To(Equal(0))
+		Expect(ctr2.OutputToString()).To(ContainSubstring("helloworld"))
+
+		// HACK: `volume rm -f` is timing out trying to remove containers using the volume.
+		// Solution: remove them manually...
+		// TODO: fix this when I get back
+		rmAll := podmanTest.Podman([]string{"rm", "-af"})
+		rmAll.WaitWithDefaultTimeout()
+		Expect(rmAll.ExitCode()).To(Equal(0))
+	})
+})

--- a/test/python/docker/test_containers.py
+++ b/test/python/docker/test_containers.py
@@ -179,11 +179,3 @@ class TestContainers(unittest.TestCase):
         filters = {"name": "top"}
         ctnrs = self.client.containers.list(all=True, filters=filters)
         self.assertEqual(len(ctnrs), 1)
-
-    def test_rename_container(self):
-        top = self.client.containers.get(TestContainers.topContainerId)
-
-        # rename bogus container
-        with self.assertRaises(errors.APIError) as error:
-            top.rename(name="newname")
-        self.assertEqual(error.exception.response.status_code, 404)

--- a/test/testvol/main.go
+++ b/test/testvol/main.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/docker/go-plugins-helpers/volume"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "testvol",
+	Short: "testvol - volume plugin for Podman",
+	Long:  `Creates simple directory volumes using the Volume Plugin API for testing volume plugin functionality`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return startServer(config.sockName)
+	},
+	PersistentPreRunE: before,
+}
+
+// Configuration for the volume plugin
+type cliConfig struct {
+	logLevel string
+	sockName string
+	path     string
+}
+
+// Default configuration is stored here. Will be overwritten by flags.
+var config cliConfig = cliConfig{
+	logLevel: "error",
+	sockName: "test-volume-plugin",
+}
+
+func init() {
+	rootCmd.Flags().StringVar(&config.sockName, "sock-name", config.sockName, "Name of unix socket for plugin")
+	rootCmd.Flags().StringVar(&config.path, "path", "", "Path to initialize state and mount points")
+	rootCmd.PersistentFlags().StringVar(&config.logLevel, "log-level", config.logLevel, "Log messages including and over the specified level: debug, info, warn, error, fatal, panic")
+}
+
+func before(cmd *cobra.Command, args []string) error {
+	if config.logLevel == "" {
+		config.logLevel = "error"
+	}
+
+	level, err := logrus.ParseLevel(config.logLevel)
+	if err != nil {
+		return err
+	}
+
+	logrus.SetLevel(level)
+
+	return nil
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Errorf("Error running volume plugin: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+// startServer runs the HTTP server and responds to requests
+func startServer(socketPath string) error {
+	logrus.Debugf("Starting server...")
+
+	if config.path == "" {
+		path, err := ioutil.TempDir("", "test_volume_plugin")
+		if err != nil {
+			return errors.Wrapf(err, "error getting directory for plugin")
+		}
+		config.path = path
+	} else {
+		pathStat, err := os.Stat(config.path)
+		if err != nil {
+			return errors.Wrapf(err, "unable to access requested plugin state directory")
+		}
+		if !pathStat.IsDir() {
+			return errors.Errorf("cannot use %v as plugin state dir as it is not a directory", config.path)
+		}
+	}
+
+	handle, err := makeDirDriver(config.path)
+	if err != nil {
+		return errors.Wrapf(err, "error making volume driver")
+	}
+	logrus.Infof("Using %s for volume path", config.path)
+
+	server := volume.NewHandler(handle)
+	if err := server.ServeUnix(socketPath, 0); err != nil {
+		return errors.Wrapf(err, "error starting server")
+	}
+	return nil
+}
+
+// DirDriver is a trivial volume driver implementation.
+// the volumes field maps name to volume
+type DirDriver struct {
+	lock        sync.Mutex
+	volumesPath string
+	volumes     map[string]*dirVol
+}
+
+type dirVol struct {
+	name       string
+	path       string
+	options    map[string]string
+	mounts     map[string]bool
+	createTime time.Time
+}
+
+// Make a new DirDriver.
+func makeDirDriver(path string) (volume.Driver, error) {
+	drv := new(DirDriver)
+	drv.volumesPath = path
+	drv.volumes = make(map[string]*dirVol)
+
+	return drv, nil
+}
+
+// Capabilities returns the capabilities of the driver.
+func (d *DirDriver) Capabilities() *volume.CapabilitiesResponse {
+	logrus.Infof("Hit Capabilities() endpoint")
+
+	return &volume.CapabilitiesResponse{
+		volume.Capability{
+			"local",
+		},
+	}
+}
+
+// Create creates a volume.
+func (d *DirDriver) Create(opts *volume.CreateRequest) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	logrus.Infof("Hit Create() endpoint")
+
+	if _, exists := d.volumes[opts.Name]; exists {
+		return errors.Errorf("volume with name %s already exists", opts.Name)
+	}
+
+	newVol := new(dirVol)
+	newVol.name = opts.Name
+	newVol.mounts = make(map[string]bool)
+	newVol.options = make(map[string]string)
+	newVol.createTime = time.Now()
+	for k, v := range opts.Options {
+		newVol.options[k] = v
+	}
+
+	volPath := filepath.Join(d.volumesPath, opts.Name)
+	if err := os.Mkdir(volPath, 0755); err != nil {
+		return errors.Wrapf(err, "error making volume directory")
+	}
+	newVol.path = volPath
+
+	d.volumes[opts.Name] = newVol
+
+	logrus.Debugf("Made volume with name %s and path %s", newVol.name, newVol.path)
+
+	return nil
+}
+
+// List lists all volumes available.
+func (d *DirDriver) List() (*volume.ListResponse, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	logrus.Infof("Hit List() endpoint")
+
+	vols := new(volume.ListResponse)
+	vols.Volumes = []*volume.Volume{}
+
+	for _, vol := range d.volumes {
+		newVol := new(volume.Volume)
+		newVol.Name = vol.name
+		newVol.Mountpoint = vol.path
+		newVol.CreatedAt = vol.createTime.String()
+		vols.Volumes = append(vols.Volumes, newVol)
+		logrus.Debugf("Adding volume %s to list response", newVol.Name)
+	}
+
+	return vols, nil
+}
+
+// Get retrieves a single volume.
+func (d *DirDriver) Get(req *volume.GetRequest) (*volume.GetResponse, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	logrus.Infof("Hit Get() endpoint")
+
+	vol, exists := d.volumes[req.Name]
+	if !exists {
+		logrus.Debugf("Did not find volume %s", req.Name)
+		return nil, errors.Errorf("no volume with name %s found", req.Name)
+	}
+
+	logrus.Debugf("Found volume %s", req.Name)
+
+	resp := new(volume.GetResponse)
+	resp.Volume = new(volume.Volume)
+	resp.Volume.Name = vol.name
+	resp.Volume.Mountpoint = vol.path
+	resp.Volume.CreatedAt = vol.createTime.String()
+
+	return resp, nil
+}
+
+// Remove removes a single volume.
+func (d *DirDriver) Remove(req *volume.RemoveRequest) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	logrus.Infof("Hit Remove() endpoint")
+
+	vol, exists := d.volumes[req.Name]
+	if !exists {
+		logrus.Debugf("Did not find volume %s", req.Name)
+		return errors.Errorf("no volume with name %s found")
+	}
+	logrus.Debugf("Found volume %s", req.Name)
+
+	if len(vol.mounts) > 0 {
+		logrus.Debugf("Cannot remove %s, is mounted", req.Name)
+		return errors.Errorf("volume %s is mounted and cannot be removed")
+	}
+
+	delete(d.volumes, req.Name)
+
+	if err := os.RemoveAll(vol.path); err != nil {
+		return errors.Wrapf(err, "error removing mountpoint of volume %s", req.Name)
+	}
+
+	logrus.Debugf("Removed volume %s", req.Name)
+
+	return nil
+}
+
+// Path returns the path a single volume is mounted at.
+func (d *DirDriver) Path(req *volume.PathRequest) (*volume.PathResponse, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	logrus.Infof("Hit Path() endpoint")
+
+	// TODO: Should we return error if not mounted?
+
+	vol, exists := d.volumes[req.Name]
+	if !exists {
+		logrus.Debugf("Cannot locate volume %s", req.Name)
+		return nil, errors.Errorf("no volume with name %s found", req.Name)
+	}
+
+	return &volume.PathResponse{
+		vol.path,
+	}, nil
+}
+
+// Mount mounts the volume.
+func (d *DirDriver) Mount(req *volume.MountRequest) (*volume.MountResponse, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	logrus.Infof("Hit Mount() endpoint")
+
+	vol, exists := d.volumes[req.Name]
+	if !exists {
+		logrus.Debugf("Cannot locate volume %s", req.Name)
+		return nil, errors.Errorf("no volume with name %s found", req.Name)
+	}
+
+	vol.mounts[req.ID] = true
+
+	return &volume.MountResponse{
+		vol.path,
+	}, nil
+}
+
+// Unmount unmounts the volume.
+func (d *DirDriver) Unmount(req *volume.UnmountRequest) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	logrus.Infof("Hit Unmount() endpoint")
+
+	vol, exists := d.volumes[req.Name]
+	if !exists {
+		logrus.Debugf("Cannot locate volume %s", req.Name)
+		return errors.Errorf("no volume with name %s found", req.Name)
+	}
+
+	mount := vol.mounts[req.ID]
+	if !mount {
+		logrus.Debugf("Volume %s is not mounted by %s", req.Name, req.ID)
+		return errors.Errorf("volume %s is not mounted by %s", req.Name, req.ID)
+	}
+
+	delete(vol.mounts, req.ID)
+
+	return nil
+}


### PR DESCRIPTION
This implements support for mounting and unmounting volumes backed by volume plugins. Support for actually retrieving plugins requires a pull request to land in containers.conf and then that to be vendored, and as such is not yet ready. Given this, this code is only compile tested. However, the code for everything past retrieving the plugin has been written - there is support for creating, removing, mounting, and unmounting volumes, which should allow full functionality once the c/common PR is merged.

A major change is the signature of the MountPoint function for volumes, which now, by necessity, returns an error. Named volumes managed by a plugin do not have a mountpoint we control; instead, it is managed entirely by the plugin. As such, we need to cache the path in the DB, and calls to retrieve it now need to access the DB (and may fail as such).

Notably absent is support for SELinux relabelling and chowning these volumes. Given that we don't manage the mountpoint for these volumes, I am extremely reluctant to try and modify it - we could easily break the plugin trying to chown or relabel it.

Fixes #4304
