### PR TITLE
Jira RUN-1106 System handlers updates

### DIFF
--- a/pkg/api/handlers/compat/ping.go
+++ b/pkg/api/handlers/compat/ping.go
@@ -15,6 +15,7 @@ import (
 func Ping(w http.ResponseWriter, r *http.Request) {
 	// Note API-Version and Libpod-API-Version are set in handler_api.go
 	w.Header().Set("BuildKit-Version", "")
+	w.Header().Set("Builder-Version", "")
 	w.Header().Set("Docker-Experimental", "true")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Pragma", "no-cache")

--- a/pkg/api/handlers/compat/system.go
+++ b/pkg/api/handlers/compat/system.go
@@ -2,17 +2,91 @@ package compat
 
 import (
 	"net/http"
+	"strings"
 
+	"github.com/containers/podman/v2/libpod"
 	"github.com/containers/podman/v2/pkg/api/handlers"
 	"github.com/containers/podman/v2/pkg/api/handlers/utils"
+	"github.com/containers/podman/v2/pkg/domain/entities"
+	"github.com/containers/podman/v2/pkg/domain/infra/abi"
 	docker "github.com/docker/docker/api/types"
 )
 
 func GetDiskUsage(w http.ResponseWriter, r *http.Request) {
+	options := entities.SystemDfOptions{}
+	runtime := r.Context().Value("runtime").(*libpod.Runtime)
+	ic := abi.ContainerEngine{Libpod: runtime}
+	df, err := ic.SystemDf(r.Context(), options)
+	if err != nil {
+		utils.InternalServerError(w, err)
+	}
+
+	imgs := make([]*docker.ImageSummary, len(df.Images))
+	for i, o := range df.Images {
+		t := docker.ImageSummary{
+			Containers:  int64(o.Containers),
+			Created:     o.Created.Unix(),
+			ID:          o.ImageID,
+			Labels:      map[string]string{},
+			ParentID:    "",
+			RepoDigests: nil,
+			RepoTags:    []string{o.Tag},
+			SharedSize:  o.SharedSize,
+			Size:        o.Size,
+			VirtualSize: o.Size - o.UniqueSize,
+		}
+		imgs[i] = &t
+	}
+
+	ctnrs := make([]*docker.Container, len(df.Containers))
+	for i, o := range df.Containers {
+		t := docker.Container{
+			ID:         o.ContainerID,
+			Names:      []string{o.Names},
+			Image:      o.Image,
+			ImageID:    o.Image,
+			Command:    strings.Join(o.Command, " "),
+			Created:    o.Created.Unix(),
+			Ports:      nil,
+			SizeRw:     o.RWSize,
+			SizeRootFs: o.Size,
+			Labels:     map[string]string{},
+			State:      o.Status,
+			Status:     o.Status,
+			HostConfig: struct {
+				NetworkMode string `json:",omitempty"`
+			}{},
+			NetworkSettings: nil,
+			Mounts:          nil,
+		}
+		ctnrs[i] = &t
+	}
+
+	vols := make([]*docker.Volume, len(df.Volumes))
+	for i, o := range df.Volumes {
+		t := docker.Volume{
+			CreatedAt:  "",
+			Driver:     "",
+			Labels:     map[string]string{},
+			Mountpoint: "",
+			Name:       o.VolumeName,
+			Options:    nil,
+			Scope:      "local",
+			Status:     nil,
+			UsageData: &docker.VolumeUsageData{
+				RefCount: 1,
+				Size:     o.Size,
+			},
+		}
+		vols[i] = &t
+	}
+
 	utils.WriteResponse(w, http.StatusOK, handlers.DiskUsage{DiskUsage: docker.DiskUsage{
-		LayersSize: 0,
-		Images:     nil,
-		Containers: nil,
-		Volumes:    nil,
+		LayersSize:  0,
+		Images:      imgs,
+		Containers:  ctnrs,
+		Volumes:     vols,
+		BuildCache:  []*docker.BuildCache{},
+		BuilderSize: 0,
 	}})
 }


### PR DESCRIPTION
* Update tests to reflect system endpoints
* First implementation of compat /system/df, only fields that are
  populated by libpod are set

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
