### PR TITLE
Prefer read/write images over read/only images

### DIFF
--- a/test/e2e/exists_test.go
+++ b/test/e2e/exists_test.go
@@ -38,7 +38,6 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session).Should(Exit(0))
 	})
 	It("podman image exists in local storage by short name", func() {
-		Skip("FIXME-8165: shortnames don't seem to work with quay (#8176)")
 		session := podmanTest.Podman([]string{"image", "exists", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))


### PR DESCRIPTION
With additional stores there is a risk that you could have
multiple images with the same name.  IE An older image in a
read/only store versus a newer version in the read/write store.

This patch will ignore multiple images with the same name iff
one is read/write and all of the others are read/only.  It will
still return errors if only multiple read/only images or multiple
read/write images exists. Multipl read/write images should be
impossible.

Fixes: https://github.com/containers/podman/issues/8176

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
