### PR TITLE
[CI:DOCS] Update Website Link for Install Instructions

### DIFF
--- a/install.md
+++ b/install.md
@@ -1,5 +1,5 @@
 # libpod Installation Instructions
 
-The installation instructions for Podman and libpod now reside **[here](https://podman.io/getting-started/installation)** in the **[podman.io](https://podman.io)** site.  From the homepage, the installation instructions can be found under "Get Started->Installing Podman".
+The installation instructions for Podman and libpod now reside **[here](https://podman.io/getting-started/installation)** on the **[podman.io](https://podman.io)** site.
 
-The podman.io site resides in a GitHub under the Containers repository at [https://github.com/containers/podman.io](https://github.com/containers/podman.io).  If you see a change that needs to happen to the installation instructions, please feel free to open a pull request there, we're always happy to have new contributors!
+The podman.io site resides in a GitHub repository under the containers organization at [https://github.com/containers/podman.io](https://github.com/containers/podman.io). If you see a change that needs to happen to the installation instructions, please feel free to open a pull request there. We're always happy to have new contributors!


### PR DESCRIPTION
This pull request makes minor changes to `install.md`:
* More direct link to website install instructions to assist users finding install instructions through GitHub
* Minor language edits
