### PR TITLE
container create: do not clear image name

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -98,7 +98,6 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		// present.
 		imgName := newImage.InputName
 		if s.Image == newImage.InputName && strings.HasPrefix(newImage.ID(), s.Image) {
-			imgName = ""
 			names := newImage.Names()
 			if len(names) > 0 {
 				imgName = names[0]

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -536,6 +536,17 @@ json-file | f
     run_podman untag $IMAGE $newtag $newtag2
 }
 
+# Regression test for issue #8558
+@test "podman run on untagged image: make sure that image metadata is set" {
+    run_podman inspect $IMAGE --format "{{.ID}}"
+    imageID="$output"
+
+    run_podman untag $IMAGE
+    run_podman run --rm $imageID ls
+
+    run_podman tag $imageID $IMAGE
+}
+
 @test "Verify /run/.containerenv exist" {
 	run_podman run --rm $IMAGE ls -1 /run/.containerenv
 	is "$output" "/run/.containerenv"


### PR DESCRIPTION
When creating a container, do not clear the input-image name before
looking up image names.  Also add a regression test.

Fixes: #8558
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
