### PR TITLE
Docker compat API - containers create ignores the name

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -37,6 +37,9 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Override the container name in the body struct
+	body.Name = query.Name
+
 	if len(body.HostConfig.Links) > 0 {
 		utils.Error(w, utils.ErrLinkNotSupport.Error(), http.StatusBadRequest, errors.Wrapf(utils.ErrLinkNotSupport, "bad parameter"))
 		return
@@ -68,9 +71,6 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "fill out specgen"))
 		return
 	}
-
-	// Override the container name in the body struct
-	body.Name = query.Name
 
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.ContainerCreate(r.Context(), sg)

--- a/test/apiv2/rest_api/test_rest_v2_0_0.py
+++ b/test/apiv2/rest_api/test_rest_v2_0_0.py
@@ -181,7 +181,7 @@ class TestApi(unittest.TestCase):
         self.assertEqual(net_default.status_code, 201, net_default.text)
 
         create = requests.post(
-            PODMAN_URL + "/v1.40/containers/create?name=postCreate",
+            PODMAN_URL + "/v1.40/containers/create?name=postCreateConnect",
             json={
                 "Cmd": ["top"],
                 "Image": "alpine:latest",


### PR DESCRIPTION
/containers/create compat endpoint does not set the name
correctly (#7857)

Signed-off-by: Milivoje Legenovic <m.legenovic@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
