### PR TITLE
[CI:DOCS] add comment to #8558 regression test

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -541,6 +541,8 @@ json-file | f
     run_podman inspect $IMAGE --format "{{.ID}}"
     imageID="$output"
 
+    # prior to #8623 `podman run` would error out on untagged images with:
+    # Error: both RootfsImageName and RootfsImageID must be set if either is set: invalid argument
     run_podman untag $IMAGE
     run_podman run --rm $imageID ls
 


### PR DESCRIPTION
As suggested by @edsantiago, add a comment to the regression test
of #8558 to better document the context.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
