### PR TITLE
Do not error on installing duplicate shutdown handler

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -190,7 +190,7 @@ func newRuntimeFromConfig(ctx context.Context, conf *config.Config, options ...R
 	if err := shutdown.Register("libpod", func(sig os.Signal) error {
 		os.Exit(1)
 		return nil
-	}); err != nil {
+	}); err != nil && errors.Cause(err) != shutdown.ErrHandlerExists {
 		logrus.Errorf("Error registering shutdown handler for libpod: %v", err)
 	}
 

--- a/libpod/shutdown/handler.go
+++ b/libpod/shutdown/handler.go
@@ -11,6 +11,10 @@ import (
 )
 
 var (
+	ErrHandlerExists error = errors.New("handler with given name already exists")
+)
+
+var (
 	stopped    bool
 	sigChan    chan os.Signal
 	cancelChan chan bool
@@ -98,7 +102,7 @@ func Register(name string, handler func(os.Signal) error) error {
 	}
 
 	if _, ok := handlers[name]; ok {
-		return errors.Errorf("handler with name %s already exists", name)
+		return ErrHandlerExists
 	}
 
 	handlers[name] = handler


### PR DESCRIPTION
Installing a duplicate shutdown handler fails, but if a handler with the same name is already present, we should be set to go. There's no reason to print a user-facing error about it.

This comes up almost nowhere because Podman never makes more than one Libpod runtime, but there is one exception (`system reset`) and the error messages, while harmless, were making people very confused (we got several bug reports that `system reset` was nonfunctional).
