### PR TITLE
Change name of imageVolumes in container config JSON

### DIFF
--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -135,7 +135,13 @@ type ContainerRootFSConfig struct {
 	// OverlayVolumes lists the overlay volumes to mount into the container.
 	OverlayVolumes []*ContainerOverlayVolume `json:"overlayVolumes,omitempty"`
 	// ImageVolumes lists the image volumes to mount into the container.
-	ImageVolumes []*ContainerImageVolume `json:"imageVolumes,omitempty"`
+	// Please note that this is named ctrImageVolumes in JSON to
+	// distinguish between these and the old `imageVolumes` field in Podman
+	// pre-1.8, which was used in very old Podman versions to determine how
+	// image volumes were handled in Libpod (support for these eventually
+	// moved out of Libpod into pkg/specgen).
+	// Please DO NOT re-use the `imageVolumes` name in container JSON again.
+	ImageVolumes []*ContainerImageVolume `json:"ctrImageVolumes,omitempty"`
 	// CreateWorkingDir indicates that Libpod should create the container's
 	// working directory if it does not exist. Some OCI runtimes do this by
 	// default, but others do not.


### PR DESCRIPTION
Podman pre-1.8 also included a field with this name, which was a String. Podman 2.2.0 added a new field reusing the name but as a Struct. This completely broke JSON decode for pre-1.8 containers in Podman 2.2, resulting in completely broken behavior.

Re-name the JSON field and add a note that the old name should not be re-used to prevent this problem from re-occurring. This will still result in containers from 2.2.0 being broken (specifically, containers with image volumes will have them disappear) but this is the lesser of two evils. 

Fixes #8613
