### PR TITLE
Pass full NetworkMode to ParseNetworkNamespace

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -237,7 +237,7 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 	}
 
 	// netMode
-	nsmode, _, err := specgen.ParseNetworkNamespace(cc.HostConfig.NetworkMode.NetworkName())
+	nsmode, _, err := specgen.ParseNetworkNamespace(string(cc.HostConfig.NetworkMode))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
When creating a container using a docker client pointed to the compat api, setting the HostConfig.NetworkMode to something like `container:8a16f7abf12aee67342f3e5a9323c6ec33e70ac2e6365c8e4866a45a5b80478d` there is an error returned:

```
Error response from daemon: command rootless-cni-infra [alloc 0be27a5fb43a79dd3f5f2cd046e37cb961b5d57cc6719c53833d2645b7ae83fb container:8a16f7abf12aee67342f3e5a9323c6ec33e70ac2e6365c8e4866a45a5b80478d kubevirt-registry] in container 61a91ef143b3d9901b4f6f9a2d4f9bee1f6c27238ca3e3040139b01f8d662c2a failed with status 1, stdout="", stderr="no net configuration with name \"container:8a16f7abf12aee67342f3e5a9323c6ec33e70ac2e6365c8e4866a45a5b80478d\" in /etc/cni/net.d\n"
```

After looking at the code, it seems like https://github.com/kwiesmueller/podman/blob/master/pkg/specgen/namespaces.go#L284 checks for the passed in `ns` to have a `container:` prefix. But the `NetworkMode.NetworkName()` [method only returns `container`](https://github.com/moby/moby/blob/master/api/types/container/hostconfig_unix.go#L11).

Note that this fix is probably wrong, it solved it for me locally but I'm not familiar enough with what's going on yet and what this might cause.

/hold

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
