### PR TITLE
Fix network ls --filter invalid value flake

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -119,7 +119,13 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network list --filter invalid value", func() {
-		session := podmanTest.Podman([]string{"network", "ls", "--filter", "namr=ab"})
+		net := "net" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", net})
+		session.WaitWithDefaultTimeout()
+		defer podmanTest.removeCNINetwork(net)
+		Expect(session.ExitCode()).To(BeZero())
+
+		session = podmanTest.Podman([]string{"network", "ls", "--filter", "namr=ab"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring(`invalid filter "namr"`))


### PR DESCRIPTION
The filter is only validated when at least one network exists.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
