### PR TITLE
Do not pull if image domain is localhost

### DIFF
--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -15,6 +15,8 @@ Ideally the input file would be one created by Podman (see podman-generate-kube(
 
 Note: HostPath volume types created by play kube will be given an SELinux private label (Z)
 
+Note: If the `:latest` tag is used, Podman will attempt to pull the image from a registry. If the image was built locally with Podman or Buildah, it will have `localhost` as the domain, in that case, Podman will use the image from the local store even if it has the `:latest` tag.
+
 ## OPTIONS
 
 #### **--authfile**=*path*

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -212,8 +212,10 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			return nil, errors.Wrapf(err, "Failed to parse image %q", container.Image)
 		}
 		// In kube, if the image is tagged with latest, it should always pull
+		// but if the domain is localhost, that means the image was built locally
+		// so do not attempt a pull.
 		if tagged, isTagged := named.(reference.NamedTagged); isTagged {
-			if tagged.Tag() == image.LatestTag {
+			if tagged.Tag() == image.LatestTag && reference.Domain(named) != image.DefaultLocalRegistry {
 				pullPolicy = util.PullImageAlways
 			}
 		}


### PR DESCRIPTION
With podman play kube, podman would always attempt to
pull if the image has the :latest tag. But this would
fail if the image was built locally and given latest
as the tag. Images build with podman and buildah have
localhost as the domain, so check if the domain is localhost.
If that is the case, then don't attempt a pull.

Fixes https://github.com/containers/podman/issues/7838

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
