### PR TITLE
Make `podman stats` slirp check more robust

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -900,10 +900,9 @@ func (r *Runtime) reloadContainerNetwork(ctr *Container) ([]*cnitypes.Result, er
 
 func getContainerNetIO(ctr *Container) (*netlink.LinkStatistics, error) {
 	var netStats *netlink.LinkStatistics
-	// rootless v2 cannot seem to resolve its network connection to
-	// collect statistics.  For now, we allow stats to at least run
-	// by returning nil
-	if rootless.IsRootless() {
+	// With slirp4netns, we can't collect statistics at present.
+	// For now, we allow stats to at least run by returning nil
+	if rootless.IsRootless() || ctr.config.NetMode.IsSlirp4netns() {
 		return netStats, nil
 	}
 	netNSPath, netPathErr := getContainerNetNS(ctr)

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -128,6 +128,16 @@ var _ = Describe("Podman stats", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman stats on container with forced slirp4netns", func() {
+		// This will force the slirp4netns net mode to be tested as root
+		session := podmanTest.Podman([]string{"run", "-d", "--net", "slirp4netns", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"stats", "--no-stream", "-a"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	// Regression test for #8265
 	It("podman stats with custom memory limits", func() {
 		// Run thre containers. One with a memory limit.  Make sure


### PR DESCRIPTION
Just checking for `rootless.IsRootless()` does not catch all the cases where slirp4netns is in use - we actually allow it to be used as root as well. Fortify the conditional here so we don't  fail in the root + slirp case.

Fixes #7883
