### PR TITLE
Honor the --layers flag

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -115,6 +115,7 @@ func buildFlags(cmd *cobra.Command) {
 	// --layers flag
 	flag = layerFlags.Lookup("layers")
 	useLayersVal := useLayers()
+	buildOpts.Layers = useLayersVal == "true"
 	if err := flag.Value.Set(useLayersVal); err != nil {
 		logrus.Errorf("unable to set --layers to %v: %v", useLayersVal, err)
 	}
@@ -274,11 +275,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 			}
 		}
 	}
-	// Check to see if the BUILDAH_LAYERS environment variable is set and
-	// override command-line.
-	if _, ok := os.LookupEnv("BUILDAH_LAYERS"); ok {
-		flags.Layers = true
-	}
+	flags.Layers = buildOpts.Layers
 
 	// `buildah bud --layers=false` acts like `docker build --squash` does.
 	// That is all of the new layers created during the build process are

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -71,6 +71,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		ForceRm     bool     `schema:"forcerm"`
 		HTTPProxy   bool     `schema:"httpproxy"`
 		Labels      string   `schema:"labels"`
+		Layers      bool     `schema:"layers"`
 		MemSwap     int64    `schema:"memswap"`
 		Memory      int64    `schema:"memory"`
 		NetworkMode string   `schema:"networkmode"`
@@ -165,6 +166,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		Registry:                       query.Registry,
 		IgnoreUnrecognizedInstructions: true,
 		Quiet:                          query.Quiet,
+		Layers:                         query.Layers,
 		Isolation:                      buildah.IsolationChroot,
 		Compression:                    archive.Gzip,
 		Args:                           buildArgs,

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -41,6 +41,9 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 	if options.NoCache {
 		params.Set("nocache", "1")
 	}
+	if options.Layers {
+		params.Set("layers", "1")
+	}
 	//	 TODO cachefrom
 	if options.PullPolicy == buildah.PullAlways {
 		params.Set("pull", "1")


### PR DESCRIPTION
Currently the --layers flag set by the user is ignored, and only the BUILDAH_LAYERS
environment variable being set is observed.

Fixes: https://github.com/containers/podman/issues/8643

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
