### PR TITLE
security: honor systempaths=unconfined for ro paths

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -854,8 +854,8 @@ Security Options
 - `seccomp=profile.json` :  White listed syscalls seccomp Json file to be used as a seccomp filter
 
 - `unmask=ALL or /path/1:/path/2` : Paths to unmask separated by a colon. If set to **ALL**, it will
-  unmask all the paths that are masked by default.
-  The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.**
+  unmask all the paths that are masked or made read only by default.
+  The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.**  The default paths that are read only are **/proc/asound, /proc/bus, /proc/fs, /proc/irq, /proc/sys, /proc/sysrq-trigger**.
 
 - `proc-opts=OPTIONS` : Comma separated list of options to use for the /proc mount. More details for the
   possible mount options are specified at **proc(5)** man page.

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -896,8 +896,8 @@ Security Options
 - **proc-opts**=_OPTIONS_ : Comma separated list of options to use for the /proc mount. More details
   for the possible mount options are specified at **proc(5)** man page.
 - **unmask**=_ALL_ or _/path/1:/path/2_: Paths to unmask separated by a colon. If set to **ALL**, it will
-  unmask all the paths that are masked by default.
-  The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.**
+  unmask all the paths that are masked or made read only by default.
+  The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.**.  The default paths that are read only are **/proc/asound**, **/proc/bus**, **/proc/fs**, **/proc/irq**, **/proc/sys**, **/proc/sysrq-trigger**.
 
 Note: Labeling can be disabled for all containers by setting **label=false** in the **containers.conf**(5) file.
 

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -167,21 +167,22 @@ func BlockAccessToKernelFilesystems(privileged, pidModeIsHost bool, mask, unmask
 					g.AddLinuxMaskedPaths(mp)
 				}
 			}
+			for _, rp := range []string{
+				"/proc/asound",
+				"/proc/bus",
+				"/proc/fs",
+				"/proc/irq",
+				"/proc/sys",
+				"/proc/sysrq-trigger",
+			} {
+				if !util.StringInSlice(rp, unmask) {
+					g.AddLinuxReadonlyPaths(rp)
+				}
+			}
 		}
 
 		if pidModeIsHost && rootless.IsRootless() {
 			return
-		}
-
-		for _, rp := range []string{
-			"/proc/asound",
-			"/proc/bus",
-			"/proc/fs",
-			"/proc/irq",
-			"/proc/sys",
-			"/proc/sysrq-trigger",
-		} {
-			g.AddLinuxReadonlyPaths(rp)
 		}
 	}
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -272,6 +272,13 @@ var _ = Describe("Podman run", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.OutputToString()).To(Not(BeEmpty()))
 		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"run", "-d", "--name=maskCtr5", "--security-opt", "systempaths=unconfined", ALPINE, "grep", "/proc", "/proc/self/mounts"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		stdoutLines := session.OutputToStringArray()
+		Expect(stdoutLines).Should(HaveLen(1))
+
 	})
 
 	It("podman run seccomp test", func() {


### PR DESCRIPTION
we must honor systempaths=unconfined also for read-only paths, as
Docker does:

proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
