### PR TITLE
Properly handle --cap-add all when running with a --user flag

### DIFF
--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -141,7 +141,7 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 		configSpec.Process.Capabilities.Effective = caplist
 		configSpec.Process.Capabilities.Permitted = caplist
 	} else {
-		userCaps, err := capabilities.NormalizeCapabilities(s.CapAdd)
+		userCaps, err := capabilities.MergeCapabilities(nil, s.CapAdd, nil)
 		if err != nil {
 			return errors.Wrapf(err, "capabilities requested by user are not valid: %q", strings.Join(s.CapAdd, ","))
 		}

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -90,6 +90,18 @@ var _ = Describe("Podman privileged container tests", func() {
 		containerCapMatchesHost(session.OutputToString(), host_cap.OutputToString())
 	})
 
+	It("podman cap-add CapEff with --user", func() {
+		// Get caps of current process
+		host_cap := SystemExec("awk", []string{"/^CapEff/ { print $2 }", "/proc/self/status"})
+		Expect(host_cap.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"run", "--user=bin", "--cap-add", "all", "busybox", "awk", "/^CapEff/ { print $2 }", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		containerCapMatchesHost(session.OutputToString(), host_cap.OutputToString())
+	})
+
 	It("podman cap-drop CapEff", func() {
 		session := podmanTest.Podman([]string{"run", "--cap-drop", "all", "busybox", "grep", "CapEff", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Handle the ALL Flag when running with an account as a user.

Currently we throw an error when the user specifies

podman run --user bin --cap-add all fedora echo hello

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
