### PR TITLE
Fix panic in libpod images exists endpoint

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -51,7 +51,7 @@ func ImageExists(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !report.Value {
-		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(nil, "failed to find image %s", name))
+		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Errorf("failed to find image %s", name))
 		return
 	}
 	utils.WriteResponse(w, http.StatusNoContent, "")

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -12,6 +12,8 @@ iid=$(jq -r '.[0].Id' <<<"$output")
 
 t GET libpod/images/$iid/exists                     204
 t GET libpod/images/$PODMAN_TEST_IMAGE_NAME/exists  204
+t GET libpod/images/${iid}abcdef/exists  404 \
+  .cause="failed to find image ${iid}abcdef"
 
 # FIXME: compare to actual podman info
 t GET libpod/images/json 200  \


### PR DESCRIPTION
The libpod images exists endpoint panics when called with
a non existing image and therefore returns 500 as status
code instead of the expected 404.

A test is added to ensure it is working.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
