### PR TITLE
podman logs honor stderr correctly

### DIFF
--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -122,6 +122,7 @@ func logs(_ *cobra.Command, args []string) error {
 		}
 		logsOptions.Since = since
 	}
-	logsOptions.Writer = os.Stdout
+	logsOptions.StdoutWriter = os.Stdout
+	logsOptions.StderrWriter = os.Stderr
 	return registry.ContainerEngine().ContainerLogs(registry.GetContext(), args, logsOptions.ContainerLogsOptions)
 }

--- a/libpod/logs/log.go
+++ b/libpod/logs/log.go
@@ -210,3 +210,19 @@ func NewLogLine(line string) (*LogLine, error) {
 func (l *LogLine) Partial() bool {
 	return l.ParseLogType == PartialLogType
 }
+
+func (l *LogLine) Write(stdout io.Writer, stderr io.Writer, logOpts *LogOptions) {
+	switch l.Device {
+	case "stdout":
+		if stdout != nil {
+			fmt.Fprintln(stdout, l.String(logOpts))
+		}
+	case "stderr":
+		if stderr != nil {
+			fmt.Fprintln(stderr, l.String(logOpts))
+		}
+	default:
+		// Warn the user if the device type does not match. Most likely the file is corrupted.
+		logrus.Warnf("unknown Device type '%s' in log file from Container %s", l.Device, l.CID)
+	}
+}

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -227,8 +227,10 @@ type ContainerLogsOptions struct {
 	Tail int64
 	// Show timestamps in the logs.
 	Timestamps bool
-	// Write the logs to Writer.
-	Writer io.Writer
+	// Write the stdout to this Writer.
+	StdoutWriter io.Writer
+	// Write the stderr to this Writer.
+	StderrWriter io.Writer
 }
 
 // ExecOptions describes the cli values to exec into

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -925,7 +925,7 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 }
 
 func (ic *ContainerEngine) ContainerLogs(ctx context.Context, containers []string, options entities.ContainerLogsOptions) error {
-	if options.Writer == nil {
+	if options.StdoutWriter == nil && options.StderrWriter == nil {
 		return errors.New("no io.Writer set for container logs")
 	}
 
@@ -963,7 +963,7 @@ func (ic *ContainerEngine) ContainerLogs(ctx context.Context, containers []strin
 	}()
 
 	for line := range logChannel {
-		fmt.Fprintln(options.Writer, line.String(logOpts))
+		line.Write(options.StdoutWriter, options.StderrWriter, logOpts)
 	}
 
 	return nil

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -355,4 +355,21 @@ var _ = Describe("Podman logs", func() {
 		Expect(outlines[0]).To(Equal("1\r"))
 		Expect(outlines[1]).To(Equal("2\r"))
 	})
+
+	It("podman logs test stdout and stderr", func() {
+		cname := "log-test"
+		logc := podmanTest.Podman([]string{"run", "--name", cname, ALPINE, "sh", "-c", "echo stdout; echo stderr >&2"})
+		logc.WaitWithDefaultTimeout()
+		Expect(logc).To(Exit(0))
+
+		wait := podmanTest.Podman([]string{"wait", cname})
+		wait.WaitWithDefaultTimeout()
+		Expect(wait).To(Exit(0))
+
+		results := podmanTest.Podman([]string{"logs", cname})
+		results.WaitWithDefaultTimeout()
+		Expect(results).To(Exit(0))
+		Expect(results.OutputToString()).To(Equal("stdout"))
+		Expect(results.ErrorToString()).To(Equal("stderr"))
+	})
 })

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1072,7 +1072,7 @@ var _ = Describe("Podman play kube", func() {
 		logs := podmanTest.Podman([]string{"logs", getCtrNameInPod(pod)})
 		logs.WaitWithDefaultTimeout()
 		Expect(logs.ExitCode()).To(Equal(0))
-		Expect(logs.OutputToString()).To(ContainSubstring("Operation not permitted"))
+		Expect(logs.ErrorToString()).To(ContainSubstring("Operation not permitted"))
 	})
 
 	It("podman play kube seccomp pod level", func() {
@@ -1099,7 +1099,7 @@ var _ = Describe("Podman play kube", func() {
 		logs := podmanTest.Podman([]string{"logs", getCtrNameInPod(pod)})
 		logs.WaitWithDefaultTimeout()
 		Expect(logs.ExitCode()).To(Equal(0))
-		Expect(logs.OutputToString()).To(ContainSubstring("Operation not permitted"))
+		Expect(logs.ErrorToString()).To(ContainSubstring("Operation not permitted"))
 	})
 
 	It("podman play kube with pull policy of never should be 125", func() {

--- a/test/e2e/toolbox_test.go
+++ b/test/e2e/toolbox_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Toolbox-specific testing", func() {
 		session = podmanTest.Podman([]string{"logs", "test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(ContainSubstring(expectedOutput))
+		Expect(session.ErrorToString()).To(ContainSubstring(expectedOutput))
 	})
 
 	It("podman create --userns=keep-id + podman exec - adding group with groupadd", func() {


### PR DESCRIPTION
Make the ContainerLogsOptions support two io.Writers,
one for stdout and the other for stderr. The logline already
includes the information to which Writer it has to be written.

Fixes #8683 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
