### PR TITLE
Add volume prune --filter support

### DIFF
--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -8,7 +8,8 @@ podman\-volume\-prune - Remove all unused volumes
 
 ## DESCRIPTION
 
-Removes all unused volumes. You will be prompted to confirm the removal of all the
+Removes unused volumes. By default all unused volumes will be removed, the **--filter** flag can
+be used to filter specific volumes. You will be prompted to confirm the removal of all the
 unused volumes. To bypass the confirmation, use the **--force** flag.
 
 
@@ -17,6 +18,17 @@ unused volumes. To bypass the confirmation, use the **--force** flag.
 #### **--force**, **-f**
 
 Do not prompt for confirmation.
+
+#### **--filter**
+
+Filter volumes to be pruned. Volumes can be filtered by the following attributes:
+
+- dangling
+- driver
+- label
+- name
+- opt
+- scope
 
 #### **--help**
 
@@ -29,6 +41,8 @@ Print usage statement
 $ podman volume prune
 
 $ podman volume prune --force
+
+$ podman volume prune --filter label=mylabel=mylabelvalue
 ```
 
 ## SEE ALSO

--- a/libpod/runtime_volume.go
+++ b/libpod/runtime_volume.go
@@ -133,9 +133,9 @@ func (r *Runtime) GetAllVolumes() ([]*Volume, error) {
 }
 
 // PruneVolumes removes unused volumes from the system
-func (r *Runtime) PruneVolumes(ctx context.Context) (map[string]error, error) {
+func (r *Runtime) PruneVolumes(ctx context.Context, filterFuncs []VolumeFilter) (map[string]error, error) {
 	reports := make(map[string]error)
-	vols, err := r.GetAllVolumes()
+	vols, err := r.Volumes(filterFuncs...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/handlers/compat/volumes.go
+++ b/pkg/api/handlers/compat/volumes.go
@@ -3,6 +3,7 @@ package compat
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/containers/podman/v2/libpod"
@@ -254,14 +255,15 @@ func PruneVolumes(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
-	// TODO: We have no ability to pass pruning filters to `PruneVolumes()` so
-	// we'll explicitly reject the request if we see any
-	if len(query.Filters) > 0 {
-		utils.InternalServerError(w, errors.New("filters for pruning volumes is not implemented"))
+
+	f := (url.Values)(query.Filters)
+	filterFuncs, err := filters.GenerateVolumeFilters(f)
+	if err != nil {
+		utils.Error(w, "Something when wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse filters for %s", f.Encode()))
 		return
 	}
 
-	pruned, err := runtime.PruneVolumes(r.Context())
+	pruned, err := runtime.PruneVolumes(r.Context(), filterFuncs)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/bindings/volumes/volumes.go
+++ b/pkg/bindings/volumes/volumes.go
@@ -75,7 +75,7 @@ func List(ctx context.Context, filters map[string][]string) ([]*entities.VolumeL
 }
 
 // Prune removes unused volumes from the local filesystem.
-func Prune(ctx context.Context) ([]*entities.VolumePruneReport, error) {
+func Prune(ctx context.Context, filters map[string][]string) ([]*entities.VolumePruneReport, error) {
 	var (
 		pruned []*entities.VolumePruneReport
 	)
@@ -83,7 +83,15 @@ func Prune(ctx context.Context) ([]*entities.VolumePruneReport, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/volumes/prune", nil, nil)
+	params := url.Values{}
+	if len(filters) > 0 {
+		strFilters, err := bindings.FiltersToString(filters)
+		if err != nil {
+			return nil, err
+		}
+		params.Set("filters", strFilters)
+	}
+	response, err := conn.DoRequest(nil, http.MethodPost, "/volumes/prune", params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -80,6 +80,6 @@ type ContainerEngine interface {
 	VolumeCreate(ctx context.Context, opts VolumeCreateOptions) (*IDOrNameResponse, error)
 	VolumeInspect(ctx context.Context, namesOrIds []string, opts InspectOptions) ([]*VolumeInspectReport, []error, error)
 	VolumeList(ctx context.Context, opts VolumeListOptions) ([]*VolumeListReport, error)
-	VolumePrune(ctx context.Context) ([]*VolumePruneReport, error)
+	VolumePrune(ctx context.Context, options VolumePruneOptions) ([]*VolumePruneReport, error)
 	VolumeRm(ctx context.Context, namesOrIds []string, opts VolumeRmOptions) ([]*VolumeRmReport, error)
 }

--- a/pkg/domain/entities/volumes.go
+++ b/pkg/domain/entities/volumes.go
@@ -1,6 +1,7 @@
 package entities
 
 import (
+	"net/url"
 	"time"
 
 	docker_api_types "github.com/docker/docker/api/types"
@@ -107,6 +108,12 @@ type VolumeRmReport struct {
 
 type VolumeInspectReport struct {
 	*VolumeConfigResponse
+}
+
+// VolumePruneOptions describes the options needed
+// to prune a volume from the CLI
+type VolumePruneOptions struct {
+	Filters url.Values `json:"filters" schema:"filters"`
 }
 
 type VolumePruneReport struct {

--- a/pkg/domain/filters/helpers.go
+++ b/pkg/domain/filters/helpers.go
@@ -1,0 +1,20 @@
+package filters
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func ParseFilterArgumentsIntoFilters(filters []string) (url.Values, error) {
+	parsedFilters := make(url.Values)
+	for _, f := range filters {
+		t := strings.SplitN(f, "=", 2)
+		if len(t) < 2 {
+			return parsedFilters, errors.Errorf("filter input must be in the form of filter=value: %s is invalid", f)
+		}
+		parsedFilters.Add(t[0], t[1])
+	}
+	return parsedFilters, nil
+}

--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -1,13 +1,14 @@
 package filters
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/containers/podman/v2/libpod"
 	"github.com/pkg/errors"
 )
 
-func GenerateVolumeFilters(filters map[string][]string) ([]libpod.VolumeFilter, error) {
+func GenerateVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, error) {
 	var vf []libpod.VolumeFilter
 	for filter, v := range filters {
 		for _, val := range v {

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -214,7 +214,7 @@ func (ic *ContainerEngine) SystemPrune(ctx context.Context, options entities.Sys
 			systemPruneReport.ImagePruneReport.Report.Id = append(systemPruneReport.ImagePruneReport.Report.Id, results...)
 		}
 		if options.Volume {
-			volumePruneReport, err := ic.pruneVolumesHelper(ctx)
+			volumePruneReport, err := ic.pruneVolumesHelper(ctx, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -127,12 +127,16 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 	return reports, errs, nil
 }
 
-func (ic *ContainerEngine) VolumePrune(ctx context.Context) ([]*entities.VolumePruneReport, error) {
-	return ic.pruneVolumesHelper(ctx)
+func (ic *ContainerEngine) VolumePrune(ctx context.Context, options entities.VolumePruneOptions) ([]*entities.VolumePruneReport, error) {
+	filterFuncs, err := filters.GenerateVolumeFilters(options.Filters)
+	if err != nil {
+		return nil, err
+	}
+	return ic.pruneVolumesHelper(ctx, filterFuncs)
 }
 
-func (ic *ContainerEngine) pruneVolumesHelper(ctx context.Context) ([]*entities.VolumePruneReport, error) {
-	pruned, err := ic.Libpod.PruneVolumes(ctx)
+func (ic *ContainerEngine) pruneVolumesHelper(ctx context.Context, filterFuncs []libpod.VolumeFilter) ([]*entities.VolumePruneReport, error) {
+	pruned, err := ic.Libpod.PruneVolumes(ctx, filterFuncs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/infra/tunnel/volumes.go
+++ b/pkg/domain/infra/tunnel/volumes.go
@@ -68,8 +68,8 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 	return reports, errs, nil
 }
 
-func (ic *ContainerEngine) VolumePrune(ctx context.Context) ([]*entities.VolumePruneReport, error) {
-	return volumes.Prune(ic.ClientCxt)
+func (ic *ContainerEngine) VolumePrune(ctx context.Context, opts entities.VolumePruneOptions) ([]*entities.VolumePruneReport, error) {
+	return volumes.Prune(ic.ClientCxt, (map[string][]string)(opts.Filters))
 }
 
 func (ic *ContainerEngine) VolumeList(ctx context.Context, opts entities.VolumeListOptions) ([]*entities.VolumeListReport, error) {

--- a/test/apiv2/30-volumes.at
+++ b/test/apiv2/30-volumes.at
@@ -20,6 +20,18 @@ t POST libpod/volumes/create \
     .Labels.testlabel=testonly \
     .Options.type=tmpfs \
     .Options.o=nodev,noexec
+t POST libpod/volumes/create \
+    '"Name":"foo3","Label":{"testlabel":""},"Options":{"type":"tmpfs","o":"nodev,noexec"}}' 201 \
+    .Name=foo3 \
+    .Labels.testlabel="" \
+    .Options.type=tmpfs \
+    .Options.o=nodev,noexec
+t POST libpod/volumes/create \
+    '"Name":"foo4","Label":{"testlabel1":"testonly"},"Options":{"type":"tmpfs","o":"nodev,noexec"}}' 201 \
+    .Name=foo4 \
+    .Labels.testlabel1=testonly \
+    .Options.type=tmpfs \
+    .Options.o=nodev,noexec
 
 # Negative test
 # We have created a volume named "foo1"
@@ -39,6 +51,12 @@ t GET libpod/volumes/json?filters=%7B%22name%22%3A%5B%22foo1%22%5D%7D 200 length
 t GET libpod/volumes/json?filters=%7B%22name%22%3A%20%5B%22foo1%22%2C%20%22foo2%22%5D%7D 200 length=2 .[0].Name=foo1 .[1].Name=foo2
 # -G --data-urlencode 'filters={"name":["notexist"]}'
 t GET libpod/volumes/json?filters=%7B%22name%22%3A%5B%22notexists%22%5D%7D 200 length=0
+# -G --data-urlencode 'filters={"label":["testlabel"]}'
+t GET libpod/volumes/json?filters=%7B%22label%22:%5B%22testlabel%22%5D%7D 200 length=2
+# -G --data-urlencode 'filters={"label":["testlabel=testonly"]}'
+t GET libpod/volumes/json?filters=%7B%22label%22:%5B%22testlabel=testonly%22%5D%7D 200 length=1
+# -G --data-urlencode 'filters={"label":["testlabel1=testonly"]}'
+t GET libpod/volumes/json?filters=%7B%22label%22:%5B%22testlabel1=testonly%22%5D%7D 200 length=1
 
 ## inspect volume
 t GET libpod/volumes/foo1/json 200 \
@@ -59,6 +77,18 @@ t DELETE libpod/volumes/foo1 404 \
     .cause="no such volume" \
     .message~.* \
     .response=404
+
+## Prune volumes with label matching 'testlabel1=testonly'
+# -G --data-urlencode 'filters={"label":["testlabel1=testonly"]}'
+t POST libpod/volumes/prune?filters=%7B%22label%22:%5B%22testlabel1=testonly%22%5D%7D "" 200
+# -G --data-urlencode 'filters={"label":["testlabel1=testonly"]}'
+t GET libpod/volumes/json?filters=%7B%22label%22:%5B%22testlabel1=testonly%22%5D%7D 200 length=0
+
+## Prune volumes with label matching 'testlabel'
+# -G --data-urlencode 'filters={"label":["testlabel"]}'
+t POST libpod/volumes/prune?filters=%7B%22label%22:%5B%22testlabel%22%5D%7D "" 200
+# -G --data-urlencode 'filters={"label":["testlabel"]}'
+t GET libpod/volumes/json?filters=%7B%22label%22:%5B%22testlabel%22%5D%7D 200 length=0
 
 ## Prune volumes
 t POST libpod/volumes/prune "" 200

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -62,6 +62,66 @@ var _ = Describe("Podman volume prune", func() {
 		podmanTest.Cleanup()
 	})
 
+	It("podman prune volume --filter", func() {
+		session := podmanTest.Podman([]string{"volume", "create", "--label", "label1=value1", "myvol1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1=slv1", "myvol2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1=slv2", "myvol3"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "create", "--label", "sharedlabel1", "myvol4"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"create", "-v", "myvol5:/myvol5", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"create", "-v", "myvol6:/myvol6", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(7))
+
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=label1=value1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(6))
+
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=sharedlabel1=slv1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(5))
+
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "label=sharedlabel1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(3))
+
+		podmanTest.Cleanup()
+	})
+
 	It("podman system prune --volume", func() {
 		session := podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
This change adds support for the `--filter` / `?filters` arguments on
the `podman volume prune` subcommand.

  * Adds ParseFilterArgumentsIntoFilters helper for consistent
    Filter string slice handling
  * Adds `--filter` support to podman volume prune cli
  * Adds `?filters...` support to podman volume prune api
  * Updates apiv2 / e2e tests

Closes #8672

Signed-off-by: Baron Lenardson <lenardson.baron@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
