### PR TITLE
Fix Wrong img name used when creating a container from an image which had multi names

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -5,8 +5,10 @@
 
 # WORKDIR=/data
 ENV_WORKDIR_IMG=quay.io/libpod/testimage:20200929
+MultiTagName=localhost/test/testformultitag:tag
 
 podman pull $IMAGE &>/dev/null
+podman tag $IMAGE $MultiTagName
 podman pull $ENV_WORKDIR_IMG &>/dev/null
 # Unimplemented
 #t POST libpod/containers/create '' 201 'sdf'
@@ -216,4 +218,13 @@ t GET containers/$cid/json 200 \
 
 t DELETE containers/$cid 204
 
+# when the image had multi tags, the container's Image should be correct
+# Fixes https://github.com/containers/podman/issues/8547
+t POST containers/create Image=${MultiTagName} 201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .Image=${MultiTagName}
+t DELETE containers/$cid 204
+t DELETE images/${MultiTagName}?force=true 200
 # vim: filetype=sh


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/8547

Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
