### PR TITLE
Fix some network compat api problems

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -131,7 +131,7 @@ func getNetworkResourceByNameOrID(nameOrID string, runtime *libpod.Runtime, filt
 		Name:       conf.Name,
 		ID:         network.GetNetworkID(conf.Name),
 		Created:    time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec)), // nolint: unconvert
-		Scope:      "",
+		Scope:      "local",
 		Driver:     network.DefaultNetworkDriver,
 		EnableIPv6: false,
 		IPAM: dockerNetwork.IPAM{
@@ -197,7 +197,7 @@ func ListNetworks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var reports []*types.NetworkResource
-	logrus.Errorf("netNames: %q", strings.Join(netNames, ", "))
+	logrus.Debugf("netNames: %q", strings.Join(netNames, ", "))
 	for _, name := range netNames {
 		report, err := getNetworkResourceByNameOrID(name, runtime, query.Filters)
 		if err != nil {
@@ -239,7 +239,7 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 		Internal: networkCreate.Internal,
 		Labels:   networkCreate.Labels,
 	}
-	if networkCreate.IPAM != nil && networkCreate.IPAM.Config != nil {
+	if networkCreate.IPAM != nil && len(networkCreate.IPAM.Config) > 0 {
 		if len(networkCreate.IPAM.Config) > 1 {
 			utils.InternalServerError(w, errors.New("compat network create can only support one IPAM config"))
 			return

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -50,7 +50,13 @@ t GET networks?filters=%7B%22dangling%22%3A%5B%221%22%5D%7D 500 \
 # network inspect docker
 t GET networks/a7662f44d65029fd4635c91feea3d720a57cef52e2a9fcc7772b69072cc1ccd1 200 \
 .Name=network1 \
-.Id=a7662f44d65029fd4635c91feea3d720a57cef52e2a9fcc7772b69072cc1ccd1
+.Id=a7662f44d65029fd4635c91feea3d720a57cef52e2a9fcc7772b69072cc1ccd1 \
+.Scope=local
+
+# network create docker
+t POST networks/create '"Name":"net3","IPAM":{"Config":[]}' 201
+# network delete docker
+t DELETE networks/net3 204
 
 # clean the network
 t DELETE libpod/networks/network1 200 \


### PR DESCRIPTION
Network create could panic when used with a json body like this:
`{"Name":"net","IPAM":{"Config":[]}}`

The network scope for list and inspect should not be empty. It can
be swarm, global or local. We only support local networks so
hardcode this field to local.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
