### PR TITLE
[CI:DOCS] Cleanup CNI Networks on reboot

### DIFF
--- a/contrib/tmpfile/podman.conf
+++ b/contrib/tmpfile/podman.conf
@@ -1,4 +1,5 @@
 # /tmp/podman-run-* directory can contain content for Podman containers that have run
 # for many days. This following line prevents systemd from removing this content.
-x /tmp/podman-run-.*
-d /run/podman 0700 root root
+x /tmp/podman-run-*
+D! /run/podman 0700 root root
+D! /var/lib/cni/networks


### PR DESCRIPTION
CNI sometimes leaves Network information in /var/lib/cni/networks
when the system crashes or containers do not shut down properly.

This PR will cleanup these left over files, so that container engines
will get a clean enviroment when the system reboots.

Related to: https://github.com/containers/podman/issues/3759

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
