### PR TITLE
podman: drop checking valid rootless UID

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -3,7 +3,6 @@ package containers
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
@@ -15,7 +14,6 @@ import (
 	"github.com/containers/podman/v2/pkg/errorhandling"
 	"github.com/containers/podman/v2/pkg/rootless"
 	"github.com/containers/podman/v2/pkg/specgen"
-	"github.com/containers/podman/v2/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -106,15 +104,6 @@ func run(cmd *cobra.Command, args []string) error {
 	cliVals.Net, err = common.NetFlagsToNetOptions(cmd)
 	if err != nil {
 		return err
-	}
-
-	if rootless.IsRootless() && !registry.IsRemote() {
-		userspec := strings.SplitN(cliVals.User, ":", 2)[0]
-		if uid, err := strconv.ParseInt(userspec, 10, 32); err == nil {
-			if err := util.CheckRootlessUIDRange(int(uid)); err != nil {
-				return err
-			}
-		}
 	}
 
 	if af := cliVals.Authfile; len(af) > 0 {

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -424,11 +424,6 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 	}
 
 	if c.config.User != "" {
-		if rootless.IsRootless() {
-			if err := util.CheckRootlessUIDRange(execUser.Uid); err != nil {
-				return nil, err
-			}
-		}
 		// User and Group must go together
 		g.SetProcessUID(uint32(execUser.Uid))
 		g.SetProcessGID(uint32(execUser.Gid))

--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/containers/podman/v2/pkg/rootless"
 	"github.com/containers/psgo"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -52,20 +51,4 @@ func FindDeviceNodes() (map[string]string, error) {
 	}
 
 	return nodes, nil
-}
-
-// CheckRootlessUIDRange checks the uid within the rootless container is in the range from /etc/subuid
-func CheckRootlessUIDRange(uid int) error {
-	uids, _, err := rootless.GetConfiguredMappings()
-	if err != nil {
-		return err
-	}
-	total := 0
-	for _, u := range uids {
-		total += u.Size
-	}
-	if uid > total {
-		return errors.Errorf("requested user's UID %d is too large for the rootless user namespace", uid)
-	}
-	return nil
 }

--- a/pkg/util/utils_unsupported.go
+++ b/pkg/util/utils_unsupported.go
@@ -10,8 +10,3 @@ import (
 func FindDeviceNodes() (map[string]string, error) {
 	return nil, errors.Errorf("not supported on non-Linux OSes")
 }
-
-// CheckRootlessUIDRange is not implemented anywhere except Linux.
-func CheckRootlessUIDRange(uid int) error {
-	return nil
-}


### PR DESCRIPTION
do not check whether the specified ID is valid in the user namespace.

crun handles this case[1], so the check in Podman prevents to get to
the OCI runtime at all.

$ podman run --user 10:0 --uidmap 0:0:1 --rm -ti fedora:33 sh -c 'id; cat /proc/self/uid_map'
uid=10(10) gid=0(root) groups=0(root),65534(nobody)
        10          0          1

[1] https://github.com/containers/crun/pull/556

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
