### PR TITLE
podman events allow future time for --until

### DIFF
--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -216,8 +216,5 @@ func (e EventLogFile) getTail(options ReadOptions) (*tail.Tail, error) {
 		reopen = false
 	}
 	stream := options.Stream
-	if len(options.Until) > 0 {
-		stream = false
-	}
 	return tail.TailFile(e.options.LogFilePath, tail.Config{ReOpen: reopen, Follow: stream, Location: &seek, Logger: tail.DiscardingLogger, Poll: true})
 }

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/containers/podman/v2/pkg/util"
 	"github.com/coreos/go-systemd/v22/journal"
 	"github.com/coreos/go-systemd/v22/sdjournal"
 	"github.com/pkg/errors"
@@ -72,6 +73,13 @@ func (e EventJournalD) Read(ctx context.Context, options ReadOptions) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate event options")
 	}
+	var untilTime time.Time
+	if len(options.Until) > 0 {
+		untilTime, err = util.ParseInputTime(options.Until)
+		if err != nil {
+			return err
+		}
+	}
 	j, err := sdjournal.NewJournal()
 	if err != nil {
 		return err
@@ -122,10 +130,14 @@ func (e EventJournalD) Read(ctx context.Context, options ReadOptions) error {
 			return errors.Wrap(err, "failed to get journal cursor")
 		}
 		if prevCursor == newCursor {
-			if len(options.Until) > 0 || !options.Stream {
+			if !options.Stream || (len(options.Until) > 0 && time.Now().After(untilTime)) {
 				break
 			}
-			_ = j.Wait(sdjournal.IndefiniteWait)
+			t := sdjournal.IndefiniteWait
+			if len(options.Until) > 0 {
+				t = time.Until(untilTime)
+			}
+			_ = j.Wait(t)
 			continue
 		}
 		prevCursor = newCursor

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/containers/podman/v2/pkg/util"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
 )
@@ -50,6 +52,16 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 	t, err := e.getTail(options)
 	if err != nil {
 		return err
+	}
+	if len(options.Until) > 0 {
+		untilTime, err := util.ParseInputTime(options.Until)
+		if err != nil {
+			return err
+		}
+		go func() {
+			time.Sleep(time.Until(untilTime))
+			t.Stop()
+		}()
 	}
 	funcDone := make(chan bool)
 	copy := true

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -502,6 +502,7 @@ func WithEventsLogger(logger string) RuntimeOption {
 		}
 
 		rt.config.Engine.EventsLogger = logger
+		rt.config.Engine.EventsLogFilePath = filepath.Join(rt.config.Engine.TmpDir, "events", "events.log")
 
 		return nil
 	}

--- a/pkg/api/handlers/compat/events.go
+++ b/pkg/api/handlers/compat/events.go
@@ -110,6 +110,7 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 			Until:        query.Until,
 		}
 		errorChannel <- runtime.Events(r.Context(), readOpts)
+
 	}()
 
 	var flush = func() {}
@@ -130,8 +131,8 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				// FIXME StatusOK already sent above cannot send 500 here
 				utils.InternalServerError(w, err)
-				return
 			}
+			return
 		case evt := <-eventChannel:
 			if evt == nil {
 				continue


### PR DESCRIPTION
The podman events aren't read until the given timestamp if the
timestamp is in the future. It just reads all events until now
and exits afterwards.
This does not make sense and does not match docker. The correct
behavior is to read all events until the given time is reached.

This fixes a bug where the wrong event log file path was used
when running first time with a new storage location.
Fixes #8694

This also fixes the events api endpoint which only exited when
an error occurred. Otherwise it just hung after reading all events.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
