### PR TITLE
RHEL gating tests: more journald exceptions

### DIFF
--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -55,14 +55,7 @@ ${cid[0]} d"   "Sequential output from logs"
 
 @test "podman logs over journald" {
     # We can't use journald on RHEL as rootless: rhbz#1895105
-    if is_rootless; then
-        run journalctl -n 1
-        if [[ $status -ne 0 ]]; then
-            if [[ $output =~ permission ]]; then
-                skip "Cannot use rootless journald on this system"
-            fi
-        fi
-    fi
+    skip_if_journald_unavailable
 
     msg=$(random_string 20)
 


### PR DESCRIPTION
Followup to #8284, due to my not having noticed #8096.

RHEL gating tests are failing again due to rhbz#1895105, the
one where we can't run journalctl rootless on RHEL. #8284 fixed
this for some RHEL builds of older podman, but I missed #8096
which added yet another logs test.

This brings us to three journalctl exceptions, which means
it gets complicated because I have to refactor it all.

**THIS IS NOT SUSTAINABLE**. We need some way to have a similar
setup in CI, with a permission-less rootless login, so we don't
add yet another logs test some day and discover, months later,
that it doesn't work on RHEL and then have to go into crisis
mode.

Signed-off-by: Ed Santiago <santiago@redhat.com>
