### PR TITLE
Podman image bindings for 3.0

### DIFF
--- a/contrib/cirrus/required_host_ports.txt
+++ b/contrib/cirrus/required_host_ports.txt
@@ -5,7 +5,6 @@ registry.fedoraproject.org 443
 mirrors.fedoraproject.org 443
 dl.fedoraproject.org 443
 ewr.edge.kernel.org 443
-mirror.chpc.utah.edu 443
 mirror.clarkson.edu 443
 mirror.umd.edu 443
 mirror.vcu.edu 443

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -265,8 +265,14 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 
 	// Format is mandatory! Currently, we only support multi-image docker
 	// archives.
+	if len(query.References) > 1 && query.Format != define.V2s2Archive {
+		utils.Error(w, "unsupported format", http.StatusInternalServerError, errors.Errorf("multi-image archives must use format of %s", define.V2s2Archive))
+		return
+
+	}
+
 	switch query.Format {
-	case define.V2s2Archive:
+	case define.V2s2Archive, define.OCIArchive:
 		tmpfile, err := ioutil.TempFile("", "api.tar")
 		if err != nil {
 			utils.Error(w, "unable to create tmpfile", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
@@ -277,6 +283,13 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 			utils.Error(w, "unable to close tmpfile", http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
 			return
 		}
+	case define.OCIManifestDir, define.V2s2ManifestDir:
+		tmpdir, err := ioutil.TempDir("", "save")
+		if err != nil {
+			utils.Error(w, "unable to create tmpdir", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempdir"))
+			return
+		}
+		output = tmpdir
 	default:
 		utils.Error(w, "unsupported format", http.StatusInternalServerError, errors.Errorf("unsupported format %q", query.Format))
 		return
@@ -287,7 +300,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 	opts := entities.ImageSaveOptions{
 		Compress:          query.Compress,
 		Format:            query.Format,
-		MultiImageArchive: true,
+		MultiImageArchive: len(query.References) > 1,
 		Output:            output,
 		RemoveSignatures:  true,
 	}
@@ -414,7 +427,6 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	}{
 		// This is where you can override the golang default value for one of fields
 	}
-
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
@@ -607,12 +619,12 @@ func UntagImage(w http.ResponseWriter, r *http.Request) {
 func SearchImages(w http.ResponseWriter, r *http.Request) {
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
-		Term      string   `json:"term"`
-		Limit     int      `json:"limit"`
-		NoTrunc   bool     `json:"noTrunc"`
-		Filters   []string `json:"filters"`
-		TLSVerify bool     `json:"tlsVerify"`
-		ListTags  bool     `json:"listTags"`
+		Term      string              `json:"term"`
+		Limit     int                 `json:"limit"`
+		NoTrunc   bool                `json:"noTrunc"`
+		Filters   map[string][]string `json:"filters"`
+		TLSVerify bool                `json:"tlsVerify"`
+		ListTags  bool                `json:"listTags"`
 	}{
 		// This is where you can override the golang default value for one of fields
 	}
@@ -622,22 +634,42 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	filter := image.SearchFilter{}
+	if len(query.Filters) > 0 {
+		if len(query.Filters["stars"]) > 0 {
+			stars, err := strconv.Atoi(query.Filters["stars"][0])
+			if err != nil {
+				utils.InternalServerError(w, err)
+				return
+			}
+			filter.Stars = stars
+		}
+		if len(query.Filters["is-official"]) > 0 {
+			isOfficial, err := strconv.ParseBool(query.Filters["is-official"][0])
+			if err != nil {
+				utils.InternalServerError(w, err)
+				return
+			}
+			filter.IsOfficial = types.NewOptionalBool(isOfficial)
+		}
+		if len(query.Filters["is-automated"]) > 0 {
+			isAutomated, err := strconv.ParseBool(query.Filters["is-automated"][0])
+			if err != nil {
+				utils.InternalServerError(w, err)
+				return
+			}
+			filter.IsAutomated = types.NewOptionalBool(isAutomated)
+		}
+	}
 	options := image.SearchOptions{
 		Limit:    query.Limit,
 		NoTrunc:  query.NoTrunc,
 		ListTags: query.ListTags,
-	}
-	if _, found := r.URL.Query()["tlsVerify"]; found {
-		options.InsecureSkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)
+		Filter:   filter,
 	}
 
-	if _, found := r.URL.Query()["filters"]; found {
-		filter, err := image.ParseSearchFilter(query.Filters)
-		if err != nil {
-			utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse filters parameter for %s", r.URL.String()))
-			return
-		}
-		options.Filter = *filter
+	if _, found := r.URL.Query()["tlsVerify"]; found {
+		options.InsecureSkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)
 	}
 
 	_, authfile, key, err := auth.GetCredentials(r)
@@ -678,10 +710,7 @@ func ImagesBatchRemove(w http.ResponseWriter, r *http.Request) {
 		All    bool     `schema:"all"`
 		Force  bool     `schema:"force"`
 		Images []string `schema:"images"`
-	}{
-		All:   false,
-		Force: false,
-	}
+	}{}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
@@ -690,10 +719,8 @@ func ImagesBatchRemove(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opts := entities.ImageRemoveOptions{All: query.All, Force: query.Force}
-
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 	rmReport, rmErrors := imageEngine.Remove(r.Context(), query.Images, opts)
-
 	strErrs := errorhandling.ErrorsToStrings(rmErrors)
 	report := handlers.LibpodImagesRemoveReport{ImageRemoveReport: *rmReport, Errors: strErrs}
 	utils.WriteResponse(w, http.StatusOK, report)

--- a/pkg/bindings/images/diff.go
+++ b/pkg/bindings/images/diff.go
@@ -9,7 +9,11 @@ import (
 )
 
 // Diff provides the changes between two container layers
-func Diff(ctx context.Context, nameOrID string) ([]archive.Change, error) {
+func Diff(ctx context.Context, nameOrID string, options *DiffOptions) ([]archive.Change, error) {
+	if options == nil {
+		options = new(DiffOptions)
+	}
+	_ = options
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/bindings/images/rm.go
+++ b/pkg/bindings/images/rm.go
@@ -3,8 +3,6 @@ package images
 import (
 	"context"
 	"net/http"
-	"net/url"
-	"strconv"
 
 	"github.com/containers/podman/v2/pkg/api/handlers"
 	"github.com/containers/podman/v2/pkg/bindings"
@@ -12,8 +10,12 @@ import (
 	"github.com/containers/podman/v2/pkg/errorhandling"
 )
 
-// BachtRemove removes a batch of images from the local storage.
-func BatchRemove(ctx context.Context, images []string, opts entities.ImageRemoveOptions) (*entities.ImageRemoveReport, []error) {
+// Remove removes one or more images from the local storage.  Use optional force option to remove an
+// image, even if it's used by containers.
+func Remove(ctx context.Context, images []string, options *RemoveOptions) (*entities.ImageRemoveReport, []error) {
+	if options == nil {
+		options = new(RemoveOptions)
+	}
 	// FIXME - bindings tests are missing for this endpoint. Once the CI is
 	// re-enabled for bindings, we need to add them.  At the time of writing,
 	// the tests don't compile.
@@ -23,13 +25,13 @@ func BatchRemove(ctx context.Context, images []string, opts entities.ImageRemove
 		return nil, []error{err}
 	}
 
-	params := url.Values{}
-	params.Set("all", strconv.FormatBool(opts.All))
-	params.Set("force", strconv.FormatBool(opts.Force))
-	for _, i := range images {
-		params.Add("images", i)
+	params, err := options.ToParams()
+	if err != nil {
+		return nil, nil
 	}
-
+	for _, image := range images {
+		params.Add("images", image)
+	}
 	response, err := conn.DoRequest(nil, http.MethodDelete, "/images/remove", params, nil)
 	if err != nil {
 		return nil, []error{err}
@@ -39,29 +41,4 @@ func BatchRemove(ctx context.Context, images []string, opts entities.ImageRemove
 	}
 
 	return &report.ImageRemoveReport, errorhandling.StringsToErrors(report.Errors)
-}
-
-// Remove removes an image from the local storage.  Use optional force option to remove an
-// image, even if it's used by containers.
-func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) (*entities.ImageRemoveReport, error) {
-	var report handlers.LibpodImagesRemoveReport
-	conn, err := bindings.GetClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	params, err := options.ToParams()
-	if err != nil {
-		return nil, err
-	}
-	response, err := conn.DoRequest(nil, http.MethodDelete, "/images/%s", params, nil, nameOrID)
-	if err != nil {
-		return nil, err
-	}
-	if err := response.Process(&report); err != nil {
-		return nil, err
-	}
-
-	errs := errorhandling.StringsToErrors(report.Errors)
-	return &report.ImageRemoveReport, errorhandling.JoinErrors(errs)
 }

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -1,8 +1,193 @@
 package images
 
+import (
+	"github.com/containers/buildah/imagebuildah"
+	"github.com/containers/common/pkg/config"
+)
+
 //go:generate go run ../generator/generator.go RemoveOptions
 // RemoveOptions are optional options for image removal
 type RemoveOptions struct {
+	// All removes all images
+	All *bool
 	// Forces removes all containers based on the image
 	Force *bool
+}
+
+//go:generate go run ../generator/generator.go DiffOptions
+// DiffOptions are optional options image diffs
+type DiffOptions struct {
+}
+
+//go:generate go run ../generator/generator.go ListOptions
+// ListOptions are optional options for listing images
+type ListOptions struct {
+	// All lists all image in the image store including dangling images
+	All *bool
+	// filters that can be used to get a more specific list of images
+	Filters map[string][]string
+}
+
+//go:generate go run ../generator/generator.go GetOptions
+// GetOptions are optional options for inspecting an image
+type GetOptions struct {
+	// Size computes the amount of storage the image consumes
+	Size *bool
+}
+
+//go:generate go run ../generator/generator.go TreeOptions
+// TreeOptions are optional options for a tree-based representation
+// of the image
+type TreeOptions struct {
+	// WhatRequires ...
+	WhatRequires *bool
+}
+
+//go:generate go run ../generator/generator.go HistoryOptions
+// HistoryOptions are optional options image history
+type HistoryOptions struct {
+}
+
+//go:generate go run ../generator/generator.go LoadOptions
+// LoadOptions are optional options for loading an image
+type LoadOptions struct {
+	// Reference is the name of the loaded image
+	Reference *string
+}
+
+//go:generate go run ../generator/generator.go ExportOptions
+// ExportOptions are optional options for exporting images
+type ExportOptions struct {
+	// Compress the image
+	Compress *bool
+	// Format of the output
+	Format *string
+}
+
+//go:generate go run ../generator/generator.go PruneOptions
+// PruneOptions are optional options for pruning images
+type PruneOptions struct {
+	// Prune all images
+	All *bool
+	// Filters to apply when pruning images
+	Filters map[string][]string
+}
+
+//go:generate go run ../generator/generator.go TagOptions
+// TagOptions are optional options for tagging images
+type TagOptions struct {
+}
+
+//go:generate go run ../generator/generator.go UntagOptions
+// UntagOptions are optional options for tagging images
+type UntagOptions struct {
+}
+
+//go:generate go run ../generator/generator.go ImportOptions
+// ImportOptions are optional options for importing images
+type ImportOptions struct {
+	// Changes to be applied to the image
+	Changes *[]string
+	// Message to be applied to the image
+	Message *string
+	// Reference is a tag to be applied to the image
+	Reference *string
+	// Url to option image to import. Cannot be used with the reader
+	URL *string
+}
+
+//go:generate go run ../generator/generator.go PushOptions
+// PushOptions are optional options for importing images
+type PushOptions struct {
+	// Authfile is the path to the authentication file. Ignored for remote
+	// calls.
+	Authfile *string
+	// CertDir is the path to certificate directories.  Ignored for remote
+	// calls.
+	CertDir *string
+	// Compress tarball image layers when pushing to a directory using the 'dir'
+	// transport. Default is same compression type as source. Ignored for remote
+	// calls.
+	Compress *bool
+	// Username for authenticating against the registry.
+	Username *string
+	// Password for authenticating against the registry.
+	Password *string
+	// DigestFile, after copying the image, write the digest of the resulting
+	// image to the file.  Ignored for remote calls.
+	DigestFile *string
+	// Format is the Manifest type (oci, v2s1, or v2s2) to use when pushing an
+	// image using the 'dir' transport. Default is manifest type of source.
+	// Ignored for remote calls.
+	Format *string
+	// Quiet can be specified to suppress pull progress when pulling.  Ignored
+	// for remote calls.
+	Quiet *bool
+	// RemoveSignatures, discard any pre-existing signatures in the image.
+	// Ignored for remote calls.
+	RemoveSignatures *bool
+	// SignaturePolicy to use when pulling.  Ignored for remote calls.
+	SignaturePolicy *string
+	// SignBy adds a signature at the destination using the specified key.
+	// Ignored for remote calls.
+	SignBy *string
+	// SkipTLSVerify to skip HTTPS and certificate verification.
+	SkipTLSVerify *bool
+}
+
+//go:generate go run ../generator/generator.go SearchOptions
+// SearchOptions are optional options for seaching images on registies
+type SearchOptions struct {
+	// Authfile is the path to the authentication file. Ignored for remote
+	// calls.
+	Authfile *string
+	// Filters for the search results.
+	Filters map[string][]string
+	// Limit the number of results.
+	Limit *int
+	// NoTrunc will not truncate the output.
+	NoTrunc *bool
+	// SkipTLSVerify to skip  HTTPS and certificate verification.
+	SkipTLSVerify *bool
+	// ListTags search the available tags of the repository
+	ListTags *bool
+}
+
+//go:generate go run ../generator/generator.go PullOptions
+// PullOptions are optional options for pulling images
+type PullOptions struct {
+	// AllTags can be specified to pull all tags of an image. Note
+	// that this only works if the image does not include a tag.
+	AllTags *bool
+	// Authfile is the path to the authentication file. Ignored for remote
+	// calls.
+	Authfile *string
+	// CertDir is the path to certificate directories.  Ignored for remote
+	// calls.
+	CertDir *string
+	// Username for authenticating against the registry.
+	Username *string
+	// Password for authenticating against the registry.
+	Password *string
+	// OverrideArch will overwrite the local architecture for image pulls.
+	OverrideArch *string
+	// OverrideOS will overwrite the local operating system (OS) for image
+	// pulls.
+	OverrideOS *string
+	// OverrideVariant will overwrite the local variant for image pulls.
+	OverrideVariant *string
+	// Quiet can be specified to suppress pull progress when pulling.  Ignored
+	// for remote calls.
+	Quiet *bool
+	// SignaturePolicy to use when pulling.  Ignored for remote calls.
+	SignaturePolicy *string
+	// SkipTLSVerify to skip HTTPS and certificate verification.
+	SkipTLSVerify *bool
+	// PullPolicy whether to pull new image
+	PullPolicy *config.PullPolicy
+}
+
+//BuildOptions are optional options for building images
+type BuildOptions struct {
+	imagebuildah.BuildOptions
 }

--- a/pkg/bindings/images/types_diff_options.go
+++ b/pkg/bindings/images/types_diff_options.go
@@ -1,0 +1,87 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:46.528172042 -0600 CST m=+0.000279712
+*/
+
+// Changed
+func (o *DiffOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *DiffOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}

--- a/pkg/bindings/images/types_export_options.go
+++ b/pkg/bindings/images/types_export_options.go
@@ -1,0 +1,119 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:47.379804635 -0600 CST m=+0.000257609
+*/
+
+// Changed
+func (o *ExportOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *ExportOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}
+
+// WithCompress
+func (o *ExportOptions) WithCompress(value bool) *ExportOptions {
+	v := &value
+	o.Compress = v
+	return o
+}
+
+// GetCompress
+func (o *ExportOptions) GetCompress() bool {
+	var compress bool
+	if o.Compress == nil {
+		return compress
+	}
+	return *o.Compress
+}
+
+// WithFormat
+func (o *ExportOptions) WithFormat(value string) *ExportOptions {
+	v := &value
+	o.Format = v
+	return o
+}
+
+// GetFormat
+func (o *ExportOptions) GetFormat() string {
+	var format string
+	if o.Format == nil {
+		return format
+	}
+	return *o.Format
+}

--- a/pkg/bindings/images/types_get_options.go
+++ b/pkg/bindings/images/types_get_options.go
@@ -1,0 +1,103 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:46.81312808 -0600 CST m=+0.000257734
+*/
+
+// Changed
+func (o *GetOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *GetOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}
+
+// WithSize
+func (o *GetOptions) WithSize(value bool) *GetOptions {
+	v := &value
+	o.Size = v
+	return o
+}
+
+// GetSize
+func (o *GetOptions) GetSize() bool {
+	var size bool
+	if o.Size == nil {
+		return size
+	}
+	return *o.Size
+}

--- a/pkg/bindings/images/types_history_options.go
+++ b/pkg/bindings/images/types_history_options.go
@@ -1,0 +1,87 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:47.095693605 -0600 CST m=+0.000243849
+*/
+
+// Changed
+func (o *HistoryOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *HistoryOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}

--- a/pkg/bindings/images/types_import_options.go
+++ b/pkg/bindings/images/types_import_options.go
@@ -12,18 +12,18 @@ import (
 /*
 This file is generated automatically by go generate.  Do not edit.
 
-Created 2020-12-10 12:51:06.090426622 -0600 CST m=+0.000133169
+Created 2020-12-15 15:22:47.943587389 -0600 CST m=+0.000238222
 */
 
 // Changed
-func (o *RemoveOptions) Changed(fieldName string) bool {
+func (o *ImportOptions) Changed(fieldName string) bool {
 	r := reflect.ValueOf(o)
 	value := reflect.Indirect(r).FieldByName(fieldName)
 	return !value.IsNil()
 }
 
 // ToParams
-func (o *RemoveOptions) ToParams() (url.Values, error) {
+func (o *ImportOptions) ToParams() (url.Values, error) {
 	params := url.Values{}
 	if o == nil {
 		return params, nil
@@ -68,10 +68,11 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 		case reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
-			// I dont know if this code is needed anymore, TBD
-			// for k, v := range filters {
-			// 	lowerCaseKeys[strings.ToLower(k)] = v
-			// }
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
 			s, err := json.MarshalToString(lowerCaseKeys)
 			if err != nil {
 				return nil, err
@@ -85,9 +86,66 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 	return params, nil
 }
 
-// WithForce
-func (o *RemoveOptions) WithForce(value bool) *RemoveOptions {
+// WithChanges
+func (o *ImportOptions) WithChanges(value []string) *ImportOptions {
 	v := &value
-	o.Force = v
+	o.Changes = v
 	return o
+}
+
+// GetChanges
+func (o *ImportOptions) GetChanges() []string {
+	var changes []string
+	if o.Changes == nil {
+		return changes
+	}
+	return *o.Changes
+}
+
+// WithMessage
+func (o *ImportOptions) WithMessage(value string) *ImportOptions {
+	v := &value
+	o.Message = v
+	return o
+}
+
+// GetMessage
+func (o *ImportOptions) GetMessage() string {
+	var message string
+	if o.Message == nil {
+		return message
+	}
+	return *o.Message
+}
+
+// WithReference
+func (o *ImportOptions) WithReference(value string) *ImportOptions {
+	v := &value
+	o.Reference = v
+	return o
+}
+
+// GetReference
+func (o *ImportOptions) GetReference() string {
+	var reference string
+	if o.Reference == nil {
+		return reference
+	}
+	return *o.Reference
+}
+
+// WithURL
+func (o *ImportOptions) WithURL(value string) *ImportOptions {
+	v := &value
+	o.URL = v
+	return o
+}
+
+// GetURL
+func (o *ImportOptions) GetURL() string {
+	var uRL string
+	if o.URL == nil {
+		return uRL
+	}
+	return *o.URL
 }

--- a/pkg/bindings/images/types_list_options.go
+++ b/pkg/bindings/images/types_list_options.go
@@ -1,0 +1,119 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:46.671238196 -0600 CST m=+0.000266757
+*/
+
+// Changed
+func (o *ListOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *ListOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}
+
+// WithAll
+func (o *ListOptions) WithAll(value bool) *ListOptions {
+	v := &value
+	o.All = v
+	return o
+}
+
+// GetAll
+func (o *ListOptions) GetAll() bool {
+	var all bool
+	if o.All == nil {
+		return all
+	}
+	return *o.All
+}
+
+// WithFilters
+func (o *ListOptions) WithFilters(value map[string][]string) *ListOptions {
+	v := value
+	o.Filters = v
+	return o
+}
+
+// GetFilters
+func (o *ListOptions) GetFilters() map[string][]string {
+	var filters map[string][]string
+	if o.Filters == nil {
+		return filters
+	}
+	return o.Filters
+}

--- a/pkg/bindings/images/types_load_options.go
+++ b/pkg/bindings/images/types_load_options.go
@@ -1,0 +1,103 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:47.237599061 -0600 CST m=+0.000247138
+*/
+
+// Changed
+func (o *LoadOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *LoadOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}
+
+// WithReference
+func (o *LoadOptions) WithReference(value string) *LoadOptions {
+	v := &value
+	o.Reference = v
+	return o
+}
+
+// GetReference
+func (o *LoadOptions) GetReference() string {
+	var reference string
+	if o.Reference == nil {
+		return reference
+	}
+	return *o.Reference
+}

--- a/pkg/bindings/images/types_prune_options.go
+++ b/pkg/bindings/images/types_prune_options.go
@@ -1,0 +1,119 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:47.521471344 -0600 CST m=+0.000250491
+*/
+
+// Changed
+func (o *PruneOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *PruneOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}
+
+// WithAll
+func (o *PruneOptions) WithAll(value bool) *PruneOptions {
+	v := &value
+	o.All = v
+	return o
+}
+
+// GetAll
+func (o *PruneOptions) GetAll() bool {
+	var all bool
+	if o.All == nil {
+		return all
+	}
+	return *o.All
+}
+
+// WithFilters
+func (o *PruneOptions) WithFilters(value map[string][]string) *PruneOptions {
+	v := value
+	o.Filters = v
+	return o
+}
+
+// GetFilters
+func (o *PruneOptions) GetFilters() map[string][]string {
+	var filters map[string][]string
+	if o.Filters == nil {
+		return filters
+	}
+	return o.Filters
+}

--- a/pkg/bindings/images/types_pull_options.go
+++ b/pkg/bindings/images/types_pull_options.go
@@ -1,0 +1,280 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	"github.com/containers/common/pkg/config"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:48.373345229 -0600 CST m=+0.000247562
+*/
+
+// Changed
+func (o *PullOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *PullOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}
+
+// WithAllTags
+func (o *PullOptions) WithAllTags(value bool) *PullOptions {
+	v := &value
+	o.AllTags = v
+	return o
+}
+
+// GetAllTags
+func (o *PullOptions) GetAllTags() bool {
+	var allTags bool
+	if o.AllTags == nil {
+		return allTags
+	}
+	return *o.AllTags
+}
+
+// WithAuthfile
+func (o *PullOptions) WithAuthfile(value string) *PullOptions {
+	v := &value
+	o.Authfile = v
+	return o
+}
+
+// GetAuthfile
+func (o *PullOptions) GetAuthfile() string {
+	var authfile string
+	if o.Authfile == nil {
+		return authfile
+	}
+	return *o.Authfile
+}
+
+// WithCertDir
+func (o *PullOptions) WithCertDir(value string) *PullOptions {
+	v := &value
+	o.CertDir = v
+	return o
+}
+
+// GetCertDir
+func (o *PullOptions) GetCertDir() string {
+	var certDir string
+	if o.CertDir == nil {
+		return certDir
+	}
+	return *o.CertDir
+}
+
+// WithUsername
+func (o *PullOptions) WithUsername(value string) *PullOptions {
+	v := &value
+	o.Username = v
+	return o
+}
+
+// GetUsername
+func (o *PullOptions) GetUsername() string {
+	var username string
+	if o.Username == nil {
+		return username
+	}
+	return *o.Username
+}
+
+// WithPassword
+func (o *PullOptions) WithPassword(value string) *PullOptions {
+	v := &value
+	o.Password = v
+	return o
+}
+
+// GetPassword
+func (o *PullOptions) GetPassword() string {
+	var password string
+	if o.Password == nil {
+		return password
+	}
+	return *o.Password
+}
+
+// WithOverrideArch
+func (o *PullOptions) WithOverrideArch(value string) *PullOptions {
+	v := &value
+	o.OverrideArch = v
+	return o
+}
+
+// GetOverrideArch
+func (o *PullOptions) GetOverrideArch() string {
+	var overrideArch string
+	if o.OverrideArch == nil {
+		return overrideArch
+	}
+	return *o.OverrideArch
+}
+
+// WithOverrideOS
+func (o *PullOptions) WithOverrideOS(value string) *PullOptions {
+	v := &value
+	o.OverrideOS = v
+	return o
+}
+
+// GetOverrideOS
+func (o *PullOptions) GetOverrideOS() string {
+	var overrideOS string
+	if o.OverrideOS == nil {
+		return overrideOS
+	}
+	return *o.OverrideOS
+}
+
+// WithOverrideVariant
+func (o *PullOptions) WithOverrideVariant(value string) *PullOptions {
+	v := &value
+	o.OverrideVariant = v
+	return o
+}
+
+// GetOverrideVariant
+func (o *PullOptions) GetOverrideVariant() string {
+	var overrideVariant string
+	if o.OverrideVariant == nil {
+		return overrideVariant
+	}
+	return *o.OverrideVariant
+}
+
+// WithQuiet
+func (o *PullOptions) WithQuiet(value bool) *PullOptions {
+	v := &value
+	o.Quiet = v
+	return o
+}
+
+// GetQuiet
+func (o *PullOptions) GetQuiet() bool {
+	var quiet bool
+	if o.Quiet == nil {
+		return quiet
+	}
+	return *o.Quiet
+}
+
+// WithSignaturePolicy
+func (o *PullOptions) WithSignaturePolicy(value string) *PullOptions {
+	v := &value
+	o.SignaturePolicy = v
+	return o
+}
+
+// GetSignaturePolicy
+func (o *PullOptions) GetSignaturePolicy() string {
+	var signaturePolicy string
+	if o.SignaturePolicy == nil {
+		return signaturePolicy
+	}
+	return *o.SignaturePolicy
+}
+
+// WithSkipTLSVerify
+func (o *PullOptions) WithSkipTLSVerify(value bool) *PullOptions {
+	v := &value
+	o.SkipTLSVerify = v
+	return o
+}
+
+// GetSkipTLSVerify
+func (o *PullOptions) GetSkipTLSVerify() bool {
+	var skipTLSVerify bool
+	if o.SkipTLSVerify == nil {
+		return skipTLSVerify
+	}
+	return *o.SkipTLSVerify
+}
+
+// WithPullPolicy
+func (o *PullOptions) WithPullPolicy(value config.PullPolicy) *PullOptions {
+	v := &value
+	o.PullPolicy = v
+	return o
+}
+
+// GetPullPolicy
+func (o *PullOptions) GetPullPolicy() config.PullPolicy {
+	var pullPolicy config.PullPolicy
+	if o.PullPolicy == nil {
+		return pullPolicy
+	}
+	return *o.PullPolicy
+}

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -1,0 +1,279 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:48.08540302 -0600 CST m=+0.000302026
+*/
+
+// Changed
+func (o *PushOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *PushOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}
+
+// WithAuthfile
+func (o *PushOptions) WithAuthfile(value string) *PushOptions {
+	v := &value
+	o.Authfile = v
+	return o
+}
+
+// GetAuthfile
+func (o *PushOptions) GetAuthfile() string {
+	var authfile string
+	if o.Authfile == nil {
+		return authfile
+	}
+	return *o.Authfile
+}
+
+// WithCertDir
+func (o *PushOptions) WithCertDir(value string) *PushOptions {
+	v := &value
+	o.CertDir = v
+	return o
+}
+
+// GetCertDir
+func (o *PushOptions) GetCertDir() string {
+	var certDir string
+	if o.CertDir == nil {
+		return certDir
+	}
+	return *o.CertDir
+}
+
+// WithCompress
+func (o *PushOptions) WithCompress(value bool) *PushOptions {
+	v := &value
+	o.Compress = v
+	return o
+}
+
+// GetCompress
+func (o *PushOptions) GetCompress() bool {
+	var compress bool
+	if o.Compress == nil {
+		return compress
+	}
+	return *o.Compress
+}
+
+// WithUsername
+func (o *PushOptions) WithUsername(value string) *PushOptions {
+	v := &value
+	o.Username = v
+	return o
+}
+
+// GetUsername
+func (o *PushOptions) GetUsername() string {
+	var username string
+	if o.Username == nil {
+		return username
+	}
+	return *o.Username
+}
+
+// WithPassword
+func (o *PushOptions) WithPassword(value string) *PushOptions {
+	v := &value
+	o.Password = v
+	return o
+}
+
+// GetPassword
+func (o *PushOptions) GetPassword() string {
+	var password string
+	if o.Password == nil {
+		return password
+	}
+	return *o.Password
+}
+
+// WithDigestFile
+func (o *PushOptions) WithDigestFile(value string) *PushOptions {
+	v := &value
+	o.DigestFile = v
+	return o
+}
+
+// GetDigestFile
+func (o *PushOptions) GetDigestFile() string {
+	var digestFile string
+	if o.DigestFile == nil {
+		return digestFile
+	}
+	return *o.DigestFile
+}
+
+// WithFormat
+func (o *PushOptions) WithFormat(value string) *PushOptions {
+	v := &value
+	o.Format = v
+	return o
+}
+
+// GetFormat
+func (o *PushOptions) GetFormat() string {
+	var format string
+	if o.Format == nil {
+		return format
+	}
+	return *o.Format
+}
+
+// WithQuiet
+func (o *PushOptions) WithQuiet(value bool) *PushOptions {
+	v := &value
+	o.Quiet = v
+	return o
+}
+
+// GetQuiet
+func (o *PushOptions) GetQuiet() bool {
+	var quiet bool
+	if o.Quiet == nil {
+		return quiet
+	}
+	return *o.Quiet
+}
+
+// WithRemoveSignatures
+func (o *PushOptions) WithRemoveSignatures(value bool) *PushOptions {
+	v := &value
+	o.RemoveSignatures = v
+	return o
+}
+
+// GetRemoveSignatures
+func (o *PushOptions) GetRemoveSignatures() bool {
+	var removeSignatures bool
+	if o.RemoveSignatures == nil {
+		return removeSignatures
+	}
+	return *o.RemoveSignatures
+}
+
+// WithSignaturePolicy
+func (o *PushOptions) WithSignaturePolicy(value string) *PushOptions {
+	v := &value
+	o.SignaturePolicy = v
+	return o
+}
+
+// GetSignaturePolicy
+func (o *PushOptions) GetSignaturePolicy() string {
+	var signaturePolicy string
+	if o.SignaturePolicy == nil {
+		return signaturePolicy
+	}
+	return *o.SignaturePolicy
+}
+
+// WithSignBy
+func (o *PushOptions) WithSignBy(value string) *PushOptions {
+	v := &value
+	o.SignBy = v
+	return o
+}
+
+// GetSignBy
+func (o *PushOptions) GetSignBy() string {
+	var signBy string
+	if o.SignBy == nil {
+		return signBy
+	}
+	return *o.SignBy
+}
+
+// WithSkipTLSVerify
+func (o *PushOptions) WithSkipTLSVerify(value bool) *PushOptions {
+	v := &value
+	o.SkipTLSVerify = v
+	return o
+}
+
+// GetSkipTLSVerify
+func (o *PushOptions) GetSkipTLSVerify() bool {
+	var skipTLSVerify bool
+	if o.SkipTLSVerify == nil {
+		return skipTLSVerify
+	}
+	return *o.SkipTLSVerify
+}

--- a/pkg/bindings/images/types_remove_options.go
+++ b/pkg/bindings/images/types_remove_options.go
@@ -1,0 +1,119 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:46.378166859 -0600 CST m=+0.000249384
+*/
+
+// Changed
+func (o *RemoveOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *RemoveOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}
+
+// WithAll
+func (o *RemoveOptions) WithAll(value bool) *RemoveOptions {
+	v := &value
+	o.All = v
+	return o
+}
+
+// GetAll
+func (o *RemoveOptions) GetAll() bool {
+	var all bool
+	if o.All == nil {
+		return all
+	}
+	return *o.All
+}
+
+// WithForce
+func (o *RemoveOptions) WithForce(value bool) *RemoveOptions {
+	v := &value
+	o.Force = v
+	return o
+}
+
+// GetForce
+func (o *RemoveOptions) GetForce() bool {
+	var force bool
+	if o.Force == nil {
+		return force
+	}
+	return *o.Force
+}

--- a/pkg/bindings/images/types_search_options.go
+++ b/pkg/bindings/images/types_search_options.go
@@ -1,0 +1,183 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:48.229349981 -0600 CST m=+0.000244343
+*/
+
+// Changed
+func (o *SearchOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *SearchOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}
+
+// WithAuthfile
+func (o *SearchOptions) WithAuthfile(value string) *SearchOptions {
+	v := &value
+	o.Authfile = v
+	return o
+}
+
+// GetAuthfile
+func (o *SearchOptions) GetAuthfile() string {
+	var authfile string
+	if o.Authfile == nil {
+		return authfile
+	}
+	return *o.Authfile
+}
+
+// WithFilters
+func (o *SearchOptions) WithFilters(value map[string][]string) *SearchOptions {
+	v := value
+	o.Filters = v
+	return o
+}
+
+// GetFilters
+func (o *SearchOptions) GetFilters() map[string][]string {
+	var filters map[string][]string
+	if o.Filters == nil {
+		return filters
+	}
+	return o.Filters
+}
+
+// WithLimit
+func (o *SearchOptions) WithLimit(value int) *SearchOptions {
+	v := &value
+	o.Limit = v
+	return o
+}
+
+// GetLimit
+func (o *SearchOptions) GetLimit() int {
+	var limit int
+	if o.Limit == nil {
+		return limit
+	}
+	return *o.Limit
+}
+
+// WithNoTrunc
+func (o *SearchOptions) WithNoTrunc(value bool) *SearchOptions {
+	v := &value
+	o.NoTrunc = v
+	return o
+}
+
+// GetNoTrunc
+func (o *SearchOptions) GetNoTrunc() bool {
+	var noTrunc bool
+	if o.NoTrunc == nil {
+		return noTrunc
+	}
+	return *o.NoTrunc
+}
+
+// WithSkipTLSVerify
+func (o *SearchOptions) WithSkipTLSVerify(value bool) *SearchOptions {
+	v := &value
+	o.SkipTLSVerify = v
+	return o
+}
+
+// GetSkipTLSVerify
+func (o *SearchOptions) GetSkipTLSVerify() bool {
+	var skipTLSVerify bool
+	if o.SkipTLSVerify == nil {
+		return skipTLSVerify
+	}
+	return *o.SkipTLSVerify
+}
+
+// WithListTags
+func (o *SearchOptions) WithListTags(value bool) *SearchOptions {
+	v := &value
+	o.ListTags = v
+	return o
+}
+
+// GetListTags
+func (o *SearchOptions) GetListTags() bool {
+	var listTags bool
+	if o.ListTags == nil {
+		return listTags
+	}
+	return *o.ListTags
+}

--- a/pkg/bindings/images/types_tag_options.go
+++ b/pkg/bindings/images/types_tag_options.go
@@ -1,0 +1,87 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:47.66229668 -0600 CST m=+0.000246630
+*/
+
+// Changed
+func (o *TagOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *TagOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}

--- a/pkg/bindings/images/types_tree_options.go
+++ b/pkg/bindings/images/types_tree_options.go
@@ -1,0 +1,103 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:46.954579136 -0600 CST m=+0.000248704
+*/
+
+// Changed
+func (o *TreeOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *TreeOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}
+
+// WithWhatRequires
+func (o *TreeOptions) WithWhatRequires(value bool) *TreeOptions {
+	v := &value
+	o.WhatRequires = v
+	return o
+}
+
+// GetWhatRequires
+func (o *TreeOptions) GetWhatRequires() bool {
+	var whatRequires bool
+	if o.WhatRequires == nil {
+		return whatRequires
+	}
+	return *o.WhatRequires
+}

--- a/pkg/bindings/images/types_untag_options.go
+++ b/pkg/bindings/images/types_untag_options.go
@@ -1,0 +1,87 @@
+package images
+
+import (
+	"net/url"
+	"reflect"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+
+Created 2020-12-15 15:22:47.802372989 -0600 CST m=+0.000239766
+*/
+
+// Changed
+func (o *UntagOptions) Changed(fieldName string) bool {
+	r := reflect.ValueOf(o)
+	value := reflect.Indirect(r).FieldByName(fieldName)
+	return !value.IsNil()
+}
+
+// ToParams
+func (o *UntagOptions) ToParams() (url.Values, error) {
+	params := url.Values{}
+	if o == nil {
+		return params, nil
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	s := reflect.ValueOf(o)
+	if reflect.Ptr == s.Kind() {
+		s = s.Elem()
+	}
+	sType := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		fieldName := sType.Field(i).Name
+		if !o.Changed(fieldName) {
+			continue
+		}
+		f := s.Field(i)
+		if reflect.Ptr == f.Kind() {
+			f = f.Elem()
+		}
+		switch f.Kind() {
+		case reflect.Bool:
+			params.Set(fieldName, strconv.FormatBool(f.Bool()))
+		case reflect.String:
+			params.Set(fieldName, f.String())
+		case reflect.Int, reflect.Int64:
+			// f.Int() is always an int64
+			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
+		case reflect.Slice:
+			typ := reflect.TypeOf(f.Interface()).Elem()
+			slice := reflect.MakeSlice(reflect.SliceOf(typ), f.Len(), f.Cap())
+			switch typ.Kind() {
+			case reflect.String:
+				s, ok := slice.Interface().([]string)
+				if !ok {
+					return nil, errors.New("failed to convert to string slice")
+				}
+				for _, val := range s {
+					params.Add(fieldName, val)
+				}
+			default:
+				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
+			}
+		case reflect.Map:
+			lowerCaseKeys := make(map[string][]string)
+			iter := f.MapRange()
+			for iter.Next() {
+				lowerCaseKeys[iter.Key().Interface().(string)] = iter.Value().Interface().([]string)
+
+			}
+			s, err := json.MarshalToString(lowerCaseKeys)
+			if err != nil {
+				return nil, err
+			}
+
+			params.Set(fieldName, s)
+		default:
+			return nil, errors.Errorf("unknown type %s", f.Kind().String())
+		}
+	}
+	return params, nil
+}

--- a/pkg/bindings/test/auth_test.go
+++ b/pkg/bindings/test/auth_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/image/v5/types"
 	podmanRegistry "github.com/containers/podman/v2/hack/podman-registry-go"
 	"github.com/containers/podman/v2/pkg/bindings/images"
-	"github.com/containers/podman/v2/pkg/domain/entities"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -52,27 +51,19 @@ var _ = Describe("Podman images", func() {
 		imageRef := imageRep + ":" + imageTag
 
 		// Tag the alpine image and verify it has worked.
-		err = images.Tag(bt.conn, alpine.shortName, imageTag, imageRep)
+		err = images.Tag(bt.conn, alpine.shortName, imageTag, imageRep, nil)
 		Expect(err).To(BeNil())
 		_, err = images.GetImage(bt.conn, imageRef, nil)
 		Expect(err).To(BeNil())
 
 		// Now push the image.
-		pushOpts := entities.ImagePushOptions{
-			Username:      registry.User,
-			Password:      registry.Password,
-			SkipTLSVerify: types.OptionalBoolTrue,
-		}
-		err = images.Push(bt.conn, imageRef, imageRef, pushOpts)
+		pushOpts := new(images.PushOptions)
+		err = images.Push(bt.conn, imageRef, imageRef, pushOpts.WithUsername(registry.User).WithPassword(registry.Password).WithSkipTLSVerify(true))
 		Expect(err).To(BeNil())
 
 		// Now pull the image.
-		pullOpts := entities.ImagePullOptions{
-			Username:      registry.User,
-			Password:      registry.Password,
-			SkipTLSVerify: types.OptionalBoolTrue,
-		}
-		_, err = images.Pull(bt.conn, imageRef, pullOpts)
+		pullOpts := new(images.PullOptions)
+		_, err = images.Pull(bt.conn, imageRef, pullOpts.WithSkipTLSVerify(true).WithPassword(registry.Password).WithUsername(registry.User))
 		Expect(err).To(BeNil())
 	})
 
@@ -110,33 +101,24 @@ var _ = Describe("Podman images", func() {
 		Expect(err).To(BeNil())
 
 		// Tag the alpine image and verify it has worked.
-		err = images.Tag(bt.conn, alpine.shortName, imageTag, imageRep)
+		err = images.Tag(bt.conn, alpine.shortName, imageTag, imageRep, nil)
 		Expect(err).To(BeNil())
 		_, err = images.GetImage(bt.conn, imageRef, nil)
 		Expect(err).To(BeNil())
 
 		// Now push the image.
-		pushOpts := entities.ImagePushOptions{
-			Authfile:      authFilePath,
-			SkipTLSVerify: types.OptionalBoolTrue,
-		}
-		err = images.Push(bt.conn, imageRef, imageRef, pushOpts)
+		pushOpts := new(images.PushOptions)
+		err = images.Push(bt.conn, imageRef, imageRef, pushOpts.WithAuthfile(authFilePath).WithSkipTLSVerify(true))
 		Expect(err).To(BeNil())
 
 		// Now pull the image.
-		pullOpts := entities.ImagePullOptions{
-			Authfile:      authFilePath,
-			SkipTLSVerify: types.OptionalBoolTrue,
-		}
-		_, err = images.Pull(bt.conn, imageRef, pullOpts)
+		pullOpts := new(images.PullOptions)
+		_, err = images.Pull(bt.conn, imageRef, pullOpts.WithAuthfile(authFilePath).WithSkipTLSVerify(true))
 		Expect(err).To(BeNil())
 
 		// Last, but not least, exercise search.
-		searchOptions := entities.ImageSearchOptions{
-			Authfile:      authFilePath,
-			SkipTLSVerify: types.OptionalBoolTrue,
-		}
-		_, err = images.Search(bt.conn, imageRef, searchOptions)
+		searchOptions := new(images.SearchOptions)
+		_, err = images.Search(bt.conn, imageRef, searchOptions.WithSkipTLSVerify(true).WithAuthfile(authFilePath))
 		Expect(err).To(BeNil())
 	})
 

--- a/pkg/bindings/test/images_test.go
+++ b/pkg/bindings/test/images_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/podman/v2/pkg/bindings"
 	"github.com/containers/podman/v2/pkg/bindings/containers"
 	"github.com/containers/podman/v2/pkg/bindings/images"
-	"github.com/containers/podman/v2/pkg/domain/entities"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -75,8 +74,9 @@ var _ = Describe("Podman images", func() {
 		// of bool or not. What should we do ?
 		// Expect(data.Size).To(BeZero())
 
+		options := new(images.GetOptions).WithSize(true)
 		// Enabling the size parameter should result in size being populated
-		data, err = images.GetImage(bt.conn, alpine.name, bindings.PTrue)
+		data, err = images.GetImage(bt.conn, alpine.name, options)
 		Expect(err).To(BeNil())
 		Expect(data.Size).To(BeNumerically(">", 0))
 	})
@@ -84,23 +84,19 @@ var _ = Describe("Podman images", func() {
 	// Test to validate the remove image api
 	It("remove image", func() {
 		// Remove invalid image should be a 404
-		response, err := images.Remove(bt.conn, "foobar5000", nil)
-		Expect(err).ToNot(BeNil())
-		Expect(response).To(BeNil())
-		code, _ := bindings.CheckResponseCode(err)
-		Expect(code).To(BeNumerically("==", http.StatusNotFound))
+		response, errs := images.Remove(bt.conn, []string{"foobar5000"}, nil)
+		Expect(len(errs)).To(BeNumerically(">", 0))
+		code, _ := bindings.CheckResponseCode(errs[0])
 
 		// Remove an image by name, validate image is removed and error is nil
 		inspectData, err := images.GetImage(bt.conn, busybox.shortName, nil)
 		Expect(err).To(BeNil())
-		response, err = images.Remove(bt.conn, busybox.shortName, nil)
-		Expect(err).To(BeNil())
-		code, _ = bindings.CheckResponseCode(err)
+		response, errs = images.Remove(bt.conn, []string{busybox.shortName}, nil)
+		Expect(len(errs)).To(BeZero())
 
 		Expect(inspectData.ID).To(Equal(response.Deleted[0]))
 		inspectData, err = images.GetImage(bt.conn, busybox.shortName, nil)
 		code, _ = bindings.CheckResponseCode(err)
-		Expect(code).To(BeNumerically("==", http.StatusNotFound))
 
 		// Start a container with alpine image
 		var top string = "top"
@@ -113,24 +109,21 @@ var _ = Describe("Podman images", func() {
 
 		// try to remove the image "alpine". This should fail since we are not force
 		// deleting hence image cannot be deleted until the container is deleted.
-		response, err = images.Remove(bt.conn, alpine.shortName, nil)
-		code, _ = bindings.CheckResponseCode(err)
-		Expect(code).To(BeNumerically("==", http.StatusConflict))
+		response, errs = images.Remove(bt.conn, []string{alpine.shortName}, nil)
+		code, _ = bindings.CheckResponseCode(errs[0])
 
 		// Removing the image "alpine" where force = true
-		options := images.RemoveOptions{}
-		response, err = images.Remove(bt.conn, alpine.shortName, options.WithForce(true))
-		Expect(err).To(BeNil())
+		options := new(images.RemoveOptions).WithForce(true)
+		response, errs = images.Remove(bt.conn, []string{alpine.shortName}, options)
+		Expect(len(errs)).To(BeZero())
 		// To be extra sure, check if the previously created container
 		// is gone as well.
 		_, err = containers.Inspect(bt.conn, "top", bindings.PFalse)
 		code, _ = bindings.CheckResponseCode(err)
-		Expect(code).To(BeNumerically("==", http.StatusNotFound))
 
 		// Now make sure both images are gone.
 		inspectData, err = images.GetImage(bt.conn, busybox.shortName, nil)
 		code, _ = bindings.CheckResponseCode(err)
-		Expect(code).To(BeNumerically("==", http.StatusNotFound))
 
 		inspectData, err = images.GetImage(bt.conn, alpine.shortName, nil)
 		code, _ = bindings.CheckResponseCode(err)
@@ -139,14 +132,15 @@ var _ = Describe("Podman images", func() {
 
 	// Tests to validate the image tag command.
 	It("tag image", func() {
+
 		// Validates if invalid image name is given a bad response is encountered.
-		err = images.Tag(bt.conn, "dummy", "demo", alpine.shortName)
+		err = images.Tag(bt.conn, "dummy", "demo", alpine.shortName, nil)
 		Expect(err).ToNot(BeNil())
 		code, _ := bindings.CheckResponseCode(err)
 		Expect(code).To(BeNumerically("==", http.StatusNotFound))
 
 		// Validates if the image is tagged successfully.
-		err = images.Tag(bt.conn, alpine.shortName, "demo", alpine.shortName)
+		err = images.Tag(bt.conn, alpine.shortName, "demo", alpine.shortName, nil)
 		Expect(err).To(BeNil())
 
 		// Validates if name updates when the image is retagged.
@@ -158,7 +152,7 @@ var _ = Describe("Podman images", func() {
 	// Test to validate the List images command.
 	It("List image", func() {
 		// Array to hold the list of images returned
-		imageSummary, err := images.List(bt.conn, nil, nil)
+		imageSummary, err := images.List(bt.conn, nil)
 		// There Should be no errors in the response.
 		Expect(err).To(BeNil())
 		// Since in the begin context two images are created the
@@ -168,7 +162,7 @@ var _ = Describe("Podman images", func() {
 		// Adding one more image. There Should be no errors in the response.
 		// And the count should be three now.
 		bt.Pull("testimage:20200929")
-		imageSummary, err = images.List(bt.conn, nil, nil)
+		imageSummary, err = images.List(bt.conn, nil)
 		Expect(err).To(BeNil())
 		Expect(len(imageSummary)).To(Equal(3))
 
@@ -183,13 +177,15 @@ var _ = Describe("Podman images", func() {
 		// List  images with a filter
 		filters := make(map[string][]string)
 		filters["reference"] = []string{alpine.name}
-		filteredImages, err := images.List(bt.conn, bindings.PFalse, filters)
+		options := new(images.ListOptions).WithFilters(filters).WithAll(false)
+		filteredImages, err := images.List(bt.conn, options)
 		Expect(err).To(BeNil())
 		Expect(len(filteredImages)).To(BeNumerically("==", 1))
 
 		// List  images with a bad filter
 		filters["name"] = []string{alpine.name}
-		_, err = images.List(bt.conn, bindings.PFalse, filters)
+		options = new(images.ListOptions).WithFilters(filters)
+		_, err = images.List(bt.conn, options)
 		Expect(err).ToNot(BeNil())
 		code, _ := bindings.CheckResponseCode(err)
 		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
@@ -214,8 +210,8 @@ var _ = Describe("Podman images", func() {
 
 	It("Load|Import Image", func() {
 		// load an image
-		_, err := images.Remove(bt.conn, alpine.name, nil)
-		Expect(err).To(BeNil())
+		_, errs := images.Remove(bt.conn, []string{alpine.name}, nil)
+		Expect(len(errs)).To(BeZero())
 		exists, err := images.Exists(bt.conn, alpine.name)
 		Expect(err).To(BeNil())
 		Expect(exists).To(BeFalse())
@@ -232,13 +228,14 @@ var _ = Describe("Podman images", func() {
 		// load with a repo name
 		f, err = os.Open(filepath.Join(ImageCacheDir, alpine.tarballName))
 		Expect(err).To(BeNil())
-		_, err = images.Remove(bt.conn, alpine.name, nil)
-		Expect(err).To(BeNil())
+		_, errs = images.Remove(bt.conn, []string{alpine.name}, nil)
+		Expect(len(errs)).To(BeZero())
 		exists, err = images.Exists(bt.conn, alpine.name)
 		Expect(err).To(BeNil())
 		Expect(exists).To(BeFalse())
 		newName := "quay.io/newname:fizzle"
-		names, err = images.Load(bt.conn, f, &newName)
+		options := new(images.LoadOptions).WithReference(newName)
+		names, err = images.Load(bt.conn, f, options)
 		Expect(err).To(BeNil())
 		Expect(names.Names[0]).To(Equal(alpine.name))
 		exists, err = images.Exists(bt.conn, newName)
@@ -248,13 +245,13 @@ var _ = Describe("Podman images", func() {
 		// load with a bad repo name should trigger a 500
 		f, err = os.Open(filepath.Join(ImageCacheDir, alpine.tarballName))
 		Expect(err).To(BeNil())
-		_, err = images.Remove(bt.conn, alpine.name, nil)
-		Expect(err).To(BeNil())
+		_, errs = images.Remove(bt.conn, []string{alpine.name}, nil)
+		Expect(len(errs)).To(BeZero())
 		exists, err = images.Exists(bt.conn, alpine.name)
 		Expect(err).To(BeNil())
 		Expect(exists).To(BeFalse())
-		badName := "quay.io/newName:fizzle"
-		_, err = images.Load(bt.conn, f, &badName)
+		options = new(images.LoadOptions).WithReference("quay.io/newName:fizzle")
+		_, err = images.Load(bt.conn, f, options)
 		Expect(err).ToNot(BeNil())
 		code, _ := bindings.CheckResponseCode(err)
 		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
@@ -266,7 +263,7 @@ var _ = Describe("Podman images", func() {
 		w, err := os.Create(filepath.Join(bt.tempDirPath, alpine.tarballName))
 		defer w.Close()
 		Expect(err).To(BeNil())
-		err = images.Export(bt.conn, alpine.name, w, nil, nil)
+		err = images.Export(bt.conn, []string{alpine.name}, w, nil)
 		Expect(err).To(BeNil())
 		_, err = os.Stat(exportPath)
 		Expect(err).To(BeNil())
@@ -276,8 +273,8 @@ var _ = Describe("Podman images", func() {
 
 	It("Import Image", func() {
 		// load an image
-		_, err = images.Remove(bt.conn, alpine.name, nil)
-		Expect(err).To(BeNil())
+		_, errs := images.Remove(bt.conn, []string{alpine.name}, nil)
+		Expect(len(errs)).To(BeZero())
 		exists, err := images.Exists(bt.conn, alpine.name)
 		Expect(err).To(BeNil())
 		Expect(exists).To(BeFalse())
@@ -286,7 +283,8 @@ var _ = Describe("Podman images", func() {
 		Expect(err).To(BeNil())
 		changes := []string{"CMD /bin/foobar"}
 		testMessage := "test_import"
-		_, err = images.Import(bt.conn, changes, &testMessage, &alpine.name, nil, f)
+		options := new(images.ImportOptions).WithMessage(testMessage).WithChanges(changes).WithReference(alpine.name)
+		_, err = images.Import(bt.conn, f, options)
 		Expect(err).To(BeNil())
 		exists, err = images.Exists(bt.conn, alpine.name)
 		Expect(err).To(BeNil())
@@ -299,7 +297,7 @@ var _ = Describe("Podman images", func() {
 
 	It("History Image", func() {
 		// a bogus name should return a 404
-		_, err := images.History(bt.conn, "foobar")
+		_, err := images.History(bt.conn, "foobar", nil)
 		Expect(err).To(Not(BeNil()))
 		code, _ := bindings.CheckResponseCode(err)
 		Expect(code).To(BeNumerically("==", http.StatusNotFound))
@@ -307,7 +305,7 @@ var _ = Describe("Podman images", func() {
 		var foundID bool
 		data, err := images.GetImage(bt.conn, alpine.name, nil)
 		Expect(err).To(BeNil())
-		history, err := images.History(bt.conn, alpine.name)
+		history, err := images.History(bt.conn, alpine.name, nil)
 		Expect(err).To(BeNil())
 		for _, i := range history {
 			if i.ID == data.ID {
@@ -319,7 +317,7 @@ var _ = Describe("Podman images", func() {
 	})
 
 	It("Search for an image", func() {
-		reports, err := images.Search(bt.conn, "alpine", entities.ImageSearchOptions{})
+		reports, err := images.Search(bt.conn, "alpine", nil)
 		Expect(err).To(BeNil())
 		Expect(len(reports)).To(BeNumerically(">", 1))
 		var foundAlpine bool
@@ -332,25 +330,29 @@ var _ = Describe("Podman images", func() {
 		Expect(foundAlpine).To(BeTrue())
 
 		// Search for alpine with a limit of 10
-		reports, err = images.Search(bt.conn, "docker.io/alpine", entities.ImageSearchOptions{Limit: 10})
+		options := new(images.SearchOptions).WithLimit(10)
+		reports, err = images.Search(bt.conn, "docker.io/alpine", options)
 		Expect(err).To(BeNil())
 		Expect(len(reports)).To(BeNumerically("<=", 10))
 
+		filters := make(map[string][]string)
+		filters["stars"] = []string{"100"}
 		// Search for alpine with stars greater than 100
-		reports, err = images.Search(bt.conn, "docker.io/alpine", entities.ImageSearchOptions{Filters: []string{"stars=100"}})
+		options = new(images.SearchOptions).WithFilters(filters)
+		reports, err = images.Search(bt.conn, "docker.io/alpine", options)
 		Expect(err).To(BeNil())
 		for _, i := range reports {
 			Expect(i.Stars).To(BeNumerically(">=", 100))
 		}
 
 		//	Search with a fqdn
-		reports, err = images.Search(bt.conn, "quay.io/libpod/alpine_nginx", entities.ImageSearchOptions{})
+		reports, err = images.Search(bt.conn, "quay.io/libpod/alpine_nginx", nil)
 		Expect(len(reports)).To(BeNumerically(">=", 1))
 	})
 
 	It("Prune images", func() {
-		trueBoxed := true
-		results, err := images.Prune(bt.conn, &trueBoxed, nil)
+		options := new(images.PruneOptions).WithAll(true)
+		results, err := images.Prune(bt.conn, options)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(results)).To(BeNumerically(">", 0))
 		Expect(results).To(ContainElement("docker.io/library/alpine:latest"))
@@ -360,7 +362,7 @@ var _ = Describe("Podman images", func() {
 	It("Image Pull", func() {
 		rawImage := "docker.io/library/busybox:latest"
 
-		pulledImages, err := images.Pull(bt.conn, rawImage, entities.ImagePullOptions{})
+		pulledImages, err := images.Pull(bt.conn, rawImage, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(pulledImages)).To(Equal(1))
 
@@ -369,11 +371,11 @@ var _ = Describe("Podman images", func() {
 		Expect(exists).To(BeTrue())
 
 		// Make sure the normalization AND the full-transport reference works.
-		_, err = images.Pull(bt.conn, "docker://"+rawImage, entities.ImagePullOptions{})
+		_, err = images.Pull(bt.conn, "docker://"+rawImage, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		// The v2 endpoint only supports the docker transport.  Let's see if that's really true.
-		_, err = images.Pull(bt.conn, "bogus-transport:bogus.com/image:reference", entities.ImagePullOptions{})
+		_, err = images.Pull(bt.conn, "bogus-transport:bogus.com/image:reference", nil)
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/pkg/bindings/test/info_test.go
+++ b/pkg/bindings/test/info_test.go
@@ -17,7 +17,6 @@ var _ = Describe("Podman info", func() {
 	var (
 		bt *bindingTest
 		s  *gexec.Session
-		t  bool = true
 	)
 
 	BeforeEach(func() {
@@ -39,7 +38,8 @@ var _ = Describe("Podman info", func() {
 		Expect(err).To(BeNil())
 		Expect(info.Host.Arch).To(Equal(runtime.GOARCH))
 		Expect(info.Host.OS).To(Equal(runtime.GOOS))
-		i, err := images.List(bt.conn, &t, nil)
+		listOptions := new(images.ListOptions)
+		i, err := images.List(bt.conn, listOptions.WithAll(true))
 		Expect(err).To(BeNil())
 		Expect(info.Store.ImageStore.Number).To(Equal(len(i)))
 	})

--- a/pkg/bindings/test/manifests_test.go
+++ b/pkg/bindings/test/manifests_test.go
@@ -47,8 +47,8 @@ var _ = Describe("Podman containers ", func() {
 		code, _ := bindings.CheckResponseCode(err)
 		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
 
-		_, err = images.Remove(bt.conn, id, nil)
-		Expect(err).To(BeNil())
+		_, errs := images.Remove(bt.conn, []string{id}, nil)
+		Expect(len(errs)).To(BeZero())
 
 		// create manifest list with images
 		id, err = manifests.Create(bt.conn, []string{"quay.io/libpod/foobar:latest"}, []string{alpine.name}, nil)


### PR DESCRIPTION
Begin the migration of the image bindings for podman 3.0.  this includes
the use of options for each binding.  build was intentionally not
converted as I believe it needs more discussion before migration.
specifically, the build options themselves.

also noteworthly is that the remove image and remove images bindings
were merged into one.  the remove images (or batch remove) has one
downside in that the errors return no longer adhere to http return
codes.  this should be discussed and reimplemented in subsequent code.

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
