### PR TITLE
Clean up temporary file.

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/schema"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // mergeNameAndTagOrDigest creates an image reference as string from the
@@ -386,6 +387,12 @@ func LoadImages(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to create tempfile"))
 		return
 	}
+	defer func() {
+		err := os.Remove(f.Name())
+		if err != nil {
+			logrus.Errorf("Failed to remove temporary file: %v.", err)
+		}
+	}()
 	if err := SaveFromBody(f, r); err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to write temporary file"))
 		return


### PR DESCRIPTION
The `/images/load` APIv2 endpoint creates temporary files that are not being removed.