### PR TITLE
Allow users to specify TMPDIR in containers.conf

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -31,11 +31,6 @@ func main() {
 		return
 	}
 
-	// Hard code TMPDIR functions to use /var/tmp, if user did not override
-	if _, ok := os.LookupEnv("TMPDIR"); !ok {
-		os.Setenv("TMPDIR", "/var/tmp")
-	}
-
 	rootCmd = parseCommands()
 
 	Execute()

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -178,6 +178,10 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+	// Hard code TMPDIR functions to use /var/tmp, if user did not override
+	if _, ok := os.LookupEnv("TMPDIR"); !ok {
+		os.Setenv("TMPDIR", "/var/tmp")
+	}
 
 	if !registry.IsRemote() {
 		if cmd.Flag("cpu-profile").Changed {


### PR DESCRIPTION
Currently we hard code TMPDIR environment variable to /var/tmp
if it is not set in the Environment. This causes TMPDIR environment
variable to be ignored if set in containers.conf.

This change now uses the host environment TMPDIR, followed by
containers.conf and then hard codes TMPDIR, if it was not set.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
