### PR TITLE
libpod, conmon: change log level for rootless

### DIFF
--- a/contrib/cirrus/required_host_ports.txt
+++ b/contrib/cirrus/required_host_ports.txt
@@ -5,7 +5,6 @@ registry.fedoraproject.org 443
 mirrors.fedoraproject.org 443
 dl.fedoraproject.org 443
 ewr.edge.kernel.org 443
-mirror.chpc.utah.edu 443
 mirror.clarkson.edu 443
 mirror.umd.edu 443
 mirror.vcu.edu 443


### PR DESCRIPTION
Change the log level when running as rootless when moving conmon to a
different cgroup.

Closes: https://github.com/containers/podman/issues/8721

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
