### PR TITLE
Add LogSize to container inspect

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/libpod/driver"
 	"github.com/containers/podman/v2/pkg/util"
+	units "github.com/docker/go-units"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/runtime-tools/validate"
@@ -124,8 +125,6 @@ func (c *Container) getContainerInspectData(size bool, driverData *driver.Data) 
 		HostnamePath:    hostnamePath,
 		HostsPath:       hostsPath,
 		StaticDir:       config.StaticDir,
-		LogPath:         config.LogPath,
-		LogTag:          config.LogTag,
 		OCIRuntime:      config.OCIRuntime,
 		ConmonPidFile:   config.ConmonPidFile,
 		Name:            config.Name,
@@ -354,6 +353,10 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 
 	logConfig := new(define.InspectLogConfig)
 	logConfig.Type = c.config.LogDriver
+	logConfig.Path = c.config.LogPath
+	logConfig.Size = units.HumanSize(float64(c.config.LogSize))
+	logConfig.Tag = c.config.LogTag
+
 	hostConfig.LogConfig = logConfig
 
 	restartPolicy := new(define.InspectRestartPolicy)

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -82,10 +82,15 @@ type InspectRestartPolicy struct {
 }
 
 // InspectLogConfig holds information about a container's configured log driver
-// and is presently unused. It is retained for Docker compatibility.
 type InspectLogConfig struct {
 	Type   string            `json:"Type"`
 	Config map[string]string `json:"Config"` //idk type, TODO
+	// Path specifies a path to the log file
+	Path string `json:"Path"`
+	// Tag specifies a custom log tag for the container
+	Tag string `json:"Tag"`
+	// Size specifies a maximum size of the container log
+	Size string `json:"Size"`
 }
 
 // InspectBlkioWeightDevice holds information about the relative weight
@@ -620,8 +625,6 @@ type InspectContainerData struct {
 	StaticDir       string                      `json:"StaticDir"`
 	OCIConfigPath   string                      `json:"OCIConfigPath,omitempty"`
 	OCIRuntime      string                      `json:"OCIRuntime,omitempty"`
-	LogPath         string                      `json:"LogPath"`
-	LogTag          string                      `json:"LogTag"`
 	ConmonPidFile   string                      `json:"ConmonPidFile"`
 	Name            string                      `json:"Name"`
 	RestartCount    int32                       `json:"RestartCount"`

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -332,6 +332,11 @@ var _ = Describe("Podman logs", func() {
 		wait.WaitWithDefaultTimeout()
 		Expect(wait).To(Exit(0))
 
+		inspect := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.HostConfig.LogConfig.Size}}", cid})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).To(Exit(0))
+		Expect(inspect.OutputToString()).To(Equal("10kB"))
+
 		results := podmanTest.Podman([]string{"logs", cid})
 		results.WaitWithDefaultTimeout()
 		Expect(results).To(Exit(0))

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -401,7 +401,7 @@ json-file | f
         is "$output" "$driver" "podman inspect: driver"
 
         # If LogPath is non-null, check that it exists and has a valid log
-        run_podman inspect --format '{{.LogPath}}' myctr
+        run_podman inspect --format '{{.HostConfig.LogConfig.Path}}' myctr
         if [[ $do_check != '-' ]]; then
             is "$output" "/.*" "LogPath (driver=$driver)"
             if ! test -e "$output"; then


### PR DESCRIPTION
Other log options are available so we need to add ability to look
up LogSize.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
