### PR TITLE
podman.service should be an exec service not a notify service

### DIFF
--- a/contrib/systemd/system/podman.service
+++ b/contrib/systemd/system/podman.service
@@ -6,7 +6,7 @@ Documentation=man:podman-system-service(1)
 StartLimitIntervalSec=0
 
 [Service]
-Type=notify
+Type=exec
 KillMode=process
 Environment=LOGGING="--log-level=info"
 ExecStart=/usr/bin/podman $LOGGING system service


### PR DESCRIPTION
Podman never notifies sytemd that it is ready to recieve connections
so systemd kills it after waiting 1.5 minutes.  Changing to exec
should leave it running until podman exits or the service is stopped.

https://github.com/containers/podman/issues/8751

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
