### PR TITLE
Always add the default gateway to the cni config file

### DIFF
--- a/libpod/network/netconflist.go
+++ b/libpod/network/netconflist.go
@@ -95,6 +95,10 @@ func NewIPAMLocalHostRange(subnet *net.IPNet, ipRange *net.IPNet, gw net.IP) ([]
 	}
 	if gw != nil {
 		hostRange.Gateway = gw.String()
+	} else {
+		// Add first ip in subnet as gateway. It is not required
+		// by cni but should be included because of network inspect.
+		hostRange.Gateway = CalcGatewayIP(subnet).String()
 	}
 	ranges = append(ranges, hostRange)
 	return ranges, nil

--- a/libpod/network/netconflist_test.go
+++ b/libpod/network/netconflist_test.go
@@ -51,7 +51,8 @@ func TestNewIPAMLocalHostRange(t *testing.T) {
 			subnet: &net.IPNet{IP: net.IPv4(192, 168, 0, 0), Mask: net.IPv4Mask(255, 255, 255, 0)},
 			want: []IPAMLocalHostRangeConf{
 				{
-					Subnet: "192.168.0.0/24",
+					Subnet:  "192.168.0.0/24",
+					Gateway: "192.168.0.1",
 				},
 			},
 		},
@@ -74,7 +75,8 @@ func TestNewIPAMLocalHostRange(t *testing.T) {
 			subnet: &net.IPNet{IP: net.ParseIP("2001:DB8::"), Mask: net.IPMask(net.ParseIP("ffff:ffff:ffff::"))},
 			want: []IPAMLocalHostRangeConf{
 				{
-					Subnet: "2001:db8::/48",
+					Subnet:  "2001:db8::/48",
+					Gateway: "2001:db8::1",
 				},
 			},
 		},

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -106,6 +106,7 @@ var _ = Describe("Podman network create", func() {
 		Expect(bridgePlugin.IPAM.Routes[0].Dest).To(Equal("0.0.0.0/0"))
 		Expect(bridgePlugin.IsGW).To(BeTrue())
 		Expect(bridgePlugin.IPMasq).To(BeTrue())
+		Expect(bridgePlugin.IPAM.Ranges[0][0].Gateway).ToNot(BeEmpty())
 		Expect(portMapPlugin.Capabilities["portMappings"]).To(BeTrue())
 
 	})
@@ -153,6 +154,8 @@ var _ = Describe("Podman network create", func() {
 		// JSON the bridge info
 		bridgePlugin, err := genericPluginsToBridge(result["plugins"], "bridge")
 		Expect(err).To(BeNil())
+		// check that gateway is added to config
+		Expect(bridgePlugin.IPAM.Ranges[0][0].Gateway).To(Equal("10.11.12.1"))
 
 		// Once a container executes a new network, the nic will be created. We should clean those up
 		// best we can


### PR DESCRIPTION
`podman network create` should always add a gateway to the cni config.
If no gateway is given use the first ip in the subnet. CNI does not require
the gateway field but we need it because of network inspect.

This worked with previous version but was dropped in Commit(e7a72d72fd59).

Fixes #8748


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
