### PR TITLE
Docker compat API - /images/search returns wrong structure (#7857)

### DIFF
--- a/pkg/api/handlers/compat/images_search.go
+++ b/pkg/api/handlers/compat/images_search.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/podman/v2/libpod/image"
 	"github.com/containers/podman/v2/pkg/api/handlers/utils"
 	"github.com/containers/podman/v2/pkg/auth"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/gorilla/schema"
 	"github.com/pkg/errors"
 )
@@ -77,5 +78,18 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 		utils.BadRequest(w, "term", query.Term, err)
 		return
 	}
-	utils.WriteResponse(w, http.StatusOK, results)
+
+	compatResults := make([]registry.SearchResult, 0, len(results))
+	for _, result := range results {
+		compatResult := registry.SearchResult{
+			Name:        result.Name,
+			Description: result.Description,
+			StarCount:   result.Stars,
+			IsAutomated: result.Automated == "[OK]",
+			IsOfficial:  result.Official == "[OK]",
+		}
+		compatResults = append(compatResults, compatResult)
+	}
+
+	utils.WriteResponse(w, http.StatusOK, compatResults)
 }


### PR DESCRIPTION
Signed-off-by: Milivoje Legenovic <m.legenovic@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
