### PR TITLE
[CI:DOCS] Makefile: add target to generate bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverprofile
 /docs/build/
 /docs/remote
 .gopathok
+.generate-bindings
 .idea*
 .nfs*
 *.o

--- a/Makefile
+++ b/Makefile
@@ -445,6 +445,10 @@ podman-remote-%-release:
 	rm -f release.txt
 	$(MAKE) podman-remote-release-$*.zip
 
+BINDINGS_SOURCE = $(wildcard pkg/bindings/**/types.go)
+.generate-bindings: $(BINDINGS_SOURCE)
+	touch .generate-bindings
+
 .PHONY: docker-docs
 docker-docs: docs
 	(cd docs; ./dckrman.sh ./build/man/*.1)


### PR DESCRIPTION
Add a `.generate-bindings` make target that only runs in the absence of
the `.generate-bindings` file or when a `types.go` file below
`pkg/bindings` has changed.

It does not execute anything yet is just a template to wire in the
generation in a future change.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
