### PR TITLE
Fix support for rpmbuild < 4.12.0.

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -90,8 +90,8 @@ Recommends: crun
 Recommends: container-selinux
 Recommends: slirp4netns
 Recommends: fuse-overlayfs
-%endif
 Recommends: xz
+%endif
 
 # vendored libraries
 # awk '{print "Provides: bundled(golang("$1")) = "$2}' vendor.conf | sort


### PR DESCRIPTION
Fixes support for rpmbuild < 4.12.0 versions by only adding to >= el8.

The PR #7299 adds this `Recommends` tag, but rpmbuild only added support for the `Recommends` starting with 4.12.0.