### PR TITLE
Add support for checkpoint/restore of containers with volumes

### DIFF
--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -57,6 +57,7 @@ func init() {
 	_ = checkpointCommand.RegisterFlagCompletionFunc(exportFlagName, completion.AutocompleteDefault)
 
 	flags.BoolVar(&checkpointOptions.IgnoreRootFS, "ignore-rootfs", false, "Do not include root file-system changes when exporting")
+	flags.BoolVar(&checkpointOptions.IgnoreVolumes, "ignore-volumes", false, "Do not export volumes associated with container")
 	validate.AddLatestFlag(checkpointCommand, &checkpointOptions.Latest)
 }
 
@@ -67,6 +68,9 @@ func checkpoint(cmd *cobra.Command, args []string) error {
 	}
 	if checkpointOptions.Export == "" && checkpointOptions.IgnoreRootFS {
 		return errors.Errorf("--ignore-rootfs can only be used with --export")
+	}
+	if checkpointOptions.Export == "" && checkpointOptions.IgnoreVolumes {
+		return errors.Errorf("--ignore-volumes can only be used with --export")
 	}
 	responses, err := registry.ContainerEngine().ContainerCheckpoint(context.Background(), args, checkpointOptions)
 	if err != nil {

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -62,6 +62,7 @@ func init() {
 	flags.BoolVar(&restoreOptions.IgnoreRootFS, "ignore-rootfs", false, "Do not apply root file-system changes when importing from exported checkpoint")
 	flags.BoolVar(&restoreOptions.IgnoreStaticIP, "ignore-static-ip", false, "Ignore IP address set via --static-ip")
 	flags.BoolVar(&restoreOptions.IgnoreStaticMAC, "ignore-static-mac", false, "Ignore MAC address set via --mac-address")
+	flags.BoolVar(&restoreOptions.IgnoreVolumes, "ignore-volumes", false, "Do not export volumes associated with container")
 	validate.AddLatestFlag(restoreCommand, &restoreOptions.Latest)
 }
 
@@ -72,6 +73,9 @@ func restore(_ *cobra.Command, args []string) error {
 	}
 	if restoreOptions.Import == "" && restoreOptions.IgnoreRootFS {
 		return errors.Errorf("--ignore-rootfs can only be used with --import")
+	}
+	if restoreOptions.Import == "" && restoreOptions.IgnoreVolumes {
+		return errors.Errorf("--ignore-volumes can only be used with --import")
 	}
 	if restoreOptions.Import == "" && restoreOptions.Name != "" {
 		return errors.Errorf("--name can only be used with --import")

--- a/docs/source/markdown/podman-container-checkpoint.1.md
+++ b/docs/source/markdown/podman-container-checkpoint.1.md
@@ -52,6 +52,12 @@ exported to a tar.gz file it is possible with the help of **--ignore-rootfs**
 to explicitly disable including changes to the root file-system into
 the checkpoint archive file.
 
+#### **--ignore-volumes**
+
+This option must be used in combination with the **--export, -e** option.
+When this option is specified, the content of volumes associated with
+the container will not be included into the checkpoint tar.gz file.
+
 ## EXAMPLE
 
 podman container checkpoint mywebserver

--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -85,6 +85,13 @@ exported checkpoint with **--name, -n**.
 
 Using **--ignore-static-mac** tells Podman to ignore the MAC address if it was
 configured with **--mac-address** during container creation.
+
+#### **--ignore-volumes**
+
+This option must be used in combination with the **--import, -i** option.
+When restoring containers from a checkpoint tar.gz file with this option,
+the content of associated volumes will not be restored.
+
 ## EXAMPLE
 
 podman container restore mywebserver

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -703,6 +703,9 @@ type ContainerCheckpointOptions struct {
 	// important to be able to restore a container multiple
 	// times with '--import --name'.
 	IgnoreStaticMAC bool
+	// IgnoreVolumes tells the API to not export or not to import
+	// the content of volumes associated with the container
+	IgnoreVolumes bool
 }
 
 // Checkpoint checkpoints a container

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -275,6 +275,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 		Import          bool   `schema:"import"`
 		Name            string `schema:"name"`
 		IgnoreRootFS    bool   `schema:"ignoreRootFS"`
+		IgnoreVolumes   bool   `schema:"ignoreVolumes"`
 		IgnoreStaticIP  bool   `schema:"ignoreStaticIP"`
 		IgnoreStaticMAC bool   `schema:"ignoreStaticMAC"`
 	}{

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -173,6 +173,7 @@ type CheckpointOptions struct {
 	All            bool
 	Export         string
 	IgnoreRootFS   bool
+	IgnoreVolumes  bool
 	Keep           bool
 	Latest         bool
 	LeaveRunning   bool
@@ -187,6 +188,7 @@ type CheckpointReport struct {
 type RestoreOptions struct {
 	All             bool
 	IgnoreRootFS    bool
+	IgnoreVolumes   bool
 	IgnoreStaticIP  bool
 	IgnoreStaticMAC bool
 	Import          string

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -487,6 +487,7 @@ func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds [
 		TCPEstablished: options.TCPEstablished,
 		TargetFile:     options.Export,
 		IgnoreRootfs:   options.IgnoreRootFS,
+		IgnoreVolumes:  options.IgnoreVolumes,
 		KeepRunning:    options.LeaveRunning,
 	}
 
@@ -525,6 +526,7 @@ func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []st
 		TargetFile:      options.Import,
 		Name:            options.Name,
 		IgnoreRootfs:    options.IgnoreRootFS,
+		IgnoreVolumes:   options.IgnoreVolumes,
 		IgnoreStaticIP:  options.IgnoreStaticIP,
 		IgnoreStaticMAC: options.IgnoreStaticMAC,
 	}

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -538,7 +538,7 @@ func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []st
 
 	switch {
 	case options.Import != "":
-		cons, err = checkpoint.CRImportCheckpoint(ctx, ic.Libpod, options.Import, options.Name)
+		cons, err = checkpoint.CRImportCheckpoint(ctx, ic.Libpod, options)
 	case options.All:
 		cons, err = ic.Libpod.GetContainers(filterFuncs...)
 	default:

--- a/test/e2e/build/basicalpine/Containerfile.volume
+++ b/test/e2e/build/basicalpine/Containerfile.volume
@@ -1,0 +1,2 @@
+FROM alpine
+VOLUME "/volume0"


### PR DESCRIPTION
When migrating a container with volumes, the content of the volumes is required to be available on the destination machine.

This PR enables checkpoint/restore of containers with named volumes by including the content of volumes in checkpoint file. When restoring a container, the associated volumes are recreated and their content is restored accordingly.

In addition, this PR adds `--ignore-volumes` option to disable this feature.

Examples:

In the following example the content of associated volumes is included in checkpoint tar.gz file.
```console
# podman container checkpoint --export <checkpoint>.tar.gz <container>
```

This example doesn't include the content of volumes in the tar.gz file. This can be used to avoid unnecessary I/O operations when running checkpoint and restore on the same host.
```console
# podman container checkpoint --ignore-volumes --export <checkpoint>.tar.gz <container>
```

In the following example the container volumes will be recreated and their content restored. Note that if volumes with the same name already exist on the system, or the content of volumes is missing in the tar.gz, Podman will exit with an error.
```console
# podman container restore --import <checkpoint>.tar.gz
```

Volumes associated with container must already exist. Podman will not create them or to restore their content.
```console
# podman container restore --ignore-volumes --import <checkpoint>.tar.gz
```

Resolves https://github.com/checkpoint-restore/criu/issues/1314 https://github.com/checkpoint-restore/criu/issues/826