### PR TITLE
Set NetNS mode instead of value

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -226,7 +226,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			return nil, err
 		}
 
-		specGen, err := kube.ToSpecGen(ctx, container, container.Image, newImage, volumes, pod.ID(), podName, podInfraID, configMaps, seccompPaths, ctrRestartPolicy)
+		specGen, err := kube.ToSpecGen(ctx, container, container.Image, newImage, volumes, pod.ID(), podName, podInfraID, configMaps, seccompPaths, ctrRestartPolicy, p.NetNS.IsHost())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -30,7 +30,7 @@ func ToPodGen(ctx context.Context, podName string, podYAML *v1.PodTemplateSpec) 
 		p.Hostname = podName
 	}
 	if podYAML.Spec.HostNetwork {
-		p.NetNS.Value = "host"
+		p.NetNS.NSMode = specgen.Host
 	}
 	if podYAML.Spec.HostAliases != nil {
 		hosts := make([]string, 0, len(podYAML.Spec.HostAliases))
@@ -47,7 +47,7 @@ func ToPodGen(ctx context.Context, podName string, podYAML *v1.PodTemplateSpec) 
 	return p, nil
 }
 
-func ToSpecGen(ctx context.Context, containerYAML v1.Container, iid string, newImage *image.Image, volumes map[string]*KubeVolume, podID, podName, infraID string, configMaps []v1.ConfigMap, seccompPaths *KubeSeccompPaths, restartPolicy string) (*specgen.SpecGenerator, error) {
+func ToSpecGen(ctx context.Context, containerYAML v1.Container, iid string, newImage *image.Image, volumes map[string]*KubeVolume, podID, podName, infraID string, configMaps []v1.ConfigMap, seccompPaths *KubeSeccompPaths, restartPolicy string, hostNet bool) (*specgen.SpecGenerator, error) {
 	s := specgen.NewSpecGenerator(iid, false)
 
 	// podName should be non-empty for Deployment objects to be able to create
@@ -213,6 +213,10 @@ func ToSpecGen(ctx context.Context, containerYAML v1.Container, iid string, newI
 	}
 
 	s.RestartPolicy = restartPolicy
+
+	if hostNet {
+		s.NetNS.NSMode = specgen.Host
+	}
 
 	return s, nil
 }


### PR DESCRIPTION
Set NetNS mode instead of value when HostNetwork is true in the pod spec.
Also propagate whether host network namespace should be used for containers.

Closes #8790 