### PR TITLE
Fix missing options in volume's display while setting uid and gid

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1593,7 +1593,7 @@ func WithVolumeOptions(options map[string]string) VolumeCreateOption {
 		volume.config.Options = make(map[string]string)
 		for key, value := range options {
 			switch key {
-			case "type", "device", "o":
+			case "type", "device", "o", "UID", "GID":
 				volume.config.Options[key] = value
 			default:
 				return errors.Wrapf(define.ErrInvalidArg, "unrecognized volume option %q is not supported with local driver", key)

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -58,7 +58,7 @@ func (r *Runtime) newVolume(ctx context.Context, options ...VolumeCreateOption) 
 		// Validate options
 		for key := range volume.config.Options {
 			switch key {
-			case "device", "o", "type":
+			case "device", "o", "type", "UID", "GID":
 				// Do nothing, valid keys
 			default:
 				return nil, errors.Wrapf(define.ErrInvalidArg, "invalid mount option %s for driver 'local'", key)

--- a/pkg/domain/infra/abi/parse/parse.go
+++ b/pkg/domain/infra/abi/parse/parse.go
@@ -38,6 +38,9 @@ func VolumeOptions(opts map[string]string) ([]libpod.VolumeCreateOption, error) 
 					}
 					logrus.Debugf("Removing uid= from options and adding WithVolumeUID for UID %d", intUID)
 					libpodOptions = append(libpodOptions, libpod.WithVolumeUID(intUID))
+					finalVal = append(finalVal, o)
+					// set option "UID": "$uid"
+					volumeOptions["UID"] = splitO[1]
 				case "gid":
 					if len(splitO) != 2 {
 						return nil, errors.Wrapf(define.ErrInvalidArg, "gid option must provide a GID")
@@ -48,6 +51,9 @@ func VolumeOptions(opts map[string]string) ([]libpod.VolumeCreateOption, error) 
 					}
 					logrus.Debugf("Removing gid= from options and adding WithVolumeGID for GID %d", intGID)
 					libpodOptions = append(libpodOptions, libpod.WithVolumeGID(intGID))
+					finalVal = append(finalVal, o)
+					// set option "GID": "$gid"
+					volumeOptions["GID"] = splitO[1]
 				default:
 					finalVal = append(finalVal, o)
 				}

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -82,5 +82,13 @@ var _ = Describe("Podman volume create", func() {
 		inspectGID.WaitWithDefaultTimeout()
 		Expect(inspectGID.ExitCode()).To(Equal(0))
 		Expect(inspectGID.OutputToString()).To(Equal(gid))
+
+		// options should containt `uid=3000,gid=4000:3000:4000`
+		optionFormat := `{{ .Options.o }}:{{ .Options.UID }}:{{ .Options.GID }}`
+		optionStrFormatExpect := fmt.Sprintf(`uid=%s,gid=%s:%s:%s`, uid, gid, uid, gid)
+		inspectOpts := podmanTest.Podman([]string{"volume", "inspect", "--format", optionFormat, volName})
+		inspectOpts.WaitWithDefaultTimeout()
+		Expect(inspectOpts.ExitCode()).To(Equal(0))
+		Expect(inspectOpts.OutputToString()).To(Equal(optionStrFormatExpect))
 	})
 })


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/8791

```
$ podman   volume create testvol --opt o=uid=1001,gid=1001
testvol
$ ./bin/podman   volume create testvol2 --opt o=uid=1001,gid=1001
testvol2
$ podman volume inspect --format '{{ .Options}}' testvol 
map[]
$ podman volume inspect --format '{{ .Options}}' testvol2
map[o:uid=1001,gid=1001]
```

Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
