### PR TITLE
Fix build for mips architecture

### DIFF
--- a/pkg/signal/signal_linux_mipsx.go
+++ b/pkg/signal/signal_linux_mipsx.go
@@ -1,7 +1,7 @@
 // +build linux
-// +build !mips,!mipsle,!mips64,!mips64le
+// +build mips mipsle mips64 mips64le
 
-// Signal handling for Linux only.
+// Special signal handling for mips architecture
 package signal
 
 // Copyright 2013-2018 Docker, Inc.
@@ -18,9 +18,7 @@ import (
 
 const (
 	sigrtmin = 34
-	sigrtmax = 64
-
-	SIGWINCH = syscall.SIGWINCH // For cross-compilation with Windows
+	sigrtmax = 127
 )
 
 // signalMap is a map of Linux signals.
@@ -44,7 +42,7 @@ var signalMap = map[string]syscall.Signal{
 	"PWR":      unix.SIGPWR,
 	"QUIT":     unix.SIGQUIT,
 	"SEGV":     unix.SIGSEGV,
-	"STKFLT":   unix.SIGSTKFLT,
+	"EMT":      unix.SIGEMT,
 	"STOP":     unix.SIGSTOP,
 	"SYS":      unix.SIGSYS,
 	"TERM":     unix.SIGTERM,


### PR DESCRIPTION
The signal SIGSTKFLT does not exists on mips architectures.
Also RTMIN and RTMAX are different.

This code is copied from docker.

Fixes #8782 

Signed-off-by: Paul Holzinger <paul.holzinger@web.de>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
