### PR TITLE
Pass down EnableKeyring from containers.conf to conmon

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -69,6 +69,7 @@ type ConmonOCIRuntime struct {
 	supportsKVM       bool
 	supportsNoCgroups bool
 	sdNotify          bool
+	enableKeyring     bool
 }
 
 // Make a new Conmon-based OCI runtime with the given options.
@@ -107,6 +108,7 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 	runtime.noPivot = runtimeCfg.Engine.NoPivotRoot
 	runtime.reservePorts = runtimeCfg.Engine.EnablePortReservation
 	runtime.sdNotify = runtimeCfg.Engine.SDNotify
+	runtime.enableKeyring = runtimeCfg.Containers.EnableKeyring
 
 	// TODO: probe OCI runtime for feature and enable automatically if
 	// available.
@@ -1021,6 +1023,9 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 		args = append(args, "-i")
 	}
 
+	if !r.enableKeyring {
+		args = append(args, "--no-new-keyring")
+	}
 	if ctr.config.ConmonPidFile != "" {
 		args = append(args, "--conmon-pidfile", ctr.config.ConmonPidFile)
 	}


### PR DESCRIPTION
We have a new field in containers.conf that tells whether
or not we want to generate a new keyring in a container.

This field was being ignored.  It now will be followed and
passed down to conmon.

Fixes: https://github.com/containers/podman/issues/8384

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
