### PR TITLE
Fix podman build --logfile

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -221,7 +221,8 @@ func build(cmd *cobra.Command, args []string) error {
 
 	var logfile *os.File
 	if cmd.Flag("logfile").Changed {
-		logfile, err := os.OpenFile(buildOpts.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+		var err error
+		logfile, err = os.OpenFile(buildOpts.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 		if err != nil {
 			return err
 		}

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -424,6 +424,23 @@ EOF
     run_podman rmi -a --force
 }
 
+@test "podman build --logfile test" {
+    tmpdir=$PODMAN_TMPDIR/build-test
+    mkdir -p $tmpdir
+    tmpbuilddir=$tmpdir/build
+    mkdir -p $tmpbuilddir
+    dockerfile=$tmpbuilddir/Dockerfile
+    cat >$dockerfile <<EOF
+FROM $IMAGE
+EOF
+
+    run_podman build -t build_test --format=docker --logfile=$tmpdir/logfile $tmpbuilddir
+    run cat $tmpdir/logfile
+    is "$output" ".*STEP 2: COMMIT" "COMMIT seen in log"
+
+    run_podman rmi -f build_test
+}
+
 function teardown() {
     # A timeout or other error in 'build' can leave behind stale images
     # that podman can't even see and which will cascade into subsequent


### PR DESCRIPTION
A opened file object of a logfile gets lost because the variable
`logfile` is redefined in a `if` block. This fix stops redefining
the variable.

A system test for `--logfile` is also added.

Signed-off-by: Hironori Shiina <Hironori.Shiina@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
