### PR TITLE
rootless: automatically split userns ranges

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -529,6 +529,13 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 		}
 	}
 
+	availableUIDs, availableGIDs, err := rootless.GetAvailableIDMaps()
+	if err != nil {
+		return nil, err
+	}
+	g.Config.Linux.UIDMappings = rootless.MaybeSplitMappings(g.Config.Linux.UIDMappings, availableUIDs)
+	g.Config.Linux.GIDMappings = rootless.MaybeSplitMappings(g.Config.Linux.GIDMappings, availableGIDs)
+
 	// Hostname handling:
 	// If we have a UTS namespace, set Hostname in the OCI spec.
 	// Set the HOSTNAME environment variable unless explicitly overridden by
@@ -536,6 +543,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 	// set it to the host's hostname instead.
 	hostname := c.Hostname()
 	foundUTS := false
+
 	for _, i := range c.config.Spec.Linux.Namespaces {
 		if i.Type == spec.UTSNamespace && i.Path == "" {
 			foundUTS = true

--- a/pkg/rootless/rootless_test.go
+++ b/pkg/rootless/rootless_test.go
@@ -1,0 +1,101 @@
+package rootless
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/opencontainers/runc/libcontainer/user"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func TestMaybeSplitMappings(t *testing.T) {
+	mappings := []spec.LinuxIDMapping{
+		{
+			ContainerID: 0,
+			HostID:      0,
+			Size:        2,
+		},
+	}
+	desiredMappings := []spec.LinuxIDMapping{
+		{
+			ContainerID: 0,
+			HostID:      0,
+			Size:        1,
+		},
+		{
+			ContainerID: 1,
+			HostID:      1,
+			Size:        1,
+		},
+	}
+	availableMappings := []user.IDMap{
+		{
+			ID:       1,
+			ParentID: 1000000,
+			Count:    65536,
+		},
+		{
+			ID:       0,
+			ParentID: 1000,
+			Count:    1,
+		},
+	}
+	newMappings := MaybeSplitMappings(mappings, availableMappings)
+	if !reflect.DeepEqual(newMappings, desiredMappings) {
+		t.Fatal("wrong mappings generated")
+	}
+
+	mappings = []spec.LinuxIDMapping{
+		{
+			ContainerID: 0,
+			HostID:      0,
+			Size:        2,
+		},
+	}
+	desiredMappings = []spec.LinuxIDMapping{
+		{
+			ContainerID: 0,
+			HostID:      0,
+			Size:        2,
+		},
+	}
+	availableMappings = []user.IDMap{
+		{
+			ID:       0,
+			ParentID: 1000000,
+			Count:    65536,
+		},
+	}
+	newMappings = MaybeSplitMappings(mappings, availableMappings)
+
+	if !reflect.DeepEqual(newMappings, desiredMappings) {
+		t.Fatal("wrong mappings generated")
+	}
+
+	mappings = []spec.LinuxIDMapping{
+		{
+			ContainerID: 0,
+			HostID:      0,
+			Size:        1,
+		},
+	}
+	desiredMappings = []spec.LinuxIDMapping{
+		{
+			ContainerID: 0,
+			HostID:      0,
+			Size:        1,
+		},
+	}
+	availableMappings = []user.IDMap{
+		{
+			ID:       10000,
+			ParentID: 10000,
+			Count:    65536,
+		},
+	}
+
+	newMappings = MaybeSplitMappings(mappings, availableMappings)
+	if !reflect.DeepEqual(newMappings, desiredMappings) {
+		t.Fatal("wrong mappings generated")
+	}
+}


### PR DESCRIPTION
writing to the id map fails when an extent overlaps multiple mappings in the parent user namespace:

$ cat /proc/self/uid_map
         0       1000          1
         1     100000      65536
$ unshare -U sleep 100 &
[1] 1029703
$ printf "0 0 100\n" | tee /proc/$!/uid_map
0 0 100
tee: /proc/1029703/uid_map: Operation not permitted

This limitation is particularly annoying when working with rootless containers as each container runs in the rootless user namespace, so a command like:

$ podman run --uidmap 0:0:2 --rm fedora echo hi
Error: writing file `/proc/664087/gid_map`: Operation not permitted: OCI permission denied

would fail since the specified mapping overlaps the first mapping (where the user id is mapped to root) and the second extent with the additional IDs available.

Detect such cases and automatically split the specified mapping with the equivalent of:

$ podman run --uidmap 0:0:1 --uidmap 1:1:1 --rm fedora echo hi
hi

A fix has already been proposed for the kernel[1], but even if it accepted it will take time until it is available in a released kernel, so fix it also in pkg/rootless.

[1] https://lkml.kernel.org/lkml/20201203150252.1229077-1-gscrivan@redhat.com/

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
