### PR TITLE
add --cidfile to container kill

### DIFF
--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v2/cmd/podman/common"
 	"github.com/containers/podman/v2/cmd/podman/registry"
 	"github.com/containers/podman/v2/cmd/podman/utils"
@@ -22,7 +23,7 @@ var (
 		Long:  killDescription,
 		RunE:  kill,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndCIDFile(cmd, args, false, true)
 		},
 		ValidArgsFunction: common.AutocompleteContainersRunning,
 		Example: `podman kill mywebserver
@@ -32,7 +33,7 @@ var (
 
 	containerKillCommand = &cobra.Command{
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndCIDFile(cmd, args, false, true)
 		},
 		Use:               killCommand.Use,
 		Short:             killCommand.Short,
@@ -57,6 +58,9 @@ func killFlags(cmd *cobra.Command) {
 	signalFlagName := "signal"
 	flags.StringVarP(&killOptions.Signal, signalFlagName, "s", "KILL", "Signal to send to the container")
 	_ = cmd.RegisterFlagCompletionFunc(signalFlagName, common.AutocompleteStopSignal)
+	cidfileFlagName := "cidfile"
+	flags.StringArrayVar(&killOptions.CIDFiles, cidfileFlagName, []string{}, "Read the container ID from the file")
+	_ = cmd.RegisterFlagCompletionFunc(cidfileFlagName, completion.AutocompleteDefault)
 }
 
 func init() {

--- a/docs/source/markdown/podman-kill.1.md
+++ b/docs/source/markdown/podman-kill.1.md
@@ -16,6 +16,10 @@ The main process inside each container specified will be sent SIGKILL, or any si
 
 Signal all running containers.  This does not include paused containers.
 
+#### **--cidfile**
+
+Read container ID from the specified file and remove the container.  Can be specified multiple times.
+
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
@@ -39,6 +43,10 @@ podman kill --signal TERM 860a4b23
 podman kill --latest
 
 podman kill --signal KILL -a
+
+podman kill --cidfile /home/user/cidfile-1
+
+podman kill --cidfile /home/user/cidfile-1 --cidfile ./cidfile-2
 
 ## SEE ALSO
 podman(1), podman-stop(1)

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -104,9 +104,10 @@ type TopOptions struct {
 }
 
 type KillOptions struct {
-	All    bool
-	Latest bool
-	Signal string
+	All      bool
+	Latest   bool
+	Signal   string
+	CIDFiles []string
 }
 
 type KillReport struct {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -229,6 +229,14 @@ func (ic *ContainerEngine) pruneContainersHelper(filterFuncs []libpod.ContainerF
 }
 
 func (ic *ContainerEngine) ContainerKill(ctx context.Context, namesOrIds []string, options entities.KillOptions) ([]*entities.KillReport, error) {
+	for _, cidFile := range options.CIDFiles {
+		content, err := ioutil.ReadFile(cidFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "error reading CIDFile")
+		}
+		id := strings.Split(string(content), "\n")[0]
+		namesOrIds = append(namesOrIds, id)
+	}
 	sig, err := signal.ParseSignalNameOrNumber(options.Signal)
 	if err != nil {
 		return nil, err
@@ -246,6 +254,7 @@ func (ic *ContainerEngine) ContainerKill(ctx context.Context, namesOrIds []strin
 	}
 	return reports, nil
 }
+
 func (ic *ContainerEngine) ContainerRestart(ctx context.Context, namesOrIds []string, options entities.RestartOptions) ([]*entities.RestartReport, error) {
 	var (
 		ctrs []*libpod.Container

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -125,6 +125,14 @@ func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []strin
 }
 
 func (ic *ContainerEngine) ContainerKill(ctx context.Context, namesOrIds []string, opts entities.KillOptions) ([]*entities.KillReport, error) {
+	for _, cidFile := range opts.CIDFiles {
+		content, err := ioutil.ReadFile(cidFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "error reading CIDFile")
+		}
+		id := strings.Split(string(content), "\n")[0]
+		namesOrIds = append(namesOrIds, id)
+	}
 	ctrs, err := getContainersByContext(ic.ClientCtx, opts.All, false, namesOrIds)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add the ability to read container ids from one or more files for the
kill command.

Fixes: #8443

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
