### PR TITLE
Containers should not get inheritable caps by default

### DIFF
--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/containers/common/pkg/capabilities"
 	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/libpod/events"
 	"github.com/containers/storage/pkg/stringid"
@@ -973,20 +972,12 @@ func (c *Container) removeAllExecSessions() error {
 // Make an ExecOptions struct to start the OCI runtime and prepare its exec
 // bundle.
 func prepareForExec(c *Container, session *ExecSession) (*ExecOptions, error) {
-	// TODO: check logic here - should we set Privileged if the container is
-	// privileged?
-	var capList []string
-	if session.Config.Privileged || c.config.Privileged {
-		capList = capabilities.AllCapabilities()
-	}
-
 	if err := c.createExecBundle(session.ID()); err != nil {
 		return nil, err
 	}
 
 	opts := new(ExecOptions)
 	opts.Cmd = session.Config.Command
-	opts.CapAdd = capList
 	opts.Env = session.Config.Environment
 	opts.Terminal = session.Config.Terminal
 	opts.Cwd = session.Config.WorkDir
@@ -995,6 +986,7 @@ func prepareForExec(c *Container, session *ExecSession) (*ExecOptions, error) {
 	opts.DetachKeys = session.Config.DetachKeys
 	opts.ExitCommand = session.Config.ExitCommand
 	opts.ExitCommandDelay = session.Config.ExitCommandDelay
+	opts.Privileged = session.Config.Privileged
 
 	return opts, nil
 }

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -151,8 +151,6 @@ type OCIRuntime interface {
 type ExecOptions struct {
 	// Cmd is the command to execute.
 	Cmd []string
-	// CapAdd is a set of capabilities to add to the executed command.
-	CapAdd []string
 	// Env is a set of environment variables to add to the container.
 	Env map[string]string
 	// Terminal is whether to create a new TTY for the exec session.
@@ -181,6 +179,8 @@ type ExecOptions struct {
 	// ExitCommandDelay is a delay (in seconds) between the exec session
 	// exiting, and the exit command being invoked.
 	ExitCommandDelay uint
+	// Privileged indicates the execed process will be launched in Privileged mode
+	Privileged bool
 }
 
 // HTTPAttachStreams informs the HTTPAttach endpoint which of the container's

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -398,10 +398,6 @@ func (r *ConmonOCIRuntime) startExec(c *Container, sessionID string, options *Ex
 		args = append(args, formatRuntimeOpts("--preserve-fds", fmt.Sprintf("%d", options.PreserveFDs))...)
 	}
 
-	for _, capability := range options.CapAdd {
-		args = append(args, formatRuntimeOpts("--cap", capability)...)
-	}
-
 	if options.Terminal {
 		args = append(args, "-t")
 	}

--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -133,13 +133,13 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 	configSpec := g.Config
 	configSpec.Process.Capabilities.Ambient = []string{}
 	configSpec.Process.Capabilities.Bounding = caplist
-	configSpec.Process.Capabilities.Inheritable = caplist
 
 	user := strings.Split(s.User, ":")[0]
 
 	if (user == "" && s.UserNS.NSMode != specgen.KeepID) || user == "root" || user == "0" {
 		configSpec.Process.Capabilities.Effective = caplist
 		configSpec.Process.Capabilities.Permitted = caplist
+		configSpec.Process.Capabilities.Inheritable = caplist
 	} else {
 		userCaps, err := capabilities.MergeCapabilities(nil, s.CapAdd, nil)
 		if err != nil {
@@ -147,6 +147,7 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 		}
 		configSpec.Process.Capabilities.Effective = userCaps
 		configSpec.Process.Capabilities.Permitted = userCaps
+		configSpec.Process.Capabilities.Inheritable = userCaps
 
 		// Ambient capabilities were added to Linux 4.3.  Set ambient
 		// capabilities only when the kernel supports them.

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -378,10 +378,17 @@ func GetRandomIPAddress() string {
 // RunTopContainer runs a simple container in the background that
 // runs top.  If the name passed != "", it will have a name
 func (p *PodmanTestIntegration) RunTopContainer(name string) *PodmanSessionIntegration {
+	return p.RunTopContainerWithArgs(name, nil)
+}
+
+// RunTopContainerWithArgs runs a simple container in the background that
+// runs top.  If the name passed != "", it will have a name, command args can also be passed in
+func (p *PodmanTestIntegration) RunTopContainerWithArgs(name string, args []string) *PodmanSessionIntegration {
 	var podmanArgs = []string{"run"}
 	if name != "" {
 		podmanArgs = append(podmanArgs, "--name", name)
 	}
+	podmanArgs = append(podmanArgs, args...)
 	podmanArgs = append(podmanArgs, "-d", ALPINE, "top")
 	return p.Podman(podmanArgs)
 }
@@ -538,12 +545,7 @@ func (p *PodmanTestIntegration) CreatePodWithLabels(name string, labels map[stri
 }
 
 func (p *PodmanTestIntegration) RunTopContainerInPod(name, pod string) *PodmanSessionIntegration {
-	var podmanArgs = []string{"run", "--pod", pod}
-	if name != "" {
-		podmanArgs = append(podmanArgs, "--name", name)
-	}
-	podmanArgs = append(podmanArgs, "-d", ALPINE, "top")
-	return p.Podman(podmanArgs)
+	return p.RunTopContainerWithArgs(name, []string{"--pod", pod})
 }
 
 func (p *PodmanTestIntegration) RunHealthCheck(cid string) error {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -342,12 +342,22 @@ var _ = Describe("Podman run", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 
+		session = podmanTest.Podman([]string{"run", "--rm", "--user", "bin", ALPINE, "grep", "CapInh", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
+
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "root", ALPINE, "grep", "CapBnd", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("00000000a80425fb"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "root", ALPINE, "grep", "CapEff", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("00000000a80425fb"))
+
+		session = podmanTest.Podman([]string{"run", "--rm", "--user", "root", ALPINE, "grep", "CapInh", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("00000000a80425fb"))
@@ -367,10 +377,10 @@ var _ = Describe("Podman run", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("0000000000000002"))
 
-		session = podmanTest.Podman([]string{"run", "--user=1000:1000", "--rm", ALPINE, "grep", "CapAmb", "/proc/self/status"})
+		session = podmanTest.Podman([]string{"run", "--user=1000:1000", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
+		Expect(session.OutputToString()).To(ContainSubstring("0000000000000002"))
 
 		session = podmanTest.Podman([]string{"run", "--user=0", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapAmb", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
@@ -382,6 +392,11 @@ var _ = Describe("Podman run", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 
+		session = podmanTest.Podman([]string{"run", "--user=0:0", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("00000000a80425fb"))
+
 		if os.Geteuid() > 0 {
 			if os.Getenv("SKIP_USERNS") != "" {
 				Skip("Skip userns tests.")
@@ -390,6 +405,16 @@ var _ = Describe("Podman run", func() {
 				Skip("User namespaces not supported.")
 			}
 			session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapAmb", "/proc/self/status"})
+			session.WaitWithDefaultTimeout()
+			Expect(session.ExitCode()).To(Equal(0))
+			Expect(session.OutputToString()).To(ContainSubstring("0000000000000002"))
+
+			session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--privileged", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
+			session.WaitWithDefaultTimeout()
+			Expect(session.ExitCode()).To(Equal(0))
+			Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
+
+			session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 			session.WaitWithDefaultTimeout()
 			Expect(session.ExitCode()).To(Equal(0))
 			Expect(session.OutputToString()).To(ContainSubstring("0000000000000002"))


### PR DESCRIPTION
When I launch a container with --userns=keep-id the rootless processes
should have no caps by default even if I launch the container with
--privileged.  It should only get the caps if I specify by hand the
caps I want leaked to the process.

Currently we turn off capeff and capamb, but not capinh.  This patch
treats capinh the same way as capeff and capamb.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
