### PR TITLE
Refactor kube.ToSpecGen parameters to struct

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -226,7 +226,19 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			return nil, err
 		}
 
-		specGen, err := kube.ToSpecGen(ctx, container, container.Image, newImage, volumes, pod.ID(), podName, podInfraID, configMaps, seccompPaths, ctrRestartPolicy, p.NetNS.IsHost())
+		specgenOpts := kube.CtrSpecGenOptions{
+			Container:     container,
+			Image:         newImage,
+			Volumes:       volumes,
+			PodID:         pod.ID(),
+			PodName:       podName,
+			PodInfraID:    podInfraID,
+			ConfigMaps:    configMaps,
+			SeccompPaths:  seccompPaths,
+			RestartPolicy: ctrRestartPolicy,
+			NetNSIsHost:   p.NetNS.IsHost(),
+		}
+		specGen, err := kube.ToSpecGen(ctx, &specgenOpts)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Create kube.CtrSpecGenOptions and document parameters.
Follow-up on https://github.com/containers/podman/pull/8792#discussion_r546673758

Signed-off-by: Benedikt Ziemons <ben@rs485.network>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
