### PR TITLE
Add --all to podman start

### DIFF
--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -57,6 +57,8 @@ func startFlags(cmd *cobra.Command) {
 	flags.BoolVarP(&startOptions.Interactive, "interactive", "i", false, "Keep STDIN open even if not attached")
 	flags.BoolVar(&startOptions.SigProxy, "sig-proxy", false, "Proxy received signals to the process (default true if attaching, false otherwise)")
 
+	flags.BoolVar(&startOptions.All, "all", false, "Start all containers regardless of their state or configuration")
+
 	if registry.IsRemote() {
 		_ = flags.MarkHidden("sig-proxy")
 	}
@@ -79,7 +81,7 @@ func init() {
 }
 
 func validateStart(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 && !startOptions.Latest {
+	if len(args) == 0 && !startOptions.Latest && !startOptions.All {
 		return errors.New("start requires at least one argument")
 	}
 	if len(args) > 0 && startOptions.Latest {
@@ -87,6 +89,12 @@ func validateStart(cmd *cobra.Command, args []string) error {
 	}
 	if len(args) > 1 && startOptions.Attach {
 		return errors.Errorf("you cannot start and attach multiple containers at once")
+	}
+	if (len(args) > 0 || startOptions.Latest) && startOptions.All {
+		return errors.Errorf("either start all containers or the container(s) provided in the arguments")
+	}
+	if startOptions.Attach && startOptions.All {
+		return errors.Errorf("you cannot start and attach all containers at once")
 	}
 	return nil
 }

--- a/docs/source/markdown/podman-start.1.md
+++ b/docs/source/markdown/podman-start.1.md
@@ -38,6 +38,10 @@ to run containers such as CRI-O, the last started container could be from either
 
 Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true* when attaching, *false* otherwise.
 
+#### **\-\-all**
+
+Start all the containers created by Podman, default is only running containers.
+
 ## EXAMPLE
 
 podman start mywebserver

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -265,6 +265,7 @@ type ContainerExistsOptions struct {
 // ContainerStartOptions describes the val from the
 // CLI needed to start a container
 type ContainerStartOptions struct {
+	All         bool
 	Attach      bool
 	DetachKeys  string
 	Interactive bool

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -693,14 +693,17 @@ func (ic *ContainerEngine) ContainerExecDetached(ctx context.Context, nameOrID s
 func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []string, options entities.ContainerStartOptions) ([]*entities.ContainerStartReport, error) {
 	reports := []*entities.ContainerStartReport{}
 	var exitCode = define.ExecErrorCodeGeneric
-	ctrs, rawInputs, err := getContainersAndInputByContext(false, options.Latest, namesOrIds, ic.Libpod)
+	ctrs, rawInputs, err := getContainersAndInputByContext(options.All, options.Latest, namesOrIds, ic.Libpod)
 	if err != nil {
 		return nil, err
 	}
 	// There can only be one container if attach was used
 	for i := range ctrs {
 		ctr := ctrs[i]
-		rawInput := rawInputs[i]
+		rawInput := ctr.ID()
+		if !options.All {
+			rawInput = rawInputs[i]
+		}
 		ctrState, err := ctr.State()
 		if err != nil {
 			return nil, err

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -506,7 +506,7 @@ func startAndAttach(ic *ContainerEngine, name string, detachKeys *string, input,
 func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []string, options entities.ContainerStartOptions) ([]*entities.ContainerStartReport, error) {
 	reports := []*entities.ContainerStartReport{}
 	var exitCode = define.ExecErrorCodeGeneric
-	ctrs, err := getContainersByContext(ic.ClientCtx, false, false, namesOrIds)
+	ctrs, err := getContainersByContext(ic.ClientCtx, options.All, false, namesOrIds)
 	if err != nil {
 		return nil, err
 	}
@@ -514,9 +514,13 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 	// There can only be one container if attach was used
 	for i, ctr := range ctrs {
 		name := ctr.ID
+		rawInput := ctr.ID
+		if !options.All {
+			rawInput = namesOrIds[i]
+		}
 		report := entities.ContainerStartReport{
 			Id:       name,
-			RawInput: namesOrIds[i],
+			RawInput: rawInput,
 			ExitCode: exitCode,
 		}
 		ctrRunning := ctr.State == define.ContainerStateRunning.String()

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -602,9 +602,9 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 				reports = append(reports, &report)
 				continue
 			}
+			report.ExitCode = 0
+			reports = append(reports, &report)
 		}
-		report.ExitCode = 0
-		reports = append(reports, &report)
 	}
 	return reports, nil
 }

--- a/test/system/045-start.bats
+++ b/test/system/045-start.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats   -*- bats -*-
+
+load helpers
+
+@test "podman start --all - start all containers" {
+    # Run a bunch of short-lived containers, with different --restart settings
+    run_podman run -d $IMAGE /bin/true
+    cid_none_implicit="$output"
+    run_podman run -d --restart=no $IMAGE /bin/false
+    cid_none_explicit="$output"
+    run_podman run -d --restart=on-failure $IMAGE /bin/true
+    cid_on_failure="$output"
+
+    # Run one longer-lived one.
+    run_podman run -d --restart=always $IMAGE sleep 20
+    cid_always="$output"
+
+    run_podman wait $cid_none_implicit $cid_none_explicit $cid_on_failure
+
+    run_podman start --all
+    is "$output" ".*$cid_none_implicit" "started: container with no --restart"
+    is "$output" ".*$cid_none_explicit" "started: container with --restart=no"
+    is "$output" ".*$cid_on_failure" "started: container with --restart=on-failure"
+    if [[ $output =~ $cid_always ]]; then
+        die "podman start --all restarted a running container"
+    fi
+
+    run_podman rm $cid_none_implicit $cid_none_explicit $cid_on_failure
+    run_podman stop -t 1 $cid_always
+    run_podman rm $cid_always
+}
+
+@test "podman start --all with incompatible options" {
+    expected="Error: either start all containers or the container(s) provided in the arguments"
+    run_podman 125 start --all 12333
+    is "$output" "$expected" "start --all, with args, throws error"
+    if ! is_remote; then
+        run_podman 125 start --all --latest
+        is "$output" "$expected" "podman start --all --latest"
+    fi
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
closes #8779 

### Progress

- [x] Add `--all` flag to restart all containers in `podman start`
- [x] ~Add to `--filter` to `podman start`. This flag allows to filter for specific attributes of the containers. For instance, a filter to match a specific restart policy.~ moved to #9689
- [x] Add tests to the changes above
- [x] Update `podman start` documents accordingly
- [ ] Ship a systemd service (similar to podman-auto-update.service) that package managers would install on the system.
- [x] ~podman systemm boot~