### PR TITLE
sort api endpoints in documentation

### DIFF
--- a/docs/source/_static/api.html
+++ b/docs/source/_static/api.html
@@ -18,7 +18,7 @@
     </style>
   </head>
   <body>
-    <redoc spec-url='https://storage.googleapis.com/libpod-master-releases/swagger-latest-master.yaml'></redoc>
+    <redoc spec-url='https://storage.googleapis.com/libpod-master-releases/swagger-latest-master.yaml' sort-props-alphabetically></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
users would like api endpoints to be sorted in documentation.  this
should assist in this. i do not expect that thisd will be the entire
fix. it looks like ci is not building and pushing docs rn.

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
