### PR TITLE
Fix e2e test for `podman build --logfile`

### DIFF
--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -72,9 +72,9 @@ var _ = Describe("Podman build", func() {
 
 		st, err := os.Stat(logfile)
 		Expect(err).To(BeNil())
-		Expect(st.Size()).To(Not(Equal(0)))
+		Expect(st.Size()).To(Not(Equal(int64(0))))
 
-		session = podmanTest.Podman([]string{"rmi", "alpine"})
+		session = podmanTest.Podman([]string{"rmi", "test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})


### PR DESCRIPTION
This is a tiny follow-up for #8810
Type casting is necessary to see if the logfile size is not equal to 0.

Signed-off-by: Hironori Shiina <Hironori.Shiina@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
