### PR TITLE
support both tag and digest for pulling images

### DIFF
--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -156,9 +156,21 @@ func imagePull(cmd *cobra.Command, args []string) error {
 		pullOptions.Username = creds.Username
 		pullOptions.Password = creds.Password
 	}
+
+	rawImgName := args[0]
+	// TODO: maybe need update at github.com/containers/image/v5/docker/docker_transport.go:79-81
+	// if use tag and digest, the tag should be ignored
+	if !strings.Contains(rawImgName, "://") {
+		rawImgParts := strings.Split(rawImgName, ":")
+		if len(rawImgParts) == 3 && strings.Contains(rawImgParts[1], "@sha256") {
+			// Equal to 3, which means the tag should be ignored
+			rawImgName = fmt.Sprintf("%s@sha256:%s", rawImgParts[0], rawImgParts[2])
+		}
+	}
+
 	// Let's do all the remaining Yoga in the API to prevent us from
 	// scattering logic across (too) many parts of the code.
-	pullReport, err := registry.ImageEngine().Pull(registry.GetContext(), args[0], pullOptions.ImagePullOptions)
+	pullReport, err := registry.ImageEngine().Pull(registry.GetContext(), rawImgName, pullOptions.ImagePullOptions)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -1,20 +1,21 @@
 package integration
 
 var (
-	redis             = "quay.io/libpod/redis:alpine"
-	fedoraMinimal     = "quay.io/libpod/fedora-minimal:latest"
-	ALPINE            = "quay.io/libpod/alpine:latest"
-	ALPINELISTTAG     = "quay.io/libpod/alpine:3.10.2"
-	ALPINELISTDIGEST  = "quay.io/libpod/alpine@sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"
-	ALPINEAMD64DIGEST = "quay.io/libpod/alpine@sha256:634a8f35b5f16dcf4aaa0822adc0b1964bb786fca12f6831de8ddc45e5986a00"
-	ALPINEAMD64ID     = "961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4"
-	ALPINEARM64DIGEST = "quay.io/libpod/alpine@sha256:f270dcd11e64b85919c3bab66886e59d677cf657528ac0e4805d3c71e458e525"
-	ALPINEARM64ID     = "915beeae46751fc564998c79e73a1026542e945ca4f73dc841d09ccc6c2c0672"
-	infra             = "k8s.gcr.io/pause:3.2"
-	BB                = "quay.io/libpod/busybox:latest"
-	healthcheck       = "quay.io/libpod/alpine_healthcheck:latest"
-	ImageCacheDir     = "/tmp/podman/imagecachedir"
-	fedoraToolbox     = "registry.fedoraproject.org/f32/fedora-toolbox:latest"
+	redis                   = "quay.io/libpod/redis:alpine"
+	fedoraMinimal           = "quay.io/libpod/fedora-minimal:latest"
+	ALPINE                  = "quay.io/libpod/alpine:latest"
+	ALPINELISTTAG           = "quay.io/libpod/alpine:3.10.2"
+	ALPINELISTDIGEST        = "quay.io/libpod/alpine@sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"
+	ALPINELISTTAGWITHDIGEST = "quay.io/libpod/alpine:3.10.2@sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"
+	ALPINEAMD64DIGEST       = "quay.io/libpod/alpine@sha256:634a8f35b5f16dcf4aaa0822adc0b1964bb786fca12f6831de8ddc45e5986a00"
+	ALPINEAMD64ID           = "961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4"
+	ALPINEARM64DIGEST       = "quay.io/libpod/alpine@sha256:f270dcd11e64b85919c3bab66886e59d677cf657528ac0e4805d3c71e458e525"
+	ALPINEARM64ID           = "915beeae46751fc564998c79e73a1026542e945ca4f73dc841d09ccc6c2c0672"
+	infra                   = "k8s.gcr.io/pause:3.2"
+	BB                      = "quay.io/libpod/busybox:latest"
+	healthcheck             = "quay.io/libpod/alpine_healthcheck:latest"
+	ImageCacheDir           = "/tmp/podman/imagecachedir"
+	fedoraToolbox           = "registry.fedoraproject.org/f32/fedora-toolbox:latest"
 
 	// This image has seccomp profiles that blocks all syscalls.
 	// The intention behind blocking all syscalls is to prevent

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -91,6 +91,16 @@ var _ = Describe("Podman pull", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman pull with both a tag and digest", func() {
+		session := podmanTest.Podman([]string{"pull", ALPINELISTTAGWITHDIGEST})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"rmi", ALPINEAMD64ID})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman pull by digest (image list)", func() {
 		session := podmanTest.Podman([]string{"pull", "--override-arch=arm64", ALPINELISTDIGEST})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/6721
pull with both a tag and digest
```
$ docker pull docker.io/fedora:32@sha256:e69b5a62ce23c673885bddc94e6679c9b2af683059637ceddb9cff458537a326
$ docker images | grep fedora
fedora              <none>              2a8d315e6208        7 months ago        201MB
$ docker rmi 2a8d
```
pull without a tag
```
$ docker pull docker.io/fedora@sha256:e69b5a62ce23c673885bddc94e6679c9b2af683059637ceddb9cff458537a326
$ docker images | grep fedora
fedora              <none>              2a8d315e6208        7 months ago        201MB
```

pull with a wrong tag with the digest
```
$ docker pull docker.io/fedora:31@sha256:e69b5a62ce23c673885bddc94e6679c9b2af683059637ceddb9cff458537a326
$ docker images | grep fedora
fedora              <none>              2a8d315e6208        7 months ago        201MB
```
so the tag will be ignore when with the digest

Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
