### PR TITLE
readme: Remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,8 @@ familiar container cli commands.  For more details, see the
 [Container Tools Guide](https://github.com/containers/buildah/tree/master/docs/containertools).
 
 ## Podman Former API (Varlink)
-Podman formerly offered a [Varlink-based API](https://github.com/containers/podman/blob/master/docs/tutorials/varlink_remote_client.md)
-for remote management of containers. However, this API was replaced by the REST API.
-Varlink support has been removed as of the 3.0 release.
+Podman formerly offered a Varlink-based API for remote management of containers. However, this API
+was replaced by the REST API. Varlink support has been removed as of the 3.0 release.
 For more details, you can see [this blog](https://podman.io/blogs/2020/01/17/podman-new-api.html).
 
 ## Static Binary Builds


### PR DESCRIPTION
The file `varlink_remote_client.md` has been removed in commit: f62a356515e387b0bbcf1f08b4831d139c2039b7 ("Remove varlink support from Podman")