### PR TITLE
[wip] Support additional layer store (patch for podman)

### DIFF
--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/containers/image/v5/image"
 	istorage "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v2/libpod/define"
@@ -87,14 +88,19 @@ func (r *storageService) CreateContainerStorage(ctx context.Context, systemConte
 			return ContainerInfo{}, err
 		}
 		// Pull out a copy of the image's configuration.
-		image, err := ref.NewImage(ctx, systemContext)
+		src, err := ref.NewImageSource(ctx, systemContext)
 		if err != nil {
 			return ContainerInfo{}, err
 		}
-		defer image.Close()
+		defer src.Close()
+		ic, err := image.FromSource(ctx, systemContext, src)
+		if err != nil {
+			return ContainerInfo{}, err
+		}
+		defer ic.Close()
 
 		// Get OCI configuration of image
-		imageConfig, err = image.OCIConfig(ctx)
+		imageConfig, err = ic.OCIConfig(ctx)
 		if err != nil {
 			return ContainerInfo{}, err
 		}


### PR DESCRIPTION
https://github.com/containers/podman/issues/4739

This enables podman to create containers using layers stored in a specified directory instead of pulling them from the registry. Leveraging this feature with remotely-mountable layers provided by stargz/zstd:chunked or CVMFS, podman can achieve lazy pulling.

That directory is named "additional layer store" (call ALS in this doc) and has the following structure.

```
<ALS root>
`-- <ID of layer1>
`-- <ID of layer2>
...
`-- .pool
```

Each layer is extracted and stored in ALS with a unique directory name (`<ID of layer1>`, `<ID of layer2>` in the above). There is `.pool` directory which is used for layer discovery described later.

### Changes in contianers/storage: https://github.com/containers/storage/pull/795

When the storage driver (e.g. overlay) is configured to use ALS, it uses layers in ALS with regarding each directory name as layer ID. In overlay driver, each layer directory in ALS is treated as the layer's `diff` directory, with assuming `lower` = "" and no link in the `l` directory.

When the `storage.Store` is configured to use ALS, this loads layers from ALS as read-only with assuming they don't have compressed digest nor uncompressed digest. This assumption should be the right thing just because exploded layers aren't archived nor compressed.

`storage.Store` also has layer discovery functionality which is indispensable for enabling lazy pulling. When a layer is queried with an ID via `Layer()` API with annotations (`key1=value1`, `key2=value2`...) and if that ID doesn't exist in ALS, `storage.Store` searches that layer from `.pool` directory with the following path.

```
<ALS root>/.pool/base64("key1=value1")/base64("key2=value2")/.../rootfs.<layer ID>
```

Each path element is base64 encoded key-value pair in the annotation.
The underlying filesystem (e.g. stargz/zstd:chunked-based filesystem or CVMFS) should show the exploded view of the target layer at that location. Example filesystem implementation (currently stargz-based) is https://github.com/ktock/stargz-snapshotter/tree/als-pool-example (this must be mounted under `<ALS root>/.pool`)


If `storage.Store` successfully accessed to this location, this creates the following symlink.

```
<ALS root>/<layer ID> -> <ALS root>/base64(key1=value1)/base64(key2=value2)/.../rootfs.<layer ID>
```

Then this layer (named `<layer ID>`) is accessible by the driver (with `<layer ID>`). So podman don't need to pull this layer from the registry.

### Changes in containers/image: https://github.com/containers/image/pull/1109

Now copier leverages this store. Every time this pulls images, it first tries to reuse blobs using `Layer()` API. This passes all annotations appended to the OCI descriptor of each layer and it also adds the following annotations by default for supporting registry-backed filesystems (e.g. stargz/zstd:chunked).

- `containers/image/target.layerdigest`: The digest of the target layer.
- `containers/image/target.reference`: The image reference of an image that contains the target layer.

When this copier successfully acquired that layer, it reused it without pulling.

### Changes in containers/podman: https://github.com/containers/podman/pull/8837

This patch also fixes libpod to eliminate unnecessary check of digest and size information of each layer
at runtime.

cc: @siscia @giuseppe 