### PR TITLE
Use HTTPProxy settings from containers.conf

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -336,7 +336,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 
 	createFlags.BoolVar(
 		&cf.HTTPProxy,
-		"http-proxy", true,
+		"http-proxy", containerConfig.Containers.HTTPProxy,
 		"Set proxy environment variables in the container based on the host proxy vars",
 	)
 


### PR DESCRIPTION
This PR takes the settings from containers.conf and uses
them.  This works on the podman local but does not fix the
issue for podman remote or for APIv2.  We need a way
to specify optionalbooleans when creating containers.

Fixes: https://github.com/containers/podman/issues/8843

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
