### PR TITLE
Add support for Gentoo file to package query

### DIFF
--- a/libpod/util.go
+++ b/libpod/util.go
@@ -153,6 +153,10 @@ func queryPackageVersion(cmdArg ...string) string {
 	return strings.Trim(output, "\n")
 }
 
+func equeryVersion(path string) string {
+	return queryPackageVersion("/usr/bin/equery", "b", path)
+}
+
 func pacmanVersion(path string) string {
 	return queryPackageVersion("/usr/bin/pacman", "-Qo", path)
 }
@@ -172,7 +176,10 @@ func packageVersion(program string) string {
 	if out := dpkgVersion(program); out != unknownPackage {
 		return out
 	}
-	return pacmanVersion(program)
+	if out := pacmanVersion(program); out != unknownPackage {
+		return out
+	}
+	return equeryVersion(program)
 }
 
 func programVersion(mountProgram string) (string, error) {


### PR DESCRIPTION
On Gentoo systems where `app-portage/gentoolkit` is installed the binary
`equery` is used to query for information on which package a file
belongs to.

Tested on Gentoo:
```
$ ./bin/podman info
ERRO[0000] cannot find UID/GID for user michael: No subuid ranges found for user "michael" in /etc/subuid - check rootless mode in man pages. 
WARN[0000] using rootless single mapping into the namespace. This might break some images. Check /etc/subuid and /etc/subgid for adding sub*ids 
host:
  arch: amd64
  buildahVersion: 1.19.0-dev
  cgroupManager: cgroupfs
  cgroupVersion: v1
  conmon:
    package: app-emulation/conmon-2.0.20
    path: /usr/libexec/podman/conmon
    version: 'conmon version 2.0.20, commit: 13244db638cf987c415298a3c23393ae5abeb885'
  cpus: 8
  distribution:
    distribution: gentoo
    version: unknown
  eventLogger: file
  hostname: tuxbrain
  idMappings:
    gidmap:
    - container_id: 0
      host_id: 1000
      size: 1
    uidmap:
    - container_id: 0
      host_id: 1000
      size: 1
  kernel: 5.10.2-gentoo
  linkmode: dynamic
  memFree: 1578491904
  memTotal: 16463495168
  ociRuntime:
    name: runc
    package: app-emulation/runc-1.0.0_rc10-r1
    path: /usr/bin/runc
    version: |-
      runc version 1.0.0-rc10
      commit: dc9208a3303feef5b3839f4323d9beb36df0a9dd
      spec: 1.0.1-dev
  os: linux
  remoteSocket:
    path: /run/user/1000/podman/podman.sock
  security:
    apparmorEnabled: false
    capabilities: CAP_AUDIT_WRITE,CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER,CAP_FSETID,CAP_KILL,CAP_MKNOD,CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_SETFCAP,CAP_SETGID,CAP_SETPCAP,CAP_SETUID,CAP_SYS_CHROOT
    rootless: true
    seccompEnabled: true
    selinuxEnabled: false
  slirp4netns:
    executable: ""
    package: ""
    version: ""
  swapFree: 2828357632
  swapTotal: 4294955008
  uptime: 78h 30m 2.39s (Approximately 3.25 days)
registries: {}
store:
  configFile: /home/michael/.config/containers/storage.conf
  containerStore:
    number: 0
    paused: 0
    running: 0
    stopped: 0
  graphDriverName: vfs
  graphOptions: {}
  graphRoot: /home/michael/.local/share/containers/storage
  graphStatus: {}
  imageStore:
    number: 0
  runRoot: /run/user/1000/containers
  volumePath: /home/michael/.local/share/containers/storage/volumes
version:
  APIVersion: 3.0.0
  Built: 1609271935
  BuiltTime: Tue Dec 29 20:58:55 2020
  GitCommit: 904dec2164bee3d5276fe061c779fedebe6515af
  GoVersion: go1.15.6
  OsArch: linux/amd64
  Version: 3.0.0-dev
```

Tested on openSUSE:

```
./bin/podman info
ERRO[0000] The storage 'driver' option must be set in /etc/containers/storage.conf, guarantee proper operation. 
ERRO[0000] The storage 'driver' option must be set in /etc/containers/storage.conf, guarantee proper operation. 
host:
  arch: amd64
  buildahVersion: 1.19.0-dev
  cgroupManager: cgroupfs
  cgroupVersion: v1
  conmon:
    package: conmon-2.0.21-1.1.x86_64
    path: /usr/bin/conmon
    version: 'conmon version 2.0.21, commit: unknown'
  cpus: 4
  distribution:
    distribution: '"opensuse-tumbleweed"'
    version: "20201215"
  eventLogger: journald
  hostname: maitreya
  idMappings:
    gidmap:
    - container_id: 0
      host_id: 100
      size: 1
    uidmap:
    - container_id: 0
      host_id: 1000
      size: 1
  kernel: 5.9.14-1-default
  linkmode: dynamic
  memFree: 455077888
  memTotal: 8018780160
  ociRuntime:
    name: runc
    package: runc-1.0.0~rc92-1.1.x86_64
    path: /usr/bin/runc
    version: |-
      runc version 1.0.0-rc92
      spec: 1.0.2-dev
  os: linux
  remoteSocket:
    path: /run/user/1000/podman/podman.sock
  security:
    apparmorEnabled: false
    capabilities: CAP_AUDIT_WRITE,CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER,CAP_FSETID,CAP_KILL,CAP_MKNOD,CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_SETFCAP,CAP_SETGID,CAP_SETPCAP,CAP_SETUID,CAP_SYS_CHROOT
    rootless: true
    seccompEnabled: true
    selinuxEnabled: false
  slirp4netns:
    executable: /usr/bin/slirp4netns
    package: slirp4netns-1.0.0-1.3.x86_64
    version: |-
      slirp4netns version 1.0.0
      commit: unknown
      libslirp: 4.3.1
  swapFree: 6434697216
  swapTotal: 8027893760
  uptime: 13h 23m 54.79s (Approximately 0.54 days)
registries:
  search:
  - registry.opensuse.org
  - docker.io
store:
  configFile: /home/michael/.config/containers/storage.conf
  containerStore:
    number: 0
    paused: 0
    running: 0
    stopped: 0
  graphDriverName: overlay
  graphOptions:
    overlay.mount_program:
      Executable: /usr/bin/fuse-overlayfs
      Package: fuse-overlayfs-1.1.2-2.1.x86_64
      Version: |-
        fusermount3 version: 3.10.1
        fuse-overlayfs: version 1.1.0
        FUSE library version 3.10.1
        using FUSE kernel interface version 7.31
  graphRoot: /home/michael/.local/share/containers/storage
  graphStatus:
    Backing Filesystem: extfs
    Native Overlay Diff: "false"
    Supports d_type: "true"
    Using metacopy: "false"
  imageStore:
    number: 0
  runRoot: /run/user/1000/containers
  volumePath: /home/michael/.local/share/containers/storage/volumes
version:
  APIVersion: 3.0.0
  Built: 1609267755
  BuiltTime: Tue Dec 29 19:49:15 2020
  GitCommit: 9c9f02aad773051fa742a874844f08f2fb567d3b-dirty
  GoVersion: go1.14.13
  OsArch: linux/amd64
  Version: 3.0.0-dev
```