### PR TITLE
Disable seccomp by default when creating a privileged container.

### DIFF
--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -172,7 +172,7 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 
 	// Clear default Seccomp profile from Generator for unconfined containers
 	// and privileged containers which do not specify a seccomp profile.
-	if s.SeccompProfilePath == "unconfined" || (s.Privileged && (s.SeccompProfilePath == config.SeccompOverridePath || s.SeccompProfilePath == config.SeccompDefaultPath)) {
+	if s.SeccompProfilePath == "unconfined" || (s.Privileged && (s.SeccompProfilePath == "" || s.SeccompProfilePath == config.SeccompOverridePath || s.SeccompProfilePath == config.SeccompDefaultPath)) {
 		configSpec.Linux.Seccomp = nil
 	}
 

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -110,6 +110,15 @@ var _ = Describe("Podman privileged container tests", func() {
 		Expect("0000000000000000").To(Equal(capEff[1]))
 	})
 
+	It("podman privileged should disable seccomp by default", func() {
+		hostSeccomp := SystemExec("grep", []string{"-Ei", "^Seccomp:\\s+0$", "/proc/self/status"})
+		Expect(hostSeccomp.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"run", "--privileged", ALPINE, "grep", "-Ei", "^Seccomp:\\s+0$", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman non-privileged should have very few devices", func() {
 		session := podmanTest.Podman([]string{"run", "-t", "busybox", "ls", "-l", "/dev"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
When running a privileged container and `SeccompProfilePath` is empty no seccomp profile should be applied.
(Previously this was the case only if `SeccompProfilePath` was set to a non-empty default path.)

Closes #8849

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
