### PR TITLE
systemd: make rundir always accessible

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -193,6 +193,11 @@ func hasCurrentUserMapped(ctr *Container) bool {
 
 // CreateContainer creates a container.
 func (r *ConmonOCIRuntime) CreateContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions) error {
+	// always make the run dir accessible to the current user so that the PID files can be read without
+	// being in the rootless user namespace.
+	if err := makeAccessible(ctr.state.RunDir, 0, 0); err != nil {
+		return err
+	}
 	if !hasCurrentUserMapped(ctr) {
 		for _, i := range []string{ctr.state.RunDir, ctr.runtime.config.Engine.TmpDir, ctr.config.StaticDir, ctr.state.Mountpoint, ctr.runtime.config.Engine.VolumePath} {
 			if err := makeAccessible(i, ctr.RootUID(), ctr.RootGID()); err != nil {

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -13,10 +13,10 @@ import (
 
 var _ = Describe("Podman systemd", func() {
 	var (
-		tempdir           string
-		err               error
-		podmanTest        *PodmanTestIntegration
-		systemd_unit_file string
+		tempdir         string
+		err             error
+		podmanTest      *PodmanTestIntegration
+		systemdUnitFile string
 	)
 
 	BeforeEach(func() {
@@ -27,7 +27,7 @@ var _ = Describe("Podman systemd", func() {
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
 		podmanTest.SeedImages()
-		systemd_unit_file = `[Unit]
+		systemdUnitFile = `[Unit]
 Description=redis container
 [Service]
 Restart=always
@@ -50,7 +50,7 @@ WantedBy=multi-user.target
 		SkipIfRootless("rootless can not write to /etc")
 		SkipIfContainerized("test does not have systemd as pid 1")
 
-		sys_file := ioutil.WriteFile("/etc/systemd/system/redis.service", []byte(systemd_unit_file), 0644)
+		sys_file := ioutil.WriteFile("/etc/systemd/system/redis.service", []byte(systemdUnitFile), 0644)
 		Expect(sys_file).To(BeNil())
 		defer func() {
 			stop := SystemExec("bash", []string{"-c", "systemctl stop redis"})

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -131,6 +131,21 @@ WantedBy=multi-user.target
 		Expect(conData[0].Config.SystemdMode).To(BeTrue())
 	})
 
+	It("podman create container with --uidmap and conmon PidFile accessible", func() {
+		ctrName := "testCtrUidMap"
+		run := podmanTest.Podman([]string{"run", "-d", "--uidmap=0:1:1000", "--name", ctrName, ALPINE, "top"})
+		run.WaitWithDefaultTimeout()
+		Expect(run.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"inspect", "--format", "{{.ConmonPidFile}}", ctrName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		pidFile := strings.TrimSuffix(session.OutputToString(), "\n")
+		_, err := ioutil.ReadFile(pidFile)
+		Expect(err).To(BeNil())
+	})
+
 	It("podman create container with systemd=always triggers systemd mode", func() {
 		ctrName := "testCtr"
 		run := podmanTest.Podman([]string{"create", "--name", ctrName, "--systemd", "always", ALPINE})


### PR DESCRIPTION
so that the PIDFile can be accessed also without being in the rootless
user namespace.

Closes: https://github.com/containers/podman/issues/8506

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
