### PR TITLE
system tests (remote): reenable basic exec test

### DIFF
--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -6,8 +6,6 @@
 load helpers
 
 @test "podman exec - basic test" {
-    skip_if_remote "FIXME: pending #7241"
-
     rand_filename=$(random_string 20)
     rand_content=$(random_string 50)
 


### PR DESCRIPTION
Test was disabled August 2020 due to #7241, a hang. That issue
has been closed, so let's see if it's really fixed.

Signed-off-by: Ed Santiago <santiago@redhat.com>
