### PR TITLE
close journald when reading

### DIFF
--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -84,7 +84,11 @@ func (e EventJournalD) Read(ctx context.Context, options ReadOptions) error {
 	if err != nil {
 		return err
 	}
-
+	defer func() {
+		if err := j.Close(); err != nil {
+			logrus.Errorf("Unable to close journal :%v", err)
+		}
+	}()
 	// match only podman journal entries
 	podmanJournal := sdjournal.Match{Field: "SYSLOG_IDENTIFIER", Value: "podman"}
 	if err := j.AddMatch(podmanJournal.String()); err != nil {
@@ -112,7 +116,6 @@ func (e EventJournalD) Read(ctx context.Context, options ReadOptions) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get journal cursor")
 	}
-
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
when reading from journald, we need to close the journal handler for
events and logging.

Fixes: #8864

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
