### PR TITLE
Allow image errors to bubble up from lower level functions.

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -497,7 +497,7 @@ func (ir *Runtime) getLocalImage(inputName string) (string, *storage.Image, erro
 		return inputName, repoImage, nil
 	}
 
-	return "", nil, errors.Wrapf(ErrNoSuchImage, err.Error())
+	return "", nil, err
 }
 
 // ID returns the image ID as a string

--- a/libpod/image/utils.go
+++ b/libpod/image/utils.go
@@ -45,7 +45,8 @@ func findImageInRepotags(search imageParts, images []*Image) (*storage.Image, er
 		}
 	}
 	if len(candidates) == 0 {
-		return nil, errors.Errorf("unable to find a name and tag match for %s in repotags", searchName)
+
+		return nil, errors.Wrapf(define.ErrNoSuchImage, "unable to find a name and tag match for %s in repotags", searchName)
 	}
 
 	// If more then one candidate and the candidates all have same name


### PR DESCRIPTION
Currently we ignore ErrMultipleImages being returned from findImageInRepoTags.

Fixes: https://github.com/containers/podman/issues/8868

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
