### PR TITLE
libpod API: pull: fix channel race

### DIFF
--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -115,10 +115,10 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	writer := channel.NewWriter(make(chan []byte, 1))
+	writer := channel.NewWriter(make(chan []byte))
 	defer writer.Close()
 
-	stderr := channel.NewWriter(make(chan []byte, 1))
+	stderr := channel.NewWriter(make(chan []byte))
 	defer stderr.Close()
 
 	images := make([]string, 0, len(imagesToPull))


### PR DESCRIPTION
Fix a race condition in the pull endpoint caused by buffered channels.
Using buffered channels can lead to the context's cancel function to be
executed prior to the items being read from the channel.

Fixes: #8870
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
