### PR TITLE
Ensure we do not edit container config in Exec

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1190,7 +1190,10 @@ func prepareProcessExec(c *Container, options *ExecOptions, env []string, sessio
 	if err != nil {
 		return nil, err
 	}
-	pspec := c.config.Spec.Process
+	pspec := new(spec.Process)
+	if err := JSONDeepCopy(c.config.Spec.Process, pspec); err != nil {
+		return nil, err
+	}
 	pspec.SelinuxLabel = c.config.ProcessLabel
 	pspec.Args = options.Cmd
 	for _, cap := range options.CapAdd {


### PR DESCRIPTION
The existing code grabs the base container's process, and then modifies it for use with the exec session. This could cause errors in `podman inspect` or similar on the container, as the definition of its OCI spec has been changed by the exec session. The change never propagates to the DB, so it's limited to a single process, but we should still avoid it when possible - so deep-copy it before use.