### PR TITLE
[v2.2.1-rhel] Backport: RHEL gating tests: more journald exceptions

### DIFF
--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -52,14 +52,7 @@ ${cid[0]} d"   "Sequential output from logs"
 
 @test "podman logs over journald" {
     # We can't use journald on RHEL as rootless: rhbz#1895105
-    if is_rootless; then
-        run journalctl -n 1
-        if [[ $status -ne 0 ]]; then
-            if [[ $output =~ permission ]]; then
-                skip "Cannot use rootless journald on this system"
-            fi
-        fi
-    fi
+    skip_if_journald_unavailable
 
     msg=$(random_string 20)
 


### PR DESCRIPTION
Backport https://github.com/containers/podman/pull/8714/ to the 2.2.1-rhel branch to resolve https://bugzilla.redhat.com/show_bug.cgi?id=1912861