### PR TITLE
Ensure that user-specified HOSTNAME is honored

### DIFF
--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -364,7 +364,9 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 		// namespaces?
 		g.SetHostname(hostname)
 	}
-	g.AddProcessEnv("HOSTNAME", hostname)
+	if _, ok := s.Env["HOSTNAME"]; !ok && s.Hostname != "" {
+		g.AddProcessEnv("HOSTNAME", hostname)
+	}
 
 	// User
 	switch s.UserNS.NSMode {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1415,4 +1415,12 @@ WORKDIR /madethis`
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.ErrorToString()).To(ContainSubstring("Trying to pull"))
 	})
+
+	It("podman run container with hostname and hostname environment variable", func() {
+		hostnameEnv := "test123"
+		session := podmanTest.Podman([]string{"run", "--hostname", "testctr", "--env", fmt.Sprintf("HOSTNAME=%s", hostnameEnv), ALPINE, "printenv", "HOSTNAME"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(hostnameEnv))
+	})
 })


### PR DESCRIPTION
When adding the HOSTNAME environment variable, only do so if it is not already present in the spec. If it is already present, it was likely added by the user, and we should honor their requested value. 

Fixes #8886
