### PR TITLE
Revert e6fbc15f26b2a609936dfc11732037c70ee14cba and reenable tests

### DIFF
--- a/test/e2e/pod_stats_test.go
+++ b/test/e2e/pod_stats_test.go
@@ -177,8 +177,7 @@ var _ = Describe("Podman pod stats", func() {
 
 	It("podman stats on net=host post", func() {
 		// --net=host not supported for rootless pods at present
-		// problem with sysctls being passed to containers of the pod.
-		SkipIfCgroupV1("Bug: Error: sysctl net.ipv4.ping_group_range is not allowed in the hosts network namespace: OCI runtime error")
+		SkipIfRootlessCgroupsV1("Pause stats not supported in cgroups v1")
 		podName := "testPod"
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--net=host", "--name", podName})
 		podCreate.WaitWithDefaultTimeout()


### PR DESCRIPTION
The issue requiring these tests be disabled should be resolved. Reenable the tests as such.
