### PR TITLE
Fix podman logs read partial log lines

### DIFF
--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -82,7 +82,7 @@ func (c *Container) readFromLogFile(ctx context.Context, options *logs.LogOption
 			if nll.Partial() {
 				partial += nll.Msg
 				continue
-			} else if !nll.Partial() && len(partial) > 1 {
+			} else if !nll.Partial() && len(partial) > 0 {
 				nll.Msg = partial + nll.Msg
 				partial = ""
 			}


### PR DESCRIPTION
If a partial log line has the length 1 it was ignored by podman logs.

Fixes #8879

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
