### PR TITLE
Use HTTPProxy settings from containers.conf

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -336,7 +336,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 
 	createFlags.BoolVar(
 		&cf.HTTPProxy,
-		"http-proxy", true,
+		"http-proxy", containerConfig.Containers.HTTPProxy,
 		"Set proxy environment variables in the container based on the host proxy vars",
 	)
 

--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -135,6 +135,16 @@ func buildFlags(cmd *cobra.Command) {
 		logrus.Errorf("error setting up build flags: %v", err)
 		os.Exit(1)
 	}
+	// --http-proxy flag
+	// containers.conf defaults to true but we want to force false by default for remote, since settings do not apply
+	if registry.IsRemote() {
+		flag = fromAndBudFlags.Lookup("http-proxy")
+		buildOpts.HTTPProxy = false
+		if err := flag.Value.Set("false"); err != nil {
+			logrus.Errorf("unable to set --https-proxy to %v: %v", false, err)
+		}
+		flag.DefValue = "false"
+	}
 	flags.AddFlagSet(&fromAndBudFlags)
 	// Add the completion functions
 	fromAndBudFlagsCompletions := buildahCLI.GetFromAndBudFlagsCompletions()

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containernetworking/cni v0.8.0
 	github.com/containernetworking/plugins v0.9.0
 	github.com/containers/buildah v1.18.1-0.20201222143428-b9fdee076426
-	github.com/containers/common v0.31.2
+	github.com/containers/common v0.33.0
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.9.0
 	github.com/containers/psgo v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/containernetworking/plugins v0.9.0/go.mod h1:dbWv4dI0QrBGuVgj+TuVQ6wJ
 github.com/containers/buildah v1.18.1-0.20201222143428-b9fdee076426 h1:hgNSbIO7KUJ9jHSEHwM5D2qii5t/5f2yfxZepJFYm18=
 github.com/containers/buildah v1.18.1-0.20201222143428-b9fdee076426/go.mod h1:AM7JcGaUtTJgR6fZL2zBg5PCSCSDiX/sNdMSyrkoJ10=
 github.com/containers/common v0.31.1/go.mod h1:Fehe82hQfJQvDspnRrV9rcdAWG3IalNHEt0F6QWNBHQ=
-github.com/containers/common v0.31.2 h1:sNYwvLA4B7SpEiAWTUvkItPlCrUa2vcxh0FTKXKoC3Q=
-github.com/containers/common v0.31.2/go.mod h1:Fehe82hQfJQvDspnRrV9rcdAWG3IalNHEt0F6QWNBHQ=
+github.com/containers/common v0.33.0 h1:7Z6aAQ2s2iniEXd/IoGgc0ukmgmzAE8Oa929t6huVB8=
+github.com/containers/common v0.33.0/go.mod h1:mjDo/NKeweL/onaspLhZ38WnHXaYmrELHclIdvSnYpY=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.9.0 h1:dRmUtcluQcmasNo3DpnRoZjfU0rOu1qZeL6wlDJr10Q=
@@ -257,7 +257,6 @@ github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf h1:7+FW5aGwISbqUtkfmI
 github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf/go.mod h1:RpwtwJQFrIEPstU94h88MWPXP2ektJZ8cZ0YntAmXiE=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.4 h1:0ecGp3skIrHWPNGPJDaBIghfA6Sp7Ruo2Io8eLKzWm0=
 github.com/google/uuid v1.1.4/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -100,15 +100,9 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 	if err != nil {
 		return nil, err
 	}
-	// First transform the os env into a map. We need it for the labels later in
-	// any case.
-	osEnv, err := envLib.ParseSlice(os.Environ())
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing host environment variables")
-	}
 
 	// Get Default Environment from containers.conf
-	defaultEnvs, err := envLib.ParseSlice(rtc.GetDefaultEnv())
+	defaultEnvs, err := envLib.ParseSlice(rtc.GetDefaultEnvEx(s.EnvHost, s.HTTPProxy))
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing fields in containers.conf")
 	}
@@ -133,6 +127,12 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 		defaultEnvs = envLib.Join(defaultEnvs, envs)
 	}
 
+	// First transform the os env into a map. We need it for the labels later in
+	// any case.
+	osEnv, err := envLib.ParseSlice(os.Environ())
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing host environment variables")
+	}
 	// Caller Specified defaults
 	if s.EnvHost {
 		defaultEnvs = envLib.Join(defaultEnvs, osEnv)

--- a/vendor/github.com/containers/common/pkg/auth/auth.go
+++ b/vendor/github.com/containers/common/pkg/auth/auth.go
@@ -16,10 +16,17 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-// GetDefaultAuthFile returns env value REGISTRY_AUTH_FILE as default --authfile path
-// used in multiple --authfile flag definitions
+// GetDefaultAuthFile returns env value REGISTRY_AUTH_FILE as default
+// --authfile path used in multiple --authfile flag definitions
+// Will fail over to DOCKER_CONFIG if REGISTRY_AUTH_FILE environment is not set
 func GetDefaultAuthFile() string {
-	return os.Getenv("REGISTRY_AUTH_FILE")
+	authfile := os.Getenv("REGISTRY_AUTH_FILE")
+	if authfile == "" {
+		if authfile, ok := os.LookupEnv("DOCKER_CONFIG"); ok {
+			logrus.Infof("Using DOCKER_CONFIG environment variable for authfile path %s", authfile)
+		}
+	}
+	return authfile
 }
 
 // CheckAuthFile validates filepath given by --authfile

--- a/vendor/github.com/containers/common/pkg/completion/completion.go
+++ b/vendor/github.com/containers/common/pkg/completion/completion.go
@@ -91,3 +91,51 @@ func AutocompleteSubgidName(cmd *cobra.Command, args []string, toComplete string
 func AutocompleteSubuidName(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return autocompleteSubIDName("/etc/subuid")
 }
+
+// AutocompleteArch - Autocomplete platform supported by container engines
+func AutocompletePlatform(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	completions := []string{
+		"linux/386",
+		"linux/amd64",
+		"linux/arm",
+		"linux/arm64",
+		"linux/ppc64",
+		"linux/ppc64le",
+		"linux/mips",
+		"linux/mipsle",
+		"linux/mips64",
+		"linux/mips64le",
+		"linux/riscv64",
+		"linux/s390x",
+		"windows/386",
+		"windows/amd64",
+		"windows/arm",
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// AutocompleteArch - Autocomplete architectures supported by container engines
+func AutocompleteArch(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	completions := []string{
+		"386",
+		"amd64",
+		"arm",
+		"arm64",
+		"ppc64",
+		"ppc64le",
+		"mips",
+		"mipsle",
+		"mips64",
+		"mips64le",
+		"riscv64",
+		"s390x",
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// AutocompleteOS - Autocomplete OS supported by container engines
+func AutocompleteOS(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	completions := []string{"linux", "windows"}
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -746,13 +746,20 @@ func (c *Config) FindConmon() (string, error) {
 }
 
 // GetDefaultEnv returns the environment variables for the container.
-// It will checn the HTTPProxy and HostEnv booleans and add the appropriate
+// It will check the HTTPProxy and HostEnv booleans and add the appropriate
 // environment variables to the container.
 func (c *Config) GetDefaultEnv() []string {
+	return c.GetDefaultEnvEx(c.Containers.EnvHost, c.Containers.HTTPProxy)
+}
+
+// GetDefaultEnvEx returns the environment variables for the container.
+// It will check the HTTPProxy and HostEnv boolean parameters and return the appropriate
+// environment variables for the container.
+func (c *Config) GetDefaultEnvEx(envHost, httpProxy bool) []string {
 	var env []string
-	if c.Containers.EnvHost {
+	if envHost {
 		env = append(env, os.Environ()...)
-	} else if c.Containers.HTTPProxy {
+	} else if httpProxy {
 		proxy := []string{"http_proxy", "https_proxy", "ftp_proxy", "no_proxy", "HTTP_PROXY", "HTTPS_PROXY", "FTP_PROXY", "NO_PROXY"}
 		for _, p := range proxy {
 			if val, ok := os.LookupEnv(p); ok {

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -184,7 +184,7 @@ func DefaultConfig() (*Config, error) {
 				"TERM=xterm",
 			},
 			EnvHost:        false,
-			HTTPProxy:      false,
+			HTTPProxy:      true,
 			Init:           false,
 			InitPath:       "",
 			IPCNS:          "private",

--- a/vendor/github.com/containers/common/pkg/retry/retry_linux.go
+++ b/vendor/github.com/containers/common/pkg/retry/retry_linux.go
@@ -1,0 +1,9 @@
+package retry
+
+import (
+	"syscall"
+)
+
+func shouldRestartPlatform(e error) bool {
+	return e == syscall.ERESTART
+}

--- a/vendor/github.com/containers/common/pkg/retry/retry_unsupported.go
+++ b/vendor/github.com/containers/common/pkg/retry/retry_unsupported.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package retry
+
+func shouldRestartPlatform(e error) bool {
+	return false
+}

--- a/vendor/github.com/containers/common/pkg/seccomp/default_linux.go
+++ b/vendor/github.com/containers/common/pkg/seccomp/default_linux.go
@@ -378,7 +378,6 @@ func DefaultProfile() *Seccomp {
 				"utimensat_time64",
 				"utimes",
 				"vfork",
-				"vmsplice",
 				"wait4",
 				"waitid",
 				"waitpid",

--- a/vendor/github.com/containers/common/pkg/seccomp/seccomp.json
+++ b/vendor/github.com/containers/common/pkg/seccomp/seccomp.json
@@ -378,7 +378,6 @@
 				"utimensat_time64",
 				"utimes",
 				"vfork",
-				"vmsplice",
 				"wait4",
 				"waitid",
 				"waitpid",

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.31.2"
+const Version = "0.33.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -89,7 +89,7 @@ github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/supplemented
 github.com/containers/buildah/util
-# github.com/containers/common v0.31.2
+# github.com/containers/common v0.33.0
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/apparmor/internal/supported
 github.com/containers/common/pkg/auth


### PR DESCRIPTION
This PR takes the settings from containers.conf and uses
them.  This works on the podman local but does not fix the
issue for podman remote or for APIv2.  We need a way
to specify optionalbooleans when creating containers.

Fixes: https://github.com/containers/podman/issues/8843

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
