### PR TITLE
Fix build for mips architecture follow-up 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,11 @@ CROSS_BUILD_TARGETS := \
 	bin/podman.cross.linux.arm \
 	bin/podman.cross.linux.arm64 \
 	bin/podman.cross.linux.386 \
-	bin/podman.cross.linux.s390x
+	bin/podman.cross.linux.s390x \
+	bin/podman.cross.linux.mips \
+	bin/podman.cross.linux.mipsle \
+	bin/podman.cross.linux.mips64 \
+	bin/podman.cross.linux.mips64le
 
 .PHONY: all
 all: binaries docs

--- a/pkg/signal/signal_linux_mipsx.go
+++ b/pkg/signal/signal_linux_mipsx.go
@@ -19,6 +19,8 @@ import (
 const (
 	sigrtmin = 34
 	sigrtmax = 127
+
+	SIGWINCH = syscall.SIGWINCH
 )
 
 // signalMap is a map of Linux signals.

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -282,8 +282,8 @@ func finishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(statT.Rdev)))
-			v.Minor = (int64(unix.Minor(statT.Rdev)))
+			v.Major = (int64(unix.Major(uint64(statT.Rdev))))
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev))))
 			s.ResourceLimits.BlockIO.ThrottleReadBpsDevice = append(s.ResourceLimits.BlockIO.ThrottleReadBpsDevice, v)
 		}
 	}
@@ -293,8 +293,8 @@ func finishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(statT.Rdev)))
-			v.Minor = (int64(unix.Minor(statT.Rdev)))
+			v.Major = (int64(unix.Major(uint64(statT.Rdev))))
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev))))
 			s.ResourceLimits.BlockIO.ThrottleWriteBpsDevice = append(s.ResourceLimits.BlockIO.ThrottleWriteBpsDevice, v)
 		}
 	}
@@ -304,8 +304,8 @@ func finishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(statT.Rdev)))
-			v.Minor = (int64(unix.Minor(statT.Rdev)))
+			v.Major = (int64(unix.Major(uint64(statT.Rdev))))
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev))))
 			s.ResourceLimits.BlockIO.ThrottleReadIOPSDevice = append(s.ResourceLimits.BlockIO.ThrottleReadIOPSDevice, v)
 		}
 	}
@@ -315,8 +315,8 @@ func finishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(statT.Rdev)))
-			v.Minor = (int64(unix.Minor(statT.Rdev)))
+			v.Major = (int64(unix.Major(uint64(statT.Rdev))))
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev))))
 			s.ResourceLimits.BlockIO.ThrottleWriteIOPSDevice = append(s.ResourceLimits.BlockIO.ThrottleWriteIOPSDevice, v)
 		}
 	}


### PR DESCRIPTION
Follow-up to commit (1ad7966). The build on mips is still
failing because SIGWINCH was not defined in the signal pkg.
Also stat_t.Rdev is unit32 on mips so we need to typecast.

Second, add mips architecture to the cross build target.
I confirmed that the cross compile for mips works now.