### PR TITLE
Restore compatible API for prune endpoints

### DIFF
--- a/pkg/api/handlers/compat/images_prune.go
+++ b/pkg/api/handlers/compat/images_prune.go
@@ -1,0 +1,75 @@
+package compat
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+
+	"github.com/containers/podman/v2/libpod"
+	"github.com/containers/podman/v2/pkg/api/handlers"
+	"github.com/containers/podman/v2/pkg/api/handlers/utils"
+	"github.com/docker/docker/api/types"
+	"github.com/gorilla/schema"
+	"github.com/pkg/errors"
+)
+
+func PruneImages(w http.ResponseWriter, r *http.Request) {
+	var (
+		filters []string
+	)
+	decoder := r.Context().Value("decoder").(*schema.Decoder)
+	runtime := r.Context().Value("runtime").(*libpod.Runtime)
+
+	query := struct {
+		All     bool
+		Filters map[string][]string `schema:"filters"`
+	}{
+		// This is where you can override the golang default value for one of fields
+	}
+
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		return
+	}
+
+	for k, v := range query.Filters {
+		for _, val := range v {
+			filters = append(filters, fmt.Sprintf("%s=%s", k, val))
+		}
+	}
+	imagePruneReports, err := runtime.ImageRuntime().PruneImages(r.Context(), query.All, filters)
+	if err != nil {
+		utils.InternalServerError(w, err)
+		return
+	}
+
+	idr := make([]types.ImageDeleteResponseItem, len(imagePruneReports))
+	var reclaimedSpace uint64
+	var errorMsg bytes.Buffer
+	for _, p := range imagePruneReports {
+		if p.Err != nil {
+			// Docker stops on first error vs. libpod which keeps going. Given API constraints, concatenate all errors
+			// and return that string.
+			errorMsg.WriteString(p.Err.Error())
+			errorMsg.WriteString("; ")
+			continue
+		}
+
+		idr = append(idr, types.ImageDeleteResponseItem{
+			Deleted: p.Id,
+		})
+		reclaimedSpace = reclaimedSpace + p.Size
+	}
+	if errorMsg.Len() > 0 {
+		utils.InternalServerError(w, errors.New(errorMsg.String()))
+		return
+	}
+
+	payload := handlers.ImagesPruneReport{
+		ImagesPruneReport: types.ImagesPruneReport{
+			ImagesDeleted:  idr,
+			SpaceReclaimed: reclaimedSpace,
+		},
+	}
+	utils.WriteResponse(w, http.StatusOK, payload)
+}

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -235,7 +235,7 @@ func PodRestart(w http.ResponseWriter, r *http.Request) {
 }
 
 func PodPrune(w http.ResponseWriter, r *http.Request) {
-	reports, err := PodPruneHelper(w, r)
+	reports, err := PodPruneHelper(r)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
@@ -243,7 +243,7 @@ func PodPrune(w http.ResponseWriter, r *http.Request) {
 	utils.WriteResponse(w, http.StatusOK, reports)
 }
 
-func PodPruneHelper(w http.ResponseWriter, r *http.Request) ([]*entities.PodPruneReport, error) {
+func PodPruneHelper(r *http.Request) ([]*entities.PodPruneReport, error) {
 	var (
 		runtime = r.Context().Value("runtime").(*libpod.Runtime)
 	)

--- a/pkg/api/handlers/libpod/system.go
+++ b/pkg/api/handlers/libpod/system.go
@@ -30,7 +30,7 @@ func SystemPrune(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	podPruneReport, err := PodPruneHelper(w, r)
+	podPruneReport, err := PodPruneHelper(r)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
@@ -38,7 +38,7 @@ func SystemPrune(w http.ResponseWriter, r *http.Request) {
 	systemPruneReport.PodPruneReport = podPruneReport
 
 	// We could parallelize this, should we?
-	containerPruneReports, err := compat.PruneContainersHelper(w, r, nil)
+	containerPruneReports, err := compat.PruneContainersHelper(r, nil)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -9,6 +9,19 @@ import (
 )
 
 func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
+	// swagger:operation POST /networks/prune compat compatPruneNetwork
+	// ---
+	// tags:
+	// - networks (compat)
+	// Summary: Delete unused networks
+	// description: Not supported
+	// produces:
+	// - application/json
+	// responses:
+	//   404:
+	//     $ref: "#/responses/NoSuchNetwork"
+	r.HandleFunc(VersionedPath("/networks/prune"), compat.UnsupportedHandler).Methods(http.MethodPost)
+	r.HandleFunc("/networks/prune", compat.UnsupportedHandler).Methods(http.MethodPost)
 	// swagger:operation DELETE /networks/{name} compat compatRemoveNetwork
 	// ---
 	// tags:


### PR DESCRIPTION
* Restore correct API endpoint payloads including reclaimed space numbers
* Include tests for API prune endpoints
* Clean up function signatures with unused parameters
* Update swagger for /networks/prune

Fixes #8891

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
