### PR TITLE
Improve error message when the the podman service is not enabled

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -158,7 +158,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 
 	// Prep the engines
 	if _, err := registry.NewImageEngine(cmd, args); err != nil {
-		return err
+		return errors.Wrapf(err, "Cannot connect to the Podman socket, make sure there is a Podman REST API service running.")
 	}
 	if _, err := registry.NewContainerEngine(cmd, args); err != nil {
 		return err


### PR DESCRIPTION
Currently if server is not connected, we return an error message that
is confusing users on Mac and Windows boxes.  The hope here is to make
it a little easier to discover that a Podman service is required.

This message is similar to what Docker puts out so people might under
stand it better.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
