### PR TITLE
Ensure that `podman play kube` actually reports errors

### DIFF
--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -40,6 +40,9 @@ type PlayKubePod struct {
 	Containers []string
 	// Logs - non-fatal errors and log messages while processing.
 	Logs []string
+	// ContainerErrors - any errors that occurred while starting containers
+	// in the pod.
+	ContainerErrors []string
 }
 
 // PlayKubeReport contains the results of running play kube.


### PR DESCRIPTION
In 2.2.x, we moved `play kube` to use the Start() API for pods, which reported errors in a different way (all containers are started in parallel, and then results reported as a block). The migration attempted to preserve compatibility by returning only one error, but that's not really a viable option as it can obscure the real reason that a pod is failing. Further, the code was not correctly handling the API's errors - Pod Start() will, on any container error, return a map of container ID to error populated for all container errors *and* return ErrPodPartialFail for overall error - the existing code did not handle the partial failure error and thus would never return container errors.

Refactor the `play kube` API to include a set of errors for containers in each pod, so we can return all errors that occurred to the frontend and print them for the user, and correct the backend code so container errors are actually forwarded.
