### PR TITLE
Adding json formatting to `--list-tags` option in `podman search` command.

### DIFF
--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -26,6 +26,12 @@ type searchOptionsWrapper struct {
 	Format       string // For go templating
 }
 
+// listEntryTag is a utility structure used for json serialization.
+type listEntryTag struct {
+	Name string
+	Tags []string
+}
+
 var (
 	searchOptions     = searchOptionsWrapper{}
 	searchDescription = `Search registries for a given image. Can search all the default registries or a specific registry.
@@ -189,11 +195,8 @@ func printJson(v interface{}) error {
 	return nil
 }
 
-func buildListTagsJson(searchReport []entities.ImageSearchReport) interface{} {
-	entries := []struct {
-		Name string
-		Tags []string
-	}{}
+func buildListTagsJson(searchReport []entities.ImageSearchReport) []listEntryTag {
+	entries := []listEntryTag{}
 
 ReportLoop:
 	for _, report := range searchReport {
@@ -203,10 +206,7 @@ ReportLoop:
 				continue ReportLoop
 			}
 		}
-		newElem := struct {
-			Name string
-			Tags []string
-		}{
+		newElem := listEntryTag{
 			report.Name,
 			[]string{report.Tag},
 		}

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -124,6 +124,15 @@ registries = ['{{.Host}}:{{.Port}}']`
 		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
 	})
 
+	It("podman search format json list tags", func() {
+		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", "alpine"})
+		search.WaitWithDefaultTimeout()
+		Expect(search.ExitCode()).To(Equal(0))
+		Expect(search.IsJSONOutputValid()).To(BeTrue())
+		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.10"))
+	})
+
 	It("podman search no-trunc flag", func() {
 		search := podmanTest.Podman([]string{"search", "--no-trunc", "alpine"})
 		search.WaitWithDefaultTimeout()

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -131,6 +131,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		Expect(search.IsJSONOutputValid()).To(BeTrue())
 		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
 		Expect(search.OutputToString()).To(ContainSubstring("3.10"))
+		Expect(search.OutputToString()).To(ContainSubstring("2.7"))
 	})
 
 	It("podman search no-trunc flag", func() {


### PR DESCRIPTION
Data is formatted following this JSON structure:
```json
{
    "Name": "...",
    "Tags": ["...", "...", "..."]
}
```

Closes: #8740.

Signed-off-by: Alexandre Fourcat <afourcat@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
