### PR TITLE
podman build --force-rm defaults to true in code

### DIFF
--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -294,7 +294,7 @@ If you specify `-f -`, the Containerfile contents will be read from stdin.
 #### **--force-rm**=*true|false*
 
 Always remove intermediate containers after a build, even if the build fails
-(default false).
+(default true).
 
 #### **--format**
 


### PR DESCRIPTION
The man page and code should match for what is the default settings.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
