### PR TITLE
image list: ignore bare manifest list

### DIFF
--- a/pkg/domain/infra/abi/images_list.go
+++ b/pkg/domain/infra/abi/images_list.go
@@ -44,7 +44,10 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 		}
 		e.Labels, err = img.Labels(ctx)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error retrieving label for image %q: you may need to remove the image to resolve the error", img.ID())
+			// Ignore empty manifest lists.
+			if errors.Cause(err) != libpodImage.ErrImageIsBareList {
+				return nil, errors.Wrapf(err, "error retrieving label for image %q: you may need to remove the image to resolve the error", img.ID())
+			}
 		}
 
 		ctnrs, err := img.Containers()

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -228,4 +228,17 @@ Labels.created_at | 20[0-9-]\\\+T[0-9:]\\\+Z
     run_podman rmi ${aaa_name}:${aaa_tag} ${zzz_name}:${zzz_tag}
 }
 
+# Regression test for #8931
+@test "podman images - bare manifest list" {
+    # Create an empty manifest list and list images.
+
+    run_podman inspect --format '{{.ID}}' $IMAGE
+    iid=$output
+
+    run_podman manifest create test:1.0
+    run_podman images --format '{{.ID}}' --no-trunc
+    [[ "$output" == *"sha256:$iid"* ]]
+
+    run_podman rmi test:1.0
+}
 # vim: filetype=sh


### PR DESCRIPTION
Handle empty/bare manifest lists when listing images.

Fixes: #8931
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
