### PR TITLE
oci: keep LC_ env variables to conmon

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1308,7 +1308,12 @@ func prepareProcessExec(c *Container, options *ExecOptions, env []string, sessio
 // configureConmonEnv gets the environment values to add to conmon's exec struct
 // TODO this may want to be less hardcoded/more configurable in the future
 func (r *ConmonOCIRuntime) configureConmonEnv(ctr *Container, runtimeDir string) ([]string, []*os.File) {
-	env := make([]string, 0, 6)
+	var env []string
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "LC_") {
+			env = append(env, e)
+		}
+	}
 	env = append(env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", runtimeDir))
 	env = append(env, fmt.Sprintf("_CONTAINERS_USERNS_CONFIGURED=%s", os.Getenv("_CONTAINERS_USERNS_CONFIGURED")))
 	env = append(env, fmt.Sprintf("_CONTAINERS_ROOTLESS_UID=%s", os.Getenv("_CONTAINERS_ROOTLESS_UID")))


### PR DESCRIPTION
it is necessary for conmon to deal with the correct locale, otherwise
it uses C as a fallback.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1893567
Requires: https://github.com/containers/conmon/pull/215

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
