### PR TITLE
Cirrus: Add cross-compile test for alternative arches

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -311,6 +311,8 @@ alt_build_task:
             ALT_NAME: 'Build Without CGO'
       - env:
             ALT_NAME: 'Test build RPM'
+      - env:
+            ALT_NAME: 'Alt Arch. Cross'
     setup_script: *setup
     main_script: *main
     always: *binary_artifacts

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ bin/podman.cross.%: .gopathok
 	TARGET="$*"; \
 	GOOS="$${TARGET%%.*}" \
 	GOARCH="$${TARGET##*.}" \
-	$(GO) build $(BUILDFLAGS) -gcflags '$(GCFLAGS)' -asmflags '$(ASMFLAGS)' -ldflags '$(LDFLAGS_PODMAN)' -tags '$(BUILDTAGS_CROSS)' -o "$@" ./cmd/podman
+	CGO_ENABLED=0 $(GO) build $(BUILDFLAGS) -gcflags '$(GCFLAGS)' -asmflags '$(ASMFLAGS)' -ldflags '$(LDFLAGS_PODMAN)' -tags '$(BUILDTAGS_CROSS)' -o "$@" ./cmd/podman
 
 # Update nix/nixpkgs.json its latest stable commit
 .PHONY: nixpkgs

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -178,6 +178,9 @@ function _run_altbuild() {
             make -f ./.copr/Makefile
             rpmbuild --rebuild ./podman-*.src.rpm
             ;;
+        Alt*Cross)
+            make local-cross
+            ;;
         *Static*)
             req_env_vars CTR_FQIN
             [[ "$UID" -eq 0 ]] || \


### PR DESCRIPTION
Followup to https://github.com/containers/podman/pull/8907 that simply
ensures cross-compiling podman completes.