### PR TITLE
Fix problems reported by staticcheck

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/containers/common/pkg/auth"
@@ -181,7 +180,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	createFlags.StringSliceVar(
 		&cf.Devices,
 		deviceFlagName, devices(),
-		fmt.Sprintf("Add a host device to the container"),
+		"Add a host device to the container",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(deviceFlagName, completion.AutocompleteDefault)
 
@@ -359,7 +358,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 		&cf.InitPath,
 		initPathFlagName, initPath(),
 		// Do not use  the Value field for setting the default value to determine user input (i.e., non-empty string)
-		fmt.Sprintf("Path to the container-init binary"),
+		"Path to the container-init binary",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(initPathFlagName, completion.AutocompleteDefault)
 

--- a/cmd/podman/containers/prune.go
+++ b/cmd/podman/containers/prune.go
@@ -18,9 +18,9 @@ import (
 )
 
 var (
-	pruneDescription = fmt.Sprintf(`podman container prune
+	pruneDescription = `podman container prune
 
-	Removes all non running containers`)
+	Removes all non running containers`
 	pruneCommand = &cobra.Command{
 		Use:               "prune [options]",
 		Short:             "Remove all non running containers",

--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -127,23 +127,23 @@ func kube(cmd *cobra.Command, args []string) error {
 
 	for _, pod := range report.Pods {
 		for _, l := range pod.Logs {
-			fmt.Fprintf(os.Stderr, l)
+			fmt.Fprint(os.Stderr, l)
 		}
 	}
 
 	ctrsFailed := 0
 
 	for _, pod := range report.Pods {
-		fmt.Printf("Pod:\n")
+		fmt.Println("Pod:")
 		fmt.Println(pod.ID)
 
 		switch len(pod.Containers) {
 		case 0:
 			continue
 		case 1:
-			fmt.Printf("Container:\n")
+			fmt.Println("Container:")
 		default:
-			fmt.Printf("Containers:\n")
+			fmt.Println("Containers:")
 		}
 		for _, ctr := range pod.Containers {
 			fmt.Println(ctr)
@@ -154,7 +154,7 @@ func kube(cmd *cobra.Command, args []string) error {
 			fmt.Println()
 		}
 		for _, err := range pod.ContainerErrors {
-			fmt.Fprintf(os.Stderr, err+"\n")
+			fmt.Fprintln(os.Stderr, err)
 		}
 		// Empty line for space for next block
 		fmt.Println()

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -2,7 +2,6 @@ package pods
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"text/tabwriter"
 	"text/template"
@@ -21,9 +20,9 @@ var (
 )
 
 var (
-	inspectDescription = fmt.Sprintf(`Display the configuration for a pod by name or id
+	inspectDescription = `Display the configuration for a pod by name or id
 
-	By default, this will render all results in a JSON array.`)
+	By default, this will render all results in a JSON array.`
 
 	inspectCmd = &cobra.Command{
 		Use:               "inspect [options] POD [POD...]",

--- a/cmd/podman/pods/prune.go
+++ b/cmd/podman/pods/prune.go
@@ -20,7 +20,7 @@ var (
 )
 
 var (
-	pruneDescription = fmt.Sprintf(`podman pod prune Removes all exited pods`)
+	pruneDescription = `podman pod prune Removes all exited pods`
 
 	pruneCommand = &cobra.Command{
 		Use:               "prune [options]",

--- a/cmd/podman/pods/rm.go
+++ b/cmd/podman/pods/rm.go
@@ -25,9 +25,9 @@ type podRmOptionsWrapper struct {
 
 var (
 	rmOptions        = podRmOptionsWrapper{}
-	podRmDescription = fmt.Sprintf(`podman rm will remove one or more stopped pods and their containers from the host.
+	podRmDescription = `podman rm will remove one or more stopped pods and their containers from the host.
 
-  The pod name or ID can be used.  A pod with containers will not be removed without --force. If --force is specified, all containers will be stopped, then removed.`)
+  The pod name or ID can be used.  A pod with containers will not be removed without --force. If --force is specified, all containers will be stopped, then removed.`
 	rmCommand = &cobra.Command{
 		Use:   "rm [options] POD [POD...]",
 		Short: "Remove one or more pods",

--- a/cmd/podman/system/prune.go
+++ b/cmd/podman/system/prune.go
@@ -20,11 +20,11 @@ import (
 var (
 	pruneOptions     = entities.SystemPruneOptions{}
 	filters          []string
-	pruneDescription = fmt.Sprintf(`
+	pruneDescription = `
 	podman system prune
 
         Remove unused data
-`)
+`
 
 	pruneCommand = &cobra.Command{
 		Use:               "prune [options]",

--- a/cmd/podman/system/service.go
+++ b/cmd/podman/system/service.go
@@ -80,7 +80,7 @@ func service(cmd *cobra.Command, args []string) error {
 		}
 
 		// socket activation uses a unix:// socket in the shipped unit files but apiURI is coded as "" at this layer.
-		if "unix" == uri.Scheme && !registry.IsRemote() {
+		if uri.Scheme == "unix" && !registry.IsRemote() {
 			if err := syscall.Unlink(uri.Path); err != nil && !os.IsNotExist(err) {
 				return err
 			}

--- a/libpod/image/prune.go
+++ b/libpod/image/prune.go
@@ -29,7 +29,7 @@ func generatePruneFilterFuncs(filter, filterValue string) (ImageFilter, error) {
 				return false
 			}
 			for labelKey, labelValue := range labels {
-				if labelKey == filterKey && ("" == filterValue || labelValue == filterValue) {
+				if labelKey == filterKey && (filterValue == "" || labelValue == filterValue) {
 					return true
 				}
 			}

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -11,7 +11,6 @@ import (
 	cp "github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/directory"
 	"github.com/containers/image/v5/docker"
-	"github.com/containers/image/v5/docker/archive"
 	dockerarchive "github.com/containers/image/v5/docker/archive"
 	ociarchive "github.com/containers/image/v5/oci/archive"
 	oci "github.com/containers/image/v5/oci/layout"
@@ -130,7 +129,7 @@ func (ir *Runtime) getSinglePullRefPairGoal(srcRef types.ImageReference, destNam
 
 // getPullRefPairsFromDockerArchiveReference returns a slice of pullRefPairs
 // for the specified docker reference and the corresponding archive.Reader.
-func (ir *Runtime) getPullRefPairsFromDockerArchiveReference(ctx context.Context, reader *archive.Reader, ref types.ImageReference, sc *types.SystemContext) ([]pullRefPair, error) {
+func (ir *Runtime) getPullRefPairsFromDockerArchiveReference(ctx context.Context, reader *dockerarchive.Reader, ref types.ImageReference, sc *types.SystemContext) ([]pullRefPair, error) {
 	destNames, err := reader.ManifestTagsForReference(ref)
 	if err != nil {
 		return nil, err
@@ -178,7 +177,7 @@ func (ir *Runtime) pullGoalFromImageReference(ctx context.Context, srcRef types.
 	// supports pulling from docker-archive, oci, and registries
 	switch srcRef.Transport().Name() {
 	case DockerArchive:
-		reader, readerRef, err := archive.NewReaderForReference(sc, srcRef)
+		reader, readerRef, err := dockerarchive.NewReaderForReference(sc, srcRef)
 		if err != nil {
 			return nil, err
 		}
@@ -432,7 +431,7 @@ func checkRemoteImageForLabel(ctx context.Context, label string, imageInfo pullR
 	}
 	// Labels are case insensitive; so we iterate instead of simple lookup
 	for k := range remoteInspect.Labels {
-		if strings.ToLower(label) == strings.ToLower(k) {
+		if strings.EqualFold(label, k) {
 			return nil
 		}
 	}

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -437,12 +437,8 @@ func (s *InMemoryState) RemoveContainer(ctr *Container) error {
 	}
 
 	// Remove our network aliases
-	if _, ok := s.ctrNetworkAliases[ctr.ID()]; ok {
-		delete(s.ctrNetworkAliases, ctr.ID())
-	}
-	if _, ok := s.ctrNetworks[ctr.ID()]; ok {
-		delete(s.ctrNetworks, ctr.ID())
-	}
+	delete(s.ctrNetworkAliases, ctr.ID())
+	delete(s.ctrNetworks, ctr.ID())
 
 	return nil
 }
@@ -680,9 +676,7 @@ func (s *InMemoryState) NetworkDisconnect(ctr *Container, network string) error 
 		ctrAliases = make(map[string][]string)
 		s.ctrNetworkAliases[ctr.ID()] = ctrAliases
 	}
-	if _, ok := ctrAliases[network]; ok {
-		delete(ctrAliases, network)
-	}
+	delete(ctrAliases, network)
 
 	return nil
 }
@@ -1523,12 +1517,8 @@ func (s *InMemoryState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 	}
 
 	// Remove our network aliases
-	if _, ok := s.ctrNetworkAliases[ctr.ID()]; ok {
-		delete(s.ctrNetworkAliases, ctr.ID())
-	}
-	if _, ok := s.ctrNetworks[ctr.ID()]; ok {
-		delete(s.ctrNetworks, ctr.ID())
-	}
+	delete(s.ctrNetworkAliases, ctr.ID())
+	delete(s.ctrNetworks, ctr.ID())
 
 	return nil
 }

--- a/libpod/network/netconflist.go
+++ b/libpod/network/netconflist.go
@@ -216,7 +216,7 @@ func IfPassesFilter(netconf *libcni.NetworkConfigList, filters map[string][]stri
 					filterValue = ""
 				}
 				for labelKey, labelValue := range labels {
-					if labelKey == filterKey && ("" == filterValue || labelValue == filterValue) {
+					if labelKey == filterKey && (filterValue == "" || labelValue == filterValue) {
 						result = true
 						continue outer
 					}

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1374,6 +1374,7 @@ func (r *ConmonOCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, p
 		logDriverArg = define.NoLogging
 	case define.JSONLogging:
 		fallthrough
+	//lint:ignore ST1015 the default case has to be here
 	default: //nolint-stylecheck
 		// No case here should happen except JSONLogging, but keep this here in case the options are extended
 		logrus.Errorf("%s logging specified but not supported. Choosing k8s-file logging instead", ctr.LogDriver())

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -910,7 +910,7 @@ func WithUserNSFrom(nsCtr *Container) CtrCreateOption {
 		ctr.config.UserNsCtr = nsCtr.ID()
 		ctr.config.IDMappings = nsCtr.config.IDMappings
 
-		g := generate.NewFromSpec(ctr.config.Spec)
+		g := generate.Generator{Config: ctr.config.Spec}
 
 		g.ClearLinuxUIDMappings()
 		for _, uidmap := range nsCtr.config.IDMappings.UIDMap {

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -16,7 +16,6 @@ import (
 	"github.com/containers/podman/v2/libpod"
 	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/libpod/image"
-	image2 "github.com/containers/podman/v2/libpod/image"
 	"github.com/containers/podman/v2/pkg/api/handlers"
 	"github.com/containers/podman/v2/pkg/api/handlers/utils"
 	"github.com/containers/podman/v2/pkg/auth"
@@ -524,7 +523,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "failed to get runtime config", http.StatusInternalServerError, errors.Wrap(err, "failed to get runtime config"))
 		return
 	}
-	sc := image2.GetSystemContext(rtc.Engine.SignaturePolicyPath, "", false)
+	sc := image.GetSystemContext(rtc.Engine.SignaturePolicyPath, "", false)
 	tag := "latest"
 	options := libpod.ContainerCommitOptions{
 		Pause: true,

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -35,7 +35,7 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 					filterValue = ""
 				}
 				for labelKey, labelValue := range labels {
-					if labelKey == filterKey && ("" == filterValue || labelValue == filterValue) {
+					if labelKey == filterKey && (filterValue == "" || labelValue == filterValue) {
 						matched = true
 						break
 					}

--- a/pkg/domain/filters/pods.go
+++ b/pkg/domain/filters/pods.go
@@ -124,7 +124,7 @@ func GeneratePodFilterFunc(filter string, filterValues []string) (
 					filterValue = ""
 				}
 				for labelKey, labelValue := range labels {
-					if labelKey == filterKey && ("" == filterValue || labelValue == filterValue) {
+					if labelKey == filterKey && (filterValue == "" || labelValue == filterValue) {
 						matched = true
 						break
 					}

--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -39,7 +39,7 @@ func GenerateVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, error) {
 				}
 				vf = append(vf, func(v *libpod.Volume) bool {
 					for labelKey, labelValue := range v.Labels() {
-						if labelKey == filterKey && ("" == filterVal || labelValue == filterVal) {
+						if labelKey == filterKey && (filterVal == "" || labelValue == filterVal) {
 							return true
 						}
 					}
@@ -56,7 +56,7 @@ func GenerateVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, error) {
 				}
 				vf = append(vf, func(v *libpod.Volume) bool {
 					for labelKey, labelValue := range v.Options() {
-						if labelKey == filterKey && ("" == filterVal || labelValue == filterVal) {
+						if labelKey == filterKey && (filterVal == "" || labelValue == filterVal) {
 							return true
 						}
 					}

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -113,15 +113,7 @@ func (ic *ContainerEngine) ContainerWait(ctx context.Context, namesOrIds []strin
 }
 
 func (ic *ContainerEngine) ContainerPause(ctx context.Context, namesOrIds []string, options entities.PauseUnPauseOptions) ([]*entities.PauseUnpauseReport, error) {
-	var (
-		err error
-	)
-	ctrs := []*libpod.Container{} //nolint
-	if options.All {
-		ctrs, err = ic.Libpod.GetAllContainers()
-	} else {
-		ctrs, err = getContainersByContext(false, false, namesOrIds, ic.Libpod)
-	}
+	ctrs, err := getContainersByContext(options.All, false, namesOrIds, ic.Libpod)
 	if err != nil {
 		return nil, err
 	}
@@ -134,15 +126,7 @@ func (ic *ContainerEngine) ContainerPause(ctx context.Context, namesOrIds []stri
 }
 
 func (ic *ContainerEngine) ContainerUnpause(ctx context.Context, namesOrIds []string, options entities.PauseUnPauseOptions) ([]*entities.PauseUnpauseReport, error) {
-	var (
-		err error
-	)
-	ctrs := []*libpod.Container{} //nolint
-	if options.All {
-		ctrs, err = ic.Libpod.GetAllContainers()
-	} else {
-		ctrs, err = getContainersByContext(false, false, namesOrIds, ic.Libpod)
-	}
+	ctrs, err := getContainersByContext(options.All, false, namesOrIds, ic.Libpod)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/libpod/image"
-	libpodImage "github.com/containers/podman/v2/libpod/image"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/domain/entities/reports"
 	domainUtils "github.com/containers/podman/v2/pkg/domain/utils"
@@ -206,7 +205,7 @@ func (ir *ImageEngine) Unmount(ctx context.Context, nameOrIDs []string, options 
 	return reports, nil
 }
 
-func ToDomainHistoryLayer(layer *libpodImage.History) entities.ImageHistoryLayer {
+func ToDomainHistoryLayer(layer *image.History) entities.ImageHistoryLayer {
 	l := entities.ImageHistoryLayer{}
 	l.ID = layer.ID
 	l.Created = *layer.Created

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/containers/buildah/manifests"
 	buildahManifests "github.com/containers/buildah/pkg/manifests"
-	"github.com/containers/buildah/util"
 	buildahUtil "github.com/containers/buildah/util"
 	cp "github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/docker"
@@ -60,7 +59,7 @@ func (ir *ImageEngine) ManifestInspect(ctx context.Context, name string) ([]byte
 		}
 	}
 	sc := ir.Libpod.SystemContext()
-	refs, err := util.ResolveNameToReferences(ir.Libpod.GetStore(), sc, name)
+	refs, err := buildahUtil.ResolveNameToReferences(ir.Libpod.GetStore(), sc, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -162,11 +162,6 @@ func movePauseProcessToScope(r *libpod.Runtime) error {
 	return utils.RunUnderSystemdScope(int(pid), "user.slice", "podman-pause.scope")
 }
 
-// checkInput can be used to verify any of the globalopt values
-func checkInput() error { // nolint:deadcode,unused
-	return nil
-}
-
 // SystemPrune removes unused data from the system. Pruning pods, containers, volumes and images.
 func (ic *ContainerEngine) SystemPrune(ctx context.Context, options entities.SystemPruneOptions) (*entities.SystemPruneReport, error) {
 	var systemPruneReport = new(entities.SystemPruneReport)

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -21,9 +21,6 @@ var (
 	errNotADevice = errors.New("not a device node")
 )
 
-func u32Ptr(i int64) *uint32     { u := uint32(i); return &u }
-func fmPtr(i int64) *os.FileMode { fm := os.FileMode(i); return &fm }
-
 func addPrivilegedDevices(g *generate.Generator) error {
 	hostDevices, err := getDevices("/dev")
 	if err != nil {

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -110,7 +110,7 @@ func makeCommand(ctx context.Context, s *specgen.SpecGenerator, img *image.Image
 	// Only use image command if the user did not manually set an
 	// entrypoint.
 	command := s.Command
-	if (command == nil || len(command) == 0) && img != nil && (s.Entrypoint == nil || len(s.Entrypoint) == 0) {
+	if len(command) == 0 && img != nil && len(s.Entrypoint) == 0 {
 		newCmd, err := img.Cmd(ctx)
 		if err != nil {
 			return nil, err

--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -124,14 +124,10 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 	// named volumes, and vice versa.
 	// We'll delete the conflicts here as we supersede.
 	for dest := range unifiedMounts {
-		if _, ok := baseVolumes[dest]; ok {
-			delete(baseVolumes, dest)
-		}
+		delete(baseVolumes, dest)
 	}
 	for dest := range unifiedVolumes {
-		if _, ok := baseMounts[dest]; ok {
-			delete(baseMounts, dest)
-		}
+		delete(baseMounts, dest)
 	}
 
 	// Supersede volumes-from/image volumes with unified volumes from above.

--- a/pkg/specgen/generate/validate.go
+++ b/pkg/specgen/generate/validate.go
@@ -48,7 +48,7 @@ func verifyContainerResourcesCgroupV1(s *specgen.SpecGenerator) ([]string, error
 				warnings = append(warnings, "Your kernel does not support memory swappiness capabilities, or the cgroup is not mounted. Memory swappiness discarded.")
 				memory.Swappiness = nil
 			} else {
-				if *memory.Swappiness < 0 || *memory.Swappiness > 100 {
+				if *memory.Swappiness > 100 {
 					return warnings, errors.Errorf("invalid value: %v, valid memory swappiness range is 0-100", *memory.Swappiness)
 				}
 			}


### PR DESCRIPTION
`staticcheck` is a golang code analysis tool. https://staticcheck.io/

This commit fixes a lot of problems found in our code. Common problems are:
- unnecessary use of fmt.Sprintf
- duplicated imports with different names
- unnecessary check that a key exists before a delete call

There are still a lot of reported problems in the test files but I have
not looked at those.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
