### PR TITLE
specgen: improve heuristic for /sys bind mount

### DIFF
--- a/test/e2e/run_ns_test.go
+++ b/test/e2e/run_ns_test.go
@@ -105,6 +105,14 @@ var _ = Describe("Podman run ns", func() {
 		Expect(session).To(ExitWithError())
 	})
 
+	It("podman run mounts fresh cgroup", func() {
+		session := podmanTest.Podman([]string{"run", fedoraMinimal, "grep", "cgroup", "/proc/self/mountinfo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		output := session.OutputToString()
+		Expect(output).ToNot(ContainSubstring(".."))
+	})
+
 	It("podman run --ipc=host --pid=host", func() {
 		SkipIfRootlessCgroupsV1("Not supported for rootless + CGroupsV1")
 		cmd := exec.Command("ls", "-l", "/proc/self/ns/pid")


### PR DESCRIPTION
partially revert 95c45773d7dbca2880152de681c81f0a2afec99b
    
restrict the cases where /sys is bind mounted from the host.
    
The heuristic doesn't detect all the cases where the bind mount is not
necessary, but it is an improvement on the previous version where /sys
was always bind mounted for rootless containers unless --net none was
specified.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
