### PR TITLE
Exorcise Driver code from libpod/define

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -49,7 +49,7 @@ func (c *Container) Inspect(size bool) (*define.InspectContainerData, error) {
 	return c.inspectLocked(size)
 }
 
-func (c *Container) getContainerInspectData(size bool, driverData *driver.Data) (*define.InspectContainerData, error) {
+func (c *Container) getContainerInspectData(size bool, driverData *define.DriverData) (*define.InspectContainerData, error) {
 	config := c.config
 	runtimeInfo := c.state
 	ctrSpec, err := c.specFromState()

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/containers/image/v5/manifest"
-	"github.com/containers/podman/v2/libpod/driver"
 )
 
 // InspectContainerConfig holds further data about how a container was initially
@@ -635,7 +634,7 @@ type InspectContainerData struct {
 	EffectiveCaps   []string                    `json:"EffectiveCaps"`
 	BoundingCaps    []string                    `json:"BoundingCaps"`
 	ExecIDs         []string                    `json:"ExecIDs"`
-	GraphDriver     *driver.Data                `json:"GraphDriver"`
+	GraphDriver     *DriverData                 `json:"GraphDriver"`
 	SizeRw          *int64                      `json:"SizeRw,omitempty"`
 	SizeRootFs      int64                       `json:"SizeRootFs,omitempty"`
 	Mounts          []InspectMount              `json:"Mounts"`
@@ -699,4 +698,10 @@ type InspectExecProcess struct {
 	Tty bool `json:"tty"`
 	// User is the user the exec session was started as.
 	User string `json:"user"`
+}
+
+// DriverData handles the data for a storage driver
+type DriverData struct {
+	Name string            `json:"Name"`
+	Data map[string]string `json:"Data"`
 }

--- a/libpod/driver/driver.go
+++ b/libpod/driver/driver.go
@@ -1,40 +1,17 @@
 package driver
 
 import (
-	cstorage "github.com/containers/storage"
+	"github.com/containers/podman/v2/libpod/define"
+	"github.com/containers/storage"
 )
 
-// Data handles the data for a storage driver
-type Data struct {
-	Name string            `json:"Name"`
-	Data map[string]string `json:"Data"`
-}
-
-// GetDriverName returns the name of the driver for the given store
-func GetDriverName(store cstorage.Store) (string, error) {
-	driver, err := store.GraphDriver()
-	if err != nil {
-		return "", err
-	}
-	return driver.String(), nil
-}
-
-// GetDriverMetadata returns the metadata regarding the driver for the layer in the given store
-func GetDriverMetadata(store cstorage.Store, layerID string) (map[string]string, error) {
+// GetDriverData returns information on a given store's running graph driver.
+func GetDriverData(store storage.Store, layerID string) (*define.DriverData, error) {
 	driver, err := store.GraphDriver()
 	if err != nil {
 		return nil, err
 	}
-	return driver.Metadata(layerID)
-}
-
-// GetDriverData returns the Data struct with information of the driver used by the store
-func GetDriverData(store cstorage.Store, layerID string) (*Data, error) {
-	name, err := GetDriverName(store)
-	if err != nil {
-		return nil, err
-	}
-	metaData, err := GetDriverMetadata(store, layerID)
+	metaData, err := driver.Metadata(layerID)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +19,8 @@ func GetDriverData(store cstorage.Store, layerID string) (*Data, error) {
 		delete(metaData, "MergedDir")
 	}
 
-	return &Data{
-		Name: name,
+	return &define.DriverData{
+		Name: driver.String(),
 		Data: metaData,
 	}, nil
 }

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
+	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/libpod/driver"
 	"github.com/containers/podman/v2/libpod/events"
 	"github.com/containers/podman/v2/pkg/inspect"
@@ -972,7 +973,7 @@ func (i *Image) toImageRef(ctx context.Context) (types.Image, error) {
 }
 
 // DriverData gets the driver data from the store on a layer
-func (i *Image) DriverData() (*driver.Data, error) {
+func (i *Image) DriverData() (*define.DriverData, error) {
 	return driver.GetDriverData(i.imageruntime.store, i.TopLayer())
 }
 

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/containers/image/v5/manifest"
-	"github.com/containers/podman/v2/libpod/driver"
+	"github.com/containers/podman/v2/libpod/define"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -25,7 +25,7 @@ type ImageData struct {
 	Os           string                        `json:"Os"`
 	Size         int64                         `json:"Size"`
 	VirtualSize  int64                         `json:"VirtualSize"`
-	GraphDriver  *driver.Data                  `json:"GraphDriver"`
+	GraphDriver  *define.DriverData            `json:"GraphDriver"`
 	RootFS       *RootFS                       `json:"RootFS"`
 	Labels       map[string]string             `json:"Labels"`
 	Annotations  map[string]string             `json:"Annotations"`


### PR DESCRIPTION
The libpod/define code should not import any large dependencies, as it is intended to be structures and definitions only. It included the libpod/driver package for information on the storage driver, though, which brought in all of c/storage. Split the driver package so that define has the struct, and thus does not need to import Driver. And simplify the driver code while we're at it.
