### PR TITLE
CI: fix broken diagnostic message for -dev check

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -203,16 +203,18 @@ function _run_altbuild() {
 
 function _run_release() {
     # TODO: These tests should come from code external to the podman repo.
-    # to allow test-changes (and re-runs) in the case of a correctible test
+    # to allow test-changes (and re-runs) in the case of a correctable test
     # flaw or flake at release tag-push time.  For now, the test is here
-    # given it's simplicity.
+    # given its simplicity.
+    msg "podman info:"
+    bin/podman info
 
     msg "Checking podman release (or potential release) criteria."
-    info_output=$(bin/podman info 2>&1)
-    if grep -q -- '-dev'<<<"$info_output"; then
-        die "Releases must never contain '-dev' in output of 'podman info':
-$info_output"
+    dev=$(bin/podman info |& grep -- -dev)
+    if [[ -n "$dev" ]]; then
+        die "Releases must never contain '-dev' in output of 'podman info' ($dev)"
     fi
+    msg "All OK"
 }
 
 logformatter() {


### PR DESCRIPTION
There's a CI check for the presence of "-dev" in podman-info output
(it should not appear). This test is unlikely to fail, but if it
ever does, the diagnostic output is unhelpful. This makes it helpful.

Tested via:

    $ ln -s /bin/echo ~/bin/msg
    $ ln -s /bin/echo ~/bin/die
    $ TEST_FLAVOR=release ./contrib/cirrus/runner.sh
    ...
    Releases must never contain '-dev' in output of 'podman info' ( buildahVersion: 1.19.0-dev
      Version: 3.0.0-dev)

Signed-off-by: Ed Santiago <santiago@redhat.com>
