### PR TITLE
Fixes /etc/hosts duplicated every time after container restarted in a pod

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1742,7 +1742,7 @@ func (c *Container) generateHosts(path string) (string, error) {
 // FIXME.  Path should be used by this function,but I am not sure what is correct; remove //lint
 // once this is fixed
 func (c *Container) appendHosts(path string, netCtr *Container) (string, error) { //nolint
-	return c.appendStringToRundir("hosts", netCtr.getHosts())
+	return c.appendStringToRunDir("hosts", netCtr.getHosts())
 }
 
 // getHosts finds the pertinent information for a container's host file in its config and state


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/8921
```
$ podman pod create --name p1
$ podman run -d --pod p1 --name c1 $IMG top
$ podman exec c1 sh -c "wc -l < /etc/hosts"
5
$ podman restart c1
$ podman exec c1 sh -c "wc -l < /etc/hosts"
6 <--- should be 5
```
after fix
```
$ ./bin/podman restart c1
$ podman exec c1 sh -c "wc -l < /etc/hosts"
6 <-- don't  change to 7
```

Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
