### PR TITLE
Use errors.Is for comparing ErrOCIRuntime errors

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	goerrors "errors"
 	"fmt"
 	"os"
 	"path"
@@ -418,13 +419,14 @@ func resolveDestination() (string, string, string) {
 
 func formatError(err error) string {
 	var message string
-	if errors.Cause(err) == define.ErrOCIRuntime {
+	if goerrors.Is(err, define.ErrOCIRuntime) {
 		// OCIRuntimeErrors include the reason for the failure in the
 		// second to last message in the error chain.
 		message = fmt.Sprintf(
 			"Error: %s: %s",
 			define.ErrOCIRuntime.Error(),
-			strings.TrimSuffix(err.Error(), ": "+define.ErrOCIRuntime.Error()),
+			// The ErrOCIRuntime might wrap another error.
+			strings.ReplaceAll(err.Error(), ": "+define.ErrOCIRuntime.Error(), ""),
 		)
 	} else {
 		message = "Error: " + err.Error()

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -149,11 +149,11 @@ var (
 
 	// ErrOCIRuntimePermissionDenied indicates the OCI runtime attempted to invoke a command that returned
 	// a permission denied error
-	ErrOCIRuntimePermissionDenied = errors.New("OCI permission denied")
+	ErrOCIRuntimePermissionDenied = fmt.Errorf("%w: OCI permission denied", ErrOCIRuntime)
 
 	// ErrOCIRuntimeNotFound indicates the OCI runtime attempted to invoke a command
 	// that was not found
-	ErrOCIRuntimeNotFound = errors.New("OCI not found")
+	ErrOCIRuntimeNotFound = fmt.Errorf("%w: OCI not found", ErrOCIRuntime)
 
 	// ErrOCIRuntimeUnavailable indicates that the OCI runtime associated to a container
 	// could not be found in the configuration

--- a/libpod/define/exec_codes.go
+++ b/libpod/define/exec_codes.go
@@ -1,9 +1,9 @@
 package define
 
 import (
+	"errors"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,10 +23,10 @@ const (
 // has a predefined exit code associated. If so, it returns that, otherwise it returns
 // the exit code originally stated in libpod.Exec()
 func TranslateExecErrorToExitCode(originalEC int, err error) int {
-	if errors.Cause(err) == ErrOCIRuntimePermissionDenied {
+	if errors.Is(err, ErrOCIRuntimePermissionDenied) {
 		return ExecErrorCodeCannotInvoke
 	}
-	if errors.Cause(err) == ErrOCIRuntimeNotFound {
+	if errors.Is(err, ErrOCIRuntimeNotFound) {
 		return ExecErrorCodeNotFound
 	}
 	return originalEC

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"bufio"
 	"bytes"
+	goerrors "errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -94,11 +95,8 @@ func (c *Container) runHealthCheck() (define.HealthCheckStatus, error) {
 	config.Command = newCommand
 	exitCode, hcErr := c.Exec(config, streams, nil)
 	if hcErr != nil {
-		errCause := errors.Cause(hcErr)
 		hcResult = define.HealthCheckFailure
-		if errCause == define.ErrOCIRuntimeNotFound ||
-			errCause == define.ErrOCIRuntimePermissionDenied ||
-			errCause == define.ErrOCIRuntime {
+		if goerrors.Is(hcErr, define.ErrOCIRuntime) {
 			returnCode = 1
 			hcErr = nil
 		} else {


### PR DESCRIPTION
Use errors.Is for comparing ErrOCIRuntime errors

This simplifies checking for ErrOCIRuntime type of errors by using go's
built-in `errors.Is` function.

In order to make this practical, some errors now wrap `ErrOCIRuntime`.
Namely: `ErrOCIRuntimePermissionDenied` and `ErrOCIRuntimeNotFound`.

Given that some errors might now wrap `ErrOCIRuntime`, the error
formatting in the podman command's output was adjusted to take this into
account.