### PR TITLE
network: disallow CNI networks with user namespaces

### DIFF
--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -236,6 +236,9 @@ func namespaceOptions(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.
 	case specgen.Private:
 		fallthrough
 	case specgen.Bridge:
+		if postConfigureNetNS && rootless.IsRootless() {
+			return nil, errors.New("CNI networks not supported with user namespaces")
+		}
 		portMappings, err := createPortMappings(ctx, s, img)
 		if err != nil {
 			return nil, err

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -639,6 +639,24 @@ var _ = Describe("Podman run networking", func() {
 		Expect(create.ExitCode()).To(BeZero())
 	})
 
+	It("podman rootless fails custom CNI network with --uidmap", func() {
+		SkipIfNotRootless("The configuration works with rootless")
+
+		netName := stringid.GenerateNonCryptoID()
+		create := podmanTest.Podman([]string{"network", "create", netName})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		run := podmanTest.Podman([]string{"run", "--rm", "--net", netName, "--uidmap", "0:1:4096", ALPINE, "true"})
+		run.WaitWithDefaultTimeout()
+		Expect(run.ExitCode()).To(Equal(125))
+
+		remove := podmanTest.Podman([]string{"network", "rm", netName})
+		remove.WaitWithDefaultTimeout()
+		Expect(remove.ExitCode()).To(BeZero())
+	})
+
 	It("podman run with new:pod and static-ip", func() {
 		SkipIfRootless("Rootless does not support --ip")
 		netName := "podmantestnetwork2"

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -622,7 +622,7 @@ var _ = Describe("Podman run networking", func() {
 
 	It("podman run in custom CNI network with --static-ip", func() {
 		SkipIfRootless("Rootless mode does not support --ip")
-		netName := "podmantestnetwork"
+		netName := stringid.GenerateNonCryptoID()
 		ipAddr := "10.25.30.128"
 		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.30.0/24", netName})
 		create.WaitWithDefaultTimeout()
@@ -659,7 +659,7 @@ var _ = Describe("Podman run networking", func() {
 
 	It("podman run with new:pod and static-ip", func() {
 		SkipIfRootless("Rootless does not support --ip")
-		netName := "podmantestnetwork2"
+		netName := stringid.GenerateNonCryptoID()
 		ipAddr := "10.25.40.128"
 		podname := "testpod"
 		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.40.0/24", netName})


### PR DESCRIPTION
it solves a segfault when running as rootless a command like:

$ podman run --uidmap 0:0:1 --net foo --rm fedora true
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x5629bccc407c]

goroutine 1 [running]:
panic(0x5629bd3d39e0, 0x5629be0ab8e0)
	/usr/lib/golang/src/runtime/panic.go:1064 +0x545 fp=0xc0004592c0 sp=0xc0004591f8 pc=0x5629bbd35d85
runtime.panicmem(...)
	/usr/lib/golang/src/runtime/panic.go:212
runtime.sigpanic()
	/usr/lib/golang/src/runtime/signal_unix.go:742 +0x413 fp=0xc0004592f0 sp=0xc0004592c0 pc=0x5629bbd4cd33
github.com/containers/podman/libpod.(*Runtime).setupRootlessNetNS(0xc0003fe9c0, 0xc0003d74a0, 0x0, 0x0)
	/builddir/build/BUILD/podman-2.2.1/_build/src/github.com/containers/podman/libpod/networking_linux.go:238 +0xdc fp=0xc000459338 sp=0xc0004592f0 pc=0x5629bccc407c
github.com/containers/podman/libpod.(*Container).completeNetworkSetup(0xc0003d74a0, 0x0, 0x0)
	/builddir/build/BUILD/podman-2.2.1/_build/src/github.com/containers/podman/libpod/container_internal.go:965 +0xb72 fp=0xc0004594d8 sp=0xc000459338 pc=0x5629bcc81732

[.....]

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
