### PR TITLE
[CI:DOCS] Add more information and examples on podman and pipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ release.txt
 result
 # Necessary to prevent hack/tree-status.sh false-positive
 /*runner_stats.log
+.install.goimports
+.generate-bindings

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1011,8 +1011,11 @@ When set to **true**, Podman will allocate a pseudo-tty and attach to the standa
 input of the container. This can be used, for example, to run a throwaway
 interactive shell. The default is **false**.
 
-**NOTE**: The **-t** option is incompatible with a redirection of the Podman client
-standard input.
+**NOTE**: The --tty flag prevents redirection of standard output.  It combines STDOUT and STDERR, it can insert control characters, and it can hang pipes. This option should only be used when run interactively in a terminal. When feeding input to Podman, use -i only, not -it.
+
+```
+echo "asdf" | podman run --rm -i someimage /bin/cat
+```
 
 #### **--tz**=*timezone*
 
@@ -1526,6 +1529,13 @@ weight by **--blkio-weight-device** flag. Use the following command:
 
 ```
 $ podman run -it --blkio-weight-device "/dev/sda:200" ubuntu
+```
+
+### Using a podman container with input from a pipe
+
+```
+$ echo "asdf" | podman run --rm -i --entrypoint /bin/cat someimage
+asdf
 ```
 
 ### Setting Namespaced Kernel Parameters (Sysctls)


### PR DESCRIPTION
Improve the documentation to help users to know proper way to
use podman within a pipe.

Helps Prevent: https://github.com/containers/podman/issues/8916

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
