### PR TITLE
[v2.2] Cirrus: Skip most tests on tag-push

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,6 +67,7 @@ gcp_credentials: ENCRYPTED[a28959877b2c9c36f151781b0a05407218cda646c7d047fc556e4
 ext_svc_check_task:
     alias: 'ext_svc_check'  # int. ref. name - required for depends_on reference
     name: "Ext. services"  # Displayed Title - has no other significance
+    skip: &tags "$CIRRUS_TAG != ''"  # Don't run on tags
     # Default/small container image to execute tasks with
     container: &smallcontainer
         image: ${CTR_FQIN}
@@ -90,7 +91,7 @@ ext_svc_check_task:
 automation_task:
     alias: 'automation'
     name: "Check Automation"
-    skip: &branch "$CIRRUS_PR == '' || $CIRRUS_TAG != ''" # Don't run for branches
+    skip: &branches_and_tags "$CIRRUS_PR == '' || $CIRRUS_TAG != ''" # Don't run on branches/tags
     container: *smallcontainer
     env:
         TEST_FLAVOR: automation
@@ -107,6 +108,8 @@ automation_task:
 smoke_task:
     alias: 'smoke'
     name: "Smoke Test"
+    # git-validation app. only runs properly in PRs
+    skip: *branches_and_tags
     container: &bigcontainer
         image: ${CTR_FQIN}
         # Leave some resources for smallcontainer
@@ -209,6 +212,7 @@ build_task:
 validate_task:
     name: "Validate $DISTRO_NV Build"
     alias: validate
+    skip: *tags
     depends_on:
         - ext_svc_check
         - automation
@@ -237,7 +241,7 @@ bindings_task:
     name: "Test Bindings"
     alias: bindings
     only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
-    skip: *branch
+    skip: *branches_and_tags
     depends_on:
         - build
     gce_instance: *standardvm
@@ -293,6 +297,7 @@ endpoint_task:
 vendor_task:
     name: "Test Vendoring"
     alias: vendor
+    skip: *tags
     depends_on:
         - build
     container: *smallcontainer
@@ -395,6 +400,7 @@ osx_alt_build_task:
 docker-py_test_task:
     name: Docker-py Compat.
     alias: docker-py_test
+    skip: *tags
     only_if: *not_docs
     depends_on:
         - build
@@ -415,6 +421,7 @@ docker-py_test_task:
 unit_test_task:
     name: "Unit tests on $DISTRO_NV"
     alias: unit_test
+    skip: *tags
     only_if: *not_docs
     depends_on:
         - validate
@@ -432,6 +439,7 @@ unit_test_task:
 apiv2_test_task:
     name: "APIv2 test on $DISTRO_NV"
     alias: apiv2_test
+    skip: *tags
     depends_on:
         - validate
     gce_instance: *standardvm
@@ -465,7 +473,7 @@ local_integration_test_task: &local_integration_test_task
     name: &std_name_fmt "$TEST_FLAVOR $PODBIN_NAME $DISTRO_NV $PRIV_NAME $TEST_ENVIRON"
     alias: local_integration_test
     only_if: *not_docs
-    skip: *branch
+    skip: *branches_and_tags
     depends_on:
         - unit_test
     matrix: *platform_axis
@@ -497,7 +505,7 @@ container_integration_test_task:
     name: *std_name_fmt
     alias: container_integration_test
     only_if: *not_docs
-    skip: *branch
+    skip: *branches_and_tags
     depends_on:
         - unit_test
     matrix: &fedora_vm_axis
@@ -528,7 +536,7 @@ rootless_integration_test_task:
     name: *std_name_fmt
     alias: rootless_integration_test
     only_if: *not_docs
-    skip: *branch
+    skip: *branches_and_tags
     depends_on:
         - unit_test
     matrix: *fedora_vm_axis
@@ -551,6 +559,7 @@ rootless_integration_test_task:
 local_system_test_task: &local_system_test_task
     name: *std_name_fmt
     alias: local_system_test
+    skip: *tags
     only_if: *not_docs
     depends_on:
       - local_integration_test
@@ -578,6 +587,7 @@ remote_system_test_task:
 rootless_system_test_task:
     name: *std_name_fmt
     alias: rootless_system_test
+    skip: *tags
     only_if: *not_docs
     depends_on:
       - rootless_integration_test
@@ -663,7 +673,7 @@ success_task:
 release_task:
     name: "Verify Release"
     alias: release
-    only_if: $CIRRUS_TAG != ''
+    only_if: *tags
     depends_on:
         - success
     gce_instance: *standardvm
@@ -678,7 +688,9 @@ release_task:
 
 
 # When preparing to release a new version, this task may be manually
-# activated at the PR stage to verify the code is in a proper state.
+# activated at the PR stage to verify the build is proper for a potential
+# podman release.
+#
 # Note: This cannot use a YAML alias on 'release_task' as of this
 # comment, it is incompatible with 'trigger_type: manual'
 release_test_task:

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -209,8 +209,16 @@ function _run_altbuild() {
 }
 
 function _run_release() {
-    if bin/podman info |& grep -Eq -- '-dev'; then
-        die "Releases must never contain '-dev' in output of 'podman info'"
+    # TODO: These tests should come from code external to the podman repo.
+    # to allow test-changes (and re-runs) in the case of a correctible test
+    # flaw or flake at release tag-push time.  For now, the test is here
+    # given it's simplicity.
+
+    msg "Checking podman release (or potential release) criteria."
+    info_output=$(bin/podman info 2>&1)
+    if grep -q -- '-dev'<<<"$info_output"; then
+        die "Releases must never contain '-dev' in output of 'podman info':
+$info_output"
     fi
 }
 


### PR DESCRIPTION
Cherry-picked update from master, modified slightly to limit which tasks run during branch and tag testing.  Necessary to address [cirrus-cron invoked  failure.](https://cirrus-ci.com/build/5817365495545856).