### PR TITLE
Ensure install.tools for alt build task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -317,6 +317,8 @@ alt_build_task:
             ALT_NAME: 'Test build RPM'
       - env:
             ALT_NAME: 'Alt Arch. Cross'
+    gopath_cache: *ro_gopath_cache
+    clone_script: *noop  # Comes from cache
     setup_script: *setup
     main_script: *main
     always: *binary_artifacts


### PR DESCRIPTION
FWIW: Build cache was not used previously due to my own paranoia over possibly polluting something.