### PR TITLE
Use full attach path, rather than a symlink

### DIFF
--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -773,7 +773,7 @@ func (c *Container) cleanupExecBundle(sessionID string) error {
 		return err
 	}
 
-	return c.ociRuntime.ExecContainerCleanup(c, sessionID)
+	return nil
 }
 
 // the path to a containers exec session bundle

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -685,7 +685,11 @@ func (c *Container) removeIPv4Allocations() error {
 // This is necessary for restarting containers
 func (c *Container) removeConmonFiles() error {
 	// Files are allowed to not exist, so ignore ENOENT
-	attachFile := filepath.Join(c.bundlePath(), "attach")
+	attachFile, err := c.AttachSocketPath()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get attach socket path for container %s", c.ID())
+	}
+
 	if err := os.Remove(attachFile); err != nil && !os.IsNotExist(err) {
 		return errors.Wrapf(err, "error removing container %s attach file", c.ID())
 	}

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -206,4 +206,8 @@ var (
 	// ErrCanceled indicates that an operation has been cancelled by a user.
 	// Useful for potentially long running tasks.
 	ErrCanceled = errors.New("cancelled by user")
+
+	// ErrConmonVersionFormat is used when the expected versio-format of conmon
+	// has changed.
+	ErrConmonVersionFormat = "conmon version changed format"
 )

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -94,10 +94,6 @@ type OCIRuntime interface {
 	// ExecUpdateStatus checks the status of a given exec session.
 	// Returns true if the session is still running, or false if it exited.
 	ExecUpdateStatus(ctr *Container, sessionID string) (bool, error)
-	// ExecContainerCleanup cleans up after an exec session exits.
-	// It removes any files left by the exec session that are no longer
-	// needed, including the attach socket.
-	ExecContainerCleanup(ctr *Container, sessionID string) error
 
 	// CheckpointContainer checkpoints the given container.
 	// Some OCI runtimes may not support this - if SupportsCheckpoint()

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -284,11 +284,6 @@ func (r *ConmonOCIRuntime) ExecUpdateStatus(ctr *Container, sessionID string) (b
 	return true, nil
 }
 
-// ExecContainerCleanup cleans up files created when a command is run via ExecContainer.
-func (r *ConmonOCIRuntime) ExecContainerCleanup(ctr *Container, sessionID string) error {
-	return nil
-}
-
 // ExecAttachSocketPath is the path to a container's exec session attach socket.
 func (r *ConmonOCIRuntime) ExecAttachSocketPath(ctr *Container, sessionID string) (string, error) {
 	// We don't even use container, so don't validity check it

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -284,14 +284,8 @@ func (r *ConmonOCIRuntime) ExecUpdateStatus(ctr *Container, sessionID string) (b
 	return true, nil
 }
 
-// ExecContainerCleanup cleans up files created when a command is run via
-// ExecContainer. This includes the attach socket for the exec session.
+// ExecContainerCleanup cleans up files created when a command is run via ExecContainer.
 func (r *ConmonOCIRuntime) ExecContainerCleanup(ctr *Container, sessionID string) error {
-	// Clean up the sockets dir. Issue #3962
-	// Also ignore if it doesn't exist for some reason; hence the conditional return below
-	if err := os.RemoveAll(filepath.Join(r.socketsDir, sessionID)); err != nil && !os.IsNotExist(err) {
-		return err
-	}
 	return nil
 }
 
@@ -302,7 +296,7 @@ func (r *ConmonOCIRuntime) ExecAttachSocketPath(ctr *Container, sessionID string
 		return "", errors.Wrapf(define.ErrInvalidArg, "must provide a valid session ID to get attach socket path")
 	}
 
-	return filepath.Join(r.socketsDir, sessionID, "attach"), nil
+	return filepath.Join(ctr.execBundlePath(sessionID), "attach"), nil
 }
 
 // This contains pipes used by the exec API.

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -59,7 +59,6 @@ type ConmonOCIRuntime struct {
 	conmonEnv         []string
 	tmpDir            string
 	exitsDir          string
-	socketsDir        string
 	logSizeMax        int64
 	noPivot           bool
 	reservePorts      bool
@@ -149,7 +148,6 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 	}
 
 	runtime.exitsDir = filepath.Join(runtime.tmpDir, "exits")
-	runtime.socketsDir = filepath.Join(runtime.tmpDir, "socket")
 
 	// Create the exit files and attach sockets directories
 	if err := os.MkdirAll(runtime.exitsDir, 0750); err != nil {
@@ -158,13 +156,6 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 			return nil, errors.Wrapf(err, "error creating OCI runtime exit files directory")
 		}
 	}
-	if err := os.MkdirAll(runtime.socketsDir, 0750); err != nil {
-		// The directory is allowed to exist
-		if !os.IsExist(err) {
-			return nil, errors.Wrap(err, "error creating OCI runtime attach sockets directory")
-		}
-	}
-
 	return runtime, nil
 }
 
@@ -865,7 +856,7 @@ func (r *ConmonOCIRuntime) AttachSocketPath(ctr *Container) (string, error) {
 		return "", errors.Wrapf(define.ErrInvalidArg, "must provide a valid container to get attach socket path")
 	}
 
-	return filepath.Join(r.socketsDir, ctr.ID(), "attach"), nil
+	return filepath.Join(ctr.bundlePath(), "attach"), nil
 }
 
 // ExitFilePath is the path to a container's exit file.
@@ -1240,7 +1231,7 @@ func (r *ConmonOCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, p
 		"-p", pidPath,
 		"-n", ctr.Name(),
 		"--exit-dir", exitDir,
-		"--socket-dir-path", r.socketsDir,
+		"--full-attach",
 	}
 	if len(r.runtimeFlags) > 0 {
 		rFlags := []string{}

--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -151,11 +151,6 @@ func (r *MissingRuntime) ExecUpdateStatus(ctr *Container, sessionID string) (boo
 	return false, r.printError()
 }
 
-// ExecContainerCleanup is not available as the runtime is missing
-func (r *MissingRuntime) ExecContainerCleanup(ctr *Container, sessionID string) error {
-	return r.printError()
-}
-
 // CheckpointContainer is not available as the runtime is missing
 func (r *MissingRuntime) CheckpointContainer(ctr *Container, options ContainerCheckpointOptions) error {
 	return r.printError()

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -44,7 +44,7 @@ const (
 	conmonMinMinorVersion = 0
 
 	// conmonMinPatchVersion is the sub-minor version required for conmon.
-	conmonMinPatchVersion = 1
+	conmonMinPatchVersion = 24
 )
 
 // A RuntimeOption is a functional option which alters the Runtime created by

--- a/test/e2e/run_apparmor_test.go
+++ b/test/e2e/run_apparmor_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// wip
 func skipIfAppArmorEnabled() {
 	if apparmor.IsEnabled() {
 		Skip("Apparmor is enabled")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
conmon 2.0.24 (not yet released) will add the functionality to specify `--full-attach`, meaning the path to the attach socket will be accessed directly, rather than creating a symlink to a socketsDir. This not only drops a couple of unneeded operations, but also fixes issues that come up when a user runs podman with a sufficiently long UID (https://github.com/containers/conmon/issues/225)

This PR does many things along those lines:
- use the specified helper function AttachSocketPath, rather than building the path from scratch
- drop the use of socketDir entirely, and add the `--full-attach` option to the conmon args, so neither podman nor conmon operate with the socketDir anymore
- drops ExecContainerCleanup method from the oci interface, as the only work it was doing was cleaning up the exec specific socket dir
- returns findConmon to podman (from c/common). I don't think moving it was the correct strategy, as it makes bumping the minimum required conmon bothersome (rather than coordinating two repos, we would have to coordinate three).
- bumps the minimum required conmon to 2.0.24 to take advantage of all of this

A couple of notes:
- I am open to not moving findConmon, but we do need some way to specify the minimum conmon version for podman. it can't live in c/common. The other strategy would be to change the FindConmon() method in c/common to take major, minor and patch versions, so the calling engine can configure it themselves. However, I find this approach is better for now, because no other engines actually use FindConmon to my knowledge.
- I am not excited about throwing all of the findConmon code in libpod/runtime. it muddles up an otherwise pretty straight forward file. If there's other suggestions for where to put it, please let me know.
- this obviously relies on 2.0.24 to exist, which it does not yet. You can look at the PR that caused all of this work [here](https://github.com/containers/conmon/pull/228).