### PR TITLE
Add --if-not-exists option to podman network create

### DIFF
--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -48,6 +48,9 @@ func networkCreateFlags(cmd *cobra.Command) {
 	flags.IPVar(&networkCreateOptions.Gateway, gatewayFlagName, nil, "IPv4 or IPv6 gateway for the subnet")
 	_ = cmd.RegisterFlagCompletionFunc(gatewayFlagName, completion.AutocompleteNone)
 
+	if !registry.IsRemote() {
+		flags.BoolVar(&networkCreateOptions.IfNotExists, "if-not-exists", false, "do not error if the network name already exists")
+	}
 	flags.BoolVar(&networkCreateOptions.Internal, "internal", false, "restrict external access from this network")
 
 	ipRangeFlagName := "ip-range"

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -39,6 +39,12 @@ The `vlan` option assign VLAN tag and enables vlan\_filtering. Defaults to none.
 Define a gateway for the subnet. If you want to provide a gateway address, you must also provide a
 *subnet* option.
 
+#### **--if-not-exists**
+
+Do not error if a network with the given name already exists. Instead do nothing.
+
+This option is not supported on the remote client.
+
 #### **--internal**
 
 Restrict external access of this network

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -52,12 +52,14 @@ type NetworkCreateOptions struct {
 	DisableDNS bool
 	Driver     string
 	Gateway    net.IP
-	Internal   bool
-	Labels     map[string]string
-	MacVLAN    string
-	Range      net.IPNet
-	Subnet     net.IPNet
-	IPv6       bool
+	// Do not error if the network name is already used.
+	IfNotExists bool
+	Internal    bool
+	Labels      map[string]string
+	MacVLAN     string
+	Range       net.IPNet
+	Subnet      net.IPNet
+	IPv6        bool
 	// Mapping of driver options and values.
 	Options map[string]string
 }

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -10,6 +10,7 @@ import (
 	cniversion "github.com/containernetworking/cni/pkg/version"
 	"github.com/containers/podman/v2/libpod/network"
 	. "github.com/containers/podman/v2/test/utils"
+	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -363,6 +364,21 @@ var _ = Describe("Podman network create", func() {
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "foo=bar", net})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
+	})
+
+	It("podman network create with if not exists", func() {
+		SkipIfRemote("--if-not-exists is not supported on remote")
+		net := stringid.GenerateNonCryptoID()
+		nc := podmanTest.Podman([]string{"network", "create", "--if-not-exists", net})
+		nc.WaitWithDefaultTimeout()
+		defer podmanTest.removeCNINetwork(net)
+		Expect(nc.ExitCode()).To(BeZero())
+		Expect(nc.OutputToString()).To(ContainSubstring(net))
+
+		nc = podmanTest.Podman([]string{"network", "create", "--if-not-exists", net})
+		nc.WaitWithDefaultTimeout()
+		Expect(nc.ExitCode()).To(BeZero())
+		Expect(nc.OutputToString()).To(ContainSubstring(net))
 	})
 
 })


### PR DESCRIPTION
If `--if-not-exists` is set `podman network create` will not error
if the a network with the same given name already exists.

This option is only supported for local podman client. Supporting
the remote client would require changes in the api endpoint.

This option can be used as `ExecStartPre` command in a systemd
service file. see #8842

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
