### PR TITLE
[CI:DOCS] Rename AutocompletePortCommand func

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -517,8 +517,8 @@ func AutocompleteRunlabelCommand(cmd *cobra.Command, args []string, toComplete s
 	return nil, cobra.ShellCompDirectiveDefault
 }
 
-// AutocompletePortCommand - Autocomplete podman port command args.
-func AutocompletePortCommand(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+// AutocompleteContainerOneArg - Autocomplete containers as fist arg.
+func AutocompleteContainerOneArg(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if !validCurrentCmdLine(cmd, args, toComplete) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/cmd/podman/containers/port.go
+++ b/cmd/podman/containers/port.go
@@ -26,7 +26,7 @@ var (
 		Args: func(cmd *cobra.Command, args []string) error {
 			return validate.CheckAllLatestAndCIDFile(cmd, args, true, false)
 		},
-		ValidArgsFunction: common.AutocompletePortCommand,
+		ValidArgsFunction: common.AutocompleteContainerOneArg,
 		Example: `podman port --all
   podman port ctrID 80/tcp
   podman port --latest 80`,

--- a/cmd/podman/containers/rename.go
+++ b/cmd/podman/containers/rename.go
@@ -16,7 +16,7 @@ var (
 		Long:              renameDescription,
 		RunE:              rename,
 		Args:              cobra.ExactArgs(2),
-		ValidArgsFunction: common.AutocompletePortCommand,
+		ValidArgsFunction: common.AutocompleteContainerOneArg,
 		Example:           "podman rename containerA newName",
 	}
 


### PR DESCRIPTION
This function is now used for the port and rename command.
Rename it to AutocompleteContainerOneArg.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
