### PR TITLE
Simplify bindings generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ ifneq ($(shell uname -s), Darwin)
 		pushd $${dirname}>/dev/null;  \
 		echo $${dirname}; \
 		echo $(GO) generate; \
-		$(GO) generate; \
+		$(GO) generate -mod=vendor; \
 		popd > /dev/null; \
 	done;
 endif

--- a/Makefile
+++ b/Makefile
@@ -462,15 +462,7 @@ podman-remote-%-release:
 BINDINGS_SOURCE = $(wildcard pkg/bindings/**/types.go)
 .generate-bindings: $(BINDINGS_SOURCE)
 ifneq ($(shell uname -s), Darwin)
-	for i in $(BINDINGS_SOURCE); do \
-		dirname=$$(dirname $${i}); \
-		shortname=$$(basename $${dirname}); \
-		pushd $${dirname}>/dev/null;  \
-		echo $${dirname}; \
-		echo $(GO) generate; \
-		$(GO) generate -mod=vendor; \
-		popd > /dev/null; \
-	done;
+	$(GO) generate -mod=vendor ./pkg/bindings/... ;
 endif
 	touch .generate-bindings
 


### PR DESCRIPTION
* Use `./vendor` to avoid dependency look ups via the network
* Simplify the bindings generation

Please see the individual commit messages.

Fixes: #8989

@baude @rhatdan PTAL