### PR TITLE
[CI:DOCS] lint lint lint

### DIFF
--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -21,5 +21,5 @@ for i in tunnel abi; do
   echo Running golangci-lint for "$i"
   echo Build Tags          "$i": ${BUILD_TAGS[$i]}
   echo Skipped directories "$i": ${SKIP_DIRS[$i]}
-  golangci-lint run --build-tags=${BUILD_TAGS[$i]} --skip-dirs=${SKIP_DIRS[$i]} "$@"
+  ./bin/golangci-lint run --build-tags=${BUILD_TAGS[$i]} --skip-dirs=${SKIP_DIRS[$i]} "$@"
 done

--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
 
-set -e
-
 die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
 
 [ -n "$VERSION" ] || die "\$VERSION is empty or undefined"
-[ -n "$GOBIN" ] || die "\$GOBIN is empty or undefined"
+
+function install() {
+    echo "Installing golangci-lint v$VERSION into $BIN"
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./bin v$VERSION
+}
 
 BIN="./bin/golangci-lint"
 if [ ! -x "$BIN" ]; then
-    echo "Installing golangci-lint v$VERSION into $BIN"
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./bin v$VERSION
+	install
 else
     # Prints its own file name as part of --version output
-    echo "Using existing $(dirname $BIN)/$($BIN --version)"
+    $BIN --version | grep "$VERSION"
+    if [ $? -eq 0 ]; then
+        echo "Using existing $(dirname $BIN)/$($BIN --version)"
+    else
+        install
+    fi
 fi

--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -7,10 +7,10 @@ die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
 [ -n "$VERSION" ] || die "\$VERSION is empty or undefined"
 [ -n "$GOBIN" ] || die "\$GOBIN is empty or undefined"
 
-BIN="$GOBIN/golangci-lint"
+BIN="./bin/golangci-lint"
 if [ ! -x "$BIN" ]; then
-    echo "Installing golangci-lint v$VERSION into $GOBIN"
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOBIN v$VERSION
+    echo "Installing golangci-lint v$VERSION into $BIN"
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./bin v$VERSION
 else
     # Prints its own file name as part of --version output
     echo "Using existing $(dirname $BIN)/$($BIN --version)"


### PR DESCRIPTION
* golangci-lint: install to ./bin
* hack/install_golangci.sh: smarter install

Two commits to make the installation of golangci-lint smarter.  It'll now be installed into `./bin` to prevent sharing `$GOBIN` with other projects who may require a different version.

Since `varlink` has been removed, we can finally update golangci-lint to more recent versions.  I'll plan that soon unless somebody else is faster.