### PR TITLE
[v3.0] runner.sh : deal with bash 'set -e'

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -210,7 +210,8 @@ function _run_release() {
     bin/podman info
 
     msg "Checking podman release (or potential release) criteria."
-    dev=$(bin/podman info |& grep -- -dev)
+    # We're running under 'set -eo pipefail'; make sure this statement passes
+    dev=$(bin/podman info |& grep -- -dev || echo -n '')
     if [[ -n "$dev" ]]; then
         die "Releases must never contain '-dev' in output of 'podman info' ($dev)"
     fi


### PR DESCRIPTION
Release trigger script failed[1] because the entire script
runs under 'set -e'; so a 'grep -- -dev' that finds no
results will cause a nonzero exit status and hence the
entire script to fail. Work around that.

 [1] https://cirrus-ci.com/task/4541290882793472

Signed-off-by: Ed Santiago <santiago@redhat.com>
