### PR TITLE
make bindings generation more robust

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -274,17 +274,19 @@ swagger_task:
 
 
 # Check that all included go modules from other sources match
-# what is expected in `vendor/modules.txt` vs `go.mod`.
-vendor_task:
-    name: "Test Vendoring"
-    alias: vendor
+# what is expected in `vendor/modules.txt` vs `go.mod`.  Also
+# make sure that the generated bindings in pkg/bindings/...
+# are in sync with the code.
+consistency_task:
+    name: "Test Code Consistency"
+    alias: consistency
     skip: *tags
     depends_on:
         - build
     container: *smallcontainer
     env:
         <<: *stdenvars
-        TEST_FLAVOR: vendor
+        TEST_FLAVOR: consistency
         TEST_ENVIRON: container
         CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
     clone_script: *full_clone  # build-cache not available to container tasks
@@ -642,7 +644,7 @@ success_task:
         - validate
         - bindings
         - swagger
-        - vendor
+        - consistency
         - alt_build
         - static_alt_build
         - osx_alt_build

--- a/Makefile
+++ b/Makefile
@@ -464,6 +464,7 @@ podman-remote-%-release:
 	rm -f release.txt
 	$(MAKE) podman-remote-release-$*.zip
 
+.PHONY: generate-bindings
 generate-bindings:
 ifneq ($(shell uname -s), Darwin)
 	GO111MODULE=off $(GO) generate ./pkg/bindings/... ;

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ PODMAN_SERVER_LOG ?=
 
 # If GOPATH not specified, use one in the local directory
 ifeq ($(GOPATH),)
-export GOPATH := $(CURDIR)/_output
+export GOPATH := $(HOME)/go
 unexport GOBIN
 endif
 FIRST_GOPATH := $(firstword $(subst :, ,$(GOPATH)))
@@ -97,6 +97,8 @@ GOBIN := $(shell $(GO) env GOBIN)
 ifeq ($(GOBIN),)
 GOBIN := $(FIRST_GOPATH)/bin
 endif
+
+export PATH := $(PATH):$(GOBIN)
 
 GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
 
@@ -466,7 +468,7 @@ podman-remote-%-release:
 BINDINGS_SOURCE = $(wildcard pkg/bindings/**/types.go)
 .generate-bindings: $(BINDINGS_SOURCE)
 ifneq ($(shell uname -s), Darwin)
-	$(GO) generate -mod=vendor ./pkg/bindings/... ;
+	GO111MODULE=off $(GO) generate ./pkg/bindings/... ;
 endif
 	touch .generate-bindings
 

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ endif
 podman: bin/podman
 
 .PHONY: bin/podman-remote
-bin/podman-remote: .gopathok .generate-bindings $(SOURCES) go.mod go.sum ## Build with podman on remote environment
+bin/podman-remote: .gopathok $(SOURCES) go.mod go.sum ## Build with podman on remote environment
 	$(GO) build $(BUILDFLAGS) -gcflags '$(GCFLAGS)' -asmflags '$(ASMFLAGS)' -ldflags '$(LDFLAGS_PODMAN)' -tags "${REMOTETAGS}" -o $@ ./cmd/podman
 
 .PHONY: bin/podman-remote-static
@@ -279,7 +279,6 @@ clean: ## Clean artifacts
 		libpod/container_easyjson.go \
 		libpod/pod_easyjson.go \
 		.install.goimports \
-		.generate-bindings \
 		docs/build
 	make -C docs clean
 
@@ -465,12 +464,10 @@ podman-remote-%-release:
 	rm -f release.txt
 	$(MAKE) podman-remote-release-$*.zip
 
-BINDINGS_SOURCE = $(wildcard pkg/bindings/**/types.go)
-.generate-bindings: $(BINDINGS_SOURCE)
+generate-bindings:
 ifneq ($(shell uname -s), Darwin)
 	GO111MODULE=off $(GO) generate ./pkg/bindings/... ;
 endif
-	touch .generate-bindings
 
 .PHONY: docker-docs
 docker-docs: docs

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -146,9 +146,11 @@ function _run_swagger() {
     cp -v $GOSRC/pkg/api/swagger.yaml $GOSRC/
 }
 
-function _run_vendor() {
+function _run_consistency() {
     make vendor
-    ./hack/tree_status.sh
+    SUGGESTION="run 'make vendor' and commit all changes" ./hack/tree_status.sh
+    make generate-bindings
+    SUGGESTION="run 'make generate-bindings' and commit all changes" ./hack/tree_status.sh
 }
 
 function _run_build() {

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -214,7 +214,7 @@ case "$TEST_FLAVOR" in
 
         install_test_configs
         ;;
-    vendor) make clean ;;
+    consistency) make clean ;;
     release) ;;
     *) die_unknown TEST_FLAVOR
 esac


### PR DESCRIPTION
The Go gods did not shine upon us trying to understand what's going on
in #9000.  The symptom is that `go generate` did not add required
imports to a generated file, ultimately breaking subsequent compilation.

While it still remains unclear *why* Go is behaving like that, the
symptom disappears when `go generate` runs in module mode; that is
without `-mod=vendor` and without `GO111MODULE=off`.  This was
reproducible on two separate machines (Ubuntu and Fedora).

Also, when facing an unset GOPATH, set it to Go's default (i.e.,
$HOME/go) and make sure that GOBIN is in PATH since `goimports`
is required by `go generate`.

Fixes: #9000
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@baude @rhatdan @edsantiago PTAL