### PR TITLE
Cirrus: Upload swagger YAML in every context

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -254,20 +254,27 @@ bindings_task:
     always: *runner_stats
 
 
-# Build the "libpod" API documentation `swagger.yaml` for eventual
-# publishing along side the official podman documentation.
+# Build the "libpod" API documentation `swagger.yaml` and
+# publish it to google-cloud-storage (GCS).
 swagger_task:
     name: "Test Swagger"
     alias: swagger
     depends_on:
         - build
-    container: *smallcontainer
+    gce_instance: *standardvm
     env:
         <<: *stdenvars
         TEST_FLAVOR: swagger
-        TEST_ENVIRON: container
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-    clone_script: *full_clone  # build-cache not available to container tasks
+        # TODO: Due to podman 3.0 activity (including new images), avoid
+        # disturbing the status-quo just to incorporate this one new
+        # container image.  Uncomment line below when CI activities normalize.
+        #CTR_FQIN: 'quay.io/libpod/gcsupld:${IMAGE_SUFFIX}'
+        CTR_FQIN: 'quay.io/libpod/gcsupld:c4813063494828032'
+        GCPJSON: ENCRYPTED[927dc01e755eaddb4242b0845cf86c9098d1e3dffac38c70aefb1487fd8b4fe6dd6ae627b3bffafaba70e2c63172664e]
+        GCPNAME: ENCRYPTED[c145e9c16b6fb88d476944a454bf4c1ccc84bb4ecaca73bdd28bdacef0dfa7959ebc8171a27b2e4064d66093b2cdba49]
+        GCPPROJECT: 'libpod-218412'
+    gopath_cache: *ro_gopath_cache
+    clone_script: *noop  # Comes from cache
     setup_script: *setup
     main_script: *main
     always: *binary_artifacts

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -202,7 +202,6 @@ case "$TEST_FLAVOR" in
     int) ;&
     sys) ;&
     bindings) ;&
-    swagger) ;&
     endpoint)
         # Use existing host bits when testing is to happen inside a container
         # since this script will run again in that environment.
@@ -214,6 +213,7 @@ case "$TEST_FLAVOR" in
 
         install_test_configs
         ;;
+    swagger) ;&  # use next item
     consistency) make clean ;;
     release) ;;
     *) die_unknown TEST_FLAVOR

--- a/docs/source/_static/api.html
+++ b/docs/source/_static/api.html
@@ -18,7 +18,7 @@
     </style>
   </head>
   <body>
-    <redoc spec-url='https://storage.googleapis.com/libpod-master-releases/swagger-latest-master.yaml' sort-props-alphabetically></redoc>
+    <redoc spec-url='https://storage.googleapis.com/libpod-master-releases/swagger-latest.yaml' sort-props-alphabetically></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
The podman documentation site uses javascript to display
API documentation at:

http://docs.podman.io/en/latest/Reference.html

As input, the javascript sources from a CORS-enabled Google Cloud
Storage object.  This commit ensures the storage object is present and
updated for every Cirrus-CI execution context: Tags, Branches, and PRs.

As of this commit, the documentation site only utilizes the object
uploaded by the Cirrus-CI run on the `master` branch:
`swagger-master.yaml`.  The file produced and uploaded due to a PR is
intended for testing purposes: Confirm it's generation and uploading are
both functional.