### PR TITLE
[CI:DOCS] fix go-md2man HTMLSpan warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,7 @@ MANPAGES ?= $(MANPAGES_MD:%.md=%)
 MANPAGES_DEST ?= $(subst markdown,man, $(subst source,build,$(MANPAGES)))
 
 $(MANPAGES): %: %.md .install.md2man docdir
-	@sed -e 's/\((podman.*\.md)\)//' -e 's/\[\(podman.*\)\]/\1/' $<  | $(GOMD2MAN) -in /dev/stdin -out $(subst source/markdown,build/man,$@)
+	@sed -e 's/\((podman.*\.md)\)//' -e 's/\[\(podman.*\)\]/\1/' -e 's;<\(/\)\?\(a[^>]*\|sup\)>;;g' $<  | $(GOMD2MAN) -in /dev/stdin -out $(subst source/markdown,build/man,$@)
 
 .PHONY: docs
 docdir:

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -394,7 +394,7 @@ Name of the manifest list to which the image will be added. Creates the manifest
 if it does not exist. This option is useful for building multi architecture images.
 
 #### **--memory**, **-m**=*LIMIT*
-Memory limit (format: <number>[<unit>], where unit = b (bytes), k (kilobytes),
+Memory limit (format: `<number>[<unit>]`, where unit = b (bytes), k (kilobytes),
 m (megabytes), or g (gigabytes))
 
 Allows you to constrain the memory available to a container. If the host
@@ -944,11 +944,11 @@ useradd to stop creating the lastlog file.
 podman(1), buildah(1), containers-registries.conf(5), crun(8), runc(8), useradd(8), podman-ps(1), podman-rm(1)
 
 ## HISTORY
-Aug 2020, Additional options and .dockerignore added by Dan Walsh <dwalsh@redhat.com>
+Aug 2020, Additional options and .dockerignore added by Dan Walsh `<dwalsh@redhat.com>`
 
-May 2018, Minor revisions added by Joe Doss <joe@solidadmin.com>
+May 2018, Minor revisions added by Joe Doss `<joe@solidadmin.com>`
 
-December 2017, Originally compiled by Tom Sweeney <tsweeney@redhat.com>
+December 2017, Originally compiled by Tom Sweeney `<tsweeney@redhat.com>`
 
 ## FOOTNOTES
 <a name="Footnote1">1</a>: The Podman project is committed to inclusivity, a

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -114,10 +114,10 @@ Drop Linux capabilities
 #### **--cgroupns**=*mode*
 
 Set the cgroup namespace mode for the container.
-    **host**: use the host's cgroup namespace inside the container.
-    **container:<NAME|ID>**: join the namespace of the specified container.
-    **ns:<PATH>**: join the namespace at the specified path.
-    **private**: create a new cgroup namespace.
+    **`host`**: use the host's cgroup namespace inside the container.
+    **`container:<NAME|ID>`**: join the namespace of the specified container.
+    **`ns:<PATH>`**: join the namespace at the specified path.
+    **`private`**: create a new cgroup namespace.
 
 If the host uses cgroups v1, the default is set to **host**. On cgroups v2 the default is **private**.
 
@@ -295,7 +295,7 @@ solely for scripting compatibility.
 
 #### **--dns**=*dns*
 
-Set custom DNS servers. Invalid if using **--dns** and **--network** that is set to 'none' or 'container:<name|id>'.
+Set custom DNS servers. Invalid if using **--dns** and **--network** that is set to 'none' or `container:<name|id>`.
 
 This option can be used to override the DNS
 configuration passed to the container. Typically this is necessary when the
@@ -307,11 +307,11 @@ The **/etc/resolv.conf** file in the image will be used without changes.
 
 #### **--dns-opt**=*option*
 
-Set custom DNS options. Invalid if using **--dns-opt** and **--network** that is set to 'none' or 'container:<name|id>'.
+Set custom DNS options. Invalid if using **--dns-opt** and **--network** that is set to 'none' or `container:<name|id>`.
 
 #### **--dns-search**=*domain*
 
-Set custom DNS search domains. Invalid if using **--dns-search** and **--network** that is set to 'none' or 'container:<name|id>'. (Use --dns-search=. if you don't wish to set the search domain)
+Set custom DNS search domains. Invalid if using **--dns-search** and **--network** that is set to 'none' or `container:<name|id>`. (Use --dns-search=. if you don't wish to set the search domain)
 
 #### **--entrypoint**=*"command"* | *'["command", "arg1", ...]'*
 
@@ -453,9 +453,9 @@ The address must be within the CNI network's IP address pool (default **10.88.0.
 #### **--ipc**=*ipc*
 
 Default is to create a private IPC namespace (POSIX SysV IPC) for the container
-		'container:<name|id>': reuses another container shared memory, semaphores and message queues
-		'host': use the host shared memory,semaphores and message queues inside the container. Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
-		'ns:<path>' path to an IPC namespace to join.
+		`container:<name|id>`: reuses another container shared memory, semaphores and message queues
+		`host`: use the host shared memory,semaphores and message queues inside the container. Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+		`ns:<path>` path to an IPC namespace to join.
 
 #### **--kernel-memory**=*number[unit]*
 
@@ -516,7 +516,7 @@ according to RFC4862.
 
 #### **--memory**, **-m**=*limit*
 
-Memory limit (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
+Memory limit (format: `<number>[<unit>]`, where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 Allows you to constrain the memory available to a container. If the host
 supports swap memory, then the **-m** memory setting can be larger than physical
@@ -526,7 +526,7 @@ system's page size (the value would be very large, that's millions of trillions)
 
 #### **--memory-reservation**=*limit*
 
-Memory soft limit (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
+Memory soft limit (format: `<number>[<unit>]`, where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 After setting memory reservation, when the system detects memory contention
 or low memory, containers are forced to restrict their consumption to their
@@ -860,7 +860,7 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 #### **--shm-size**=*size*
 
-Size of `/dev/shm` (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
+Size of `/dev/shm` (format: `<number>[<unit>]`, where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
 When size is `0`, there is no limit on the amount of memory used for IPC by the container.
 
@@ -1133,7 +1133,7 @@ Mounting the volume with the nodev option means that no devices on the volume
 will be able to be used by processes within the container. By default volumes
 are mounted with `nodev`.
 
-If the <source-dir> is a mount point, then "dev", "suid", and "exec" options are
+If the `<source-dir>` is a mount point, then "dev", "suid", and "exec" options are
 ignored by the kernel.
 
 Use `df <source-dir>` to figure out the source mount and then use
@@ -1280,13 +1280,13 @@ NOTE: Use the environment variable `TMPDIR` to change the temporary storage loca
 **podman-generate-systemd**(1) **podman-rm**(1), **subgid**(5), **subuid**(5), **containers.conf**(5), **systemd.unit**(5), **setsebool**(8), **slirp4netns**(1), **fuse-overlayfs**(1), **proc**(5)**.
 
 ## HISTORY
-October 2017, converted from Docker documentation to Podman by Dan Walsh for Podman <dwalsh@redhat.com>
+October 2017, converted from Docker documentation to Podman by Dan Walsh for Podman `<dwalsh@redhat.com>`
 
-November 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+November 2014, updated by Sven Dowideit `<SvenDowideit@home.org.au>`
 
-September 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+September 2014, updated by Sven Dowideit `<SvenDowideit@home.org.au>`
 
-August 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+August 2014, updated by Sven Dowideit `<SvenDowideit@home.org.au>`
 
 ## FOOTNOTES
 <a name="Footnote1">1</a>: The Podman project is committed to inclusivity, a core value of open source. The `master` and `slave` mount propagation terminology used here is problematic and divisive, and should be changed. However, these terms are currently used within the Linux kernel and must be used as-is at this time. When the kernel maintainers rectify this usage, Podman will follow suit immediately.

--- a/docs/source/markdown/podman-image-tree.1.md
+++ b/docs/source/markdown/podman-image-tree.1.md
@@ -85,4 +85,4 @@ Image Layers
 podman(1)
 
 ## HISTORY
-Feb 2019, Originally compiled by Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>
+Feb 2019, Originally compiled by Kunal Kushwaha `<kushwaha_kunal_v7@lab.ntt.co.jp>`

--- a/docs/source/markdown/podman-images.1.md
+++ b/docs/source/markdown/podman-images.1.md
@@ -36,7 +36,7 @@ Filter output based on conditions provided
     Filter on images created before the given IMAGE (name or tag).
 
   **dangling=true|false**
-    Show dangling images. Dangling images are a file system layer that was used in a previous build of an image and is no longer referenced by any active images. They are denoted with the <none> tag, consume disk space and serve no active purpose.
+    Show dangling images. Dangling images are a file system layer that was used in a previous build of an image and is no longer referenced by any active images. They are denoted with the `<none>` tag, consume disk space and serve no active purpose.
 
   **label**
     Filter by images labels key and/or value.
@@ -191,4 +191,4 @@ docker.io/library/alpine   latest   3fd9065eaf02   5 months ago    4.41 MB
 podman(1), containers-storage.conf(5)
 
 ## HISTORY
-March 2017, Originally compiled by Dan Walsh <dwalsh@redhat.com>
+March 2017, Originally compiled by Dan Walsh `<dwalsh@redhat.com>`

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1632,15 +1632,15 @@ NOTE: Use the environment variable `TMPDIR` to change the temporary storage loca
 **podman-generate-systemd**(1) **podman-rm**(1), **subgid**(5), **subuid**(5), **containers.conf**(5), **systemd.unit**(5), **setsebool**(8), **slirp4netns**(1), **fuse-overlayfs**(1), **proc**(5)**.
 
 ## HISTORY
-September 2018, updated by Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>
+September 2018, updated by Kunal Kushwaha `<kushwaha_kunal_v7@lab.ntt.co.jp>`
 
-October 2017, converted from Docker documentation to Podman by Dan Walsh for Podman <dwalsh@redhat.com>
+October 2017, converted from Docker documentation to Podman by Dan Walsh for Podman `<dwalsh@redhat.com>`
 
-November 2015, updated by Sally O'Malley <somalley@redhat.com>
+November 2015, updated by Sally O'Malley `<somalley@redhat.com>`
 
-June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+June 2014, updated by Sven Dowideit `<SvenDowideit@home.org.au>`
 
-April 2014, Originally compiled by William Henry <whenry@redhat.com> based on docker.com source material and internal work.
+April 2014, Originally compiled by William Henry `<whenry@redhat.com>` based on docker.com source material and internal work.
 
 ## FOOTNOTES
 <a name="Footnote1">1</a>: The Podman project is committed to inclusivity, a core value of open source. The `master` and `slave` mount propagation terminology used here is problematic and divisive, and should be changed. However, these terms are currently used within the Linux kernel and must be used as-is at this time. When the kernel maintainers rectify this usage, Podman will follow suit immediately.

--- a/docs/source/markdown/podman-system-service.1.md
+++ b/docs/source/markdown/podman-system-service.1.md
@@ -41,5 +41,5 @@ podman system service --timeout 5000
 podman(1), podman-system-service(1), podman-system-connection(1)
 
 ## HISTORY
-January 2020, Originally compiled by Brent Baude<bbaude@redhat.com>
-November 2020, Updated by Jhon Honce <jhonce at redhat.com>
+January 2020, Originally compiled by Brent Baude `<bbaude@redhat.com>`
+November 2020, Updated by Jhon Honce (jhonce at redhat dot com)


### PR DESCRIPTION
I'm tired of seeing these every time I run 'make':

   WARNING: go-md2man does not handle node type HTMLSpan

Cause: left-angle-brackets ( < ) in document source

Solution:
  1) backquote-escape those that need to be shown, usually
     ones referring to an argument or email address; or
  2) Actual HTML ( &lt;sup&gt; and &lt;a&gt; ) which are meant to be
     shown in generated HTML docs but can't be shown in
     man pages, we filter out via a sed expression.

Signed-off-by: Ed Santiago <santiago@redhat.com>
