### PR TITLE
Ensure the Volumes field in Compat Create is honored

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -237,3 +237,12 @@ t GET containers/$cid/json 200 \
 t DELETE containers/$cid 204
 t DELETE images/${MultiTagName}?force=true 200
 # vim: filetype=sh
+
+# Test Volumes field adds an anonymous volume
+t POST containers/create '"Image":"'$IMAGE'","Volumes":{"/test":{}}' 201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .Mounts[0].Destination="/test"
+
+t DELETE containers/$cid?v=true 204


### PR DESCRIPTION
Docker has, for unclear reasons, three separate fields in their Create Container struct in which volumes can be placed. Right now we support two of those - Binds and Mounts, which (roughly) correspond to `-v` and `--mount` respectively. Unfortunately, we did not support the third, `Volumes`, which is used for anonymous named volumes created by `-v` (e.g. `-v /test`). It seems that volumes listed here are *not* included in the remaining two from my investigation, so it should be safe to just append them into our handling of the `Binds` (`-v`) field.

Fixes #8649
