### PR TITLE
Accept and ignore 'null' as value for X-Registry-Auth

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -297,7 +297,9 @@ func imageAuthToDockerAuth(authConfig types.DockerAuthConfig) dockerAPITypes.Aut
 func singleAuthHeader(r *http.Request) (map[string]types.DockerAuthConfig, error) {
 	authHeader := r.Header.Get(string(XRegistryAuthHeader))
 	authConfig := dockerAPITypes.AuthConfig{}
-	if len(authHeader) > 0 {
+	// Accept "null" and handle it as empty value for compatibility reason with Docker.
+	// Some java docker clients pass this value, e.g. this one used in Eclipse.
+	if len(authHeader) > 0 && authHeader != "null" {
 		authJSON := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authHeader))
 		if err := json.NewDecoder(authJSON).Decode(&authConfig); err != nil {
 			return nil, err
@@ -312,7 +314,9 @@ func singleAuthHeader(r *http.Request) (map[string]types.DockerAuthConfig, error
 // The header content is a map[string]DockerAuthConfigs.
 func multiAuthHeader(r *http.Request) (map[string]types.DockerAuthConfig, error) {
 	authHeader := r.Header.Get(string(XRegistryAuthHeader))
-	if len(authHeader) == 0 {
+	// Accept "null" and handle it as empty value for compatibility reason with Docker.
+	// Some java docker clients pass this value, e.g. this one used in Eclipse.
+	if len(authHeader) == 0 || authHeader == "null" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
docker-client is a library written in Java and used in Eclipse to
speak with Docker API. When endpoint /images/search is called,
HTTP header attribute X-Registry-Auth has value "null". This is for
sure wrong but Docker tolerates this value, and call works. With this
patch call works also with Podman. #7857

Signed-off-by: Milivoje Legenovic <m.legenovic@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
