### PR TITLE
[CI:DOCS] api: fix import image swagger definition

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -837,13 +837,16 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     name: url
 	//     description: Load image from the specified URL
 	//     type: string
-	//   - in: formData
+	//   - in: body
 	//     name: upload
-	//     type: file
 	//     required: true
 	//     description: tarball for imported image
+	//     schema:
+	//       type: "string"
 	// produces:
 	// - application/json
+	// consumes:
+	// - application/x-tar
 	// responses:
 	//   200:
 	//     $ref: "#/responses/DocsLibpodImagesImportResponse"


### PR DESCRIPTION
The podman API implementation only accepts image imports with the `application/x-tar` content type, however the [generated swagger documentation](http://docs.podman.io/en/latest/_static/api.html#operation/libpodImagesImport) currently states this should be a form encoded file with the content type `application/x-www-form-urlencoded` which does not work.

I was able to glean the correct content type from a quick issue search that revealed [this](https://github.com/containers/podman/issues/6274#issuecomment-630858340) comment on what content type is correct.

**Example of issue**

Failure with application/x-www-form-urlencoded

```
$ curl \
  --header "Content-Type: application/x-www-form-urlencoded" \
  -F "upload=@containers/apiserver.tar" \
  -X POST \
  http://infraserver:7474/v1.0.0/libpod/images/import
```
```
{"cause":"Error processing tar file(exit status 1): archive/tar: invalid tar header","message":"unable to import image: Error committing the finished image: error adding layer with blob \"sha256:d4627217f4a44893a4d20ef0ca9568adc0ba6bc6a1e98c457652933c4f6bdac8\": Error processing tar file(exit status 1): archive/tar: invalid tar header","response":500}
```

Success with application/x-tar
```
$ curl \
  --header "Content-Type: application/x-tar" \
  --data-binary "@containers/apiserver.tar" \
  -X POST \
  http://infraserver:7474/v1.0.0/libpod/images/import
```
```
{"Id":"b014dcc4e7020c2cfd0cf679cb3dfeb7a4895bd0ca39f6402457f8d8acb194c8"}
```