### PR TITLE
[CI:DOCS]Do not run compose tests with CI:DOCS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -448,6 +448,7 @@ apiv2_test_task:
 compose_test_task:
     name: "compose test on $DISTRO_NV"
     alias: compose_test
+    only_if: *not_docs
     skip: *tags
     depends_on:
         - validate


### PR DESCRIPTION
Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
