### PR TITLE
[v3.0] [CI:DOCS] Cirrus: Skip smoke task on branch-push

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -108,7 +108,7 @@ automation_task:
 smoke_task:
     alias: 'smoke'
     name: "Smoke Test"
-    skip: *tags
+    skip: *branches_and_tags
     container: &bigcontainer
         image: ${CTR_FQIN}
         # Leave some resources for smallcontainer


### PR DESCRIPTION
There is no need to re-run the same basic validation checks as were
presumably already run on a PR before it merged.  There are also
possible problems properly determining `$EPOCH_TEST_COMMIT` when
there have been no successful CI-runs on the branch (i.e. it's new).
This needlessly fouls up the git-validation tool.  Fix Both problems
by just skipping the 'smoke' task for branches and tags.