### PR TITLE
Fix Docker APIv2 container wait endpoint

### DIFF
--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -95,10 +95,11 @@ func wait(cmd *cobra.Command, args []string) error {
 		return errors.New("--latest and containers cannot be used together")
 	}
 
-	waitOptions.Condition, err = define.StringToContainerStatus(waitCondition)
+	cond, err := define.StringToContainerStatus(waitCondition)
 	if err != nil {
 		return err
 	}
+	waitOptions.Condition = []define.ContainerStatus{cond}
 
 	responses, err := registry.ContainerEngine().ContainerWait(context.Background(), args, waitOptions)
 	if err != nil {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -754,17 +754,17 @@ func (c *Container) getArtifactPath(name string) string {
 }
 
 // Used with Wait() to determine if a container has exited
-func (c *Container) isStopped() (bool, error) {
+func (c *Container) isStopped() (bool, int32, error) {
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 	}
 	err := c.syncContainer()
 	if err != nil {
-		return true, err
+		return true, -1, err
 	}
 
-	return !c.ensureState(define.ContainerStateRunning, define.ContainerStatePaused, define.ContainerStateStopping), nil
+	return !c.ensureState(define.ContainerStateRunning, define.ContainerStatePaused, define.ContainerStateStopping), c.state.ExitCode, nil
 }
 
 // save container state to the database

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -198,4 +198,8 @@ var (
 	// ErrSecurityAttribute indicates that an error processing security attributes
 	// for the container
 	ErrSecurityAttribute = fmt.Errorf("%w: unable to process security attribute", ErrOCIRuntime)
+
+	// ErrCanceled indicates that an operation has been cancelled by a user.
+	// Useful for potentially long running tasks.
+	ErrCanceled = errors.New("cancelled by user")
 )

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strconv"
 
 	"github.com/containers/podman/v2/libpod"
 	"github.com/containers/podman/v2/libpod/define"
@@ -146,17 +145,7 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 }
 
 func WaitContainer(w http.ResponseWriter, r *http.Request) {
-	exitCode, err := utils.WaitContainer(w, r)
-	if err != nil {
-		name := utils.GetName(r)
-		if errors.Cause(err) == define.ErrNoSuchCtr {
-			utils.ContainerNotFound(w, name, err)
-			return
-		}
-		logrus.Warnf("failed to wait on container %q: %v", name, err)
-		return
-	}
-	utils.WriteResponse(w, http.StatusOK, strconv.Itoa(int(exitCode)))
+	utils.WaitContainerLibpod(w, r)
 }
 
 func UnmountContainer(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -23,8 +23,8 @@ func WaitContainer(w http.ResponseWriter, r *http.Request) (int32, error) {
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
-		Interval  string                 `schema:"interval"`
-		Condition define.ContainerStatus `schema:"condition"`
+		Interval  string                   `schema:"interval"`
+		Condition []define.ContainerStatus `schema:"condition"`
 	}{
 		// Override golang default values for types
 	}
@@ -33,7 +33,7 @@ func WaitContainer(w http.ResponseWriter, r *http.Request) (int32, error) {
 		return 0, err
 	}
 	options := entities.WaitOptions{
-		Condition: define.ContainerStateStopped,
+		Condition: []define.ContainerStatus{define.ContainerStateStopped},
 	}
 	name := GetName(r)
 	if _, found := r.URL.Query()["interval"]; found {

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -1,67 +1,230 @@
 package utils
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
-	"github.com/containers/podman/v2/libpod"
-	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/domain/infra/abi"
+
+	"github.com/containers/podman/v2/pkg/api/handlers"
+	"github.com/sirupsen/logrus"
+
+	"github.com/containers/podman/v2/libpod/define"
+
+	"github.com/containers/podman/v2/libpod"
 	"github.com/gorilla/schema"
 	"github.com/pkg/errors"
 )
 
-func WaitContainer(w http.ResponseWriter, r *http.Request) (int32, error) {
-	var (
-		err      error
-		interval time.Duration
-	)
-	runtime := r.Context().Value("runtime").(*libpod.Runtime)
-	// Now use the ABI implementation to prevent us from having duplicate
-	// code.
-	containerEngine := abi.ContainerEngine{Libpod: runtime}
-	decoder := r.Context().Value("decoder").(*schema.Decoder)
-	query := struct {
-		Interval  string                   `schema:"interval"`
-		Condition []define.ContainerStatus `schema:"condition"`
-	}{
-		// Override golang default values for types
+type waitQueryDocker struct {
+	Condition string `schema:"condition"`
+}
+
+type waitQueryLibpod struct {
+	Interval  string                   `schema:"interval"`
+	Condition []define.ContainerStatus `schema:"condition"`
+}
+
+func WaitContainerDocker(w http.ResponseWriter, r *http.Request) {
+	var err error
+	ctx := r.Context()
+
+	query := waitQueryDocker{}
+
+	decoder := ctx.Value("decoder").(*schema.Decoder)
+	if err = decoder.Decode(&query, r.URL.Query()); err != nil {
+		Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		return
 	}
+
+	interval := time.Nanosecond
+
+	condition := "not-running"
+	if _, found := r.URL.Query()["condition"]; found {
+		condition = query.Condition
+		if !isValidDockerCondition(query.Condition) {
+			BadRequest(w, "condition", condition, errors.New("not a valid docker condition"))
+			return
+		}
+	}
+
+	name := GetName(r)
+
+	exists, err := containerExists(ctx, name)
+
+	if err != nil {
+		InternalServerError(w, err)
+		return
+	}
+	if !exists {
+		ContainerNotFound(w, name, define.ErrNoSuchCtr)
+		return
+	}
+
+	// In docker compatibility mode we have to send headers in advance,
+	// otherwise docker client would freeze.
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(200)
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+
+	exitCode, err := waitDockerCondition(ctx, name, interval, condition)
+	msg := ""
+	if err != nil {
+		logrus.Errorf("error while waiting on condtion: %q", err)
+		msg = err.Error()
+	}
+	responseData := handlers.ContainerWaitOKBody{
+		StatusCode: int(exitCode),
+		Error: struct {
+			Message string
+		}{
+			Message: msg,
+		},
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(true)
+	err = enc.Encode(&responseData)
+	if err != nil {
+		logrus.Errorf("unable to write json: %q", err)
+	}
+}
+
+func WaitContainerLibpod(w http.ResponseWriter, r *http.Request) {
+	var (
+		err        error
+		interval   = time.Millisecond * 250
+		conditions = []define.ContainerStatus{define.ContainerStateStopped, define.ContainerStateExited}
+	)
+	decoder := r.Context().Value("decoder").(*schema.Decoder)
+	query := waitQueryLibpod{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
-		return 0, err
 	}
-	options := entities.WaitOptions{
-		Condition: []define.ContainerStatus{define.ContainerStateStopped},
-	}
-	name := GetName(r)
+
 	if _, found := r.URL.Query()["interval"]; found {
 		interval, err = time.ParseDuration(query.Interval)
 		if err != nil {
 			InternalServerError(w, err)
-			return 0, err
-		}
-	} else {
-		interval, err = time.ParseDuration("250ms")
-		if err != nil {
-			InternalServerError(w, err)
-			return 0, err
+			return
 		}
 	}
-	options.Interval = interval
 
 	if _, found := r.URL.Query()["condition"]; found {
-		options.Condition = query.Condition
+		if len(query.Condition) > 0 {
+			conditions = query.Condition
+		}
 	}
 
-	report, err := containerEngine.ContainerWait(r.Context(), []string{name}, options)
+	name := GetName(r)
+
+	waitFn := createContainerWaitFn(r.Context(), name, interval)
+
+	exitCode, err := waitFn(conditions...)
 	if err != nil {
-		return 0, err
+		if errors.Cause(err) == define.ErrNoSuchCtr {
+			ContainerNotFound(w, name, err)
+			return
+		} else {
+			InternalServerError(w, err)
+			return
+		}
 	}
-	if len(report) == 0 {
-		InternalServerError(w, errors.New("No reports returned"))
-		return 0, err
+	WriteResponse(w, http.StatusOK, strconv.Itoa(int(exitCode)))
+}
+
+type containerWaitFn func(conditions ...define.ContainerStatus) (int32, error)
+
+func createContainerWaitFn(ctx context.Context, containerName string, interval time.Duration) containerWaitFn {
+
+	runtime := ctx.Value("runtime").(*libpod.Runtime)
+	var containerEngine entities.ContainerEngine = &abi.ContainerEngine{Libpod: runtime}
+
+	return func(conditions ...define.ContainerStatus) (int32, error) {
+		opts := entities.WaitOptions{
+			Condition: conditions,
+			Interval:  interval,
+		}
+		ctrWaitReport, err := containerEngine.ContainerWait(ctx, []string{containerName}, opts)
+		if err != nil {
+			return -1, err
+		}
+		if len(ctrWaitReport) != 1 {
+			return -1, fmt.Errorf("the ContainerWait() function returned unexpected count of reports: %d", len(ctrWaitReport))
+		}
+		return ctrWaitReport[0].ExitCode, ctrWaitReport[0].Error
 	}
-	return report[0].ExitCode, report[0].Error
+}
+
+func isValidDockerCondition(cond string) bool {
+	switch cond {
+	case "next-exit", "removed", "not-running", "":
+		return true
+	}
+	return false
+}
+
+func waitDockerCondition(ctx context.Context, containerName string, interval time.Duration, dockerCondition string) (int32, error) {
+
+	containerWait := createContainerWaitFn(ctx, containerName, interval)
+
+	var err error
+	var code int32
+	switch dockerCondition {
+	case "next-exit":
+		code, err = waitNextExit(containerWait)
+	case "removed":
+		code, err = waitRemoved(containerWait)
+	case "not-running", "":
+		code, err = waitNotRunning(containerWait)
+	default:
+		panic("not a valid docker condition")
+	}
+	return code, err
+}
+
+var notRunningStates = []define.ContainerStatus{
+	define.ContainerStateCreated,
+	define.ContainerStateRemoving,
+	define.ContainerStateStopped,
+	define.ContainerStateExited,
+	define.ContainerStateConfigured,
+}
+
+func waitRemoved(ctrWait containerWaitFn) (int32, error) {
+	code, err := ctrWait(define.ContainerStateUnknown)
+	if err != nil && errors.Cause(err) == define.ErrNoSuchCtr {
+		return code, nil
+	} else {
+		return code, err
+	}
+}
+
+func waitNextExit(ctrWait containerWaitFn) (int32, error) {
+	_, err := ctrWait(define.ContainerStateRunning)
+	if err != nil {
+		return -1, err
+	}
+	return ctrWait(notRunningStates...)
+}
+
+func waitNotRunning(ctrWait containerWaitFn) (int32, error) {
+	return ctrWait(notRunningStates...)
+}
+
+func containerExists(ctx context.Context, name string) (bool, error) {
+	runtime := ctx.Value("runtime").(*libpod.Runtime)
+	var containerEngine entities.ContainerEngine = &abi.ContainerEngine{Libpod: runtime}
+
+	var ctrExistsOpts entities.ContainerExistsOptions
+	ctrExistRep, err := containerEngine.ContainerExists(ctx, name, ctrExistsOpts)
+	if err != nil {
+		return false, err
+	}
+	return ctrExistRep.Value, nil
 }

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -176,7 +176,7 @@ type UnpauseOptions struct{}
 //go:generate go run ../generator/generator.go WaitOptions
 // WaitOptions are optional options for waiting on containers
 type WaitOptions struct {
-	Condition *define.ContainerStatus
+	Condition []define.ContainerStatus
 	Interval  *string
 }
 

--- a/pkg/bindings/containers/types_wait_options.go
+++ b/pkg/bindings/containers/types_wait_options.go
@@ -76,19 +76,19 @@ func (o *WaitOptions) ToParams() (url.Values, error) {
 }
 
 // WithCondition
-func (o *WaitOptions) WithCondition(value define.ContainerStatus) *WaitOptions {
-	v := &value
+func (o *WaitOptions) WithCondition(value []define.ContainerStatus) *WaitOptions {
+	v := value
 	o.Condition = v
 	return o
 }
 
 // GetCondition
-func (o *WaitOptions) GetCondition() define.ContainerStatus {
-	var condition define.ContainerStatus
+func (o *WaitOptions) GetCondition() []define.ContainerStatus {
+	var condition []define.ContainerStatus
 	if o.Condition == nil {
 		return condition
 	}
-	return *o.Condition
+	return o.Condition
 }
 
 // WithInterval

--- a/pkg/bindings/test/attach_test.go
+++ b/pkg/bindings/test/attach_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Podman containers attach", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		wait := define.ContainerStateRunning
-		_, err = containers.Wait(bt.conn, ctnr.ID, new(containers.WaitOptions).WithCondition(wait))
+		_, err = containers.Wait(bt.conn, ctnr.ID, new(containers.WaitOptions).WithCondition([]define.ContainerStatus{wait}))
 		Expect(err).ShouldNot(HaveOccurred())
 
 		tickTock := time.NewTimer(2 * time.Second)

--- a/pkg/bindings/test/common_test.go
+++ b/pkg/bindings/test/common_test.go
@@ -207,7 +207,7 @@ func (b *bindingTest) RunTopContainer(containerName *string, insidePod *bool, po
 		return "", err
 	}
 	wait := define.ContainerStateRunning
-	_, err = containers.Wait(b.conn, ctr.ID, new(containers.WaitOptions).WithCondition(wait))
+	_, err = containers.Wait(b.conn, ctr.ID, new(containers.WaitOptions).WithCondition([]define.ContainerStatus{wait}))
 	return ctr.ID, err
 }
 

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Podman containers ", func() {
 		_, err := bt.RunTopContainer(&name, nil, nil)
 		Expect(err).To(BeNil())
 		go func() {
-			exitCode, err = containers.Wait(bt.conn, name, new(containers.WaitOptions).WithCondition(pause))
+			exitCode, err = containers.Wait(bt.conn, name, new(containers.WaitOptions).WithCondition([]define.ContainerStatus{pause}))
 			errChan <- err
 			close(errChan)
 		}()
@@ -295,7 +295,7 @@ var _ = Describe("Podman containers ", func() {
 		go func() {
 			defer GinkgoRecover()
 
-			_, waitErr := containers.Wait(bt.conn, name, new(containers.WaitOptions).WithCondition(running))
+			_, waitErr := containers.Wait(bt.conn, name, new(containers.WaitOptions).WithCondition([]define.ContainerStatus{running}))
 			unpauseErrChan <- waitErr
 			close(unpauseErrChan)
 		}()

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -51,7 +51,7 @@ type ContainerRunlabelReport struct {
 }
 
 type WaitOptions struct {
-	Condition define.ContainerStatus
+	Condition []define.ContainerStatus
 	Interval  time.Duration
 	Latest    bool
 }

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -100,7 +100,7 @@ func (ic *ContainerEngine) ContainerWait(ctx context.Context, namesOrIds []strin
 	responses := make([]entities.WaitReport, 0, len(ctrs))
 	for _, c := range ctrs {
 		response := entities.WaitReport{Id: c.ID()}
-		exitCode, err := c.WaitForConditionWithInterval(ctx, options.Interval, options.Condition)
+		exitCode, err := c.WaitForConditionWithInterval(ctx, options.Interval, options.Condition...)
 		if err != nil {
 			response.Error = err
 		} else {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -100,7 +100,7 @@ func (ic *ContainerEngine) ContainerWait(ctx context.Context, namesOrIds []strin
 	responses := make([]entities.WaitReport, 0, len(ctrs))
 	for _, c := range ctrs {
 		response := entities.WaitReport{Id: c.ID()}
-		exitCode, err := c.WaitForConditionWithInterval(options.Interval, options.Condition)
+		exitCode, err := c.WaitForConditionWithInterval(ctx, options.Interval, options.Condition)
 		if err != nil {
 			response.Error = err
 		} else {
@@ -728,7 +728,7 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 				return reports, errors.Wrapf(err, "unable to start container %s", ctr.ID())
 			}
 
-			if ecode, err := ctr.Wait(); err != nil {
+			if ecode, err := ctr.Wait(ctx); err != nil {
 				if errors.Cause(err) == define.ErrNoSuchCtr {
 					// Check events
 					event, err := ic.Libpod.GetLastContainerEvent(ctx, ctr.ID(), events.Exited)
@@ -867,7 +867,7 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 		return &report, err
 	}
 
-	if ecode, err := ctr.Wait(); err != nil {
+	if ecode, err := ctr.Wait(ctx); err != nil {
 		if errors.Cause(err) == define.ErrNoSuchCtr {
 			// Check events
 			event, err := ic.Libpod.GetLastContainerEvent(ctx, ctr.ID(), events.Exited)

--- a/test/apiv2/26-containersWait.at
+++ b/test/apiv2/26-containersWait.at
@@ -1,0 +1,47 @@
+# -*- sh -*-
+#
+# test more container-related endpoints
+#
+
+red='\e[31m'
+nc='\e[0m'
+
+podman pull "${IMAGE}" &>/dev/null
+
+# Ensure clean slate
+podman rm -a -f &>/dev/null
+
+CTR="WaitTestingCtr"
+
+t POST "containers/nonExistent/wait?condition=next-exit" '' 404
+
+podman create --name "${CTR}" --entrypoint '["sleep", "0.5"]' "${IMAGE}"
+
+t POST "containers/${CTR}/wait?condition=non-existent-cond" '' 400
+
+t POST "containers/${CTR}/wait?condition=not-running" '' 200
+
+t POST "containers/${CTR}/wait?condition=next-exit" '' 200 &
+child_pid=$!
+podman start "${CTR}"
+wait "${child_pid}"
+
+
+# check if headers are sent in advance before body
+WAIT_TEST_ERROR=""
+curl -I -X POST "http://$HOST:$PORT/containers/${CTR}/wait?condition=next-exit" &> "/dev/null" &
+child_pid=$!
+sleep 0.5
+if kill -2 "${child_pid}" 2> "/dev/null"; then
+  echo -e "${red}NOK: Failed to get response headers immediately.${nc}"  1>&2;
+  WAIT_TEST_ERROR="1"
+fi
+
+t POST "containers/${CTR}/wait?condition=removed" '' 200 &
+child_pid=$!
+podman container rm "${CTR}"
+wait "${child_pid}"
+
+if [[ "${WAIT_TEST_ERROR}" ]] ; then
+  exit 1;
+fi

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -441,7 +441,7 @@ func (p *PodmanTestIntegration) BuildImage(dockerfile, imageName string, layers 
 	err := ioutil.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
 	Expect(err).To(BeNil())
 	session := p.Podman([]string{"build", "--layers=" + layers, "-t", imageName, "--file", dockerfilePath, p.TempDir})
-	session.Wait(120)
+	session.Wait(240)
 	Expect(session).Should(Exit(0), fmt.Sprintf("BuildImage session output: %q", session.OutputToString()))
 }
 

--- a/test/e2e/wait_test.go
+++ b/test/e2e/wait_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Podman wait", func() {
 
 	It("podman wait on bogus container", func() {
 		session := podmanTest.Podman([]string{"wait", "1234"})
-		session.Wait()
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(125))
 
 	})
@@ -45,7 +45,7 @@ var _ = Describe("Podman wait", func() {
 		cid := session.OutputToString()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"wait", cid})
-		session.Wait()
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 


### PR DESCRIPTION
resolves #8697
resolves #9157
* container wait functions are now cancel-able via `context.Context`
* container wait functions can wait for multiple states, not just single one
* docker container wait endpoint now accepts docker conditions: `not-running`, `removed`, `next-exit`
* docker container wait endpoint now sends headers in advance before actual waiting