### PR TITLE
[ci:docs] Add a notice to remove pods/containers before starting the systemd service

### DIFF
--- a/docs/source/markdown/podman-auto-update.1.md
+++ b/docs/source/markdown/podman-auto-update.1.md
@@ -58,6 +58,11 @@ $ podman generate systemd --new --files bc219740a210455fa27deacc96d50a9e20516492
 # Load the new systemd unit and start it
 $ mv ./container-bc219740a210455fa27deacc96d50a9e20516492f1417507c13ce1533dbdcd9d.service ~/.config/systemd/user
 $ systemctl --user daemon-reload
+
+# If the previously created containers or pods are using shared resources, such as ports, make sure to remove them before starting the generated systemd units.
+$ podman stop bc219740a210455fa27deacc96d50a9e20516492f1417507c13ce1533dbdcd9d
+$ podman rm bc219740a210455fa27deacc96d50a9e20516492f1417507c13ce1533dbdcd9d
+
 $ systemctl --user start container-bc219740a210455fa27deacc96d50a9e20516492f1417507c13ce1533dbdcd9d.service
 
 # Auto-update the container

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -189,6 +189,8 @@ Create and enable systemd unit files for a pod using the above examples as refer
 
 Since systemctl defaults to using the root user, all the changes using the systemctl can be seen by appending sudo to the podman cli commands. To perform `systemctl` actions as a non-root user use the `--user` flag when interacting with `systemctl`.
 
+Note: If the previously created containers or pods are using shared resources, such as ports, make sure to remove them before starting the generated systemd units.
+
 ```
 $ systemctl --user start pod-systemd-pod.service
 $ podman pod ps


### PR DESCRIPTION
The pods/containers have to be removed before starting the corresponding systemd service. Otherwise the service will fail. That hasn't been written into the doc. This PR adds that.