### PR TITLE
[3.0] Set log driver for compatability containers

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -402,7 +402,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	logDriverFlagName := "log-driver"
 	createFlags.StringVar(
 		&cf.LogDriver,
-		logDriverFlagName, "",
+		logDriverFlagName, logDriver(),
 		"Logging driver for the container",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(logDriverFlagName, AutocompleteLogDriver)

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -517,3 +517,10 @@ func volumes() []string {
 	}
 	return nil
 }
+
+func logDriver() string {
+	if !registry.IsRemote() {
+		return containerConfig.Containers.LogDriver
+	}
+	return ""
+}

--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -463,7 +463,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	if s.LogConfiguration == nil {
 		s.LogConfiguration = &specgen.LogConfig{}
 	}
-	s.LogConfiguration.Driver = define.KubernetesLogging
+
 	if ld := c.LogDriver; len(ld) > 0 {
 		s.LogConfiguration.Driver = ld
 	}

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -326,6 +326,11 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 		state.Running = true
 	}
 
+	// docker calls the configured state "created"
+	if state.Status == define.ContainerStateConfigured.String() {
+		state.Status = define.ContainerStateCreated.String()
+	}
+
 	formatCapabilities(inspect.HostConfig.CapDrop)
 	formatCapabilities(inspect.HostConfig.CapAdd)
 
@@ -336,6 +341,11 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 	hc := container.HostConfig{}
 	if err := json.Unmarshal(h, &hc); err != nil {
 		return nil, err
+	}
+
+	// k8s-file == json-file
+	if hc.LogConfig.Type == define.KubernetesLogging {
+		hc.LogConfig.Type = define.JSONLogging
 	}
 	g, err := json.Marshal(inspect.GraphDriver)
 	if err != nil {

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -257,6 +257,14 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 		}
 	}
 
+	if s.LogConfiguration == nil {
+		s.LogConfiguration = &specgen.LogConfig{}
+	}
+	// set log-driver from common if not already set
+	if len(s.LogConfiguration.Driver) < 1 {
+		s.LogConfiguration.Driver = rtc.Containers.LogDriver
+	}
+
 	warnings, err := verifyContainerResources(s)
 	if err != nil {
 		return warnings, err


### PR DESCRIPTION
when using the compatibility api to create containers, now reflect the
use of k8s-file as json-file so that clients, which are
unaware of k8s-file, can work.  specifically, if the container is using
k8s-file as the log driver, we change the log type in container
inspection to json-file.  These terms are used interchangably in other
locations in libpod/podman.

this fixes log messages in compose as well.

[NO TESTS NEEDED]

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
