### PR TITLE
disable dnsname when --internal

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -41,7 +41,8 @@ Define a gateway for the subnet. If you want to provide a gateway address, you m
 
 #### **--internal**
 
-Restrict external access of this network
+Restrict external access of this network. Note when using this option, the dnsname plugin will be
+automatically disabled.
 
 #### **--ip-range**
 


### PR DESCRIPTION
when doing a network creation, the dnsname plugin should be disabled
when the --internal bool is set.  a warning is displayed if this
happens and docs are updated.

Fixes: containers/dnsname#51

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
