### PR TITLE
[v3.0] [CI:DOCS] Cirrus: Fix running Validate task on branches

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -24,14 +24,15 @@ function _run_ext_svc() {
 }
 
 function _run_smoke() {
-    make gofmt
+    # Quick checks which do not require anything to be compiled
+    make gofmt lint validate.completions swagger-check
 
-    # There is little value to validating commits after tag-push
-    # and it's very difficult to automatically determine a starting commit.
-    # $CIRRUS_TAG is only non-empty when executing due to a tag-push
+    # git-validation tool fails if $EPOCH_TEST_COMMIT is empty
     # shellcheck disable=SC2154
-    if [[ -z "$CIRRUS_TAG" ]]; then
+    if [[ -n "$EPOCH_TEST_COMMIT" ]]; then
         make .gitvalidation
+    else
+        warn "Skipping git-validation since \$EPOCH_TEST_COMMIT is empty"
     fi
 }
 
@@ -51,7 +52,8 @@ function _run_validate() {
     bin/podman --version
     bin/podman-remote --version
 
-    make validate  # Some items require a build
+    # Confirm --help and docs match (requires compiled binaries)
+    make man-page-check
 }
 
 function _run_unit() {


### PR DESCRIPTION
Backport from master https://github.com/containers/podman/pull/9063

Followup to 4c60523

For whatever reason Cirrus-CI does not set `$CIRRUS_BASE_SHA` when
testing on a branch or tag.  If the branch happened to also not have
any successful previous runs, then `$EPOCH_TEST_COMMIT` was being set
to the error-flagging value `YOU_FOUND_A_BUG`.

Fix this by detecting an empty value when running on a branch or via
`hack/get_ci_vm.sh` (`$CIRRUS_TAG` will be empty) and setting
`$CIRRUS_BASE_SHA` based on the upstream branch HEAD.  Otherwise,
instead of using `YOU_FOUND_A_BUG`, simply reference the HEAD commit.

Signed-off-by: Chris Evich <cevich@redhat.com>