### PR TITLE
networking: lookup child IP in networks

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -550,13 +550,25 @@ func (r *Runtime) setupRootlessPortMappingViaRLK(ctr *Container, netnsPath strin
 		}
 	}
 
+	childIP := slirp4netnsIP
+outer:
+	for _, r := range ctr.state.NetworkStatus {
+		for _, i := range r.IPs {
+			ipv4 := i.Address.IP.To4()
+			if ipv4 != nil {
+				childIP = ipv4.String()
+				break outer
+			}
+		}
+	}
+
 	cfg := rootlessport.Config{
 		Mappings:  ctr.config.PortMappings,
 		NetNSPath: netnsPath,
 		ExitFD:    3,
 		ReadyFD:   4,
 		TmpDir:    ctr.runtime.config.Engine.TmpDir,
-		ChildIP:   slirp4netnsIP,
+		ChildIP:   childIP,
 	}
 	cfgJSON, err := json.Marshal(cfg)
 	if err != nil {


### PR DESCRIPTION
if a CNI network is added to the container, use the IP address in that
network instead of hard-coding the slirp4netns default.

commit 5e65f0ba30f3fca73f8c207825632afef08378c1 introduced this
regression.

Closes: https://github.com/containers/podman/issues/9065

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
