### PR TITLE
swagger.go: Fix compilation error

### DIFF
--- a/pkg/api/handlers/swagger/swagger.go
+++ b/pkg/api/handlers/swagger/swagger.go
@@ -1,7 +1,6 @@
 package swagger
 
 import (
-	"github.com/containers/podman/v2/libpod"
 	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/libpod/image"
 	"github.com/containers/podman/v2/pkg/api/handlers"
@@ -166,7 +165,7 @@ type swagInspectPodResponse struct {
 type swagInspectVolumeResponse struct {
 	// in:body
 	Body struct {
-		libpod.InspectVolumeData
+		define.InspectVolumeData
 	}
 }
 


### PR DESCRIPTION
Error looks like:

  # github.com/containers/podman/pkg/api/handlers/swagger
  src/github.com/containers/podman/pkg/api/handlers/swagger/swagger.go:169:3: undefined: libpod.InspectVolumeData

Signed-off-by: Reinhard Tartler <siretart@tauware.de>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
