### PR TITLE
Fix static build cache by using cachix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -344,14 +344,13 @@ static_alt_build_task:
         ALT_NAME: 'Static build'
         # Do not use 'latest', fixed-version tag for runtime stability.
         CTR_FQIN: "docker.io/nixos/nix:2.3.6"
-    # This is critical, it helps to avoid a very lengthy process of
-    # statically building every dependency needed to build podman.
-    # Assuming the dependency and build description hasn't changed,
-    # this cache ensures only the static podman binary is built.
-    nix_cache:
-        folder: '/var/cache/nix'
-        # Cirrus will calculate/use sha of this output as the cache key
-        fingerprint_script: echo "${IMAGE_SUFFIX}" && cat nix/*
+        # Authentication token for pushing the build cache to cachix.
+        # This is critical, it helps to avoid a very lengthy process of
+        # statically building every dependency needed to build podman.
+        # Assuming the pinned nix dependencies in nix/nixpkgs.json have not
+        # changed, this cache will ensure that only the static podman binary is
+        # built.
+        CACHIX_AUTH_TOKEN: ENCRYPTED[df0d4d0a67474e8ea49cc503221dcb912b7e2ba45c8ec4bf2e5fd9c49a18ac21c24bacee59b5393355ed9e4358d2baef]
     setup_script: *setup
     main_script: *main
     always: *binary_artifacts

--- a/contrib/cirrus/required_host_ports.txt
+++ b/contrib/cirrus/required_host_ports.txt
@@ -2,3 +2,4 @@ github.com 22
 docker.io 443
 quay.io 443
 registry.fedoraproject.org 443
+podman.cachix.org 443

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "4a75203f0270f96cbc87f5dfa5d5185690237d87",
-  "date": "2020-12-29T03:18:48+01:00",
-  "path": "/nix/store/scswsm6r4jnhp9ki0f6s81kpj5x6jkn7-nixpkgs",
-  "sha256": "0h70fm9aa7s06wkalbadw70z5rscbs3p6nblb47z523nhlzgjxk9",
+  "rev": "ce7b327a52d1b82f82ae061754545b1c54b06c66",
+  "date": "2021-01-25T11:28:05+01:00",
+  "path": "/nix/store/dpsa6a1sy8hwhwjkklc52brs9z1k5fx9-nixpkgs",
+  "sha256": "1rc4if8nmy9lrig0ddihdwpzg2s8y36vf20hfywb8hph5hpsg4vj",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false


### PR DESCRIPTION
It looks like we always hit the caching issue in Cirrus CI described within https://github.com/containers/podman/issues/8313. A solution around that is to use cachix, which has been pre-populated from my local machine.

To push all (runtime and build) dependencies, we can leverage a pre-populated store by:
```
> nix-store -qR --include-outputs $(nix-instantiate nix/default.nix) | cachix push podman
```
The cache can be re-used by everybody to rapidly build static Podman binaries: https://app.cachix.org/cache/podman