### PR TITLE
Fix --arch and --os flags to work correctly

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -474,29 +474,29 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	)
 	_ = cmd.RegisterFlagCompletionFunc(oomScoreAdjFlagName, completion.AutocompleteNone)
 
-	overrideArchFlagName := "override-arch"
+	archFlagName := "arch"
 	createFlags.StringVar(
-		&cf.OverrideArch,
-		overrideArchFlagName, "",
+		&cf.Arch,
+		archFlagName, "",
 		"use `ARCH` instead of the architecture of the machine for choosing images",
 	)
-	_ = cmd.RegisterFlagCompletionFunc(overrideArchFlagName, completion.AutocompleteNone)
+	_ = cmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteArch)
 
-	overrideOSFlagName := "override-os"
+	osFlagName := "os"
 	createFlags.StringVar(
-		&cf.OverrideOS,
-		overrideOSFlagName, "",
+		&cf.OS,
+		osFlagName, "",
 		"use `OS` instead of the running OS for choosing images",
 	)
-	_ = cmd.RegisterFlagCompletionFunc(overrideOSFlagName, completion.AutocompleteNone)
+	_ = cmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteOS)
 
-	overrideVariantFlagName := "override-variant"
+	variantFlagName := "variant"
 	createFlags.StringVar(
-		&cf.OverrideVariant,
-		overrideVariantFlagName, "",
+		&cf.Variant,
+		variantFlagName, "",
 		"Use _VARIANT_ instead of the running architecture variant for choosing images",
 	)
-	_ = cmd.RegisterFlagCompletionFunc(overrideVariantFlagName, completion.AutocompleteNone)
+	_ = cmd.RegisterFlagCompletionFunc(variantFlagName, completion.AutocompleteNone)
 
 	pidFlagName := "pid"
 	createFlags.String(
@@ -516,7 +516,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	createFlags.StringVar(
 		&cf.Platform,
 		platformFlagName, "",
-		"Specify the platform for selecting the image.  (Conflicts with override-arch and override-os)",
+		"Specify the platform for selecting the image.  (Conflicts with --arch and --os)",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(platformFlagName, completion.AutocompleteNone)
 

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -73,9 +73,9 @@ type ContainerCLIOpts struct {
 	NoHealthCheck     bool
 	OOMKillDisable    bool
 	OOMScoreAdj       int
-	OverrideArch      string
-	OverrideOS        string
-	OverrideVariant   string
+	Arch              string
+	OS                string
+	Variant           string
 	PID               string
 	PIDsLimit         *int64
 	Platform          string
@@ -346,9 +346,9 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		LogOptions:       stringMaptoArray(cc.HostConfig.LogConfig.Config),
 		Name:             cc.Name,
 		OOMScoreAdj:      cc.HostConfig.OomScoreAdj,
-		OverrideArch:     "",
-		OverrideOS:       "",
-		OverrideVariant:  "",
+		Arch:             "",
+		OS:               "",
+		Variant:          "",
 		PID:              string(cc.HostConfig.PidMode),
 		PIDsLimit:        cc.HostConfig.PidsLimit,
 		Privileged:       cc.HostConfig.Privileged,

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -237,17 +237,20 @@ func pullImage(imageName string) (string, error) {
 		imageMissing = !br.Value
 	}
 
-	if cliVals.Platform != "" {
-		if cliVals.OverrideArch != "" || cliVals.OverrideOS != "" {
-			return "", errors.Errorf("--platform option can not be specified with --override-arch or --override-os")
+	if cliVals.Platform != "" || cliVals.Arch != "" || cliVals.OS != "" {
+		if cliVals.Platform != "" {
+			if cliVals.Arch != "" || cliVals.OS != "" {
+				return "", errors.Errorf("--platform option can not be specified with --arch or --os")
+			}
+			split := strings.SplitN(cliVals.Platform, "/", 2)
+			cliVals.OS = split[0]
+			if len(split) > 1 {
+				cliVals.Arch = split[1]
+			}
 		}
-		split := strings.SplitN(cliVals.Platform, "/", 2)
-		cliVals.OverrideOS = split[0]
-		if len(split) > 1 {
-			cliVals.OverrideArch = split[1]
-		}
+
 		if pullPolicy != config.PullImageAlways {
-			logrus.Info("--platform causes the pull policy to be \"always\"")
+			logrus.Info("--platform --arch and --os causes the pull policy to be \"always\"")
 			pullPolicy = config.PullImageAlways
 		}
 	}
@@ -259,9 +262,9 @@ func pullImage(imageName string) (string, error) {
 		pullReport, pullErr := registry.ImageEngine().Pull(registry.GetContext(), imageName, entities.ImagePullOptions{
 			Authfile:        cliVals.Authfile,
 			Quiet:           cliVals.Quiet,
-			OverrideArch:    cliVals.OverrideArch,
-			OverrideOS:      cliVals.OverrideOS,
-			OverrideVariant: cliVals.OverrideVariant,
+			Arch:            cliVals.Arch,
+			OS:              cliVals.OS,
+			Variant:         cliVals.Variant,
 			SignaturePolicy: cliVals.SignaturePolicy,
 			PullPolicy:      pullPolicy,
 		})

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -84,20 +84,20 @@ func pullFlags(cmd *cobra.Command) {
 	flags.StringVar(&pullOptions.CredentialsCLI, credsFlagName, "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
 	_ = cmd.RegisterFlagCompletionFunc(credsFlagName, completion.AutocompleteNone)
 
-	overrideArchFlagName := "override-arch"
-	flags.StringVar(&pullOptions.OverrideArch, overrideArchFlagName, "", "Use `ARCH` instead of the architecture of the machine for choosing images")
-	_ = cmd.RegisterFlagCompletionFunc(overrideArchFlagName, completion.AutocompleteNone)
+	archFlagName := "arch"
+	flags.StringVar(&pullOptions.Arch, archFlagName, "", "Use `ARCH` instead of the architecture of the machine for choosing images")
+	_ = cmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteArch)
 
-	overrideOsFlagName := "override-os"
-	flags.StringVar(&pullOptions.OverrideOS, overrideOsFlagName, "", "Use `OS` instead of the running OS for choosing images")
-	_ = cmd.RegisterFlagCompletionFunc(overrideOsFlagName, completion.AutocompleteNone)
+	osFlagName := "os"
+	flags.StringVar(&pullOptions.OS, osFlagName, "", "Use `OS` instead of the running OS for choosing images")
+	_ = cmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteOS)
 
-	overrideVariantFlagName := "override-variant"
-	flags.StringVar(&pullOptions.OverrideVariant, overrideVariantFlagName, "", " use VARIANT instead of the running architecture variant for choosing images")
-	_ = cmd.RegisterFlagCompletionFunc(overrideVariantFlagName, completion.AutocompleteNone)
+	variantFlagName := "variant"
+	flags.StringVar(&pullOptions.Variant, variantFlagName, "", " use VARIANT instead of the running architecture variant for choosing images")
+	_ = cmd.RegisterFlagCompletionFunc(variantFlagName, completion.AutocompleteNone)
 
 	platformFlagName := "platform"
-	flags.String(platformFlagName, "", "Specify the platform for selecting the image.  (Conflicts with override-arch and override-os)")
+	flags.String(platformFlagName, "", "Specify the platform for selecting the image.  (Conflicts with arch and os)")
 	_ = cmd.RegisterFlagCompletionFunc(platformFlagName, completion.AutocompleteNone)
 
 	flags.Bool("disable-content-trust", false, "This is a Docker specific option and is a NOOP")
@@ -138,13 +138,13 @@ func imagePull(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if platform != "" {
-		if pullOptions.OverrideArch != "" || pullOptions.OverrideOS != "" {
-			return errors.Errorf("--platform option can not be specified with --override-arch or --override-os")
+		if pullOptions.Arch != "" || pullOptions.OS != "" {
+			return errors.Errorf("--platform option can not be specified with --arch or --os")
 		}
 		split := strings.SplitN(platform, "/", 2)
-		pullOptions.OverrideOS = split[0]
+		pullOptions.OS = split[0]
 		if len(split) > 1 {
-			pullOptions.OverrideArch = split[1]
+			pullOptions.Arch = split[1]
 		}
 	}
 

--- a/cmd/podman/manifest/add.go
+++ b/cmd/podman/manifest/add.go
@@ -52,7 +52,7 @@ func init() {
 
 	archFlagName := "arch"
 	flags.StringVar(&manifestAddOpts.Arch, archFlagName, "", "override the `architecture` of the specified image")
-	_ = addCmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteNone)
+	_ = addCmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteArch)
 
 	authfileFlagName := "authfile"
 	flags.StringVar(&manifestAddOpts.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
@@ -72,7 +72,7 @@ func init() {
 
 	osFlagName := "os"
 	flags.StringVar(&manifestAddOpts.OS, osFlagName, "", "override the `OS` of the specified image")
-	_ = addCmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteNone)
+	_ = addCmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteOS)
 
 	osVersionFlagName := "os-version"
 	flags.StringVar(&manifestAddOpts.OSVersion, osVersionFlagName, "", "override the OS `version` of the specified image")

--- a/cmd/podman/manifest/annotate.go
+++ b/cmd/podman/manifest/annotate.go
@@ -39,7 +39,7 @@ func init() {
 
 	archFlagName := "arch"
 	flags.StringVar(&manifestAnnotateOpts.Arch, archFlagName, "", "override the `architecture` of the specified image")
-	_ = annotateCmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteNone)
+	_ = annotateCmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteArch)
 
 	featuresFlagName := "features"
 	flags.StringSliceVar(&manifestAnnotateOpts.Features, featuresFlagName, nil, "override the `features` of the specified image")
@@ -47,7 +47,7 @@ func init() {
 
 	osFlagName := "os"
 	flags.StringVar(&manifestAnnotateOpts.OS, osFlagName, "", "override the `OS` of the specified image")
-	_ = annotateCmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteNone)
+	_ = annotateCmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteOS)
 
 	osFeaturesFlagName := "os-features"
 	flags.StringSliceVar(&manifestAnnotateOpts.OSFeatures, osFeaturesFlagName, nil, "override the OS `features` of the specified image")

--- a/cmd/podman/utils/alias.go
+++ b/cmd/podman/utils/alias.go
@@ -25,6 +25,12 @@ func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "external"
 	case "purge":
 		name = "rm"
+	case "override-arch":
+		name = "arch"
+	case "override-os":
+		name = "os"
+	case "override-variant":
+		name = "variant"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -77,6 +77,9 @@ option can be set multiple times.
 Add an annotation to the container. The format is key=value.
 The **--annotation** option can be set multiple times.
 
+#### **--arch**=*ARCH*
+Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
+
 #### **--attach**, **-a**=*location*
 
 Attach to STDIN, STDOUT or STDERR.
@@ -667,14 +670,8 @@ Whether to disable OOM Killer for the container or not.
 
 Tune the host's OOM preferences for containers (accepts -1000 to 1000)
 
-#### **--override-arch**=*ARCH*
-Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
-
-#### **--override-os**=*OS*
+#### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
-
-#### **--override-variant**=*VARIANT*
-Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 #### **--pid**=*pid*
 
@@ -691,7 +688,7 @@ Tune the container's pids limit. Set `0` to have unlimited pids for the containe
 
 #### **--platform**=*OS/ARCH*
 
-Specify the platform for selecting the image.   (Conflicts with override-arch and override-os)
+Specify the platform for selecting the image.   (Conflicts with --arch and --os)
 The `--platform` option can be used to override the current architecture and operating system.
 
 #### **--pod**=*name*
@@ -1006,6 +1003,9 @@ Set the UTS namespace mode for the container. The following values are supported
 - **private**: create a new namespace for the container (default).
 - **ns:[path]**: run the container in the given existing UTS namespace.
 - **container:[container]**: join the UTS namespace of the specified container.
+
+#### **--variant**=*VARIANT*
+Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 #### **--volume**, **-v**[=*[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*]
 

--- a/docs/source/markdown/podman-pull.1.md
+++ b/docs/source/markdown/podman-pull.1.md
@@ -71,6 +71,9 @@ All tagged images in the repository will be pulled.
 
 Note: When using the all-tags flag, Podman will not iterate over the search registries in the containers-registries.conf(5) but will always use docker.io for unqualified image names.
 
+#### **--arch**=*ARCH*
+Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
+
 #### **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
@@ -96,19 +99,16 @@ This is a Docker specific option to disable image verification to a Docker
 registry and is not supported by Podman.  This flag is a NOOP and provided
 solely for scripting compatibility.
 
-#### **--override-arch**=*ARCH*
-Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
+#### **--help**, **-h**
 
-#### **--override-os**=*OS*
+Print usage statement
+
+#### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
-
-#### **--override-variant**=*VARIANT*
-
-Use _VARIANT_ instead of the default architecture variant of the container image.  Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 #### **--platform**=*OS/ARCH*
 
-Specify the platform for selecting the image.  (Conflicts with override-arch and override-os)
+Specify the platform for selecting the image.  (Conflicts with --arch and --os)
 The `--platform` option can be used to override the current architecture and operating system.
 
 #### **--quiet**, **-q**
@@ -121,9 +121,9 @@ Require HTTPS and verify certificates when contacting registries (default: true)
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
 TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
-#### **--help**, **-h**
+#### **--variant**=*VARIANT*
 
-Print usage statement
+Use _VARIANT_ instead of the default architecture variant of the container image.  Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 ## EXAMPLES
 
@@ -189,7 +189,7 @@ Storing signatures
 ```
 
 ```
-$ podman pull --override-arch=arm arm32v7/debian:stretch
+$ podman pull --arch=arm arm32v7/debian:stretch
 Trying to pull docker.io/arm32v7/debian:stretch...
 Getting image source signatures
 Copying blob b531ae4a3925 done

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -93,6 +93,9 @@ This option can be set multiple times.
 Add an annotation to the container.
 This option can be set multiple times.
 
+#### **--arch**=*ARCH*
+Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
+
 #### **--attach**, **-a**=**stdin**|**stdout**|**stderr**
 
 Attach to STDIN, STDOUT or STDERR.
@@ -704,14 +707,8 @@ Whether to disable OOM Killer for the container or not.
 
 Tune the host's OOM preferences for containers (accepts values from **-1000** to **1000**).
 
-#### **--override-arch**=*ARCH*
-Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
-
-#### **--override-os**=*OS*
+#### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
-
-#### **--override-variant**=*VARIANT*
-Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 #### **--pid**=*mode*
 
@@ -729,7 +726,7 @@ Tune the container's pids limit. Set to **0** to have unlimited pids for the con
 
 #### **--platform**=*OS/ARCH*
 
-Specify the platform for selecting the image.  (Conflicts with override-arch and override-os)
+Specify the platform for selecting the image.  (Conflicts with --arch and --os)
 The `--platform` option can be used to override the current architecture and operating system.
 
 #### **--pod**=*name*
@@ -1081,6 +1078,9 @@ Set the UTS namespace mode for the container. The following values are supported
 - **private**: create a new namespace for the container (default).
 - **ns:[path]**: run the container in the given existing UTS namespace.
 - **container:[container]**: join the UTS namespace of the specified container.
+
+#### **--variant**=*VARIANT*
+Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 #### **--volume**, **-v**[=*[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*]
 

--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -30,12 +30,12 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
-		Reference       string `schema:"reference"`
-		OverrideOS      string `schema:"overrideOS"`
-		OverrideArch    string `schema:"overrideArch"`
-		OverrideVariant string `schema:"overrideVariant"`
-		TLSVerify       bool   `schema:"tlsVerify"`
-		AllTags         bool   `schema:"allTags"`
+		Reference string `schema:"reference"`
+		OS        string `schema:"OS"`
+		Arch      string `schema:"Arch"`
+		Variant   string `schema:"Variant"`
+		TLSVerify bool   `schema:"tlsVerify"`
+		AllTags   bool   `schema:"allTags"`
 	}{
 		TLSVerify: true,
 	}
@@ -83,9 +83,9 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 	// Setup the registry options
 	dockerRegistryOptions := image.DockerRegistryOptions{
 		DockerRegistryCreds: authConf,
-		OSChoice:            query.OverrideOS,
-		ArchitectureChoice:  query.OverrideArch,
-		VariantChoice:       query.OverrideVariant,
+		OSChoice:            query.OS,
+		ArchitectureChoice:  query.Arch,
+		VariantChoice:       query.Variant,
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		dockerRegistryOptions.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -930,15 +930,15 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     description: "username:password for the registry"
 	//     type: string
 	//   - in: query
-	//     name: overrideArch
+	//     name: Arch
 	//     description: Pull image for the specified architecture.
 	//     type: string
 	//   - in: query
-	//     name: overrideOS
+	//     name: OS
 	//     description: Pull image for the specified operating system.
 	//     type: string
 	//   - in: query
-	//     name: overrideVariant
+	//     name: Variant
 	//     description: Pull image for the specified variant.
 	//     type: string
 	//   - in: query

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -171,13 +171,13 @@ type PullOptions struct {
 	Username *string
 	// Password for authenticating against the registry.
 	Password *string
-	// OverrideArch will overwrite the local architecture for image pulls.
-	OverrideArch *string
-	// OverrideOS will overwrite the local operating system (OS) for image
+	// Arch will overwrite the local architecture for image pulls.
+	Arch *string
+	// OS will overwrite the local operating system (OS) for image
 	// pulls.
-	OverrideOS *string
-	// OverrideVariant will overwrite the local variant for image pulls.
-	OverrideVariant *string
+	OS *string
+	// Variant will overwrite the local variant for image pulls.
+	Variant *string
 	// Quiet can be specified to suppress pull progress when pulling.  Ignored
 	// for remote calls.
 	Quiet *bool

--- a/pkg/bindings/images/types_pull_options.go
+++ b/pkg/bindings/images/types_pull_options.go
@@ -168,52 +168,52 @@ func (o *PullOptions) GetPassword() string {
 	return *o.Password
 }
 
-// WithOverrideArch
-func (o *PullOptions) WithOverrideArch(value string) *PullOptions {
+// WithArch
+func (o *PullOptions) WithArch(value string) *PullOptions {
 	v := &value
-	o.OverrideArch = v
+	o.Arch = v
 	return o
 }
 
-// GetOverrideArch
-func (o *PullOptions) GetOverrideArch() string {
-	var overrideArch string
-	if o.OverrideArch == nil {
-		return overrideArch
+// GetArch
+func (o *PullOptions) GetArch() string {
+	var arch string
+	if o.Arch == nil {
+		return arch
 	}
-	return *o.OverrideArch
+	return *o.Arch
 }
 
-// WithOverrideOS
-func (o *PullOptions) WithOverrideOS(value string) *PullOptions {
+// WithOS
+func (o *PullOptions) WithOS(value string) *PullOptions {
 	v := &value
-	o.OverrideOS = v
+	o.OS = v
 	return o
 }
 
-// GetOverrideOS
-func (o *PullOptions) GetOverrideOS() string {
-	var overrideOS string
-	if o.OverrideOS == nil {
-		return overrideOS
+// GetOS
+func (o *PullOptions) GetOS() string {
+	var oS string
+	if o.OS == nil {
+		return oS
 	}
-	return *o.OverrideOS
+	return *o.OS
 }
 
-// WithOverrideVariant
-func (o *PullOptions) WithOverrideVariant(value string) *PullOptions {
+// WithVariant
+func (o *PullOptions) WithVariant(value string) *PullOptions {
 	v := &value
-	o.OverrideVariant = v
+	o.Variant = v
 	return o
 }
 
-// GetOverrideVariant
-func (o *PullOptions) GetOverrideVariant() string {
-	var overrideVariant string
-	if o.OverrideVariant == nil {
-		return overrideVariant
+// GetVariant
+func (o *PullOptions) GetVariant() string {
+	var variant string
+	if o.Variant == nil {
+		return variant
 	}
-	return *o.OverrideVariant
+	return *o.Variant
 }
 
 // WithQuiet

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -133,13 +133,13 @@ type ImagePullOptions struct {
 	Username string
 	// Password for authenticating against the registry.
 	Password string
-	// OverrideArch will overwrite the local architecture for image pulls.
-	OverrideArch string
-	// OverrideOS will overwrite the local operating system (OS) for image
+	// Arch will overwrite the local architecture for image pulls.
+	Arch string
+	// OS will overwrite the local operating system (OS) for image
 	// pulls.
-	OverrideOS string
-	// OverrideVariant will overwrite the local variant for image pulls.
-	OverrideVariant string
+	OS string
+	// Variant will overwrite the local variant for image pulls.
+	Variant string
 	// Quiet can be specified to suppress pull progress when pulling.  Ignored
 	// for remote calls.
 	Quiet bool

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -241,9 +241,9 @@ func pull(ctx context.Context, runtime *image.Runtime, rawImage string, options 
 	dockerRegistryOptions := image.DockerRegistryOptions{
 		DockerRegistryCreds:         registryCreds,
 		DockerCertPath:              options.CertDir,
-		OSChoice:                    options.OverrideOS,
-		ArchitectureChoice:          options.OverrideArch,
-		VariantChoice:               options.OverrideVariant,
+		OSChoice:                    options.OS,
+		ArchitectureChoice:          options.Arch,
+		VariantChoice:               options.Variant,
 		DockerInsecureSkipTLSVerify: options.SkipTLSVerify,
 	}
 

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -106,8 +106,8 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 
 func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, opts entities.ImagePullOptions) (*entities.ImagePullReport, error) {
 	options := new(images.PullOptions)
-	options.WithAllTags(opts.AllTags).WithAuthfile(opts.Authfile).WithCertDir(opts.CertDir).WithOverrideArch(opts.OverrideArch).WithOverrideOS(opts.OverrideOS)
-	options.WithOverrideVariant(opts.OverrideVariant).WithPassword(opts.Password).WithPullPolicy(opts.PullPolicy)
+	options.WithAllTags(opts.AllTags).WithAuthfile(opts.Authfile).WithCertDir(opts.CertDir).WithArch(opts.Arch).WithOS(opts.OS)
+	options.WithVariant(opts.Variant).WithPassword(opts.Password).WithPullPolicy(opts.PullPolicy)
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {
 			options.WithSkipTLSVerify(true)

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create using image list by tag", func() {
-		session := podmanTest.Podman([]string{"create", "--pull=always", "--override-arch=arm64", "--name=foo", ALPINELISTTAG})
+		session := podmanTest.Podman([]string{"create", "--pull=always", "--arch=arm64", "--name=foo", ALPINELISTTAG})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To((Equal(0)))
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.Image}}", "foo"})
@@ -296,7 +296,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create using image list by digest", func() {
-		session := podmanTest.Podman([]string{"create", "--pull=always", "--override-arch=arm64", "--name=foo", ALPINELISTDIGEST})
+		session := podmanTest.Podman([]string{"create", "--pull=always", "--arch=arm64", "--name=foo", ALPINELISTDIGEST})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To((Equal(0)))
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.Image}}", "foo"})
@@ -310,7 +310,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create using image list instance by digest", func() {
-		session := podmanTest.Podman([]string{"create", "--pull=always", "--override-arch=arm64", "--name=foo", ALPINEARM64DIGEST})
+		session := podmanTest.Podman([]string{"create", "--pull=always", "--arch=arm64", "--name=foo", ALPINEARM64DIGEST})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To((Equal(0)))
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.Image}}", "foo"})
@@ -324,7 +324,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create using cross-arch image list instance by digest", func() {
-		session := podmanTest.Podman([]string{"create", "--pull=always", "--override-arch=arm64", "--name=foo", ALPINEARM64DIGEST})
+		session := podmanTest.Podman([]string{"create", "--pull=always", "--arch=arm64", "--name=foo", ALPINEARM64DIGEST})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To((Equal(0)))
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.Image}}", "foo"})
@@ -652,10 +652,10 @@ var _ = Describe("Podman create", func() {
 		expectedError := "no image found in manifest list for architecture bogus"
 		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
 
-		session = podmanTest.Podman([]string{"create", "--platform=linux/arm64", "--override-os", "windows", ALPINE})
+		session = podmanTest.Podman([]string{"create", "--platform=linux/arm64", "--os", "windows", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(125))
-		expectedError = "--platform option can not be specified with --override-arch or --override-os"
+		expectedError = "--platform option can not be specified with --arch or --os"
 		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
 
 		session = podmanTest.Podman([]string{"create", "-q", "--platform=linux/arm64", ALPINE})

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull by digest (image list)", func() {
-		session := podmanTest.Podman([]string{"pull", "--override-arch=arm64", ALPINELISTDIGEST})
+		session := podmanTest.Podman([]string{"pull", "--arch=arm64", ALPINELISTDIGEST})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		// inspect using the digest of the list
@@ -135,7 +135,7 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull by instance digest (image list)", func() {
-		session := podmanTest.Podman([]string{"pull", "--override-arch=arm64", ALPINEARM64DIGEST})
+		session := podmanTest.Podman([]string{"pull", "--arch=arm64", ALPINEARM64DIGEST})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		// inspect using the digest of the list
@@ -175,7 +175,7 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull by tag (image list)", func() {
-		session := podmanTest.Podman([]string{"pull", "--override-arch=arm64", ALPINELISTTAG})
+		session := podmanTest.Podman([]string{"pull", "--arch=arm64", ALPINELISTTAG})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		// inspect using the tag we used for pulling
@@ -503,10 +503,10 @@ var _ = Describe("Podman pull", func() {
 		expectedError := "no image found in manifest list for architecture bogus"
 		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
 
-		session = podmanTest.Podman([]string{"pull", "--platform=linux/arm64", "--override-os", "windows", ALPINE})
+		session = podmanTest.Podman([]string{"pull", "--platform=linux/arm64", "--os", "windows", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(125))
-		expectedError = "--platform option can not be specified with --override-arch or --override-os"
+		expectedError = "--platform option can not be specified with --arch or --os"
 		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
 
 		session = podmanTest.Podman([]string{"pull", "-q", "--platform=linux/arm64", ALPINE})


### PR DESCRIPTION
Currently podman implements --override-arch and --overide-os
But Podman has made these aliases for --arch and --os.  No
reason to have to specify --override, since it is clear what
the user intends.

Currently if the user specifies an --override-arch field but the
image was previously pulled for a different Arch, podman run uses
the different arch.  This PR also fixes this issue.

Fixes: https://github.com/containers/podman/issues/8001

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
