### PR TITLE
[NO TESTS NEEDED] Ensure shutdown handler access is syncronized

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -180,19 +180,19 @@ func newRuntimeFromConfig(ctx context.Context, conf *config.Config, options ...R
 		}
 	}
 
+	if err := shutdown.Register("libpod", func(sig os.Signal) error {
+		os.Exit(1)
+		return nil
+	}); err != nil && errors.Cause(err) != shutdown.ErrHandlerExists {
+		logrus.Errorf("Error registering shutdown handler for libpod: %v", err)
+	}
+
 	if err := shutdown.Start(); err != nil {
 		return nil, errors.Wrapf(err, "error starting shutdown signal handler")
 	}
 
 	if err := makeRuntime(ctx, runtime); err != nil {
 		return nil, err
-	}
-
-	if err := shutdown.Register("libpod", func(sig os.Signal) error {
-		os.Exit(1)
-		return nil
-	}); err != nil && errors.Cause(err) != shutdown.ErrHandlerExists {
-		logrus.Errorf("Error registering shutdown handler for libpod: %v", err)
 	}
 
 	return runtime, nil

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -179,13 +179,13 @@ func setupSystemd() {
 func (s *APIServer) Serve() error {
 	setupSystemd()
 
-	// Start the shutdown signal handler.
-	if err := shutdown.Start(); err != nil {
-		return err
-	}
 	if err := shutdown.Register("server", func(sig os.Signal) error {
 		return s.Shutdown()
 	}); err != nil {
+		return err
+	}
+	// Start the shutdown signal handler.
+	if err := shutdown.Start(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
There was a potential race where two handlers could be added at the same time. Go Maps are not thread-safe, so that could do unpleasant things. Add a mutex to keep things safe.

Also, swap the order or Register and Start for the handlers in Libpod runtime created. As written, there was a small gap between Start and Register where SIGTERM/SIGINT would be completely ignored, instead of stopping Podman. Swapping the two closes  this gap.