### PR TITLE
System tests: cover gaps from the last month

### DIFF
--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -171,4 +171,15 @@ function check_label() {
     run_podman pod rm myselinuxpod
 }
 
+# #8946 - better diagnostics for nonexistent attributes
+@test "podman with nonexistent labels" {
+    skip_if_no_selinux
+
+    # The '.*' in the error below is for dealing with podman-remote, which
+    # includes "error preparing container <sha> for attach" in output.
+    run_podman 126 run --security-opt label=type:foo.bar $IMAGE true
+    is "$output" "Error.*: \`/proc/thread-self/attr/exec\`: OCI runtime error: unable to assign security attribute" "useful diagnostic"
+}
+
+
 # vim: filetype=sh


### PR DESCRIPTION
- stop: test --all and --ignore (#9051)
- build: test /run/secrets (#8679, but see below)
- sensitive mount points: deal with 'stat' failures
- selinux: confirm useful diagnostics on unknown labels (#8946)

The 'build' test is intended as a fix for #8679, in which
'podman build' does not mount secrets from mounts.conf.
Unfortunately, as of this writing, 'podman build' does
not pass the --default-mounts-file option to buildah,
so there's no reasonable way to test this path. Still,
we can at least confirm /run/secrets on 'podman run'.

The /sys thing is related to #8949: RHEL8, rootless, cgroups v1.
It's just a workaround to get gating tests to pass on RHEL.

Signed-off-by: Ed Santiago <santiago@redhat.com>
