### PR TITLE
Add default net info in container inspect

### DIFF
--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -443,4 +443,16 @@ var _ = Describe("Podman inspect", func() {
 		Expect(inspect.OutputToString()).To(Equal(`"{"80/tcp":[{"HostIp":"","HostPort":"8080"}]}"`))
 	})
 
+	It("Verify container inspect has default network", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		cid := session.OutputToString()
+		inspect := podmanTest.Podman([]string{"inspect", cid})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(BeZero())
+		data := inspect.InspectContainerToJSON()
+		Expect(len(data[0].NetworkSettings.Networks)).To(BeNumerically(">", 0))
+	})
+
 })


### PR DESCRIPTION
when inspecting a container that is only connected to the default
network, we should populate the default network in the container inspect
information.

Fixes: #6618

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
