### PR TITLE
podman-remote ps --external --pod --sort do not work.

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -78,7 +78,7 @@ func listFlagSet(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
 	flags.BoolVarP(&listOpts.All, "all", "a", false, "Show all the containers, default is only running containers")
-	flags.BoolVar(&listOpts.Storage, "external", false, "Show containers in storage not controlled by Podman")
+	flags.BoolVar(&listOpts.External, "external", false, "Show containers in storage not controlled by Podman")
 
 	filterFlagName := "filter"
 	flags.StringSliceVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
@@ -132,10 +132,10 @@ func checkFlags(c *cobra.Command) error {
 	}
 	cfg := registry.PodmanConfig()
 	if cfg.Engine.Namespace != "" {
-		if c.Flag("storage").Changed && listOpts.Storage {
-			return errors.New("--namespace and --storage flags can not both be set")
+		if c.Flag("storage").Changed && listOpts.External {
+			return errors.New("--namespace and --external flags can not both be set")
 		}
-		listOpts.Storage = false
+		listOpts.External = false
 	}
 
 	return nil

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -140,6 +140,10 @@ func removeContainers(namesOrIDs []string, rmOptions entities.RmOptions, setExit
 }
 
 func setExitCode(err error) {
+	// If error is set to no such container, do not reset
+	if registry.GetExitCode() == 1 {
+		return
+	}
 	cause := errors.Cause(err)
 	switch {
 	case cause == define.ErrNoSuchCtr:

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -73,7 +73,7 @@ func RemoveContainer(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
-	if report[0].Err != nil {
+	if len(report) > 0 && report[0].Err != nil {
 		utils.InternalServerError(w, report[0].Err)
 		return
 	}

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -48,6 +48,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    default: false
 	//    description: Return all containers. By default, only running containers are shown
 	//  - in: query
+	//    name: external
+	//    type: boolean
+	//    default: false
+	//    description: Return containers in storage not controlled by Podman
+	//  - in: query
 	//    name: limit
 	//    description: Return this number of most recently created containers, including non-running ones.
 	//    type: integer

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -106,6 +106,7 @@ type MountedContainerPathsOptions struct{}
 // ListOptions are optional options for listing containers
 type ListOptions struct {
 	All       *bool
+	External  *bool
 	Filters   map[string][]string
 	Last      *int
 	Namespace *bool

--- a/pkg/bindings/containers/types_list_options.go
+++ b/pkg/bindings/containers/types_list_options.go
@@ -103,6 +103,22 @@ func (o *ListOptions) GetAll() bool {
 	return *o.All
 }
 
+// WithExternal
+func (o *ListOptions) WithExternal(value bool) *ListOptions {
+	v := &value
+	o.External = v
+	return o
+}
+
+// GetExternal
+func (o *ListOptions) GetExternal() bool {
+	var external bool
+	if o.External == nil {
+		return external
+	}
+	return *o.External
+}
+
 // WithFilters
 func (o *ListOptions) WithFilters(value map[string][]string) *ListOptions {
 	v := value

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -297,8 +297,8 @@ type ContainerListOptions struct {
 	Pod       bool
 	Quiet     bool
 	Size      bool
+	External  bool
 	Sort      string
-	Storage   bool
 	Sync      bool
 	Watch     uint
 }

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -173,19 +173,32 @@ func (ic *ContainerEngine) ContainerRestart(ctx context.Context, namesOrIds []st
 }
 
 func (ic *ContainerEngine) ContainerRm(ctx context.Context, namesOrIds []string, opts entities.RmOptions) ([]*entities.RmReport, error) {
-	ctrs, err := getContainersByContext(ic.ClientCtx, opts.All, opts.Ignore, namesOrIds)
-	if err != nil {
-		return nil, err
-	}
 	// TODO there is no endpoint for container eviction.  Need to discuss
-	reports := make([]*entities.RmReport, 0, len(ctrs))
-	options := new(containers.RemoveOptions).WithForce(opts.Force).WithVolumes(opts.Volumes)
-	for _, c := range ctrs {
+	options := new(containers.RemoveOptions).WithForce(opts.Force).WithVolumes(opts.Volumes).WithIgnore(opts.Ignore)
+
+	if opts.All {
+		ctrs, err := getContainersByContext(ic.ClientCtx, opts.All, opts.Ignore, namesOrIds)
+		if err != nil {
+			return nil, err
+		}
+		reports := make([]*entities.RmReport, 0, len(ctrs))
+		for _, c := range ctrs {
+			reports = append(reports, &entities.RmReport{
+				Id:  c.ID,
+				Err: containers.Remove(ic.ClientCtx, c.ID, options),
+			})
+		}
+		return reports, nil
+	}
+
+	reports := make([]*entities.RmReport, 0, len(namesOrIds))
+	for _, name := range namesOrIds {
 		reports = append(reports, &entities.RmReport{
-			Id:  c.ID,
-			Err: containers.Remove(ic.ClientCtx, c.ID, options),
+			Id:  name,
+			Err: containers.Remove(ic.ClientCtx, name, options),
 		})
 	}
+
 	return reports, nil
 }
 
@@ -601,7 +614,7 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 
 func (ic *ContainerEngine) ContainerList(ctx context.Context, opts entities.ContainerListOptions) ([]entities.ListContainer, error) {
 	options := new(containers.ListOptions).WithFilters(opts.Filters).WithAll(opts.All).WithLast(opts.Last)
-	options.WithNamespace(opts.Namespace).WithSize(opts.Size).WithSync(opts.Sync)
+	options.WithNamespace(opts.Namespace).WithSize(opts.Size).WithSync(opts.Sync).WithExternal(opts.External)
 	return containers.List(ic.ClientCtx, options)
 }
 

--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -69,7 +69,7 @@ func GetContainerLists(runtime *libpod.Runtime, options entities.ContainerListOp
 		pss = append(pss, listCon)
 	}
 
-	if options.All && options.Storage {
+	if options.All && options.External {
 		externCons, err := runtime.StorageContainers()
 		if err != nil {
 			return nil, err

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -396,11 +396,14 @@ var _ = Describe("Podman ps", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"ps", "--pod", "--no-trunc"})
-
+		session = podmanTest.Podman([]string{"ps", "--no-trunc"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Not(ContainSubstring(podid)))
 
+		session = podmanTest.Podman([]string{"ps", "--pod", "--no-trunc"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring(podid))
 	})
 

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Podman rm", func() {
 
 		latest := "-l"
 		if IsRemote() {
-			latest = "test1"
+			latest = cid
 		}
 		result := podmanTest.Podman([]string{"rm", latest})
 		result.WaitWithDefaultTimeout()

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -82,11 +82,10 @@ load helpers
     run_podman rm -a
 }
 
-@test "podman ps -a --storage" {
-    skip_if_remote "ps --storage does not work over remote"
+@test "podman ps -a --external" {
 
     # Setup: ensure that we have no hidden storage containers
-    run_podman ps --storage -a
+    run_podman ps --external -a
     is "${#lines[@]}" "1" "setup check: no storage containers at start of test"
 
     # Force a buildah timeout; this leaves a buildah container behind
@@ -98,18 +97,18 @@ EOF
     run_podman ps -a
     is "${#lines[@]}" "1" "podman ps -a does not see buildah container"
 
-    run_podman ps --storage -a
-    is "${#lines[@]}" "2" "podman ps -a --storage sees buildah container"
+    run_podman ps --external -a
+    is "${#lines[@]}" "2" "podman ps -a --external sees buildah container"
     is "${lines[1]}" \
        "[0-9a-f]\{12\} \+$IMAGE *buildah .* seconds ago .* storage .* ${PODMAN_TEST_IMAGE_NAME}-working-container" \
-       "podman ps --storage"
+       "podman ps --external"
 
     cid="${lines[1]:0:12}"
 
     # 'rm -a' should be a NOP
     run_podman rm -a
-    run_podman ps --storage -a
-    is "${#lines[@]}" "2" "podman ps -a --storage sees buildah container"
+    run_podman ps --external -a
+    is "${#lines[@]}" "2" "podman ps -a --external sees buildah container"
 
     # We can't rm it without -f, but podman should issue a helpful message
     run_podman 2 rm "$cid"
@@ -118,7 +117,7 @@ EOF
     # With -f, we can remove it.
     run_podman rm -f "$cid"
 
-    run_podman ps --storage -a
+    run_podman ps --external -a
     is "${#lines[@]}" "1" "storage container has been removed"
 }
 


### PR DESCRIPTION
 Fixup the bindings and the handling of the --external --pod and --sort
flags.

The --storage option was renamed --external, make sure we use
external up and down the stack.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
