### PR TITLE
Fix #9100 Change console mode message to debug

### DIFF
--- a/pkg/terminal/console_windows.go
+++ b/pkg/terminal/console_windows.go
@@ -30,7 +30,7 @@ func setConsoleMode(handle windows.Handle, flags uint32) error {
 	if err := windows.SetConsoleMode(handle, mode|flags); err != nil {
 		// In similar code, it is not considered an error if we cannot set the
 		// console mode.  Following same line of thinking here.
-		logrus.WithError(err).Error("Failed to set console mode for cli")
+		logrus.WithError(err).Debug("Failed to set console mode for cli")
 	}
 
 	return nil


### PR DESCRIPTION
When using PowerShel the console mode continously shows as an error message.
This doesn't happen for the Command prompt on Windows. As it does not affect
the functionality, it is probably betetr to treat this as a debug log level?

