### PR TITLE
[CI:DOCS]update state of restful service

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,9 @@ Podman_ is a daemonless, open source, Linux native tool designed to make it easy
 
 Containers under the control of Podman can either be run by root or by a non-privileged user. Podman manages the entire container ecosystem which includes pods, containers, container images, and container volumes using the libpod_ library. Podman specializes in all of the commands and functions that help you to maintain and modify OCI container images, such as pulling and tagging. It allows you to create, run, and maintain those containers and container images in a production environment.
 
-The Podman service runs only on Linux platforms, however a REST API and clients are currently under development which will allow Mac and Windows platforms to call the service. There is currently a RESTful based remote client which runs on Mac or Windows platforms that allows the remote client to talk to the Podman server on a Linux platform. In addition to those clients, there is also a Mac client.
+There is a RESTFul API to manage containers.  We also have a remote Podman client that can interact with
+the RESTFul service.  We currently support clients on Linux, Mac, and Windows.  The RESTFul service is only
+supported on Linux.
 
 If you are completely new to containers, we recommend that you check out the :doc:`Introduction`. For power users or those coming from Docker, check out our :doc:`Tutorials`. For advanced users and contributors, you can get very detailed information about the Podman CLI by looking at our :doc:`Commands` page. Finally, for Developers looking at how to interact with the Podman API, please see our API documentation :doc:`Reference`.
 


### PR DESCRIPTION
we have not updated the state of the restful service. it is no longer
considered under development.  additionally, clarified our support of
remote clients.

Fixes: #9104

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
