### PR TITLE
Fix #6618

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -977,7 +977,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 	if c.state.NetNS == nil {
 		// We still want to make dummy configurations for each CNI net
 		// the container joined.
-		if len(networks) > 0 && !isDefault {
+		if len(networks) > 0 {
 			settings.Networks = make(map[string]*define.InspectAdditionalNetwork, len(networks))
 			for _, net := range networks {
 				cniNet := new(define.InspectAdditionalNetwork)
@@ -998,7 +998,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 	}
 
 	// If we have CNI networks - handle that here
-	if len(networks) > 0 && !isDefault {
+	if len(networks) > 0 {
 		if len(networks) != len(c.state.NetworkStatus) {
 			return nil, errors.Wrapf(define.ErrInternal, "network inspection mismatch: asked to join %d CNI network(s) %v, but have information on %d network(s)", len(networks), networks, len(c.state.NetworkStatus))
 		}
@@ -1028,7 +1028,9 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 			settings.Networks[name] = addedNet
 		}
 
-		return settings, nil
+		if !isDefault {
+			return settings, nil
+		}
 	}
 
 	// If not joining networks, we should have at most 1 result

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -443,4 +443,27 @@ var _ = Describe("Podman inspect", func() {
 		Expect(inspect.OutputToString()).To(Equal(`"{"80/tcp":[{"HostIp":"","HostPort":"8080"}]}"`))
 	})
 
+	It("Verify container inspect has default network", func() {
+		SkipIfRootless("Requires root CNI networking")
+		ctrName := "testctr"
+		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+
+		inspect := podmanTest.InspectContainer(ctrName)
+		Expect(len(inspect)).To(Equal(1))
+		Expect(len(inspect[0].NetworkSettings.Networks)).To(Equal(1))
+	})
+
+	It("Verify stopped container still has default network in inspect", func() {
+		SkipIfRootless("Requires root CNI networking")
+		ctrName := "testctr"
+		session := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+
+		inspect := podmanTest.InspectContainer(ctrName)
+		Expect(len(inspect)).To(Equal(1))
+		Expect(len(inspect[0].NetworkSettings.Networks)).To(Equal(1))
+	})
 })


### PR DESCRIPTION
Obsoletes #9092 

Ensure that the networks list is populated, even when only the default network is in use.