### PR TITLE
Don't fail if one of the cgroups is not setup

### DIFF
--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -1,0 +1,32 @@
+package cgroups
+
+import (
+	"testing"
+
+	"github.com/containers/podman/v2/pkg/rootless"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func TestCreated(t *testing.T) {
+	// tests only works in rootless mode
+	if rootless.IsRootless() {
+		return
+	}
+
+	var resources spec.LinuxResources
+	cgr, err := New("machine.slice", &resources)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := cgr.Delete(); err != nil {
+		t.Error(err)
+	}
+
+	cgr, err = NewSystemd("machine.slice")
+	if err != nil {
+		t.Error(err)
+	}
+	if err := cgr.Delete(); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
It is fairly common for certain cgroups controllers to
not be enabled on a system.  We should Warn when this happens
versus failing, when doing podman stats command.  This way users
can get information from the other controllers.

Fixes: https://github.com/containers/podman/issues/8588

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
