### PR TITLE
Fix podman history --no-trunc for the CREATED BY field

### DIFF
--- a/cmd/podman/images/history.go
+++ b/cmd/podman/images/history.go
@@ -162,7 +162,7 @@ func (h historyReporter) Size() string {
 }
 
 func (h historyReporter) CreatedBy() string {
-	if len(h.ImageHistoryLayer.CreatedBy) > 45 {
+	if !opts.noTrunc && len(h.ImageHistoryLayer.CreatedBy) > 45 {
 		return h.ImageHistoryLayer.CreatedBy[:45-3] + "..."
 	}
 	return h.ImageHistoryLayer.CreatedBy

--- a/test/e2e/history_test.go
+++ b/test/e2e/history_test.go
@@ -65,6 +65,23 @@ var _ = Describe("Podman history", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 0))
+
+		session = podmanTest.Podman([]string{"history", "--no-trunc", "--format", "{{.ID}}", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		lines := session.OutputToStringArray()
+		Expect(len(lines)).To(BeNumerically(">", 0))
+		// the image id must be 64 chars long
+		Expect(len(lines[0])).To(BeNumerically("==", 64))
+
+		session = podmanTest.Podman([]string{"history", "--no-trunc", "--format", "{{.CreatedBy}}", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		lines = session.OutputToStringArray()
+		Expect(len(lines)).To(BeNumerically(">", 0))
+		Expect(session.OutputToString()).ToNot(ContainSubstring("..."))
+		// the second line in the alpine history contains a command longer than 45 chars
+		Expect(len(lines[1])).To(BeNumerically(">", 45))
 	})
 
 	It("podman history with json flag", func() {


### PR DESCRIPTION
Fixes #9120


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
