### PR TITLE
[CI:DOCS] swagger: add operationIds that match with docker

### DIFF
--- a/pkg/api/server/register_archive.go
+++ b/pkg/api/server/register_archive.go
@@ -8,10 +8,9 @@ import (
 )
 
 func (s *APIServer) registerArchiveHandlers(r *mux.Router) error {
-	// swagger:operation PUT /containers/{name}/archive compat putArchive
+	// swagger:operation PUT /containers/{name}/archive compat PutContainerArchive
 	// ---
 	//  summary: Put files into a container
-	//  operationId: PutContainerArchive
 	//  description: Put a tar archive of files into a container
 	//  tags:
 	//   - containers (compat)
@@ -53,10 +52,9 @@ func (s *APIServer) registerArchiveHandlers(r *mux.Router) error {
 	//    500:
 	//      $ref: "#/responses/InternalError"
 
-	// swagger:operation GET /containers/{name}/archive compat getArchive
+	// swagger:operation GET /containers/{name}/archive compat ContainerArchive
 	// ---
 	//  summary: Get files from a container
-	//  operationId: ContainerArchive
 	//  description: Get a tar archive of files from a container
 	//  tags:
 	//   - containers (compat)

--- a/pkg/api/server/register_archive.go
+++ b/pkg/api/server/register_archive.go
@@ -11,6 +11,7 @@ func (s *APIServer) registerArchiveHandlers(r *mux.Router) error {
 	// swagger:operation PUT /containers/{name}/archive compat putArchive
 	// ---
 	//  summary: Put files into a container
+	//  operationId: PutContainerArchive
 	//  description: Put a tar archive of files into a container
 	//  tags:
 	//   - containers (compat)
@@ -55,6 +56,7 @@ func (s *APIServer) registerArchiveHandlers(r *mux.Router) error {
 	// swagger:operation GET /containers/{name}/archive compat getArchive
 	// ---
 	//  summary: Get files from a container
+	//  operationId: ContainerArchive
 	//  description: Get a tar archive of files from a container
 	//  tags:
 	//   - containers (compat)

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -9,10 +9,9 @@ import (
 )
 
 func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
-	// swagger:operation POST /containers/create compat createContainer
+	// swagger:operation POST /containers/create compat ContainerCreate
 	// ---
 	//   summary: Create a container
-	//   operationId: ContainerCreate
 	//   tags:
 	//    - containers (compat)
 	//   produces:
@@ -36,12 +35,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/create"), s.APIHandler(compat.CreateContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/create", s.APIHandler(compat.CreateContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/json compat listContainers
+	// swagger:operation GET /containers/json compat ContainerList
 	// ---
 	// tags:
 	//  - containers (compat)
 	// summary: List containers
-	// operationId: ContainerList
 	// description: Returns a list of containers
 	// parameters:
 	//  - in: query
@@ -89,12 +87,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/json"), s.APIHandler(compat.ListContainers)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/json", s.APIHandler(compat.ListContainers)).Methods(http.MethodGet)
-	// swagger:operation POST  /containers/prune compat pruneContainers
+	// swagger:operation POST  /containers/prune compat ContainerPrune
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Delete stopped containers
-	// operationId: ContainerPrune
 	// description: Remove containers not in use
 	// parameters:
 	//  - in: query
@@ -114,12 +111,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/prune"), s.APIHandler(compat.PruneContainers)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/prune", s.APIHandler(compat.PruneContainers)).Methods(http.MethodPost)
-	// swagger:operation DELETE /containers/{name} compat removeContainer
+	// swagger:operation DELETE /containers/{name} compat ContainerDelete
 	// ---
 	// tags:
 	//  - containers (compat)
 	// summary: Remove a container
-	// operationId: ContainerDelete
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -156,12 +152,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}"), s.APIHandler(compat.RemoveContainer)).Methods(http.MethodDelete)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}", s.APIHandler(compat.RemoveContainer)).Methods(http.MethodDelete)
-	// swagger:operation GET /containers/{name}/json compat getContainer
+	// swagger:operation GET /containers/{name}/json compat ContainerInspect
 	// ---
 	// tags:
 	//  - containers (compat)
 	// summary: Inspect container
-	// operationId: ContainerInspect
 	// description: Return low-level information about a container.
 	// parameters:
 	//  - in: path
@@ -186,12 +181,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/json"), s.APIHandler(compat.GetContainer)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/json", s.APIHandler(compat.GetContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /containers/{name}/kill compat killContainer
+	// swagger:operation POST /containers/{name}/kill compat ContainerKill
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Kill container
-	// operationId: ContainerKill
 	// description: Signal to send to the container as an integer or string (e.g. SIGINT)
 	// parameters:
 	//  - in: path
@@ -219,12 +213,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/kill"), s.APIHandler(compat.KillContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/kill", s.APIHandler(compat.KillContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{name}/logs compat logsFromContainer
+	// swagger:operation GET /containers/{name}/logs compat ContainerLogs
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Get container logs
-	// operationId: ContainerLogs
 	// description: Get stdout and stderr logs from a container.
 	// parameters:
 	//  - in: path
@@ -274,12 +267,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/logs"), s.APIHandler(compat.LogsFromContainer)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/logs", s.APIHandler(compat.LogsFromContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /containers/{name}/pause compat pauseContainer
+	// swagger:operation POST /containers/{name}/pause compat ContainerPause
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Pause container
-	// operationId: ContainerPause
 	// description: Use the cgroups freezer to suspend all processes in a container.
 	// parameters:
 	//  - in: path
@@ -299,12 +291,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/pause"), s.APIHandler(compat.PauseContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/pause", s.APIHandler(compat.PauseContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{name}/restart compat restartContainer
+	// swagger:operation POST /containers/{name}/restart compat ContainerRestart
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Restart container
-	// operationId: ContainerRestart
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -327,12 +318,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/restart"), s.APIHandler(compat.RestartContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/restart", s.APIHandler(compat.RestartContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{name}/start compat startContainer
+	// swagger:operation POST /containers/{name}/start compat ContainerStart
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Start a container
-	// operationId: ContainerStart
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -358,12 +348,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/start"), s.APIHandler(compat.StartContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/start", s.APIHandler(compat.StartContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{name}/stats compat statsContainer
+	// swagger:operation GET /containers/{name}/stats compat ContainerStats
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Get stats for a container
-	// operationId: ContainerStats
 	// description: This returns a live stream of a container’s resource usage statistics.
 	// parameters:
 	//  - in: path
@@ -388,12 +377,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/stats"), s.APIHandler(compat.StatsContainer)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/stats", s.APIHandler(compat.StatsContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /containers/{name}/stop compat stopContainer
+	// swagger:operation POST /containers/{name}/stop compat ContainerStop
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Stop a container
-	// operationId: ContainerStop
 	// description: Stop a container
 	// parameters:
 	//  - in: path
@@ -419,12 +407,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/stop"), s.APIHandler(compat.StopContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/stop", s.APIHandler(compat.StopContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{name}/top compat topContainer
+	// swagger:operation GET /containers/{name}/top compat ContainerTop
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: List processes running inside a container
-	// operationId: ContainerTop
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -447,12 +434,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/top"), s.APIHandler(compat.TopContainer)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/top", s.APIHandler(compat.TopContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /containers/{name}/unpause compat unpauseContainer
+	// swagger:operation POST /containers/{name}/unpause compat ContainerUnpause
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Unpause container
-	// operationId: ContainerUnpause
 	// description: Resume a paused container
 	// parameters:
 	//  - in: path
@@ -472,12 +458,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/unpause"), s.APIHandler(compat.UnpauseContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/unpause", s.APIHandler(compat.UnpauseContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{name}/wait compat waitContainer
+	// swagger:operation POST /containers/{name}/wait compat ContainerWait
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Wait on a container
-	// operationId: ContainerWait
 	// description: Block until a container stops or given condition is met.
 	// parameters:
 	//  - in: path
@@ -508,12 +493,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/wait"), s.APIHandler(compat.WaitContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/wait", s.APIHandler(compat.WaitContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{name}/attach compat attachContainer
+	// swagger:operation POST /containers/{name}/attach compat ContainerAttach
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Attach to a container
-	// operationId: ContainerAttach
 	// description: Hijacks the connection to forward the container's standard streams to the client.
 	// parameters:
 	//  - in: path
@@ -566,12 +550,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/attach"), s.APIHandler(compat.AttachContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/attach", s.APIHandler(compat.AttachContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{name}/resize compat resizeContainer
+	// swagger:operation POST /containers/{name}/resize compat ContainerResize
 	// ---
 	// tags:
 	//  - containers (compat)
 	// summary: Resize a container's TTY
-	// operationId: ContainerResize
 	// description: Resize the terminal attached to a container (for use with Attach).
 	// parameters:
 	//  - in: path
@@ -601,12 +584,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/resize"), s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/resize", s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{name}/export compat exportContainer
+	// swagger:operation GET /containers/{name}/export compat ContainerExport
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Export a container
-	// operationId: ContainerExport
 	// description: Export the contents of a container as a tarball.
 	// parameters:
 	//  - in: path
@@ -625,12 +607,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/export"), s.APIHandler(compat.ExportContainer)).Methods(http.MethodGet)
 	r.HandleFunc("/containers/{name}/export", s.APIHandler(compat.ExportContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /containers/{name}/rename compat renameContainer
+	// swagger:operation POST /containers/{name}/rename compat ContainerRename
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Rename an existing container
-	// operationId: ContainerRename
 	// description: Change the name of an existing container.
 	// parameters:
 	//  - in: path
@@ -1452,14 +1433,13 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/restore"), s.APIHandler(libpod.Restore)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{name}/changes libpod libpodChangesContainer
+	// swagger:operation GET /containers/{name}/changes libpod ContainerChanges
 	// swagger:operation GET /libpod/containers/{name}/changes compat changesContainer
 	// ---
 	// tags:
 	//   - containers
 	//   - containers (compat)
 	// summary: Report on changes to container's filesystem; adds, deletes or modifications.
-	// operationId: ContainerChanges
 	// description: |
 	//   Returns which files in a container's filesystem have been added, deleted, or modified. The Kind of modification can be one of:
 	//

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -12,6 +12,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// swagger:operation POST /containers/create compat createContainer
 	// ---
 	//   summary: Create a container
+	//   operationId: ContainerCreate
 	//   tags:
 	//    - containers (compat)
 	//   produces:
@@ -40,6 +41,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//  - containers (compat)
 	// summary: List containers
+	// operationId: ContainerList
 	// description: Returns a list of containers
 	// parameters:
 	//  - in: query
@@ -92,6 +94,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Delete stopped containers
+	// operationId: ContainerPrune
 	// description: Remove containers not in use
 	// parameters:
 	//  - in: query
@@ -116,6 +119,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//  - containers (compat)
 	// summary: Remove a container
+	// operationId: ContainerDelete
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -157,6 +161,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//  - containers (compat)
 	// summary: Inspect container
+	// operationId: ContainerInspect
 	// description: Return low-level information about a container.
 	// parameters:
 	//  - in: path
@@ -186,6 +191,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Kill container
+	// operationId: ContainerKill
 	// description: Signal to send to the container as an integer or string (e.g. SIGINT)
 	// parameters:
 	//  - in: path
@@ -218,6 +224,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Get container logs
+	// operationId: ContainerLogs
 	// description: Get stdout and stderr logs from a container.
 	// parameters:
 	//  - in: path
@@ -272,6 +279,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Pause container
+	// operationId: ContainerPause
 	// description: Use the cgroups freezer to suspend all processes in a container.
 	// parameters:
 	//  - in: path
@@ -296,6 +304,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Restart container
+	// operationId: ContainerRestart
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -323,6 +332,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Start a container
+	// operationId: ContainerStart
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -353,6 +363,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Get stats for a container
+	// operationId: ContainerStats
 	// description: This returns a live stream of a container’s resource usage statistics.
 	// parameters:
 	//  - in: path
@@ -382,6 +393,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Stop a container
+	// operationId: ContainerStop
 	// description: Stop a container
 	// parameters:
 	//  - in: path
@@ -412,6 +424,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: List processes running inside a container
+	// operationId: ContainerTop
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -439,6 +452,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Unpause container
+	// operationId: ContainerUnpause
 	// description: Resume a paused container
 	// parameters:
 	//  - in: path
@@ -463,6 +477,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Wait on a container
+	// operationId: ContainerWait
 	// description: Block until a container stops or given condition is met.
 	// parameters:
 	//  - in: path
@@ -498,6 +513,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Attach to a container
+	// operationId: ContainerAttach
 	// description: Hijacks the connection to forward the container's standard streams to the client.
 	// parameters:
 	//  - in: path
@@ -555,6 +571,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//  - containers (compat)
 	// summary: Resize a container's TTY
+	// operationId: ContainerResize
 	// description: Resize the terminal attached to a container (for use with Attach).
 	// parameters:
 	//  - in: path
@@ -589,6 +606,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Export a container
+	// operationId: ContainerExport
 	// description: Export the contents of a container as a tarball.
 	// parameters:
 	//  - in: path
@@ -612,6 +630,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Rename an existing container
+	// operationId: ContainerRename
 	// description: Change the name of an existing container.
 	// parameters:
 	//  - in: path
@@ -1440,6 +1459,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   - containers
 	//   - containers (compat)
 	// summary: Report on changes to container's filesystem; adds, deletes or modifications.
+	// operationId: ContainerChanges
 	// description: |
 	//   Returns which files in a container's filesystem have been added, deleted, or modified. The Kind of modification can be one of:
 	//

--- a/pkg/api/server/register_events.go
+++ b/pkg/api/server/register_events.go
@@ -8,12 +8,11 @@ import (
 )
 
 func (s *APIServer) registerEventsHandlers(r *mux.Router) error {
-	// swagger:operation GET /events system getEvents
+	// swagger:operation GET /events system SystemEvents
 	// ---
 	// tags:
 	//   - system (compat)
 	// summary: Get events
-	// operationId: SystemEvents
 	// description: Returns events filtered on query parameters
 	// produces:
 	// - application/json

--- a/pkg/api/server/register_events.go
+++ b/pkg/api/server/register_events.go
@@ -13,6 +13,7 @@ func (s *APIServer) registerEventsHandlers(r *mux.Router) error {
 	// tags:
 	//   - system (compat)
 	// summary: Get events
+	// operationId: SystemEvents
 	// description: Returns events filtered on query parameters
 	// produces:
 	// - application/json

--- a/pkg/api/server/register_exec.go
+++ b/pkg/api/server/register_exec.go
@@ -8,12 +8,11 @@ import (
 )
 
 func (s *APIServer) registerExecHandlers(r *mux.Router) error {
-	// swagger:operation POST /containers/{name}/exec compat createExec
+	// swagger:operation POST /containers/{name}/exec compat ContainerExec
 	// ---
 	// tags:
 	//   - exec (compat)
 	// summary: Create an exec instance
-	// operationId: ContainerExec
 	// description: Create an exec session to run a command inside a running container. Exec sessions will be automatically removed 5 minutes after they exit.
 	// parameters:
 	//  - in: path
@@ -78,12 +77,11 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/containers/{name}/exec"), s.APIHandler(compat.ExecCreateHandler)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/containers/{name}/exec", s.APIHandler(compat.ExecCreateHandler)).Methods(http.MethodPost)
-	// swagger:operation POST /exec/{id}/start compat startExec
+	// swagger:operation POST /exec/{id}/start compat ExecStart
 	// ---
 	// tags:
 	//   - exec (compat)
 	// summary: Start an exec instance
-	// operationId: ExecStart
 	// description: Starts a previously set up exec instance. If detach is true, this endpoint returns immediately after starting the command. Otherwise, it sets up an interactive session with the command.
 	// parameters:
 	//  - in: path
@@ -117,12 +115,11 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/exec/{id}/start"), s.APIHandler(compat.ExecStartHandler)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/exec/{id}/start", s.APIHandler(compat.ExecStartHandler)).Methods(http.MethodPost)
-	// swagger:operation POST /exec/{id}/resize compat resizeExec
+	// swagger:operation POST /exec/{id}/resize compat ExecResize
 	// ---
 	// tags:
 	//   - exec (compat)
 	// summary: Resize an exec instance
-	// operationId: ExecResize
 	// description: |
 	//  Resize the TTY session used by an exec instance. This endpoint only works if tty was specified as part of creating and starting the exec instance.
 	// parameters:
@@ -151,12 +148,11 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/exec/{id}/resize"), s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/exec/{id}/resize", s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
-	// swagger:operation GET /exec/{id}/json compat inspectExec
+	// swagger:operation GET /exec/{id}/json compat ExecInspect
 	// ---
 	// tags:
 	//   - exec (compat)
 	// summary: Inspect an exec instance
-	// operationId: ExecInspect
 	// description: Return low-level information about an exec instance.
 	// parameters:
 	//  - in: path

--- a/pkg/api/server/register_exec.go
+++ b/pkg/api/server/register_exec.go
@@ -13,6 +13,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	// tags:
 	//   - exec (compat)
 	// summary: Create an exec instance
+	// operationId: ContainerExec
 	// description: Create an exec session to run a command inside a running container. Exec sessions will be automatically removed 5 minutes after they exit.
 	// parameters:
 	//  - in: path
@@ -82,6 +83,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	// tags:
 	//   - exec (compat)
 	// summary: Start an exec instance
+	// operationId: ExecStart
 	// description: Starts a previously set up exec instance. If detach is true, this endpoint returns immediately after starting the command. Otherwise, it sets up an interactive session with the command.
 	// parameters:
 	//  - in: path
@@ -120,6 +122,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	// tags:
 	//   - exec (compat)
 	// summary: Resize an exec instance
+	// operationId: ExecResize
 	// description: |
 	//  Resize the TTY session used by an exec instance. This endpoint only works if tty was specified as part of creating and starting the exec instance.
 	// parameters:
@@ -153,6 +156,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	// tags:
 	//   - exec (compat)
 	// summary: Inspect an exec instance
+	// operationId: ExecInspect
 	// description: Return low-level information about an exec instance.
 	// parameters:
 	//  - in: path

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -13,12 +13,11 @@ import (
 // * /images/create is missing the "message" and "platform" parameters
 
 func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
-	// swagger:operation POST /images/create compat createImage
+	// swagger:operation POST /images/create compat ImageCreate
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Create an image
-	// operationId: ImageCreate
 	// description: Create an image by either pulling it from a registry or importing it.
 	// produces:
 	// - application/json
@@ -57,12 +56,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/create"), s.APIHandler(compat.CreateImageFromSrc)).Methods(http.MethodPost).Queries("fromSrc", "{fromSrc}")
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/create", s.APIHandler(compat.CreateImageFromSrc)).Methods(http.MethodPost).Queries("fromSrc", "{fromSrc}")
-	// swagger:operation GET /images/json compat listImages
+	// swagger:operation GET /images/json compat ImageList
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: List Images
-	// operationId: ImageList
 	// description: Returns a list of images on the server. Note that it uses a different, smaller representation of an image than inspecting a single image.
 	// parameters:
 	//   - name: all
@@ -95,12 +93,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/json"), s.APIHandler(compat.GetImages)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/json", s.APIHandler(compat.GetImages)).Methods(http.MethodGet)
-	// swagger:operation POST /images/load compat importImage
+	// swagger:operation POST /images/load compat ImageLoad
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Import image
-	// operationId: ImageLoad
 	// description: Load a set of images and tags into a repository.
 	// parameters:
 	//  - in: query
@@ -122,12 +119,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/load"), s.APIHandler(compat.LoadImages)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/load", s.APIHandler(compat.LoadImages)).Methods(http.MethodPost)
-	// swagger:operation POST /images/prune compat pruneImages
+	// swagger:operation POST /images/prune compat ImagePrune
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Prune unused images
-	// operationId: ImagePrune
 	// description: Remove images from local storage that are not being used by a container
 	// parameters:
 	//  - in: query
@@ -150,12 +146,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/prune"), s.APIHandler(compat.PruneImages)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/prune", s.APIHandler(compat.PruneImages)).Methods(http.MethodPost)
-	// swagger:operation GET /images/search compat searchImages
+	// swagger:operation GET /images/search compat ImageSearch
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Search images
-	// operationId: ImageSearch
 	// description: Search registries for an image
 	// parameters:
 	//  - in: query
@@ -190,12 +185,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/search"), s.APIHandler(compat.SearchImages)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/search", s.APIHandler(compat.SearchImages)).Methods(http.MethodGet)
-	// swagger:operation DELETE /images/{name:.*} compat removeImage
+	// swagger:operation DELETE /images/{name:.*} compat ImageDelete
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Remove Image
-	// operationId: ImageDelete
 	// description: Delete an image from local storage
 	// parameters:
 	//  - in: path
@@ -225,12 +219,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}"), s.APIHandler(compat.RemoveImage)).Methods(http.MethodDelete)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}", s.APIHandler(compat.RemoveImage)).Methods(http.MethodDelete)
-	// swagger:operation POST /images/{name:.*}/push compat pushImage
+	// swagger:operation POST /images/{name:.*}/push compat ImagePush
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Push Image
-	// operationId: ImagePush
 	// description: Push an image to a container registry
 	// parameters:
 	//  - in: path
@@ -261,12 +254,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}/push"), s.APIHandler(compat.PushImage)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}/push", s.APIHandler(compat.PushImage)).Methods(http.MethodPost)
-	// swagger:operation GET /images/{name:.*}/get compat exportImage
+	// swagger:operation GET /images/{name:.*}/get compat ImageGet
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Export an image
-	// operationId: ImageGet
 	// description: Export an image in tarball format
 	// parameters:
 	//  - in: path
@@ -287,12 +279,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}/get"), s.APIHandler(compat.ExportImage)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}/get", s.APIHandler(compat.ExportImage)).Methods(http.MethodGet)
-	// swagger:operation GET /images/get compat get
+	// swagger:operation GET /images/get compat ImageGetAll
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Export several images
-	// operationId: ImageGetAll
 	// description: Get a tarball containing all images and metadata for several image repositories
 	// parameters:
 	//  - in:  query
@@ -313,12 +304,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/get"), s.APIHandler(compat.ExportImages)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/get", s.APIHandler(compat.ExportImages)).Methods(http.MethodGet)
-	// swagger:operation GET /images/{name:.*}/history compat imageHistory
+	// swagger:operation GET /images/{name:.*}/history compat ImageHistory
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: History of an image
-	// operationId: ImageHistory
 	// description: Return parent layers of an image.
 	// parameters:
 	//  - in: path
@@ -338,12 +328,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}/history"), s.APIHandler(compat.HistoryImage)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}/history", s.APIHandler(compat.HistoryImage)).Methods(http.MethodGet)
-	// swagger:operation GET /images/{name:.*}/json compat inspectImage
+	// swagger:operation GET /images/{name:.*}/json compat ImageInspect
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Inspect an image
-	// operationId: ImageInspect
 	// description: Return low-level information about an image.
 	// parameters:
 	//  - in: path
@@ -363,12 +352,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}/json"), s.APIHandler(compat.GetImage)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}/json", s.APIHandler(compat.GetImage)).Methods(http.MethodGet)
-	// swagger:operation POST /images/{name:.*}/tag compat tagImage
+	// swagger:operation POST /images/{name:.*}/tag compat ImageTag
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Tag an image
-	// operationId: ImageTag
 	// description: Tag an image so that it becomes part of a repository.
 	// parameters:
 	//  - in: path
@@ -400,12 +388,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}/tag"), s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}/tag", s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
-	// swagger:operation POST /commit compat commitContainer
+	// swagger:operation POST /commit compat ImageCommit
 	// ---
 	// tags:
 	//  - containers (compat)
 	// summary: New Image
-	// operationId: ImageCommit
 	// description: Create a new image from a container
 	// parameters:
 	//  - in: query
@@ -449,12 +436,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/commit", s.APIHandler(compat.CommitContainer)).Methods(http.MethodPost)
 
-	// swagger:operation POST /build compat buildImage
+	// swagger:operation POST /build compat ImageBuild
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Create image
-	// operationId: ImageBuild
 	// description: Build an image from the given Dockerfile(s)
 	// parameters:
 	//  - in: query

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -18,6 +18,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Create an image
+	// operationId: ImageCreate
 	// description: Create an image by either pulling it from a registry or importing it.
 	// produces:
 	// - application/json
@@ -61,6 +62,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: List Images
+	// operationId: ImageList
 	// description: Returns a list of images on the server. Note that it uses a different, smaller representation of an image than inspecting a single image.
 	// parameters:
 	//   - name: all
@@ -98,6 +100,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Import image
+	// operationId: ImageLoad
 	// description: Load a set of images and tags into a repository.
 	// parameters:
 	//  - in: query
@@ -124,6 +127,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Prune unused images
+	// operationId: ImagePrune
 	// description: Remove images from local storage that are not being used by a container
 	// parameters:
 	//  - in: query
@@ -151,6 +155,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Search images
+	// operationId: ImageSearch
 	// description: Search registries for an image
 	// parameters:
 	//  - in: query
@@ -190,6 +195,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Remove Image
+	// operationId: ImageDelete
 	// description: Delete an image from local storage
 	// parameters:
 	//  - in: path
@@ -224,6 +230,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Push Image
+	// operationId: ImagePush
 	// description: Push an image to a container registry
 	// parameters:
 	//  - in: path
@@ -259,6 +266,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Export an image
+	// operationId: ImageGet
 	// description: Export an image in tarball format
 	// parameters:
 	//  - in: path
@@ -284,6 +292,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Export several images
+	// operationId: ImageGetAll
 	// description: Get a tarball containing all images and metadata for several image repositories
 	// parameters:
 	//  - in:  query
@@ -309,6 +318,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: History of an image
+	// operationId: ImageHistory
 	// description: Return parent layers of an image.
 	// parameters:
 	//  - in: path
@@ -333,6 +343,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Inspect an image
+	// operationId: ImageInspect
 	// description: Return low-level information about an image.
 	// parameters:
 	//  - in: path
@@ -357,6 +368,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Tag an image
+	// operationId: ImageTag
 	// description: Tag an image so that it becomes part of a repository.
 	// parameters:
 	//  - in: path
@@ -393,6 +405,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - containers (compat)
 	// summary: New Image
+	// operationId: ImageCommit
 	// description: Create a new image from a container
 	// parameters:
 	//  - in: query
@@ -441,6 +454,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Create image
+	// operationId: ImageBuild
 	// description: Build an image from the given Dockerfile(s)
 	// parameters:
 	//  - in: query

--- a/pkg/api/server/register_info.go
+++ b/pkg/api/server/register_info.go
@@ -9,12 +9,11 @@ import (
 )
 
 func (s *APIServer) registerInfoHandlers(r *mux.Router) error {
-	// swagger:operation GET /info compat getInfo
+	// swagger:operation GET /info compat SystemInfo
 	// ---
 	// tags:
 	//  - system (compat)
 	// summary: Get info
-	// operationId: SystemInfo
 	// description: Returns information on the system and libpod configuration
 	// produces:
 	// - application/json

--- a/pkg/api/server/register_info.go
+++ b/pkg/api/server/register_info.go
@@ -14,6 +14,7 @@ func (s *APIServer) registerInfoHandlers(r *mux.Router) error {
 	// tags:
 	//  - system (compat)
 	// summary: Get info
+	// operationId: SystemInfo
 	// description: Returns information on the system and libpod configuration
 	// produces:
 	// - application/json

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -9,12 +9,11 @@ import (
 )
 
 func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
-	// swagger:operation POST /networks/prune compat compatPruneNetwork
+	// swagger:operation POST /networks/prune compat NetworkPrune
 	// ---
 	// tags:
 	// - networks (compat)
 	// Summary: Delete unused networks
-	// operationId: NetworkPrune
 	// description: Not supported
 	// produces:
 	// - application/json
@@ -23,12 +22,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchNetwork"
 	r.HandleFunc(VersionedPath("/networks/prune"), compat.UnsupportedHandler).Methods(http.MethodPost)
 	r.HandleFunc("/networks/prune", compat.UnsupportedHandler).Methods(http.MethodPost)
-	// swagger:operation DELETE /networks/{name} compat compatRemoveNetwork
+	// swagger:operation DELETE /networks/{name} compat NetworkDelete
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: Remove a network
-	// operationId: NetworkDelete
 	// description: Remove a network
 	// parameters:
 	//  - in: path
@@ -47,12 +45,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks/{name}"), s.APIHandler(compat.RemoveNetwork)).Methods(http.MethodDelete)
 	r.HandleFunc("/networks/{name}", s.APIHandler(compat.RemoveNetwork)).Methods(http.MethodDelete)
-	// swagger:operation GET /networks/{name} compat compatInspectNetwork
+	// swagger:operation GET /networks/{name} compat NetworkInspect
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: Inspect a network
-	// operationId: NetworkInspect
 	// description: Display low level configuration network
 	// parameters:
 	//  - in: path
@@ -71,12 +68,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks/{name}"), s.APIHandler(compat.InspectNetwork)).Methods(http.MethodGet)
 	r.HandleFunc("/networks/{name}", s.APIHandler(compat.InspectNetwork)).Methods(http.MethodGet)
-	// swagger:operation GET /networks compat compatListNetwork
+	// swagger:operation GET /networks compat NetworkList
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: List networks
-	// operationId: NetworkList
 	// description: Display summary of network configurations
 	// parameters:
 	//  - in: query
@@ -97,12 +93,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks"), s.APIHandler(compat.ListNetworks)).Methods(http.MethodGet)
 	r.HandleFunc("/networks", s.APIHandler(compat.ListNetworks)).Methods(http.MethodGet)
-	// swagger:operation POST /networks/create compat compatCreateNetwork
+	// swagger:operation POST /networks/create compat NetworkCreate
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: Create network
-	// operationId: NetworkCreate
 	// description: Create a network configuration
 	// produces:
 	// - application/json
@@ -121,12 +116,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks/create"), s.APIHandler(compat.CreateNetwork)).Methods(http.MethodPost)
 	r.HandleFunc("/networks/create", s.APIHandler(compat.CreateNetwork)).Methods(http.MethodPost)
-	// swagger:operation POST /networks/{name}/connect compat compatConnectNetwork
+	// swagger:operation POST /networks/{name}/connect compat NetworkConnect
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: Connect container to network
-	// operationId: NetworkConnect
 	// description: Connect a container to a network.  This endpoint is current a no-op
 	// produces:
 	// - application/json
@@ -150,12 +144,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks/{name}/connect"), s.APIHandler(compat.Connect)).Methods(http.MethodPost)
 	r.HandleFunc("/networks/{name}/connect", s.APIHandler(compat.Connect)).Methods(http.MethodPost)
-	// swagger:operation POST /networks/{name}/disconnect compat compatDisconnectNetwork
+	// swagger:operation POST /networks/{name}/disconnect compat NetworkDisconnect
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: Disconnect container from network
-	// operationId: NetworkDisconnect
 	// description: Disconnect a container from a network.  This endpoint is current a no-op
 	// produces:
 	// - application/json

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -14,6 +14,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	// - networks (compat)
 	// Summary: Delete unused networks
+	// operationId: NetworkPrune
 	// description: Not supported
 	// produces:
 	// - application/json
@@ -27,6 +28,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Remove a network
+	// operationId: NetworkDelete
 	// description: Remove a network
 	// parameters:
 	//  - in: path
@@ -50,6 +52,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Inspect a network
+	// operationId: NetworkInspect
 	// description: Display low level configuration network
 	// parameters:
 	//  - in: path
@@ -73,6 +76,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: List networks
+	// operationId: NetworkList
 	// description: Display summary of network configurations
 	// parameters:
 	//  - in: query
@@ -98,6 +102,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Create network
+	// operationId: NetworkCreate
 	// description: Create a network configuration
 	// produces:
 	// - application/json
@@ -121,6 +126,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Connect container to network
+	// operationId: NetworkConnect
 	// description: Connect a container to a network.  This endpoint is current a no-op
 	// produces:
 	// - application/json
@@ -149,6 +155,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Disconnect container from network
+	// operationId: NetworkDisconnect
 	// description: Disconnect a container from a network.  This endpoint is current a no-op
 	// produces:
 	// - application/json

--- a/pkg/api/server/register_version.go
+++ b/pkg/api/server/register_version.go
@@ -8,10 +8,9 @@ import (
 )
 
 func (s *APIServer) registerVersionHandlers(r *mux.Router) error {
-	// swagger:operation GET /version compat CompatSystemVersion
+	// swagger:operation GET /version compat SystemVersion
 	// ---
 	// summary: Component Version information
-	// operationId: SystemVersion
 	// tags:
 	// - system (compat)
 	// produces:

--- a/pkg/api/server/register_version.go
+++ b/pkg/api/server/register_version.go
@@ -11,6 +11,7 @@ func (s *APIServer) registerVersionHandlers(r *mux.Router) error {
 	// swagger:operation GET /version compat CompatSystemVersion
 	// ---
 	// summary: Component Version information
+	// operationId: SystemVersion
 	// tags:
 	// - system (compat)
 	// produces:

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -140,12 +140,11 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	 * Docker compatibility endpoints
 	 */
 
-	// swagger:operation GET /volumes compat listVolumes
+	// swagger:operation GET /volumes compat VolumeList
 	// ---
 	// tags:
 	//  - volumes (compat)
 	// summary: List volumes
-	// operationId: VolumeList
 	// description: Returns a list of volume
 	// produces:
 	// - application/json
@@ -169,12 +168,11 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/volumes"), s.APIHandler(compat.ListVolumes)).Methods(http.MethodGet)
 	r.Handle("/volumes", s.APIHandler(compat.ListVolumes)).Methods(http.MethodGet)
 
-	// swagger:operation POST /volumes/create compat createVolume
+	// swagger:operation POST /volumes/create compat VolumeCreate
 	// ---
 	// tags:
 	//  - volumes (compat)
 	// summary: Create a volume
-	// operationId: VolumeCreate
 	// parameters:
 	//  - in: body
 	//    name: create
@@ -193,12 +191,11 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/volumes/create"), s.APIHandler(compat.CreateVolume)).Methods(http.MethodPost)
 	r.Handle("/volumes/create", s.APIHandler(compat.CreateVolume)).Methods(http.MethodPost)
 
-	// swagger:operation GET /volumes/{name} compat inspectVolume
+	// swagger:operation GET /volumes/{name} compat VolumeInspect
 	// ---
 	// tags:
 	//  - volumes (compat)
 	// summary: Inspect volume
-	// operationId: VolumeInspect
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -217,12 +214,11 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/volumes/{name}"), s.APIHandler(compat.InspectVolume)).Methods(http.MethodGet)
 	r.Handle("/volumes/{name}", s.APIHandler(compat.InspectVolume)).Methods(http.MethodGet)
 
-	// swagger:operation DELETE /volumes/{name} compat removeVolume
+	// swagger:operation DELETE /volumes/{name} compat VolumeDelete
 	// ---
 	// tags:
 	//  - volumes (compat)
 	// summary: Remove volume
-	// operationId: VolumeDelete
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -250,12 +246,11 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/volumes/{name}"), s.APIHandler(compat.RemoveVolume)).Methods(http.MethodDelete)
 	r.Handle("/volumes/{name}", s.APIHandler(compat.RemoveVolume)).Methods(http.MethodDelete)
 
-	// swagger:operation POST /volumes/prune compat pruneVolumes
+	// swagger:operation POST /volumes/prune compat VolumePrune
 	// ---
 	// tags:
 	//  - volumes (compat)
 	// summary: Prune volumes
-	// operationId: VolumePrune
 	// produces:
 	// - application/json
 	// parameters:

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -145,6 +145,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// tags:
 	//  - volumes (compat)
 	// summary: List volumes
+	// operationId: VolumeList
 	// description: Returns a list of volume
 	// produces:
 	// - application/json
@@ -173,6 +174,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// tags:
 	//  - volumes (compat)
 	// summary: Create a volume
+	// operationId: VolumeCreate
 	// parameters:
 	//  - in: body
 	//    name: create
@@ -196,6 +198,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// tags:
 	//  - volumes (compat)
 	// summary: Inspect volume
+	// operationId: VolumeInspect
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -219,6 +222,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// tags:
 	//  - volumes (compat)
 	// summary: Remove volume
+	// operationId: VolumeDelete
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -251,6 +255,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// tags:
 	//  - volumes (compat)
 	// summary: Prune volumes
+	// operationId: VolumePrune
 	// produces:
 	// - application/json
 	// parameters:


### PR DESCRIPTION
@jwhonce @baude ptal.

I only added operationIds to to match with the docker ones.
You may want to add operationIds to the operations specific to podman too.