### PR TITLE
e2e tests: synchronize test results

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -84,6 +85,7 @@ type testResultsSortedLength struct{ testResultsSorted }
 func (a testResultsSorted) Less(i, j int) bool { return a[i].length < a[j].length }
 
 var testResults []testResult
+var testResultsMutex sync.Mutex
 
 func TestMain(m *testing.M) {
 	if reexec.Init() {
@@ -349,7 +351,9 @@ func (p *PodmanTestIntegration) InspectContainer(name string) []define.InspectCo
 
 func processTestResult(f GinkgoTestDescription) {
 	tr := testResult{length: f.Duration.Seconds(), name: f.TestText}
+	testResultsMutex.Lock()
 	testResults = append(testResults, tr)
+	testResultsMutex.Unlock()
 }
 
 func GetPortLock(port string) storage.Locker {


### PR DESCRIPTION
Use a mutex to synchronize the slice for storing tests results.
Running the e2e tests in parallel is otherwise subject to race
conditions surfacing in lost entries.

Fixes: #8358
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
