### PR TITLE
[No merge] swagger: add missing parameters

### DIFF
--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -21,6 +21,19 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//      name: name
 	//      type: string
 	//      description: container name
+	//    - in: body
+	//      name: body
+	//      description: Container to create
+	//      schema:
+	//        allOf:
+	//          - $ref: "#/definitions/ContainerConfig"
+	//          - type: object
+	//            properties:
+	//              HostConfig:
+	//                $ref: "#/definitions/HostConfig"
+	//              NetworkingConfig:
+	//                $ref: "#/definitions/NetworkingConfig"
+	//      required: true
 	//   responses:
 	//     201:
 	//       $ref: "#/responses/ContainerCreateResponse"
@@ -365,6 +378,10 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    type: boolean
 	//    default: true
 	//    description: Stream the output
+	//  - in: query
+	//    name: one-shot
+	//    type: boolean
+	//    default: false
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -31,18 +31,31 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    type: string
 	//    description: needs description
 	//  - in: query
+	//    name: repo
+	//    description: the repository name for the created image
+	//    type: string
+	//  - in: query
 	//    name: tag
 	//    type: string
 	//    description: needs description
+	//  - in: query
+	//    name: message
+	//    description: commit message
+	//    type: string
 	//  - in: header
 	//    name: X-Registry-Auth
 	//    type: string
 	//    description: A base64-encoded auth configuration.
 	//  - in: body
-	//    name: request
+	//    name: inputImage
 	//    schema:
 	//      type: string
 	//    description: Image content if fromSrc parameter was used
+	//  - in: query
+	//    name: platform
+	//    description: Platform in the format os[/arch[/variant]]
+	//    type: string
+	//    default: ""
 	// responses:
 	//   200:
 	//     $ref: "#/responses/ok"
@@ -423,6 +436,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    name: changes
 	//    type: string
 	//    description: instructions to apply while committing in Dockerfile format
+	//  - in: body
+	//    name: containerConfig
+	//    description: The container configuration
+	//    schema:
+	//      $ref: "#/definitions/ContainerConfig"
 	// produces:
 	// - application/json
 	// responses:
@@ -624,6 +642,21 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    description: |
 	//      output configuration TBD
 	//      (As of version 1.xx)
+	//  - name: inputStream
+	//    in: body
+	//    description: "A tar archive compressed with one of the following algorithms: identity (no compression), gzip, bzip2, xz."
+	//    schema:
+	//      type: string
+	//      format: binary
+	//  - name: Content-type
+	//    in: header
+	//    type: string
+	//    enum:
+	//      - application/x-tar
+	//    default: application/x-tar
+	//  - name: X-Registry-Config
+	//    in: header
+	//    type: string
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -57,6 +57,13 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    type: string
 	//    required: true
 	//    description: the name of the network
+	//  - in: query
+	//    name: verbose
+	//    type: boolean
+	//    default: false
+	//  - in: query
+	//    name: scope
+	//    type: string
 	// produces:
 	// - application/json
 	// responses:


### PR DESCRIPTION
@jwhonce @baude this PR gives an overview of parameters which are missing in podman swagger compared to docker.

This PR isn't meant for merging. You can go over the parameters and see which you want to add, and which you won't support.