### PR TITLE
podman build --pull: use correct policy

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -266,7 +266,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 
 	pullPolicy := imagebuildah.PullIfMissing
 	if c.Flags().Changed("pull") && flags.Pull {
-		pullPolicy = imagebuildah.PullAlways
+		pullPolicy = imagebuildah.PullIfNewer
 	}
 	if flags.PullAlways {
 		pullPolicy = imagebuildah.PullAlways

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -29,6 +29,29 @@ EOF
     run_podman rmi -f build_test
 }
 
+@test "podman build - basic test with --pull" {
+    rand_filename=$(random_string 20)
+    rand_content=$(random_string 50)
+
+    run_podman tag $IMAGE localhost/localonly
+
+    tmpdir=$PODMAN_TMPDIR/build-test
+    mkdir -p $tmpdir
+    dockerfile=$tmpdir/Dockerfile
+    cat >$dockerfile <<EOF
+FROM localhost/localonly
+RUN echo $rand_content > /$rand_filename
+EOF
+    # With --pull, Podman would try to pull a newer image but use the local one
+    # if present. See #9111.
+    run_podman build --pull -t build_test $tmpdir
+
+    run_podman run --rm build_test cat /$rand_filename
+    is "$output"   "$rand_content"   "reading generated file in image"
+
+    run_podman rmi -f build_test localhost/localonly
+}
+
 @test "podman build - global runtime flags test" {
     skip_if_remote "--runtime-flag flag not supported for remote"
 


### PR DESCRIPTION
The `--pull` flag should be using the "pull if newer" pull policy rather
than "pull always".  This aligns with what the help message states, what
Buildah does and, according to #9111, what was done before,

Also add a test to prevent future regressions.

Fixes: #9111
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
