### PR TITLE
Cirrus: Build static podman-remote

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -342,7 +342,7 @@ static_alt_build_task:
         - build
     # Community-maintained task, may fail on occasion.  If so, uncomment
     # the next line and file an issue with details about the failure.
-    allow_failures: $CI == $CI
+    # allow_failures: $CI == $CI
     gce_instance: *bigvm
     env:
         <<: *stdenvars

--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -39,6 +39,7 @@ filtered_changes=$(git diff --name-status $base $head |
                        egrep -v  '^contrib/'          |
                        egrep -v  '^docs/'             |
                        egrep -v  '^hack/'             |
+                       egrep -v  '^nix/'              |
                        egrep -v  '^vendor/'           |
                        egrep -v  '^version/')
 if [[ -z "$filtered_changes" ]]; then

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -49,9 +49,11 @@ let
     buildPhase = ''
       patchShebangs .
       make bin/podman
+      make bin/podman-remote
     '';
     installPhase = ''
       install -Dm755 bin/podman $out/bin/podman
+      install -Dm755 bin/podman-remote $out/bin/podman-remote
     '';
   };
 in self


### PR DESCRIPTION
Prior to this commit, the "Static Build" task only produced a
`bin/podman`.  Update this to also include a `bin/podman-remote`
binary.

Update the pr-should-include-tests checker to ignore the `nix`
directory, which isn't applicable.

Lastly, restore the static build task to 'required' for CI success.
Leaving the comment inplace in case it needs to be bypassed in the
future on short notice.

Signed-off-by: Chris Evich <cevich@redhat.com>