### PR TITLE
[v2.2.1-rhel] Cirrus: Upd. ext. service check host list

### DIFF
--- a/contrib/cirrus/required_host_ports.txt
+++ b/contrib/cirrus/required_host_ports.txt
@@ -2,14 +2,3 @@ github.com 22
 docker.io 443
 quay.io 443
 registry.fedoraproject.org 443
-mirrors.fedoraproject.org 443
-dl.fedoraproject.org 443
-ewr.edge.kernel.org 443
-mirror.chpc.utah.edu 443
-mirror.clarkson.edu 443
-mirror.umd.edu 443
-mirror.vcu.edu 443
-mirrors.cat.pdx.edu 443
-pubmirror1.math.uh.edu 443
-pubmirror2.math.uh.edu 443
-sjc.edge.kernel.org 443


### PR DESCRIPTION
Backport from master to [address cirrus-cron branch build failure.](https://cirrus-ci.com/build/6016509103308800)