### PR TITLE
Podman-remote push can support --format 

### DIFF
--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -98,7 +98,7 @@ func pushFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(digestfileFlagName, completion.AutocompleteDefault)
 
 	formatFlagName := "format"
-	flags.StringVarP(&pushOptions.Format, formatFlagName, "f", "", "Manifest type (oci, v2s1, or v2s2) to use when pushing an image using the 'dir' transport (default is manifest type of source)")
+	flags.StringVarP(&pushOptions.Format, formatFlagName, "f", "", "Manifest type (oci, v2s2, or v2s1) to use when pushing an image using the 'dir' transport (default is manifest type of source)")
 	_ = cmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteManifestFormat)
 
 	flags.BoolVarP(&pushOptions.Quiet, "quiet", "q", false, "Suppress output information when pushing images")
@@ -115,7 +115,6 @@ func pushFlags(cmd *cobra.Command) {
 		_ = flags.MarkHidden("cert-dir")
 		_ = flags.MarkHidden("compress")
 		_ = flags.MarkHidden("digestfile")
-		_ = flags.MarkHidden("format")
 		_ = flags.MarkHidden("quiet")
 		_ = flags.MarkHidden("remove-signatures")
 		_ = flags.MarkHidden("sign-by")

--- a/docs/source/markdown/podman-push.1.md
+++ b/docs/source/markdown/podman-push.1.md
@@ -90,8 +90,7 @@ solely for scripting compatibility.
 
 #### **--format**, **-f**=*format*
 
-Manifest Type (oci, v2s1, or v2s2) to use when pushing an image to a directory using the 'dir:' transport (default is manifest type of source)
-Note: This flag can only be set when using the **dir** transport. (Not available for remote commands)
+Manifest Type (oci, v2s2, or v2s1) to use when pushing an image.
 
 #### **--quiet**, **-q**
 

--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v2/libpod"
 	"github.com/containers/podman/v2/pkg/api/handlers/utils"
 	"github.com/containers/podman/v2/pkg/auth"
@@ -27,8 +28,9 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		All         bool   `schema:"all"`
 		Compress    bool   `schema:"compress"`
 		Destination string `schema:"destination"`
-		Tag         string `schema:"tag"`
+		Format      string `schema:"format"`
 		TLSVerify   bool   `schema:"tlsVerify"`
+		Tag         string `schema:"tag"`
 	}{
 		// This is where you can override the golang default value for one of fields
 		TLSVerify: true,
@@ -67,8 +69,12 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		All:      query.All,
 		Authfile: authfile,
 		Compress: query.Compress,
-		Username: username,
+		Format:   query.Format,
 		Password: password,
+		Username: username,
+	}
+	if _, found := r.URL.Query()["tlsVerify"]; found {
+		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)
 	}
 	if err := imageEngine.Push(context.Background(), imageName, query.Destination, options); err != nil {
 		if errors.Cause(err) != storage.ErrImageUnknown {

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -106,6 +106,8 @@ type PushOptions struct {
 	Authfile *string
 	// Compress tarball image layers when pushing to a directory using the 'dir' transport.
 	Compress *bool
+	// Manifest type of the pushed image
+	Format *string
 	// Password for authenticating against the registry.
 	Password *string
 	// SkipTLSVerify to skip HTTPS and certificate verification.

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -135,6 +135,22 @@ func (o *PushOptions) GetCompress() bool {
 	return *o.Compress
 }
 
+// WithFormat
+func (o *PushOptions) WithFormat(value string) *PushOptions {
+	v := &value
+	o.Format = v
+	return o
+}
+
+// GetFormat
+func (o *PushOptions) GetFormat() string {
+	var format string
+	if o.Format == nil {
+		return format
+	}
+	return *o.Format
+}
+
 // WithPassword
 func (o *PushOptions) WithPassword(value string) *PushOptions {
 	v := &value

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -236,7 +236,7 @@ func (ir *ImageEngine) Import(ctx context.Context, opts entities.ImageImportOpti
 
 func (ir *ImageEngine) Push(ctx context.Context, source string, destination string, opts entities.ImagePushOptions) error {
 	options := new(images.PushOptions)
-	options.WithAll(opts.All).WithCompress(opts.Compress).WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile)
+	options.WithAll(opts.All).WithCompress(opts.Compress).WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithFormat(opts.Format)
 
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to local registry", func() {
-		SkipIfRemote("Remote does not support --digestfile or --remove-sginatures")
+		SkipIfRemote("Remote does not support --digestfile or --remove-signatures")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
@@ -145,7 +145,7 @@ var _ = Describe("Podman push", func() {
 		session = podmanTest.Podman([]string{"logs", "registry"})
 		session.WaitWithDefaultTimeout()
 
-		push := podmanTest.Podman([]string{"push", "--creds=podmantest:test", ALPINE, "localhost:5000/tlstest"})
+		push := podmanTest.Podman([]string{"push", "--format=v2s2", "--creds=podmantest:test", ALPINE, "localhost:5000/tlstest"})
 		push.WaitWithDefaultTimeout()
 		Expect(push).To(ExitWithError())
 


### PR DESCRIPTION
Fix man page to document podman push --format fully.

Also found that push was not handling the tlsverify so fixed this.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>