### PR TITLE
Docker ignores mount flags that begin with constency

### DIFF
--- a/cmd/podman/common/volumes.go
+++ b/cmd/podman/common/volumes.go
@@ -353,6 +353,10 @@ func getBindMount(args []string) (spec.Mount, error) {
 			default:
 				return newMount, errors.Wrapf(util.ErrBadMntOption, "%s mount option must be 'private' or 'shared'", kv[0])
 			}
+		case "consistency":
+			// Often used on MACs and mistakenly on Linux platforms.
+			// Since Docker ignores this option so shall we.
+			continue
 		default:
 			return newMount, errors.Wrapf(util.ErrBadMntOption, kv[0])
 		}
@@ -437,6 +441,10 @@ func getTmpfsMount(args []string) (spec.Mount, error) {
 			}
 			newMount.Destination = filepath.Clean(kv[1])
 			setDest = true
+		case "consistency":
+			// Often used on MACs and mistakenly on Linux platforms.
+			// Since Docker ignores this option so shall we.
+			continue
 		default:
 			return newMount, errors.Wrapf(util.ErrBadMntOption, kv[0])
 		}
@@ -534,6 +542,10 @@ func getNamedVolume(args []string) (*specgen.NamedVolume, error) {
 			}
 			newVolume.Dest = filepath.Clean(kv[1])
 			setDest = true
+		case "consistency":
+			// Often used on MACs and mistakenly on Linux platforms.
+			// Since Docker ignores this option so shall we.
+			continue
 		default:
 			return nil, errors.Wrapf(util.ErrBadMntOption, kv[0])
 		}
@@ -581,6 +593,10 @@ func getImageVolume(args []string) (*specgen.ImageVolume, error) {
 			default:
 				return nil, errors.Wrapf(util.ErrBadMntOption, "invalid rw value %q", kv[1])
 			}
+		case "consistency":
+			// Often used on MACs and mistakenly on Linux platforms.
+			// Since Docker ignores this option so shall we.
+			continue
 		default:
 			return nil, errors.Wrapf(util.ErrBadMntOption, kv[0])
 		}

--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -86,6 +86,10 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 				return nil, errors.Wrapf(ErrDupeMntOption, "the 'tmpcopyup' or 'notmpcopyup' option can only be set once")
 			}
 			foundCopyUp = true
+		case "consistency":
+			// Often used on MACs and mistakenly on Linux platforms.
+			// Since Docker ignores this option so shall we.
+			continue
 		case "notmpcopyup":
 			if !isTmpfs {
 				return nil, errors.Wrapf(ErrBadMntOption, "the 'notmpcopyup' option is only allowed with tmpfs mounts")

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring(dest + " ro"))
 
-		session = podmanTest.Podman([]string{"run", "--rm", "--mount", mount + ",shared", ALPINE, "grep", dest, "/proc/self/mountinfo"})
+		session = podmanTest.Podman([]string{"run", "--rm", "--mount", mount + ",consistency=delegated,shared", ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		found, matches := session.GrepString(dest)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1915332

```
According to the Docker docs, the consistency option should be ignored on Linux.

the possible values are 'cached', 'delegated', and 'consistent', but they should be ignored equally.

This is a widely used option in scripts run by developer machines, as this makes file I/O less horribly slow on MacOS.
```

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
