### PR TITLE
Fix --network parsing for podman pod create

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -171,33 +171,6 @@ func create(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	createOptions.Net.Network = specgen.Namespace{}
-	if cmd.Flag("network").Changed {
-		netInput, err := cmd.Flags().GetString("network")
-		if err != nil {
-			return err
-		}
-		parts := strings.SplitN(netInput, ":", 2)
-
-		n := specgen.Namespace{}
-		switch {
-		case netInput == "bridge":
-			n.NSMode = specgen.Bridge
-		case netInput == "host":
-			n.NSMode = specgen.Host
-		case netInput == "slirp4netns", strings.HasPrefix(netInput, "slirp4netns:"):
-			n.NSMode = specgen.Slirp
-			if len(parts) > 1 {
-				createOptions.Net.NetworkOptions = make(map[string][]string)
-				createOptions.Net.NetworkOptions[parts[0]] = strings.Split(parts[1], ",")
-			}
-		default:
-			// Container and NS mode are presently unsupported
-			n.NSMode = specgen.Bridge
-			createOptions.Net.CNINetworks = strings.Split(netInput, ",")
-		}
-		createOptions.Net.Network = n
-	}
 	if len(createOptions.Net.PublishPorts) > 0 {
 		if !createOptions.Infra {
 			return errors.Errorf("you must have an infra container to publish port bindings to the host")

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -476,4 +476,21 @@ entrypoint ["/fromimage"]
 		Expect(status3.ExitCode()).To(Equal(0))
 		Expect(strings.Contains(status3.OutputToString(), "Degraded")).To(BeTrue())
 	})
+
+	It("podman create with unsupported network options", func() {
+		podCreate := podmanTest.Podman([]string{"pod", "create", "--network", "none"})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate.ExitCode()).To(Equal(125))
+		Expect(podCreate.ErrorToString()).To(ContainSubstring("pods presently do not support network mode none"))
+
+		podCreate = podmanTest.Podman([]string{"pod", "create", "--network", "container:doesnotmatter"})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate.ExitCode()).To(Equal(125))
+		Expect(podCreate.ErrorToString()).To(ContainSubstring("pods presently do not support network mode container"))
+
+		podCreate = podmanTest.Podman([]string{"pod", "create", "--network", "ns:/does/not/matter"})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate.ExitCode()).To(Equal(125))
+		Expect(podCreate.ErrorToString()).To(ContainSubstring("pods presently do not support network mode path"))
+	})
 })


### PR DESCRIPTION
The `--network` flag is parsed differently for `podman pod create`.
This causes confusion and problems for users. The extra parsing
logic ignored unsupported network options such as `none`,
`container:...` and `ns:...` and instead interpreted them as cni
network names.

Tests are added to ensure the correct errors are shown.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
