### PR TITLE
Endpoint that lists containers does not return correct Status value

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
+	"github.com/docker/go-units"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/schema"
 	"github.com/pkg/errors"
@@ -264,6 +265,7 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 		sizeRootFs int64
 		sizeRW     int64
 		state      define.ContainerStatus
+		status     string
 	)
 
 	if state, err = l.State(); err != nil {
@@ -272,6 +274,35 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 	stateStr := state.String()
 	if stateStr == "configured" {
 		stateStr = "created"
+	}
+
+	if state == define.ContainerStateConfigured || state == define.ContainerStateCreated {
+		status = "Created"
+	} else if state == define.ContainerStateStopped || state == define.ContainerStateExited {
+		exitCode, _, err := l.ExitCode()
+		if err != nil {
+			return nil, err
+		}
+		finishedTime, err := l.FinishedTime()
+		if err != nil {
+			return nil, err
+		}
+		status = fmt.Sprintf("Exited (%d) %s ago", exitCode, units.HumanDuration(time.Since(finishedTime)))
+	} else if state == define.ContainerStateRunning || state == define.ContainerStatePaused {
+		startedTime, err := l.StartedTime()
+		if err != nil {
+			return nil, err
+		}
+		status = fmt.Sprintf("Up %s", units.HumanDuration(time.Since(startedTime)))
+		if state == define.ContainerStatePaused {
+			status += " (Paused)"
+		}
+	} else if state == define.ContainerStateRemoving {
+		status = "Removal In Progress"
+	} else if state == define.ContainerStateStopping {
+		status = "Stopping"
+	} else {
+		status = "Unknown"
 	}
 
 	if sz {
@@ -295,7 +326,7 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 		SizeRootFs: sizeRootFs,
 		Labels:     l.Labels(),
 		State:      stateStr,
-		Status:     "",
+		Status:     status,
 		HostConfig: struct {
 			NetworkMode string `json:",omitempty"`
 		}{

--- a/test/apiv2/rest_api/test_rest_v2_0_0.py
+++ b/test/apiv2/rest_api/test_rest_v2_0_0.py
@@ -1,7 +1,6 @@
 import json
 import os
 import random
-import shutil
 import string
 import subprocess
 import sys
@@ -357,6 +356,7 @@ class TestApi(unittest.TestCase):
 
     def test_search_compat(self):
         url = PODMAN_URL + "/v1.40/images/search"
+
         # Had issues with this test hanging when repositories not happy
         def do_search1():
             payload = {'term': 'alpine'}
@@ -618,6 +618,53 @@ class TestApi(unittest.TestCase):
         # TODO should handler be recursive when deleting images?
         # self.assertIn(img["Id"], prune_payload["ImagesDeleted"][1]["Deleted"])
         self.assertIsNotNone(prune_payload["ImagesDeleted"][1]["Deleted"])
+
+    def test_status_compat(self):
+        r = requests.post(PODMAN_URL + "/v1.40/containers/create?name=topcontainer",
+                          json={"Cmd": ["top"], "Image": "alpine:latest"})
+        self.assertEqual(r.status_code, 201, r.text)
+        payload = json.loads(r.text)
+        container_id = payload["Id"]
+        self.assertIsNotNone(container_id)
+
+        r = requests.get(PODMAN_URL + "/v1.40/containers/json",
+                         params={'all': 'true', 'filters': f'{{"id":["{container_id}"]}}'})
+        self.assertEqual(r.status_code, 200, r.text)
+        payload = json.loads(r.text)
+        self.assertEqual(payload[0]["Status"], "Created")
+
+        r = requests.post(PODMAN_URL + f"/v1.40/containers/{container_id}/start")
+        self.assertEqual(r.status_code, 204, r.text)
+
+        r = requests.get(PODMAN_URL + "/v1.40/containers/json",
+                         params={'all': 'true', 'filters': f'{{"id":["{container_id}"]}}'})
+        self.assertEqual(r.status_code, 200, r.text)
+        payload = json.loads(r.text)
+        self.assertTrue(str(payload[0]["Status"]).startswith("Up"))
+
+        r = requests.post(PODMAN_URL + f"/v1.40/containers/{container_id}/pause")
+        self.assertEqual(r.status_code, 204, r.text)
+
+        r = requests.get(PODMAN_URL + "/v1.40/containers/json",
+                         params={'all': 'true', 'filters': f'{{"id":["{container_id}"]}}'})
+        self.assertEqual(r.status_code, 200, r.text)
+        payload = json.loads(r.text)
+        self.assertTrue(str(payload[0]["Status"]).startswith("Up"))
+        self.assertTrue(str(payload[0]["Status"]).endswith("(Paused)"))
+
+        r = requests.post(PODMAN_URL + f"/v1.40/containers/{container_id}/unpause")
+        self.assertEqual(r.status_code, 204, r.text)
+        r = requests.post(PODMAN_URL + f"/v1.40/containers/{container_id}/stop")
+        self.assertEqual(r.status_code, 204, r.text)
+
+        r = requests.get(PODMAN_URL + "/v1.40/containers/json",
+                         params={'all': 'true', 'filters': f'{{"id":["{container_id}"]}}'})
+        self.assertEqual(r.status_code, 200, r.text)
+        payload = json.loads(r.text)
+        self.assertTrue(str(payload[0]["Status"]).startswith("Exited"))
+
+        r = requests.delete(PODMAN_URL + f"/v1.40/containers/{container_id}")
+        self.assertEqual(r.status_code, 204, r.text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Eclipse and Intellij Docker plugin determines the state of the
container via the Status field, returned from /containers/json call.
Podman always returns empty string, and because of that, both IDEs
show the wrong state of the container.

Signed-off-by: Milivoje Legenovic <m.legenovic@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
