### PR TITLE
Make slirp MTU configurable (network_cmd_options)

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -817,6 +817,7 @@ func AutocompleteNetworkFlag(cmd *cobra.Command, args []string, toComplete strin
 				"allow_host_loopback=": getBoolCompletion,
 				"cidr=":                nil,
 				"enable_ipv6=":         getBoolCompletion,
+				"mtu=":                 nil,
 				"outbound_addr=":       nil,
 				"outbound_addr6=":      nil,
 				"port_handler=": func(_ string) ([]string, cobra.ShellCompDirective) {

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -638,6 +638,7 @@ Valid _mode_ values are:
 - **private**: create a new namespace for the container (default)
 - **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options:
   - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
+  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
   - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
   - **enable_ipv6=true|false**: Enable IPv6. Default is false. (Required for `outbound_addr6`).
   - **outbound_addr=INTERFACE**: Specify the outbound interface slirp should bind to (ipv4 traffic only).

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -674,6 +674,7 @@ Valid _mode_ values are:
 - **private**: create a new namespace for the container (default)
 - **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options:
   - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
+  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
   - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
   - **enable_ipv6=true|false**: Enable IPv6. Default is false. (Required for `outbound_addr6`).
   - **outbound_addr=INTERFACE**: Specify the outbound interface slirp should bind to (ipv4 traffic only).

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -42,6 +43,9 @@ const (
 
 	// slirp4netnsDNS is the IP for the built-in DNS server in the slirp network
 	slirp4netnsDNS = "10.0.2.3"
+
+	// slirp4netnsMTU the default MTU override
+	slirp4netnsMTU = 65520
 )
 
 // Get an OCICNI network config
@@ -282,6 +286,7 @@ func (r *Runtime) setupSlirp4netns(ctr *Container) error {
 	enableIPv6 := false
 	outboundAddr := ""
 	outboundAddr6 := ""
+	mtu := slirp4netnsMTU
 
 	if ctr.config.NetworkOptions != nil {
 		slirpOptions = append(slirpOptions, ctr.config.NetworkOptions["slirp4netns"]...)
@@ -345,6 +350,11 @@ func (r *Runtime) setupSlirp4netns(ctr *Container) error {
 				}
 			}
 			outboundAddr6 = value
+		case "mtu":
+			mtu, err = strconv.Atoi(value)
+			if mtu < 68 || err != nil {
+				return errors.Errorf("invalid mtu %q", value)
+			}
 		default:
 			return errors.Errorf("unknown option for slirp4netns: %q", o)
 		}
@@ -358,8 +368,8 @@ func (r *Runtime) setupSlirp4netns(ctr *Container) error {
 	if disableHostLoopback && slirpFeatures.HasDisableHostLoopback {
 		cmdArgs = append(cmdArgs, "--disable-host-loopback")
 	}
-	if slirpFeatures.HasMTU {
-		cmdArgs = append(cmdArgs, "--mtu", "65520")
+	if mtu > -1 && slirpFeatures.HasMTU {
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--mtu=%d", mtu))
 	}
 	if !noPivotRoot && slirpFeatures.HasEnableSandbox {
 		cmdArgs = append(cmdArgs, "--enable-sandbox")

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -376,6 +376,13 @@ var _ = Describe("Podman run networking", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman run slirp4netns network with mtu", func() {
+		session := podmanTest.Podman([]string{"run", "--network", "slirp4netns:mtu=9000", ALPINE, "ip", "addr"})
+		session.Wait(30)
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("mtu 9000"))
+	})
+
 	It("podman run slirp4netns network with different cidr", func() {
 		slirp4netnsHelp := SystemExec("slirp4netns", []string{"--help"})
 		Expect(slirp4netnsHelp.ExitCode()).To(Equal(0))


### PR DESCRIPTION
The mtu default value is currently forced to 65520.
This let the user control it using the config key network_cmd_options,
i.e.: network_cmd_options=["mtu=9000"]
