### PR TITLE
Bump remote API version to 3.0.0

### DIFF
--- a/pkg/api/handlers/utils/handler.go
+++ b/pkg/api/handlers/utils/handler.go
@@ -43,8 +43,8 @@ var (
 	//       clients to shop for the Version they wish to support
 	APIVersion = map[VersionTree]map[VersionLevel]semver.Version{
 		LibpodTree: {
-			CurrentAPIVersion: semver.MustParse("2.0.0"),
-			MinimalAPIVersion: semver.MustParse("2.0.0"),
+			CurrentAPIVersion: semver.MustParse("3.0.0"),
+			MinimalAPIVersion: semver.MustParse("3.0.0"),
 		},
 		CompatTree: {
 			CurrentAPIVersion: semver.MustParse("1.40.0"),

--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -18,8 +18,8 @@ t HEAD libpod/_ping 200
 for i in /version version; do
     t GET  $i      200                           \
       .Components[0].Name="Podman Engine"        \
-      .Components[0].Details.APIVersion=2.0.0    \
-      .Components[0].Details.MinAPIVersion=2.0.0 \
+      .Components[0].Details.APIVersion=3.0.0    \
+      .Components[0].Details.MinAPIVersion=3.0.0 \
       .Components[0].Details.Os=linux            \
       .ApiVersion=1.40                          \
       .MinAPIVersion=1.24                       \


### PR DESCRIPTION
Fixes #9175

I thought I did this during the initial bump to v3.0.0-dev a few months back, but evidently not.