### PR TITLE
[3.0] podman build --pull: refine help message and docs

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -106,7 +106,9 @@ func buildFlags(cmd *cobra.Command) {
 		logrus.Errorf("unable to set --pull to true: %v", err)
 	}
 	flag.DefValue = "true"
+	flag.Usage = "Always attempt to pull the image (errors are fatal)"
 	flags.AddFlagSet(&budFlags)
+
 	// Add the completion functions
 	budCompletions := buildahCLI.GetBudFlagsCompletions()
 	completion.CompleteCommandFlags(cmd, budCompletions)

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -455,9 +455,8 @@ not required for Buildah as it supports only Linux.
 
 #### **--pull**
 
-When the option is specified or set to "true", pull the image from the first
-registry it is found in as listed in registries.conf.  Raise an error if not
-found in the registries, even if the image is present locally.
+When the option is specified or set to "true", pull the image.  Raise an error
+if the image could not be pulled, even if the image is present locally.
 
 If the option is disabled (with *--pull=false*) or not specified, pull the
 image from the registry only if the image is not present locally. Raise an


### PR DESCRIPTION
Refine and correct the wording of the `--pull` flag in the help message
and the docs.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@mheon PTAL :)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
