### PR TITLE
Allow pods to use --net=none

### DIFF
--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -93,6 +93,7 @@ type podState struct {
 type InfraContainerConfig struct {
 	ConmonPidFile      string               `json:"conmonPidFile"`
 	HasInfraContainer  bool                 `json:"makeInfraContainer"`
+	NoNetwork          bool                 `json:"noNetwork,omitempty"`
 	HostNetwork        bool                 `json:"infraHostNetwork,omitempty"`
 	PortBindings       []ocicni.PortMapping `json:"infraPortBindings"`
 	StaticIP           net.IP               `json:"staticIP,omitempty"`

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -102,6 +102,9 @@ func createPodOptions(p *specgen.PodSpecGenerator, rt *libpod.Runtime) ([]libpod
 	case specgen.Slirp:
 		logrus.Debugf("Pod will use slirp4netns")
 		options = append(options, libpod.WithPodSlirp4netns(p.NetworkOptions))
+	case specgen.NoNetwork:
+		logrus.Debugf("Pod will not use networking")
+		options = append(options, libpod.WithPodNoNetwork())
 	default:
 		return nil, errors.Errorf("pods presently do not support network mode %s", p.NetNS.NSMode)
 	}

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -478,12 +478,7 @@ entrypoint ["/fromimage"]
 	})
 
 	It("podman create with unsupported network options", func() {
-		podCreate := podmanTest.Podman([]string{"pod", "create", "--network", "none"})
-		podCreate.WaitWithDefaultTimeout()
-		Expect(podCreate.ExitCode()).To(Equal(125))
-		Expect(podCreate.ErrorToString()).To(ContainSubstring("pods presently do not support network mode none"))
-
-		podCreate = podmanTest.Podman([]string{"pod", "create", "--network", "container:doesnotmatter"})
+		podCreate := podmanTest.Podman([]string{"pod", "create", "--network", "container:doesnotmatter"})
 		podCreate.WaitWithDefaultTimeout()
 		Expect(podCreate.ExitCode()).To(Equal(125))
 		Expect(podCreate.ErrorToString()).To(ContainSubstring("pods presently do not support network mode container"))
@@ -492,5 +487,18 @@ entrypoint ["/fromimage"]
 		podCreate.WaitWithDefaultTimeout()
 		Expect(podCreate.ExitCode()).To(Equal(125))
 		Expect(podCreate.ErrorToString()).To(ContainSubstring("pods presently do not support network mode path"))
+	})
+
+	It("podman pod create with --net=none", func() {
+		podName := "testPod"
+		podCreate := podmanTest.Podman([]string{"pod", "create", "--network", "none", "--name", podName})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "ip", "-o", "-4", "addr"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("inet 127.0.0.1/8 scope host lo"))
+		Expect(len(session.OutputToStringArray())).To(Equal(1))
 	})
 })


### PR DESCRIPTION
We need an extra field in the pod infra container config. We may want to reevaluate that struct at some point, as storing network modes as bools will rapidly become unsustainable, but that's a discussion for another time. Otherwise, straightforward plumbing.

Fixes #9165