### PR TITLE
Report StatusConflict on Pod opt partial failures

### DIFF
--- a/pkg/api/handlers/compat/resize.go
+++ b/pkg/api/handlers/compat/resize.go
@@ -84,5 +84,5 @@ func ResizeTTY(w http.ResponseWriter, r *http.Request) {
 		// reasons.
 		status = http.StatusCreated
 	}
-	utils.WriteResponse(w, status, "")
+	w.WriteHeader(status)
 }

--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -43,6 +43,11 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/definitions/IdResponse"
 	//   400:
 	//     $ref: "#/responses/BadParamError"
+	//   409:
+	//     description: status conflict
+	//     schema:
+	//       type: string
+	//       description: message describing error
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/create"), s.APIHandler(libpod.PodCreate)).Methods(http.MethodPost)
@@ -149,7 +154,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   404:
 	//     $ref: "#/responses/NoSuchPod"
 	//   409:
-	//     $ref: "#/responses/ConflictError"
+	//     $ref: "#/responses/PodKillReport"
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/kill"), s.APIHandler(libpod.PodKill)).Methods(http.MethodPost)
@@ -170,6 +175,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/PodPauseReport'
 	//   404:
 	//     $ref: "#/responses/NoSuchPod"
+	//   409:
+	//     $ref: '#/responses/PodPauseReport'
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/pause"), s.APIHandler(libpod.PodPause)).Methods(http.MethodPost)
@@ -189,6 +196,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/PodRestartReport'
 	//   404:
 	//     $ref: "#/responses/NoSuchPod"
+	//   409:
+	//     $ref: "#/responses/PodRestartReport"
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/restart"), s.APIHandler(libpod.PodRestart)).Methods(http.MethodPost)
@@ -210,6 +219,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/PodAlreadyStartedError"
 	//   404:
 	//     $ref: "#/responses/NoSuchPod"
+	//   409:
+	//     $ref: '#/responses/PodStartReport'
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/start"), s.APIHandler(libpod.PodStart)).Methods(http.MethodPost)
@@ -237,6 +248,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/BadParamError"
 	//   404:
 	//     $ref: "#/responses/NoSuchPod"
+	//   409:
+	//     $ref: "#/responses/PodStopReport"
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/stop"), s.APIHandler(libpod.PodStop)).Methods(http.MethodPost)
@@ -256,6 +269,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/PodUnpauseReport'
 	//   404:
 	//     $ref: "#/responses/NoSuchPod"
+	//   409:
+	//     $ref: '#/responses/PodUnpauseReport'
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/unpause"), s.APIHandler(libpod.PodUnpause)).Methods(http.MethodPost)

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -518,27 +518,15 @@ func (s *PodmanSessionIntegration) InspectPodArrToJSON() []define.InspectPodData
 
 // CreatePod creates a pod with no infra container
 // it optionally takes a pod name
-func (p *PodmanTestIntegration) CreatePod(name string) (*PodmanSessionIntegration, int, string) {
-	var podmanArgs = []string{"pod", "create", "--infra=false", "--share", ""}
-	if name != "" {
-		podmanArgs = append(podmanArgs, "--name", name)
+func (p *PodmanTestIntegration) CreatePod(options map[string][]string) (*PodmanSessionIntegration, int, string) {
+	var args = []string{"pod", "create", "--infra=false", "--share", ""}
+	for k, values := range options {
+		for _, v := range values {
+			args = append(args, k+"="+v)
+		}
 	}
-	session := p.Podman(podmanArgs)
-	session.WaitWithDefaultTimeout()
-	return session, session.ExitCode(), session.OutputToString()
-}
 
-// CreatePod creates a pod with no infra container and some labels.
-// it optionally takes a pod name
-func (p *PodmanTestIntegration) CreatePodWithLabels(name string, labels map[string]string) (*PodmanSessionIntegration, int, string) {
-	var podmanArgs = []string{"pod", "create", "--infra=false", "--share", ""}
-	if name != "" {
-		podmanArgs = append(podmanArgs, "--name", name)
-	}
-	for labelKey, labelValue := range labels {
-		podmanArgs = append(podmanArgs, "--label", fmt.Sprintf("%s=%s", labelKey, labelValue))
-	}
-	session := p.Podman(podmanArgs)
+	session := p.Podman(args)
 	session.WaitWithDefaultTimeout()
 	return session, session.ExitCode(), session.OutputToString()
 }

--- a/test/e2e/exists_test.go
+++ b/test/e2e/exists_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Podman image|container exists", func() {
 	})
 
 	It("podman pod exists in local storage by name", func() {
-		setup, _, _ := podmanTest.CreatePod("foobar")
+		setup, _, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar"}})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(Exit(0))
 
@@ -92,7 +92,7 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session).Should(Exit(0))
 	})
 	It("podman pod exists in local storage by container ID", func() {
-		setup, _, podID := podmanTest.CreatePod("")
+		setup, _, podID := podmanTest.CreatePod(nil)
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(Exit(0))
 
@@ -101,7 +101,7 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session).Should(Exit(0))
 	})
 	It("podman pod exists in local storage by short container ID", func() {
-		setup, _, podID := podmanTest.CreatePod("")
+		setup, _, podID := podmanTest.CreatePod(nil)
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(Exit(0))
 

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman generate kube on pod", func() {
-		_, rc, _ := podmanTest.CreatePod("toppod")
+		_, rc, _ := podmanTest.CreatePod(map[string][]string{"--name": {"toppod"}})
 		Expect(rc).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("topcontainer", "toppod")
@@ -221,7 +221,7 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman generate service kube on pod", func() {
-		_, rc, _ := podmanTest.CreatePod("toppod")
+		_, rc, _ := podmanTest.CreatePod(map[string][]string{"--name": {"toppod"}})
 		Expect(rc).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("topcontainer", "toppod")
@@ -373,7 +373,7 @@ var _ = Describe("Podman generate kube", func() {
 
 	It("podman generate and reimport kube on pod", func() {
 		podName := "toppod"
-		_, rc, _ := podmanTest.CreatePod(podName)
+		_, rc, _ := podmanTest.CreatePod(map[string][]string{"--name": {podName}})
 		Expect(rc).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test1", ALPINE, "top"})
@@ -412,7 +412,7 @@ var _ = Describe("Podman generate kube", func() {
 
 	It("podman generate with user and reimport kube on pod", func() {
 		podName := "toppod"
-		_, rc, _ := podmanTest.CreatePod(podName)
+		_, rc, _ := podmanTest.CreatePod(map[string][]string{"--name": {podName}})
 		Expect(rc).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"create", "--pod", podName, "--name", "test1", "--user", "100:200", ALPINE, "top"})

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Podman pod create", func() {
 	})
 
 	It("podman create pod", func() {
-		_, ec, podID := podmanTest.CreatePod("")
+		_, ec, podID := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		check := podmanTest.Podman([]string{"pod", "ps", "-q", "--no-trunc"})
@@ -50,7 +50,7 @@ var _ = Describe("Podman pod create", func() {
 
 	It("podman create pod with name", func() {
 		name := "test"
-		_, ec, _ := podmanTest.CreatePod(name)
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {name}})
 		Expect(ec).To(Equal(0))
 
 		check := podmanTest.Podman([]string{"pod", "ps", "--no-trunc"})
@@ -61,10 +61,10 @@ var _ = Describe("Podman pod create", func() {
 
 	It("podman create pod with doubled name", func() {
 		name := "test"
-		_, ec, _ := podmanTest.CreatePod(name)
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {name}})
 		Expect(ec).To(Equal(0))
 
-		_, ec2, _ := podmanTest.CreatePod(name)
+		_, ec2, _ := podmanTest.CreatePod(map[string][]string{"--name": {name}})
 		Expect(ec2).To(Not(Equal(0)))
 
 		check := podmanTest.Podman([]string{"pod", "ps", "-q"})
@@ -78,7 +78,7 @@ var _ = Describe("Podman pod create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec, _ := podmanTest.CreatePod(name)
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {name}})
 		Expect(ec).To(Not(Equal(0)))
 
 		check := podmanTest.Podman([]string{"pod", "ps", "-q"})

--- a/test/e2e/pod_inspect_test.go
+++ b/test/e2e/pod_inspect_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Podman pod inspect", func() {
 	})
 
 	It("podman inspect a pod", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)

--- a/test/e2e/pod_kill_test.go
+++ b/test/e2e/pod_kill_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Podman pod kill", func() {
 	})
 
 	It("podman pod kill a pod by id", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -58,7 +58,7 @@ var _ = Describe("Podman pod kill", func() {
 	})
 
 	It("podman pod kill a pod by id with TERM", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -72,7 +72,7 @@ var _ = Describe("Podman pod kill", func() {
 	})
 
 	It("podman pod kill a pod by name", func() {
-		_, ec, podid := podmanTest.CreatePod("test1")
+		_, ec, podid := podmanTest.CreatePod(map[string][]string{"--name": {"test1"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -86,7 +86,7 @@ var _ = Describe("Podman pod kill", func() {
 	})
 
 	It("podman pod kill a pod by id with a bogus signal", func() {
-		_, ec, podid := podmanTest.CreatePod("test1")
+		_, ec, podid := podmanTest.CreatePod(map[string][]string{"--name": {"test1"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -100,14 +100,14 @@ var _ = Describe("Podman pod kill", func() {
 	})
 
 	It("podman pod kill latest pod", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec, podid2 := podmanTest.CreatePod("")
+		_, ec, podid2 := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session = podmanTest.RunTopContainerInPod("", podid2)
@@ -128,7 +128,7 @@ var _ = Describe("Podman pod kill", func() {
 
 	It("podman pod kill all", func() {
 		SkipIfRootlessCgroupsV1("Not supported for rootless + CGroupsV1")
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -139,7 +139,7 @@ var _ = Describe("Podman pod kill", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec, podid2 := podmanTest.CreatePod("")
+		_, ec, podid2 := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session = podmanTest.RunTopContainerInPod("", podid2)

--- a/test/e2e/pod_pause_test.go
+++ b/test/e2e/pod_pause_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Podman pod pause", func() {
 	})
 
 	It("podman pod pause a created pod by id", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		result := podmanTest.Podman([]string{"pod", "pause", podid})
@@ -57,7 +57,7 @@ var _ = Describe("Podman pod pause", func() {
 	})
 
 	It("podman pod pause a running pod by id", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -78,7 +78,7 @@ var _ = Describe("Podman pod pause", func() {
 	})
 
 	It("podman unpause a running pod by id", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -93,7 +93,7 @@ var _ = Describe("Podman pod pause", func() {
 	})
 
 	It("podman pod pause a running pod by name", func() {
-		_, ec, _ := podmanTest.CreatePod("test1")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"test1"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", "test1")

--- a/test/e2e/pod_prune_test.go
+++ b/test/e2e/pod_prune_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Podman pod prune", func() {
 	})
 
 	It("podman pod prune empty pod", func() {
-		_, ec, _ := podmanTest.CreatePod("")
+		_, ec, _ := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		result := podmanTest.Podman([]string{"pod", "prune", "--force"})
@@ -42,7 +42,7 @@ var _ = Describe("Podman pod prune", func() {
 	})
 
 	It("podman pod prune doesn't remove a pod with a running container", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		ec2 := podmanTest.RunTopContainerInPod("", podid)
@@ -59,7 +59,7 @@ var _ = Describe("Podman pod prune", func() {
 	})
 
 	It("podman pod prune removes a pod with a stopped container", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		_, ec2, _ := podmanTest.RunLsContainerInPod("", podid)

--- a/test/e2e/pod_restart_test.go
+++ b/test/e2e/pod_restart_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Podman pod restart", func() {
 	})
 
 	It("podman pod restart single empty pod", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"pod", "restart", podid})
@@ -48,7 +48,7 @@ var _ = Describe("Podman pod restart", func() {
 	})
 
 	It("podman pod restart single pod by name", func() {
-		_, ec, _ := podmanTest.CreatePod("foobar99")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("test1", "foobar99")
@@ -68,14 +68,14 @@ var _ = Describe("Podman pod restart", func() {
 	})
 
 	It("podman pod restart multiple pods", func() {
-		_, ec, _ := podmanTest.CreatePod("foobar99")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("test1", "foobar99")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec, _ = podmanTest.CreatePod("foobar100")
+		_, ec, _ = podmanTest.CreatePod(map[string][]string{"--name": {"foobar100"}})
 		Expect(ec).To(Equal(0))
 
 		session = podmanTest.RunTopContainerInPod("test2", "foobar100")
@@ -106,14 +106,14 @@ var _ = Describe("Podman pod restart", func() {
 	})
 
 	It("podman pod restart all pods", func() {
-		_, ec, _ := podmanTest.CreatePod("foobar99")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("test1", "foobar99")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec, _ = podmanTest.CreatePod("foobar100")
+		_, ec, _ = podmanTest.CreatePod(map[string][]string{"--name": {"foobar100"}})
 		Expect(ec).To(Equal(0))
 
 		session = podmanTest.RunTopContainerInPod("test2", "foobar100")
@@ -134,14 +134,14 @@ var _ = Describe("Podman pod restart", func() {
 	})
 
 	It("podman pod restart latest pod", func() {
-		_, ec, _ := podmanTest.CreatePod("foobar99")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("test1", "foobar99")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec, _ = podmanTest.CreatePod("foobar100")
+		_, ec, _ = podmanTest.CreatePod(map[string][]string{"--name": {"foobar100"}})
 		Expect(ec).To(Equal(0))
 
 		session = podmanTest.RunTopContainerInPod("test2", "foobar100")
@@ -166,7 +166,7 @@ var _ = Describe("Podman pod restart", func() {
 	})
 
 	It("podman pod restart multiple pods with bogus", func() {
-		_, ec, podid1 := podmanTest.CreatePod("foobar99")
+		_, ec, podid1 := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", "foobar99")

--- a/test/e2e/pod_rm_test.go
+++ b/test/e2e/pod_rm_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Podman pod rm", func() {
 	})
 
 	It("podman pod rm empty pod", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		result := podmanTest.Podman([]string{"pod", "rm", podid})
@@ -61,10 +61,10 @@ var _ = Describe("Podman pod rm", func() {
 	})
 
 	It("podman pod rm latest pod", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
-		_, ec2, podid2 := podmanTest.CreatePod("pod2")
+		_, ec2, podid2 := podmanTest.CreatePod(map[string][]string{"--name": {"pod2"}})
 		Expect(ec2).To(Equal(0))
 
 		latest := "--latest"
@@ -83,7 +83,7 @@ var _ = Describe("Podman pod rm", func() {
 	})
 
 	It("podman pod rm removes a pod with a container", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		_, ec2, _ := podmanTest.RunLsContainerInPod("", podid)
@@ -99,7 +99,7 @@ var _ = Describe("Podman pod rm", func() {
 	})
 
 	It("podman pod rm -f does remove a running container", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -117,10 +117,10 @@ var _ = Describe("Podman pod rm", func() {
 
 	It("podman pod rm -a doesn't remove a running container", func() {
 		fmt.Printf("To start, there are %d pods\n", podmanTest.NumberOfPods())
-		_, ec, podid1 := podmanTest.CreatePod("")
+		_, ec, podid1 := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
-		_, ec, _ = podmanTest.CreatePod("")
+		_, ec, _ = podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 		fmt.Printf("Started %d pods\n", podmanTest.NumberOfPods())
 
@@ -154,13 +154,13 @@ var _ = Describe("Podman pod rm", func() {
 	})
 
 	It("podman pod rm -fa removes everything", func() {
-		_, ec, podid1 := podmanTest.CreatePod("")
+		_, ec, podid1 := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
-		_, ec, podid2 := podmanTest.CreatePod("")
+		_, ec, podid2 := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
-		_, ec, _ = podmanTest.CreatePod("")
+		_, ec, _ = podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid1)
@@ -199,7 +199,7 @@ var _ = Describe("Podman pod rm", func() {
 	})
 
 	It("podman rm bogus pod and a running pod", func() {
-		_, ec, podid1 := podmanTest.CreatePod("")
+		_, ec, podid1 := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("test1", podid1)
@@ -217,7 +217,7 @@ var _ = Describe("Podman pod rm", func() {
 
 	It("podman rm --ignore bogus pod and a running pod", func() {
 
-		_, ec, podid1 := podmanTest.CreatePod("")
+		_, ec, podid1 := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("test1", podid1)

--- a/test/e2e/pod_start_test.go
+++ b/test/e2e/pod_start_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/containers/podman/v2/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman pod start", func() {
@@ -43,7 +44,7 @@ var _ = Describe("Podman pod start", func() {
 	})
 
 	It("podman pod start single empty pod", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"pod", "start", podid})
@@ -52,7 +53,7 @@ var _ = Describe("Podman pod start", func() {
 	})
 
 	It("podman pod start single pod by name", func() {
-		_, ec, _ := podmanTest.CreatePod("foobar99")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"create", "--pod", "foobar99", ALPINE, "ls"})
@@ -65,14 +66,14 @@ var _ = Describe("Podman pod start", func() {
 	})
 
 	It("podman pod start multiple pods", func() {
-		_, ec, podid1 := podmanTest.CreatePod("foobar99")
+		_, ec, podid1 := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"create", "--pod", "foobar99", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec2, podid2 := podmanTest.CreatePod("foobar100")
+		_, ec2, podid2 := podmanTest.CreatePod(map[string][]string{"--name": {"foobar100"}})
 		Expect(ec2).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"create", "--pod", "foobar100", ALPINE, "top"})
@@ -85,15 +86,45 @@ var _ = Describe("Podman pod start", func() {
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
 	})
 
+	It("multiple pods in conflict", func() {
+		podName := []string{"Pod_" + RandomString(10), "Pod_" + RandomString(10)}
+
+		pod, _, podid1 := podmanTest.CreatePod(map[string][]string{
+			"--infra":   {"true"},
+			"--name":    {podName[0]},
+			"--publish": {"127.0.0.1:8080:80"},
+		})
+		Expect(pod).To(Exit(0))
+
+		session := podmanTest.Podman([]string{"create", "--pod", podName[0], ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(Exit(0))
+
+		pod, _, podid2 := podmanTest.CreatePod(map[string][]string{
+			"--infra":   {"true"},
+			"--name":    {podName[1]},
+			"--publish": {"127.0.0.1:8080:80"},
+		})
+		Expect(pod).To(Exit(0))
+
+		session = podmanTest.Podman([]string{"create", "--pod", podName[1], ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(Exit(0))
+
+		session = podmanTest.Podman([]string{"pod", "start", podid1, podid2})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(Exit(125))
+	})
+
 	It("podman pod start all pods", func() {
-		_, ec, _ := podmanTest.CreatePod("foobar99")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"create", "--pod", "foobar99", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec, _ = podmanTest.CreatePod("foobar100")
+		_, ec, _ = podmanTest.CreatePod(map[string][]string{"--name": {"foobar100"}})
 		Expect(ec).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"create", "--pod", "foobar100", ALPINE, "top"})
@@ -107,14 +138,14 @@ var _ = Describe("Podman pod start", func() {
 	})
 
 	It("podman pod start latest pod", func() {
-		_, ec, _ := podmanTest.CreatePod("foobar99")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"create", "--pod", "foobar99", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec, _ = podmanTest.CreatePod("foobar100")
+		_, ec, _ = podmanTest.CreatePod(map[string][]string{"--name": {"foobar100"}})
 		Expect(ec).To(Equal(0))
 
 		session = podmanTest.Podman([]string{"create", "--pod", "foobar100", ALPINE, "top"})
@@ -132,7 +163,7 @@ var _ = Describe("Podman pod start", func() {
 	})
 
 	It("podman pod start multiple pods with bogus", func() {
-		_, ec, podid := podmanTest.CreatePod("foobar99")
+		_, ec, podid := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"create", "--pod", "foobar99", ALPINE, "top"})

--- a/test/e2e/pod_stats_test.go
+++ b/test/e2e/pod_stats_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Podman pod stats", func() {
 	})
 
 	It("podman stats on a specific running pod", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -67,7 +67,7 @@ var _ = Describe("Podman pod stats", func() {
 	})
 
 	It("podman stats on a specific running pod with shortID", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -84,7 +84,7 @@ var _ = Describe("Podman pod stats", func() {
 	})
 
 	It("podman stats on a specific running pod with name", func() {
-		_, ec, podid := podmanTest.CreatePod("test")
+		_, ec, podid := podmanTest.CreatePod(map[string][]string{"--name": {"test"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -101,7 +101,7 @@ var _ = Describe("Podman pod stats", func() {
 	})
 
 	It("podman stats on running pods", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -118,7 +118,7 @@ var _ = Describe("Podman pod stats", func() {
 	})
 
 	It("podman stats on all pods", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -135,7 +135,7 @@ var _ = Describe("Podman pod stats", func() {
 	})
 
 	It("podman stats with json output", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -152,7 +152,7 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(stats.IsJSONOutputValid()).To(BeTrue())
 	})
 	It("podman stats with GO template", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -164,7 +164,7 @@ var _ = Describe("Podman pod stats", func() {
 	})
 
 	It("podman stats with invalid GO template", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)

--- a/test/e2e/pod_stop_test.go
+++ b/test/e2e/pod_stop_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Podman pod stop", func() {
 	})
 
 	It("podman stop bogus pod and a running pod", func() {
-		_, ec, podid1 := podmanTest.CreatePod("")
+		_, ec, podid1 := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("test1", podid1)
@@ -61,7 +61,7 @@ var _ = Describe("Podman pod stop", func() {
 
 	It("podman stop --ignore bogus pod and a running pod", func() {
 
-		_, ec, podid1 := podmanTest.CreatePod("")
+		_, ec, podid1 := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("test1", podid1)
@@ -78,7 +78,7 @@ var _ = Describe("Podman pod stop", func() {
 	})
 
 	It("podman pod stop single empty pod", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"pod", "stop", podid})
@@ -87,7 +87,7 @@ var _ = Describe("Podman pod stop", func() {
 	})
 
 	It("podman pod stop single pod by name", func() {
-		_, ec, _ := podmanTest.CreatePod("foobar99")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", "foobar99")
@@ -101,14 +101,14 @@ var _ = Describe("Podman pod stop", func() {
 	})
 
 	It("podman pod stop multiple pods", func() {
-		_, ec, podid1 := podmanTest.CreatePod("foobar99")
+		_, ec, podid1 := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", "foobar99")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec2, podid2 := podmanTest.CreatePod("foobar100")
+		_, ec2, podid2 := podmanTest.CreatePod(map[string][]string{"--name": {"foobar100"}})
 		Expect(ec2).To(Equal(0))
 
 		session = podmanTest.RunTopContainerInPod("", "foobar100")
@@ -122,14 +122,14 @@ var _ = Describe("Podman pod stop", func() {
 	})
 
 	It("podman pod stop all pods", func() {
-		_, ec, _ := podmanTest.CreatePod("foobar99")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", "foobar99")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec, _ = podmanTest.CreatePod("foobar100")
+		_, ec, _ = podmanTest.CreatePod(map[string][]string{"--name": {"foobar100"}})
 		Expect(ec).To(Equal(0))
 
 		session = podmanTest.RunTopContainerInPod("", "foobar100")
@@ -143,14 +143,14 @@ var _ = Describe("Podman pod stop", func() {
 	})
 
 	It("podman pod stop latest pod", func() {
-		_, ec, _ := podmanTest.CreatePod("foobar99")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", "foobar99")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		_, ec, _ = podmanTest.CreatePod("foobar100")
+		_, ec, _ = podmanTest.CreatePod(map[string][]string{"--name": {"foobar100"}})
 		Expect(ec).To(Equal(0))
 
 		session = podmanTest.RunTopContainerInPod("", "foobar100")
@@ -168,7 +168,7 @@ var _ = Describe("Podman pod stop", func() {
 	})
 
 	It("podman pod stop multiple pods with bogus", func() {
-		_, ec, podid1 := podmanTest.CreatePod("foobar99")
+		_, ec, podid1 := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", "foobar99")

--- a/test/e2e/pod_top_test.go
+++ b/test/e2e/pod_top_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Podman top", func() {
 	})
 
 	It("podman pod top on non-running pod", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		result := podmanTest.Podman([]string{"top", podid})
@@ -56,7 +56,7 @@ var _ = Describe("Podman top", func() {
 	})
 
 	It("podman pod top on pod", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"run", "-d", "--pod", podid, ALPINE, "top", "-d", "2"})
@@ -73,7 +73,7 @@ var _ = Describe("Podman top", func() {
 	})
 
 	It("podman pod top with options", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"run", "-d", "--pod", podid, ALPINE, "top", "-d", "2"})
@@ -87,7 +87,7 @@ var _ = Describe("Podman top", func() {
 	})
 
 	It("podman pod top on pod invalid options", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"run", "-d", "--pod", podid, ALPINE, "top", "-d", "2"})
@@ -104,7 +104,7 @@ var _ = Describe("Podman top", func() {
 	})
 
 	It("podman pod top on pod with containers in same pid namespace", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"run", "-d", "--pod", podid, ALPINE, "top", "-d", "2"})
@@ -123,7 +123,7 @@ var _ = Describe("Podman top", func() {
 	})
 
 	It("podman pod top on pod with containers in different namespace", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"run", "-d", "--pod", podid, ALPINE, "top", "-d", "2"})

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -389,7 +389,7 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman --pod", func() {
-		_, ec, podid := podmanTest.CreatePod("")
+		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podid)
@@ -409,7 +409,7 @@ var _ = Describe("Podman ps", func() {
 
 	It("podman --pod with a non-empty pod name", func() {
 		podName := "testPodName"
-		_, ec, podid := podmanTest.CreatePod(podName)
+		_, ec, podid := podmanTest.CreatePod(map[string][]string{"--name": {podName}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("", podName)

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -197,10 +197,10 @@ var _ = Describe("Podman restart", func() {
 		Expect(restartTime.OutputToStringArray()[1]).To(Not(Equal(startTime.OutputToStringArray()[1])))
 	})
 
-	It("Podman restart a container in a pod and hosts shouln't duplicated", func() {
+	It("Podman restart a container in a pod and hosts should not duplicated", func() {
 		// Fixes: https://github.com/containers/podman/issues/8921
 
-		_, ec, _ := podmanTest.CreatePod("foobar99")
+		_, ec, _ := podmanTest.CreatePod(map[string][]string{"--name": {"foobar99"}})
 		Expect(ec).To(Equal(0))
 
 		session := podmanTest.RunTopContainerInPod("host-restart-test", "foobar99")

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -467,11 +467,14 @@ func Containerized() bool {
 	return false
 }
 
+func init() {
+	rand.Seed(GinkgoRandomSeed())
+}
+
 var randomLetters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 // RandomString returns a string of given length composed of random characters
 func RandomString(n int) string {
-	rand.Seed(GinkgoRandomSeed())
 
 	b := make([]rune, n)
 	for i := range b {


### PR DESCRIPTION
- When one or more containers in the Pod reports an error on an operation
report `StatusConflict` and report the error(s)

- `jsoniter.RegisterTypeEncoderFunc()` used to marshal error as string using `error.Error()`. This picks up any other places in API where `error` has been used.

- Update test framework to allow setting any flag when creating pods

Fixes #8865

Signed-off-by: Jhon Honce <jhonce@redhat.com>
