### PR TITLE
add macvlan as a supported network driver

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -7,8 +7,9 @@ podman\-network-create - Create a Podman CNI network
 **podman network create**  [*options*] name
 
 ## DESCRIPTION
-Create a CNI-network configuration for use with Podman. By default, Podman creates a bridge connection. A
-*Macvlan* connection can be created with the *macvlan* option. In the case of *Macvlan* connections, the
+Create a CNI-network configuration for use with Podman. By default, Podman creates a bridge connection.
+A *Macvlan* connection can be created with the *-d macvlan* option. A parent device for macvlan can
+be designated with the *-o parent=<device>* option. In the case of *Macvlan* connections, the
 CNI *dhcp* plugin needs to be activated or the container image must have a DHCP client to interact
 with the host network's DHCP server.
 
@@ -54,6 +55,8 @@ must be used with a *subnet* option.
 Set metadata for a network (e.g., --label mykey=value).
 
 #### **--macvlan**
+
+*This option is being deprecated*
 
 Create a *Macvlan* based connection rather than a classic bridge.  You must pass an interface name from the host for the
 Macvlan connection.
@@ -101,7 +104,7 @@ Create a network that uses a *192.168.55.0/24** subnet and has an IP address ran
 
 Create a Macvlan based network using the host interface eth0
 ```
-# podman network create --macvlan eth0 newnet
+# podman network create -d macvlan -o parent=eth0 newnet
 /etc/cni/net.d/newnet.conflist
 ```
 

--- a/libpod/network/netconflist.go
+++ b/libpod/network/netconflist.go
@@ -177,8 +177,12 @@ func NewMacVLANPlugin(device string) MacVLANConfig {
 
 	m := MacVLANConfig{
 		PluginType: "macvlan",
-		Master:     device,
 		IPAM:       i,
+	}
+	// CNI is supposed to use the default route if a
+	// parent device is not provided
+	if len(device) > 0 {
+		m.Master = device
 	}
 	return m
 }

--- a/libpod/network/network.go
+++ b/libpod/network/network.go
@@ -17,11 +17,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// DefaultNetworkDriver is the default network type used
-var DefaultNetworkDriver = "bridge"
+var (
+	// BridgeNetworkDriver defines the bridge cni driver
+	BridgeNetworkDriver = "bridge"
+	// DefaultNetworkDriver is the default network type used
+	DefaultNetworkDriver = BridgeNetworkDriver
+	// MacVLANNetworkDriver defines the macvlan cni driver
+	MacVLANNetworkDriver = "macvlan"
+)
 
 // SupportedNetworkDrivers describes the list of supported drivers
-var SupportedNetworkDrivers = []string{DefaultNetworkDriver}
+var SupportedNetworkDrivers = []string{BridgeNetworkDriver, MacVLANNetworkDriver}
 
 // isSupportedDriver checks if the user provided driver is supported
 func isSupportedDriver(driver string) error {

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -793,4 +794,13 @@ func (p *PodmanTestIntegration) removeCNINetwork(name string) {
 	session := p.Podman([]string{"network", "rm", "-f", name})
 	session.WaitWithDefaultTimeout()
 	Expect(session.ExitCode()).To(BeNumerically("<=", 1))
+}
+
+func (p *PodmanSessionIntegration) jq(jqCommand string) (string, error) {
+	var out bytes.Buffer
+	cmd := exec.Command("jq", jqCommand)
+	cmd.Stdin = strings.NewReader(p.OutputToString())
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimRight(out.String(), "\n"), err
 }

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -457,6 +457,47 @@ var _ = Describe("Podman network", func() {
 		Expect(nc.ExitCode()).To(Equal(0))
 	})
 
+	It("podman network create/remove macvlan as driver (-d) no device name", func() {
+		net := "macvlan" + stringid.GenerateNonCryptoID()
+		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", net})
+		nc.WaitWithDefaultTimeout()
+		defer podmanTest.removeCNINetwork(net)
+		Expect(nc.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"network", "inspect", net})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(BeZero())
+
+		out, err := inspect.jq(".[0].plugins[0].master")
+		Expect(err).To(BeNil())
+		Expect(out).To(Equal("\"\""))
+
+		nc = podmanTest.Podman([]string{"network", "rm", net})
+		nc.WaitWithDefaultTimeout()
+		Expect(nc.ExitCode()).To(Equal(0))
+	})
+
+	It("podman network create/remove macvlan as driver (-d) with device name", func() {
+		net := "macvlan" + stringid.GenerateNonCryptoID()
+		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", "parent=lo", net})
+		nc.WaitWithDefaultTimeout()
+		defer podmanTest.removeCNINetwork(net)
+		Expect(nc.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"network", "inspect", net})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(BeZero())
+		fmt.Println(inspect.OutputToString())
+
+		out, err := inspect.jq(".[0].plugins[0].master")
+		Expect(err).To(BeNil())
+		Expect(out).To(Equal("\"lo\""))
+
+		nc = podmanTest.Podman([]string{"network", "rm", net})
+		nc.WaitWithDefaultTimeout()
+		Expect(nc.ExitCode()).To(Equal(0))
+	})
+
 	It("podman network exists", func() {
 		net := "net" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", net})


### PR DESCRIPTION
instead of using the --macvlan to indicate that you want to make a
macvlan network, podman network create now honors the driver name of
*macvlan*.  Any options to macvlan, like the parent device, should be
specified as a -o option.  For example, -o parent=eth0.

the --macvlan option was marked as deprecated in the man page but is
still supported for the duration of 3.0.

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
