### PR TITLE
Makefile: refactor ginkgo * ginkgo-remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,13 +303,17 @@ localunit: test/goecho/goecho
 .PHONY: test
 test: localunit localintegration remoteintegration localsystem remotesystem  ## Run unit, integration, and system tests.
 
+.PHONY: ginkgo-run
+ginkgo-run:
+	$(GOBIN)/ginkgo -v $(TESTFLAGS) -tags "$(TAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes 3 -debug test/e2e/. $(HACK)
+
 .PHONY: ginkgo
 ginkgo:
-	$(GOBIN)/ginkgo -v $(TESTFLAGS) -tags "$(BUILDTAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes 3 -debug test/e2e/. hack/.
+	$(MAKE) ginkgo-run TAGS="$(BUILDTAGS)" HACK=hack/.
 
 .PHONY: ginkgo-remote
 ginkgo-remote:
-	$(GOBIN)/ginkgo -v $(TESTFLAGS) -tags "$(REMOTETAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.
+	$(MAKE) ginkgo-run TAGS="$(REMOTETAGS)" HACK=
 
 .PHONY: localintegration
 localintegration: test-binaries ginkgo


### PR DESCRIPTION
Create a new common target, ginkgo-run, with the main ginkgo
test incantation; ginkgo and ginkgo-remote now invoke that,
with a clearer distinction between their arguments.

Reason for this: 'make remoteintegration' was not generating
ginkgo logs in CI. Reason: '-debug' option was missing from
the ginkgo incantation. Reason: impossibility of maintaining
duplicate long-complicated lines. This PR distills the common
aspects, making the differences clearer between local & remote.

IMPORTANT NOTE: '-nodes 3' was also missing from remote ginkgo.
This PR adds it. If this was intentionally omitted, please let
me know (with reasons) so I can refactor that too.

Signed-off-by: Ed Santiago <santiago@redhat.com>
