### PR TITLE
[NO TESTS NEEDED] Improve binding generator

### DIFF
--- a/pkg/bindings/containers/types_attach_options.go
+++ b/pkg/bindings/containers/types_attach_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *AttachOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_attach_options.go
+++ b/pkg/bindings/containers/types_attach_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *AttachOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *AttachOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_checkpoint_options.go
+++ b/pkg/bindings/containers/types_checkpoint_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CheckpointOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_checkpoint_options.go
+++ b/pkg/bindings/containers/types_checkpoint_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *CheckpointOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CheckpointOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_commit_options.go
+++ b/pkg/bindings/containers/types_commit_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CommitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_commit_options.go
+++ b/pkg/bindings/containers/types_commit_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *CommitOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CommitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_create_options.go
+++ b/pkg/bindings/containers/types_create_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_create_options.go
+++ b/pkg/bindings/containers/types_create_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_diff_options.go
+++ b/pkg/bindings/containers/types_diff_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_diff_options.go
+++ b/pkg/bindings/containers/types_diff_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_execinspect_options.go
+++ b/pkg/bindings/containers/types_execinspect_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExecInspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExecInspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_execinspect_options.go
+++ b/pkg/bindings/containers/types_execinspect_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExecInspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_execstart_options.go
+++ b/pkg/bindings/containers/types_execstart_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExecStartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExecStartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_execstart_options.go
+++ b/pkg/bindings/containers/types_execstart_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExecStartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_execstartandattach_options.go
+++ b/pkg/bindings/containers/types_execstartandattach_options.go
@@ -2,12 +2,13 @@ package containers
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -45,33 +46,19 @@ func (o *ExecStartAndAttachOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -84,7 +71,10 @@ func (o *ExecStartAndAttachOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_execstartandattach_options.go
+++ b/pkg/bindings/containers/types_execstartandattach_options.go
@@ -2,7 +2,6 @@ package containers
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"net/url"
 	"reflect"
@@ -71,8 +70,6 @@ func (o *ExecStartAndAttachOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_exists_options.go
+++ b/pkg/bindings/containers/types_exists_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_exists_options.go
+++ b/pkg/bindings/containers/types_exists_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_export_options.go
+++ b/pkg/bindings/containers/types_export_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_export_options.go
+++ b/pkg/bindings/containers/types_export_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_healthcheck_options.go
+++ b/pkg/bindings/containers/types_healthcheck_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *HealthCheckOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *HealthCheckOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_healthcheck_options.go
+++ b/pkg/bindings/containers/types_healthcheck_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *HealthCheckOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_init_options.go
+++ b/pkg/bindings/containers/types_init_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InitOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_init_options.go
+++ b/pkg/bindings/containers/types_init_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_inspect_options.go
+++ b/pkg/bindings/containers/types_inspect_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_inspect_options.go
+++ b/pkg/bindings/containers/types_inspect_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_kill_options.go
+++ b/pkg/bindings/containers/types_kill_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_kill_options.go
+++ b/pkg/bindings/containers/types_kill_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_list_options.go
+++ b/pkg/bindings/containers/types_list_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_list_options.go
+++ b/pkg/bindings/containers/types_list_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_log_options.go
+++ b/pkg/bindings/containers/types_log_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *LogOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *LogOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_log_options.go
+++ b/pkg/bindings/containers/types_log_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *LogOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_mount_options.go
+++ b/pkg/bindings/containers/types_mount_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *MountOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_mount_options.go
+++ b/pkg/bindings/containers/types_mount_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *MountOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *MountOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_mountedcontainerpaths_options.go
+++ b/pkg/bindings/containers/types_mountedcontainerpaths_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *MountedContainerPathsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_mountedcontainerpaths_options.go
+++ b/pkg/bindings/containers/types_mountedcontainerpaths_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *MountedContainerPathsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *MountedContainerPathsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_pause_options.go
+++ b/pkg/bindings/containers/types_pause_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_pause_options.go
+++ b/pkg/bindings/containers/types_pause_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_prune_options.go
+++ b/pkg/bindings/containers/types_prune_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_prune_options.go
+++ b/pkg/bindings/containers/types_prune_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_remove_options.go
+++ b/pkg/bindings/containers/types_remove_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_remove_options.go
+++ b/pkg/bindings/containers/types_remove_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_rename_options.go
+++ b/pkg/bindings/containers/types_rename_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RenameOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_rename_options.go
+++ b/pkg/bindings/containers/types_rename_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RenameOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RenameOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_resizeexectty_options.go
+++ b/pkg/bindings/containers/types_resizeexectty_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ResizeExecTTYOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ResizeExecTTYOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_resizeexectty_options.go
+++ b/pkg/bindings/containers/types_resizeexectty_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ResizeExecTTYOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_resizetty_options.go
+++ b/pkg/bindings/containers/types_resizetty_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ResizeTTYOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_resizetty_options.go
+++ b/pkg/bindings/containers/types_resizetty_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ResizeTTYOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ResizeTTYOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_restart_options.go
+++ b/pkg/bindings/containers/types_restart_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_restart_options.go
+++ b/pkg/bindings/containers/types_restart_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_restore_options.go
+++ b/pkg/bindings/containers/types_restore_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RestoreOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RestoreOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_restore_options.go
+++ b/pkg/bindings/containers/types_restore_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RestoreOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_shouldrestart_options.go
+++ b/pkg/bindings/containers/types_shouldrestart_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ShouldRestartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ShouldRestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_shouldrestart_options.go
+++ b/pkg/bindings/containers/types_shouldrestart_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ShouldRestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_start_options.go
+++ b/pkg/bindings/containers/types_start_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_start_options.go
+++ b/pkg/bindings/containers/types_start_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_stats_options.go
+++ b/pkg/bindings/containers/types_stats_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_stats_options.go
+++ b/pkg/bindings/containers/types_stats_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_stop_options.go
+++ b/pkg/bindings/containers/types_stop_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_stop_options.go
+++ b/pkg/bindings/containers/types_stop_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_top_options.go
+++ b/pkg/bindings/containers/types_top_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_top_options.go
+++ b/pkg/bindings/containers/types_top_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_unmount_options.go
+++ b/pkg/bindings/containers/types_unmount_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *UnmountOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *UnmountOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_unmount_options.go
+++ b/pkg/bindings/containers/types_unmount_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *UnmountOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_unpause_options.go
+++ b/pkg/bindings/containers/types_unpause_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_unpause_options.go
+++ b/pkg/bindings/containers/types_unpause_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_wait_options.go
+++ b/pkg/bindings/containers/types_wait_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -70,8 +69,6 @@ func (o *WaitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_wait_options.go
+++ b/pkg/bindings/containers/types_wait_options.go
@@ -1,12 +1,13 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/containers/podman/v2/libpod/define"
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -44,33 +45,19 @@ func (o *WaitOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -83,7 +70,10 @@ func (o *WaitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/generate/types_kube_options.go
+++ b/pkg/bindings/generate/types_kube_options.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/generate/types_kube_options.go
+++ b/pkg/bindings/generate/types_kube_options.go
@@ -1,13 +1,14 @@
 package generate
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/generate/types_systemd_options.go
+++ b/pkg/bindings/generate/types_systemd_options.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *SystemdOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/generate/types_systemd_options.go
+++ b/pkg/bindings/generate/types_systemd_options.go
@@ -1,13 +1,14 @@
 package generate
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *SystemdOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *SystemdOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/generator/generator.go
+++ b/pkg/bindings/generator/generator.go
@@ -54,33 +54,19 @@ func (o *{{.StructName}}) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+				switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -93,7 +79,10 @@ func (o *{{.StructName}}) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }
@@ -144,7 +133,7 @@ func main() {
 		panic(err)
 	}
 	// always add reflect
-	imports := []string{"\"reflect\""}
+	imports := []string{"\"reflect\"", "\"github.com/containers/podman/v2/pkg/bindings/util\""}
 	for _, imp := range f.Imports {
 		imports = append(imports, imp.Path.Value)
 	}

--- a/pkg/bindings/generator/generator.go
+++ b/pkg/bindings/generator/generator.go
@@ -79,8 +79,6 @@ func (o *{{.StructName}}) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/generator/generator.go
+++ b/pkg/bindings/generator/generator.go
@@ -54,7 +54,7 @@ func (o *{{.StructName}}) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-				switch {
+		switch {
 		case util.IsSimpleType(f):
 			params.Set(fieldName, util.SimpleTypeToParam(f))
 		case f.Kind() == reflect.Slice:

--- a/pkg/bindings/images/types_diff_options.go
+++ b/pkg/bindings/images/types_diff_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_diff_options.go
+++ b/pkg/bindings/images/types_diff_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_exists_options.go
+++ b/pkg/bindings/images/types_exists_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_exists_options.go
+++ b/pkg/bindings/images/types_exists_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_export_options.go
+++ b/pkg/bindings/images/types_export_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_export_options.go
+++ b/pkg/bindings/images/types_export_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_get_options.go
+++ b/pkg/bindings/images/types_get_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *GetOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_get_options.go
+++ b/pkg/bindings/images/types_get_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *GetOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *GetOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_history_options.go
+++ b/pkg/bindings/images/types_history_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *HistoryOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *HistoryOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_history_options.go
+++ b/pkg/bindings/images/types_history_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *HistoryOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_import_options.go
+++ b/pkg/bindings/images/types_import_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ImportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_import_options.go
+++ b/pkg/bindings/images/types_import_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ImportOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ImportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_list_options.go
+++ b/pkg/bindings/images/types_list_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_list_options.go
+++ b/pkg/bindings/images/types_list_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_load_options.go
+++ b/pkg/bindings/images/types_load_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *LoadOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *LoadOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_load_options.go
+++ b/pkg/bindings/images/types_load_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *LoadOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_prune_options.go
+++ b/pkg/bindings/images/types_prune_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_prune_options.go
+++ b/pkg/bindings/images/types_prune_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_pull_options.go
+++ b/pkg/bindings/images/types_pull_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PullOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PullOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_pull_options.go
+++ b/pkg/bindings/images/types_pull_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PullOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PushOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PushOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PushOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_remove_options.go
+++ b/pkg/bindings/images/types_remove_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_remove_options.go
+++ b/pkg/bindings/images/types_remove_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_search_options.go
+++ b/pkg/bindings/images/types_search_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *SearchOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_search_options.go
+++ b/pkg/bindings/images/types_search_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *SearchOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *SearchOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_tag_options.go
+++ b/pkg/bindings/images/types_tag_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *TagOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_tag_options.go
+++ b/pkg/bindings/images/types_tag_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *TagOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *TagOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_tree_options.go
+++ b/pkg/bindings/images/types_tree_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *TreeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_tree_options.go
+++ b/pkg/bindings/images/types_tree_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *TreeOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *TreeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_untag_options.go
+++ b/pkg/bindings/images/types_untag_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *UntagOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *UntagOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_untag_options.go
+++ b/pkg/bindings/images/types_untag_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *UntagOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/manifests/types_add_options.go
+++ b/pkg/bindings/manifests/types_add_options.go
@@ -1,13 +1,14 @@
 package manifests
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *AddOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *AddOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/manifests/types_add_options.go
+++ b/pkg/bindings/manifests/types_add_options.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *AddOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/manifests/types_create_options.go
+++ b/pkg/bindings/manifests/types_create_options.go
@@ -1,13 +1,14 @@
 package manifests
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/manifests/types_create_options.go
+++ b/pkg/bindings/manifests/types_create_options.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/manifests/types_exists_options.go
+++ b/pkg/bindings/manifests/types_exists_options.go
@@ -1,13 +1,14 @@
 package manifests
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/manifests/types_exists_options.go
+++ b/pkg/bindings/manifests/types_exists_options.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/manifests/types_inspect_options.go
+++ b/pkg/bindings/manifests/types_inspect_options.go
@@ -1,13 +1,14 @@
 package manifests
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/manifests/types_inspect_options.go
+++ b/pkg/bindings/manifests/types_inspect_options.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/manifests/types_remove_options.go
+++ b/pkg/bindings/manifests/types_remove_options.go
@@ -1,13 +1,14 @@
 package manifests
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/manifests/types_remove_options.go
+++ b/pkg/bindings/manifests/types_remove_options.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_connect_options.go
+++ b/pkg/bindings/network/types_connect_options.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ConnectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ConnectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_connect_options.go
+++ b/pkg/bindings/network/types_connect_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ConnectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_create_options.go
+++ b/pkg/bindings/network/types_create_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net"
 	"net/url"
 	"reflect"
@@ -70,8 +69,6 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_create_options.go
+++ b/pkg/bindings/network/types_create_options.go
@@ -1,12 +1,13 @@
 package network
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -44,33 +45,19 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -83,7 +70,10 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_disconnect_options.go
+++ b/pkg/bindings/network/types_disconnect_options.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *DisconnectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *DisconnectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_disconnect_options.go
+++ b/pkg/bindings/network/types_disconnect_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *DisconnectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_exists_options.go
+++ b/pkg/bindings/network/types_exists_options.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_exists_options.go
+++ b/pkg/bindings/network/types_exists_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_inspect_options.go
+++ b/pkg/bindings/network/types_inspect_options.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_inspect_options.go
+++ b/pkg/bindings/network/types_inspect_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_list_options.go
+++ b/pkg/bindings/network/types_list_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_list_options.go
+++ b/pkg/bindings/network/types_list_options.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_remove_options.go
+++ b/pkg/bindings/network/types_remove_options.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_remove_options.go
+++ b/pkg/bindings/network/types_remove_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/play/types_kube_options.go
+++ b/pkg/bindings/play/types_kube_options.go
@@ -2,7 +2,6 @@ package play
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/play/types_kube_options.go
+++ b/pkg/bindings/play/types_kube_options.go
@@ -1,13 +1,14 @@
 package play
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_create_options.go
+++ b/pkg/bindings/pods/types_create_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_create_options.go
+++ b/pkg/bindings/pods/types_create_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_exists_options.go
+++ b/pkg/bindings/pods/types_exists_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_exists_options.go
+++ b/pkg/bindings/pods/types_exists_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_inspect_options.go
+++ b/pkg/bindings/pods/types_inspect_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_inspect_options.go
+++ b/pkg/bindings/pods/types_inspect_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_kill_options.go
+++ b/pkg/bindings/pods/types_kill_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_kill_options.go
+++ b/pkg/bindings/pods/types_kill_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_list_options.go
+++ b/pkg/bindings/pods/types_list_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_list_options.go
+++ b/pkg/bindings/pods/types_list_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_pause_options.go
+++ b/pkg/bindings/pods/types_pause_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_pause_options.go
+++ b/pkg/bindings/pods/types_pause_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_prune_options.go
+++ b/pkg/bindings/pods/types_prune_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_prune_options.go
+++ b/pkg/bindings/pods/types_prune_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_remove_options.go
+++ b/pkg/bindings/pods/types_remove_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_remove_options.go
+++ b/pkg/bindings/pods/types_remove_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_restart_options.go
+++ b/pkg/bindings/pods/types_restart_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_restart_options.go
+++ b/pkg/bindings/pods/types_restart_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_start_options.go
+++ b/pkg/bindings/pods/types_start_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_start_options.go
+++ b/pkg/bindings/pods/types_start_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_stats_options.go
+++ b/pkg/bindings/pods/types_stats_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_stats_options.go
+++ b/pkg/bindings/pods/types_stats_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_stop_options.go
+++ b/pkg/bindings/pods/types_stop_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_stop_options.go
+++ b/pkg/bindings/pods/types_stop_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_top_options.go
+++ b/pkg/bindings/pods/types_top_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_top_options.go
+++ b/pkg/bindings/pods/types_top_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_unpause_options.go
+++ b/pkg/bindings/pods/types_unpause_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_unpause_options.go
+++ b/pkg/bindings/pods/types_unpause_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_disk_options.go
+++ b/pkg/bindings/system/types_disk_options.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *DiskOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *DiskOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_disk_options.go
+++ b/pkg/bindings/system/types_disk_options.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *DiskOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/system/types_events_options.go
+++ b/pkg/bindings/system/types_events_options.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *EventsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *EventsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_events_options.go
+++ b/pkg/bindings/system/types_events_options.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *EventsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/system/types_info_options.go
+++ b/pkg/bindings/system/types_info_options.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InfoOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InfoOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_info_options.go
+++ b/pkg/bindings/system/types_info_options.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InfoOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/system/types_prune_options.go
+++ b/pkg/bindings/system/types_prune_options.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/system/types_prune_options.go
+++ b/pkg/bindings/system/types_prune_options.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_version_options.go
+++ b/pkg/bindings/system/types_version_options.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *VersionOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *VersionOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_version_options.go
+++ b/pkg/bindings/system/types_version_options.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *VersionOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/util/util.go
+++ b/pkg/bindings/util/util.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"reflect"
+	"strconv"
+)
+
+func IsSimpleType(f reflect.Value) bool {
+	switch f.Kind() {
+	case reflect.Bool, reflect.Int, reflect.Int64, reflect.Uint, reflect.Uint64, reflect.String:
+		return true
+	}
+	return false
+}
+
+func SimpleTypeToParam(f reflect.Value) string {
+	switch f.Kind() {
+	case reflect.Bool:
+		return strconv.FormatBool(f.Bool())
+	case reflect.Int, reflect.Int64:
+		// f.Int() is always an int64
+		return strconv.FormatInt(f.Int(), 10)
+	case reflect.Uint, reflect.Uint64:
+		// f.Uint() is always an uint64
+		return strconv.FormatUint(f.Uint(), 10)
+	case reflect.String:
+		return f.String()
+	}
+	panic("the input parameter is not a simple type")
+}

--- a/pkg/bindings/volumes/types_create_options.go
+++ b/pkg/bindings/volumes/types_create_options.go
@@ -1,11 +1,12 @@
 package volumes
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/volumes/types_create_options.go
+++ b/pkg/bindings/volumes/types_create_options.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/volumes/types_exists_options.go
+++ b/pkg/bindings/volumes/types_exists_options.go
@@ -1,11 +1,12 @@
 package volumes
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/volumes/types_exists_options.go
+++ b/pkg/bindings/volumes/types_exists_options.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/volumes/types_inspect_options.go
+++ b/pkg/bindings/volumes/types_inspect_options.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/volumes/types_inspect_options.go
+++ b/pkg/bindings/volumes/types_inspect_options.go
@@ -1,11 +1,12 @@
 package volumes
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/volumes/types_list_options.go
+++ b/pkg/bindings/volumes/types_list_options.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/volumes/types_list_options.go
+++ b/pkg/bindings/volumes/types_list_options.go
@@ -1,11 +1,12 @@
 package volumes
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/volumes/types_prune_options.go
+++ b/pkg/bindings/volumes/types_prune_options.go
@@ -1,11 +1,12 @@
 package volumes
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/volumes/types_prune_options.go
+++ b/pkg/bindings/volumes/types_prune_options.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/volumes/types_remove_options.go
+++ b/pkg/bindings/volumes/types_remove_options.go
@@ -1,11 +1,12 @@
 package volumes
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/volumes/types_remove_options.go
+++ b/pkg/bindings/volumes/types_remove_options.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}


### PR DESCRIPTION
This allows to have slices other than slices of strings in options structs.

Before this wasn't possible:
```go
type WaitOptions struct {
	Conditions []define.ContainerStatus // <- non-string slice
	Interval   time.Duration
	Latest     bool
}
```