### PR TITLE
Honor network options for macvlan networks

### DIFF
--- a/libpod/network/config.go
+++ b/libpod/network/config.go
@@ -103,7 +103,9 @@ func (p PortMapConfig) Bytes() ([]byte, error) {
 
 // IPAMDHCP describes the ipamdhcp config
 type IPAMDHCP struct {
-	DHCP string `json:"type"`
+	DHCP   string                     `json:"type"`
+	Routes []IPAMRoute                `json:"routes,omitempty"`
+	Ranges [][]IPAMLocalHostRangeConf `json:"ranges,omitempty"`
 }
 
 // MacVLANConfig describes the macvlan config
@@ -111,6 +113,7 @@ type MacVLANConfig struct {
 	PluginType string   `json:"type"`
 	Master     string   `json:"master"`
 	IPAM       IPAMDHCP `json:"ipam"`
+	MTU        int      `json:"mtu,omitempty"`
 }
 
 // Bytes outputs the configuration as []byte


### PR DESCRIPTION
when creating a macvlan network, we should honor gateway, subnet, and
mtu as provided by the user.

Fixes: #9167

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
