### PR TITLE
play kube selinux label issue

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -282,16 +282,16 @@ func setupSecurityContext(s *specgen.SpecGenerator, containerYAML v1.Container) 
 
 	if seopt := containerYAML.SecurityContext.SELinuxOptions; seopt != nil {
 		if seopt.User != "" {
-			s.SelinuxOpts = append(s.SelinuxOpts, fmt.Sprintf("role:%s", seopt.User))
+			s.SelinuxOpts = append(s.SelinuxOpts, fmt.Sprintf("user:%s", seopt.User))
 		}
 		if seopt.Role != "" {
 			s.SelinuxOpts = append(s.SelinuxOpts, fmt.Sprintf("role:%s", seopt.Role))
 		}
 		if seopt.Type != "" {
-			s.SelinuxOpts = append(s.SelinuxOpts, fmt.Sprintf("role:%s", seopt.Type))
+			s.SelinuxOpts = append(s.SelinuxOpts, fmt.Sprintf("type:%s", seopt.Type))
 		}
 		if seopt.Level != "" {
-			s.SelinuxOpts = append(s.SelinuxOpts, fmt.Sprintf("role:%s", seopt.Level))
+			s.SelinuxOpts = append(s.SelinuxOpts, fmt.Sprintf("level:%s", seopt.Level))
 		}
 	}
 	if caps := containerYAML.SecurityContext.Capabilities; caps != nil {

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/containers/podman/v2/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/opencontainers/selinux/go-selinux"
 )
 
 var unknownKindYaml = `
@@ -847,6 +848,9 @@ var _ = Describe("Podman play kube", func() {
 	})
 
 	It("podman play kube fail with custom selinux label", func() {
+		if !selinux.GetEnabled() {
+			Skip("SELinux not enabled")
+		}
 		err := writeYaml(selinuxLabelPodYaml, kubeYaml)
 		Expect(err).To(BeNil())
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -858,7 +858,7 @@ var _ = Describe("Podman play kube", func() {
 		inspect.WaitWithDefaultTimeout()
 		label := inspect.OutputToString()
 
-		Expect(label).To(ContainSubstring("nconfined_u:system_r:spc_t:s0"))
+		Expect(label).To(ContainSubstring("unconfined_u:system_r:spc_t:s0"))
 	})
 
 	It("podman play kube fail with nonexistent authfile", func() {

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -26,6 +26,49 @@ spec:
   hostname: unknown
 `
 
+var selinuxLabelPodYaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2021-02-02T22:18:20Z"
+  labels:
+    app: label-pod
+  name: label-pod
+spec:
+  containers:
+  - command:
+    - top
+    - -d
+    - "1.5"
+    env:
+    - name: PATH
+      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    - name: TERM
+      value: xterm
+    - name: container
+      value: podman
+    - name: HOSTNAME
+      value: label-pod
+    image: quay.io/libpod/alpine:latest
+    name: test
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - CAP_MKNOD
+        - CAP_NET_RAW
+        - CAP_AUDIT_WRITE
+      privileged: false
+      readOnlyRootFilesystem: false
+      seLinuxOptions:
+        user: unconfined_u
+        role: system_r
+        type: spc_t
+        level: s0
+    workingDir: /
+status: {}
+`
+
 var configMapYamlTemplate = `
 apiVersion: v1
 kind: ConfigMap
@@ -801,6 +844,21 @@ var _ = Describe("Podman play kube", func() {
 		kube.WaitWithDefaultTimeout()
 		Expect(kube.ExitCode()).To(Not(Equal(0)))
 
+	})
+
+	It("podman play kube fail with custom selinux label", func() {
+		err := writeYaml(selinuxLabelPodYaml, kubeYaml)
+		Expect(err).To(BeNil())
+
+		kube := podmanTest.Podman([]string{"play", "kube", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", "label-pod-test", "--format", "'{{ .ProcessLabel }}'"})
+		inspect.WaitWithDefaultTimeout()
+		label := inspect.OutputToString()
+
+		Expect(label).To(ContainSubstring("nconfined_u:system_r:spc_t:s0"))
 	})
 
 	It("podman play kube fail with nonexistent authfile", func() {


### PR DESCRIPTION
play kube function not respecting selinux options in kube yaml, all options were
being mapped to role.

fixes issue 8710

Signed-off-by: Steven Taylor <steven@taylormuff.co.uk>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
