### PR TITLE
Makefile: make bin/* real targets!

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -9,7 +9,7 @@ podman\-network-create - Create a Podman CNI network
 ## DESCRIPTION
 Create a CNI-network configuration for use with Podman. By default, Podman creates a bridge connection.
 A *Macvlan* connection can be created with the *-d macvlan* option. A parent device for macvlan can
-be designated with the *-o parent=<device>* option. In the case of *Macvlan* connections, the
+be designated with the *-o parent=\<device>* option. In the case of *Macvlan* connections, the
 CNI *dhcp* plugin needs to be activated or the container image must have a DHCP client to interact
 with the host network's DHCP server.
 


### PR DESCRIPTION
Backstory: every time you run 'make podman' or even
just 'make', you get a full recompile. This is sub-ideal.

Cause: I don't really know. It looks complicated. #5017
introduced a .PHONY for bin/podman, for reasons not
explained in the PR. Then, much later, #5880 well-
intentionedly but improperly tweaked the 'find'
command used in defining SOURCES, adding a -prune
but without the corresponding and required -print.
Let's just say, it was an unfortunate cascade of events.

This PR fixes the SOURCES definition and removes the
highly-undesired .PHONY from podman & podman-remote,
making it so you can type 'make' and, oh joy, not
build anything if it's current. The way 'make' is
supposed to work.

Why fix this now? Because my PR (#9209) was failing in CI,
in the Validate step:

    Can't exec "./bin/podman": No such file or directory at hack/xref-helpmsgs-manpages line 223.

It failed even on Re-run, and only passed once I force-pushed
the PR (with no changes, just a new commit SHA). I have no idea
why bin/podman wasn't built, and I have zero interest in pursuing
that right now, but the proper solution is to add bin/podman as
a Makefile dependency for that particular test. So done.

While I'm at it, fix what is pretty clearly a typo in a .PHONY

And, finally, fix a go-md2man warning introduced in #9189

Signed-off-by: Ed Santiago <santiago@redhat.com>
