### PR TITLE
[v3.0] Gating tests: diff test: workaround for RHEL8 failure

### DIFF
--- a/test/system/140-diff.bats
+++ b/test/system/140-diff.bats
@@ -25,7 +25,12 @@ load helpers
     )
 
     for field in ${!expect[@]}; do
-        result=$(jq -r -c ".${field}[]" <<<"$output")
+        # ARGH! The /sys/fs kludgery is for RHEL8 rootless, which mumble mumble
+        # does some sort of magic muckery with /sys - I think the relevant
+        # PR is https://github.com/containers/podman/pull/8561
+        # Anyhow, without the egrep below, this test fails about 50% of the
+        # time on rootless RHEL8. (No, I don't know why it's not 100%).
+        result=$(jq -r -c ".${field}[]" <<<"$output" | egrep -v '^/sys/fs')
         is "$result" "${expect[$field]}" "$field"
     done
 


### PR DESCRIPTION
RHEL8 rootless gating tests are inconsistently failing with:
```
   $ podman diff --format json -l
   #
   {"changed":["/etc"],"added":["/sys/fs","/sys/fs/cgroup","/pMOm1Q0fnN"],"deleted":["/etc/services"]}
   # #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
   # #|     FAIL: added
   # #| expected: '/pMOm1Q0fnN'
   # #|   actual: '/sys/fs'
   # #|         > '/sys/fs/cgroup'
   # #|         > '/pMOm1Q0fnN'
   # #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
Reason: PR #8561, I think (something to do with /sys on RHEL).

Workaround: ignore '/sys/fs' in diffs.

Signed-off-by: Ed Santiago <santiago@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
