### PR TITLE
Fix invalid wait condition on kill

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -233,8 +233,8 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if sig == 0 || syscall.Signal(sig) == syscall.SIGKILL {
-			var opts entities.WaitOptions
-			if _, err := containerEngine.ContainerWait(r.Context(), []string{name}, opts); err != nil {
+			if _, err := utils.WaitContainer(w, r); err != nil {
+
 				utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
 				return
 			}

--- a/test/python/docker/test_containers.py
+++ b/test/python/docker/test_containers.py
@@ -95,6 +95,15 @@ class TestContainers(unittest.TestCase):
         top.reload()
         self.assertIn(top.status, ("stopped", "exited"))
 
+    def test_kill_container(self):
+        top = self.client.containers.get(TestContainers.topContainerId)
+        self.assertEqual(top.status, "running")
+
+        # Kill a running container and validate the state
+        top.kill()
+        top.reload()
+        self.assertIn(top.status, ("stopped", "exited"))
+
     def test_restart_container(self):
         # Validate the container state
         top = self.client.containers.get(TestContainers.topContainerId)


### PR DESCRIPTION
When using the compatability tests on kill, the kill
function goes into an infinite wait loop taking all of the CPU.

This change will use the correct wait function and exit properly.

Fixes: https://github.com/containers/podman/issues/9206

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
