### PR TITLE
bindings: attach: warn correct error

### DIFF
--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -348,7 +348,7 @@ func attachHandleResize(ctx, winCtx context.Context, winChange chan os.Signal, i
 				resizeErr = ResizeContainerTTY(ctx, id, new(ResizeTTYOptions).WithHeight(h).WithWidth(w))
 			}
 			if resizeErr != nil {
-				logrus.Warnf("failed to resize TTY: %v", err)
+				logrus.Warnf("failed to resize TTY: %v", resizeErr)
 			}
 		}
 	}


### PR DESCRIPTION
The resize warning logged the wrong error.  While this does not fix
 #9172, it may very well be helpful finding its root cause.

[NO TESTS NEEDED]

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
