### PR TITLE
fix logic when not creating a workdir

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -213,6 +213,7 @@ func (c *Container) resolveWorkDir() error {
 			// we need to return the full error.
 			return errors.Wrapf(err, "error detecting workdir %q on container %s", workdir, c.ID())
 		}
+		return nil
 	}
 
 	// Ensure container entrypoint is created (if required).

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -608,6 +608,19 @@ json-file | f
     # a subdir of a volume.
     run_podman run --rm --workdir /IamNotOntheImage -v $testdir/content:/IamNotOntheImage/foo $IMAGE cat foo
     is "$output" "$randomcontent" "cat random content"
+
+    # Make sure that running on a read-only rootfs works (#9230).
+    if ! is_rootless && ! is_remote; then
+        # image mount is hard to test as a rootless user
+        # and does not work remotely
+        run_podman image mount $IMAGE
+        romount="$output"
+
+        run_podman run --rm --rootfs $romount echo "Hello world"
+        is "$output" "Hello world"
+
+        run_podman image unmount $IMAGE
+    fi
 }
 
 # https://github.com/containers/podman/issues/9096


### PR DESCRIPTION
When resolving the workdir of a container, we may need to create it unless
the user sets it explicitly on the command line.  Otherwise, we just do a
presence check.  Unfortunately, there was a missing return that lead us
to fall through into attempting to create and chown the workdir.  That
caused a regression when running on a read-only root fs.

Fixes: #9230
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@Luap99 PTAL

It took me longer than I want to admit until I found an easy way to test it (doing the unshare+mount dance didn't work out well in the system tests).