### PR TITLE
Fix podman network disconnect wrong NetworkStatus number

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1180,7 +1180,7 @@ func (c *Container) NetworkDisconnect(nameOrID, netName string, force bool) erro
 	// update network status if container is not running
 	networkStatus := c.state.NetworkStatus
 	// clip out the index of the network
-	tmpNetworkStatus := make([]*cnitypes.Result, len(networkStatus)-1)
+	tmpNetworkStatus := make([]*cnitypes.Result, 0, len(networkStatus)-1)
 	for k, v := range networkStatus {
 		if index != k {
 			tmpNetworkStatus = append(tmpNetworkStatus, v)

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -74,6 +74,11 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		dis.WaitWithDefaultTimeout()
 		Expect(dis.ExitCode()).To(BeZero())
 
+		inspect := podmanTest.Podman([]string{"container", "inspect", "test", "--format", "{{len .NetworkSettings.Networks}}"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(BeZero())
+		Expect(inspect.OutputToString()).To(Equal("0"))
+
 		exec = podmanTest.Podman([]string{"exec", "-it", "test", "ip", "addr", "show", "eth0"})
 		exec.WaitWithDefaultTimeout()
 		Expect(exec.ExitCode()).ToNot(BeZero())
@@ -146,6 +151,11 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		connect.WaitWithDefaultTimeout()
 		Expect(connect.ExitCode()).To(BeZero())
 
+		inspect := podmanTest.Podman([]string{"container", "inspect", "test", "--format", "{{len .NetworkSettings.Networks}}"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(BeZero())
+		Expect(inspect.OutputToString()).To(Equal("2"))
+
 		exec = podmanTest.Podman([]string{"exec", "-it", "test", "ip", "addr", "show", "eth1"})
 		exec.WaitWithDefaultTimeout()
 		Expect(exec.ExitCode()).To(BeZero())
@@ -166,6 +176,11 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		dis := podmanTest.Podman([]string{"network", "connect", netName, "test"})
 		dis.WaitWithDefaultTimeout()
 		Expect(dis.ExitCode()).To(BeZero())
+
+		inspect := podmanTest.Podman([]string{"container", "inspect", "test", "--format", "{{len .NetworkSettings.Networks}}"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(BeZero())
+		Expect(inspect.OutputToString()).To(Equal("2"))
 
 		start := podmanTest.Podman([]string{"start", "test"})
 		start.WaitWithDefaultTimeout()
@@ -201,6 +216,11 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		dis := podmanTest.Podman([]string{"network", "disconnect", netName1, "test"})
 		dis.WaitWithDefaultTimeout()
 		Expect(dis.ExitCode()).To(BeZero())
+
+		inspect := podmanTest.Podman([]string{"container", "inspect", "test", "--format", "{{len .NetworkSettings.Networks}}"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(BeZero())
+		Expect(inspect.OutputToString()).To(Equal("1"))
 
 		start := podmanTest.Podman([]string{"start", "test"})
 		start.WaitWithDefaultTimeout()


### PR DESCRIPTION
The allocated `tmpNetworkStatus` must be allocated with the length 0.
Otherwise append would add new elements to the end of the slice and
not at the beginning of the allocated memory.

This caused inspect to fail since the number of networks did not
matched the number of network statuses.

Fixes #9234


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
