### PR TITLE
vendor latest containers/common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.0
 	github.com/containers/buildah v1.19.3
-	github.com/containers/common v0.33.1
+	github.com/containers/common v0.34.3-0.20210208115708-8668c76dd577
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.10.1
 	github.com/containers/psgo v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/containers/buildah v1.19.3 h1:U0E1UKzqW5C11W7giHhLZI06xkZiV40ZKDK/c1j
 github.com/containers/buildah v1.19.3/go.mod h1:uZb6GuE36tmRSOcIXGfiYqdpr+GPXWmlUIJSk5sn19w=
 github.com/containers/common v0.33.1 h1:XpDiq8Cta8+u1s4kpYSEWdB140ZmqgyIXfWkLqKx3z0=
 github.com/containers/common v0.33.1/go.mod h1:mjDo/NKeweL/onaspLhZ38WnHXaYmrELHclIdvSnYpY=
+github.com/containers/common v0.34.3-0.20210208115708-8668c76dd577 h1:tUJcLouJ1bC3w9gdqgKqZBsj2uCuM8D8jSR592lxbhE=
+github.com/containers/common v0.34.3-0.20210208115708-8668c76dd577/go.mod h1:mwZ9H8sK4+dtWxsnVLyWcjxK/gEQClrLsXsqLvbEKbI=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.9.0 h1:dRmUtcluQcmasNo3DpnRoZjfU0rOu1qZeL6wlDJr10Q=

--- a/vendor/github.com/containers/common/pkg/cgroupv2/cgroups_linux.go
+++ b/vendor/github.com/containers/common/pkg/cgroupv2/cgroups_linux.go
@@ -13,7 +13,7 @@ var (
 	isCgroupV2Err  error
 )
 
-// Enabled returns whether we are running in cgroup 2 cgroup2 mode.
+// Enabled returns whether we are running on cgroup v2
 func Enabled() (bool, error) {
 	isCgroupV2Once.Do(func() {
 		var st syscall.Statfs_t

--- a/vendor/github.com/containers/common/pkg/cgroupv2/cgroups_unsupported.go
+++ b/vendor/github.com/containers/common/pkg/cgroupv2/cgroups_unsupported.go
@@ -2,7 +2,7 @@
 
 package cgroupv2
 
-// Enabled returns whether we are running in cgroup 2 cgroup2 mode.
+// Enabled returns whether we are running on cgroup v2
 func Enabled() (bool, error) {
 	return false, nil
 }

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -187,10 +187,6 @@ type ContainersConfig struct {
 
 // EngineConfig contains configuration options used to set up a engine runtime
 type EngineConfig struct {
-	// ImageBuildFormat indicates the default image format to building
-	// container images.  Valid values are "oci" (default) or "docker".
-	ImageBuildFormat string `toml:"image_build_format,omitempty"`
-
 	// CgroupCheck indicates the configuration has been rewritten after an
 	// upgrade to Fedora 31 to change the default OCI runtime for cgroupv2v2.
 	CgroupCheck bool `toml:"cgroup_check,omitempty"`
@@ -235,9 +231,24 @@ type EngineConfig struct {
 	// this slice takes precedence.
 	HooksDir []string `toml:"hooks_dir,omitempty"`
 
+	// ImageBuildFormat (DEPRECATED) indicates the default image format to
+	// building container images. Should use ImageDefaultFormat
+	ImageBuildFormat string `toml:"image_build_format,omitempty"`
+
 	// ImageDefaultTransport is the default transport method used to fetch
 	// images.
 	ImageDefaultTransport string `toml:"image_default_transport,omitempty"`
+
+	// ImageParallelCopies indicates the maximum number of image layers
+	// to be copied simultaneously. If this is zero, container engines
+	// will fall back to containers/image defaults.
+	ImageParallelCopies uint `toml:"image_parallel_copies,omitempty"`
+
+	// ImageDefaultFormat sepecified the manifest Type (oci, v2s2, or v2s1)
+	// to use when pulling, pushing, building container images. By default
+	// image pulled and pushed match the format of the source image.
+	// Building/committing defaults to OCI.
+	ImageDefaultFormat string `toml:"image_default_format,omitempty"`
 
 	// InfraCommand is the command run to start up a pod infra container.
 	InfraCommand string `toml:"infra_command,omitempty"`

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -246,9 +246,14 @@ default_sysctls = [
 # network_config_dir = "/etc/cni/net.d/"
 
 [engine]
-# ImageBuildFormat indicates the default image format to building
-# container images. Valid values are "oci" (default) or "docker".
-# image_build_format = "oci"
+# Maximum number of image layers to be copied (pulled/pushed) simultaneously.
+# Not setting this field, or setting it to zero, will fall back to containers/image defaults.
+# image_parallel_copies=0
+
+# Manifest Type (oci, v2s2, or v2s1) to use when pulling, pushing, building
+# container images. By default image pulled and pushed match the format of the
+# source image. Building/commiting defaults to OCI.
+# image_default_format = ""
 
 # Cgroup management implementation used for the runtime.
 # Valid options "systemd" or "cgroupfs"

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -518,3 +518,9 @@ func (c *Config) TZ() string {
 func (c *Config) Umask() string {
 	return c.Containers.Umask
 }
+
+// LogDriver returns the logging driver to be used
+// currently k8s-file or journald
+func (c *Config) LogDriver() string {
+	return c.Containers.LogDriver
+}

--- a/vendor/github.com/containers/common/pkg/parse/parse.go
+++ b/vendor/github.com/containers/common/pkg/parse/parse.go
@@ -13,7 +13,7 @@ import (
 
 // ValidateVolumeOpts validates a volume's options
 func ValidateVolumeOpts(options []string) ([]string, error) {
-	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid int
+	var foundRootPropagation, foundRWRO, foundLabelChange, bindType, foundExec, foundDev, foundSuid, foundChown int
 	finalOpts := make([]string, 0, len(options))
 	for _, opt := range options {
 		switch opt {
@@ -41,6 +41,11 @@ func ValidateVolumeOpts(options []string) ([]string, error) {
 			foundLabelChange++
 			if foundLabelChange > 1 {
 				return nil, errors.Errorf("invalid options %q, can only specify 1 'z', 'Z', or 'O' option", strings.Join(options, ", "))
+			}
+		case "U":
+			foundChown++
+			if foundChown > 1 {
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'U' option", strings.Join(options, ", "))
 			}
 		case "private", "rprivate", "shared", "rshared", "slave", "rslave", "unbindable", "runbindable":
 			foundRootPropagation++

--- a/vendor/github.com/containers/common/pkg/report/doc.go
+++ b/vendor/github.com/containers/common/pkg/report/doc.go
@@ -38,7 +38,17 @@ Helpers:
 		... process JSON and output
 	}
 
-and
+Template Functions:
+
+The following template functions are added to the template when parsed:
+	- join  strings.Join, {{join .Field separator}}
+	- lower strings.ToLower {{ .Field | lower }}
+	- split strings.Split {{ .Field | split }}
+	- title strings.Title {{ .Field | title }}
+	- upper strings.ToUpper {{ .Field | upper }}
+
+report.Funcs() may be used to add additional template functions.
+Adding an existing function will replace that function for the life of that template.
 
 
 Note: Your code should not ignore errors

--- a/vendor/github.com/containers/common/pkg/seccomp/default_linux.go
+++ b/vendor/github.com/containers/common/pkg/seccomp/default_linux.go
@@ -5,8 +5,6 @@
 package seccomp
 
 import (
-	"syscall"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -45,7 +43,7 @@ func arches() []Architecture {
 
 // DefaultProfile defines the allowlist for the default seccomp profile.
 func DefaultProfile() *Seccomp {
-	einval := uint(syscall.EINVAL)
+	einval := uint(unix.EINVAL)
 
 	syscalls := []*Syscall{
 		{
@@ -87,6 +85,7 @@ func DefaultProfile() *Seccomp {
 				"epoll_ctl",
 				"epoll_ctl_old",
 				"epoll_pwait",
+				"epoll_pwait2",
 				"epoll_wait",
 				"epoll_wait_old",
 				"eventfd",
@@ -115,7 +114,11 @@ func DefaultProfile() *Seccomp {
 				"flock",
 				"fork",
 				"fremovexattr",
+				"fsconfig",
 				"fsetxattr",
+				"fsmount",
+				"fsopen",
+				"fspick",
 				"fstat",
 				"fstat64",
 				"fstatat64",
@@ -203,6 +206,7 @@ func DefaultProfile() *Seccomp {
 				"mmap",
 				"mmap2",
 				"mount",
+				"move_mount",
 				"mprotect",
 				"mq_getsetattr",
 				"mq_notify",
@@ -225,6 +229,7 @@ func DefaultProfile() *Seccomp {
 				"open",
 				"openat",
 				"openat2",
+				"open_tree",
 				"pause",
 				"pidfd_getfd",
 				"pidfd_open",
@@ -331,7 +336,6 @@ func DefaultProfile() *Seccomp {
 				"signalfd",
 				"signalfd4",
 				"sigreturn",
-				"socket",
 				"socketcall",
 				"socketpair",
 				"splice",
@@ -512,73 +516,18 @@ func DefaultProfile() *Seccomp {
 		{
 			Names: []string{
 				"bpf",
-				"clone",
 				"fanotify_init",
 				"lookup_dcookie",
-				"mount",
-				"name_to_handle_at",
 				"perf_event_open",
 				"quotactl",
 				"setdomainname",
 				"sethostname",
 				"setns",
-				"umount",
-				"umount2",
-				"unshare",
 			},
 			Action: ActAllow,
 			Args:   []*Arg{},
 			Includes: Filter{
 				Caps: []string{"CAP_SYS_ADMIN"},
-			},
-		},
-		{
-			Names: []string{
-				"clone",
-			},
-			Action: ActAllow,
-			Args: []*Arg{
-				{
-					Index:    0,
-					Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET,
-					ValueTwo: 0,
-					Op:       OpMaskedEqual,
-				},
-			},
-			Excludes: Filter{
-				Caps:   []string{"CAP_SYS_ADMIN"},
-				Arches: []string{"s390", "s390x"},
-			},
-		},
-		{
-			Names: []string{
-				"clone",
-			},
-			Action: ActAllow,
-			Args: []*Arg{
-				{
-					Index:    1,
-					Value:    unix.CLONE_NEWNS | unix.CLONE_NEWUTS | unix.CLONE_NEWIPC | unix.CLONE_NEWUSER | unix.CLONE_NEWPID | unix.CLONE_NEWNET,
-					ValueTwo: 0,
-					Op:       OpMaskedEqual,
-				},
-			},
-			Comment: "s390 parameter ordering for clone is different",
-			Includes: Filter{
-				Arches: []string{"s390", "s390x"},
-			},
-			Excludes: Filter{
-				Caps: []string{"CAP_SYS_ADMIN"},
-			},
-		},
-		{
-			Names: []string{
-				"reboot",
-			},
-			Action: ActAllow,
-			Args:   []*Arg{},
-			Includes: Filter{
-				Caps: []string{"CAP_SYS_BOOT"},
 			},
 		},
 		{
@@ -608,7 +557,6 @@ func DefaultProfile() *Seccomp {
 			Names: []string{
 				"get_mempolicy",
 				"mbind",
-				"name_to_handle_at",
 				"set_mempolicy",
 			},
 			Action: ActAllow,
@@ -630,6 +578,7 @@ func DefaultProfile() *Seccomp {
 		{
 			Names: []string{
 				"kcmp",
+				"process_madvise",
 				"process_vm_readv",
 				"process_vm_writev",
 				"ptrace",
@@ -683,12 +632,12 @@ func DefaultProfile() *Seccomp {
 			Args: []*Arg{
 				{
 					Index: 0,
-					Value: syscall.AF_NETLINK,
+					Value: unix.AF_NETLINK,
 					Op:    OpEqualTo,
 				},
 				{
 					Index: 2,
-					Value: syscall.NETLINK_AUDIT,
+					Value: unix.NETLINK_AUDIT,
 					Op:    OpEqualTo,
 				},
 			},
@@ -704,7 +653,7 @@ func DefaultProfile() *Seccomp {
 			Args: []*Arg{
 				{
 					Index: 2,
-					Value: syscall.NETLINK_AUDIT,
+					Value: unix.NETLINK_AUDIT,
 					Op:    OpNotEqual,
 				},
 			},
@@ -720,7 +669,7 @@ func DefaultProfile() *Seccomp {
 			Args: []*Arg{
 				{
 					Index: 0,
-					Value: syscall.AF_NETLINK,
+					Value: unix.AF_NETLINK,
 					Op:    OpNotEqual,
 				},
 			},
@@ -736,7 +685,7 @@ func DefaultProfile() *Seccomp {
 			Args: []*Arg{
 				{
 					Index: 2,
-					Value: syscall.NETLINK_AUDIT,
+					Value: unix.NETLINK_AUDIT,
 					Op:    OpNotEqual,
 				},
 			},

--- a/vendor/github.com/containers/common/pkg/seccomp/seccomp.json
+++ b/vendor/github.com/containers/common/pkg/seccomp/seccomp.json
@@ -89,6 +89,7 @@
 				"epoll_ctl",
 				"epoll_ctl_old",
 				"epoll_pwait",
+				"epoll_pwait2",
 				"epoll_wait",
 				"epoll_wait_old",
 				"eventfd",
@@ -117,7 +118,11 @@
 				"flock",
 				"fork",
 				"fremovexattr",
+				"fsconfig",
 				"fsetxattr",
+				"fsmount",
+				"fsopen",
+				"fspick",
 				"fstat",
 				"fstat64",
 				"fstatat64",
@@ -177,6 +182,7 @@
 				"ioprio_get",
 				"ioprio_set",
 				"ipc",
+				"keyctl",
 				"kill",
 				"lchown",
 				"lchown32",
@@ -204,6 +210,7 @@
 				"mmap",
 				"mmap2",
 				"mount",
+				"move_mount",
 				"mprotect",
 				"mq_getsetattr",
 				"mq_notify",
@@ -226,6 +233,7 @@
 				"open",
 				"openat",
 				"openat2",
+				"open_tree",
 				"pause",
 				"pidfd_getfd",
 				"pidfd_open",
@@ -574,19 +582,13 @@
 		{
 			"names": [
 				"bpf",
-				"clone",
 				"fanotify_init",
 				"lookup_dcookie",
-				"mount",
-				"name_to_handle_at",
 				"perf_event_open",
 				"quotactl",
 				"setdomainname",
 				"sethostname",
-				"setns",
-				"umount",
-				"umount2",
-				"unshare"
+				"setns"
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [],
@@ -594,71 +596,6 @@
 			"includes": {
 				"caps": [
 					"CAP_SYS_ADMIN"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"clone"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 2080505856,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_MASKED_EQ"
-				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_ADMIN"
-				],
-				"arches": [
-					"s390",
-					"s390x"
-				]
-			}
-		},
-		{
-			"names": [
-				"clone"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 1,
-					"value": 2080505856,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_MASKED_EQ"
-				}
-			],
-			"comment": "s390 parameter ordering for clone is different",
-			"includes": {
-				"arches": [
-					"s390",
-					"s390x"
-				]
-			},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_ADMIN"
-				]
-			}
-		},
-		{
-			"names": [
-				"reboot"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_SYS_BOOT"
 				]
 			},
 			"excludes": {}
@@ -698,7 +635,6 @@
 			"names": [
 				"get_mempolicy",
 				"mbind",
-				"name_to_handle_at",
 				"set_mempolicy"
 			],
 			"action": "SCMP_ACT_ALLOW",
@@ -728,6 +664,7 @@
 		{
 			"names": [
 				"kcmp",
+				"process_madvise",
 				"process_vm_readv",
 				"process_vm_writev",
 				"ptrace"

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.33.1"
+const Version = "0.34.3-dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -89,7 +89,7 @@ github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/supplemented
 github.com/containers/buildah/util
-# github.com/containers/common v0.33.1
+# github.com/containers/common v0.34.3-0.20210208115708-8668c76dd577
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/apparmor/internal/supported
 github.com/containers/common/pkg/auth


### PR DESCRIPTION
We had a couple of regressions in containers/common in the last release.
Before cutting a new release, let's vendor it here.  Since 3.0 has been
branched, we can vendor a non-release commit of c/common.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
