### PR TITLE
[CI:DOCS] Cirrus: Send cirrus-cron report e-mail to list.

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -6,6 +6,7 @@
 name: check_cirrus_cron
 
 on:
+    # Note: This only applies to the master branch.
     schedule:
         # Assume cirrus cron jobs runs at least once per day
         - cron:  '59 23 * * *'
@@ -53,6 +54,7 @@ jobs:
                 echo ""
                 echo "# Source: ${{ github.workflow }} workflow on ${{ github.repository }}."
                 # Separate content from sendgrid.com automatic footer.
+                echo ""
                 echo ""
                 ) > ./artifacts/email_body.txt
 

--- a/contrib/cirrus/cron-fail_addrs.csv
+++ b/contrib/cirrus/cron-fail_addrs.csv
@@ -1,1 +1,1 @@
-rh.container.bot@gmail.com
+rh.container.bot@gmail.com,podman-monitor@lists.podman.io


### PR DESCRIPTION
This mailing-list was established to allow people to sub/unsub from
automated notifications.  Add it to the list of destinations picked up
by the Github Actions workflow
`.github/workflows/check_cirrus_cron.yml`.

***NOTE:*** Github Actions only operates on this list from the master branch, there is no way to test this on a PR.  Instead, I verified it's [functioning with a github action workflow on the c/automation_sandbox repository](https://github.com/containers/automation_sandbox/runs/1856378361?check_suite_focus=true#step:4:29).  I confirmed that test message was successfully received and relayed to subscribers by the podman-monitor list service.