### PR TITLE
Allow path completion for podman create/run --rootfs

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -426,6 +426,12 @@ func AutocompleteCreateRun(cmd *cobra.Command, args []string, toComplete string)
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	if len(args) < 1 {
+		// check if the rootfs flag is set
+		// if it is set to true provide directory completion
+		rootfs, err := cmd.Flags().GetBool("rootfs")
+		if err == nil && rootfs {
+			return nil, cobra.ShellCompDirectiveFilterDirs
+		}
 		return getImages(cmd, toComplete)
 	}
 	// TODO: add path completion for files in the image


### PR DESCRIPTION
If the --rootfs flag is set podman create/run expect a host
path as first argument. The shell completion should provide
path completion in that case.

[NO TESTS NEEDED]
This can manually be verified with `podman run --rootfs [TAB]`.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
