### PR TITLE
Fix Docker APIv2 push endpoint

### DIFF
--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -1,7 +1,6 @@
 package compat
 
 import (
-	"context"
 	"net/http"
 	"strings"
 
@@ -76,7 +75,15 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)
 	}
-	if err := imageEngine.Push(context.Background(), imageName, query.Destination, options); err != nil {
+
+	var destination string
+	if _, found := r.URL.Query()["destination"]; found {
+		destination = query.Destination
+	} else {
+		destination = imageName
+	}
+
+	if err := imageEngine.Push(r.Context(), imageName, destination, options); err != nil {
 		if errors.Cause(err) != storage.ErrImageUnknown {
 			utils.ImageNotFound(w, imageName, errors.Wrapf(err, "failed to find image %s", imageName))
 			return

--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -24,13 +24,10 @@ t GET libpod/images/$IMAGE/json 200 \
 
 # Run registry container
 podman run -d --name registry -p 5000:5000 quay.io/libpod/registry:2.6 /entrypoint.sh /etc/docker/registry/config.yml
+sleep 2
 
 # Push to local registry
-# FIXME: this is failing:
-#   "cause": "received unexpected HTTP status: 500 Internal Server Error",
-#   "message": "error pushing image \"localhost:5000/myrepo:mytag\": error copying image to the remote destination: Error writing blob: Error initiating layer upload to /v2/myrepo/blobs/uploads/ in localhost:5000: received unexpected HTTP status: 500 Internal Server Error",
-#   "response": 400
-#t POST libpod/images/localhost:5000/myrepo:mytag/push\?tlsVerify\=false '' 200
+t POST "images/localhost:5000/myrepo/push?tlsVerify=false&tag=mytag" '' 200
 
 # Untag the image
 t POST "libpod/images/$iid/untag?repo=localhost:5000/myrepo&tag=mytag" '' 201


### PR DESCRIPTION
Docker doesn't have destination parameter as libpod,
the "image name" path parameter is supposed to be destination.

Signed-off-by: Matej Vasek <mvasek@redhat.com>