### PR TITLE
[v3.0] Backport final breaking API change to v3.0

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -474,29 +474,29 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	)
 	_ = cmd.RegisterFlagCompletionFunc(oomScoreAdjFlagName, completion.AutocompleteNone)
 
-	overrideArchFlagName := "override-arch"
+	archFlagName := "arch"
 	createFlags.StringVar(
-		&cf.OverrideArch,
-		overrideArchFlagName, "",
+		&cf.Arch,
+		archFlagName, "",
 		"use `ARCH` instead of the architecture of the machine for choosing images",
 	)
-	_ = cmd.RegisterFlagCompletionFunc(overrideArchFlagName, completion.AutocompleteNone)
+	_ = cmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteArch)
 
-	overrideOSFlagName := "override-os"
+	osFlagName := "os"
 	createFlags.StringVar(
-		&cf.OverrideOS,
-		overrideOSFlagName, "",
+		&cf.OS,
+		osFlagName, "",
 		"use `OS` instead of the running OS for choosing images",
 	)
-	_ = cmd.RegisterFlagCompletionFunc(overrideOSFlagName, completion.AutocompleteNone)
+	_ = cmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteOS)
 
-	overrideVariantFlagName := "override-variant"
+	variantFlagName := "variant"
 	createFlags.StringVar(
-		&cf.OverrideVariant,
-		overrideVariantFlagName, "",
+		&cf.Variant,
+		variantFlagName, "",
 		"Use _VARIANT_ instead of the running architecture variant for choosing images",
 	)
-	_ = cmd.RegisterFlagCompletionFunc(overrideVariantFlagName, completion.AutocompleteNone)
+	_ = cmd.RegisterFlagCompletionFunc(variantFlagName, completion.AutocompleteNone)
 
 	pidFlagName := "pid"
 	createFlags.String(
@@ -516,7 +516,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	createFlags.StringVar(
 		&cf.Platform,
 		platformFlagName, "",
-		"Specify the platform for selecting the image.  (Conflicts with override-arch and override-os)",
+		"Specify the platform for selecting the image.  (Conflicts with --arch and --os)",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(platformFlagName, completion.AutocompleteNone)
 

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -74,9 +74,9 @@ type ContainerCLIOpts struct {
 	NoHealthCheck     bool
 	OOMKillDisable    bool
 	OOMScoreAdj       int
-	OverrideArch      string
-	OverrideOS        string
-	OverrideVariant   string
+	Arch              string
+	OS                string
+	Variant           string
 	PID               string
 	PIDsLimit         *int64
 	Platform          string
@@ -347,9 +347,9 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		LogOptions:       stringMaptoArray(cc.HostConfig.LogConfig.Config),
 		Name:             cc.Name,
 		OOMScoreAdj:      cc.HostConfig.OomScoreAdj,
-		OverrideArch:     "",
-		OverrideOS:       "",
-		OverrideVariant:  "",
+		Arch:             "",
+		OS:               "",
+		Variant:          "",
 		PID:              string(cc.HostConfig.PidMode),
 		PIDsLimit:        cc.HostConfig.PidsLimit,
 		Privileged:       cc.HostConfig.Privileged,

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -237,17 +237,20 @@ func pullImage(imageName string) (string, error) {
 		imageMissing = !br.Value
 	}
 
-	if cliVals.Platform != "" {
-		if cliVals.OverrideArch != "" || cliVals.OverrideOS != "" {
-			return "", errors.Errorf("--platform option can not be specified with --override-arch or --override-os")
+	if cliVals.Platform != "" || cliVals.Arch != "" || cliVals.OS != "" {
+		if cliVals.Platform != "" {
+			if cliVals.Arch != "" || cliVals.OS != "" {
+				return "", errors.Errorf("--platform option can not be specified with --arch or --os")
+			}
+			split := strings.SplitN(cliVals.Platform, "/", 2)
+			cliVals.OS = split[0]
+			if len(split) > 1 {
+				cliVals.Arch = split[1]
+			}
 		}
-		split := strings.SplitN(cliVals.Platform, "/", 2)
-		cliVals.OverrideOS = split[0]
-		if len(split) > 1 {
-			cliVals.OverrideArch = split[1]
-		}
+
 		if pullPolicy != config.PullImageAlways {
-			logrus.Info("--platform causes the pull policy to be \"always\"")
+			logrus.Info("--platform --arch and --os causes the pull policy to be \"always\"")
 			pullPolicy = config.PullImageAlways
 		}
 	}
@@ -259,9 +262,9 @@ func pullImage(imageName string) (string, error) {
 		pullReport, pullErr := registry.ImageEngine().Pull(registry.GetContext(), imageName, entities.ImagePullOptions{
 			Authfile:        cliVals.Authfile,
 			Quiet:           cliVals.Quiet,
-			OverrideArch:    cliVals.OverrideArch,
-			OverrideOS:      cliVals.OverrideOS,
-			OverrideVariant: cliVals.OverrideVariant,
+			Arch:            cliVals.Arch,
+			OS:              cliVals.OS,
+			Variant:         cliVals.Variant,
 			SignaturePolicy: cliVals.SignaturePolicy,
 			PullPolicy:      pullPolicy,
 		})

--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -78,7 +78,7 @@ func listFlagSet(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
 	flags.BoolVarP(&listOpts.All, "all", "a", false, "Show all the containers, default is only running containers")
-	flags.BoolVar(&listOpts.Storage, "external", false, "Show containers in storage not controlled by Podman")
+	flags.BoolVar(&listOpts.External, "external", false, "Show containers in storage not controlled by Podman")
 
 	filterFlagName := "filter"
 	flags.StringSliceVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
@@ -132,10 +132,10 @@ func checkFlags(c *cobra.Command) error {
 	}
 	cfg := registry.PodmanConfig()
 	if cfg.Engine.Namespace != "" {
-		if c.Flag("storage").Changed && listOpts.Storage {
-			return errors.New("--namespace and --storage flags can not both be set")
+		if c.Flag("storage").Changed && listOpts.External {
+			return errors.New("--namespace and --external flags can not both be set")
 		}
-		listOpts.Storage = false
+		listOpts.External = false
 	}
 
 	return nil

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -140,6 +140,10 @@ func removeContainers(namesOrIDs []string, rmOptions entities.RmOptions, setExit
 }
 
 func setExitCode(err error) {
+	// If error is set to no such container, do not reset
+	if registry.GetExitCode() == 1 {
+		return
+	}
 	cause := errors.Cause(err)
 	switch {
 	case cause == define.ErrNoSuchCtr:

--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -95,10 +95,11 @@ func wait(cmd *cobra.Command, args []string) error {
 		return errors.New("--latest and containers cannot be used together")
 	}
 
-	waitOptions.Condition, err = define.StringToContainerStatus(waitCondition)
+	cond, err := define.StringToContainerStatus(waitCondition)
 	if err != nil {
 		return err
 	}
+	waitOptions.Condition = []define.ContainerStatus{cond}
 
 	responses, err := registry.ContainerEngine().ContainerWait(context.Background(), args, waitOptions)
 	if err != nil {

--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -50,7 +50,7 @@ func waitFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
 	intervalFlagName := "interval"
-	flags.StringVarP(&waitInterval, intervalFlagName, "i", "250ns", "Time Interval to wait before polling for completion")
+	flags.StringVarP(&waitInterval, intervalFlagName, "i", "250ms", "Time Interval to wait before polling for completion")
 	_ = cmd.RegisterFlagCompletionFunc(intervalFlagName, completion.AutocompleteNone)
 
 	conditionFlagName := "condition"

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -84,20 +84,20 @@ func pullFlags(cmd *cobra.Command) {
 	flags.StringVar(&pullOptions.CredentialsCLI, credsFlagName, "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
 	_ = cmd.RegisterFlagCompletionFunc(credsFlagName, completion.AutocompleteNone)
 
-	overrideArchFlagName := "override-arch"
-	flags.StringVar(&pullOptions.OverrideArch, overrideArchFlagName, "", "Use `ARCH` instead of the architecture of the machine for choosing images")
-	_ = cmd.RegisterFlagCompletionFunc(overrideArchFlagName, completion.AutocompleteNone)
+	archFlagName := "arch"
+	flags.StringVar(&pullOptions.Arch, archFlagName, "", "Use `ARCH` instead of the architecture of the machine for choosing images")
+	_ = cmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteArch)
 
-	overrideOsFlagName := "override-os"
-	flags.StringVar(&pullOptions.OverrideOS, overrideOsFlagName, "", "Use `OS` instead of the running OS for choosing images")
-	_ = cmd.RegisterFlagCompletionFunc(overrideOsFlagName, completion.AutocompleteNone)
+	osFlagName := "os"
+	flags.StringVar(&pullOptions.OS, osFlagName, "", "Use `OS` instead of the running OS for choosing images")
+	_ = cmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteOS)
 
-	overrideVariantFlagName := "override-variant"
-	flags.StringVar(&pullOptions.OverrideVariant, overrideVariantFlagName, "", " use VARIANT instead of the running architecture variant for choosing images")
-	_ = cmd.RegisterFlagCompletionFunc(overrideVariantFlagName, completion.AutocompleteNone)
+	variantFlagName := "variant"
+	flags.StringVar(&pullOptions.Variant, variantFlagName, "", " use VARIANT instead of the running architecture variant for choosing images")
+	_ = cmd.RegisterFlagCompletionFunc(variantFlagName, completion.AutocompleteNone)
 
 	platformFlagName := "platform"
-	flags.String(platformFlagName, "", "Specify the platform for selecting the image.  (Conflicts with override-arch and override-os)")
+	flags.String(platformFlagName, "", "Specify the platform for selecting the image.  (Conflicts with arch and os)")
 	_ = cmd.RegisterFlagCompletionFunc(platformFlagName, completion.AutocompleteNone)
 
 	flags.Bool("disable-content-trust", false, "This is a Docker specific option and is a NOOP")
@@ -138,13 +138,13 @@ func imagePull(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if platform != "" {
-		if pullOptions.OverrideArch != "" || pullOptions.OverrideOS != "" {
-			return errors.Errorf("--platform option can not be specified with --override-arch or --override-os")
+		if pullOptions.Arch != "" || pullOptions.OS != "" {
+			return errors.Errorf("--platform option can not be specified with --arch or --os")
 		}
 		split := strings.SplitN(platform, "/", 2)
-		pullOptions.OverrideOS = split[0]
+		pullOptions.OS = split[0]
 		if len(split) > 1 {
-			pullOptions.OverrideArch = split[1]
+			pullOptions.Arch = split[1]
 		}
 	}
 

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -114,7 +114,11 @@ func pushFlags(cmd *cobra.Command) {
 	if registry.IsRemote() {
 		_ = flags.MarkHidden("cert-dir")
 		_ = flags.MarkHidden("compress")
+		_ = flags.MarkHidden("digestfile")
+		_ = flags.MarkHidden("format")
 		_ = flags.MarkHidden("quiet")
+		_ = flags.MarkHidden("remove-signatures")
+		_ = flags.MarkHidden("sign-by")
 	}
 	_ = flags.MarkHidden("signature-policy")
 }

--- a/cmd/podman/manifest/add.go
+++ b/cmd/podman/manifest/add.go
@@ -52,7 +52,7 @@ func init() {
 
 	archFlagName := "arch"
 	flags.StringVar(&manifestAddOpts.Arch, archFlagName, "", "override the `architecture` of the specified image")
-	_ = addCmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteNone)
+	_ = addCmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteArch)
 
 	authfileFlagName := "authfile"
 	flags.StringVar(&manifestAddOpts.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
@@ -72,7 +72,7 @@ func init() {
 
 	osFlagName := "os"
 	flags.StringVar(&manifestAddOpts.OS, osFlagName, "", "override the `OS` of the specified image")
-	_ = addCmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteNone)
+	_ = addCmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteOS)
 
 	osVersionFlagName := "os-version"
 	flags.StringVar(&manifestAddOpts.OSVersion, osVersionFlagName, "", "override the OS `version` of the specified image")

--- a/cmd/podman/manifest/annotate.go
+++ b/cmd/podman/manifest/annotate.go
@@ -39,7 +39,7 @@ func init() {
 
 	archFlagName := "arch"
 	flags.StringVar(&manifestAnnotateOpts.Arch, archFlagName, "", "override the `architecture` of the specified image")
-	_ = annotateCmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteNone)
+	_ = annotateCmd.RegisterFlagCompletionFunc(archFlagName, completion.AutocompleteArch)
 
 	featuresFlagName := "features"
 	flags.StringSliceVar(&manifestAnnotateOpts.Features, featuresFlagName, nil, "override the `features` of the specified image")
@@ -47,7 +47,7 @@ func init() {
 
 	osFlagName := "os"
 	flags.StringVar(&manifestAnnotateOpts.OS, osFlagName, "", "override the `OS` of the specified image")
-	_ = annotateCmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteNone)
+	_ = annotateCmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteOS)
 
 	osFeaturesFlagName := "os-features"
 	flags.StringSliceVar(&manifestAnnotateOpts.OSFeatures, osFeaturesFlagName, nil, "override the OS `features` of the specified image")

--- a/cmd/podman/utils/alias.go
+++ b/cmd/podman/utils/alias.go
@@ -25,6 +25,12 @@ func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "external"
 	case "purge":
 		name = "rm"
+	case "override-arch":
+		name = "arch"
+	case "override-os":
+		name = "os"
+	case "override-variant":
+		name = "variant"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -77,6 +77,9 @@ option can be set multiple times.
 Add an annotation to the container. The format is key=value.
 The **--annotation** option can be set multiple times.
 
+#### **--arch**=*ARCH*
+Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
+
 #### **--attach**, **-a**=*location*
 
 Attach to STDIN, STDOUT or STDERR.
@@ -668,14 +671,8 @@ Whether to disable OOM Killer for the container or not.
 
 Tune the host's OOM preferences for containers (accepts -1000 to 1000)
 
-#### **--override-arch**=*ARCH*
-Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
-
-#### **--override-os**=*OS*
+#### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
-
-#### **--override-variant**=*VARIANT*
-Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 #### **--pid**=*pid*
 
@@ -692,7 +689,7 @@ Tune the container's pids limit. Set `0` to have unlimited pids for the containe
 
 #### **--platform**=*OS/ARCH*
 
-Specify the platform for selecting the image.   (Conflicts with override-arch and override-os)
+Specify the platform for selecting the image.   (Conflicts with --arch and --os)
 The `--platform` option can be used to override the current architecture and operating system.
 
 #### **--pod**=*name*
@@ -1007,6 +1004,9 @@ Set the UTS namespace mode for the container. The following values are supported
 - **private**: create a new namespace for the container (default).
 - **ns:[path]**: run the container in the given existing UTS namespace.
 - **container:[container]**: join the UTS namespace of the specified container.
+
+#### **--variant**=*VARIANT*
+Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 #### **--volume**, **-v**[=*[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*]
 

--- a/docs/source/markdown/podman-pull.1.md
+++ b/docs/source/markdown/podman-pull.1.md
@@ -71,6 +71,9 @@ All tagged images in the repository will be pulled.
 
 Note: When using the all-tags flag, Podman will not iterate over the search registries in the containers-registries.conf(5) but will always use docker.io for unqualified image names.
 
+#### **--arch**=*ARCH*
+Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
+
 #### **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
@@ -96,19 +99,16 @@ This is a Docker specific option to disable image verification to a Docker
 registry and is not supported by Podman.  This flag is a NOOP and provided
 solely for scripting compatibility.
 
-#### **--override-arch**=*ARCH*
-Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
+#### **--help**, **-h**
 
-#### **--override-os**=*OS*
+Print usage statement
+
+#### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
-
-#### **--override-variant**=*VARIANT*
-
-Use _VARIANT_ instead of the default architecture variant of the container image.  Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 #### **--platform**=*OS/ARCH*
 
-Specify the platform for selecting the image.  (Conflicts with override-arch and override-os)
+Specify the platform for selecting the image.  (Conflicts with --arch and --os)
 The `--platform` option can be used to override the current architecture and operating system.
 
 #### **--quiet**, **-q**
@@ -121,9 +121,9 @@ Require HTTPS and verify certificates when contacting registries (default: true)
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
 TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
-#### **--help**, **-h**
+#### **--variant**=*VARIANT*
 
-Print usage statement
+Use _VARIANT_ instead of the default architecture variant of the container image.  Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 ## EXAMPLES
 
@@ -189,7 +189,7 @@ Storing signatures
 ```
 
 ```
-$ podman pull --override-arch=arm arm32v7/debian:stretch
+$ podman pull --arch=arm arm32v7/debian:stretch
 Trying to pull docker.io/arm32v7/debian:stretch...
 Getting image source signatures
 Copying blob b531ae4a3925 done

--- a/docs/source/markdown/podman-push.1.md
+++ b/docs/source/markdown/podman-push.1.md
@@ -91,7 +91,7 @@ solely for scripting compatibility.
 #### **--format**, **-f**=*format*
 
 Manifest Type (oci, v2s1, or v2s2) to use when pushing an image to a directory using the 'dir:' transport (default is manifest type of source)
-Note: This flag can only be set when using the **dir** transport
+Note: This flag can only be set when using the **dir** transport. (Not available for remote commands)
 
 #### **--quiet**, **-q**
 
@@ -99,11 +99,11 @@ When writing the output image, suppress progress output
 
 #### **--remove-signatures**
 
-Discard any pre-existing signatures in the image
+Discard any pre-existing signatures in the image. (Not available for remote commands)
 
 #### **--sign-by**=*key*
 
-Add a signature at the destination using the specified key
+Add a signature at the destination using the specified key. (Not available for remote commands)
 
 #### **--tls-verify**=*true|false*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -93,6 +93,9 @@ This option can be set multiple times.
 Add an annotation to the container.
 This option can be set multiple times.
 
+#### **--arch**=*ARCH*
+Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
+
 #### **--attach**, **-a**=**stdin**|**stdout**|**stderr**
 
 Attach to STDIN, STDOUT or STDERR.
@@ -705,14 +708,8 @@ Whether to disable OOM Killer for the container or not.
 
 Tune the host's OOM preferences for containers (accepts values from **-1000** to **1000**).
 
-#### **--override-arch**=*ARCH*
-Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
-
-#### **--override-os**=*OS*
+#### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
-
-#### **--override-variant**=*VARIANT*
-Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 #### **--pid**=*mode*
 
@@ -730,7 +727,7 @@ Tune the container's pids limit. Set to **0** to have unlimited pids for the con
 
 #### **--platform**=*OS/ARCH*
 
-Specify the platform for selecting the image.  (Conflicts with override-arch and override-os)
+Specify the platform for selecting the image.  (Conflicts with --arch and --os)
 The `--platform` option can be used to override the current architecture and operating system.
 
 #### **--pod**=*name*
@@ -1082,6 +1079,9 @@ Set the UTS namespace mode for the container. The following values are supported
 - **private**: create a new namespace for the container (default).
 - **ns:[path]**: run the container in the given existing UTS namespace.
 - **container:[container]**: join the UTS namespace of the specified container.
+
+#### **--variant**=*VARIANT*
+Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
 
 #### **--volume**, **-v**[=*[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*]
 

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -754,17 +754,17 @@ func (c *Container) getArtifactPath(name string) string {
 }
 
 // Used with Wait() to determine if a container has exited
-func (c *Container) isStopped() (bool, error) {
+func (c *Container) isStopped() (bool, int32, error) {
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 	}
 	err := c.syncContainer()
 	if err != nil {
-		return true, err
+		return true, -1, err
 	}
 
-	return !c.ensureState(define.ContainerStateRunning, define.ContainerStatePaused, define.ContainerStateStopping), nil
+	return !c.ensureState(define.ContainerStateRunning, define.ContainerStatePaused, define.ContainerStateStopping), c.state.ExitCode, nil
 }
 
 // save container state to the database

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -198,4 +198,8 @@ var (
 	// ErrSecurityAttribute indicates that an error processing security attributes
 	// for the container
 	ErrSecurityAttribute = fmt.Errorf("%w: unable to process security attribute", ErrOCIRuntime)
+
+	// ErrCanceled indicates that an operation has been cancelled by a user.
+	// Useful for potentially long running tasks.
+	ErrCanceled = errors.New("cancelled by user")
 )

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -77,7 +77,7 @@ func RemoveContainer(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
-	if report[0].Err != nil {
+	if len(report) > 0 && report[0].Err != nil {
 		utils.InternalServerError(w, report[0].Err)
 		return
 	}

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -14,7 +14,9 @@ import (
 	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/pkg/api/handlers"
 	"github.com/containers/podman/v2/pkg/api/handlers/utils"
+	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/domain/filters"
+	"github.com/containers/podman/v2/pkg/domain/infra/abi"
 	"github.com/containers/podman/v2/pkg/ps"
 	"github.com/containers/podman/v2/pkg/signal"
 	"github.com/docker/docker/api/types"
@@ -30,9 +32,11 @@ import (
 func RemoveContainer(w http.ResponseWriter, r *http.Request) {
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
-		Force bool `schema:"force"`
-		Vols  bool `schema:"v"`
-		Link  bool `schema:"link"`
+		All     bool `schema:"all"`
+		Force   bool `schema:"force"`
+		Ignore  bool `schema:"ignore"`
+		Link    bool `schema:"link"`
+		Volumes bool `schema:"v"`
 	}{
 		// override any golang type defaults
 	}
@@ -50,34 +54,31 @@ func RemoveContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
+	// Now use the ABI implementation to prevent us from having duplicate
+	// code.
+	containerEngine := abi.ContainerEngine{Libpod: runtime}
 	name := utils.GetName(r)
-	con, err := runtime.LookupContainer(name)
-	if err != nil && errors.Cause(err) == define.ErrNoSuchCtr {
-		// Failed to get container. If force is specified, get the container's ID
-		// and evict it
-		if !query.Force {
+	options := entities.RmOptions{
+		All:     query.All,
+		Force:   query.Force,
+		Volumes: query.Volumes,
+		Ignore:  query.Ignore,
+	}
+	report, err := containerEngine.ContainerRm(r.Context(), []string{name}, options)
+	if err != nil {
+		if errors.Cause(err) == define.ErrNoSuchCtr {
 			utils.ContainerNotFound(w, name, err)
 			return
 		}
 
-		if _, err := runtime.EvictContainer(r.Context(), name, query.Vols); err != nil {
-			if errors.Cause(err) == define.ErrNoSuchCtr {
-				logrus.Debugf("Ignoring error (--allow-missing): %q", err)
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-			logrus.Warn(errors.Wrapf(err, "failed to evict container: %q", name))
-			utils.InternalServerError(w, err)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
-	if err := runtime.RemoveContainer(r.Context(), con, query.Force, query.Vols); err != nil {
 		utils.InternalServerError(w, err)
 		return
 	}
+	if report[0].Err != nil {
+		utils.InternalServerError(w, report[0].Err)
+		return
+	}
+
 	utils.WriteResponse(w, http.StatusNoContent, nil)
 }
 

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -233,8 +233,8 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if sig == 0 || syscall.Signal(sig) == syscall.SIGKILL {
-			var opts entities.WaitOptions
-			if _, err := containerEngine.ContainerWait(r.Context(), []string{name}, opts); err != nil {
+			if _, err := utils.WaitContainer(w, r); err != nil {
+
 				utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
 				return
 			}

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strconv"
 
 	"github.com/containers/podman/v2/libpod"
 	"github.com/containers/podman/v2/libpod/define"
@@ -146,17 +145,7 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 }
 
 func WaitContainer(w http.ResponseWriter, r *http.Request) {
-	exitCode, err := utils.WaitContainer(w, r)
-	if err != nil {
-		name := utils.GetName(r)
-		if errors.Cause(err) == define.ErrNoSuchCtr {
-			utils.ContainerNotFound(w, name, err)
-			return
-		}
-		logrus.Warnf("failed to wait on container %q: %v", name, err)
-		return
-	}
-	utils.WriteResponse(w, http.StatusOK, strconv.Itoa(int(exitCode)))
+	utils.WaitContainerLibpod(w, r)
 }
 
 func UnmountContainer(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -143,6 +143,12 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 func WaitContainer(w http.ResponseWriter, r *http.Request) {
 	exitCode, err := utils.WaitContainer(w, r)
 	if err != nil {
+		name := utils.GetName(r)
+		if errors.Cause(err) == define.ErrNoSuchCtr {
+			utils.ContainerNotFound(w, name, err)
+			return
+		}
+		logrus.Warnf("failed to wait on container %q: %v", name, err)
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, strconv.Itoa(int(exitCode)))

--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -30,12 +30,12 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
-		Reference       string `schema:"reference"`
-		OverrideOS      string `schema:"overrideOS"`
-		OverrideArch    string `schema:"overrideArch"`
-		OverrideVariant string `schema:"overrideVariant"`
-		TLSVerify       bool   `schema:"tlsVerify"`
-		AllTags         bool   `schema:"allTags"`
+		Reference string `schema:"reference"`
+		OS        string `schema:"OS"`
+		Arch      string `schema:"Arch"`
+		Variant   string `schema:"Variant"`
+		TLSVerify bool   `schema:"tlsVerify"`
+		AllTags   bool   `schema:"allTags"`
 	}{
 		TLSVerify: true,
 	}
@@ -83,9 +83,9 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 	// Setup the registry options
 	dockerRegistryOptions := image.DockerRegistryOptions{
 		DockerRegistryCreds: authConf,
-		OSChoice:            query.OverrideOS,
-		ArchitectureChoice:  query.OverrideArch,
-		VariantChoice:       query.OverrideVariant,
+		OSChoice:            query.OS,
+		ArchitectureChoice:  query.Arch,
+		VariantChoice:       query.Variant,
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		dockerRegistryOptions.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -129,7 +129,6 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 	query := struct {
 		All         bool   `schema:"all"`
 		Destination string `schema:"destination"`
-		Format      string `schema:"format"`
 		TLSVerify   bool   `schema:"tlsVerify"`
 	}{
 		// Add defaults here once needed.
@@ -145,24 +144,21 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 	}
 
 	source := utils.GetName(r)
-	authConf, authfile, key, err := auth.GetCredentials(r)
+	authconf, authfile, key, err := auth.GetCredentials(r)
 	if err != nil {
 		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)
 	var username, password string
-	if authConf != nil {
-		username = authConf.Username
-		password = authConf.Password
-
+	if authconf != nil {
+		username = authconf.Username
+		password = authconf.Password
 	}
-
 	options := entities.ImagePushOptions{
 		Authfile: authfile,
 		Username: username,
 		Password: password,
-		Format:   query.Format,
 		All:      query.All,
 	}
 	if sys := runtime.SystemContext(); sys != nil {

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -23,8 +23,8 @@ func WaitContainer(w http.ResponseWriter, r *http.Request) (int32, error) {
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
-		Interval  string                 `schema:"interval"`
-		Condition define.ContainerStatus `schema:"condition"`
+		Interval  string                   `schema:"interval"`
+		Condition []define.ContainerStatus `schema:"condition"`
 	}{
 		// Override golang default values for types
 	}
@@ -33,7 +33,7 @@ func WaitContainer(w http.ResponseWriter, r *http.Request) (int32, error) {
 		return 0, err
 	}
 	options := entities.WaitOptions{
-		Condition: define.ContainerStateStopped,
+		Condition: []define.ContainerStatus{define.ContainerStateStopped},
 	}
 	name := GetName(r)
 	if _, found := r.URL.Query()["interval"]; found {

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -1,67 +1,230 @@
 package utils
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
-	"github.com/containers/podman/v2/libpod"
-	"github.com/containers/podman/v2/libpod/define"
 	"github.com/containers/podman/v2/pkg/domain/entities"
 	"github.com/containers/podman/v2/pkg/domain/infra/abi"
+
+	"github.com/containers/podman/v2/pkg/api/handlers"
+	"github.com/sirupsen/logrus"
+
+	"github.com/containers/podman/v2/libpod/define"
+
+	"github.com/containers/podman/v2/libpod"
 	"github.com/gorilla/schema"
 	"github.com/pkg/errors"
 )
 
-func WaitContainer(w http.ResponseWriter, r *http.Request) (int32, error) {
-	var (
-		err      error
-		interval time.Duration
-	)
-	runtime := r.Context().Value("runtime").(*libpod.Runtime)
-	// Now use the ABI implementation to prevent us from having duplicate
-	// code.
-	containerEngine := abi.ContainerEngine{Libpod: runtime}
-	decoder := r.Context().Value("decoder").(*schema.Decoder)
-	query := struct {
-		Interval  string                   `schema:"interval"`
-		Condition []define.ContainerStatus `schema:"condition"`
-	}{
-		// Override golang default values for types
+type waitQueryDocker struct {
+	Condition string `schema:"condition"`
+}
+
+type waitQueryLibpod struct {
+	Interval  string                   `schema:"interval"`
+	Condition []define.ContainerStatus `schema:"condition"`
+}
+
+func WaitContainerDocker(w http.ResponseWriter, r *http.Request) {
+	var err error
+	ctx := r.Context()
+
+	query := waitQueryDocker{}
+
+	decoder := ctx.Value("decoder").(*schema.Decoder)
+	if err = decoder.Decode(&query, r.URL.Query()); err != nil {
+		Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		return
 	}
+
+	interval := time.Nanosecond
+
+	condition := "not-running"
+	if _, found := r.URL.Query()["condition"]; found {
+		condition = query.Condition
+		if !isValidDockerCondition(query.Condition) {
+			BadRequest(w, "condition", condition, errors.New("not a valid docker condition"))
+			return
+		}
+	}
+
+	name := GetName(r)
+
+	exists, err := containerExists(ctx, name)
+
+	if err != nil {
+		InternalServerError(w, err)
+		return
+	}
+	if !exists {
+		ContainerNotFound(w, name, define.ErrNoSuchCtr)
+		return
+	}
+
+	// In docker compatibility mode we have to send headers in advance,
+	// otherwise docker client would freeze.
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(200)
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+
+	exitCode, err := waitDockerCondition(ctx, name, interval, condition)
+	msg := ""
+	if err != nil {
+		logrus.Errorf("error while waiting on condtion: %q", err)
+		msg = err.Error()
+	}
+	responseData := handlers.ContainerWaitOKBody{
+		StatusCode: int(exitCode),
+		Error: struct {
+			Message string
+		}{
+			Message: msg,
+		},
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(true)
+	err = enc.Encode(&responseData)
+	if err != nil {
+		logrus.Errorf("unable to write json: %q", err)
+	}
+}
+
+func WaitContainerLibpod(w http.ResponseWriter, r *http.Request) {
+	var (
+		err        error
+		interval   = time.Millisecond * 250
+		conditions = []define.ContainerStatus{define.ContainerStateStopped, define.ContainerStateExited}
+	)
+	decoder := r.Context().Value("decoder").(*schema.Decoder)
+	query := waitQueryLibpod{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
-		return 0, err
 	}
-	options := entities.WaitOptions{
-		Condition: []define.ContainerStatus{define.ContainerStateStopped},
-	}
-	name := GetName(r)
+
 	if _, found := r.URL.Query()["interval"]; found {
 		interval, err = time.ParseDuration(query.Interval)
 		if err != nil {
 			InternalServerError(w, err)
-			return 0, err
-		}
-	} else {
-		interval, err = time.ParseDuration("250ms")
-		if err != nil {
-			InternalServerError(w, err)
-			return 0, err
+			return
 		}
 	}
-	options.Interval = interval
 
 	if _, found := r.URL.Query()["condition"]; found {
-		options.Condition = query.Condition
+		if len(query.Condition) > 0 {
+			conditions = query.Condition
+		}
 	}
 
-	report, err := containerEngine.ContainerWait(r.Context(), []string{name}, options)
+	name := GetName(r)
+
+	waitFn := createContainerWaitFn(r.Context(), name, interval)
+
+	exitCode, err := waitFn(conditions...)
 	if err != nil {
-		return 0, err
+		if errors.Cause(err) == define.ErrNoSuchCtr {
+			ContainerNotFound(w, name, err)
+			return
+		} else {
+			InternalServerError(w, err)
+			return
+		}
 	}
-	if len(report) == 0 {
-		InternalServerError(w, errors.New("No reports returned"))
-		return 0, err
+	WriteResponse(w, http.StatusOK, strconv.Itoa(int(exitCode)))
+}
+
+type containerWaitFn func(conditions ...define.ContainerStatus) (int32, error)
+
+func createContainerWaitFn(ctx context.Context, containerName string, interval time.Duration) containerWaitFn {
+
+	runtime := ctx.Value("runtime").(*libpod.Runtime)
+	var containerEngine entities.ContainerEngine = &abi.ContainerEngine{Libpod: runtime}
+
+	return func(conditions ...define.ContainerStatus) (int32, error) {
+		opts := entities.WaitOptions{
+			Condition: conditions,
+			Interval:  interval,
+		}
+		ctrWaitReport, err := containerEngine.ContainerWait(ctx, []string{containerName}, opts)
+		if err != nil {
+			return -1, err
+		}
+		if len(ctrWaitReport) != 1 {
+			return -1, fmt.Errorf("the ContainerWait() function returned unexpected count of reports: %d", len(ctrWaitReport))
+		}
+		return ctrWaitReport[0].ExitCode, ctrWaitReport[0].Error
 	}
-	return report[0].ExitCode, report[0].Error
+}
+
+func isValidDockerCondition(cond string) bool {
+	switch cond {
+	case "next-exit", "removed", "not-running", "":
+		return true
+	}
+	return false
+}
+
+func waitDockerCondition(ctx context.Context, containerName string, interval time.Duration, dockerCondition string) (int32, error) {
+
+	containerWait := createContainerWaitFn(ctx, containerName, interval)
+
+	var err error
+	var code int32
+	switch dockerCondition {
+	case "next-exit":
+		code, err = waitNextExit(containerWait)
+	case "removed":
+		code, err = waitRemoved(containerWait)
+	case "not-running", "":
+		code, err = waitNotRunning(containerWait)
+	default:
+		panic("not a valid docker condition")
+	}
+	return code, err
+}
+
+var notRunningStates = []define.ContainerStatus{
+	define.ContainerStateCreated,
+	define.ContainerStateRemoving,
+	define.ContainerStateStopped,
+	define.ContainerStateExited,
+	define.ContainerStateConfigured,
+}
+
+func waitRemoved(ctrWait containerWaitFn) (int32, error) {
+	code, err := ctrWait(define.ContainerStateUnknown)
+	if err != nil && errors.Cause(err) == define.ErrNoSuchCtr {
+		return code, nil
+	} else {
+		return code, err
+	}
+}
+
+func waitNextExit(ctrWait containerWaitFn) (int32, error) {
+	_, err := ctrWait(define.ContainerStateRunning)
+	if err != nil {
+		return -1, err
+	}
+	return ctrWait(notRunningStates...)
+}
+
+func waitNotRunning(ctrWait containerWaitFn) (int32, error) {
+	return ctrWait(notRunningStates...)
+}
+
+func containerExists(ctx context.Context, name string) (bool, error) {
+	runtime := ctx.Value("runtime").(*libpod.Runtime)
+	var containerEngine entities.ContainerEngine = &abi.ContainerEngine{Libpod: runtime}
+
+	var ctrExistsOpts entities.ContainerExistsOptions
+	ctrExistRep, err := containerEngine.ContainerExists(ctx, name, ctrExistsOpts)
+	if err != nil {
+		return false, err
+	}
+	return ctrExistRep.Value, nil
 }

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -48,6 +48,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    default: false
 	//    description: Return all containers. By default, only running containers are shown
 	//  - in: query
+	//    name: external
+	//    type: boolean
+	//    default: false
+	//    description: Return containers in storage not controlled by Podman
+	//  - in: query
 	//    name: limit
 	//    description: Return this number of most recently created containers, including non-running ones.
 	//    type: integer

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -194,6 +194,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    required: true
 	//    description: the name or ID of the container
 	//  - in: query
+	//    name: all
+	//    type: boolean
+	//    default: false
+	//    description: Send kill signal to all containers
+	//  - in: query
 	//    name: signal
 	//    type: string
 	//    default: TERM
@@ -481,6 +486,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//        - paused
 	//        - running
 	//        - stopped
+	//  - in: query
+	//    name: interval
+	//    type: string
+	//    default: "250ms"
+	//    description: Time Interval to wait before polling for completion.
 	// produces:
 	// - application/json
 	// responses:
@@ -1214,9 +1224,20 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    required: true
 	//    description: the name or ID of the container
 	//  - in: query
-	//    name: t
+	//    name: all
+	//    type: boolean
+	//    default: false
+	//    description: Stop all containers
+	//  - in: query
+	//    name: timeout
 	//    type: integer
+	//    default: 10
 	//    description: number of seconds to wait before killing container
+	//  - in: query
+	//    name: Ignore
+	//    type: boolean
+	//    default: false
+	//    description: do not return error if container is already stopped
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -930,15 +930,15 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     description: "username:password for the registry"
 	//     type: string
 	//   - in: query
-	//     name: overrideArch
+	//     name: Arch
 	//     description: Pull image for the specified architecture.
 	//     type: string
 	//   - in: query
-	//     name: overrideOS
+	//     name: OS
 	//     description: Pull image for the specified operating system.
 	//     type: string
 	//   - in: query
-	//     name: overrideVariant
+	//     name: Variant
 	//     description: Pull image for the specified variant.
 	//     type: string
 	//   - in: query

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -235,6 +235,18 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    name: tag
 	//    type: string
 	//    description: The tag to associate with the image on the registry.
+	//  - in: query
+	//    name: all
+	//    type: boolean
+	//    description: All indicates whether to push all images related to the image list
+	//  - in: query
+	//    name: compress
+	//    type: boolean
+	//    description: use compression on image
+	//  - in: query
+	//    name: destination
+	//    type: string
+	//    description: destination name for the image being pushed
 	//  - in: header
 	//    name: X-Registry-Auth
 	//    type: string

--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/containers/podman/v2/libpod/define"
@@ -83,18 +82,9 @@ func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) error 
 	if err != nil {
 		return err
 	}
-	params := url.Values{}
-	if v := options.GetVolumes(); options.Changed("Volumes") {
-		params.Set("v", strconv.FormatBool(v))
-	}
-	if all := options.GetAll(); options.Changed("All") {
-		params.Set("all", strconv.FormatBool(all))
-	}
-	if force := options.GetForce(); options.Changed("Force") {
-		params.Set("force", strconv.FormatBool(force))
-	}
-	if ignore := options.GetIgnore(); options.Changed("Ignore") {
-		params.Set("ignore", strconv.FormatBool(ignore))
+	params, err := options.ToParams()
+	if err != nil {
+		return err
 	}
 	response, err := conn.DoRequest(nil, http.MethodDelete, "/containers/%s", params, nil, nameOrID)
 	if err != nil {
@@ -130,7 +120,7 @@ func Inspect(ctx context.Context, nameOrID string, options *InspectOptions) (*de
 // Kill sends a given signal to a given container.  The signal should be the string
 // representation of a signal like 'SIGKILL'. The nameOrID can be a container name
 // or a partial/full ID
-func Kill(ctx context.Context, nameOrID string, sig string, options *KillOptions) error {
+func Kill(ctx context.Context, nameOrID string, options *KillOptions) error {
 	if options == nil {
 		options = new(KillOptions)
 	}
@@ -142,7 +132,6 @@ func Kill(ctx context.Context, nameOrID string, sig string, options *KillOptions
 	if err != nil {
 		return err
 	}
-	params.Set("signal", sig)
 	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/kill", params, nil, nameOrID)
 	if err != nil {
 		return err
@@ -180,9 +169,9 @@ func Restart(ctx context.Context, nameOrID string, options *RestartOptions) erro
 	if err != nil {
 		return err
 	}
-	params := url.Values{}
-	if options.Changed("Timeout") {
-		params.Set("t", strconv.Itoa(options.GetTimeout()))
+	params, err := options.ToParams()
+	if err != nil {
+		return err
 	}
 	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/restart", params, nil, nameOrID)
 	if err != nil {
@@ -335,9 +324,9 @@ func Wait(ctx context.Context, nameOrID string, options *WaitOptions) (int32, er
 	if err != nil {
 		return exitCode, err
 	}
-	params := url.Values{}
-	if options.Changed("Condition") {
-		params.Set("condition", options.GetCondition().String())
+	params, err := options.ToParams()
+	if err != nil {
+		return exitCode, err
 	}
 	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/wait", params, nil, nameOrID)
 	if err != nil {

--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -71,8 +71,10 @@ func Prune(ctx context.Context, options *PruneOptions) ([]*reports.PruneReport, 
 }
 
 // Remove removes a container from local storage.  The force bool designates
-// that the container should be removed forcibly (example, even it is running).  The volumes
-// bool dictates that a container's volumes should also be removed.
+// that the container should be removed forcibly (example, even it is running).
+// The volumes bool dictates that a container's volumes should also be removed.
+// The All option indicates that all containers should be removed
+// The Ignore option indicates that if a container did not exist, ignore the error
 func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) error {
 	if options == nil {
 		options = new(RemoveOptions)
@@ -85,8 +87,14 @@ func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) error 
 	if v := options.GetVolumes(); options.Changed("Volumes") {
 		params.Set("v", strconv.FormatBool(v))
 	}
+	if all := options.GetAll(); options.Changed("All") {
+		params.Set("all", strconv.FormatBool(all))
+	}
 	if force := options.GetForce(); options.Changed("Force") {
 		params.Set("force", strconv.FormatBool(force))
+	}
+	if ignore := options.GetIgnore(); options.Changed("Ignore") {
+		params.Set("ignore", strconv.FormatBool(ignore))
 	}
 	response, err := conn.DoRequest(nil, http.MethodDelete, "/containers/%s", params, nil, nameOrID)
 	if err != nil {

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -176,7 +176,7 @@ type UnpauseOptions struct{}
 //go:generate go run ../generator/generator.go WaitOptions
 // WaitOptions are optional options for waiting on containers
 type WaitOptions struct {
-	Condition *define.ContainerStatus
+	Condition []define.ContainerStatus
 	Interval  *string
 }
 

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -122,7 +122,6 @@ type PruneOptions struct {
 //go:generate go run ../generator/generator.go RemoveOptions
 // RemoveOptions are optional options for removing containers
 type RemoveOptions struct {
-	All     *bool
 	Ignore  *bool
 	Force   *bool
 	Volumes *bool
@@ -137,6 +136,7 @@ type InspectOptions struct {
 //go:generate go run ../generator/generator.go KillOptions
 // KillOptions are optional options for killing containers
 type KillOptions struct {
+	Signal *string
 }
 
 //go:generate go run ../generator/generator.go PauseOptions
@@ -176,11 +176,13 @@ type UnpauseOptions struct{}
 // WaitOptions are optional options for waiting on containers
 type WaitOptions struct {
 	Condition *define.ContainerStatus
+	Interval  *string
 }
 
 //go:generate go run ../generator/generator.go StopOptions
 // StopOptions are optional options for stopping containers
 type StopOptions struct {
+	Ignore  *bool
 	Timeout *uint
 }
 

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -106,6 +106,7 @@ type MountedContainerPathsOptions struct{}
 // ListOptions are optional options for listing containers
 type ListOptions struct {
 	All       *bool
+	External  *bool
 	Filters   map[string][]string
 	Last      *int
 	Namespace *bool

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -122,6 +122,8 @@ type PruneOptions struct {
 //go:generate go run ../generator/generator.go RemoveOptions
 // RemoveOptions are optional options for removing containers
 type RemoveOptions struct {
+	All     *bool
+	Ignore  *bool
 	Force   *bool
 	Volumes *bool
 }

--- a/pkg/bindings/containers/types_attach_options.go
+++ b/pkg/bindings/containers/types_attach_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *AttachOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_attach_options.go
+++ b/pkg/bindings/containers/types_attach_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *AttachOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *AttachOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_checkpoint_options.go
+++ b/pkg/bindings/containers/types_checkpoint_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CheckpointOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_checkpoint_options.go
+++ b/pkg/bindings/containers/types_checkpoint_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *CheckpointOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CheckpointOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_commit_options.go
+++ b/pkg/bindings/containers/types_commit_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CommitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_commit_options.go
+++ b/pkg/bindings/containers/types_commit_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *CommitOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CommitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_create_options.go
+++ b/pkg/bindings/containers/types_create_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_create_options.go
+++ b/pkg/bindings/containers/types_create_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_diff_options.go
+++ b/pkg/bindings/containers/types_diff_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_diff_options.go
+++ b/pkg/bindings/containers/types_diff_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_execinspect_options.go
+++ b/pkg/bindings/containers/types_execinspect_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExecInspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExecInspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_execinspect_options.go
+++ b/pkg/bindings/containers/types_execinspect_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExecInspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_execstart_options.go
+++ b/pkg/bindings/containers/types_execstart_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExecStartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExecStartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_execstart_options.go
+++ b/pkg/bindings/containers/types_execstart_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExecStartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_execstartandattach_options.go
+++ b/pkg/bindings/containers/types_execstartandattach_options.go
@@ -2,12 +2,13 @@ package containers
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -45,33 +46,19 @@ func (o *ExecStartAndAttachOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -84,7 +71,10 @@ func (o *ExecStartAndAttachOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_execstartandattach_options.go
+++ b/pkg/bindings/containers/types_execstartandattach_options.go
@@ -2,7 +2,6 @@ package containers
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"net/url"
 	"reflect"
@@ -71,8 +70,6 @@ func (o *ExecStartAndAttachOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_exists_options.go
+++ b/pkg/bindings/containers/types_exists_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_exists_options.go
+++ b/pkg/bindings/containers/types_exists_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_export_options.go
+++ b/pkg/bindings/containers/types_export_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_export_options.go
+++ b/pkg/bindings/containers/types_export_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_healthcheck_options.go
+++ b/pkg/bindings/containers/types_healthcheck_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *HealthCheckOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *HealthCheckOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_healthcheck_options.go
+++ b/pkg/bindings/containers/types_healthcheck_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *HealthCheckOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_init_options.go
+++ b/pkg/bindings/containers/types_init_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InitOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_init_options.go
+++ b/pkg/bindings/containers/types_init_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_inspect_options.go
+++ b/pkg/bindings/containers/types_inspect_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_inspect_options.go
+++ b/pkg/bindings/containers/types_inspect_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_kill_options.go
+++ b/pkg/bindings/containers/types_kill_options.go
@@ -86,3 +86,19 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 	}
 	return params, nil
 }
+
+// WithSignal
+func (o *KillOptions) WithSignal(value string) *KillOptions {
+	v := &value
+	o.Signal = v
+	return o
+}
+
+// GetSignal
+func (o *KillOptions) GetSignal() string {
+	var signal string
+	if o.Signal == nil {
+		return signal
+	}
+	return *o.Signal
+}

--- a/pkg/bindings/containers/types_kill_options.go
+++ b/pkg/bindings/containers/types_kill_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_kill_options.go
+++ b/pkg/bindings/containers/types_kill_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_list_options.go
+++ b/pkg/bindings/containers/types_list_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_list_options.go
+++ b/pkg/bindings/containers/types_list_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_list_options.go
+++ b/pkg/bindings/containers/types_list_options.go
@@ -103,6 +103,22 @@ func (o *ListOptions) GetAll() bool {
 	return *o.All
 }
 
+// WithExternal
+func (o *ListOptions) WithExternal(value bool) *ListOptions {
+	v := &value
+	o.External = v
+	return o
+}
+
+// GetExternal
+func (o *ListOptions) GetExternal() bool {
+	var external bool
+	if o.External == nil {
+		return external
+	}
+	return *o.External
+}
+
 // WithFilters
 func (o *ListOptions) WithFilters(value map[string][]string) *ListOptions {
 	v := value

--- a/pkg/bindings/containers/types_log_options.go
+++ b/pkg/bindings/containers/types_log_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *LogOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *LogOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_log_options.go
+++ b/pkg/bindings/containers/types_log_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *LogOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_mount_options.go
+++ b/pkg/bindings/containers/types_mount_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *MountOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_mount_options.go
+++ b/pkg/bindings/containers/types_mount_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *MountOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *MountOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_mountedcontainerpaths_options.go
+++ b/pkg/bindings/containers/types_mountedcontainerpaths_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *MountedContainerPathsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_mountedcontainerpaths_options.go
+++ b/pkg/bindings/containers/types_mountedcontainerpaths_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *MountedContainerPathsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *MountedContainerPathsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_pause_options.go
+++ b/pkg/bindings/containers/types_pause_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_pause_options.go
+++ b/pkg/bindings/containers/types_pause_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_prune_options.go
+++ b/pkg/bindings/containers/types_prune_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_prune_options.go
+++ b/pkg/bindings/containers/types_prune_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_remove_options.go
+++ b/pkg/bindings/containers/types_remove_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_remove_options.go
+++ b/pkg/bindings/containers/types_remove_options.go
@@ -87,22 +87,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 	return params, nil
 }
 
-// WithAll
-func (o *RemoveOptions) WithAll(value bool) *RemoveOptions {
-	v := &value
-	o.All = v
-	return o
-}
-
-// GetAll
-func (o *RemoveOptions) GetAll() bool {
-	var all bool
-	if o.All == nil {
-		return all
-	}
-	return *o.All
-}
-
 // WithIgnore
 func (o *RemoveOptions) WithIgnore(value bool) *RemoveOptions {
 	v := &value

--- a/pkg/bindings/containers/types_remove_options.go
+++ b/pkg/bindings/containers/types_remove_options.go
@@ -87,6 +87,38 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 	return params, nil
 }
 
+// WithAll
+func (o *RemoveOptions) WithAll(value bool) *RemoveOptions {
+	v := &value
+	o.All = v
+	return o
+}
+
+// GetAll
+func (o *RemoveOptions) GetAll() bool {
+	var all bool
+	if o.All == nil {
+		return all
+	}
+	return *o.All
+}
+
+// WithIgnore
+func (o *RemoveOptions) WithIgnore(value bool) *RemoveOptions {
+	v := &value
+	o.Ignore = v
+	return o
+}
+
+// GetIgnore
+func (o *RemoveOptions) GetIgnore() bool {
+	var ignore bool
+	if o.Ignore == nil {
+		return ignore
+	}
+	return *o.Ignore
+}
+
 // WithForce
 func (o *RemoveOptions) WithForce(value bool) *RemoveOptions {
 	v := &value

--- a/pkg/bindings/containers/types_remove_options.go
+++ b/pkg/bindings/containers/types_remove_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_rename_options.go
+++ b/pkg/bindings/containers/types_rename_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RenameOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_rename_options.go
+++ b/pkg/bindings/containers/types_rename_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RenameOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RenameOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_resizeexectty_options.go
+++ b/pkg/bindings/containers/types_resizeexectty_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ResizeExecTTYOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ResizeExecTTYOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_resizeexectty_options.go
+++ b/pkg/bindings/containers/types_resizeexectty_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ResizeExecTTYOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_resizetty_options.go
+++ b/pkg/bindings/containers/types_resizetty_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ResizeTTYOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_resizetty_options.go
+++ b/pkg/bindings/containers/types_resizetty_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ResizeTTYOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ResizeTTYOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_restart_options.go
+++ b/pkg/bindings/containers/types_restart_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_restart_options.go
+++ b/pkg/bindings/containers/types_restart_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_restore_options.go
+++ b/pkg/bindings/containers/types_restore_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RestoreOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RestoreOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_restore_options.go
+++ b/pkg/bindings/containers/types_restore_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RestoreOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_shouldrestart_options.go
+++ b/pkg/bindings/containers/types_shouldrestart_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ShouldRestartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ShouldRestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_shouldrestart_options.go
+++ b/pkg/bindings/containers/types_shouldrestart_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ShouldRestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_start_options.go
+++ b/pkg/bindings/containers/types_start_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_start_options.go
+++ b/pkg/bindings/containers/types_start_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_stats_options.go
+++ b/pkg/bindings/containers/types_stats_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_stats_options.go
+++ b/pkg/bindings/containers/types_stats_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_stop_options.go
+++ b/pkg/bindings/containers/types_stop_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_stop_options.go
+++ b/pkg/bindings/containers/types_stop_options.go
@@ -87,6 +87,22 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 	return params, nil
 }
 
+// WithIgnore
+func (o *StopOptions) WithIgnore(value bool) *StopOptions {
+	v := &value
+	o.Ignore = v
+	return o
+}
+
+// GetIgnore
+func (o *StopOptions) GetIgnore() bool {
+	var ignore bool
+	if o.Ignore == nil {
+		return ignore
+	}
+	return *o.Ignore
+}
+
 // WithTimeout
 func (o *StopOptions) WithTimeout(value uint) *StopOptions {
 	v := &value

--- a/pkg/bindings/containers/types_stop_options.go
+++ b/pkg/bindings/containers/types_stop_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_top_options.go
+++ b/pkg/bindings/containers/types_top_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_top_options.go
+++ b/pkg/bindings/containers/types_top_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_unmount_options.go
+++ b/pkg/bindings/containers/types_unmount_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *UnmountOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *UnmountOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_unmount_options.go
+++ b/pkg/bindings/containers/types_unmount_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *UnmountOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_unpause_options.go
+++ b/pkg/bindings/containers/types_unpause_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_unpause_options.go
+++ b/pkg/bindings/containers/types_unpause_options.go
@@ -1,11 +1,12 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/containers/types_wait_options.go
+++ b/pkg/bindings/containers/types_wait_options.go
@@ -76,19 +76,19 @@ func (o *WaitOptions) ToParams() (url.Values, error) {
 }
 
 // WithCondition
-func (o *WaitOptions) WithCondition(value define.ContainerStatus) *WaitOptions {
-	v := &value
+func (o *WaitOptions) WithCondition(value []define.ContainerStatus) *WaitOptions {
+	v := value
 	o.Condition = v
 	return o
 }
 
 // GetCondition
-func (o *WaitOptions) GetCondition() define.ContainerStatus {
-	var condition define.ContainerStatus
+func (o *WaitOptions) GetCondition() []define.ContainerStatus {
+	var condition []define.ContainerStatus
 	if o.Condition == nil {
 		return condition
 	}
-	return *o.Condition
+	return o.Condition
 }
 
 // WithInterval

--- a/pkg/bindings/containers/types_wait_options.go
+++ b/pkg/bindings/containers/types_wait_options.go
@@ -103,3 +103,19 @@ func (o *WaitOptions) GetCondition() define.ContainerStatus {
 	}
 	return *o.Condition
 }
+
+// WithInterval
+func (o *WaitOptions) WithInterval(value string) *WaitOptions {
+	v := &value
+	o.Interval = v
+	return o
+}
+
+// GetInterval
+func (o *WaitOptions) GetInterval() string {
+	var interval string
+	if o.Interval == nil {
+		return interval
+	}
+	return *o.Interval
+}

--- a/pkg/bindings/containers/types_wait_options.go
+++ b/pkg/bindings/containers/types_wait_options.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -70,8 +69,6 @@ func (o *WaitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/containers/types_wait_options.go
+++ b/pkg/bindings/containers/types_wait_options.go
@@ -1,12 +1,13 @@
 package containers
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/containers/podman/v2/libpod/define"
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -44,33 +45,19 @@ func (o *WaitOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -83,7 +70,10 @@ func (o *WaitOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/generate/types_kube_options.go
+++ b/pkg/bindings/generate/types_kube_options.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/generate/types_kube_options.go
+++ b/pkg/bindings/generate/types_kube_options.go
@@ -1,13 +1,14 @@
 package generate
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/generate/types_systemd_options.go
+++ b/pkg/bindings/generate/types_systemd_options.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *SystemdOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/generate/types_systemd_options.go
+++ b/pkg/bindings/generate/types_systemd_options.go
@@ -1,13 +1,14 @@
 package generate
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *SystemdOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *SystemdOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/generator/generator.go
+++ b/pkg/bindings/generator/generator.go
@@ -54,33 +54,19 @@ func (o *{{.StructName}}) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+				switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -93,7 +79,10 @@ func (o *{{.StructName}}) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }
@@ -144,7 +133,7 @@ func main() {
 		panic(err)
 	}
 	// always add reflect
-	imports := []string{"\"reflect\""}
+	imports := []string{"\"reflect\"", "\"github.com/containers/podman/v2/pkg/bindings/util\""}
 	for _, imp := range f.Imports {
 		imports = append(imports, imp.Path.Value)
 	}

--- a/pkg/bindings/generator/generator.go
+++ b/pkg/bindings/generator/generator.go
@@ -79,8 +79,6 @@ func (o *{{.StructName}}) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/generator/generator.go
+++ b/pkg/bindings/generator/generator.go
@@ -54,7 +54,7 @@ func (o *{{.StructName}}) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-				switch {
+		switch {
 		case util.IsSimpleType(f):
 			params.Set(fieldName, util.SimpleTypeToParam(f))
 		case f.Kind() == reflect.Slice:

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -171,13 +171,13 @@ type PullOptions struct {
 	Username *string
 	// Password for authenticating against the registry.
 	Password *string
-	// OverrideArch will overwrite the local architecture for image pulls.
-	OverrideArch *string
-	// OverrideOS will overwrite the local operating system (OS) for image
+	// Arch will overwrite the local architecture for image pulls.
+	Arch *string
+	// OS will overwrite the local operating system (OS) for image
 	// pulls.
-	OverrideOS *string
-	// OverrideVariant will overwrite the local variant for image pulls.
-	OverrideVariant *string
+	OS *string
+	// Variant will overwrite the local variant for image pulls.
+	Variant *string
 	// Quiet can be specified to suppress pull progress when pulling.  Ignored
 	// for remote calls.
 	Quiet *bool

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"github.com/containers/buildah/imagebuildah"
-	"github.com/containers/common/pkg/config"
 )
 
 //go:generate go run ../generator/generator.go RemoveOptions
@@ -138,32 +137,25 @@ type PullOptions struct {
 	// AllTags can be specified to pull all tags of an image. Note
 	// that this only works if the image does not include a tag.
 	AllTags *bool
+	// Arch will overwrite the local architecture for image pulls.
+	Arch *string
 	// Authfile is the path to the authentication file. Ignored for remote
 	// calls.
 	Authfile *string
-	// CertDir is the path to certificate directories.  Ignored for remote
-	// calls.
-	CertDir *string
-	// Username for authenticating against the registry.
-	Username *string
-	// Password for authenticating against the registry.
-	Password *string
-	// Arch will overwrite the local architecture for image pulls.
-	Arch *string
 	// OS will overwrite the local operating system (OS) for image
 	// pulls.
 	OS *string
-	// Variant will overwrite the local variant for image pulls.
-	Variant *string
+	// Password for authenticating against the registry.
+	Password *string
 	// Quiet can be specified to suppress pull progress when pulling.  Ignored
 	// for remote calls.
 	Quiet *bool
-	// SignaturePolicy to use when pulling.  Ignored for remote calls.
-	SignaturePolicy *string
 	// SkipTLSVerify to skip HTTPS and certificate verification.
 	SkipTLSVerify *bool
-	// PullPolicy whether to pull new image
-	PullPolicy *config.PullPolicy
+	// Username for authenticating against the registry.
+	Username *string
+	// Variant will overwrite the local variant for image pulls.
+	Variant *string
 }
 
 //BuildOptions are optional options for building images

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -104,37 +104,14 @@ type PushOptions struct {
 	// Authfile is the path to the authentication file. Ignored for remote
 	// calls.
 	Authfile *string
-	// CertDir is the path to certificate directories.  Ignored for remote
-	// calls.
-	CertDir *string
-	// Compress tarball image layers when pushing to a directory using the 'dir'
-	// transport. Default is same compression type as source. Ignored for remote
-	// calls.
+	// Compress tarball image layers when pushing to a directory using the 'dir' transport.
 	Compress *bool
-	// Username for authenticating against the registry.
-	Username *string
 	// Password for authenticating against the registry.
 	Password *string
-	// DigestFile, after copying the image, write the digest of the resulting
-	// image to the file.  Ignored for remote calls.
-	DigestFile *string
-	// Format is the Manifest type (oci, v2s1, or v2s2) to use when pushing an
-	// image using the 'dir' transport. Default is manifest type of source.
-	// Ignored for remote calls.
-	Format *string
-	// Quiet can be specified to suppress pull progress when pulling.  Ignored
-	// for remote calls.
-	Quiet *bool
-	// RemoveSignatures, discard any pre-existing signatures in the image.
-	// Ignored for remote calls.
-	RemoveSignatures *bool
-	// SignaturePolicy to use when pulling.  Ignored for remote calls.
-	SignaturePolicy *string
-	// SignBy adds a signature at the destination using the specified key.
-	// Ignored for remote calls.
-	SignBy *string
 	// SkipTLSVerify to skip HTTPS and certificate verification.
 	SkipTLSVerify *bool
+	// Username for authenticating against the registry.
+	Username *string
 }
 
 //go:generate go run ../generator/generator.go SearchOptions

--- a/pkg/bindings/images/types_diff_options.go
+++ b/pkg/bindings/images/types_diff_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_diff_options.go
+++ b/pkg/bindings/images/types_diff_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *DiffOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_exists_options.go
+++ b/pkg/bindings/images/types_exists_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_exists_options.go
+++ b/pkg/bindings/images/types_exists_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_export_options.go
+++ b/pkg/bindings/images/types_export_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_export_options.go
+++ b/pkg/bindings/images/types_export_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_get_options.go
+++ b/pkg/bindings/images/types_get_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *GetOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_get_options.go
+++ b/pkg/bindings/images/types_get_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *GetOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *GetOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_history_options.go
+++ b/pkg/bindings/images/types_history_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *HistoryOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *HistoryOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_history_options.go
+++ b/pkg/bindings/images/types_history_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *HistoryOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_import_options.go
+++ b/pkg/bindings/images/types_import_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ImportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_import_options.go
+++ b/pkg/bindings/images/types_import_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ImportOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ImportOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_list_options.go
+++ b/pkg/bindings/images/types_list_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_list_options.go
+++ b/pkg/bindings/images/types_list_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_load_options.go
+++ b/pkg/bindings/images/types_load_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *LoadOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *LoadOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_load_options.go
+++ b/pkg/bindings/images/types_load_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *LoadOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_prune_options.go
+++ b/pkg/bindings/images/types_prune_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_prune_options.go
+++ b/pkg/bindings/images/types_prune_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_pull_options.go
+++ b/pkg/bindings/images/types_pull_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PullOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PullOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_pull_options.go
+++ b/pkg/bindings/images/types_pull_options.go
@@ -168,52 +168,52 @@ func (o *PullOptions) GetPassword() string {
 	return *o.Password
 }
 
-// WithOverrideArch
-func (o *PullOptions) WithOverrideArch(value string) *PullOptions {
+// WithArch
+func (o *PullOptions) WithArch(value string) *PullOptions {
 	v := &value
-	o.OverrideArch = v
+	o.Arch = v
 	return o
 }
 
-// GetOverrideArch
-func (o *PullOptions) GetOverrideArch() string {
-	var overrideArch string
-	if o.OverrideArch == nil {
-		return overrideArch
+// GetArch
+func (o *PullOptions) GetArch() string {
+	var arch string
+	if o.Arch == nil {
+		return arch
 	}
-	return *o.OverrideArch
+	return *o.Arch
 }
 
-// WithOverrideOS
-func (o *PullOptions) WithOverrideOS(value string) *PullOptions {
+// WithOS
+func (o *PullOptions) WithOS(value string) *PullOptions {
 	v := &value
-	o.OverrideOS = v
+	o.OS = v
 	return o
 }
 
-// GetOverrideOS
-func (o *PullOptions) GetOverrideOS() string {
-	var overrideOS string
-	if o.OverrideOS == nil {
-		return overrideOS
+// GetOS
+func (o *PullOptions) GetOS() string {
+	var oS string
+	if o.OS == nil {
+		return oS
 	}
-	return *o.OverrideOS
+	return *o.OS
 }
 
-// WithOverrideVariant
-func (o *PullOptions) WithOverrideVariant(value string) *PullOptions {
+// WithVariant
+func (o *PullOptions) WithVariant(value string) *PullOptions {
 	v := &value
-	o.OverrideVariant = v
+	o.Variant = v
 	return o
 }
 
-// GetOverrideVariant
-func (o *PullOptions) GetOverrideVariant() string {
-	var overrideVariant string
-	if o.OverrideVariant == nil {
-		return overrideVariant
+// GetVariant
+func (o *PullOptions) GetVariant() string {
+	var variant string
+	if o.Variant == nil {
+		return variant
 	}
-	return *o.OverrideVariant
+	return *o.Variant
 }
 
 // WithQuiet

--- a/pkg/bindings/images/types_pull_options.go
+++ b/pkg/bindings/images/types_pull_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PullOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_pull_options.go
+++ b/pkg/bindings/images/types_pull_options.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containers/common/pkg/config"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -104,70 +103,6 @@ func (o *PullOptions) GetAllTags() bool {
 	return *o.AllTags
 }
 
-// WithAuthfile
-func (o *PullOptions) WithAuthfile(value string) *PullOptions {
-	v := &value
-	o.Authfile = v
-	return o
-}
-
-// GetAuthfile
-func (o *PullOptions) GetAuthfile() string {
-	var authfile string
-	if o.Authfile == nil {
-		return authfile
-	}
-	return *o.Authfile
-}
-
-// WithCertDir
-func (o *PullOptions) WithCertDir(value string) *PullOptions {
-	v := &value
-	o.CertDir = v
-	return o
-}
-
-// GetCertDir
-func (o *PullOptions) GetCertDir() string {
-	var certDir string
-	if o.CertDir == nil {
-		return certDir
-	}
-	return *o.CertDir
-}
-
-// WithUsername
-func (o *PullOptions) WithUsername(value string) *PullOptions {
-	v := &value
-	o.Username = v
-	return o
-}
-
-// GetUsername
-func (o *PullOptions) GetUsername() string {
-	var username string
-	if o.Username == nil {
-		return username
-	}
-	return *o.Username
-}
-
-// WithPassword
-func (o *PullOptions) WithPassword(value string) *PullOptions {
-	v := &value
-	o.Password = v
-	return o
-}
-
-// GetPassword
-func (o *PullOptions) GetPassword() string {
-	var password string
-	if o.Password == nil {
-		return password
-	}
-	return *o.Password
-}
-
 // WithArch
 func (o *PullOptions) WithArch(value string) *PullOptions {
 	v := &value
@@ -182,6 +117,22 @@ func (o *PullOptions) GetArch() string {
 		return arch
 	}
 	return *o.Arch
+}
+
+// WithAuthfile
+func (o *PullOptions) WithAuthfile(value string) *PullOptions {
+	v := &value
+	o.Authfile = v
+	return o
+}
+
+// GetAuthfile
+func (o *PullOptions) GetAuthfile() string {
+	var authfile string
+	if o.Authfile == nil {
+		return authfile
+	}
+	return *o.Authfile
 }
 
 // WithOS
@@ -200,20 +151,20 @@ func (o *PullOptions) GetOS() string {
 	return *o.OS
 }
 
-// WithVariant
-func (o *PullOptions) WithVariant(value string) *PullOptions {
+// WithPassword
+func (o *PullOptions) WithPassword(value string) *PullOptions {
 	v := &value
-	o.Variant = v
+	o.Password = v
 	return o
 }
 
-// GetVariant
-func (o *PullOptions) GetVariant() string {
-	var variant string
-	if o.Variant == nil {
-		return variant
+// GetPassword
+func (o *PullOptions) GetPassword() string {
+	var password string
+	if o.Password == nil {
+		return password
 	}
-	return *o.Variant
+	return *o.Password
 }
 
 // WithQuiet
@@ -232,22 +183,6 @@ func (o *PullOptions) GetQuiet() bool {
 	return *o.Quiet
 }
 
-// WithSignaturePolicy
-func (o *PullOptions) WithSignaturePolicy(value string) *PullOptions {
-	v := &value
-	o.SignaturePolicy = v
-	return o
-}
-
-// GetSignaturePolicy
-func (o *PullOptions) GetSignaturePolicy() string {
-	var signaturePolicy string
-	if o.SignaturePolicy == nil {
-		return signaturePolicy
-	}
-	return *o.SignaturePolicy
-}
-
 // WithSkipTLSVerify
 func (o *PullOptions) WithSkipTLSVerify(value bool) *PullOptions {
 	v := &value
@@ -264,18 +199,34 @@ func (o *PullOptions) GetSkipTLSVerify() bool {
 	return *o.SkipTLSVerify
 }
 
-// WithPullPolicy
-func (o *PullOptions) WithPullPolicy(value config.PullPolicy) *PullOptions {
+// WithUsername
+func (o *PullOptions) WithUsername(value string) *PullOptions {
 	v := &value
-	o.PullPolicy = v
+	o.Username = v
 	return o
 }
 
-// GetPullPolicy
-func (o *PullOptions) GetPullPolicy() config.PullPolicy {
-	var pullPolicy config.PullPolicy
-	if o.PullPolicy == nil {
-		return pullPolicy
+// GetUsername
+func (o *PullOptions) GetUsername() string {
+	var username string
+	if o.Username == nil {
+		return username
 	}
-	return *o.PullPolicy
+	return *o.Username
+}
+
+// WithVariant
+func (o *PullOptions) WithVariant(value string) *PullOptions {
+	v := &value
+	o.Variant = v
+	return o
+}
+
+// GetVariant
+func (o *PullOptions) GetVariant() string {
+	var variant string
+	if o.Variant == nil {
+		return variant
+	}
+	return *o.Variant
 }

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PushOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PushOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PushOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -119,22 +119,6 @@ func (o *PushOptions) GetAuthfile() string {
 	return *o.Authfile
 }
 
-// WithCertDir
-func (o *PushOptions) WithCertDir(value string) *PushOptions {
-	v := &value
-	o.CertDir = v
-	return o
-}
-
-// GetCertDir
-func (o *PushOptions) GetCertDir() string {
-	var certDir string
-	if o.CertDir == nil {
-		return certDir
-	}
-	return *o.CertDir
-}
-
 // WithCompress
 func (o *PushOptions) WithCompress(value bool) *PushOptions {
 	v := &value
@@ -149,22 +133,6 @@ func (o *PushOptions) GetCompress() bool {
 		return compress
 	}
 	return *o.Compress
-}
-
-// WithUsername
-func (o *PushOptions) WithUsername(value string) *PushOptions {
-	v := &value
-	o.Username = v
-	return o
-}
-
-// GetUsername
-func (o *PushOptions) GetUsername() string {
-	var username string
-	if o.Username == nil {
-		return username
-	}
-	return *o.Username
 }
 
 // WithPassword
@@ -183,102 +151,6 @@ func (o *PushOptions) GetPassword() string {
 	return *o.Password
 }
 
-// WithDigestFile
-func (o *PushOptions) WithDigestFile(value string) *PushOptions {
-	v := &value
-	o.DigestFile = v
-	return o
-}
-
-// GetDigestFile
-func (o *PushOptions) GetDigestFile() string {
-	var digestFile string
-	if o.DigestFile == nil {
-		return digestFile
-	}
-	return *o.DigestFile
-}
-
-// WithFormat
-func (o *PushOptions) WithFormat(value string) *PushOptions {
-	v := &value
-	o.Format = v
-	return o
-}
-
-// GetFormat
-func (o *PushOptions) GetFormat() string {
-	var format string
-	if o.Format == nil {
-		return format
-	}
-	return *o.Format
-}
-
-// WithQuiet
-func (o *PushOptions) WithQuiet(value bool) *PushOptions {
-	v := &value
-	o.Quiet = v
-	return o
-}
-
-// GetQuiet
-func (o *PushOptions) GetQuiet() bool {
-	var quiet bool
-	if o.Quiet == nil {
-		return quiet
-	}
-	return *o.Quiet
-}
-
-// WithRemoveSignatures
-func (o *PushOptions) WithRemoveSignatures(value bool) *PushOptions {
-	v := &value
-	o.RemoveSignatures = v
-	return o
-}
-
-// GetRemoveSignatures
-func (o *PushOptions) GetRemoveSignatures() bool {
-	var removeSignatures bool
-	if o.RemoveSignatures == nil {
-		return removeSignatures
-	}
-	return *o.RemoveSignatures
-}
-
-// WithSignaturePolicy
-func (o *PushOptions) WithSignaturePolicy(value string) *PushOptions {
-	v := &value
-	o.SignaturePolicy = v
-	return o
-}
-
-// GetSignaturePolicy
-func (o *PushOptions) GetSignaturePolicy() string {
-	var signaturePolicy string
-	if o.SignaturePolicy == nil {
-		return signaturePolicy
-	}
-	return *o.SignaturePolicy
-}
-
-// WithSignBy
-func (o *PushOptions) WithSignBy(value string) *PushOptions {
-	v := &value
-	o.SignBy = v
-	return o
-}
-
-// GetSignBy
-func (o *PushOptions) GetSignBy() string {
-	var signBy string
-	if o.SignBy == nil {
-		return signBy
-	}
-	return *o.SignBy
-}
-
 // WithSkipTLSVerify
 func (o *PushOptions) WithSkipTLSVerify(value bool) *PushOptions {
 	v := &value
@@ -293,4 +165,20 @@ func (o *PushOptions) GetSkipTLSVerify() bool {
 		return skipTLSVerify
 	}
 	return *o.SkipTLSVerify
+}
+
+// WithUsername
+func (o *PushOptions) WithUsername(value string) *PushOptions {
+	v := &value
+	o.Username = v
+	return o
+}
+
+// GetUsername
+func (o *PushOptions) GetUsername() string {
+	var username string
+	if o.Username == nil {
+		return username
+	}
+	return *o.Username
 }

--- a/pkg/bindings/images/types_remove_options.go
+++ b/pkg/bindings/images/types_remove_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_remove_options.go
+++ b/pkg/bindings/images/types_remove_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_search_options.go
+++ b/pkg/bindings/images/types_search_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *SearchOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_search_options.go
+++ b/pkg/bindings/images/types_search_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *SearchOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *SearchOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_tag_options.go
+++ b/pkg/bindings/images/types_tag_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *TagOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_tag_options.go
+++ b/pkg/bindings/images/types_tag_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *TagOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *TagOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_tree_options.go
+++ b/pkg/bindings/images/types_tree_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *TreeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/images/types_tree_options.go
+++ b/pkg/bindings/images/types_tree_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *TreeOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *TreeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_untag_options.go
+++ b/pkg/bindings/images/types_untag_options.go
@@ -1,11 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *UntagOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *UntagOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/images/types_untag_options.go
+++ b/pkg/bindings/images/types_untag_options.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *UntagOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -140,7 +140,6 @@ func Push(ctx context.Context, name, destination string, options *images.PushOpt
 	}
 	params.Set("image", name)
 	params.Set("destination", destination)
-	params.Set("format", *options.Format)
 	_, err = conn.DoRequest(nil, http.MethodPost, "/manifests/%s/push", params, nil, name)
 	if err != nil {
 		return "", err

--- a/pkg/bindings/manifests/types_add_options.go
+++ b/pkg/bindings/manifests/types_add_options.go
@@ -1,13 +1,14 @@
 package manifests
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *AddOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *AddOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/manifests/types_add_options.go
+++ b/pkg/bindings/manifests/types_add_options.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *AddOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/manifests/types_create_options.go
+++ b/pkg/bindings/manifests/types_create_options.go
@@ -1,13 +1,14 @@
 package manifests
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/manifests/types_create_options.go
+++ b/pkg/bindings/manifests/types_create_options.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/manifests/types_inspect_options.go
+++ b/pkg/bindings/manifests/types_inspect_options.go
@@ -1,13 +1,14 @@
 package manifests
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/manifests/types_inspect_options.go
+++ b/pkg/bindings/manifests/types_inspect_options.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/manifests/types_remove_options.go
+++ b/pkg/bindings/manifests/types_remove_options.go
@@ -1,13 +1,14 @@
 package manifests
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/manifests/types_remove_options.go
+++ b/pkg/bindings/manifests/types_remove_options.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_connect_options.go
+++ b/pkg/bindings/network/types_connect_options.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ConnectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ConnectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_connect_options.go
+++ b/pkg/bindings/network/types_connect_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ConnectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_create_options.go
+++ b/pkg/bindings/network/types_create_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net"
 	"net/url"
 	"reflect"
@@ -70,8 +69,6 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_create_options.go
+++ b/pkg/bindings/network/types_create_options.go
@@ -1,12 +1,13 @@
 package network
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -44,33 +45,19 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -83,7 +70,10 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_disconnect_options.go
+++ b/pkg/bindings/network/types_disconnect_options.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *DisconnectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *DisconnectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_disconnect_options.go
+++ b/pkg/bindings/network/types_disconnect_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *DisconnectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_inspect_options.go
+++ b/pkg/bindings/network/types_inspect_options.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_inspect_options.go
+++ b/pkg/bindings/network/types_inspect_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_list_options.go
+++ b/pkg/bindings/network/types_list_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/network/types_list_options.go
+++ b/pkg/bindings/network/types_list_options.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_remove_options.go
+++ b/pkg/bindings/network/types_remove_options.go
@@ -1,11 +1,12 @@
 package network
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/network/types_remove_options.go
+++ b/pkg/bindings/network/types_remove_options.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/play/types_kube_options.go
+++ b/pkg/bindings/play/types_kube_options.go
@@ -2,7 +2,6 @@ package play
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/play/types_kube_options.go
+++ b/pkg/bindings/play/types_kube_options.go
@@ -1,13 +1,14 @@
 package play
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 /*
@@ -43,33 +44,19 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *KubeOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_create_options.go
+++ b/pkg/bindings/pods/types_create_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_create_options.go
+++ b/pkg/bindings/pods/types_create_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_exists_options.go
+++ b/pkg/bindings/pods/types_exists_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_exists_options.go
+++ b/pkg/bindings/pods/types_exists_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ExistsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_inspect_options.go
+++ b/pkg/bindings/pods/types_inspect_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_inspect_options.go
+++ b/pkg/bindings/pods/types_inspect_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_kill_options.go
+++ b/pkg/bindings/pods/types_kill_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_kill_options.go
+++ b/pkg/bindings/pods/types_kill_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *KillOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_list_options.go
+++ b/pkg/bindings/pods/types_list_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_list_options.go
+++ b/pkg/bindings/pods/types_list_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_pause_options.go
+++ b/pkg/bindings/pods/types_pause_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_pause_options.go
+++ b/pkg/bindings/pods/types_pause_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_prune_options.go
+++ b/pkg/bindings/pods/types_prune_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_prune_options.go
+++ b/pkg/bindings/pods/types_prune_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_remove_options.go
+++ b/pkg/bindings/pods/types_remove_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_remove_options.go
+++ b/pkg/bindings/pods/types_remove_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_restart_options.go
+++ b/pkg/bindings/pods/types_restart_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_restart_options.go
+++ b/pkg/bindings/pods/types_restart_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RestartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_start_options.go
+++ b/pkg/bindings/pods/types_start_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_start_options.go
+++ b/pkg/bindings/pods/types_start_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StartOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_stats_options.go
+++ b/pkg/bindings/pods/types_stats_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_stats_options.go
+++ b/pkg/bindings/pods/types_stats_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StatsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_stop_options.go
+++ b/pkg/bindings/pods/types_stop_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_stop_options.go
+++ b/pkg/bindings/pods/types_stop_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *StopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_top_options.go
+++ b/pkg/bindings/pods/types_top_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/pods/types_top_options.go
+++ b/pkg/bindings/pods/types_top_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *TopOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_unpause_options.go
+++ b/pkg/bindings/pods/types_unpause_options.go
@@ -1,7 +1,6 @@
 package pods
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/pods/types_unpause_options.go
+++ b/pkg/bindings/pods/types_unpause_options.go
@@ -1,11 +1,12 @@
 package pods
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *UnpauseOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_disk_options.go
+++ b/pkg/bindings/system/types_disk_options.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *DiskOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *DiskOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_disk_options.go
+++ b/pkg/bindings/system/types_disk_options.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *DiskOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/system/types_events_options.go
+++ b/pkg/bindings/system/types_events_options.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *EventsOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *EventsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_events_options.go
+++ b/pkg/bindings/system/types_events_options.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *EventsOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/system/types_info_options.go
+++ b/pkg/bindings/system/types_info_options.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InfoOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InfoOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_info_options.go
+++ b/pkg/bindings/system/types_info_options.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InfoOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/system/types_prune_options.go
+++ b/pkg/bindings/system/types_prune_options.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/system/types_prune_options.go
+++ b/pkg/bindings/system/types_prune_options.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_version_options.go
+++ b/pkg/bindings/system/types_version_options.go
@@ -1,11 +1,12 @@
 package system
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *VersionOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *VersionOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/system/types_version_options.go
+++ b/pkg/bindings/system/types_version_options.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *VersionOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/test/attach_test.go
+++ b/pkg/bindings/test/attach_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Podman containers attach", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		wait := define.ContainerStateRunning
-		_, err = containers.Wait(bt.conn, ctnr.ID, new(containers.WaitOptions).WithCondition(wait))
+		_, err = containers.Wait(bt.conn, ctnr.ID, new(containers.WaitOptions).WithCondition([]define.ContainerStatus{wait}))
 		Expect(err).ShouldNot(HaveOccurred())
 
 		tickTock := time.NewTimer(2 * time.Second)

--- a/pkg/bindings/test/common_test.go
+++ b/pkg/bindings/test/common_test.go
@@ -207,7 +207,7 @@ func (b *bindingTest) RunTopContainer(containerName *string, insidePod *bool, po
 		return "", err
 	}
 	wait := define.ContainerStateRunning
-	_, err = containers.Wait(b.conn, ctr.ID, new(containers.WaitOptions).WithCondition(wait))
+	_, err = containers.Wait(b.conn, ctr.ID, new(containers.WaitOptions).WithCondition([]define.ContainerStatus{wait}))
 	return ctr.ID, err
 }
 

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Podman containers ", func() {
 		_, err := bt.RunTopContainer(&name, nil, nil)
 		Expect(err).To(BeNil())
 		go func() {
-			exitCode, err = containers.Wait(bt.conn, name, new(containers.WaitOptions).WithCondition(pause))
+			exitCode, err = containers.Wait(bt.conn, name, new(containers.WaitOptions).WithCondition([]define.ContainerStatus{pause}))
 			errChan <- err
 			close(errChan)
 		}()
@@ -295,7 +295,7 @@ var _ = Describe("Podman containers ", func() {
 		go func() {
 			defer GinkgoRecover()
 
-			_, waitErr := containers.Wait(bt.conn, name, new(containers.WaitOptions).WithCondition(running))
+			_, waitErr := containers.Wait(bt.conn, name, new(containers.WaitOptions).WithCondition([]define.ContainerStatus{running}))
 			unpauseErrChan <- waitErr
 			close(unpauseErrChan)
 		}()

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -443,7 +443,7 @@ var _ = Describe("Podman containers ", func() {
 
 	It("podman kill bogus container", func() {
 		// Killing bogus container should return 404
-		err := containers.Kill(bt.conn, "foobar", "SIGTERM", nil)
+		err := containers.Kill(bt.conn, "foobar", new(containers.KillOptions).WithSignal("SIGTERM"))
 		Expect(err).ToNot(BeNil())
 		code, _ := bindings.CheckResponseCode(err)
 		Expect(code).To(BeNumerically("==", http.StatusNotFound))
@@ -454,7 +454,7 @@ var _ = Describe("Podman containers ", func() {
 		var name = "top"
 		_, err := bt.RunTopContainer(&name, bindings.PFalse, nil)
 		Expect(err).To(BeNil())
-		err = containers.Kill(bt.conn, name, "SIGINT", nil)
+		err = containers.Kill(bt.conn, name, new(containers.KillOptions).WithSignal("SIGINT"))
 		Expect(err).To(BeNil())
 		_, err = containers.Exists(bt.conn, name, nil)
 		Expect(err).To(BeNil())
@@ -465,7 +465,7 @@ var _ = Describe("Podman containers ", func() {
 		var name = "top"
 		cid, err := bt.RunTopContainer(&name, bindings.PFalse, nil)
 		Expect(err).To(BeNil())
-		err = containers.Kill(bt.conn, cid, "SIGTERM", nil)
+		err = containers.Kill(bt.conn, cid, new(containers.KillOptions).WithSignal("SIGTERM"))
 		Expect(err).To(BeNil())
 		_, err = containers.Exists(bt.conn, cid, nil)
 		Expect(err).To(BeNil())
@@ -476,7 +476,7 @@ var _ = Describe("Podman containers ", func() {
 		var name = "top"
 		cid, err := bt.RunTopContainer(&name, bindings.PFalse, nil)
 		Expect(err).To(BeNil())
-		err = containers.Kill(bt.conn, cid, "SIGKILL", nil)
+		err = containers.Kill(bt.conn, cid, new(containers.KillOptions).WithSignal("SIGKILL"))
 		Expect(err).To(BeNil())
 	})
 
@@ -485,7 +485,7 @@ var _ = Describe("Podman containers ", func() {
 		var name = "top"
 		cid, err := bt.RunTopContainer(&name, bindings.PFalse, nil)
 		Expect(err).To(BeNil())
-		err = containers.Kill(bt.conn, cid, "foobar", nil)
+		err = containers.Kill(bt.conn, cid, new(containers.KillOptions).WithSignal("foobar"))
 		Expect(err).ToNot(BeNil())
 		code, _ := bindings.CheckResponseCode(err)
 		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
@@ -501,7 +501,7 @@ var _ = Describe("Podman containers ", func() {
 		Expect(err).To(BeNil())
 		containerLatestList, err := containers.List(bt.conn, new(containers.ListOptions).WithLast(1))
 		Expect(err).To(BeNil())
-		err = containers.Kill(bt.conn, containerLatestList[0].Names[0], "SIGTERM", nil)
+		err = containers.Kill(bt.conn, containerLatestList[0].Names[0], new(containers.KillOptions).WithSignal("SIGTERM"))
 		Expect(err).To(BeNil())
 	})
 

--- a/pkg/bindings/util/util.go
+++ b/pkg/bindings/util/util.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"reflect"
+	"strconv"
+)
+
+func IsSimpleType(f reflect.Value) bool {
+	switch f.Kind() {
+	case reflect.Bool, reflect.Int, reflect.Int64, reflect.Uint, reflect.Uint64, reflect.String:
+		return true
+	}
+	return false
+}
+
+func SimpleTypeToParam(f reflect.Value) string {
+	switch f.Kind() {
+	case reflect.Bool:
+		return strconv.FormatBool(f.Bool())
+	case reflect.Int, reflect.Int64:
+		// f.Int() is always an int64
+		return strconv.FormatInt(f.Int(), 10)
+	case reflect.Uint, reflect.Uint64:
+		// f.Uint() is always an uint64
+		return strconv.FormatUint(f.Uint(), 10)
+	case reflect.String:
+		return f.String()
+	}
+	panic("the input parameter is not a simple type")
+}

--- a/pkg/bindings/volumes/types_create_options.go
+++ b/pkg/bindings/volumes/types_create_options.go
@@ -1,11 +1,12 @@
 package volumes
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/volumes/types_create_options.go
+++ b/pkg/bindings/volumes/types_create_options.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *CreateOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/volumes/types_inspect_options.go
+++ b/pkg/bindings/volumes/types_inspect_options.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/volumes/types_inspect_options.go
+++ b/pkg/bindings/volumes/types_inspect_options.go
@@ -1,11 +1,12 @@
 package volumes
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *InspectOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/volumes/types_list_options.go
+++ b/pkg/bindings/volumes/types_list_options.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/volumes/types_list_options.go
+++ b/pkg/bindings/volumes/types_list_options.go
@@ -1,11 +1,12 @@
 package volumes
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *ListOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/volumes/types_prune_options.go
+++ b/pkg/bindings/volumes/types_prune_options.go
@@ -1,11 +1,12 @@
 package volumes
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/volumes/types_prune_options.go
+++ b/pkg/bindings/volumes/types_prune_options.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *PruneOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/bindings/volumes/types_remove_options.go
+++ b/pkg/bindings/volumes/types_remove_options.go
@@ -1,11 +1,12 @@
 package volumes
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
+	"github.com/containers/podman/v2/pkg/bindings/util"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
@@ -43,33 +44,19 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
-		switch f.Kind() {
-		case reflect.Bool:
-			params.Set(fieldName, strconv.FormatBool(f.Bool()))
-		case reflect.String:
-			params.Set(fieldName, f.String())
-		case reflect.Int, reflect.Int64:
-			// f.Int() is always an int64
-			params.Set(fieldName, strconv.FormatInt(f.Int(), 10))
-		case reflect.Uint, reflect.Uint64:
-			// f.Uint() is always an uint64
-			params.Set(fieldName, strconv.FormatUint(f.Uint(), 10))
-		case reflect.Slice:
-			typ := reflect.TypeOf(f.Interface()).Elem()
-			switch typ.Kind() {
-			case reflect.String:
-				sl := f.Slice(0, f.Len())
-				s, ok := sl.Interface().([]string)
-				if !ok {
-					return nil, errors.New("failed to convert to string slice")
+		switch {
+		case util.IsSimpleType(f):
+			params.Set(fieldName, util.SimpleTypeToParam(f))
+		case f.Kind() == reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				elem := f.Index(i)
+				if util.IsSimpleType(elem) {
+					params.Add(fieldName, util.SimpleTypeToParam(elem))
+				} else {
+					return nil, errors.New("slices must contain only simple types")
 				}
-				for _, val := range s {
-					params.Add(fieldName, val)
-				}
-			default:
-				return nil, errors.Errorf("unknown slice type %s", f.Kind().String())
 			}
-		case reflect.Map:
+		case f.Kind() == reflect.Map:
 			lowerCaseKeys := make(map[string][]string)
 			iter := f.MapRange()
 			for iter.Next() {
@@ -82,7 +69,10 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
+		default:
+			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
+
 	}
 	return params, nil
 }

--- a/pkg/bindings/volumes/types_remove_options.go
+++ b/pkg/bindings/volumes/types_remove_options.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
@@ -69,8 +68,6 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 			}
 
 			params.Set(fieldName, s)
-		default:
-			panic(fmt.Sprintf("don't known how to handle %s", f.Type().String()))
 		}
 
 	}

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -81,11 +81,10 @@ type PauseUnpauseReport struct {
 }
 
 type StopOptions struct {
-	All      bool
-	CIDFiles []string
-	Ignore   bool
-	Latest   bool
-	Timeout  *uint
+	All     bool
+	Ignore  bool
+	Latest  bool
+	Timeout *uint
 }
 
 type StopReport struct {
@@ -104,10 +103,9 @@ type TopOptions struct {
 }
 
 type KillOptions struct {
-	All      bool
-	Latest   bool
-	Signal   string
-	CIDFiles []string
+	All    bool
+	Latest bool
+	Signal string
 }
 
 type KillReport struct {

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -51,7 +51,7 @@ type ContainerRunlabelReport struct {
 }
 
 type WaitOptions struct {
-	Condition define.ContainerStatus
+	Condition []define.ContainerStatus
 	Interval  time.Duration
 	Latest    bool
 }

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -128,12 +128,11 @@ type RestartReport struct {
 }
 
 type RmOptions struct {
-	All      bool
-	CIDFiles []string
-	Force    bool
-	Ignore   bool
-	Latest   bool
-	Volumes  bool
+	All     bool
+	Force   bool
+	Ignore  bool
+	Latest  bool
+	Volumes bool
 }
 
 type RmReport struct {

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -295,8 +295,8 @@ type ContainerListOptions struct {
 	Pod       bool
 	Quiet     bool
 	Size      bool
+	External  bool
 	Sort      string
-	Storage   bool
 	Sync      bool
 	Watch     uint
 }

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -133,13 +133,13 @@ type ImagePullOptions struct {
 	Username string
 	// Password for authenticating against the registry.
 	Password string
-	// OverrideArch will overwrite the local architecture for image pulls.
-	OverrideArch string
-	// OverrideOS will overwrite the local operating system (OS) for image
+	// Arch will overwrite the local architecture for image pulls.
+	Arch string
+	// OS will overwrite the local operating system (OS) for image
 	// pulls.
-	OverrideOS string
-	// OverrideVariant will overwrite the local variant for image pulls.
-	OverrideVariant string
+	OS string
+	// Variant will overwrite the local variant for image pulls.
+	Variant string
 	// Quiet can be specified to suppress pull progress when pulling.  Ignored
 	// for remote calls.
 	Quiet bool

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -139,14 +138,6 @@ func (ic *ContainerEngine) ContainerUnpause(ctx context.Context, namesOrIds []st
 }
 func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []string, options entities.StopOptions) ([]*entities.StopReport, error) {
 	names := namesOrIds
-	for _, cidFile := range options.CIDFiles {
-		content, err := ioutil.ReadFile(cidFile)
-		if err != nil {
-			return nil, errors.Wrap(err, "error reading CIDFile")
-		}
-		id := strings.Split(string(content), "\n")[0]
-		names = append(names, id)
-	}
 	ctrs, err := getContainersByContext(options.All, options.Latest, names, ic.Libpod)
 	if err != nil && !(options.Ignore && errors.Cause(err) == define.ErrNoSuchCtr) {
 		return nil, err
@@ -202,14 +193,6 @@ func (ic *ContainerEngine) ContainerPrune(ctx context.Context, options entities.
 }
 
 func (ic *ContainerEngine) ContainerKill(ctx context.Context, namesOrIds []string, options entities.KillOptions) ([]*entities.KillReport, error) {
-	for _, cidFile := range options.CIDFiles {
-		content, err := ioutil.ReadFile(cidFile)
-		if err != nil {
-			return nil, errors.Wrap(err, "error reading CIDFile")
-		}
-		id := strings.Split(string(content), "\n")[0]
-		namesOrIds = append(namesOrIds, id)
-	}
 	sig, err := signal.ParseSignalNameOrNumber(options.Signal)
 	if err != nil {
 		return nil, err

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -100,7 +100,7 @@ func (ic *ContainerEngine) ContainerWait(ctx context.Context, namesOrIds []strin
 	responses := make([]entities.WaitReport, 0, len(ctrs))
 	for _, c := range ctrs {
 		response := entities.WaitReport{Id: c.ID()}
-		exitCode, err := c.WaitForConditionWithInterval(ctx, options.Interval, options.Condition)
+		exitCode, err := c.WaitForConditionWithInterval(ctx, options.Interval, options.Condition...)
 		if err != nil {
 			response.Error = err
 		} else {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -100,7 +100,7 @@ func (ic *ContainerEngine) ContainerWait(ctx context.Context, namesOrIds []strin
 	responses := make([]entities.WaitReport, 0, len(ctrs))
 	for _, c := range ctrs {
 		response := entities.WaitReport{Id: c.ID()}
-		exitCode, err := c.WaitForConditionWithInterval(options.Interval, options.Condition)
+		exitCode, err := c.WaitForConditionWithInterval(ctx, options.Interval, options.Condition)
 		if err != nil {
 			response.Error = err
 		} else {
@@ -728,7 +728,7 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 				return reports, errors.Wrapf(err, "unable to start container %s", ctr.ID())
 			}
 
-			if ecode, err := ctr.Wait(); err != nil {
+			if ecode, err := ctr.Wait(ctx); err != nil {
 				if errors.Cause(err) == define.ErrNoSuchCtr {
 					// Check events
 					event, err := ic.Libpod.GetLastContainerEvent(ctx, ctr.ID(), events.Exited)
@@ -867,7 +867,7 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 		return &report, err
 	}
 
-	if ecode, err := ctr.Wait(); err != nil {
+	if ecode, err := ctr.Wait(ctx); err != nil {
 		if errors.Cause(err) == define.ErrNoSuchCtr {
 			// Check events
 			event, err := ic.Libpod.GetLastContainerEvent(ctx, ctr.ID(), events.Exited)

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -241,9 +241,9 @@ func pull(ctx context.Context, runtime *image.Runtime, rawImage string, options 
 	dockerRegistryOptions := image.DockerRegistryOptions{
 		DockerRegistryCreds:         registryCreds,
 		DockerCertPath:              options.CertDir,
-		OSChoice:                    options.OverrideOS,
-		ArchitectureChoice:          options.OverrideArch,
-		VariantChoice:               options.OverrideVariant,
+		OSChoice:                    options.OS,
+		ArchitectureChoice:          options.Arch,
+		VariantChoice:               options.Variant,
 		DockerInsecureSkipTLSVerify: options.SkipTLSVerify,
 	}
 

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -173,14 +173,6 @@ func (ic *ContainerEngine) ContainerRestart(ctx context.Context, namesOrIds []st
 }
 
 func (ic *ContainerEngine) ContainerRm(ctx context.Context, namesOrIds []string, opts entities.RmOptions) ([]*entities.RmReport, error) {
-	for _, cidFile := range opts.CIDFiles {
-		content, err := ioutil.ReadFile(cidFile)
-		if err != nil {
-			return nil, errors.Wrap(err, "error reading CIDFile")
-		}
-		id := strings.Split(string(content), "\n")[0]
-		namesOrIds = append(namesOrIds, id)
-	}
 	ctrs, err := getContainersByContext(ic.ClientCtx, opts.All, opts.Ignore, namesOrIds)
 	if err != nil {
 		return nil, err

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -106,8 +106,8 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 
 func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, opts entities.ImagePullOptions) (*entities.ImagePullReport, error) {
 	options := new(images.PullOptions)
-	options.WithAllTags(opts.AllTags).WithAuthfile(opts.Authfile).WithCertDir(opts.CertDir).WithOverrideArch(opts.OverrideArch).WithOverrideOS(opts.OverrideOS)
-	options.WithOverrideVariant(opts.OverrideVariant).WithPassword(opts.Password).WithPullPolicy(opts.PullPolicy)
+	options.WithAllTags(opts.AllTags).WithAuthfile(opts.Authfile).WithCertDir(opts.CertDir).WithArch(opts.Arch).WithOS(opts.OS)
+	options.WithVariant(opts.Variant).WithPassword(opts.Password).WithPullPolicy(opts.PullPolicy)
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {
 			options.WithSkipTLSVerify(true)

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -106,8 +106,9 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 
 func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, opts entities.ImagePullOptions) (*entities.ImagePullReport, error) {
 	options := new(images.PullOptions)
-	options.WithAllTags(opts.AllTags).WithAuthfile(opts.Authfile).WithCertDir(opts.CertDir).WithArch(opts.Arch).WithOS(opts.OS)
-	options.WithVariant(opts.Variant).WithPassword(opts.Password).WithPullPolicy(opts.PullPolicy)
+	options.WithAllTags(opts.AllTags).WithAuthfile(opts.Authfile).WithArch(opts.Arch).WithOS(opts.OS)
+	options.WithVariant(opts.Variant).WithPassword(opts.Password)
+	options.WithQuiet(opts.Quiet).WithUsername(opts.Username)
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {
 			options.WithSkipTLSVerify(true)
@@ -115,7 +116,6 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, opts entities.
 			options.WithSkipTLSVerify(false)
 		}
 	}
-	options.WithQuiet(opts.Quiet).WithSignaturePolicy(opts.SignaturePolicy).WithUsername(opts.Username)
 	pulledImages, err := images.Pull(ir.ClientCtx, rawImage, options)
 	if err != nil {
 		return nil, err

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -236,10 +236,7 @@ func (ir *ImageEngine) Import(ctx context.Context, opts entities.ImageImportOpti
 
 func (ir *ImageEngine) Push(ctx context.Context, source string, destination string, opts entities.ImagePushOptions) error {
 	options := new(images.PushOptions)
-	options.WithUsername(opts.Username).WithSignaturePolicy(opts.SignaturePolicy).WithQuiet(opts.Quiet)
-	options.WithPassword(opts.Password).WithCertDir(opts.CertDir).WithAuthfile(opts.Authfile)
-	options.WithCompress(opts.Compress).WithDigestFile(opts.DigestFile).WithFormat(opts.Format)
-	options.WithRemoveSignatures(opts.RemoveSignatures).WithSignBy(opts.SignBy)
+	options.WithAll(opts.All).WithCompress(opts.Compress).WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile)
 
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -77,10 +77,8 @@ func (ir *ImageEngine) ManifestRemove(ctx context.Context, names []string) (stri
 // ManifestPush pushes a manifest list or image index to the destination
 func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination string, opts entities.ImagePushOptions) (string, error) {
 	options := new(images.PushOptions)
-	options.WithUsername(opts.Username).WithSignaturePolicy(opts.SignaturePolicy).WithQuiet(opts.Quiet)
-	options.WithPassword(opts.Password).WithCertDir(opts.CertDir).WithAuthfile(opts.Authfile)
-	options.WithCompress(opts.Compress).WithDigestFile(opts.DigestFile).WithFormat(opts.Format)
-	options.WithRemoveSignatures(opts.RemoveSignatures).WithSignBy(opts.SignBy)
+	options.WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile)
+	options.WithAll(opts.All)
 
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {

--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -69,7 +69,7 @@ func GetContainerLists(runtime *libpod.Runtime, options entities.ContainerListOp
 		pss = append(pss, listCon)
 	}
 
-	if options.All && options.Storage {
+	if options.All && options.External {
 		externCons, err := runtime.StorageContainers()
 		if err != nil {
 			return nil, err

--- a/test/apiv2/26-containersWait.at
+++ b/test/apiv2/26-containersWait.at
@@ -1,0 +1,47 @@
+# -*- sh -*-
+#
+# test more container-related endpoints
+#
+
+red='\e[31m'
+nc='\e[0m'
+
+podman pull "${IMAGE}" &>/dev/null
+
+# Ensure clean slate
+podman rm -a -f &>/dev/null
+
+CTR="WaitTestingCtr"
+
+t POST "containers/nonExistent/wait?condition=next-exit" '' 404
+
+podman create --name "${CTR}" --entrypoint '["sleep", "0.5"]' "${IMAGE}"
+
+t POST "containers/${CTR}/wait?condition=non-existent-cond" '' 400
+
+t POST "containers/${CTR}/wait?condition=not-running" '' 200
+
+t POST "containers/${CTR}/wait?condition=next-exit" '' 200 &
+child_pid=$!
+podman start "${CTR}"
+wait "${child_pid}"
+
+
+# check if headers are sent in advance before body
+WAIT_TEST_ERROR=""
+curl -I -X POST "http://$HOST:$PORT/containers/${CTR}/wait?condition=next-exit" &> "/dev/null" &
+child_pid=$!
+sleep 0.5
+if kill -2 "${child_pid}" 2> "/dev/null"; then
+  echo -e "${red}NOK: Failed to get response headers immediately.${nc}"  1>&2;
+  WAIT_TEST_ERROR="1"
+fi
+
+t POST "containers/${CTR}/wait?condition=removed" '' 200 &
+child_pid=$!
+podman container rm "${CTR}"
+wait "${child_pid}"
+
+if [[ "${WAIT_TEST_ERROR}" ]] ; then
+  exit 1;
+fi

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -437,7 +437,7 @@ func (p *PodmanTestIntegration) BuildImage(dockerfile, imageName string, layers 
 	err := ioutil.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
 	Expect(err).To(BeNil())
 	session := p.Podman([]string{"build", "--layers=" + layers, "-t", imageName, "--file", dockerfilePath, p.TempDir})
-	session.Wait(120)
+	session.Wait(240)
 	Expect(session).Should(Exit(0), fmt.Sprintf("BuildImage session output: %q", session.OutputToString()))
 }
 

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create using image list by tag", func() {
-		session := podmanTest.Podman([]string{"create", "--pull=always", "--override-arch=arm64", "--name=foo", ALPINELISTTAG})
+		session := podmanTest.Podman([]string{"create", "--pull=always", "--arch=arm64", "--name=foo", ALPINELISTTAG})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To((Equal(0)))
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.Image}}", "foo"})
@@ -296,7 +296,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create using image list by digest", func() {
-		session := podmanTest.Podman([]string{"create", "--pull=always", "--override-arch=arm64", "--name=foo", ALPINELISTDIGEST})
+		session := podmanTest.Podman([]string{"create", "--pull=always", "--arch=arm64", "--name=foo", ALPINELISTDIGEST})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To((Equal(0)))
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.Image}}", "foo"})
@@ -310,7 +310,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create using image list instance by digest", func() {
-		session := podmanTest.Podman([]string{"create", "--pull=always", "--override-arch=arm64", "--name=foo", ALPINEARM64DIGEST})
+		session := podmanTest.Podman([]string{"create", "--pull=always", "--arch=arm64", "--name=foo", ALPINEARM64DIGEST})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To((Equal(0)))
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.Image}}", "foo"})
@@ -324,7 +324,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create using cross-arch image list instance by digest", func() {
-		session := podmanTest.Podman([]string{"create", "--pull=always", "--override-arch=arm64", "--name=foo", ALPINEARM64DIGEST})
+		session := podmanTest.Podman([]string{"create", "--pull=always", "--arch=arm64", "--name=foo", ALPINEARM64DIGEST})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To((Equal(0)))
 		session = podmanTest.Podman([]string{"inspect", "--format", "{{.Image}}", "foo"})
@@ -652,10 +652,10 @@ var _ = Describe("Podman create", func() {
 		expectedError := "no image found in manifest list for architecture bogus"
 		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
 
-		session = podmanTest.Podman([]string{"create", "--platform=linux/arm64", "--override-os", "windows", ALPINE})
+		session = podmanTest.Podman([]string{"create", "--platform=linux/arm64", "--os", "windows", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(125))
-		expectedError = "--platform option can not be specified with --override-arch or --override-os"
+		expectedError = "--platform option can not be specified with --arch or --os"
 		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
 
 		session = podmanTest.Podman([]string{"create", "-q", "--platform=linux/arm64", ALPINE})

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -167,4 +167,20 @@ var _ = Describe("Podman kill", func() {
 		Expect(wait.ExitCode()).To(BeZero())
 	})
 
+	It("podman stop --all", func() {
+		session := podmanTest.RunTopContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+
+		session = podmanTest.RunTopContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
+
+		session = podmanTest.Podman([]string{"kill", "--all"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+	})
 })

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -396,11 +396,14 @@ var _ = Describe("Podman ps", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"ps", "--pod", "--no-trunc"})
-
+		session = podmanTest.Podman([]string{"ps", "--no-trunc"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Not(ContainSubstring(podid)))
 
+		session = podmanTest.Podman([]string{"ps", "--pod", "--no-trunc"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring(podid))
 	})
 

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull by digest (image list)", func() {
-		session := podmanTest.Podman([]string{"pull", "--override-arch=arm64", ALPINELISTDIGEST})
+		session := podmanTest.Podman([]string{"pull", "--arch=arm64", ALPINELISTDIGEST})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		// inspect using the digest of the list
@@ -135,7 +135,7 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull by instance digest (image list)", func() {
-		session := podmanTest.Podman([]string{"pull", "--override-arch=arm64", ALPINEARM64DIGEST})
+		session := podmanTest.Podman([]string{"pull", "--arch=arm64", ALPINEARM64DIGEST})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		// inspect using the digest of the list
@@ -175,7 +175,7 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull by tag (image list)", func() {
-		session := podmanTest.Podman([]string{"pull", "--override-arch=arm64", ALPINELISTTAG})
+		session := podmanTest.Podman([]string{"pull", "--arch=arm64", ALPINELISTTAG})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		// inspect using the tag we used for pulling
@@ -503,10 +503,10 @@ var _ = Describe("Podman pull", func() {
 		expectedError := "no image found in manifest list for architecture bogus"
 		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
 
-		session = podmanTest.Podman([]string{"pull", "--platform=linux/arm64", "--override-os", "windows", ALPINE})
+		session = podmanTest.Podman([]string{"pull", "--platform=linux/arm64", "--os", "windows", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(125))
-		expectedError = "--platform option can not be specified with --override-arch or --override-os"
+		expectedError = "--platform option can not be specified with --arch or --os"
 		Expect(session.ErrorToString()).To(ContainSubstring(expectedError))
 
 		session = podmanTest.Podman([]string{"pull", "-q", "--platform=linux/arm64", ALPINE})

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -225,4 +225,26 @@ var _ = Describe("Podman restart", func() {
 		// line count should be equal
 		Expect(beforeRestart.OutputToString()).To(Equal(afterRestart.OutputToString()))
 	})
+
+	It("podman restart --all", func() {
+		session := podmanTest.RunTopContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+
+		session = podmanTest.RunTopContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
+
+		session = podmanTest.Podman([]string{"stop", "--all"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"restart", "--all"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
+	})
 })

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Podman rm", func() {
 
 		latest := "-l"
 		if IsRemote() {
-			latest = "test1"
+			latest = cid
 		}
 		result := podmanTest.Podman([]string{"rm", latest})
 		result.WaitWithDefaultTimeout()

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -215,6 +215,40 @@ var _ = Describe("Podman rm", func() {
 		Expect(result.ExitCode()).To(Equal(125))
 	})
 
+	It("podman rm --all", func() {
+		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+
+		session = podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(2))
+
+		session = podmanTest.Podman([]string{"rm", "--all"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
+	})
+
+	It("podman rm --ignore", func() {
+		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToStringArray()[0]
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+
+		session = podmanTest.Podman([]string{"rm", "bogus", cid})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(1))
+
+		session = podmanTest.Podman([]string{"rm", "--ignore", "bogus", cid})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
+	})
+
 	It("podman rm bogus container", func() {
 		session := podmanTest.Podman([]string{"rm", "bogus"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/wait_test.go
+++ b/test/e2e/wait_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Podman wait", func() {
 
 	It("podman wait on bogus container", func() {
 		session := podmanTest.Podman([]string{"wait", "1234"})
-		session.Wait()
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(125))
 
 	})
@@ -45,7 +45,7 @@ var _ = Describe("Podman wait", func() {
 		cid := session.OutputToString()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"wait", cid})
-		session.Wait()
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 

--- a/test/python/docker/test_containers.py
+++ b/test/python/docker/test_containers.py
@@ -95,6 +95,15 @@ class TestContainers(unittest.TestCase):
         top.reload()
         self.assertIn(top.status, ("stopped", "exited"))
 
+    def test_kill_container(self):
+        top = self.client.containers.get(TestContainers.topContainerId)
+        self.assertEqual(top.status, "running")
+
+        # Kill a running container and validate the state
+        top.kill()
+        top.reload()
+        self.assertIn(top.status, ("stopped", "exited"))
+
     def test_restart_container(self):
         # Validate the container state
         top = self.client.containers.get(TestContainers.topContainerId)

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -111,8 +111,11 @@ EOF
     run_podman ps --storage -a
     is "${#lines[@]}" "2" "podman ps -a --storage sees buildah container"
 
-    # This is what deletes the container
-    # FIXME: why doesn't "podman rm --storage $cid" do anything?
+    # We can't rm it without -f, but podman should issue a helpful message
+    run_podman 2 rm "$cid"
+    is "$output" "Error: container .* is mounted and cannot be removed without using force: container state improper" "podman rm <buildah container> without -f"
+
+    # With -f, we can remove it.
     run_podman rm -f "$cid"
 
     run_podman ps --storage -a

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -82,11 +82,10 @@ load helpers
     run_podman rm -a
 }
 
-@test "podman ps -a --storage" {
-    skip_if_remote "ps --storage does not work over remote"
+@test "podman ps -a --external" {
 
     # Setup: ensure that we have no hidden storage containers
-    run_podman ps --storage -a
+    run_podman ps --external -a
     is "${#lines[@]}" "1" "setup check: no storage containers at start of test"
 
     # Force a buildah timeout; this leaves a buildah container behind
@@ -98,18 +97,18 @@ EOF
     run_podman ps -a
     is "${#lines[@]}" "1" "podman ps -a does not see buildah container"
 
-    run_podman ps --storage -a
-    is "${#lines[@]}" "2" "podman ps -a --storage sees buildah container"
+    run_podman ps --external -a
+    is "${#lines[@]}" "2" "podman ps -a --external sees buildah container"
     is "${lines[1]}" \
        "[0-9a-f]\{12\} \+$IMAGE *buildah .* seconds ago .* storage .* ${PODMAN_TEST_IMAGE_NAME}-working-container" \
-       "podman ps --storage"
+       "podman ps --external"
 
     cid="${lines[1]:0:12}"
 
     # 'rm -a' should be a NOP
     run_podman rm -a
-    run_podman ps --storage -a
-    is "${#lines[@]}" "2" "podman ps -a --storage sees buildah container"
+    run_podman ps --external -a
+    is "${#lines[@]}" "2" "podman ps -a --external sees buildah container"
 
     # We can't rm it without -f, but podman should issue a helpful message
     run_podman 2 rm "$cid"
@@ -118,7 +117,7 @@ EOF
     # With -f, we can remove it.
     run_podman rm -f "$cid"
 
-    run_podman ps --storage -a
+    run_podman ps --external -a
     is "${#lines[@]}" "1" "storage container has been removed"
 }
 

--- a/test/system/150-login.bats
+++ b/test/system/150-login.bats
@@ -197,6 +197,7 @@ EOF
     destname=ok-$(random_string 10 | tr A-Z a-z)-ok
     # Use command-line credentials
     run_podman push --tls-verify=false \
+               --format docker \
                --creds ${PODMAN_LOGIN_USER}:${PODMAN_LOGIN_PASS} \
                $IMAGE localhost:${PODMAN_LOGIN_REGISTRY_PORT}/$destname
 


### PR DESCRIPTION
I was hoping to avoid this until 3.1, but it's a potentially breaking API change so let's get it into 3.0.

This backports https://github.com/containers/podman/pull/9048. Unfortunately, this requires that we also backport an uncomfortably large amount of changes to API handler code from @rhatdan.