### PR TITLE
Fix varlink GetVersion()

### DIFF
--- a/libpod/define/version.go
+++ b/libpod/define/version.go
@@ -42,7 +42,7 @@ func GetVersion() (Version, error) {
 		}
 	}
 	return Version{
-		APIVersion: podmanVersion.APIVersion.String(),
+		APIVersion: strconv.Itoa(int(podmanVersion.APIVersion.Major)),
 		Version:    podmanVersion.Version.String(),
 		GoVersion:  runtime.Version(),
 		GitCommit:  gitCommit,

--- a/pkg/varlinkapi/system.go
+++ b/pkg/varlinkapi/system.go
@@ -20,12 +20,12 @@ import (
 func (i *VarlinkAPI) GetVersion(call iopodman.VarlinkCall) error {
 	versionInfo, err := define.GetVersion()
 	if err != nil {
-		return err
+		return call.ReplyErrorOccurred(err.Error())
 	}
 
 	int64APIVersion, err := strconv.ParseInt(versionInfo.APIVersion, 10, 64)
 	if err != nil {
-		return err
+		return call.ReplyErrorOccurred(err.Error())
 	}
 
 	return call.ReplyGetVersion(


### PR DESCRIPTION
Fixed two small problems with the varlink GetVersion() call.  The first
was that an error was being eaten and not returned to users when a
string to int conversion was being done.  The second was that the
variable given to the string to int conversion was not something that
could be converted into an integer (i.e. 2.1.0).  Adjusted the
APIVersion to be only representative of the major number (i.e. 2).

Fixes bugzilla: #1925928

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
