### PR TITLE
Support annotations from containers.conf

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/podman/v2/libpod"
@@ -197,6 +198,15 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 		annotations[ann.ContainerType] = ann.ContainerTypeContainer
 	}
 
+	for _, v := range rtc.Containers.Annotations {
+		split := strings.SplitN(v, "=", 2)
+		k := split[0]
+		v := ""
+		if len(split) == 2 {
+			v = split[1]
+		}
+		annotations[k] = v
+	}
 	// now pass in the values from client
 	for k, v := range s.Annotations {
 		annotations[k] = v

--- a/test/e2e/config/containers.conf
+++ b/test/e2e/config/containers.conf
@@ -53,6 +53,8 @@ tz = "Pacific/Honolulu"
 
 umask = "0002"
 
+annotations=["run.oci.keep_original_groups=1",]
+
 [engine]
 
 network_cmd_options=["allow_host_loopback=true"]

--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -320,4 +320,15 @@ var _ = Describe("Podman run", func() {
 		Expect(session.OutputToString()).To(Equal("0022"))
 	})
 
+	It("podman run containers.conf annotations test", func() {
+		//containers.conf is set to   "run.oci.keep_original_groups=1"
+		session := podmanTest.Podman([]string{"create", "--rm", "--name", "test", fedoraMinimal})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", "--format", "{{ .Config.Annotations }}", "test"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.OutputToString()).To(ContainSubstring("run.oci.keep_original_groups:1"))
+	})
+
 })

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -332,6 +332,9 @@ var _ = Describe("Podman run", func() {
 	It("podman run user capabilities test", func() {
 		// We need to ignore the containers.conf on the test distribution for this test
 		os.Setenv("CONTAINERS_CONF", "/dev/null")
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+		}
 		session := podmanTest.Podman([]string{"run", "--rm", "--user", "bin", ALPINE, "grep", "CapBnd", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -424,6 +427,9 @@ var _ = Describe("Podman run", func() {
 	It("podman run user capabilities test with image", func() {
 		// We need to ignore the containers.conf on the test distribution for this test
 		os.Setenv("CONTAINERS_CONF", "/dev/null")
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+		}
 		dockerfile := `FROM busybox
 USER bin`
 		podmanTest.BuildImage(dockerfile, "test", "false")


### PR DESCRIPTION
Currently podman does not use the annotations specified in the
containers.conf. This PR fixes this.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
