### PR TITLE
Add default template functions

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -223,7 +223,9 @@ func ps(cmd *cobra.Command, _ []string) error {
 	ns := strings.NewReplacer(".Namespaces.", ".")
 	format = ns.Replace(format)
 
-	tmpl, err := template.New("listContainers").Parse(format)
+	tmpl, err := template.New("listContainers").
+		Funcs(template.FuncMap(report.DefaultFuncs)).
+		Parse(format)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -1,7 +1,6 @@
 package inspect
 
 import (
-	"bytes"
 	"context"
 	"encoding/json" // due to a bug in json-iterator it cannot be used here
 	"fmt"
@@ -246,15 +245,8 @@ func printJSON(data []interface{}) error {
 }
 
 func printTmpl(typ, row string, data []interface{}) error {
-	t, err := template.New(typ + " inspect").Funcs(map[string]interface{}{
-		"json": func(v interface{}) string {
-			b := &bytes.Buffer{}
-			e := registry.JSONLibrary().NewEncoder(b)
-			e.SetEscapeHTML(false)
-			_ = e.Encode(v)
-			return strings.TrimSpace(b.String())
-		},
-	}).Parse(row)
+	// We cannot use c/common/reports here, too many levels of interface{}
+	t, err := template.New(typ + " inspect").Funcs(template.FuncMap(report.DefaultFuncs)).Parse(row)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For commands that use the golang template library directly add the
compatible template functions

Fixes #8773

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
