### PR TITLE
apiv2 test fixes

### DIFF
--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -1,7 +1,6 @@
 package compat
 
 import (
-	"context"
 	"net/http"
 	"strings"
 
@@ -76,7 +75,15 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)
 	}
-	if err := imageEngine.Push(context.Background(), imageName, query.Destination, options); err != nil {
+
+	var destination string
+	if _, found := r.URL.Query()["destination"]; found {
+		destination = query.Destination
+	} else {
+		destination = imageName
+	}
+
+	if err := imageEngine.Push(r.Context(), imageName, destination, options); err != nil {
 		if errors.Cause(err) != storage.ErrImageUnknown {
 			utils.ImageNotFound(w, imageName, errors.Wrapf(err, "failed to find image %s", imageName))
 			return

--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -24,13 +24,10 @@ t GET libpod/images/$IMAGE/json 200 \
 
 # Run registry container
 podman run -d --name registry -p 5000:5000 quay.io/libpod/registry:2.6 /entrypoint.sh /etc/docker/registry/config.yml
+sleep 2
 
 # Push to local registry
-# FIXME: this is failing:
-#   "cause": "received unexpected HTTP status: 500 Internal Server Error",
-#   "message": "error pushing image \"localhost:5000/myrepo:mytag\": error copying image to the remote destination: Error writing blob: Error initiating layer upload to /v2/myrepo/blobs/uploads/ in localhost:5000: received unexpected HTTP status: 500 Internal Server Error",
-#   "response": 400
-#t POST libpod/images/localhost:5000/myrepo:mytag/push\?tlsVerify\=false '' 200
+t POST "images/localhost:5000/myrepo/push?tlsVerify=false&tag=mytag" '' 200
 
 # Untag the image
 t POST "libpod/images/$iid/untag?repo=localhost:5000/myrepo&tag=mytag" '' 201

--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -24,7 +24,7 @@ t GET libpod/images/$IMAGE/json 200 \
 
 # Run registry container
 podman run -d --name registry -p 5000:5000 quay.io/libpod/registry:2.6 /entrypoint.sh /etc/docker/registry/config.yml
-sleep 2
+wait_for_port localhost 5000
 
 # Push to local registry
 t POST "images/localhost:5000/myrepo/push?tlsVerify=false&tag=mytag" '' 200

--- a/test/apiv2/23-containersArchive.at
+++ b/test/apiv2/23-containersArchive.at
@@ -13,13 +13,10 @@ podman rm -a -f &>/dev/null
 
 CTR="ArchiveTestingCtr"
 
-TMPD=$(mktemp -d)
-pushd "${TMPD}"
-echo "Hello" > "hello.txt"
-tar --format=posix -cvf "hello.tar" "hello.txt" &> /dev/null
-popd
-
+TMPD=$(mktemp -d podman-apiv2-test.archive.XXXXXXXX)
 HELLO_TAR="${TMPD}/hello.tar"
+echo "Hello" > $TMPD/hello.txt
+tar --format=posix -C $TMPD -cvf ${HELLO_TAR} hello.txt &> /dev/null
 
 podman run -d --name "${CTR}" "${IMAGE}" top
 

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -84,7 +84,9 @@ function like() {
 
     if expr "$actual" : "$expect" &>/dev/null; then
         # On success, include expected value; this helps readers understand
-        _show_ok 1 "$testname ('$actual') ~ $expect"
+        # (but don't show enormous multi-line output like 'generate kube')
+        blurb=$(head -n1 <<<"$actual")
+        _show_ok 1 "$testname ('$blurb') ~ $expect"
         return
     fi
     _show_ok 0 "$testname" "~ $expect" "$actual"
@@ -231,14 +233,17 @@ function t() {
     if [[ $content_type =~ /octet ]]; then
         output="[$(file --brief $WORKDIR/curl.result.out)]"
         echo "$output" >>$LOG
-    else
+    elif [[ -e $WORKDIR/curl.result.out ]]; then
         output=$(< $WORKDIR/curl.result.out)
 
-        if [[ $content_type =~ application/json ]]; then
+        if [[ $content_type =~ application/json ]] && [[ $method != "HEAD" ]]; then
             jq . <<<"$output" >>$LOG
         else
             echo "$output" >>$LOG
         fi
+    else
+        output=
+        echo "[no output]" >>$LOG
     fi
 
     # Test return code
@@ -305,10 +310,20 @@ function start_service() {
         &> $WORKDIR/server.log &
     service_pid=$!
 
+    wait_for_port $HOST $PORT
+}
+
+###################
+#  wait_for_port  #  Returns once port is available on host
+###################
+function wait_for_port() {
+    local host=$1                      # Probably "localhost"
+    local port=$2                      # Numeric port
+    local timeout=${3:-5}              # Optional; default to 5 seconds
+
     # Wait
-    local _timeout=5
-    while [ $_timeout -gt 0 ]; do
-        { exec 3<> /dev/tcp/$HOST/$PORT; } &>/dev/null && return
+    while [ $timeout -gt 0 ]; do
+        { exec 3<> /dev/tcp/$host/$port; } &>/dev/null && return
         sleep 1
         _timeout=$(( $_timeout - 1 ))
     done
@@ -385,6 +400,12 @@ done
 # Clean up
 
 if [ -n "$service_pid" ]; then
+    # Remove any containers and images; this prevents the following warning:
+    #  'rm: cannot remove '/.../overlay': Device or resource busy
+    podman rm -a
+    podman rmi -af
+
+    # Stop the server
     kill $service_pid
     wait $service_pid
 fi


### PR DESCRIPTION
It's been a while since I last looked at these; some cruft
has crept in, generating noise and hence unreadable test
results. Clean it up:

 * remove pushd/popd in one subtest, replace with 'tar -C'.
   (Also remove confusing quotation marks). This removes
   spurious directory names from output.

 * in like(), show only first line of actual output.
   Some commands ('tree', 'generate kube') produce
   voluminous multi-line output, which is super useless
   and distracting when reading a test run.

 * Recognize that some queries will not generate output,
   e.g. HEAD requests and some POSTs. Deal with that.
   This fixes "curl.result.out: no such file" and "parse
   error" warnings.

 * In cleanup, 'podman rm -a' and 'rmi -af'; this gets
   rid of errors when deleting $WORKDIR. (EBUSY error
   when root, EPERM when rootless).

And, the original reason for poking in here: refactor the
wait-for-port part of start_server() into its own helper
function, so we can use it when starting a local registry
in 12-imagesMore. (Ref: #9270)

Signed-off-by: Ed Santiago <santiago@redhat.com>
