### PR TITLE
hardening flags for fedora rpmbuilds

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -380,6 +380,29 @@ tar zxf %{SOURCE1}
 %build
 mkdir _build
 pushd _build
+
+# These flags should work for all rpm distros and arches
+export CGO_CFLAGS="-O2 -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -ffat-lto-objects -fexceptions -fasynchronous-unwind-tables -fstack-protector-strong -fstack-clash-protection -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE"
+
+%if 0%{?fedora} || 0%{?rhel}
+# This flag is only present on RH-family distros
+export CGO_CFLAGS+=" -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1"
+%endif
+
+%ifnarch %{ix86}
+# Build fails on i686 with this flag
+export CGO_CFLAGS+=" -D_FILE_OFFSET_BITS=64"
+%endif
+
+%ifarch x86_64
+# Builds only on x86_64 with this flag
+export CGO_CFLAGS+=" -m64 -mtune=generic"
+%if 0%{?fedora} || 0%{?rhel} >= 8
+# Build fails on rhel7 and non-86_64 with this flag
+export CGO_CFLAGS+=" -fcf-protection"
+%endif
+%endif
+
 mkdir -p src/%{provider}.%{provider_tld}/%{project}
 ln -s ../../../../ src/%{import_path}
 popd


### PR DESCRIPTION
This commit sets the CGO_CFLAGS variable for hardening the Fedora rpm
binaries.
    
The flags used are the same as used in the official Fedora rpms.
Setting the flags in upstream spec would provide early warnings for
flag adjustments or other hardening issues.


Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->


@baude @cevich @rhatdan PTAL.