### PR TITLE
Fix compat networks endpoint for a empty result

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -196,7 +196,7 @@ func ListNetworks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var reports []*types.NetworkResource
+	reports := []*types.NetworkResource{}
 	logrus.Debugf("netNames: %q", strings.Join(netNames, ", "))
 	for _, name := range netNames {
 		report, err := getNetworkResourceByNameOrID(name, runtime, query.Filters)

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -46,6 +46,9 @@ length=1 \
 # invalid filter filters={"dangling":["1"]}
 t GET networks?filters=%7B%22dangling%22%3A%5B%221%22%5D%7D 500 \
 .cause='invalid filter "dangling"'
+# (#9293 with no networks the endpoint should return empty array instead of null)
+t GET networks?filters=%7B%22name%22%3A%5B%22doesnotexists%22%5D%7D 200 \
+"[]"
 
 # network inspect docker
 t GET networks/a7662f44d65029fd4635c91feea3d720a57cef52e2a9fcc7772b69072cc1ccd1 200 \


### PR DESCRIPTION
The networks list compat api endpoint must return `[]`
and not `null` if no networks are found.

Fixes #9293
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
