### PR TITLE
Add shell completion tests for secrets

### DIFF
--- a/cmd/podman/secrets/create.go
+++ b/cmd/podman/secrets/create.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	createCmd = &cobra.Command{
-		Use:   "create [options] SECRET FILE|-",
+		Use:   "create [options] NAME FILE|-",
 		Short: "Create a new secret",
 		Long:  "Create a secret. Input can be a path to a file or \"-\" (read from stdin). Default driver is file (unencrypted).",
 		RunE:  create,


### PR DESCRIPTION
Add the SECRET keyword to the shell completion test. Also update the
use line for podman secret create to use `NAME` instead of `SECRET`.
This matches the other commands such as network/volume create.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
