### PR TITLE
[v1.0] Correct handling of capabilities

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -325,6 +325,14 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 		}
 	} else {
 		g.SetupPrivileged(true)
+		if config.User != "" {
+			user := strings.SplitN(config.User, ":", 2)[0]
+			if user != "root" && user != "0" {
+				g.Spec().Process.Capabilities.Effective = []string{}
+				g.Spec().Process.Capabilities.Permitted = []string{}
+				g.Spec().Process.Capabilities.Ambient = []string{}
+			}
+		}
 	}
 
 	// HANDLE SECCOMP


### PR DESCRIPTION
Ensure that capabilities are properly handled for non-root users in privileged containers. We do not want to give full caps, but instead only CapInh and CapEff (others should be all-zeroes).

