### PR TITLE
[v1.6.4-rhel] Restrict caps of non-root processes in priv containers

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -105,8 +105,6 @@ type OCIRuntime interface {
 type ExecOptions struct {
 	// Cmd is the command to execute.
 	Cmd []string
-	// CapAdd is a set of capabilities to add to the executed command.
-	CapAdd []string
 	// Env is a set of environment variables to add to the container.
 	Env map[string]string
 	// Terminal is whether to create a new TTY for the exec session.
@@ -129,4 +127,6 @@ type ExecOptions struct {
 	// DetachKeys is a set of keys that, when pressed in sequence, will
 	// detach from the container.
 	DetachKeys string
+	// Privileged is whether the exec session is privileged.
+	Privileged bool
 }

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -374,6 +374,14 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 		}
 	} else {
 		g.SetupPrivileged(true)
+		if config.User != "" {
+			user := strings.SplitN(config.User, ":", 2)[0]
+			if user != "root" && user != "0" {
+				g.Spec().Process.Capabilities.Effective = []string{}
+				g.Spec().Process.Capabilities.Permitted = []string{}
+				g.Spec().Process.Capabilities.Ambient = []string{}
+			}
+		}
 	}
 
 	// HANDLE SECCOMP


### PR DESCRIPTION
Non-root processes in privileged containers do not get all caps, and instead only have Bounding and Inherited set to all; the other caps are left empty. This behavior matches Docker and newer Podman releases.
