### PR TITLE
Rewrite copy-up to use buildah Copier

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2278,23 +2278,6 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 	return passwdPath, groupPath, nil
 }
 
-func (c *Container) copyOwnerAndPerms(source, dest string) error {
-	info, err := os.Stat(source)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	if err := os.Chmod(dest, info.Mode()); err != nil {
-		return err
-	}
-	if err := os.Chown(dest, int(info.Sys().(*syscall.Stat_t).Uid), int(info.Sys().(*syscall.Stat_t).Gid)); err != nil {
-		return err
-	}
-	return nil
-}
-
 // Get cgroup path in a format suitable for the OCI spec
 func (c *Container) getOCICgroupPath() (string, error) {
 	unified, err := cgroups.IsCgroup2UnifiedMode()

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -130,11 +130,18 @@ func (v *Volume) MountPoint() (string, error) {
 		if err := v.update(); err != nil {
 			return "", err
 		}
-
-		return v.state.MountPoint, nil
 	}
 
-	return v.config.MountPoint, nil
+	return v.mountPoint(), nil
+}
+
+// Internal-only helper for volume mountpoint
+func (v *Volume) mountPoint() string {
+	if v.UsesVolumeDriver() {
+		return v.state.MountPoint
+	}
+
+	return v.config.MountPoint
 }
 
 // Options return the volume's options


### PR DESCRIPTION
The old copy-up implementation was very unhappy with symlinks, which could cause containers to fail to start for unclear reasons when a directory we wanted to copy-up contained one. Rewrite to use the Buildah Copier, which is more recent and should be both safer and less likely to blow up over links.

At the same time, fix a deadlock in copy-up for volumes requiring mounting - the Mountpoint() function tried to take the already-acquired volume lock.

Fixes #6003
