### PR TITLE
Display correct value for unlimited ulimit

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -871,8 +871,8 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 		for _, limit := range ctrSpec.Process.Rlimits {
 			newLimit := define.InspectUlimit{}
 			newLimit.Name = limit.Type
-			newLimit.Soft = limit.Soft
-			newLimit.Hard = limit.Hard
+			newLimit.Soft = int64(limit.Soft)
+			newLimit.Hard = int64(limit.Hard)
 			hostConfig.Ulimits = append(hostConfig.Ulimits, newLimit)
 		}
 	}

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -122,9 +122,9 @@ type InspectUlimit struct {
 	// Name is the name (type) of the ulimit.
 	Name string `json:"Name"`
 	// Soft is the soft limit that will be applied.
-	Soft uint64 `json:"Soft"`
+	Soft int64 `json:"Soft"`
 	// Hard is the hard limit that will be applied.
-	Hard uint64 `json:"Hard"`
+	Hard int64 `json:"Hard"`
 }
 
 // InspectDevice is a single device that will be mounted into the container.


### PR DESCRIPTION
When doing a container inspect on a container with unlimited ulimits,
the value should be -1.  But because the OCI spec requires the ulimit
value to be uint64, we were displaying the inspect values as a uint64 as
well.  Simple change to display as an int64.

Fixes: #9303

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
