### PR TITLE
apiv2: handle docker-java clients pulling

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -265,12 +265,12 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 	// Success
 	utils.WriteResponse(w, http.StatusOK, struct {
 		Status         string            `json:"status"`
-		Error          string            `json:"error"`
+		Error          string            `json:"error,omitempty"`
 		Progress       string            `json:"progress"`
 		ProgressDetail map[string]string `json:"progressDetail"`
 		Id             string            `json:"id"` // nolint
 	}{
-		Status:         fmt.Sprintf("pulling image (%s) from %s", img.Tag, strings.Join(img.Names(), ", ")),
+		Status:         fmt.Sprintf("pulling image (%s) from %s (Download complete)", img.Tag, strings.Join(img.Names(), ", ")),
 		ProgressDetail: map[string]string{},
 		Id:             img.ID(),
 	})

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -41,7 +41,7 @@ t GET images/$iid/json 200 \
   .Id=sha256:$iid \
   .RepoTags[0]=$IMAGE
 
-t POST "images/create?fromImage=alpine" '' 200
+t POST "images/create?fromImage=alpine" '' 200 .error=null .status~".*Download complete.*"
 
 t POST "images/create?fromImage=alpine&tag=latest" '' 200
 


### PR DESCRIPTION
When docker-java calls images/create?fromImage=x, it expects two things for a successful response:
that both "error" and "errorDetail" are not set,
and that the "status" message contains one of five hard-coded strings ("Download complete" being one of them).

See:
https://github.com/docker-java/docker-java/blob/master/docker-java-api/src/main/java/com/github/dockerjava/api/model/PullResponseItem.java#L28-L39


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
