### PR TITLE
Correct compat network prune response

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -400,6 +400,9 @@ func Prune(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
 		return
 	}
+	type response struct {
+		NetworksDeleted []string
+	}
 	var prunedNetworks []string //nolint
 	for _, pr := range pruneReports {
 		if pr.Error != nil {
@@ -408,5 +411,5 @@ func Prune(w http.ResponseWriter, r *http.Request) {
 		}
 		prunedNetworks = append(prunedNetworks, pr.Name)
 	}
-	utils.WriteResponse(w, http.StatusOK, prunedNetworks)
+	utils.WriteResponse(w, http.StatusOK, response{NetworksDeleted: prunedNetworks})
 }

--- a/test/apiv2/rest_api/test_rest_v2_0_0.py
+++ b/test/apiv2/rest_api/test_rest_v2_0_0.py
@@ -483,8 +483,16 @@ class TestApi(unittest.TestCase):
         inspect = requests.get(PODMAN_URL + f"/v1.40/networks/{ident}")
         self.assertEqual(inspect.status_code, 404, inspect.content)
 
+        # network prune
+        prune_name = "Network_" + "".join(random.choice(string.ascii_letters) for i in range(10))
+        prune_create = requests.post(PODMAN_URL + "/v1.40/networks/create", json={"Name": prune_name})
+        self.assertEqual(create.status_code, 201, prune_create.content)
+
         prune = requests.post(PODMAN_URL + "/v1.40/networks/prune")
         self.assertEqual(prune.status_code, 200, prune.content)
+        obj = json.loads(prune.content)
+        self.assertTrue(prune_name in obj["NetworksDeleted"])
+
 
     def test_volumes_compat(self):
         name = "Volume_" + "".join(random.choice(string.ascii_letters) for i in range(10))


### PR DESCRIPTION
Correcting the structure of the compat network prune response.  They
should follow {"NetworksDeleted": [<network_name>",...]}

Fixes: #9310

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
