### PR TITLE
container ps json format miscue

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -142,11 +142,19 @@ func checkFlags(c *cobra.Command) error {
 }
 
 func jsonOut(responses []entities.ListContainer) error {
-	r := make([]entities.ListContainer, 0)
+	type jsonFormat struct {
+		entities.ListContainer
+		Created int64
+	}
+	r := make([]jsonFormat, 0)
 	for _, con := range responses {
 		con.CreatedAt = units.HumanDuration(time.Since(con.Created)) + " ago"
 		con.Status = psReporter{con}.Status()
-		r = append(r, con)
+		jf := jsonFormat{
+			ListContainer: con,
+			Created:       con.Created.UnixNano(),
+		}
+		r = append(r, jf)
 	}
 	b, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	. "github.com/containers/podman/v2/test/utils"
@@ -208,6 +209,22 @@ var _ = Describe("Podman ps", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(result.IsJSONOutputValid()).To(BeTrue())
+	})
+
+	It("podman ps json format Created field is int64", func() {
+		session := podmanTest.RunTopContainer("test1")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"ps", "--format", "json"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		// Make sure Created field is an int64
+		created, err := result.jq(".[0].Created")
+		Expect(err).To(BeNil())
+		_, err = strconv.ParseInt(created, 10, 64)
+		Expect(err).To(BeNil())
 	})
 
 	It("podman ps print a human-readable `Status` with json format", func() {


### PR DESCRIPTION
when printing out json format, we mistakenly changed the Created field
output to be a time.time in a different commit.  This allows for
override of the Created field to be a unix ts as type int64.

Fixes: #9315

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
