### PR TITLE
[3.0] utils: takes the longest path on cgroup v1

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -600,6 +600,13 @@ func SkipIfNotRootless(reason string) {
 	}
 }
 
+func SkipIfNotSystemd(manager, reason string) {
+	checkReason(reason)
+	if manager != "systemd" {
+		ginkgo.Skip("[notSystemd]: " + reason)
+	}
+}
+
 func SkipIfNotFedora() {
 	info := GetHostDistributionInfo()
 	if info.Distribution != "fedora" {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1185,6 +1185,37 @@ USER mail`
 		Expect(found).To(BeTrue())
 	})
 
+	It("podman run with cgroups=split", func() {
+		SkipIfNotSystemd(podmanTest.CgroupManager, "do not test --cgroups=split if not running on systemd")
+		SkipIfRootlessCgroupsV1("Disable cgroups not supported on cgroupv1 for rootless users")
+		SkipIfRemote("--cgroups=split cannot be used in remote mode")
+
+		container := podmanTest.Podman([]string{"run", "--rm", "--cgroups=split", ALPINE, "cat", "/proc/self/cgroup"})
+		container.WaitWithDefaultTimeout()
+		Expect(container.ExitCode()).To(Equal(0))
+		lines := container.OutputToStringArray()
+
+		cgroup := ""
+		for _, line := range lines {
+			parts := strings.SplitN(line, ":", 3)
+			if !CGROUPSV2 {
+				// ignore unified on cgroup v1
+				// both runc and crun do not set it.
+				if parts[1] == "" {
+					continue
+				}
+			}
+			if parts[2] == "/" {
+				continue
+			}
+			if cgroup == "" {
+				cgroup = parts[2]
+				continue
+			}
+			Expect(cgroup).To(Equal(parts[2]))
+		}
+	})
+
 	It("podman run with cgroups=disabled runs without cgroups", func() {
 		SkipIfRootless("FIXME:  I believe this should work but need to fix this test")
 		SkipIfRootlessCgroupsV1("Disable cgroups not supported on cgroupv1 for rootless users")

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -183,6 +183,9 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 				return err
 			}
 			for _, pid := range bytes.Split(processesData, []byte("\n")) {
+				if len(pid) == 0 {
+					continue
+				}
 				if _, err := f.Write(pid); err != nil {
 					logrus.Warnf("Cannot move process %s to cgroup %q", string(pid), newCgroup)
 				}

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -166,7 +166,7 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 			parentCgroup = parts[2]
 		}
 		newCgroup := filepath.Join(cgroupRoot, parentCgroup, subtree)
-		if err := os.Mkdir(newCgroup, 0755); err != nil && !os.IsExist(err) {
+		if err := os.MkdirAll(newCgroup, 0755); err != nil && !os.IsExist(err) {
 			return err
 		}
 

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -81,16 +81,9 @@ func getCgroupProcess(procFile string) (string, error) {
 			cgroup = line[3:]
 			break
 		}
-		// root cgroup, skip it
-		if parts[2] == "/" {
-			continue
+		if len(parts[2]) > len(cgroup) {
+			cgroup = parts[2]
 		}
-		// The process must have the same cgroup path for all controllers
-		// The OCI runtime spec file allow us to specify only one path.
-		if cgroup != "/" && cgroup != parts[2] {
-			return "", errors.Errorf("cgroup configuration not supported, the process is in two different cgroups")
-		}
-		cgroup = parts[2]
 	}
 	if cgroup == "/" {
 		return "", errors.Errorf("could not find cgroup mount in %q", procFile)

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -150,6 +150,11 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 			// If it is not using unified mode, the cgroup v2 hierarchy is
 			// usually mounted under /sys/fs/cgroup/unified
 			cgroupRoot = filepath.Join(cgroupRoot, "unified")
+
+			// Ignore the unified mount if it doesn't exist
+			if _, err := os.Stat(cgroupRoot); err != nil && os.IsNotExist(err) {
+				continue
+			}
 		} else if parts[1] != "" {
 			// Assume the controller is mounted at /sys/fs/cgroup/$CONTROLLER.
 			controller := strings.TrimPrefix(parts[1], "name=")


### PR DESCRIPTION
backport of: https://github.com/containers/podman/pull/9302

now getCgroupProcess takes the longest path on cgroup v1, instead of
complaining if the paths are different.

This should help when --cgroups=split is used on cgroup v1 and the
process cgroups look like:

$ cat /proc/self/cgroup
11:pids:/user.slice/user-0.slice/session-4.scope
10:blkio:/
9:cpuset:/
8:devices:/user.slice
7:freezer:/
6:memory:/user.slice/user-0.slice/session-4.scope
5:net_cls,net_prio:/
4:hugetlb:/
3:cpu,cpuacct:/
2:perf_event:/

Signed-off-by: Giuseppe Scrivano gscrivan@redhat.com