### PR TITLE
Enable more golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,14 +4,10 @@ run:
   deadline: 5m
   skip-dirs-use-default: true
   skip-dirs:
-    - dependencies
     - contrib
     - dependencies
     - test
-    - pkg/spec
-    - vendor
   skip-files:
-    - iopodman.go
     - swagger.go
   modules-download-mode: readonly
 linters:
@@ -51,12 +47,7 @@ linters:
     - goconst
     - gocyclo
     - lll
-    - structcheck
-    - typecheck
     - unconvert
-    - varcheck
-    - deadcode
-    - depguard
     - errcheck
     - gocritic
     - gosec

--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -29,7 +29,6 @@ func exclusiveOptions(opt1, opt2 string) error {
 // Validate verifies that the given SpecGenerator is valid and satisfies required
 // input for creating a container.
 func (s *SpecGenerator) Validate() error {
-
 	if rootless.IsRootless() && len(s.CNINetworks) == 0 {
 		if s.StaticIP != nil || s.StaticIPv6 != nil {
 			return ErrNoStaticIPRootless

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -113,7 +113,6 @@ func DevicesFromPath(g *generate.Generator, devicePath string) error {
 
 		// mount the internal devices recursively
 		if err := filepath.Walk(resolvedDevicePath, func(dpath string, f os.FileInfo, e error) error {
-
 			if f.Mode()&os.ModeDevice == os.ModeDevice {
 				found = true
 				device := fmt.Sprintf("%s:%s", dpath, filepath.Join(dest, strings.TrimPrefix(dpath, src)))

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -384,7 +384,6 @@ func getPodPorts(containers []v1.Container) []specgen.PortMapping {
 			if p.HostPort != 0 {
 				infraPorts = append(infraPorts, portBinding)
 			}
-
 		}
 	}
 	return infraPorts

--- a/pkg/specgen/generate/kube/seccomp.go
+++ b/pkg/specgen/generate/kube/seccomp.go
@@ -11,6 +11,7 @@ import (
 
 // KubeSeccompPaths holds information about a pod YAML's seccomp configuration
 // it holds both container and pod seccomp paths
+// nolint:golint
 type KubeSeccompPaths struct {
 	containerPaths map[string]string
 	podPath        string

--- a/pkg/specgen/generate/kube/volume.go
+++ b/pkg/specgen/generate/kube/volume.go
@@ -17,6 +17,7 @@ const (
 	kubeFilePermission = 0644
 )
 
+// nolint:golint
 type KubeVolumeType int
 
 const (
@@ -24,6 +25,7 @@ const (
 	KubeVolumeTypeNamed     KubeVolumeType = iota
 )
 
+// nolint:golint
 type KubeVolume struct {
 	// Type of volume to create
 	Type KubeVolumeType

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -219,7 +219,6 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		if !mappingFound {
 			gid5Available = false
 		}
-
 	}
 	if !gid5Available {
 		// If we have no GID mappings, the gid=5 default option would fail, so drop it.

--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -109,17 +109,15 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 			}
 		}
 		if !s.Privileged && len(capsRequiredRequested) > 0 {
-
 			// Pass capRequiredRequested in CapAdd field to normalize capabilities names
 			capsRequired, err := capabilities.MergeCapabilities(nil, capsRequiredRequested, nil)
 			if err != nil {
 				return errors.Wrapf(err, "capabilities requested by user or image are not valid: %q", strings.Join(capsRequired, ","))
-			} else {
-				// Verify all capRequired are in the capList
-				for _, cap := range capsRequired {
-					if !util.StringInSlice(cap, caplist) {
-						privCapsRequired = append(privCapsRequired, cap)
-					}
+			}
+			// Verify all capRequired are in the capList
+			for _, cap := range capsRequired {
+				if !util.StringInSlice(cap, caplist) {
+					privCapsRequired = append(privCapsRequired, cap)
 				}
 			}
 			if len(privCapsRequired) == 0 {
@@ -189,7 +187,6 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 		return err
 	}
 	for sysctlKey, sysctlVal := range defaultSysctls {
-
 		// Ignore mqueue sysctls if --ipc=host
 		if noUseIPC && strings.HasPrefix(sysctlKey, "fs.mqueue.") {
 			logrus.Infof("Sysctl %s=%s ignored in containers.conf, since IPC Namespace set to host", sysctlKey, sysctlVal)
@@ -213,7 +210,6 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 	}
 
 	for sysctlKey, sysctlVal := range s.Sysctl {
-
 		if s.IpcNS.IsHost() && strings.HasPrefix(sysctlKey, "fs.mqueue.") {
 			return errors.Wrapf(define.ErrInvalidArg, "sysctl %s=%s can't be set since IPC Namespace set to host", sysctlKey, sysctlVal)
 		}

--- a/pkg/specgen/pod_validate.go
+++ b/pkg/specgen/pod_validate.go
@@ -19,7 +19,6 @@ func exclusivePodOptions(opt1, opt2 string) error {
 
 // Validate verifies the input is valid
 func (p *PodSpecGenerator) Validate() error {
-
 	if rootless.IsRootless() && len(p.CNINetworks) == 0 {
 		if p.StaticIP != nil {
 			return ErrNoStaticIPRootless


### PR DESCRIPTION
Cleanup the golangci.yml file and enable more linters.

`pkg/spec` and `iopodman.io` is history. The vendor directory
is excluded by default. The dependencies dir was listed twice.

Fix the reported problems in `pkg/specgen` because that was also
excluded by `pkg/spec`.

Enable the structcheck, typecheck, varcheck, deadcode and depguard
linters.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
