### PR TITLE
Fix superfluous response.WriteHeader call in WaitContainerLibpod()

### DIFF
--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -105,6 +105,7 @@ func WaitContainerLibpod(w http.ResponseWriter, r *http.Request) {
 	query := waitQueryLibpod{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		return
 	}
 
 	if _, found := r.URL.Query()["interval"]; found {


### PR DESCRIPTION
When the query decoding fails at the beginning of `WaitContainerLibpod()`, the `Error()` sets the header but doesn't returns after that.

This causes the execution flow to reach the `WriteResponse()` at the end of `WaitContainerLibpod()`, which attempts to set another header, thus causing the following error:

```
http: superfluous response.WriteHeader call from github.com/containers/podman/pkg/api/handlers/utils.WriteResponse (handler.go:124)
```