### PR TITLE
Enable noctx lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
     - tparallel
     - gomnd
     - nlreturn
-    - noctx
     - nestif
     - predeclared
     - thelper

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -474,7 +475,7 @@ func (s *BoltState) getPodFromDB(id []byte, pod *Pod, podBkt *bolt.Bucket) error
 	return nil
 }
 
-func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bucket) error {
+func (s *BoltState) getVolumeFromDB(ctx context.Context, name []byte, volume *Volume, volBkt *bolt.Bucket) error {
 	volDB := volBkt.Bucket(name)
 	if volDB == nil {
 		return errors.Wrapf(define.ErrNoSuchVolume, "volume with name %s not found", string(name))
@@ -499,7 +500,7 @@ func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bu
 
 	// Retrieve volume driver
 	if volume.UsesVolumeDriver() {
-		plugin, err := s.runtime.getVolumePlugin(volume.config.Driver)
+		plugin, err := s.runtime.getVolumePlugin(ctx, volume.config.Driver)
 		if err != nil {
 			// We want to fail gracefully here, to ensure that we
 			// can still remove volumes even if their plugin is

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -55,7 +55,7 @@ func (c *Container) Init(ctx context.Context, recursive bool) error {
 		}
 	}
 
-	if err := c.prepare(); err != nil {
+	if err := c.prepare(ctx); err != nil {
 		if err2 := c.cleanup(ctx); err2 != nil {
 			logrus.Errorf("error cleaning up container %s: %v", c.ID(), err2)
 		}
@@ -874,5 +874,5 @@ func (c *Container) ResolvePath(ctx context.Context, root string, path string) (
 		}
 	}
 
-	return c.resolvePath(root, path)
+	return c.resolvePath(ctx, root, path)
 }

--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -133,7 +133,7 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 				}
 			}
 			if include {
-				vol, err := c.runtime.GetVolume(v.Name)
+				vol, err := c.runtime.GetVolume(ctx, v.Name)
 				if err != nil {
 					return nil, errors.Wrapf(err, "volume %s used in container %s has been removed", v.Name, c.ID())
 				}

--- a/libpod/container_internal_unsupported.go
+++ b/libpod/container_internal_unsupported.go
@@ -18,7 +18,7 @@ func (c *Container) unmountSHM(mount string) error {
 	return define.ErrNotImplemented
 }
 
-func (c *Container) prepare() error {
+func (c *Container) prepare(ctx context.Context) error {
 	return define.ErrNotImplemented
 }
 

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"context"
 	"strings"
 
 	"github.com/containers/podman/v2/libpod/define"
@@ -863,7 +864,7 @@ func (s *InMemoryState) RewriteVolumeConfig(volume *Volume, newCfg *VolumeConfig
 }
 
 // Volume retrieves a volume from its full name
-func (s *InMemoryState) Volume(name string) (*Volume, error) {
+func (s *InMemoryState) Volume(ctx context.Context, name string) (*Volume, error) {
 	if name == "" {
 		return nil, define.ErrEmptyID
 	}
@@ -877,7 +878,7 @@ func (s *InMemoryState) Volume(name string) (*Volume, error) {
 }
 
 // LookupVolume finds a volume from an unambiguous partial ID.
-func (s *InMemoryState) LookupVolume(name string) (*Volume, error) {
+func (s *InMemoryState) LookupVolume(ctx context.Context, name string) (*Volume, error) {
 	if name == "" {
 		return nil, define.ErrEmptyID
 	}
@@ -1010,7 +1011,7 @@ func (s *InMemoryState) VolumeInUse(volume *Volume) ([]string, error) {
 }
 
 // AllVolumes returns all volumes that exist in the state
-func (s *InMemoryState) AllVolumes() ([]*Volume, error) {
+func (s *InMemoryState) AllVolumes(ctx context.Context) ([]*Volume, error) {
 	allVols := make([]*Volume, 0, len(s.volumes))
 	for _, v := range s.volumes {
 		allVols = append(allVols, v)

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/containers/podman/v2/libpod/define"
@@ -24,7 +25,7 @@ type OCIRuntime interface {
 	Path() string
 
 	// CreateContainer creates the container in the OCI runtime.
-	CreateContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions) error
+	CreateContainer(ctx context.Context, ctr *Container, restoreOptions *ContainerCheckpointOptions) error
 	// UpdateContainerStatus updates the status of the given container.
 	UpdateContainerStatus(ctr *Container) error
 	// StartContainer starts the given container.

--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -67,7 +68,7 @@ func (r *MissingRuntime) Path() string {
 }
 
 // CreateContainer is not available as the runtime is missing
-func (r *MissingRuntime) CreateContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions) error {
+func (r *MissingRuntime) CreateContainer(ctx context.Context, ctr *Container, restoreOptions *ContainerCheckpointOptions) error {
 	return r.printError()
 }
 

--- a/libpod/reset.go
+++ b/libpod/reset.go
@@ -63,7 +63,7 @@ func (r *Runtime) Reset(ctx context.Context) error {
 			logrus.Errorf("Error removing image %s: %v", i.ID(), err)
 		}
 	}
-	volumes, err := r.state.AllVolumes()
+	volumes, err := r.state.AllVolumes(ctx)
 	if err != nil {
 		return err
 	}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -502,7 +502,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	// It breaks out of normal runtime init, and will not return a valid
 	// runtime.
 	if runtime.doRenumber {
-		if err := runtime.renumberLocks(); err != nil {
+		if err := runtime.renumberLocks(ctx); err != nil {
 			return err
 		}
 	}
@@ -517,7 +517,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 			}
 		}
 
-		if err2 := runtime.refresh(runtimeAliveFile); err2 != nil {
+		if err2 := runtime.refresh(ctx, runtimeAliveFile); err2 != nil {
 			return err2
 		}
 	}
@@ -619,7 +619,7 @@ func (r *Runtime) Shutdown(force bool) error {
 // Reconfigures the runtime after a reboot
 // Refreshes the state, recreating temporary files
 // Does not check validity as the runtime is not valid until after this has run
-func (r *Runtime) refresh(alivePath string) error {
+func (r *Runtime) refresh(ctx context.Context, alivePath string) error {
 	logrus.Debugf("Podman detected system restart - performing state refresh")
 
 	// First clear the state in the database
@@ -638,7 +638,7 @@ func (r *Runtime) refresh(alivePath string) error {
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving all pods from state")
 	}
-	vols, err := r.state.AllVolumes()
+	vols, err := r.state.AllVolumes(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving all volumes from state")
 	}
@@ -886,7 +886,7 @@ func (r *Runtime) reloadStorageConf() error {
 }
 
 // getVolumePlugin gets a specific volume plugin given its name.
-func (r *Runtime) getVolumePlugin(name string) (*plugin.VolumePlugin, error) {
+func (r *Runtime) getVolumePlugin(ctx context.Context, name string) (*plugin.VolumePlugin, error) {
 	// There is no plugin for local.
 	if name == define.VolumeDriverLocal || name == "" {
 		return nil, nil
@@ -897,7 +897,7 @@ func (r *Runtime) getVolumePlugin(name string) (*plugin.VolumePlugin, error) {
 		return nil, errors.Wrapf(define.ErrMissingPlugin, "no volume plugin with name %s available", name)
 	}
 
-	return plugin.GetVolumePlugin(name, pluginPath)
+	return plugin.GetVolumePlugin(ctx, name, pluginPath)
 }
 
 // GetSecretsStoreageDir returns the directory that the secrets manager should take

--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -250,7 +250,7 @@ func (r *Runtime) removePod(ctx context.Context, p *Pod, removeCtrs, force bool)
 	}
 
 	for volName := range ctrNamedVolumes {
-		volume, err := r.state.Volume(volName)
+		volume, err := r.state.Volume(ctx, volName)
 		if err != nil && errors.Cause(err) != define.ErrNoSuchVolume {
 			logrus.Errorf("Error retrieving volume %s: %v", volName, err)
 			continue

--- a/libpod/runtime_renumber.go
+++ b/libpod/runtime_renumber.go
@@ -1,6 +1,8 @@
 package libpod
 
 import (
+	"context"
+
 	"github.com/containers/podman/v2/libpod/events"
 	"github.com/pkg/errors"
 )
@@ -13,7 +15,7 @@ import (
 // lock as read, renumber attempting to take a write lock?
 // The alternative is some sort of session tracking, and I don't know how
 // reliable that can be.
-func (r *Runtime) renumberLocks() error {
+func (r *Runtime) renumberLocks(ctx context.Context) error {
 	// Start off by deallocating all locks
 	if err := r.lockManager.FreeAllLocks(); err != nil {
 		return err
@@ -53,7 +55,7 @@ func (r *Runtime) renumberLocks() error {
 			return err
 		}
 	}
-	allVols, err := r.state.AllVolumes()
+	allVols, err := r.state.AllVolumes(ctx)
 	if err != nil {
 		return err
 	}

--- a/libpod/runtime_volume.go
+++ b/libpod/runtime_volume.go
@@ -40,7 +40,7 @@ func (r *Runtime) RemoveVolume(ctx context.Context, v *Volume, force bool) error
 }
 
 // GetVolume retrieves a volume given its full name.
-func (r *Runtime) GetVolume(name string) (*Volume, error) {
+func (r *Runtime) GetVolume(ctx context.Context, name string) (*Volume, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
@@ -48,7 +48,7 @@ func (r *Runtime) GetVolume(name string) (*Volume, error) {
 		return nil, define.ErrRuntimeStopped
 	}
 
-	vol, err := r.state.Volume(name)
+	vol, err := r.state.Volume(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (r *Runtime) GetVolume(name string) (*Volume, error) {
 }
 
 // LookupVolume retrieves a volume by unambiguous partial name.
-func (r *Runtime) LookupVolume(name string) (*Volume, error) {
+func (r *Runtime) LookupVolume(ctx context.Context, name string) (*Volume, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
@@ -65,7 +65,7 @@ func (r *Runtime) LookupVolume(name string) (*Volume, error) {
 		return nil, define.ErrRuntimeStopped
 	}
 
-	vol, err := r.state.LookupVolume(name)
+	vol, err := r.state.LookupVolume(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (r *Runtime) HasVolume(name string) (bool, error) {
 // Filters can be provided which will determine which volumes are included in the
 // output. If multiple filters are used, a volume will be returned if
 // any of the filters are matched
-func (r *Runtime) Volumes(filters ...VolumeFilter) ([]*Volume, error) {
+func (r *Runtime) Volumes(ctx context.Context, filters ...VolumeFilter) ([]*Volume, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
@@ -97,7 +97,7 @@ func (r *Runtime) Volumes(filters ...VolumeFilter) ([]*Volume, error) {
 		return nil, define.ErrRuntimeStopped
 	}
 
-	vols, err := r.state.AllVolumes()
+	vols, err := r.state.AllVolumes(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (r *Runtime) Volumes(filters ...VolumeFilter) ([]*Volume, error) {
 }
 
 // GetAllVolumes retrieves all the volumes
-func (r *Runtime) GetAllVolumes() ([]*Volume, error) {
+func (r *Runtime) GetAllVolumes(ctx context.Context) ([]*Volume, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
@@ -130,13 +130,13 @@ func (r *Runtime) GetAllVolumes() ([]*Volume, error) {
 		return nil, define.ErrRuntimeStopped
 	}
 
-	return r.state.AllVolumes()
+	return r.state.AllVolumes(ctx)
 }
 
 // PruneVolumes removes unused volumes from the system
 func (r *Runtime) PruneVolumes(ctx context.Context, filterFuncs []VolumeFilter) ([]*reports.PruneReport, error) {
 	preports := make([]*reports.PruneReport, 0)
-	vols, err := r.Volumes(filterFuncs...)
+	vols, err := r.Volumes(ctx, filterFuncs...)
 	if err != nil {
 		return nil, err
 	}

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -1,5 +1,7 @@
 package libpod
 
+import "context"
+
 // State is a storage backend for libpod's current state.
 // A State is only initialized once per instance of libpod.
 // As such, initialization methods for State implementations may safely assume
@@ -229,10 +231,10 @@ type State interface {
 
 	// Volume accepts full name of volume
 	// If the volume doesn't exist, an error will be returned
-	Volume(volName string) (*Volume, error)
+	Volume(ctx context.Context, volName string) (*Volume, error)
 	// LookupVolume accepts an unambiguous partial name or full name of a
 	// volume. Ambiguous names will result in an error.
-	LookupVolume(name string) (*Volume, error)
+	LookupVolume(ctx context.Context, name string) (*Volume, error)
 	// HasVolume returns true if volName exists in the state,
 	// otherwise it returns false
 	HasVolume(volName string) (bool, error)
@@ -251,5 +253,5 @@ type State interface {
 	// SaveVolume saves a volume's state to the database.
 	SaveVolume(volume *Volume) error
 	// AllVolumes returns all the volumes available in the state
-	AllVolumes() ([]*Volume, error)
+	AllVolumes(ctx context.Context) ([]*Volume, error)
 }

--- a/libpod/volume_inspect.go
+++ b/libpod/volume_inspect.go
@@ -1,6 +1,8 @@
 package libpod
 
 import (
+	"context"
+
 	"github.com/containers/podman/v2/libpod/define"
 	pluginapi "github.com/docker/go-plugins-helpers/volume"
 	"github.com/pkg/errors"
@@ -9,7 +11,7 @@ import (
 
 // Inspect provides detailed information about the configuration of the given
 // volume.
-func (v *Volume) Inspect() (*define.InspectVolumeData, error) {
+func (v *Volume) Inspect(ctx context.Context) (*define.InspectVolumeData, error) {
 	if !v.valid {
 		return nil, define.ErrVolumeRemoved
 	}
@@ -36,7 +38,7 @@ func (v *Volume) Inspect() (*define.InspectVolumeData, error) {
 		// Need to query the volume driver.
 		req := new(pluginapi.GetRequest)
 		req.Name = v.Name()
-		resp, err := v.plugin.GetVolume(req)
+		resp, err := v.plugin.GetVolume(ctx, req)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error retrieving volume %s information from plugin %s", v.Name(), v.Driver())
 		}

--- a/libpod/volume_internal_linux.go
+++ b/libpod/volume_internal_linux.go
@@ -3,6 +3,7 @@
 package libpod
 
 import (
+	"context"
 	"os/exec"
 	"strings"
 
@@ -27,7 +28,7 @@ const pseudoCtrID = "2f73349cfc4630255319c6c8dfc1b46a8996ace9d14d8e07563b1659159
 // Must be done while the volume is locked.
 // Is a no-op on volumes that do not require a mount (as defined by
 // volumeNeedsMount()).
-func (v *Volume) mount() error {
+func (v *Volume) mount(ctx context.Context) error {
 	if !v.needsMount() {
 		return nil
 	}
@@ -62,7 +63,7 @@ func (v *Volume) mount() error {
 		req := new(pluginapi.MountRequest)
 		req.Name = v.Name()
 		req.ID = pseudoCtrID
-		mountPoint, err := v.plugin.MountVolume(req)
+		mountPoint, err := v.plugin.MountVolume(ctx, req)
 		if err != nil {
 			return err
 		}
@@ -122,7 +123,7 @@ func (v *Volume) mount() error {
 // the volume will really be unmounted, as no further containers are using the
 // volume.
 // If force is set, the volume will be unmounted regardless of mount counter.
-func (v *Volume) unmount(force bool) error {
+func (v *Volume) unmount(ctx context.Context, force bool) error {
 	if !v.needsMount() {
 		return nil
 	}
@@ -168,7 +169,7 @@ func (v *Volume) unmount(force bool) error {
 			req := new(pluginapi.UnmountRequest)
 			req.Name = v.Name()
 			req.ID = pseudoCtrID
-			if err := v.plugin.UnmountVolume(req); err != nil {
+			if err := v.plugin.UnmountVolume(ctx, req); err != nil {
 				return err
 			}
 

--- a/libpod/volume_internal_unsupported.go
+++ b/libpod/volume_internal_unsupported.go
@@ -3,13 +3,14 @@
 package libpod
 
 import (
+	"context"
 	"github.com/containers/podman/v2/libpod/define"
 )
 
-func (v *Volume) mount() error {
+func (v *Volume) mount(ctx context.Context) error {
 	return define.ErrNotImplemented
 }
 
-func (v *Volume) unmount(force bool) error {
+func (v *Volume) unmount(ctx context.Context, force bool) error {
 	return define.ErrNotImplemented
 }

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -1,6 +1,7 @@
 package compat
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -173,7 +174,7 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 		utils.ContainerNotFound(w, name, err)
 		return
 	}
-	api, err := LibpodToContainerJSON(ctnr, query.Size)
+	api, err := LibpodToContainerJSON(r.Context(), ctnr, query.Size)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
@@ -331,9 +332,9 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 	}, nil
 }
 
-func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, error) {
+func LibpodToContainerJSON(ctx context.Context, l *libpod.Container, sz bool) (*types.ContainerJSON, error) {
 	_, imageName := l.Image()
-	inspect, err := l.Inspect(sz)
+	inspect, err := l.Inspect(ctx, sz)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/handlers/compat/containers_logs.go
+++ b/pkg/api/handlers/compat/containers_logs.go
@@ -109,7 +109,7 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 	writeHeader := true
 	// Docker does not write stream headers iff the container has a tty.
 	if !utils.IsLibpodRequest(r) {
-		inspectData, err := ctnr.Inspect(false)
+		inspectData, err := ctnr.Inspect(r.Context(), false)
 		if err != nil {
 			utils.InternalServerError(w, errors.Wrapf(err, "failed to obtain logs for Container '%s'", name))
 			return

--- a/pkg/api/handlers/compat/containers_stats.go
+++ b/pkg/api/handlers/compat/containers_stats.go
@@ -98,7 +98,7 @@ streamLabel: // A label to flatten the scope
 			logrus.Errorf("Unable to get container stats: %v", err)
 			return
 		}
-		inspect, err := ctnr.Inspect(false)
+		inspect, err := ctnr.Inspect(r.Context(), false)
 		if err != nil {
 			logrus.Errorf("Unable to inspect container: %v", err)
 			return

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -268,7 +268,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
-	runCtx, cancel := context.WithCancel(context.Background())
+	runCtx, cancel := context.WithCancel(r.Context())
 	var imageID string
 	go func() {
 		defer cancel()

--- a/pkg/api/handlers/compat/volumes.go
+++ b/pkg/api/handlers/compat/volumes.go
@@ -51,7 +51,7 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	vols, err := runtime.Volumes(volumeFilters...)
+	vols, err := runtime.Volumes(r.Context(), volumeFilters...)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
@@ -102,7 +102,7 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// See if the volume exists already
-	existingVolume, err := runtime.GetVolume(input.Name)
+	existingVolume, err := runtime.GetVolume(r.Context(), input.Name)
 	if err != nil && errors.Cause(err) != define.ErrNoSuchVolume {
 		utils.InternalServerError(w, err)
 		return
@@ -183,7 +183,7 @@ func InspectVolume(w http.ResponseWriter, r *http.Request) {
 		runtime = r.Context().Value("runtime").(*libpod.Runtime)
 	)
 	name := utils.GetName(r)
-	vol, err := runtime.GetVolume(name)
+	vol, err := runtime.GetVolume(r.Context(), name)
 	if err != nil {
 		utils.VolumeNotFound(w, name, err)
 		return
@@ -235,7 +235,7 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 	 * respectively.
 	 */
 	name := utils.GetName(r)
-	vol, err := runtime.LookupVolume(name)
+	vol, err := runtime.LookupVolume(r.Context(), name)
 	if err == nil {
 		// As above, we do not pass `force` from the query parameters here
 		if err := runtime.RemoveVolume(r.Context(), vol, false); err != nil {

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -135,7 +135,7 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 		utils.ContainerNotFound(w, name, err)
 		return
 	}
-	data, err := container.Inspect(query.Size)
+	data, err := container.Inspect(r.Context(), query.Size)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -1,7 +1,6 @@
 package libpod
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 
@@ -27,7 +26,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
-	ctr, err := generate.MakeContainer(context.Background(), runtime, &sg)
+	ctr, err := generate.MakeContainer(r.Context(), runtime, &sg)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -1,7 +1,6 @@
 package libpod
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -346,7 +345,7 @@ func ImagesLoad(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tmpfile.Close()
-	loadedImage, err := runtime.LoadImage(context.Background(), tmpfile.Name(), os.Stderr, "")
+	loadedImage, err := runtime.LoadImage(r.Context(), tmpfile.Name(), os.Stderr, "")
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to load image"))
 		return
@@ -391,7 +390,7 @@ func ImagesImport(w http.ResponseWriter, r *http.Request) {
 		tmpfile.Close()
 		source = tmpfile.Name()
 	}
-	importedImage, err := runtime.Import(context.Background(), source, query.Reference, "", query.Changes, query.Message, true)
+	importedImage, err := runtime.Import(r.Context(), source, query.Reference, "", query.Changes, query.Message, true)
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to import image"))
 		return
@@ -457,7 +456,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}
-	if err := imageEngine.Push(context.Background(), source, destination, options); err != nil {
+	if err := imageEngine.Push(r.Context(), source, destination, options); err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "error pushing image %q", destination))
 		return
 	}

--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -105,7 +105,7 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 	if !query.AllTags {
 		imagesToPull = append(imagesToPull, imageName)
 	} else {
-		tags, err := docker.GetRepositoryTags(context.Background(), sys, imageRef)
+		tags, err := docker.GetRepositoryTags(r.Context(), sys, imageRef)
 		if err != nil {
 			utils.InternalServerError(w, errors.Wrap(err, "error getting repository tags"))
 			return
@@ -122,7 +122,7 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 	defer stderr.Close()
 
 	images := make([]string, 0, len(imagesToPull))
-	runCtx, cancel := context.WithCancel(context.Background())
+	runCtx, cancel := context.WithCancel(r.Context())
 	go func(imgs []string) {
 		defer cancel()
 		// Finally pull the images

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -1,7 +1,6 @@
 package libpod
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 
@@ -186,7 +185,7 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)
 	}
 	imageEngine := abi.ImageEngine{Libpod: runtime}
-	digest, err := imageEngine.ManifestPush(context.Background(), source, query.Destination, options)
+	digest, err := imageEngine.ManifestPush(r.Context(), source, query.Destination, options)
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "error pushing image %q", query.Destination))
 		return

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -61,7 +61,7 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
-	inspectOut, err := vol.Inspect()
+	inspectOut, err := vol.Inspect(r.Context())
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
@@ -77,12 +77,12 @@ func InspectVolume(w http.ResponseWriter, r *http.Request) {
 		runtime = r.Context().Value("runtime").(*libpod.Runtime)
 	)
 	name := utils.GetName(r)
-	vol, err := runtime.GetVolume(name)
+	vol, err := runtime.GetVolume(r.Context(), name)
 	if err != nil {
 		utils.VolumeNotFound(w, name, err)
 		return
 	}
-	inspectOut, err := vol.Inspect()
+	inspectOut, err := vol.Inspect(r.Context())
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
@@ -116,14 +116,14 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	vols, err := runtime.Volumes(volumeFilters...)
+	vols, err := runtime.Volumes(r.Context(), volumeFilters...)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
 	}
 	volumeConfigs := make([]*entities.VolumeListReport, 0, len(vols))
 	for _, v := range vols {
-		inspectOut, err := v.Inspect()
+		inspectOut, err := v.Inspect(r.Context())
 		if err != nil {
 			utils.InternalServerError(w, err)
 			return
@@ -189,7 +189,7 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	name := utils.GetName(r)
-	vol, err := runtime.LookupVolume(name)
+	vol, err := runtime.LookupVolume(r.Context(), name)
 	if err != nil {
 		utils.VolumeNotFound(w, name, err)
 		return

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -211,7 +211,7 @@ func ImageToImageSummary(l *libpodImage.Image) (*entities.ImageSummary, error) {
 }
 
 func ImageDataToImageInspect(ctx context.Context, l *libpodImage.Image) (*ImageInspect, error) {
-	info, err := l.Inspect(context.Background())
+	info, err := l.Inspect(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/handlers/utils/handler_test.go
+++ b/pkg/api/handlers/utils/handler_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,7 +12,7 @@ import (
 )
 
 func TestSupportedVersion(t *testing.T) {
-	req, err := http.NewRequest("GET",
+	req, err := http.NewRequestWithContext(context.TODO(), "GET",
 		fmt.Sprintf("/v%s/libpod/testing/versions", APIVersion[LibpodTree][CurrentAPIVersion]),
 		nil)
 	if err != nil {
@@ -54,7 +55,7 @@ func TestSupportedVersion(t *testing.T) {
 
 func TestUnsupportedVersion(t *testing.T) {
 	version := "999.999.999"
-	req, err := http.NewRequest("GET",
+	req, err := http.NewRequestWithContext(context.TODO(), "GET",
 		fmt.Sprintf("/v%s/libpod/testing/versions", version),
 		nil)
 	if err != nil {
@@ -97,7 +98,7 @@ func TestUnsupportedVersion(t *testing.T) {
 
 func TestEqualVersion(t *testing.T) {
 	version := "1.30.0"
-	req, err := http.NewRequest("GET",
+	req, err := http.NewRequestWithContext(context.TODO(), "GET",
 		fmt.Sprintf("/v%s/libpod/testing/versions", version),
 		nil)
 	if err != nil {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -332,7 +332,7 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 			return nil, nil, err
 		}
 
-		inspect, err := ctr.Inspect(options.Size)
+		inspect, err := ctr.Inspect(ctx, options.Size)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -359,7 +359,7 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 			return nil, nil, err
 		}
 
-		inspect, err := ctr.Inspect(options.Size)
+		inspect, err := ctr.Inspect(ctx, options.Size)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -294,7 +294,7 @@ func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.System
 	}
 
 	//	Get volumes and iterate them
-	vols, err := ic.Libpod.GetAllVolumes()
+	vols, err := ic.Libpod.GetAllVolumes(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -47,13 +47,13 @@ func (ic *ContainerEngine) VolumeRm(ctx context.Context, namesOrIds []string, op
 	)
 
 	if opts.All {
-		vols, err = ic.Libpod.Volumes()
+		vols, err = ic.Libpod.Volumes(ctx)
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		for _, id := range namesOrIds {
-			vol, err := ic.Libpod.LookupVolume(id)
+			vol, err := ic.Libpod.LookupVolume(ctx, id)
 			if err != nil {
 				reports = append(reports, &entities.VolumeRmReport{
 					Err: err,
@@ -83,13 +83,13 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 	// Note: as with previous implementation, a single failure here
 	// results a return.
 	if opts.All {
-		vols, err = ic.Libpod.GetAllVolumes()
+		vols, err = ic.Libpod.GetAllVolumes(ctx)
 		if err != nil {
 			return nil, nil, err
 		}
 	} else {
 		for _, v := range namesOrIds {
-			vol, err := ic.Libpod.LookupVolume(v)
+			vol, err := ic.Libpod.LookupVolume(ctx, v)
 			if err != nil {
 				if errors.Cause(err) == define.ErrNoSuchVolume {
 					errs = append(errs, errors.Errorf("no such volume %s", v))
@@ -103,7 +103,7 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 	}
 	reports := make([]*entities.VolumeInspectReport, 0, len(vols))
 	for _, v := range vols {
-		inspectOut, err := v.Inspect()
+		inspectOut, err := v.Inspect(ctx)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -136,13 +136,13 @@ func (ic *ContainerEngine) VolumeList(ctx context.Context, opts entities.VolumeL
 	if err != nil {
 		return nil, err
 	}
-	vols, err := ic.Libpod.Volumes(volumeFilters...)
+	vols, err := ic.Libpod.Volumes(ctx, volumeFilters...)
 	if err != nil {
 		return nil, err
 	}
 	reports := make([]*entities.VolumeListReport, 0, len(vols))
 	for _, v := range vols {
-		inspectOut, err := v.Inspect()
+		inspectOut, err := v.Inspect(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This improves context propagation which might be useful for cancellation of running processes.

For example a user call some `/libpod/` RESTful endpoint, and the handler of the endpoint itself does some other HTTP request.
If the user cancels the HTTP request to the `/libpod` API (i.e. closes `TCP` connection), the HTTP request invoked by the handler will be also cancelled now.