### PR TITLE
Add missing early returns in compat API

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -47,6 +47,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	rtc, err := runtime.GetConfig()
 	if err != nil {
 		utils.Error(w, "unable to obtain runtime config", http.StatusInternalServerError, errors.Wrap(err, "unable to get runtime config"))
+		return
 	}
 
 	newImage, err := runtime.ImageRuntime().NewFromLocal(body.Config.Image)

--- a/pkg/api/handlers/compat/secrets.go
+++ b/pkg/api/handlers/compat/secrets.go
@@ -30,7 +30,9 @@ func ListSecrets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(query.Filters) > 0 {
-		utils.Error(w, "filters not supported", http.StatusBadRequest, errors.New("bad parameter"))
+		utils.Error(w, "filters not supported", http.StatusBadRequest,
+			errors.Wrapf(errors.New("bad parameter"), "filters not supported"))
+		return
 	}
 	ic := abi.ContainerEngine{Libpod: runtime}
 	reports, err := ic.SecretList(r.Context())
@@ -95,7 +97,9 @@ func CreateSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(createParams.Labels) > 0 {
-		utils.Error(w, "labels not supported", http.StatusBadRequest, errors.New("bad parameter"))
+		utils.Error(w, "labels not supported", http.StatusBadRequest,
+			errors.Wrapf(errors.New("bad parameter"), "labels not supported"))
+		return
 	}
 
 	decoded, _ := base64.StdEncoding.DecodeString(createParams.Data)

--- a/pkg/api/handlers/compat/system.go
+++ b/pkg/api/handlers/compat/system.go
@@ -19,6 +19,7 @@ func GetDiskUsage(w http.ResponseWriter, r *http.Request) {
 	df, err := ic.SystemDf(r.Context(), options)
 	if err != nil {
 		utils.InternalServerError(w, err)
+		return
 	}
 
 	imgs := make([]*docker.ImageSummary, len(df.Images))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
While looking to "fix" #9314 I found a few more missing early returns.
This only fixes the double response part of #9314.

The weird thing is [utils.Error() totally ignores the 2nd (i.e. `apiMessage`) argument](
https://github.com/containers/podman/blob/master/pkg/api/handlers/utils/errors.go#L24-L33) which is sometimes used to add context to the error, but doesn't end up in either the logs or the response. This seems to be an oversight since its initial implementation. o.O


Closes #9314