### PR TITLE
[CI:DOCS] Update troubleshooting.md for registries.conf v2

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -72,8 +72,8 @@ error pulling image "fedora": unable to pull fedora: error getting default regis
 #### Solution
 
   * Verify that the `/etc/containers/registries.conf` file exists.  If not, verify that the containers-common package is installed.
-  * Verify that the entries in the `[registries.search]` section of the /etc/containers/registries.conf file are valid and reachable.
-    *  i.e. `registries = ['registry.fedoraproject.org', 'quay.io', 'registry.access.redhat.com']`
+  * Verify that the entries in the `unqualified-search-registries` list of the `/etc/containers/registries.conf` file are valid and reachable.
+    * i.e. `unqualified-search-registries = ["registry.fedoraproject.org", "quay.io", "registry.access.redhat.com"]`
 
 ---
 ### 4) http: server gave HTTP response to HTTPS client


### PR DESCRIPTION
Note that `[registries.search]` (the v1 format) is still supported, but `registries.conf` can not mix v1 with v2 syntax

[1] https://github.com/containers/image/commit/c04fa245754dc2c250424445f4190f348401f27b#diff-968a44bf11ad55a626a0d13a78ade8944ade3a36f53c7a3f985a9036cd64f5a5

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
