### PR TITLE
podman build: pass runtime to buildah

### DIFF
--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -166,6 +166,11 @@ func (r *Runtime) newImageBuildCompleteEvent(idOrName string) {
 
 // Build adds the runtime to the imagebuildah call
 func (r *Runtime) Build(ctx context.Context, options imagebuildah.BuildOptions, dockerfiles ...string) (string, reference.Canonical, error) {
+	if options.Runtime == "" {
+		// Make sure that build containers use the same runtime as Podman (see #9365).
+		conf := util.DefaultContainerConfig()
+		options.Runtime = conf.Engine.OCIRuntime
+	}
 	id, ref, err := imagebuildah.BuildDockerfiles(ctx, r.store, options, dockerfiles...)
 	// Write event for build completion
 	r.newImageBuildCompleteEvent(id)


### PR DESCRIPTION
Make sure that Podman's default OCI runtime is passed to Buildah in
`podman build`.  In theory, Podman and Buildah should use the same
defaults but the projects move at different speeds and it turns out
we caused a regression in v3.0.

Fixes: #9365
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@containers/podman-maintainers PTAL
