### PR TITLE
correct startup error message

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -158,7 +158,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 
 	// Prep the engines
 	if _, err := registry.NewImageEngine(cmd, args); err != nil {
-		return errors.Wrapf(err, "Cannot connect to the Podman socket, make sure there is a Podman REST API service running.")
+		return err
 	}
 	if _, err := registry.NewContainerEngine(cmd, args); err != nil {
 		return err

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -124,7 +124,7 @@ func NewConnectionWithIdentity(ctx context.Context, uri string, identity string)
 
 	ctx = context.WithValue(ctx, clientKey, &connection)
 	if err := pingNewConnection(ctx); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "cannot connect to the Podman socket, please verify that Podman REST API service is running")
 	}
 	return ctx, nil
 }


### PR DESCRIPTION
The error message when failing to create an image engine unconditionally
pointed to the Podman socket which is quite confusing when running
locally.

Move the error message to the point where the first ping to the service
fails.

[NO TESTS NEEDED]

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@containers/podman-maintainers 