### PR TITLE
Docker [APIv2] create container: handle empty host port

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -223,7 +223,11 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 	// publish
 	for port, pbs := range cc.HostConfig.PortBindings {
 		for _, pb := range pbs {
-			hostport, err := strconv.Atoi(pb.HostPort)
+			var hostport int
+			var err error
+			if pb.HostPort != "" {
+				hostport, err = strconv.Atoi(pb.HostPort)
+			}
 			if err != nil {
 				return nil, nil, err
 			}

--- a/test/python/docker/test_containers.py
+++ b/test/python/docker/test_containers.py
@@ -86,6 +86,13 @@ class TestContainers(unittest.TestCase):
         containers = self.client.containers.list(all=True)
         self.assertEqual(len(containers), 2)
 
+    def test_start_container_with_random_port_bind(self):
+        container = self.client.containers.create(image=constant.ALPINE,
+                                                  name="containerWithRandomBind",
+                                                  ports={'1234/tcp': None})
+        containers = self.client.containers.list(all=True)
+        self.assertTrue(container in containers)
+
     def test_stop_container(self):
         top = self.client.containers.get(TestContainers.topContainerId)
         self.assertEqual(top.status, "running")


### PR DESCRIPTION
Port binding may have empty string value for host port. In such a case port should be random.

`docker run -it --rm -p 8080 quay.io/mvasek/foo:latest`

Before this PR such a request ended with 500.

```json
{
  "Hostname": "",
  "Domainname": "",
  "User": "",
  "AttachStdin": false,
  "AttachStdout": false,
  "AttachStderr": false,
  "Tty": false,
  "OpenStdin": false,
  "StdinOnce": false,
  "Env": [
    "REGISTRY_AUTH=htpasswd",
    "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm",
    "REGISTRY_AUTH_HTPASSWD_PATH=/registry_test_htpasswd"
  ],
  "Cmd": null,
  "Image": "library/registry:2",
  "Volumes": null,
  "WorkingDir": "",
  "Entrypoint": null,
  "OnBuild": null,
  "Labels": {
    "author": "pack"
  },
  "HostConfig": {
    "Binds": null,
    "ContainerIDFile": "",
    "LogConfig": {
      "Type": "",
      "Config": null
    },
    "NetworkMode": "",
    "PortBindings": {
      "5000/tcp": [
        {
          "HostIp": "",
          "HostPort": "" //  <== THIS
        }
      ]
    },
    "RestartPolicy": {
      "Name": "",
      "MaximumRetryCount": 0
    },
    "AutoRemove": true,
    "VolumeDriver": "",
    "VolumesFrom": null,
    "CapAdd": null,
    "CapDrop": null,
    "CgroupnsMode": "",
    "Dns": null,
    "DnsOptions": null,
    "DnsSearch": null,
    "ExtraHosts": null,
    "GroupAdd": null,
    "IpcMode": "",
    "Cgroup": "",
    "Links": null,
    "OomScoreAdj": 0,
    "PidMode": "",
    "Privileged": false,
    "PublishAllPorts": false,
    "ReadonlyRootfs": false,
    "SecurityOpt": null,
    "UTSMode": "",
    "UsernsMode": "",
    "ShmSize": 0,
    "ConsoleSize": [
      0,
      0
    ],
    "Isolation": "",
    "CpuShares": 0,
    "Memory": 0,
    "NanoCpus": 0,
    "CgroupParent": "",
    "BlkioWeight": 0,
    "BlkioWeightDevice": null,
    "BlkioDeviceReadBps": null,
    "BlkioDeviceWriteBps": null,
    "BlkioDeviceReadIOps": null,
    "BlkioDeviceWriteIOps": null,
    "CpuPeriod": 0,
    "CpuQuota": 0,
    "CpuRealtimePeriod": 0,
    "CpuRealtimeRuntime": 0,
    "CpusetCpus": "",
    "CpusetMems": "",
    "Devices": null,
    "DeviceCgroupRules": null,
    "DeviceRequests": null,
    "KernelMemory": 0,
    "KernelMemoryTCP": 0,
    "MemoryReservation": 0,
    "MemorySwap": 0,
    "MemorySwappiness": null,
    "OomKillDisable": null,
    "PidsLimit": null,
    "Ulimits": null,
    "CpuCount": 0,
    "CpuPercent": 0,
    "IOMaximumIOps": 0,
    "IOMaximumBandwidth": 0,
    "MaskedPaths": null,
    "ReadonlyPaths": null
  },
  "NetworkingConfig": null,
  "Platform": null
}
```

Signed-off-by: Matej Vasek <mvasek@redhat.com>
