### PR TITLE
Fix broken podman generate systemd --new with pods

### DIFF
--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -68,7 +68,7 @@ type containerInfo struct {
 
 	// If not nil, the container is part of the pod.  We can use the
 	// podInfo to extract the relevant data.
-	pod *podInfo
+	Pod *podInfo
 }
 
 const containerTemplate = headerTemplate + `
@@ -215,8 +215,8 @@ func executeContainerTemplate(info *containerInfo, options entities.GenerateSyst
 		)
 		// If the container is in a pod, make sure that the
 		// --pod-id-file is set correctly.
-		if info.pod != nil {
-			podFlags := []string{"--pod-id-file", info.pod.PodIDFile}
+		if info.Pod != nil {
+			podFlags := []string{"--pod-id-file", "{{{{.Pod.PodIDFile}}}}"}
 			startCommand = append(startCommand, podFlags...)
 			info.CreateCommand = filterPodFlags(info.CreateCommand)
 		}

--- a/pkg/systemd/generate/containers_test.go
+++ b/pkg/systemd/generate/containers_test.go
@@ -170,7 +170,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/jadda-jadda.pid %t/jadda-jadda.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/jadda-jadda.pid --cidfile %t/jadda-jadda.ctr-id --cgroups=no-conmon --pod-id-file /tmp/pod-foobar.pod-id-file --replace -d --name jadda-jadda --hostname hello-world awesome-image:latest command arg1 ... argN
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/jadda-jadda.pid --cidfile %t/jadda-jadda.ctr-id --cgroups=no-conmon --pod-id-file %t/pod-foobar.pod-id-file --replace -d --name jadda-jadda --hostname hello-world awesome-image:latest command arg1 ... argN
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/jadda-jadda.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/jadda-jadda.ctr-id
 PIDFile=%t/jadda-jadda.pid
@@ -487,8 +487,8 @@ WantedBy=multi-user.target default.target
 				PodmanVersion:     "CI",
 				CreateCommand:     []string{"I'll get stripped", "run", "-d", "--name", "jadda-jadda", "--hostname", "hello-world", "awesome-image:latest", "command", "arg1", "...", "argN"},
 				EnvVariable:       EnvVariable,
-				pod: &podInfo{
-					PodIDFile: "/tmp/pod-foobar.pod-id-file",
+				Pod: &podInfo{
+					PodIDFile: "%t/pod-foobar.pod-id-file",
 				},
 			},
 			goodNameNewWithPodFile,

--- a/pkg/systemd/generate/pods.go
+++ b/pkg/systemd/generate/pods.go
@@ -162,7 +162,7 @@ func PodUnits(pod *libpod.Pod, options entities.GenerateSystemdOptions) (map[str
 	}
 	units[podInfo.ServiceName] = out
 	for _, info := range containerInfos {
-		info.pod = podInfo
+		info.Pod = podInfo
 		out, err := executeContainerTemplate(info, options)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The unit generation accidentally escaped the %t in the pod id file path.
This is a regression caused by #9178. This was not caught by the tests
because the test itself was wrong. It used a full path instead of the
systemd variable %t like the actual code does.

Fixes #9373


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
