### PR TITLE
Fix panic in pod creation

### DIFF
--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -225,7 +225,10 @@ func (r *Runtime) createInfraContainer(ctx context.Context, p *Pod) (*Container,
 	if err != nil {
 		return nil, err
 	}
-	imageName := newImage.Names()[0]
+	imageName := "none"
+	if len(newImage.Names()) > 0 {
+		imageName = newImage.Names()[0]
+	}
 	imageID := data.ID
 
 	return r.makeInfraContainer(ctx, p, imageName, r.config.Engine.InfraImage, imageID, data.Config)

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -436,13 +436,20 @@ func (p *PodmanTestIntegration) RunLsContainerInPod(name, pod string) (*PodmanSe
 
 // BuildImage uses podman build and buildah to build an image
 // called imageName based on a string dockerfile
-func (p *PodmanTestIntegration) BuildImage(dockerfile, imageName string, layers string) {
+func (p *PodmanTestIntegration) BuildImage(dockerfile, imageName string, layers string) string {
 	dockerfilePath := filepath.Join(p.TempDir, "Dockerfile")
 	err := ioutil.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
 	Expect(err).To(BeNil())
-	session := p.Podman([]string{"build", "--layers=" + layers, "-t", imageName, "--file", dockerfilePath, p.TempDir})
+	cmd := []string{"build", "--layers=" + layers, "--file", dockerfilePath}
+	if len(imageName) > 0 {
+		cmd = append(cmd, []string{"-t", imageName}...)
+	}
+	cmd = append(cmd, p.TempDir)
+	session := p.Podman(cmd)
 	session.Wait(240)
 	Expect(session).Should(Exit(0), fmt.Sprintf("BuildImage session output: %q", session.OutputToString()))
+	output := session.OutputToStringArray()
+	return output[len(output)-1]
 }
 
 // PodmanPID execs podman and returns its PID

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -501,4 +501,18 @@ entrypoint ["/fromimage"]
 		Expect(session.OutputToString()).To(ContainSubstring("inet 127.0.0.1/8 scope host lo"))
 		Expect(len(session.OutputToStringArray())).To(Equal(1))
 	})
+
+	It("podman pod create --infra-image w/untagged image", func() {
+		podmanTest.AddImageToRWStore(ALPINE)
+		dockerfile := `FROM quay.io/libpod/alpine:latest
+ENTRYPOINT ["sleep","99999"]
+		`
+		// This builds a none/none image
+		iid := podmanTest.BuildImage(dockerfile, "", "true")
+
+		create := podmanTest.Podman([]string{"pod", "create", "--infra-image", iid})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(BeZero())
+	})
+
 })


### PR DESCRIPTION
when creating a pod with --infra-image and using a untagged image for
the infra-image (none/none), the lookup for the image's name was
creating a panic.

Fixes: #9374

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
