### PR TITLE
Fix an issue where copyup could fail with ENOENT

### DIFF
--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -322,6 +322,18 @@ RUN sh -c "cd /etc/apk && ln -s ../../testfile"`
 		Expect(outputSession.OutputToString()).To(Equal(baselineOutput))
 	})
 
+	It("podman named volume copyup empty directory", func() {
+		baselineSession := podmanTest.Podman([]string{"run", "--rm", "-t", "-i", ALPINE, "ls", "/srv"})
+		baselineSession.WaitWithDefaultTimeout()
+		Expect(baselineSession.ExitCode()).To(Equal(0))
+		baselineOutput := baselineSession.OutputToString()
+
+		outputSession := podmanTest.Podman([]string{"run", "-t", "-i", "-v", "/srv", ALPINE, "ls", "/srv"})
+		outputSession.WaitWithDefaultTimeout()
+		Expect(outputSession.ExitCode()).To(Equal(0))
+		Expect(outputSession.OutputToString()).To(Equal(baselineOutput))
+	})
+
 	It("podman read-only tmpfs conflict with volume", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "-t", "-i", "--read-only", "-v", "tmp_volume:" + dest, ALPINE, "touch", dest + "/a"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
This one is rather bizarre because it triggers only on some systems. I've included a CI test, for example, but I'm 99% sure we use images in CI that have volumes over empty directories, and the earlier patch to change copy-up implementation passed CI without complaint.

I can reproduce this on a stock F33 VM, but that's the only place I have been able to see it.

Regardless, the issue: under certain as-yet-unidentified environmental conditions, the copier.Get method will return an ENOENT attempting to stream a directory that is empty. Work around this by avoiding the copy altogether in this case.
