### PR TITLE
exitcode/timestamp consistency after checkpoint creation/restore

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1329,6 +1329,7 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 	c.state.State = define.ContainerStateRunning
 	c.state.ExitCode = 0
 	c.state.FinishedTime = time.Time{}
+	c.state.StartedTime = time.Now()
 
 	if !options.Keep {
 		// Delete all checkpoint related files. At this point, in theory, all files

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1079,7 +1079,9 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 	logrus.Debugf("Checkpointed container %s", c.ID())
 
 	if !options.KeepRunning && !options.PreCheckPoint {
-		c.state.State = define.ContainerStateStopped
+		if err := c.waitForExitFileAndSync(); err != nil {
+			return err
+		}
 
 		// Cleanup Storage and Network
 		if err := c.cleanup(ctx); err != nil {
@@ -1102,7 +1104,6 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 		}
 	}
 
-	c.state.FinishedTime = time.Now()
 	return c.save()
 }
 

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1327,6 +1327,8 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 	logrus.Debugf("Restored container %s", c.ID())
 
 	c.state.State = define.ContainerStateRunning
+	c.state.ExitCode = 0
+	c.state.FinishedTime = time.Time{}
 
 	if !options.Keep {
 		// Delete all checkpoint related files. At this point, in theory, all files


### PR DESCRIPTION
In docker, the exitcode of a container checkpointed without `--leave-running` is 137, which matches the exitcode of a container that is manually stopped. podman leaves the exitcode as 0

In `libpod/container_internal_linux.go::checkpoint()`, I used `libpod/container_internal.go::stop()` as an example and copied the call to `c.waitForExitFileAndSync()` rather than manually assigning the exitcode to 137. I assumed this would be better than using 137 as a magic number, but maybe that would've been fine. I'm not totally sure if there are other implications to this function call. Additionally in `checkpoint()`, I removed the unconditional assignment to the container's FinishedTime. This happens within the `waitForExitFileAndSync` call chain if the container is stopped, and probably shouldn't have been happening at all if `--leave-running` was specified.

In `libpod/container_internal_linux.go::restore()` after the container state is set to running, I explicitly set the container exitcode to zero, its StartedTime to now, and clear its FinishedTime.

With these changes, the timestamps and exitcode _almost_ track with docker's behavior. I noticed in collecting the output here that docker never actually resets the "FinishedAt" time when a container is restored. If the goal is completely matching docker, I can remove the line that clears it upon restore. IMO, it seems more logical to have a null FinishedAt time for a container that's running.

Podman:
```
$ sudo podman run --detach --name cr busybox /bin/sleep 60
7f2de709a7be88542d03cebf194deca877b5ad69557f48597259767e1b4a8f83
$ sudo podman container inspect cr |grep -E "(\"Created|FinishedAt|StartedAt|ExitCode)"
        "Created": "2021-02-15T16:07:48.815788417-05:00",
            "ExitCode": 0,
            "StartedAt": "2021-02-15T16:07:49.374606028-05:00",
            "FinishedAt": "0001-01-01T00:00:00Z",
$ sudo podman container checkpoint cr
7f2de709a7be88542d03cebf194deca877b5ad69557f48597259767e1b4a8f83
$ sudo podman container inspect cr |grep -E "(\"Created|FinishedAt|StartedAt|ExitCode)"
        "Created": "2021-02-15T16:07:48.815788417-05:00",
            "ExitCode": 137,
            "StartedAt": "2021-02-15T16:07:49.374606028-05:00",
            "FinishedAt": "2021-02-15T16:08:03.296056384-05:00",
$ sudo podman container restore cr
7f2de709a7be88542d03cebf194deca877b5ad69557f48597259767e1b4a8f83
$ sudo podman container inspect cr |grep -E "(\"Created|FinishedAt|StartedAt|ExitCode)"
        "Created": "2021-02-15T16:07:48.815788417-05:00",
            "ExitCode": 0,
            "StartedAt": "2021-02-15T16:08:23.071588181-05:00",
            "FinishedAt": "0001-01-01T00:00:00Z",
$ sleep 60
$ sudo podman container inspect cr |grep -E "(\"Created|FinishedAt|StartedAt|ExitCode)"
        "Created": "2021-02-15T16:07:48.815788417-05:00",
            "ExitCode": 0,
            "StartedAt": "2021-02-15T16:08:23.071588181-05:00",
            "FinishedAt": "2021-02-15T16:09:09.804056384-05:00",

```

Docker:
```
$ docker run --detach --name cr busybox /bin/sleep 60
66d0545e3d3932f58e2b59f8ea7489dea1c909ebbf02789883478f98ebd9fc3d
$ docker container inspect cr | grep -E "(\"Created|FinishedAt|StartedAt|ExitCode)"
        "Created": "2021-02-15T21:11:54.129271959Z",
            "ExitCode": 0,
            "StartedAt": "2021-02-15T21:11:54.772211374Z",
            "FinishedAt": "0001-01-01T00:00:00Z"
$ docker checkpoint create cr chk
chk
$ docker container inspect cr | grep -E "(\"Created|FinishedAt|StartedAt|ExitCode)"
        "Created": "2021-02-15T21:11:54.129271959Z",
            "ExitCode": 137,
            "StartedAt": "2021-02-15T21:11:54.772211374Z",
            "FinishedAt": "2021-02-15T21:12:06.879920447Z"
$ docker start --checkpoint chk cr
$ docker container inspect cr | grep -E "(\"Created|FinishedAt|StartedAt|ExitCode)"
        "Created": "2021-02-15T21:11:54.129271959Z",
            "ExitCode": 0,
            "StartedAt": "2021-02-15T21:12:25.566876155Z",
            "FinishedAt": "2021-02-15T21:12:06.879920447Z"
$ sleep 60
$ docker container inspect cr | grep -E "(\"Created|FinishedAt|StartedAt|ExitCode)"
        "Created": "2021-02-15T21:11:54.129271959Z",
            "ExitCode": 0,
            "StartedAt": "2021-02-15T21:12:25.566876155Z",
            "FinishedAt": "2021-02-15T21:13:14.151229075Z"

```

Unfortunately I couldn't get the `validate` or `lint` tests to function. Not sure what I'm missing in following the instructions in the contributing doc :/

Closes #8432 
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
