### PR TITLE
[CI:DOCS] Fix typo podman run doc in flag -pid=mode "efault"

### DIFF
--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -714,7 +714,7 @@ Override the OS, defaults to hosts, of the image to be pulled. For example, `win
 #### **--pid**=*mode*
 
 Set the PID namespace mode for the container.
-The efault is to create a private PID namespace for the container.
+The default is to create a private PID namespace for the container.
 
 - **container:**_id_: join another container's PID namespace;
 - **host**: use the host's PID namespace for the container. Note the host mode gives the container full access to local PID and is therefore considered insecure;


### PR DESCRIPTION
Hello! I am Paran Lee

When I am reading the podman run doc

http://docs.podman.io/en/latest/markdown/podman-run.1.html

find typo in flag –pid=mode 

"efault"

If the flag is not explicitly declared, it is created as a PID namespace.

Signed-off-by: Paran Lee <paran.lee@mail.uk>
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
