### PR TITLE
When stopping a container, print rawInput

### DIFF
--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -115,7 +115,7 @@ func stop(cmd *cobra.Command, args []string) error {
 	}
 	for _, r := range responses {
 		if r.Err == nil {
-			fmt.Println(r.Id)
+			fmt.Println(r.RawInput)
 		} else {
 			errs = append(errs, r.Err)
 		}

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -88,8 +88,9 @@ type StopOptions struct {
 }
 
 type StopReport struct {
-	Err error
-	Id  string //nolint
+	Err      error
+	Id       string //nolint
+	RawInput string
 }
 
 type TopOptions struct {

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -95,6 +95,23 @@ var _ = Describe("Podman start", func() {
 		Expect(session.OutputToString()).To(Equal(shortID))
 	})
 
+	It("podman container start single container by short id", func() {
+		session := podmanTest.Podman([]string{"container", "create", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+		shortID := cid[0:10]
+		session = podmanTest.Podman([]string{"container", "start", shortID})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal(shortID))
+
+		session = podmanTest.Podman([]string{"stop", shortID})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal(shortID))
+	})
+
 	It("podman start single container by name", func() {
 		name := "foobar99"
 		session := podmanTest.Podman([]string{"create", "--name", name, ALPINE, "ls"})

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -149,13 +149,12 @@ var _ = Describe("Podman stop", func() {
 		session := podmanTest.RunTopContainer("test4")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		cid1 := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"stop", "--time", "1", "test4"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		output := session.OutputToString()
-		Expect(output).To(ContainSubstring(cid1))
+		Expect(output).To(ContainSubstring("test4"))
 
 		finalCtrs := podmanTest.Podman([]string{"ps", "-q"})
 		finalCtrs.WaitWithDefaultTimeout()
@@ -167,14 +166,13 @@ var _ = Describe("Podman stop", func() {
 		session := podmanTest.Podman([]string{"run", "-d", "--name", "test5", ALPINE, "sleep", "100"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		cid1 := session.OutputToString()
 		session = podmanTest.Podman([]string{"stop", "--timeout", "1", "test5"})
 		// Without timeout container stops in 10 seconds
 		// If not stopped in 5 seconds, then --timeout did not work
 		session.Wait(5)
 		Expect(session.ExitCode()).To(Equal(0))
 		output := session.OutputToString()
-		Expect(output).To(ContainSubstring(cid1))
+		Expect(output).To(ContainSubstring("test5"))
 
 		finalCtrs := podmanTest.Podman([]string{"ps", "-q"})
 		finalCtrs.WaitWithDefaultTimeout()


### PR DESCRIPTION
When we stop a container we are printing the full id,
this does not match Docker behaviour or the start behavior.
We should be printing the users rawInput when we successfully
stop the container.

Fixes: https://github.com/containers/podman/issues/9386

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
