### PR TITLE
images/create: always pull image

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/containers/buildah"
-	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/podman/v2/libpod"
 	image2 "github.com/containers/podman/v2/libpod/image"
@@ -18,6 +17,7 @@ import (
 	"github.com/containers/podman/v2/pkg/api/handlers/utils"
 	"github.com/containers/podman/v2/pkg/auth"
 	"github.com/containers/podman/v2/pkg/domain/entities"
+	"github.com/containers/podman/v2/pkg/util"
 	"github.com/gorilla/schema"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -236,16 +236,6 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 	if sys := runtime.SystemContext(); sys != nil {
 		registryOpts.DockerCertPath = sys.DockerCertPath
 	}
-	rtc, err := runtime.GetConfig()
-	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
-		return
-	}
-	pullPolicy, err := config.ValidatePullPolicy(rtc.Engine.PullPolicy)
-	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
-		return
-	}
 	img, err := runtime.ImageRuntime().New(r.Context(),
 		fromImage,
 		"", // signature policy
@@ -254,7 +244,7 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 		&registryOpts,
 		image2.SigningOptions{},
 		nil, // label
-		pullPolicy,
+		util.PullImageAlways,
 	)
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -45,6 +45,13 @@ t POST "images/create?fromImage=alpine" '' 200 .error=null .status~".*Download c
 
 t POST "images/create?fromImage=alpine&tag=latest" '' 200
 
+# Make sure that new images are pulled
+old_iid=$(podman image inspect --format "{{.ID}}" docker.io/library/alpine:latest)
+podman rmi -f docker.io/library/alpine:latest
+podman tag $IMAGE docker.io/library/alpine:latest
+t POST "images/create?fromImage=alpine" '' 200 .error=null .status~".*$old_iid.*"
+podman untag $IMAGE docker.io/library/alpine:latest
+
 t POST "images/create?fromImage=quay.io/libpod/alpine&tag=sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f" '' 200
 
 # Display the image history


### PR DESCRIPTION
The `images/create` endpoint should always attempt to pull a newer
image.  Previously, the local image was used which is not compatible
with Docker and caused issues in the Gitlab CI.

Fixes: #9232
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>