### PR TITLE
do not set empty $HOME

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -458,7 +458,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 			break
 		}
 	}
-	if !hasHomeSet {
+	if !hasHomeSet && execUser.Home != "" {
 		c.config.Spec.Process.Env = append(c.config.Spec.Process.Env, fmt.Sprintf("HOME=%s", execUser.Home))
 	}
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -662,4 +662,10 @@ json-file | f
     run_podman rm $cname
 }
 
+@test "podman run - do not set empty HOME" {
+    # Regression test for #9378.
+    run_podman run --rm --user 100 $IMAGE printenv
+    is "$output" ".*HOME=/.*"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Make sure to not set an empty $HOME for containers and let it default to
"/".

https://github.com/containers/crun/pull/599 is required to fully
address #9378.

Partially-Fixes: #9378
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
