### PR TITLE
podman kill should report rawInput not container id

### DIFF
--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -111,7 +111,7 @@ func kill(_ *cobra.Command, args []string) error {
 	}
 	for _, r := range responses {
 		if r.Err == nil {
-			fmt.Println(r.Id)
+			fmt.Println(r.RawInput)
 		} else {
 			errs = append(errs, r.Err)
 		}

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -110,8 +110,9 @@ type KillOptions struct {
 }
 
 type KillReport struct {
-	Err error
-	Id  string //nolint
+	Err      error
+	Id       string //nolint
+	RawInput string
 }
 
 type RestartOptions struct {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -208,15 +208,22 @@ func (ic *ContainerEngine) ContainerKill(ctx context.Context, namesOrIds []strin
 	if err != nil {
 		return nil, err
 	}
-	ctrs, err := getContainersByContext(options.All, options.Latest, namesOrIds, ic.Libpod)
+	ctrs, rawInputs, err := getContainersAndInputByContext(options.All, options.Latest, namesOrIds, ic.Libpod)
 	if err != nil {
 		return nil, err
+	}
+	ctrMap := map[string]string{}
+	if len(rawInputs) == len(ctrs) {
+		for i := range ctrs {
+			ctrMap[ctrs[i].ID()] = rawInputs[i]
+		}
 	}
 	reports := make([]*entities.KillReport, 0, len(ctrs))
 	for _, con := range ctrs {
 		reports = append(reports, &entities.KillReport{
-			Id:  con.ID(),
-			Err: con.Kill(uint(sig)),
+			Id:       con.ID(),
+			Err:      con.Kill(uint(sig)),
+			RawInput: ctrMap[con.ID()],
 		})
 	}
 	return reports, nil

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -51,6 +51,19 @@ var _ = Describe("Podman kill", func() {
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
+	It("podman container kill a running container by short id", func() {
+		session := podmanTest.RunTopContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"container", "kill", cid[:5]})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(result.OutputToString()).To(Equal(cid[:5]))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+	})
+
 	It("podman kill a running container by id", func() {
 		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Docker always reports back the users input, not the full
id, we should do the same.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
