### PR TITLE
Ignore entrypoint=[""]

### DIFF
--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -105,7 +105,10 @@ func makeCommand(ctx context.Context, s *specgen.SpecGenerator, img *image.Image
 		entrypoint = newEntry
 	}
 
-	finalCommand = append(finalCommand, entrypoint...)
+	// Don't append the entrypoint if it is [""]
+	if len(entrypoint) != 1 || entrypoint[0] != "" {
+		finalCommand = append(finalCommand, entrypoint...)
+	}
 
 	// Only use image command if the user did not manually set an
 	// entrypoint.

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -43,6 +43,18 @@ CMD []
 		Expect(session.ExitCode()).To(Equal(125))
 	})
 
+	It("podman run entrypoint == [\"\"]", func() {
+		dockerfile := `FROM quay.io/libpod/alpine:latest
+ENTRYPOINT [""]
+CMD []
+`
+		podmanTest.BuildImage(dockerfile, "foobar.com/entrypoint:latest", "false")
+		session := podmanTest.Podman([]string{"run", "foobar.com/entrypoint:latest", "echo", "hello"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("hello"))
+	})
+
 	It("podman run entrypoint", func() {
 		dockerfile := `FROM quay.io/libpod/alpine:latest
 ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]


### PR DESCRIPTION
We recieved an issue with an image that was built with
entrypoint=[""]
This blows up on Podman, but works on Docker.

When we setup the OCI Runtime, we should drop
entrypoint if it is == [""]

Fixes #9377

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
