### PR TITLE
Change source path resolution for volume copy-up

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1644,7 +1644,7 @@ func (c *Container) mountNamedVolume(v *ContainerNamedVolume, mountpoint string)
 			getOptions := copier.GetOptions{
 				KeepDirectoryNames: false,
 			}
-			errChan <- copier.Get(mountpoint, "", getOptions, []string{v.Dest + "/."}, writer)
+			errChan <- copier.Get(srcDir, "", getOptions, []string{"/."}, writer)
 		}()
 
 		// Copy, volume side: stream what we've written to the pipe, into

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -334,6 +334,18 @@ RUN sh -c "cd /etc/apk && ln -s ../../testfile"`
 		Expect(outputSession.OutputToString()).To(Equal(baselineOutput))
 	})
 
+	It("podman named volume copyup of /var", func() {
+		baselineSession := podmanTest.Podman([]string{"run", "--rm", "-t", "-i", fedoraMinimal, "ls", "/var"})
+		baselineSession.WaitWithDefaultTimeout()
+		Expect(baselineSession.ExitCode()).To(Equal(0))
+		baselineOutput := baselineSession.OutputToString()
+
+		outputSession := podmanTest.Podman([]string{"run", "-t", "-i", "-v", "/var", fedoraMinimal, "ls", "/var"})
+		outputSession.WaitWithDefaultTimeout()
+		Expect(outputSession.ExitCode()).To(Equal(0))
+		Expect(outputSession.OutputToString()).To(Equal(baselineOutput))
+	})
+
 	It("podman read-only tmpfs conflict with volume", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "-t", "-i", "--read-only", "-v", "tmp_volume:" + dest, ALPINE, "touch", dest + "/a"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Instead of using the container's mountpoint as the base of the chroot and indexing from there by the volume directory, instead use the full path of what we want to copy as the base of the chroot and copy everything in it. This resolves the bug, ends up being a bit simpler code-wise (no string concatenation, as we already have the full path calculated for other checks), and seems more understandable than trying to resolve things on the destination side of the copy-up.

Fixes #9354