### PR TITLE
[NO TESTS NEEDED] Allow podman play kube to read yaml file from stdin

### DIFF
--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -35,13 +35,14 @@ var (
   It creates the pod and containers described in the YAML.  The containers within the pod are then started and the ID of the new Pod is output.`
 
 	kubeCmd = &cobra.Command{
-		Use:               "kube [options] KUBEFILE",
+		Use:               "kube [options] KUBEFILE|-",
 		Short:             "Play a pod based on Kubernetes YAML.",
 		Long:              kubeDescription,
 		RunE:              kube,
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: common.AutocompleteDefaultOneArg,
 		Example: `podman play kube nginx.yml
+  cat nginx.yml | podman play kube -
   podman play kube --creds user:password --seccomp-profile-root /custom/path apache.yml`,
 	}
 )
@@ -119,7 +120,11 @@ func kube(cmd *cobra.Command, args []string) error {
 		kubeOptions.Password = creds.Password
 	}
 
-	report, err := registry.ContainerEngine().PlayKube(registry.GetContext(), args[0], kubeOptions.PlayKubeOptions)
+	yamlfile := args[0]
+	if yamlfile == "-" {
+		yamlfile = "/dev/stdin"
+	}
+	report, err := registry.ContainerEngine().PlayKube(registry.GetContext(), yamlfile, kubeOptions.PlayKubeOptions)
 	if err != nil {
 		return err
 	}

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -4,12 +4,10 @@
 podman-play-kube - Create pods and containers based on Kubernetes YAML
 
 ## SYNOPSIS
-**podman play kube** [*options*] *file*__.yml__
+**podman play kube** [*options*] *file.yml|-*
 
 ## DESCRIPTION
-**podman play kube** will read in a structured file of Kubernetes YAML.  It will then recreate
-the pod and containers described in the YAML.  The containers within the pod are then started and
-the ID of the new Pod is output.
+**podman play kube** will read in a structured file of Kubernetes YAML.  It will then recreate the pod and containers described in the YAML.  The containers within the pod are then started and the ID of the new Pod is output. If the yaml file is specified as "-" then `podman play kube` with read the yaml file from stdin.
 
 Ideally the input file would be one created by Podman (see podman-generate-kube(1)).  This would guarantee a smooth import and expected results.
 
@@ -79,6 +77,12 @@ Print usage statement
 Recreate the pod and containers as described in a file called `demo.yml`
 ```
 $ podman play kube demo.yml
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+```
+
+Recreate the pod and containers as described in a file `demo.yml` sent to stdin
+```
+$ cat demo.yml | podman play kube -
 52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
 ```
 

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -1,13 +1,17 @@
-# Save the output of this file and use kubectl create -f to import
-# it into Kubernetes.
+#!/usr/bin/env bats   -*- bats -*-
 #
-# Created with podman-1.6.2
+# Test podman play
+#
+
+load helpers
+
+testYaml="
 apiVersion: v1
 kind: Pod
 metadata:
   labels:
     app: test
-  name: test
+  name: test_pod
 spec:
   containers:
   - command:
@@ -20,7 +24,7 @@ spec:
       value: xterm
     - name: container
       value: podman
-    image: docker.io/library/fedora:latest
+    image: quay.io/libpod/alpine:latest
     name: test
     resources: {}
     securityContext:
@@ -31,7 +35,20 @@ spec:
       capabilities: {}
       privileged: false
       seLinuxOptions:
-	  level: "s0:c1,c2"
+         level: "s0:c1,c2"
       readOnlyRootFilesystem: false
     workingDir: /
 status: {}
+"
+
+@test "podman play with stdin" {
+    echo "$testYaml" > $PODMAN_TMPDIR/test.yaml
+    run_podman play kube - < $PODMAN_TMPDIR/test.yaml
+    run_podman pod rm -f test_pod
+}
+
+@test "podman play" {
+    echo "$testYaml" > $PODMAN_TMPDIR/test.yaml
+    run_podman play kube $PODMAN_TMPDIR/test.yaml
+    run_podman pod rm -f test_pod
+}


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/8996

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
