### PR TITLE
cp: treat "." and "/." correctly

### DIFF
--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -311,8 +311,8 @@ func copyToContainer(container string, containerPath string, hostPath string) er
 		}
 
 		getOptions := buildahCopiah.GetOptions{
-			// Unless the specified path ends with ".", we want to copy the base directory.
-			KeepDirectoryNames: !strings.HasSuffix(hostPath, "."),
+			// Unless the specified points to ".", we want to copy the base directory.
+			KeepDirectoryNames: hostInfo.IsDir && filepath.Base(hostPath) != ".",
 		}
 		if !hostInfo.IsDir && (!containerInfo.IsDir || containerInfoErr != nil) {
 			// If we're having a file-to-file copy, make sure to


### PR DESCRIPTION
Make sure to treat "." and "/." correctly.  Both cases imply to copy the
contents of a directory in contrast to the directory.  This implies to
unset the KeepDirectoryNames options of the copiah package.

Previously, the code was performing a simple string suffix check which
is not enough since it would match files and directories ending with
".".

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
