### PR TITLE
Fix segfault in run with memory-swap

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -148,17 +148,16 @@ func getMemoryLimits(s *specgen.SpecGenerator, c *ContainerCLIOpts) (*specs.Linu
 	}
 	if m := c.MemorySwap; len(m) > 0 {
 		var ms int64
-		if m == "-1" {
-			ms = int64(-1)
-			s.ResourceLimits.Memory.Swap = &ms
-		} else {
+		// only set memory swap if it was set
+		// -1 indicates unlimited
+		if m != "-1" {
 			ms, err = units.RAMInBytes(m)
+			memory.Swap = &ms
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid value for memory")
 			}
+			hasLimits = true
 		}
-		memory.Swap = &ms
-		hasLimits = true
 	}
 	if m := c.KernelMemory; len(m) > 0 {
 		mk, err := units.RAMInBytes(m)


### PR DESCRIPTION
when unlimited (-1) was being passed to memory-swap, podman threw a
segfault.

Fixes #9429

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
