### PR TITLE
[NO TESTS NEEDED] leak fix in rootless_linux.c fcn can_use_shortcut

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -196,7 +196,11 @@ can_use_shortcut ()
     return false;
 
   if (strstr (argv[0], "podman") == NULL)
-    return false;
+    {
+      free (argv[0]);
+      free (argv);
+      return false;
+    }
 
   for (argc = 0; argv[argc]; argc++)
     {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
/kind bug

I found a memory leak in can_use_shortcut() in rootless_linux.c function.
The leak is present in all podman versions that use the current version of rootless_linux.c (maybe from the beginning). The leak was detected while working on Golang <-> c bindings using memory sanitizer in the clang compiler.

How to reproduce:
1. download repo https://github.com/jmguzik/podman-bindings-c
2. comment or delete everything in main.c (empty function)
3. compile golang to c lib (as in description): `go build -buildmode=c-shared -o libpodc.so libpodc.go`
4. Instead of gcc use clang with memory sanitizer to compile: `clang -fsanitize=address -fno-omit-frame-pointer -O2 -L. -Wl,-rpath=. -Wall -o main main.c -lpodc`
5. `export ASAN_OPTIONS=fast_unwind_on_malloc=0` to have more verbose output and run ./main (int main function is empty)
6. Memory sanitizer reports leak detection (one of the possible paths do not free argv allocated memory):

```
3834415==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x4993cd in malloc (/home/guzikj/golang/ex/podman-bindings-c/main+0x4993cd)
    #1 0x7f299bf0bd14 in get_cmd_line_args /home/guzikj/go/pkg/mod/github.com/containers/podman/v2@v2.2.1/pkg/rootless/rootless_linux.c:165:10
    #2 0x7f299b496c74 in can_use_shortcut /home/guzikj/go/pkg/mod/github.com/containers/podman/v2@v2.2.1/pkg/rootless/rootless_linux.c:195:10
    #3 0x7f299b496c74 in init /home/guzikj/go/pkg/mod/github.com/containers/podman/v2@v2.2.1/pkg/rootless/rootless_linux.c:304:67
    #4 0x7f299c8fcfb1 in call_init elf/dl-init.c:72:3
    #5 0x7f299c8fd0b8 in call_init elf/dl-init.c:30:6
    #6 0x7f299c8fd0b8 in _dl_init elf/dl-init.c:119:5
    #7 0x7f299c8ee0c9  (/lib64/ld-linux-x86-64.so.2+0x10c9)

Indirect leak of 512 byte(s) in 1 object(s) allocated from:
    #0 0x4993cd in malloc (/home/guzikj/golang/ex/podman-bindings-c/main+0x4993cd)
    #1 0x7f299bf0bc42 in get_cmd_line_args /home/guzikj/go/pkg/mod/github.com/containers/podman/v2@v2.2.1/pkg/rootless/rootless_linux.c:126:12
    #2 0x7f299b496c74 in can_use_shortcut /home/guzikj/go/pkg/mod/github.com/containers/podman/v2@v2.2.1/pkg/rootless/rootless_linux.c:195:10
    #3 0x7f299b496c74 in init /home/guzikj/go/pkg/mod/github.com/containers/podman/v2@v2.2.1/pkg/rootless/rootless_linux.c:304:67
    #4 0x7f299c8fcfb1 in call_init elf/dl-init.c:72:3
    #5 0x7f299c8fd0b8 in call_init elf/dl-init.c:30:6
    #6 0x7f299c8fd0b8 in _dl_init elf/dl-init.c:119:5
    #7 0x7f299c8ee0c9  (/lib64/ld-linux-x86-64.so.2+0x10c9)

SUMMARY: AddressSanitizer: 528 byte(s) leaked in 2 allocation(s).
```

