### PR TITLE
[3.0] cp: treat "." and "/." correctly

### DIFF
--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -311,8 +311,8 @@ func copyToContainer(container string, containerPath string, hostPath string) er
 		}
 
 		getOptions := buildahCopiah.GetOptions{
-			// Unless the specified path ends with ".", we want to copy the base directory.
-			KeepDirectoryNames: !strings.HasSuffix(hostPath, "."),
+			// Unless the specified points to ".", we want to copy the base directory.
+			KeepDirectoryNames: hostInfo.IsDir && filepath.Base(hostPath) != ".",
 		}
 		if !hostInfo.IsDir && (!containerInfo.IsDir || containerInfoErr != nil) {
 			// If we're having a file-to-file copy, make sure to


### PR DESCRIPTION
Make sure to treat "." and "/." correctly.  Both cases imply to copy the
contents of a directory in contrast to the directory.  This implies to
unset the KeepDirectoryNames options of the copiah package.

Previously, the code was performing a simple string suffix check which
is not enough since it would match files and directories ending with
".".

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
