### PR TITLE
[NO TESTS NEEDED] Log working dir when chdir fails

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -398,7 +398,7 @@ static void __attribute__((constructor)) init()
 
       if (chdir (cwd) < 0)
         {
-          fprintf (stderr, "cannot chdir: %s\n", strerror (errno));
+          fprintf (stderr, "cannot chdir to %s: %s\n", cwd, strerror (errno));
           _exit (EXIT_FAILURE);
         }
 
@@ -689,7 +689,7 @@ reexec_userns_join (int pid_to_join, char *pause_pid_file_path)
 
   if (chdir (cwd) < 0)
     {
-      fprintf (stderr, "cannot chdir: %s\n", strerror (errno));
+      fprintf (stderr, "cannot chdir to %s: %s\n", cwd, strerror (errno));
       _exit (EXIT_FAILURE);
     }
   free (cwd);
@@ -893,7 +893,7 @@ reexec_in_user_namespace (int ready, char *pause_pid_file_path, char *file_to_re
 
   if (chdir (cwd) < 0)
     {
-      fprintf (stderr, "cannot chdir: %s\n", strerror (errno));
+      fprintf (stderr, "cannot chdir to %s: %s\n", cwd, strerror (errno));
       TEMP_FAILURE_RETRY (write (ready, "1", 1));
       _exit (EXIT_FAILURE);
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

This provides a bit more info when `chdir` fails, making it easier to debug setup issues.