### PR TITLE
Fix podman network IDs handling

### DIFF
--- a/libpod/network/files.go
+++ b/libpod/network/files.go
@@ -81,9 +81,9 @@ func GetCNIConfigPathByNameOrID(config *config.Config, name string) (string, err
 	return "", errors.Wrap(define.ErrNoSuchNetwork, fmt.Sprintf("unable to find network configuration for %s", name))
 }
 
-// ReadRawCNIConfByName reads the raw CNI configuration for a CNI
+// ReadRawCNIConfByNameOrID reads the raw CNI configuration for a CNI
 // network by name
-func ReadRawCNIConfByName(config *config.Config, name string) ([]byte, error) {
+func ReadRawCNIConfByNameOrID(config *config.Config, name string) ([]byte, error) {
 	confFile, err := GetCNIConfigPathByNameOrID(config, name)
 	if err != nil {
 		return nil, err

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1139,12 +1139,11 @@ func (c *Container) NetworkDisconnect(nameOrID, netName string, force bool) erro
 		return err
 	}
 
-	exists, err := network.Exists(c.runtime.config, netName)
+	// check if network exists and if the input is a ID we get the name
+	// ocicni only uses names so it is important that we only use the name
+	netName, err = network.NormalizeName(c.runtime.config, netName)
 	if err != nil {
 		return err
-	}
-	if !exists {
-		return errors.Wrap(define.ErrNoSuchNetwork, netName)
 	}
 
 	index, nameExists := networks[netName]
@@ -1196,12 +1195,11 @@ func (c *Container) NetworkConnect(nameOrID, netName string, aliases []string) e
 		return err
 	}
 
-	exists, err := network.Exists(c.runtime.config, netName)
+	// check if network exists and if the input is a ID we get the name
+	// ocicni only uses names so it is important that we only use the name
+	netName, err = network.NormalizeName(c.runtime.config, netName)
 	if err != nil {
 		return err
-	}
-	if !exists {
-		return errors.Wrap(define.ErrNoSuchNetwork, netName)
 	}
 
 	c.lock.Lock()


### PR DESCRIPTION
The libpod network logic knows about networks IDs but OCICNI
does not. We cannot pass the network ID to OCICNI. Instead we
need to make sure we only use network names internally. This
is also important for libpod since we also only store the
network names in the state. If we would add a ID there the
same networks could accidentally be added twice.

Fixes #9451

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
