### PR TITLE
cgroup: change cgroup deletion logic on v1

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -331,18 +331,24 @@ func Load(path string) (*CgroupControl, error) {
 		control.additionalControllers = controllers
 	}
 	if !cgroup2 {
+		oneExists := false
+		// check that the cgroup exists at least under one controller
 		for name := range handlers {
 			p := control.getCgroupv1Path(name)
-			if _, err := os.Stat(p); err != nil {
-				if os.IsNotExist(err) {
-					if rootless.IsRootless() {
-						return nil, ErrCgroupV1Rootless
-					}
-					// compatible with the error code
-					// used by containerd/cgroups
-					return nil, ErrCgroupDeleted
-				}
+			if _, err := os.Stat(p); err == nil {
+				oneExists = true
+				break
 			}
+		}
+
+		// if there is no controller at all, raise an error
+		if !oneExists {
+			if rootless.IsRootless() {
+				return nil, ErrCgroupV1Rootless
+			}
+			// compatible with the error code
+			// used by containerd/cgroups
+			return nil, ErrCgroupDeleted
 		}
 	}
 	return control, nil


### PR DESCRIPTION
do not raise an error if the cgroup exists at least on one
controller.

Previously it expected the cgroup to exists under all the
controllers.

[NO TESTS NEEDED]

Closes: https://github.com/containers/podman/issues/9252

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
