### PR TITLE
[NO TESTS NEEDED] Turn on podman-remote build --isolation

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
 	buildahCLI "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
@@ -159,11 +158,11 @@ func buildFlags(cmd *cobra.Command) {
 	flags.SetNormalizeFunc(buildahCLI.AliasFlags)
 	if registry.IsRemote() {
 		flag = flags.Lookup("isolation")
-		buildOpts.Isolation = buildah.OCI
-		if err := flag.Value.Set(buildah.OCI); err != nil {
-			logrus.Errorf("unable to set --isolation to %v: %v", buildah.OCI, err)
+		buildOpts.Isolation = define.OCI
+		if err := flag.Value.Set(define.OCI); err != nil {
+			logrus.Errorf("unable to set --isolation to %v: %v", define.OCI, err)
 		}
-		flag.DefValue = buildah.OCI
+		flag.DefValue = define.OCI
 		_ = flags.MarkHidden("disable-content-trust")
 		_ = flags.MarkHidden("cache-from")
 		_ = flags.MarkHidden("sign-by")
@@ -412,10 +411,10 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 	format := ""
 	flags.Format = strings.ToLower(flags.Format)
 	switch {
-	case strings.HasPrefix(flags.Format, buildah.OCI):
-		format = buildah.OCIv1ImageManifest
-	case strings.HasPrefix(flags.Format, buildah.DOCKER):
-		format = buildah.Dockerv2ImageManifest
+	case strings.HasPrefix(flags.Format, define.OCI):
+		format = define.OCIv1ImageManifest
+	case strings.HasPrefix(flags.Format, define.DOCKER):
+		format = define.Dockerv2ImageManifest
 	default:
 		return nil, errors.Errorf("unrecognized image type %q", flags.Format)
 	}

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -36,6 +36,9 @@ do
     fi
 done
 
+# Make sure cni network plugins directory exists
+mkdir -p /etc/cni/net.d
+
 # Ensure that all lower-level contexts and child-processes have
 # ready access to higher level orchestration (e.g Cirrus-CI)
 # variables.

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -199,13 +199,9 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	}
 	format := buildah.Dockerv2ImageManifest
 	registry := query.Registry
-	isolation := buildah.IsolationChroot
-	/*
-		// FIXME, This is very broken.  Buildah will only work with chroot
-		isolation := buildah.IsolationDefault
-	*/
+	isolation := buildah.IsolationDefault
 	if utils.IsLibpodRequest(r) {
-		// isolation = parseLibPodIsolation(query.Isolation)
+		isolation = parseLibPodIsolation(query.Isolation)
 		registry = ""
 		format = query.OutputFormat
 	} else {


### PR DESCRIPTION
Currently podman only works with --isolation chroot.  This PR
fixes this by allowing the isolation mode to default to OCI and to
also allow users to pass the isolation mode into the containers.

The current tests for --isolation should cause this code to be tested.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
