### PR TITLE
pr-should-include-tests: recognized "renamed" tests

### DIFF
--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -22,7 +22,8 @@ base=$(git merge-base ${DEST_BRANCH:-master} $head)
 #    A    foo.c
 #    M    bar.c
 # We look for Added or Modified (not Deleted!) files under 'test'.
-if git diff --name-status $base $head | egrep -q '^[AM]\s+(test/|.*_test\.go)'; then
+# --no-renames ensures that renamed tests (#9420) show up as 'A'dded.
+if git diff --name-status --no-renames $base $head | egrep -q '^[AM]\s+(test/|.*_test\.go)'; then
     exit 0
 fi
 

--- a/contrib/cirrus/pr-should-include-tests.t
+++ b/contrib/cirrus/pr-should-include-tests.t
@@ -38,6 +38,7 @@ tests="
 0  c342583da  12f835d12   PR 8523, version.go + podman.spec.in
 0  c342583da  db1d2ff11   version bump to v2.2.0
 0  8f75ed958  7b3ad6d89   PR 8835, only a README.md change
+0  b6db60e58  f06dd45e0   PR 9420, a test rename
 "
 
 # The script we're testing


### PR DESCRIPTION
git tries to recognize renamed files. This isn't always
as helpful as intended. Turn it off, so we'll always see
files as 'A'dded.

Signed-off-by: Ed Santiago <santiago@redhat.com>
