### PR TITLE
Tidy duplicate log tests

### DIFF
--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -29,7 +29,6 @@ func (c *Container) ReadLog(ctx context.Context, options *logs.LogOptions, logCh
 	case define.NoLogging:
 		return errors.Wrapf(define.ErrNoLogs, "this container is using the 'none' log driver, cannot read logs")
 	case define.JournaldLogging:
-		// TODO Skip sending logs until journald logs can be read
 		return c.readFromJournal(ctx, options, logChannel)
 	case define.JSONLogging:
 		// TODO provide a separate implementation of this when Conmon

--- a/libpod/container_log_linux.go
+++ b/libpod/container_log_linux.go
@@ -52,6 +52,7 @@ func (c *Container) readFromJournal(ctx context.Context, options *logs.LogOption
 		if time.Now().Before(options.Since) {
 			return nil
 		}
+		// coreos/go-systemd/sdjournal expects a negative time.Duration for times in the past
 		config.Since = -time.Since(options.Since)
 	}
 	config.Matches = append(config.Matches, journal.Match{


### PR DESCRIPTION
Some log tests were duplicated, and some didn't need to be repeated for
every driver. Also, added some comments

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
