### PR TITLE
test: ignore named hierarchies for cgroups=split

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1228,9 +1228,10 @@ USER mail`
 		for _, line := range lines {
 			parts := strings.SplitN(line, ":", 3)
 			if !CGROUPSV2 {
-				// ignore unified on cgroup v1
+				// ignore unified on cgroup v1.
 				// both runc and crun do not set it.
-				if parts[1] == "" {
+				// crun does not set named hierarchies.
+				if parts[1] == "" || strings.Contains(parts[1], "name=") {
 					continue
 				}
 			}


### PR DESCRIPTION
ignore named hierarchies for the --cgroups=split test as crun does not
set it.

Closes: https://github.com/containers/podman/pull/9302#issuecomment-784157272

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
