### PR TITLE
Sort CapDrop in inspect to guarantee order

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/containers/common/pkg/config"
@@ -698,6 +699,8 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 		for cap := range boundingCaps {
 			capDrop = append(capDrop, cap)
 		}
+		// Sort CapDrop so it displays in consistent order (GH #9490)
+		sort.Strings(capDrop)
 	}
 	hostConfig.CapAdd = capAdd
 	hostConfig.CapDrop = capDrop

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -490,4 +490,22 @@ var _ = Describe("Podman inspect", func() {
 		}
 		Expect(found).To(BeTrue())
 	})
+
+	It("Dropped capabilities are sorted", func() {
+		ctrName := "testCtr"
+		session := podmanTest.Podman([]string{"run", "-d", "--cap-drop", "CAP_AUDIT_WRITE", "--cap-drop", "CAP_MKNOD", "--cap-drop", "CAP_NET_RAW", "--name", ctrName, ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+
+		inspect := podmanTest.Podman([]string{"inspect", ctrName})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(BeZero())
+
+		data := inspect.InspectContainerToJSON()
+		Expect(len(data)).To(Equal(1))
+		Expect(len(data[0].HostConfig.CapDrop)).To(Equal(3))
+		Expect(data[0].HostConfig.CapDrop[0]).To(Equal("CAP_AUDIT_WRITE"))
+		Expect(data[0].HostConfig.CapDrop[1]).To(Equal("CAP_MKNOD"))
+		Expect(data[0].HostConfig.CapDrop[2]).To(Equal("CAP_NET_RAW"))
+	})
 })


### PR DESCRIPTION
The order of CapAdd when inspecting containers is deterministic. However, the order of CapDrop is not (for unclear reasons). Add a quick sort on the final array to guarantee a consistent order.

Fixes #9490
