### PR TITLE
Add '--group-add keep-groups': supplementary groups into container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ err_if_empty = $(if $(strip $($(1))),$(strip $($(1))),$(error Required variable 
 
 # Podman does not work w/o CGO_ENABLED, except in some very specific cases
 CGO_ENABLED ?= 1
-# Default to the native OS type and archetecture unless otherwise specified
+# Default to the native OS type and architecture unless otherwise specified
 GOOS ?= $(shell $(GO) env GOOS)
 ifeq ($(call err_if_empty,GOOS),windows)
 BINSFX := .exe
@@ -255,7 +255,7 @@ test/goecho/goecho: .gopathok $(wildcard test/goecho/*.go)
 
 .PHONY: codespell
 codespell:
-	codespell -S bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go" -L uint,iff,od,seeked,splitted,marge,ERRO,hist -w
+	codespell -S bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go" -L uint,iff,od,seeked,splitted,marge,ERRO,hist,ether -w
 
 .PHONY: validate
 validate: gofmt lint .gitvalidation validate.completions man-page-check swagger-check tests-included

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -196,7 +196,7 @@ spelled with complete minutiae.
    1. Merge the PR (or ask someone else to review and merge, to be safer).
    1. **Note:** This is the last point where any test-failures can be addressed
       by code changes. After pushing the new version-tag upstream, no further
-      changes can be made to the code without lots of unpleasent efforts.  Please
+      changes can be made to the code without lots of unpleasant efforts.  Please
       seek assistance if needed, before proceeding.
 
    1. Assuming the "Bump to ..." PR merged successfully, and you're **really**

--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -277,7 +277,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	createFlags.StringSliceVar(
 		&cf.GroupAdd,
 		groupAddFlagName, []string{},
-		"Add additional groups to join",
+		"Add additional groups to the primary container process. 'keep-groups' allows container processes to use suplementary groups.",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(groupAddFlagName, completion.AutocompleteNone)
 

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -193,6 +193,25 @@ func createInit(c *cobra.Command) error {
 		val := c.Flag("entrypoint").Value.String()
 		cliVals.Entrypoint = &val
 	}
+
+	if c.Flags().Changed("group-add") {
+		groups := []string{}
+		for _, g := range cliVals.GroupAdd {
+			if g == "keep-groups" {
+				if len(cliVals.GroupAdd) > 1 {
+					return errors.New("the '--group-add keep-groups' option is not allowed with any other --group-add options")
+				}
+				if registry.IsRemote() {
+					return errors.New("the '--group-add keep-groups' option is not supported in remote mode")
+				}
+				cliVals.Annotation = append(cliVals.Annotation, "run.oci.keep_original_groups=1")
+			} else {
+				groups = append(groups, g)
+			}
+		}
+		cliVals.GroupAdd = groups
+	}
+
 	if c.Flags().Changed("pids-limit") {
 		val := c.Flag("pids-limit").Value.String()
 		pidsLimit, err := strconv.ParseInt(val, 10, 32)

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -30,7 +30,7 @@ func init() {
 	})
 }
 
-// TODO  Name shouldnt be required, need to create a default vm
+// TODO  Name shouldn't be required, need to create a default vm
 func stop(cmd *cobra.Command, args []string) error {
 	var (
 		err    error

--- a/completions/powershell/podman-remote.ps1
+++ b/completions/powershell/podman-remote.ps1
@@ -161,7 +161,7 @@ Register-ArgumentCompleter -CommandName 'podman-remote' -ScriptBlock {
 
     $Values | ForEach-Object {
 
-        # store temporay because switch will overwrite $_
+        # store temporary because switch will overwrite $_
         $comp = $_
 
         # PowerShell supports three different completion modes
@@ -216,7 +216,7 @@ Register-ArgumentCompleter -CommandName 'podman-remote' -ScriptBlock {
             Default {
                 # Like MenuComplete but we don't want to add a space here because
                 # the user need to press space anyway to get the completion.
-                # Description will not be shown because thats not possible with TabCompleteNext
+                # Description will not be shown because that's not possible with TabCompleteNext
                 [System.Management.Automation.CompletionResult]::new($($comp.Name | __podman-remote_escapeStringWithSpecialChars), "$($comp.Name)", 'ParameterValue', "$($comp.Description)")
             }
         }

--- a/completions/powershell/podman.ps1
+++ b/completions/powershell/podman.ps1
@@ -161,7 +161,7 @@ Register-ArgumentCompleter -CommandName 'podman' -ScriptBlock {
 
     $Values | ForEach-Object {
 
-        # store temporay because switch will overwrite $_
+        # store temporary because switch will overwrite $_
         $comp = $_
 
         # PowerShell supports three different completion modes
@@ -216,7 +216,7 @@ Register-ArgumentCompleter -CommandName 'podman' -ScriptBlock {
             Default {
                 # Like MenuComplete but we don't want to add a space here because
                 # the user need to press space anyway to get the completion.
-                # Description will not be shown because thats not possible with TabCompleteNext
+                # Description will not be shown because that's not possible with TabCompleteNext
                 [System.Management.Automation.CompletionResult]::new($($comp.Name | __podman_escapeStringWithSpecialChars), "$($comp.Name)", 'ParameterValue', "$($comp.Description)")
             }
         }

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -277,7 +277,7 @@ logformatter() {
             |& awk --file "${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/timestamp.awk" \
             |& "${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/logformatter" "$output_name"
     else
-        # Assume script is run by a human, they want output immediatly
+        # Assume script is run by a human, they want output immediately
         cat -
     fi
 }

--- a/docs/remote-docs.sh
+++ b/docs/remote-docs.sh
@@ -6,7 +6,7 @@ PLATFORM=$1                         ## linux, windows or darwin
 TARGET=${2}                         ## where to output files
 SOURCES=${@:3}                      ## directories to find markdown files
 
-# Overriden for testing.  Native podman-remote binary expected filepaths
+# Overridden for testing.  Native podman-remote binary expected filepaths
 if [[ -z "$PODMAN" ]]; then
     case $(env -i HOME=$HOME PATH=$PATH go env GOOS) in
         windows)

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -688,7 +688,7 @@ Set the architecture variant of the image to be pulled.
    bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the Podman
    container. (This option is not available with the remote Podman client)
 
-   The `OPTIONS` are a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
+   The `OPTIONS` are a comma-separated list and can be: <sup>[[1]](#Footnote1)</sup>
 
    * [rw|ro]
    * [z|Z|O]

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -125,7 +125,7 @@ If another pod with the same name already exists, replace and remove it.  The de
 
 #### **\-\-share**=*namespace*
 
-A comma delimited list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared. The namespaces to choose from are ipc, net, pid, uts.
+A comma-separated list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared. The namespaces to choose from are ipc, net, pid, uts.
 
 The operator can identify a pod in three ways:
 UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”)

--- a/docs/source/markdown/podman-secret-create.1.md
+++ b/docs/source/markdown/podman-secret-create.1.md
@@ -16,7 +16,7 @@ A secret is a blob of sensitive data which a container needs at runtime but
 should not be stored in the image or in source control, such as usernames and passwords,
 TLS certificates and keys, SSH keys or other important generic strings or binary content (up to 500 kb in size).
 
-Secrets will not be commited to an image with `podman commit`, and will not be in the archive created by a `podman export`
+Secrets will not be committed to an image with `podman commit`, and will not be in the archive created by a `podman export`
 
 ## OPTIONS
 

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1313,7 +1313,7 @@ func (c *Container) stop(timeout uint) error {
 	}
 
 	// We have to check stopErr *after* we lock again - otherwise, we have a
-	// change of panicing on a double-unlock. Ref: GH Issue 9615
+	// change of panicking on a double-unlock. Ref: GH Issue 9615
 	if stopErr != nil {
 		return stopErr
 	}
@@ -1676,7 +1676,7 @@ func (c *Container) chownVolume(volumeName string) error {
 
 	// TODO: For now, I've disabled chowning volumes owned by non-Podman
 	// drivers. This may be safe, but it's really going to be a case-by-case
-	// thing, I think - safest to leave disabled now and reenable later if
+	// thing, I think - safest to leave disabled now and re-enable later if
 	// there is a demand.
 	if vol.state.NeedsChown && !vol.UsesVolumeDriver() {
 		vol.state.NeedsChown = false

--- a/libpod/define/fileinfo.go
+++ b/libpod/define/fileinfo.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// FileInfo describes the attributes of a file or diretory.
+// FileInfo describes the attributes of a file or directory.
 type FileInfo struct {
 	Name       string      `json:"name"`
 	Size       int64       `json:"size"`

--- a/libpod/image/utils.go
+++ b/libpod/image/utils.go
@@ -50,7 +50,7 @@ func findImageInRepotags(search imageParts, images []*Image) (*storage.Image, er
 
 	// If more then one candidate and the candidates all have same name
 	// and only one is read/write return it.
-	// Othewise return error with the list of candidates
+	// Otherwise return error with the list of candidates
 	if len(candidates) > 1 {
 		var (
 			rwImage    *Image

--- a/libpod/shutdown/handler.go
+++ b/libpod/shutdown/handler.go
@@ -18,7 +18,7 @@ var (
 	stopped    bool
 	sigChan    chan os.Signal
 	cancelChan chan bool
-	// Syncronize accesses to the map
+	// Synchronize accesses to the map
 	handlerLock sync.Mutex
 	// Definitions of all on-shutdown handlers
 	handlers map[string]func(os.Signal) error

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -76,7 +76,7 @@ func WaitContainerDocker(w http.ResponseWriter, r *http.Request) {
 	exitCode, err := waitDockerCondition(ctx, name, interval, condition)
 	msg := ""
 	if err != nil {
-		logrus.Errorf("error while waiting on condtion: %q", err)
+		logrus.Errorf("error while waiting on condition: %q", err)
 		msg = err.Error()
 	}
 	responseData := handlers.ContainerWaitOKBody{

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -428,7 +428,7 @@ func readConfigMapFromFile(r io.Reader) (v1.ConfigMap, error) {
 	return cm, nil
 }
 
-// splitMultiDocYAML reads mutiple documents in a YAML file and
+// splitMultiDocYAML reads multiple documents in a YAML file and
 // returns them as a list.
 func splitMultiDocYAML(yamlContent []byte) ([][]byte, error) {
 	var documentList [][]byte
@@ -471,7 +471,7 @@ func getKubeKind(obj []byte) (string, error) {
 }
 
 // sortKubeKinds adds the correct creation order for the kube kinds.
-// Any pod dependecy will be created first like volumes, secrets, etc.
+// Any pod dependency will be created first like volumes, secrets, etc.
 func sortKubeKinds(documentList [][]byte) ([][]byte, error) {
 	var sortedDocumentList [][]byte
 

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -170,7 +170,7 @@ func Decompress(localPath, uncompressedPath string) error {
 
 // Will error out if file without .xz already exists
 // Maybe extracting then renameing is a good idea here..
-// depends on xz: not pre-installed on mac, so it becomes a brew dependecy
+// depends on xz: not pre-installed on mac, so it becomes a brew dependency
 func decompressXZ(src string, output io.Writer) error {
 	fmt.Println("Extracting compressed file")
 	cmd := exec.Command("xzcat", "-k", src)

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -56,7 +56,7 @@ func ToPodGen(ctx context.Context, podName string, podYAML *v1.PodTemplateSpec) 
 			}
 			p.DNSServer = servers
 		}
-		// search domans
+		// search domains
 		if domains := dnsConfig.Searches; len(domains) > 0 {
 			p.DNSSearch = domains
 		}

--- a/pkg/systemd/generate/common_test.go
+++ b/pkg/systemd/generate/common_test.go
@@ -199,8 +199,8 @@ func TestEscapeSystemdArguments(t *testing.T) {
 			[]string{"foo", `"command with backslash \\"`},
 		},
 		{
-			[]string{"foo", `command with two backslashs \\`},
-			[]string{"foo", `"command with two backslashs \\\\"`},
+			[]string{"foo", `command with two backslashes \\`},
+			[]string{"foo", `"command with two backslashes \\\\"`},
 		},
 	}
 

--- a/pkg/util/filters.go
+++ b/pkg/util/filters.go
@@ -94,7 +94,7 @@ func PrepareFilters(r *http.Request) (*map[string][]string, error) {
 	return &filterMap, nil
 }
 
-// MatchLabelFilters matches labels and returs true if they are valid
+// MatchLabelFilters matches labels and returns true if they are valid
 func MatchLabelFilters(filterValues []string, labels map[string]string) bool {
 outer:
 	for _, filterValue := range filterValues {

--- a/test/apiv2/rest_api/test_rest_v2_0_0.py
+++ b/test/apiv2/rest_api/test_rest_v2_0_0.py
@@ -378,7 +378,7 @@ class TestApi(unittest.TestCase):
             self.assertEqual(r.status_code, 200, r.text)
             objs = json.loads(r.text)
             self.assertIn(type(objs), (list,))
-            # There should be only one offical image
+            # There should be only one official image
             self.assertEqual(len(objs), 1)
 
         def do_search4():

--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -114,7 +114,7 @@ load helpers
 @test "podman stop - unlock while waiting for timeout" {
     # Test that the container state transitions to "stopping" and that other
     # commands can get the container's lock.  To do that, run a container that
-    # ingores SIGTERM such that the Podman would wait 20 seconds for the stop
+    # ignores SIGTERM such that the Podman would wait 20 seconds for the stop
     # to finish.  This gives us enough time to try some commands and inspect
     # the container's status.
 

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -354,7 +354,7 @@ Cmd[1]             | $s_echo
 WorkingDir         | $workdir
 Labels.$label_name | $label_value
 "
-    # FIXME: 2021-02-24: Fixed in buildah #3036; reenable this once podman
+    # FIXME: 2021-02-24: Fixed in buildah #3036; re-enable this once podman
     #        vendors in a newer buildah!
     # Labels.\"io.buildah.version\" | $buildah_version
 

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats   -*- bats -*-
+# shellcheck disable=SC2096
+#
+# Tests for podman build
+#
+
+load helpers
+
+@test "podman --group-add keep-groups while in a userns" {
+    skip_if_rootless "choot is not allowed in rootless mode"
+    skip_if_remote "--group-add keep-groups not supported in remote mode"
+    run chroot --groups 1234 / ${PODMAN} run --uidmap 0:200000:5000 --group-add keep-groups $IMAGE id
+    is "$output" ".*65534(nobody)" "Check group leaked into user namespace"
+}
+
+@test "podman --group-add keep-groups while not in a userns" {
+    skip_if_rootless "choot is not allowed in rootless mode"
+    skip_if_remote "--group-add keep-groups not supported in remote mode"
+    run chroot --groups 1234,5678 / ${PODMAN} run --group-add keep-groups $IMAGE id
+    is "$output" ".*1234" "Check group leaked into container"
+}
+
+@test "podman --group-add without keep-groups while in a userns" {
+    skip_if_rootless "choot is not allowed in rootless mode"
+    skip_if_remote "--group-add keep-groups not supported in remote mode"
+    run chroot --groups 1234,5678 / ${PODMAN} run --uidmap 0:200000:5000 --group-add 457 $IMAGE id
+    is "$output" ".*457" "Check group leaked into container"
+}
+
+@test "podman --remote --group-add keep-groups " {
+    if is_remote; then
+        run_podman 125 run --group-add keep-groups $IMAGE id
+        is "$output" ".*not supported in remote mode" "Remote check --group-add keep-groups"
+    fi
+}
+
+@test "podman --group-add without keep-groups " {
+    run_podman run --group-add 457 $IMAGE id
+    is "$output" ".*457" "Check group leaked into container"
+}
+
+@test "podman --group-add keep-groups plus added groups " {
+    run_podman 125 run --group-add keep-groups --group-add 457 $IMAGE id
+    is "$output" ".*the '--group-add keep-groups' option is not allowed with any other --group-add options" "Check group leaked into container"
+}


### PR DESCRIPTION
Currently we have rootless users who want to leak their groups access
into containers, but this group access is only able to be pushed in by
a hard to find OCI Runtime annotation.  This PR makes this option a lot
more visable and hides the complexity within the podman client.

This option is only really needed for local rootless users. It makes
no sense for remote clients, and probably makes little sense for
rootfull containers.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
