### PR TITLE
Network connect error if net mode is not bridge

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1134,6 +1134,11 @@ func (w *logrusDebugWriter) Write(p []byte) (int, error) {
 
 // NetworkDisconnect removes a container from the network
 func (c *Container) NetworkDisconnect(nameOrID, netName string, force bool) error {
+	// only the bridge mode supports cni networks
+	if !c.config.NetMode.IsBridge() {
+		return errors.Errorf("network mode %q is not supported", c.config.NetMode)
+	}
+
 	networks, err := c.networksByNameIndex()
 	if err != nil {
 		return err
@@ -1190,6 +1195,11 @@ func (c *Container) NetworkDisconnect(nameOrID, netName string, force bool) erro
 
 // ConnectNetwork connects a container to a given network
 func (c *Container) NetworkConnect(nameOrID, netName string, aliases []string) error {
+	// only the bridge mode supports cni networks
+	if !c.config.NetMode.IsBridge() {
+		return errors.Errorf("network mode %q is not supported", c.config.NetMode)
+	}
+
 	networks, err := c.networksByNameIndex()
 	if err != nil {
 		return err

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -37,7 +37,6 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		dis := podmanTest.Podman([]string{"network", "disconnect", "foobar", "test"})
 		dis.WaitWithDefaultTimeout()
 		Expect(dis.ExitCode()).ToNot(BeZero())
-
 	})
 
 	It("bad container name in network disconnect should result in error", func() {
@@ -51,7 +50,25 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		dis := podmanTest.Podman([]string{"network", "disconnect", netName, "foobar"})
 		dis.WaitWithDefaultTimeout()
 		Expect(dis.ExitCode()).ToNot(BeZero())
+	})
 
+	It("network disconnect with net mode slirp4netns should result in error", func() {
+		SkipIfRootless("network connect and disconnect are only rootful")
+		netName := "slirp" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		session = podmanTest.Podman([]string{"create", "--name", "test", "--network", "slirp4netns", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		con := podmanTest.Podman([]string{"network", "disconnect", netName, "test"})
+		con.WaitWithDefaultTimeout()
+		Expect(con.ExitCode()).ToNot(BeZero())
+		Expect(con.ErrorToString()).To(ContainSubstring(`network mode "slirp4netns" is not supported`))
 	})
 
 	It("podman network disconnect", func() {
@@ -89,7 +106,6 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		dis := podmanTest.Podman([]string{"network", "connect", "foobar", "test"})
 		dis.WaitWithDefaultTimeout()
 		Expect(dis.ExitCode()).ToNot(BeZero())
-
 	})
 
 	It("bad container name in network connect should result in error", func() {
@@ -103,7 +119,25 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		dis := podmanTest.Podman([]string{"network", "connect", netName, "foobar"})
 		dis.WaitWithDefaultTimeout()
 		Expect(dis.ExitCode()).ToNot(BeZero())
+	})
 
+	It("network connect with net mode slirp4netns should result in error", func() {
+		SkipIfRootless("network connect and disconnect are only rootful")
+		netName := "slirp" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", netName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		session = podmanTest.Podman([]string{"create", "--name", "test", "--network", "slirp4netns", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+		defer podmanTest.removeCNINetwork(netName)
+
+		con := podmanTest.Podman([]string{"network", "connect", netName, "test"})
+		con.WaitWithDefaultTimeout()
+		Expect(con.ExitCode()).ToNot(BeZero())
+		Expect(con.ErrorToString()).To(ContainSubstring(`network mode "slirp4netns" is not supported`))
 	})
 
 	It("podman connect on a container that already is connected to the network should error", func() {


### PR DESCRIPTION
Only the the network mode bridge supports cni networks.
Other network modes cannot use network connect/disconnect
so we should throw a error.

Fixes #9496

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
