### PR TITLE
[CI:DOCS] swagger: removes the schema type for PodSpecGenerator $ref

### DIFF
--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -36,7 +36,6 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   name: create
 	//   description: attributes for creating a pod
 	//   schema:
-	//     type: object
 	//     $ref: "#/definitions/PodSpecGenerator"
 	// responses:
 	//   200:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
