### PR TITLE
Fix parsing of Tmpfs field in compat create

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -311,6 +311,15 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		netInfo.CNINetworks = []string{string(cc.HostConfig.NetworkMode)}
 	}
 
+	parsedTmp := make([]string, 0, len(cc.HostConfig.Tmpfs))
+	for path, options := range cc.HostConfig.Tmpfs {
+		finalString := path
+		if options != "" {
+			finalString += ":" + options
+		}
+		parsedTmp = append(parsedTmp, finalString)
+	}
+
 	// Note: several options here are marked as "don't need". this is based
 	// on speculation by Matt and I. We think that these come into play later
 	// like with start. We believe this is just a difference in podman/compat
@@ -367,7 +376,7 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		StorageOpt:       stringMaptoArray(cc.HostConfig.StorageOpt),
 		Sysctl:           stringMaptoArray(cc.HostConfig.Sysctls),
 		Systemd:          "true", // podman default
-		TmpFS:            stringMaptoArray(cc.HostConfig.Tmpfs),
+		TmpFS:            parsedTmp,
 		TTY:              cc.Config.Tty,
 		User:             cc.Config.User,
 		UserNS:           string(cc.HostConfig.UsernsMode),

--- a/test/apiv2/44-mounts.at
+++ b/test/apiv2/44-mounts.at
@@ -1,0 +1,21 @@
+# -*- sh -*-
+
+podman pull $IMAGE &>/dev/null
+
+# Test various HostConfig options
+tmpfs_name="/mytmpfs"
+t POST containers/create?name=hostconfig_test '"Image":"'$IMAGE'","Cmd":["df"],"HostConfig":{"TmpFs":{"'$tmpfs_name'":"rw"}}' 201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+
+# Prior to #9512, the tmpfs would be called '/mytmpfs=rw', with the '=rw'
+t GET containers/${cid}/json 200 \
+  .HostConfig.Tmpfs[\"${tmpfs_name}\"]~rw,
+
+# Run the container, verify output
+t POST containers/${cid}/start '' 204
+t POST containers/${cid}/wait  '' 200
+t GET  containers/${cid}/logs?stdout=true  200
+
+like "$(<$WORKDIR/curl.result.out)" ".* ${tmpfs_name}" \
+     "'df' output includes tmpfs name"


### PR DESCRIPTION
Create is not formatted as `key=value` but rather `key:value` (technically `path:option1,option2`). As such we can't use the stringMapToArray function, and instead need to generate it manually.

Fixes #9511
