### PR TITLE
[Compat API] Also print successfully tagging images in /build endpoint

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -395,6 +395,13 @@ loop:
 						logrus.Warnf("Failed to json encode error %v", err)
 					}
 					flush()
+					for _, tag := range query.Tag {
+						m.Stream = fmt.Sprintf("Successfully tagged %s\n", tag)
+						if err := enc.Encode(m); err != nil {
+							logrus.Warnf("Failed to json encode error %v", err)
+						}
+						flush()
+					}
 				}
 			}
 			break loop

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -652,6 +652,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//           example: |
 	//             (build details...)
 	//             Successfully built 8ba084515c724cbf90d447a63600c0a6
+	//             Successfully tagged your_image:latest
 	//   400:
 	//     $ref: "#/responses/BadParamError"
 	//   500:
@@ -1485,7 +1486,6 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//           description: output from build process
 	//           example: |
 	//             (build details...)
-	//             Successfully built 8ba084515c724cbf90d447a63600c0a6
 	//   400:
 	//     $ref: "#/responses/BadParamError"
 	//   500:


### PR DESCRIPTION
Trying to find regressions by exercising the APIv2 trough [docker-py](https://github.com/docker/docker-py)'s test suite (see #5386) I came across a bug in the [`BuildTest::test_build_in_context_dockerfile`](https://github.com/docker/docker-py/blob/master/tests/integration/api_build_test.py#494) test (there're a few tests failing because of the same issue).

There're several tests that check for Docker's "summary lines" (e.g. "Successfully ...") in the output stream of the /build endpoint.

Example output from Docker's /build endpoint:
```
{"stream":"Step 1/4 : FROM busybox"}
{"stream":"\n"}
{"stream":" ---\u003e 491198851f0c\n"}
{"stream":"Step 2/4 : ENV FOO=bar"}
{"stream":"\n"}
{"stream":" ---\u003e Using cache\n"}
{"stream":" ---\u003e d8a2bf82d287\n"}
{"stream":"Step 3/4 : RUN touch baz"}
{"stream":"\n"}
{"stream":" ---\u003e Using cache\n"}
{"stream":" ---\u003e bd627c1ed937\n"}
{"stream":"Step 4/4 : RUN touch bax"}
{"stream":"\n"}
{"stream":" ---\u003e Using cache\n"}
{"stream":" ---\u003e 18cabba43a7d\n"}
{"aux":{"ID":"sha256:18cabba43a7d7523a29f4a1f63e4c5796930e301f01b4b013bacb13ecfd597a8"}}
{"stream":"Successfully built 18cabba43a7d\n"}
{"stream":"Successfully tagged docker_compat_test:latest\n"}

```

Building the same container with Podman:
```
{"stream":"STEP 1: FROM busybox\n"}
{"stream":"STEP 2: ENV FOO=bar\n"}
{"stream":"STEP 3: RUN touch baz\n"}
{"stream":"STEP 4: RUN touch bax\n"}
{"stream":"STEP 5: COMMIT docker_compat_test\n"}
{"stream":"Getting image source signatures\n"}
{"stream":"Copying blob sha256:84009204da3f70b09d2be3914e12844ae9db893aa85ef95df83604f95df05187\n"}
{"stream":"Copying blob sha256:087b0e9db0ecf766354b7c48d7ca9ae9ab93843fd97dcfc51c1685443536ec26\n"}
{"stream":"Copying config sha256:4d3709bf17edc199ce3999904a2fa050dad849d4a75e1e6e2061c8d8ccf6d046\n"}
{"stream":"Writing manifest to image destination\n"}
{"stream":"Storing signatures\n"}
{"stream":"--\u003e 4d3709bf17e\n"}
{"stream":"4d3709bf17edc199ce3999904a2fa050dad849d4a75e1e6e2061c8d8ccf6d046\n"}
{"stream":"Successfully built 4d3709bf17ed\n"}

```

Note that the current code already mimics Docker's behavior by additionally sending the "Successfully built ..." line when using the compat API.
This PR "superficially" improves compatibility with Docker by also adding the "Successfully tagged ..." messages.

