### PR TITLE
Enable no_hosts from containers.conf

### DIFF
--- a/cmd/podman/common/netflags.go
+++ b/cmd/podman/common/netflags.go
@@ -80,7 +80,7 @@ func DefineNetFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(publishFlagName, completion.AutocompleteNone)
 
 	netFlags.Bool(
-		"no-hosts", false,
+		"no-hosts", containerConfig.Containers.NoHosts,
 		"Do not create /etc/hosts within the container, instead use the version from the image",
 	)
 }

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -166,7 +166,11 @@ func createInit(c *cobra.Command) error {
 		return errors.Errorf("--cpu-quota and --cpus cannot be set together")
 	}
 
-	if c.Flag("no-hosts").Changed && c.Flag("add-host").Changed {
+	noHosts, err := c.Flags().GetBool("no-hosts")
+	if err != nil {
+		return err
+	}
+	if noHosts && c.Flag("add-host").Changed {
 		return errors.Errorf("--no-hosts and --add-host cannot be set together")
 	}
 	cliVals.UserNS = c.Flag("userns").Value.String()

--- a/test/e2e/config/containers.conf
+++ b/test/e2e/config/containers.conf
@@ -55,6 +55,7 @@ umask = "0002"
 
 annotations=["run.oci.keep_original_groups=1",]
 
+no_hosts=true
 [engine]
 
 network_cmd_options=["allow_host_loopback=true"]


### PR DESCRIPTION
Since we have no good way to enable this on the server side, we will
just allow it to be set on the client side. This should solve almost all
cases.

Partially fixes: https://github.com/containers/podman/issues/9500

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
