### PR TITLE
[CI:DOCS] podman-image-sign.1.md: typo fix

### DIFF
--- a/docs/source/markdown/podman-image-sign.1.md
+++ b/docs/source/markdown/podman-image-sign.1.md
@@ -37,7 +37,7 @@ Store the signatures in the specified directory.  Default: /var/lib/containers/s
 Override the default identity of the signature.
 
 ## EXAMPLES
-Sign the busybox image with the identify of foo@bar.com with a user's keyring and save the signature in /tmp/signatures/.
+Sign the busybox image with the identity of foo@bar.com with a user's keyring and save the signature in /tmp/signatures/.
 
    sudo podman image sign --sign-by foo@bar.com --directory /tmp/signatures docker://privateregistry.example.com/foobar
 


### PR DESCRIPTION
identify -> identity