### PR TITLE
[v1.6.4-rhel] Fix RHBZ#1930552

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1107,7 +1107,7 @@ func prepareProcessExec(c *Container, cmd, env []string, tty bool, cwd, user, se
 	pspec.Capabilities.Effective = []string{}
 	if privileged {
 		pspec.Capabilities.Bounding = allCaps
-	} else {
+	} else if execUser.Uid != 0 {
 		pspec.Capabilities.Bounding = []string{}
 	}
 	pspec.Capabilities.Inheritable = pspec.Capabilities.Bounding


### PR DESCRIPTION
We were dropping too many capabilities in our earlier CVE fix patch to v1.6. Fortunately, easy to resolve.