### PR TITLE
Support label type dict on compat build

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -221,9 +221,17 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	// convert label formats
 	var labels = []string{}
 	if _, found := r.URL.Query()["labels"]; found {
-		if err := json.Unmarshal([]byte(query.Labels), &labels); err != nil {
-			utils.BadRequest(w, "labels", query.Labels, err)
-			return
+		makeLabels := make(map[string]string)
+		err := json.Unmarshal([]byte(query.Labels), &makeLabels)
+		if err == nil {
+			for k, v := range makeLabels {
+				labels = append(labels, k+"="+v)
+			}
+		} else {
+			if err := json.Unmarshal([]byte(query.Labels), &labels); err != nil {
+				utils.BadRequest(w, "labels", query.Labels, err)
+				return
+			}
 		}
 	}
 	jobs := 1

--- a/test/python/docker/build_labels/Dockerfile
+++ b/test/python/docker/build_labels/Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/libpod/alpine:latest

--- a/test/python/docker/compat/test_images.py
+++ b/test/python/docker/compat/test_images.py
@@ -149,6 +149,14 @@ class TestImages(unittest.TestCase):
 
         self.assertEqual(len(self.client.images.list()), 2)
 
+    def test_build_image(self):
+        labels = {"apple": "red", "grape": "green"}
+        _ = self.client.images.build(path="test/python/docker/build_labels", labels=labels, tag="labels")
+        image = self.client.images.get("labels")
+        self.assertEqual(image.labels["apple"], labels["apple"])
+        self.assertEqual(image.labels["grape"], labels["grape"])
+
+
 
 if __name__ == "__main__":
     # Setup temporary space


### PR DESCRIPTION
The compatibility endpoint for build labels should be of type dict (not
list).  For backwards compatibility, we support both.

Fixes: #9517

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
