### PR TITLE
[ci:docs] podman-system-service.1.md: fix timeout example

### DIFF
--- a/docs/source/markdown/podman-system-service.1.md
+++ b/docs/source/markdown/podman-system-service.1.md
@@ -34,7 +34,7 @@ Print usage statement.
 
 Run an API listening for 5 seconds using the default socket.
 ```
-podman system service --timeout 5000
+podman system service --time 5
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
The rest of this document claims that the argument is called '--time',
not '--timeout', and that the value is expressed in seconds. As
currently written, the example (which ostensibly runs the API service
for 5 seconds) uses the '--timeout' spelling (which actually does work,
as an undocumented alias) and passes a value of '5000', which is more
than an hour. Fix both.

[NO TESTS NEEDED] as this is a simple documentation change.

Signed-off-by: Will Thompson <wjt@endlessos.org>
