### PR TITLE
Fix support for podman build --timestamp

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -509,6 +509,11 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		TransientMounts:         flags.Volumes,
 	}
 
+	if c.Flag("timestamp").Changed {
+		timestamp := time.Unix(flags.Timestamp, 0).UTC()
+		opts.Timestamp = &timestamp
+	}
+
 	return &entities.BuildOptions{BuildOptions: opts}, nil
 }
 

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -104,6 +104,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		Squash      bool     `schema:"squash"`
 		Tag         []string `schema:"t"`
 		Target      string   `schema:"target"`
+		Timestamp   int64    `schema:"timestamp"`
 	}{
 		Dockerfile: "Dockerfile",
 		Registry:   "docker.io",
@@ -316,6 +317,11 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			DockerAuthConfig: creds,
 		},
 		Target: query.Target,
+	}
+
+	if _, found := r.URL.Query()["timestamp"]; found {
+		ts := time.Unix(query.Timestamp, 0)
+		buildOptions.Timestamp = &ts
 	}
 
 	runCtx, cancel := context.WithCancel(context.Background())

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -185,6 +185,12 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 	if options.Squash {
 		params.Set("squash", "1")
 	}
+
+	if options.Timestamp != nil {
+		t := *options.Timestamp
+		params.Set("timestamp", strconv.FormatInt(t.Unix(), 10))
+	}
+
 	var (
 		headers map[string]string
 		err     error

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -532,4 +532,20 @@ RUN grep CapEff /proc/self/status`
 		// Then
 		Expect(session.ExitCode()).To(Equal(125))
 	})
+
+	It("podman build --timestamp flag", func() {
+		containerfile := `FROM quay.io/libpod/alpine:latest
+RUN echo hello`
+
+		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
+		err := ioutil.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		Expect(err).To(BeNil())
+		session := podmanTest.Podman([]string{"build", "-t", "test", "--timestamp", "0", "--file", containerfilePath, podmanTest.TempDir})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"image", "inspect", "--format", "{{ .Created }}", "test"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.OutputToString()).To(Equal("1970-01-01 00:00:00 +0000 UTC"))
+	})
 })


### PR DESCRIPTION
Currently podman is ignoreing the build --timestamp flag.
This PR fixes this for local and remote clients.

Fixes: https://github.com/containers/podman/issues/9569

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
