### PR TITLE
Add network summary to compat ps

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -321,6 +321,19 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 			Type:        portMapping.Protocol,
 		}
 	}
+	inspect, err := l.Inspect(false)
+	if err != nil {
+		return nil, err
+	}
+
+	n, err := json.Marshal(inspect.NetworkSettings)
+	if err != nil {
+		return nil, err
+	}
+	networkSettings := types.SummaryNetworkSettings{}
+	if err := json.Unmarshal(n, &networkSettings); err != nil {
+		return nil, err
+	}
 
 	return &handlers.Container{Container: types.Container{
 		ID:         l.ID(),
@@ -339,7 +352,7 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 			NetworkMode string `json:",omitempty"`
 		}{
 			"host"},
-		NetworkSettings: nil,
+		NetworkSettings: &networkSettings,
 		Mounts:          nil,
 	},
 		ContainerCreateConfig: types.ContainerCreateConfig{},

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -31,6 +31,13 @@ t GET libpod/containers/json?all=true 200 \
   .[0].ExitCode=0 \
   .[0].IsInfra=false
 
+# Test compat API for Network Settings
+t GET /containers/json?all=true 200 \
+  length=1 \
+  .[0].Id~[0-9a-f]\\{64\\} \
+  .[0].Image=$IMAGE \
+  .[0].NetworkSettings.Networks.podman.NetworkID=podman
+
 # Make sure `limit` works.
 t GET libpod/containers/json?limit=1 200 \
   length=1 \


### PR DESCRIPTION
The compatibility endpoint for listing containers should have the
summarized network configuration with it.

Fixes: #9529

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
