### PR TITLE
Add version field to secret compat list/inspect api

### DIFF
--- a/pkg/api/server/register_secrets.go
+++ b/pkg/api/server/register_secrets.go
@@ -115,7 +115,7 @@ func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
 	// parameters:
 	// responses:
 	//   '200':
-	//     "$ref": "#/responses/SecretListResponse"
+	//     "$ref": "#/responses/SecretListCompatResponse"
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/secrets"), s.APIHandler(compat.ListSecrets)).Methods(http.MethodGet)
@@ -158,7 +158,7 @@ func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
 	// - application/json
 	// responses:
 	//   '200':
-	//     "$ref": "#/responses/SecretInspectResponse"
+	//     "$ref": "#/responses/SecretInspectCompatResponse"
 	//   '404':
 	//     "$ref": "#/responses/NoSuchSecret"
 	//   '500':

--- a/pkg/domain/entities/secrets.go
+++ b/pkg/domain/entities/secrets.go
@@ -42,6 +42,15 @@ type SecretInfoReport struct {
 	Spec      SecretSpec
 }
 
+type SecretInfoReportCompat struct {
+	SecretInfoReport
+	Version SecretVersion
+}
+
+type SecretVersion struct {
+	Index int
+}
+
 type SecretSpec struct {
 	Name   string
 	Driver SecretDriverSpec
@@ -78,11 +87,25 @@ type SwagSecretListResponse struct {
 	Body []*SecretInfoReport
 }
 
+// Secret list response
+// swagger:response SecretListCompatResponse
+type SwagSecretListCompatResponse struct {
+	// in:body
+	Body []*SecretInfoReportCompat
+}
+
 // Secret inspect response
 // swagger:response SecretInspectResponse
 type SwagSecretInspectResponse struct {
 	// in:body
 	Body SecretInfoReport
+}
+
+// Secret inspect compat
+// swagger:response SecretInspectCompatResponse
+type SwagSecretInspectCompatResponse struct {
+	// in:body
+	Body SecretInfoReportCompat
 }
 
 // No such secret

--- a/test/apiv2/50-secrets.at
+++ b/test/apiv2/50-secrets.at
@@ -14,15 +14,18 @@ t POST secrets/create '"Name":"mysecret","Data":"c2VjcmV0","Labels":{"fail":"fai
 t POST secrets/create '"Name":"mysecret","Data":"c2VjcmV0"' 409
 
 # secret inspect
-t GET secrets/mysecret 200\
-    .Spec.Name=mysecret
+t GET secrets/mysecret 200 \
+    .Spec.Name=mysecret \
+    .Version.Index=1
 
 # secret inspect non-existent secret
 t GET secrets/bogus 404
 
 # secret list
-t GET secrets 200\
-    length=1
+t GET secrets 200 \
+    length=1 \
+    .[0].Spec.Name=mysecret \
+    .[0].Version.Index=1
 
 # secret list unsupported filters
 t GET secrets?filters='{"name":["foo1"]}' 400


### PR DESCRIPTION
Docker api expects secrets endpoint to have a version field. So, the
version field is added into the compat endpoint only. The version field
is always 1, since Docker uses the version to keep track of updates to
the secret, and currently we cannot update a secret.

Signed-off-by: Ashley Cui <acui@redhat.com>

Closes https://github.com/containers/podman/issues/9316

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
