### PR TITLE
libpod: Apply SELinux KVM label if process contains "kata" in its name

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -467,7 +467,7 @@ func (c *Container) setupStorage(ctx context.Context) error {
 
 	processLabel := containerInfo.ProcessLabel
 	switch {
-	case c.ociRuntime.SupportsKVM():
+	case c.ociRuntime.SupportsKVM(), strings.Contains(strings.ToLower(filepath.Base(c.ociRuntime.Path())), "kata"):
 		processLabel, err = selinux.KVMLabel(processLabel)
 		if err != nil {
 			return err


### PR DESCRIPTION
We currently only apply the label when the user calls `podman --runtime
kata ...`, which may not happen in several different cases, including
testing binaries which are not part of the PATH.

In order to avoid forcing the user to pass `--security-opt
label=type:...`, let's follow a similar logic than the one implemented
on the CRI-O side and apply the KVM label to the processes in case the
runtime binary contains "kata" as part of its name.

Fixes: #9582

Signed-off-by: Fabiano Fidêncio <fabiano@fidencio.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
