### PR TITLE
Numerous buildah fixes found by Ed's testing of buildah tests against podman.

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -318,7 +318,12 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 			if len(av) > 1 {
 				args[av[0]] = av[1]
 			} else {
-				delete(args, av[0])
+				// check if the env is set in the local environment and use that value if it is
+				if val, present := os.LookupEnv(av[0]); present {
+					args[av[0]] = val
+				} else {
+					delete(args, av[0])
+				}
 			}
 		}
 	}

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -259,7 +259,7 @@ solely for scripting compatibility.
 
 #### **--dns**=*dns*
 
-Set custom DNS servers
+Set custom DNS servers to be used during the build.
 
 This option can be used to override the DNS configuration passed to the
 container. Typically this is necessary when the host DNS configuration is
@@ -272,11 +272,11 @@ image will be used without changes.
 
 #### **--dns-option**=*option*
 
-Set custom DNS options
+Set custom DNS options to be used during the build.
 
 #### **--dns-search**=*domain*
 
-Set custom DNS search domains
+Set custom DNS search domains to be used during the build.
 
 #### **--file**, **-f**=*Containerfile*
 

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -77,6 +77,9 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		Devices                string `schema:"devices"`
 		Dockerfile             string `schema:"dockerfile"`
 		DropCapabilities       string `schema:"dropcaps"`
+		DNSServers             string `schema:"dnsservers"`
+		DNSOptions             string `schema:"dnsoptions"`
+		DNSSearch              string `schema:"dnssearch"`
 		Excludes               string `schema:"excludes"`
 		ForceRm                bool   `schema:"forcerm"`
 		From                   string `schema:"from"`
@@ -158,6 +161,36 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		devices = m
+	}
+
+	var dnsservers = []string{}
+	if _, found := r.URL.Query()["dnsservers"]; found {
+		var m = []string{}
+		if err := json.Unmarshal([]byte(query.DNSServers), &m); err != nil {
+			utils.BadRequest(w, "dnsservers", query.DNSServers, err)
+			return
+		}
+		dnsservers = m
+	}
+
+	var dnsoptions = []string{}
+	if _, found := r.URL.Query()["dnsoptions"]; found {
+		var m = []string{}
+		if err := json.Unmarshal([]byte(query.DNSOptions), &m); err != nil {
+			utils.BadRequest(w, "dnsoptions", query.DNSOptions, err)
+			return
+		}
+		dnsoptions = m
+	}
+
+	var dnssearch = []string{}
+	if _, found := r.URL.Query()["dnssearch"]; found {
+		var m = []string{}
+		if err := json.Unmarshal([]byte(query.DNSSearch), &m); err != nil {
+			utils.BadRequest(w, "dnssearches", query.DNSSearch, err)
+			return
+		}
+		dnssearch = m
 	}
 
 	var output string
@@ -285,6 +318,9 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			CPUQuota:   query.CpuQuota,
 			CPUShares:  query.CpuShares,
 			CPUSetCPUs: query.CpuSetCpus,
+			DNSServers: dnsservers,
+			DNSOptions: dnsoptions,
+			DNSSearch:  dnssearch,
 			HTTPProxy:  query.HTTPProxy,
 			Memory:     query.Memory,
 			MemorySwap: query.MemSwap,

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -87,6 +87,28 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		params.Add("devices", d)
 	}
 
+	if dnsservers := options.CommonBuildOpts.DNSServers; len(dnsservers) > 0 {
+		c, err := jsoniter.MarshalToString(dnsservers)
+		if err != nil {
+			return nil, err
+		}
+		params.Add("dnsservers", c)
+	}
+	if dnsoptions := options.CommonBuildOpts.DNSOptions; len(dnsoptions) > 0 {
+		c, err := jsoniter.MarshalToString(dnsoptions)
+		if err != nil {
+			return nil, err
+		}
+		params.Add("dnsoptions", c)
+	}
+	if dnssearch := options.CommonBuildOpts.DNSSearch; len(dnssearch) > 0 {
+		c, err := jsoniter.MarshalToString(dnssearch)
+		if err != nil {
+			return nil, err
+		}
+		params.Add("dnssearch", c)
+	}
+
 	if caps := options.DropCapabilities; len(caps) > 0 {
 		c, err := jsoniter.MarshalToString(caps)
 		if err != nil {


### PR DESCRIPTION
Add support for podman build --ignorefile
podman build --build-arg should fall back to environment
Handle podman build --dns-search
Fix podman build --pull-never
