### PR TITLE
podman cp: support copying on tmpfs mounts

### DIFF
--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -189,8 +189,9 @@ func copyFromContainer(container string, containerPath string, hostPath string) 
 		}
 
 		putOptions := buildahCopiah.PutOptions{
-			ChownDirs:  &idPair,
-			ChownFiles: &idPair,
+			ChownDirs:     &idPair,
+			ChownFiles:    &idPair,
+			IgnoreDevices: true,
 		}
 		if !containerInfo.IsDir && (!hostInfo.IsDir || hostInfoErr != nil) {
 			// If we're having a file-to-file copy, make sure to

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -904,6 +904,12 @@ func (c *Container) NamespacePath(linuxNS LinuxNS) (string, error) { //nolint:in
 		}
 	}
 
+	return c.namespacePath(linuxNS)
+}
+
+// namespacePath returns the path of one of the container's namespaces
+// If the container is not running, an error will be returned
+func (c *Container) namespacePath(linuxNS LinuxNS) (string, error) { //nolint:interfacer
 	if c.state.State != define.ContainerStateRunning && c.state.State != define.ContainerStatePaused {
 		return "", errors.Wrapf(define.ErrCtrStopped, "cannot get namespace path unless container %s is running", c.ID())
 	}

--- a/libpod/container_copy_linux.go
+++ b/libpod/container_copy_linux.go
@@ -1,0 +1,266 @@
+// +build linux
+
+package libpod
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	buildahCopiah "github.com/containers/buildah/copier"
+	"github.com/containers/buildah/pkg/chrootuser"
+	"github.com/containers/buildah/util"
+	"github.com/containers/podman/v3/libpod/define"
+	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+func (c *Container) copyFromArchive(ctx context.Context, path string, reader io.Reader) (func() error, error) {
+	var (
+		mountPoint   string
+		resolvedRoot string
+		resolvedPath string
+		unmount      func()
+		err          error
+	)
+
+	// Make sure that "/" copies the *contents* of the mount point and not
+	// the directory.
+	if path == "/" {
+		path = "/."
+	}
+
+	// Optimization: only mount if the container is not already.
+	if c.state.Mounted {
+		mountPoint = c.state.Mountpoint
+		unmount = func() {}
+	} else {
+		// NOTE: make sure to unmount in error paths.
+		mountPoint, err = c.mount()
+		if err != nil {
+			return nil, err
+		}
+		unmount = func() { c.unmount(false) }
+	}
+
+	if c.state.State == define.ContainerStateRunning {
+		resolvedRoot = "/"
+		resolvedPath = c.pathAbs(path)
+	} else {
+		resolvedRoot, resolvedPath, err = c.resolvePath(mountPoint, path)
+		if err != nil {
+			unmount()
+			return nil, err
+		}
+	}
+
+	decompressed, err := archive.DecompressStream(reader)
+	if err != nil {
+		unmount()
+		return nil, err
+	}
+
+	idMappings, idPair, err := getIDMappingsAndPair(c, mountPoint)
+	if err != nil {
+		decompressed.Close()
+		unmount()
+		return nil, err
+	}
+
+	logrus.Debugf("Container copy *to* %q (resolved: %q) on container %q (ID: %s)", path, resolvedPath, c.Name(), c.ID())
+
+	return func() error {
+		defer unmount()
+		defer decompressed.Close()
+		putOptions := buildahCopiah.PutOptions{
+			UIDMap:     idMappings.UIDMap,
+			GIDMap:     idMappings.GIDMap,
+			ChownDirs:  idPair,
+			ChownFiles: idPair,
+		}
+
+		return c.joinMountAndExec(ctx,
+			func() error {
+				return buildahCopiah.Put(resolvedRoot, resolvedPath, putOptions, decompressed)
+			},
+		)
+	}, nil
+}
+
+func (c *Container) copyToArchive(ctx context.Context, path string, writer io.Writer) (func() error, error) {
+	var (
+		mountPoint string
+		unmount    func()
+		err        error
+	)
+
+	// Optimization: only mount if the container is not already.
+	if c.state.Mounted {
+		mountPoint = c.state.Mountpoint
+		unmount = func() {}
+	} else {
+		// NOTE: make sure to unmount in error paths.
+		mountPoint, err = c.mount()
+		if err != nil {
+			return nil, err
+		}
+		unmount = func() { c.unmount(false) }
+	}
+
+	statInfo, resolvedRoot, resolvedPath, err := c.stat(ctx, mountPoint, path)
+	if err != nil {
+		unmount()
+		return nil, err
+	}
+
+	idMappings, idPair, err := getIDMappingsAndPair(c, mountPoint)
+	if err != nil {
+		unmount()
+		return nil, err
+	}
+
+	logrus.Debugf("Container copy *from* %q (resolved: %q) on container %q (ID: %s)", path, resolvedPath, c.Name(), c.ID())
+
+	return func() error {
+		defer unmount()
+		getOptions := buildahCopiah.GetOptions{
+			// Unless the specified points to ".", we want to copy the base directory.
+			KeepDirectoryNames: statInfo.IsDir && filepath.Base(path) != ".",
+			UIDMap:             idMappings.UIDMap,
+			GIDMap:             idMappings.GIDMap,
+			ChownDirs:          idPair,
+			ChownFiles:         idPair,
+			Excludes:           []string{"dev", "proc", "sys"},
+		}
+		return c.joinMountAndExec(ctx,
+			func() error {
+				return buildahCopiah.Get(resolvedRoot, "", getOptions, []string{resolvedPath}, writer)
+			},
+		)
+	}, nil
+}
+
+// getIDMappingsAndPair returns the ID mappings for the container and the host
+// ID pair.
+func getIDMappingsAndPair(container *Container, containerMount string) (*storage.IDMappingOptions, *idtools.IDPair, error) {
+	user, err := getContainerUser(container, containerMount)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	idMappingOpts, err := container.IDMappings()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostUID, hostGID, err := util.GetHostIDs(idtoolsToRuntimeSpec(idMappingOpts.UIDMap), idtoolsToRuntimeSpec(idMappingOpts.GIDMap), user.UID, user.GID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	idPair := idtools.IDPair{UID: int(hostUID), GID: int(hostGID)}
+	return &idMappingOpts, &idPair, nil
+}
+
+// getContainerUser returns the specs.User of the container.
+func getContainerUser(container *Container, mountPoint string) (specs.User, error) {
+	userspec := container.Config().User
+
+	uid, gid, _, err := chrootuser.GetUser(mountPoint, userspec)
+	u := specs.User{
+		UID:      uid,
+		GID:      gid,
+		Username: userspec,
+	}
+
+	if !strings.Contains(userspec, ":") {
+		groups, err2 := chrootuser.GetAdditionalGroupsForUser(mountPoint, uint64(u.UID))
+		if err2 != nil {
+			if errors.Cause(err2) != chrootuser.ErrNoSuchUser && err == nil {
+				err = err2
+			}
+		} else {
+			u.AdditionalGids = groups
+		}
+	}
+
+	return u, err
+}
+
+// idtoolsToRuntimeSpec converts idtools ID mapping to the one of the runtime spec.
+func idtoolsToRuntimeSpec(idMaps []idtools.IDMap) (convertedIDMap []specs.LinuxIDMapping) {
+	for _, idmap := range idMaps {
+		tempIDMap := specs.LinuxIDMapping{
+			ContainerID: uint32(idmap.ContainerID),
+			HostID:      uint32(idmap.HostID),
+			Size:        uint32(idmap.Size),
+		}
+		convertedIDMap = append(convertedIDMap, tempIDMap)
+	}
+	return convertedIDMap
+}
+
+// joinMountAndExec executes the specified function `f` inside the container's
+// mount and PID namespace.  That allows for having the exact view on the
+// container's file system.
+//
+// Note, if the container is not running `f()` will be executed as is.
+func (c *Container) joinMountAndExec(ctx context.Context, f func() error) error {
+	if c.state.State != define.ContainerStateRunning {
+		return f()
+	}
+
+	// Container's running, so we need to execute `f()` inside its mount NS.
+	errChan := make(chan error)
+	go func() {
+		runtime.LockOSThread()
+
+		// Join the mount and PID NS of the container.
+		getFD := func(ns LinuxNS) (*os.File, error) {
+			nsPath, err := c.namespacePath(ns)
+			if err != nil {
+				return nil, err
+			}
+			return os.Open(nsPath)
+		}
+
+		mountFD, err := getFD(MountNS)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		defer mountFD.Close()
+
+		pidFD, err := getFD(PIDNS)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		defer pidFD.Close()
+		if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
+			errChan <- err
+			return
+		}
+		if err := unix.Setns(int(pidFD.Fd()), unix.CLONE_NEWPID); err != nil {
+			errChan <- err
+			return
+		}
+
+		if err := unix.Setns(int(mountFD.Fd()), unix.CLONE_NEWNS); err != nil {
+			errChan <- err
+			return
+		}
+
+		// Last but not least, execute the workload.
+		errChan <- f()
+	}()
+	return <-errChan
+}

--- a/libpod/container_copy_unsupported.go
+++ b/libpod/container_copy_unsupported.go
@@ -1,0 +1,16 @@
+// +build !linux
+
+package libpod
+
+import (
+	"context"
+	"io"
+)
+
+func (c *Container) copyFromArchive(ctx context.Context, path string, reader io.Reader) (func() error, error) {
+	return nil, nil
+}
+
+func (c *Container) copyToArchive(ctx context.Context, path string, writer io.Writer) (func() error, error) {
+	return nil, nil
+}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -2086,6 +2086,10 @@ func (c *Container) setupOCIHooks(ctx context.Context, config *spec.Spec) (map[s
 
 // mount mounts the container's root filesystem
 func (c *Container) mount() (string, error) {
+	if c.state.State == define.ContainerStateRemoving {
+		return "", errors.Wrapf(define.ErrCtrStateInvalid, "cannot mount container %s as it is being removed", c.ID())
+	}
+
 	mountPoint, err := c.runtime.storageService.MountContainerImage(c.ID())
 	if err != nil {
 		return "", errors.Wrapf(err, "error mounting storage for container %s", c.ID())

--- a/libpod/container_stat_linux.go
+++ b/libpod/container_stat_linux.go
@@ -1,0 +1,157 @@
+// +build linux
+
+package libpod
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/buildah/copier"
+	"github.com/containers/podman/v3/libpod/define"
+	"github.com/containers/podman/v3/pkg/copy"
+	"github.com/pkg/errors"
+)
+
+// statInsideMount stats the specified path *inside* the container's mount and PID
+// namespace.  It returns the file info along with the resolved root ("/") and
+// the resolved path (relative to the root).
+func (c *Container) statInsideMount(ctx context.Context, containerPath string) (*copier.StatForItem, string, string, error) {
+	resolvedRoot := "/"
+	resolvedPath := c.pathAbs(containerPath)
+	var statInfo *copier.StatForItem
+
+	err := c.joinMountAndExec(ctx,
+		func() error {
+			var statErr error
+			statInfo, statErr = secureStat(resolvedRoot, resolvedPath)
+			return statErr
+		},
+	)
+
+	return statInfo, resolvedRoot, resolvedPath, err
+}
+
+// statOnHost stats the specified path *on the host*.  It returns the file info
+// along with the resolved root and the resolved path.  Both paths are absolute
+// to the host's root.  Note that the paths may resolved outside the
+// container's mount point (e.g., to a volume or bind mount).
+func (c *Container) statOnHost(ctx context.Context, mountPoint string, containerPath string) (*copier.StatForItem, string, string, error) {
+	// Now resolve the container's path.  It may hit a volume, it may hit a
+	// bind mount, it may be relative.
+	resolvedRoot, resolvedPath, err := c.resolvePath(mountPoint, containerPath)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	statInfo, err := secureStat(resolvedRoot, resolvedPath)
+	return statInfo, resolvedRoot, resolvedPath, err
+}
+
+func (c *Container) stat(ctx context.Context, containerMountPoint string, containerPath string) (*define.FileInfo, string, string, error) {
+	var (
+		resolvedRoot     string
+		resolvedPath     string
+		absContainerPath string
+		statInfo         *copier.StatForItem
+		statErr          error
+	)
+
+	// Make sure that "/" copies the *contents* of the mount point and not
+	// the directory.
+	if containerPath == "/" {
+		containerPath = "/."
+	}
+
+	if c.state.State == define.ContainerStateRunning {
+		// If the container is running, we need to join it's mount namespace
+		// and stat there.
+		statInfo, resolvedRoot, resolvedPath, statErr = c.statInsideMount(ctx, containerPath)
+	} else {
+		// If the container is NOT running, we need to resolve the path
+		// on the host.
+		statInfo, resolvedRoot, resolvedPath, statErr = c.statOnHost(ctx, containerMountPoint, containerPath)
+	}
+
+	if statErr != nil {
+		if statInfo == nil {
+			return nil, "", "", statErr
+		}
+		// Not all errors from secureStat map to ErrNotExist, so we
+		// have to look into the error string.  Turning it into an
+		// ENOENT let's the API handlers return the correct status code
+		// which is crucial for the remote client.
+		if os.IsNotExist(statErr) || strings.Contains(statErr.Error(), "o such file or directory") {
+			statErr = copy.ErrENOENT
+		}
+	}
+
+	if statInfo.IsSymlink {
+		// Evaluated symlinks are always relative to the container's mount point.
+		absContainerPath = statInfo.ImmediateTarget
+	} else if strings.HasPrefix(resolvedPath, containerMountPoint) {
+		// If the path is on the container's mount point, strip it off.
+		absContainerPath = strings.TrimPrefix(resolvedPath, containerMountPoint)
+		absContainerPath = filepath.Join("/", absContainerPath)
+	} else {
+		// No symlink and not on the container's mount point, so let's
+		// move it back to the original input.  It must have evaluated
+		// to a volume or bind mount but we cannot return host paths.
+		absContainerPath = containerPath
+	}
+
+	// Preserve the base path as specified by the user.  The `filepath`
+	// packages likes to remove trailing slashes and dots that are crucial
+	// to the copy logic.
+	absContainerPath = copy.PreserveBasePath(containerPath, absContainerPath)
+	resolvedPath = copy.PreserveBasePath(containerPath, resolvedPath)
+
+	info := &define.FileInfo{
+		IsDir:      statInfo.IsDir,
+		Name:       filepath.Base(absContainerPath),
+		Size:       statInfo.Size,
+		Mode:       statInfo.Mode,
+		ModTime:    statInfo.ModTime,
+		LinkTarget: absContainerPath,
+	}
+
+	return info, resolvedRoot, resolvedPath, statErr
+}
+
+// secureStat extracts file info for path in a chroot'ed environment in root.
+func secureStat(root string, path string) (*copier.StatForItem, error) {
+	var glob string
+	var err error
+
+	// If root and path are equal, then dir must be empty and the glob must
+	// be ".".
+	if filepath.Clean(root) == filepath.Clean(path) {
+		glob = "."
+	} else {
+		glob, err = filepath.Rel(root, path)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	globStats, err := copier.Stat(root, "", copier.StatOptions{}, []string{glob})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(globStats) != 1 {
+		return nil, errors.Errorf("internal error: secureStat: expected 1 item but got %d", len(globStats))
+	}
+
+	stat, exists := globStats[0].Results[glob] // only one glob passed, so that's okay
+	if !exists {
+		return nil, copy.ErrENOENT
+	}
+
+	var statErr error
+	if stat.Error != "" {
+		statErr = errors.New(stat.Error)
+	}
+	return stat, statErr
+}

--- a/libpod/container_stat_unsupported.go
+++ b/libpod/container_stat_unsupported.go
@@ -1,0 +1,13 @@
+// +build !linux
+
+package libpod
+
+import (
+	"context"
+
+	"github.com/containers/podman/v3/libpod/define"
+)
+
+func (c *Container) stat(ctx context.Context, containerMountPoint string, containerPath string) (*define.FileInfo, string, string, error) {
+	return nil, "", "", nil
+}

--- a/libpod/define/fileinfo.go
+++ b/libpod/define/fileinfo.go
@@ -1,0 +1,16 @@
+package define
+
+import (
+	"os"
+	"time"
+)
+
+// FileInfo describes the attributes of a file or diretory.
+type FileInfo struct {
+	Name       string      `json:"name"`
+	Size       int64       `json:"size"`
+	Mode       os.FileMode `json:"mode"`
+	ModTime    time.Time   `json:"mtime"`
+	IsDir      bool        `json:"isDir"`
+	LinkTarget string      `json:"linkTarget"`
+}

--- a/pkg/copy/fileinfo.go
+++ b/pkg/copy/fileinfo.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
+	"github.com/containers/podman/v3/libpod/define"
 	"github.com/pkg/errors"
 )
 
@@ -22,14 +22,7 @@ var ErrENOENT = errors.New("No such file or directory")
 
 // FileInfo describes a file or directory and is returned by
 // (*CopyItem).Stat().
-type FileInfo struct {
-	Name       string      `json:"name"`
-	Size       int64       `json:"size"`
-	Mode       os.FileMode `json:"mode"`
-	ModTime    time.Time   `json:"mtime"`
-	IsDir      bool        `json:"isDir"`
-	LinkTarget string      `json:"linkTarget"`
-}
+type FileInfo = define.FileInfo
 
 // EncodeFileInfo serializes the specified FileInfo as a base64 encoded JSON
 // payload.  Intended for Docker compat.

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v3/libpod/define"
-	"github.com/containers/podman/v3/pkg/copy"
 	"github.com/containers/podman/v3/pkg/specgen"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 )
@@ -145,7 +144,7 @@ type ContainerInspectReport struct {
 }
 
 type ContainerStatReport struct {
-	copy.FileInfo
+	define.FileInfo
 }
 
 type CommitOptions struct {

--- a/pkg/domain/infra/abi/archive.go
+++ b/pkg/domain/infra/abi/archive.go
@@ -3,72 +3,16 @@ package abi
 import (
 	"context"
 	"io"
-	"path/filepath"
-	"strings"
 
-	buildahCopiah "github.com/containers/buildah/copier"
-	"github.com/containers/buildah/pkg/chrootuser"
-	"github.com/containers/buildah/util"
-	"github.com/containers/podman/v3/libpod"
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/containers/storage"
-	"github.com/containers/storage/pkg/archive"
-	"github.com/containers/storage/pkg/idtools"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
-// NOTE: Only the parent directory of the container path must exist.  The path
-// itself may be created while copying.
 func (ic *ContainerEngine) ContainerCopyFromArchive(ctx context.Context, nameOrID string, containerPath string, reader io.Reader) (entities.ContainerCopyFunc, error) {
 	container, err := ic.Libpod.LookupContainer(nameOrID)
 	if err != nil {
 		return nil, err
 	}
-
-	containerMountPoint, err := container.Mount()
-	if err != nil {
-		return nil, err
-	}
-
-	unmount := func() {
-		if err := container.Unmount(false); err != nil {
-			logrus.Errorf("Error unmounting container: %v", err)
-		}
-	}
-
-	_, resolvedRoot, resolvedContainerPath, err := ic.containerStat(container, containerMountPoint, containerPath)
-	if err != nil {
-		unmount()
-		return nil, err
-	}
-
-	decompressed, err := archive.DecompressStream(reader)
-	if err != nil {
-		unmount()
-		return nil, err
-	}
-
-	idMappings, idPair, err := getIDMappingsAndPair(container, resolvedRoot)
-	if err != nil {
-		unmount()
-		return nil, err
-	}
-
-	logrus.Debugf("Container copy *to* %q (resolved: %q) on container %q (ID: %s)", containerPath, resolvedContainerPath, container.Name(), container.ID())
-
-	return func() error {
-		defer unmount()
-		defer decompressed.Close()
-		putOptions := buildahCopiah.PutOptions{
-			UIDMap:     idMappings.UIDMap,
-			GIDMap:     idMappings.GIDMap,
-			ChownDirs:  idPair,
-			ChownFiles: idPair,
-		}
-		return buildahCopiah.Put(resolvedRoot, resolvedContainerPath, putOptions, decompressed)
-	}, nil
+	return container.CopyFromArchive(ctx, containerPath, reader)
 }
 
 func (ic *ContainerEngine) ContainerCopyToArchive(ctx context.Context, nameOrID string, containerPath string, writer io.Writer) (entities.ContainerCopyFunc, error) {
@@ -76,108 +20,5 @@ func (ic *ContainerEngine) ContainerCopyToArchive(ctx context.Context, nameOrID 
 	if err != nil {
 		return nil, err
 	}
-
-	containerMountPoint, err := container.Mount()
-	if err != nil {
-		return nil, err
-	}
-
-	unmount := func() {
-		if err := container.Unmount(false); err != nil {
-			logrus.Errorf("Error unmounting container: %v", err)
-		}
-	}
-
-	// Make sure that "/" copies the *contents* of the mount point and not
-	// the directory.
-	if containerPath == "/" {
-		containerPath = "/."
-	}
-
-	statInfo, resolvedRoot, resolvedContainerPath, err := ic.containerStat(container, containerMountPoint, containerPath)
-	if err != nil {
-		unmount()
-		return nil, err
-	}
-
-	idMappings, idPair, err := getIDMappingsAndPair(container, resolvedRoot)
-	if err != nil {
-		unmount()
-		return nil, err
-	}
-
-	logrus.Debugf("Container copy *from* %q (resolved: %q) on container %q (ID: %s)", containerPath, resolvedContainerPath, container.Name(), container.ID())
-
-	return func() error {
-		defer container.Unmount(false)
-		getOptions := buildahCopiah.GetOptions{
-			// Unless the specified points to ".", we want to copy the base directory.
-			KeepDirectoryNames: statInfo.IsDir && filepath.Base(containerPath) != ".",
-			UIDMap:             idMappings.UIDMap,
-			GIDMap:             idMappings.GIDMap,
-			ChownDirs:          idPair,
-			ChownFiles:         idPair,
-		}
-		return buildahCopiah.Get(resolvedRoot, "", getOptions, []string{resolvedContainerPath}, writer)
-	}, nil
-}
-
-// getIDMappingsAndPair returns the ID mappings for the container and the host
-// ID pair.
-func getIDMappingsAndPair(container *libpod.Container, containerMount string) (*storage.IDMappingOptions, *idtools.IDPair, error) {
-	user, err := getContainerUser(container, containerMount)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	idMappingOpts, err := container.IDMappings()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	hostUID, hostGID, err := util.GetHostIDs(idtoolsToRuntimeSpec(idMappingOpts.UIDMap), idtoolsToRuntimeSpec(idMappingOpts.GIDMap), user.UID, user.GID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	idPair := idtools.IDPair{UID: int(hostUID), GID: int(hostGID)}
-	return &idMappingOpts, &idPair, nil
-}
-
-// getContainerUser returns the specs.User of the container.
-func getContainerUser(container *libpod.Container, mountPoint string) (specs.User, error) {
-	userspec := container.Config().User
-
-	uid, gid, _, err := chrootuser.GetUser(mountPoint, userspec)
-	u := specs.User{
-		UID:      uid,
-		GID:      gid,
-		Username: userspec,
-	}
-
-	if !strings.Contains(userspec, ":") {
-		groups, err2 := chrootuser.GetAdditionalGroupsForUser(mountPoint, uint64(u.UID))
-		if err2 != nil {
-			if errors.Cause(err2) != chrootuser.ErrNoSuchUser && err == nil {
-				err = err2
-			}
-		} else {
-			u.AdditionalGids = groups
-		}
-	}
-
-	return u, err
-}
-
-// idtoolsToRuntimeSpec converts idtools ID mapping to the one of the runtime spec.
-func idtoolsToRuntimeSpec(idMaps []idtools.IDMap) (convertedIDMap []specs.LinuxIDMapping) {
-	for _, idmap := range idMaps {
-		tempIDMap := specs.LinuxIDMapping{
-			ContainerID: uint32(idmap.ContainerID),
-			HostID:      uint32(idmap.HostID),
-			Size:        uint32(idmap.Size),
-		}
-		convertedIDMap = append(convertedIDMap, tempIDMap)
-	}
-	return convertedIDMap
+	return container.CopyToArchive(ctx, containerPath, writer)
 }

--- a/pkg/domain/infra/abi/containers_stat.go
+++ b/pkg/domain/infra/abi/containers_stat.go
@@ -2,84 +2,9 @@ package abi
 
 import (
 	"context"
-	"os"
-	"path/filepath"
-	"strings"
 
-	buildahCopiah "github.com/containers/buildah/copier"
-	"github.com/containers/podman/v3/libpod"
-	"github.com/containers/podman/v3/pkg/copy"
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
-
-func (ic *ContainerEngine) containerStat(container *libpod.Container, containerMountPoint string, containerPath string) (*entities.ContainerStatReport, string, string, error) {
-	// Make sure that "/" copies the *contents* of the mount point and not
-	// the directory.
-	if containerPath == "/" {
-		containerPath += "/."
-	}
-
-	// Now resolve the container's path.  It may hit a volume, it may hit a
-	// bind mount, it may be relative.
-	resolvedRoot, resolvedContainerPath, err := container.ResolvePath(context.Background(), containerMountPoint, containerPath)
-	if err != nil {
-		return nil, "", "", err
-	}
-
-	statInfo, statInfoErr := secureStat(resolvedRoot, resolvedContainerPath)
-	if statInfoErr != nil {
-		// Not all errors from secureStat map to ErrNotExist, so we
-		// have to look into the error string.  Turning it into an
-		// ENOENT let's the API handlers return the correct status code
-		// which is crucial for the remote client.
-		if os.IsNotExist(err) || strings.Contains(statInfoErr.Error(), "o such file or directory") {
-			statInfoErr = copy.ErrENOENT
-		}
-		//  If statInfo is nil, there's nothing we can do anymore.  A
-		//  non-nil statInfo may indicate a symlink where we must have
-		//  a closer look.
-		if statInfo == nil {
-			return nil, "", "", statInfoErr
-		}
-	}
-
-	// Now make sure that the info's LinkTarget is relative to the
-	// container's mount.
-	var absContainerPath string
-
-	if statInfo.IsSymlink {
-		// Evaluated symlinks are always relative to the container's mount point.
-		absContainerPath = statInfo.ImmediateTarget
-	} else if strings.HasPrefix(resolvedContainerPath, containerMountPoint) {
-		// If the path is on the container's mount point, strip it off.
-		absContainerPath = strings.TrimPrefix(resolvedContainerPath, containerMountPoint)
-		absContainerPath = filepath.Join("/", absContainerPath)
-	} else {
-		// No symlink and not on the container's mount point, so let's
-		// move it back to the original input.  It must have evaluated
-		// to a volume or bind mount but we cannot return host paths.
-		absContainerPath = containerPath
-	}
-
-	// Now we need to make sure to preserve the base path as specified by
-	// the user.  The `filepath` packages likes to remove trailing slashes
-	// and dots that are crucial to the copy logic.
-	absContainerPath = copy.PreserveBasePath(containerPath, absContainerPath)
-	resolvedContainerPath = copy.PreserveBasePath(containerPath, resolvedContainerPath)
-
-	info := copy.FileInfo{
-		IsDir:      statInfo.IsDir,
-		Name:       filepath.Base(absContainerPath),
-		Size:       statInfo.Size,
-		Mode:       statInfo.Mode,
-		ModTime:    statInfo.ModTime,
-		LinkTarget: absContainerPath,
-	}
-
-	return &entities.ContainerStatReport{FileInfo: info}, resolvedRoot, resolvedContainerPath, statInfoErr
-}
 
 func (ic *ContainerEngine) ContainerStat(ctx context.Context, nameOrID string, containerPath string) (*entities.ContainerStatReport, error) {
 	container, err := ic.Libpod.LookupContainer(nameOrID)
@@ -87,54 +12,10 @@ func (ic *ContainerEngine) ContainerStat(ctx context.Context, nameOrID string, c
 		return nil, err
 	}
 
-	containerMountPoint, err := container.Mount()
-	if err != nil {
-		return nil, err
+	info, err := container.Stat(ctx, containerPath)
+
+	if info != nil {
+		return &entities.ContainerStatReport{FileInfo: *info}, err
 	}
-
-	defer func() {
-		if err := container.Unmount(false); err != nil {
-			logrus.Errorf("Error unmounting container: %v", err)
-		}
-	}()
-
-	statReport, _, _, err := ic.containerStat(container, containerMountPoint, containerPath)
-	return statReport, err
-}
-
-// secureStat extracts file info for path in a chroot'ed environment in root.
-func secureStat(root string, path string) (*buildahCopiah.StatForItem, error) {
-	var glob string
-	var err error
-
-	// If root and path are equal, then dir must be empty and the glob must
-	// be ".".
-	if filepath.Clean(root) == filepath.Clean(path) {
-		glob = "."
-	} else {
-		glob, err = filepath.Rel(root, path)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	globStats, err := buildahCopiah.Stat(root, "", buildahCopiah.StatOptions{}, []string{glob})
-	if err != nil {
-		return nil, err
-	}
-
-	if len(globStats) != 1 {
-		return nil, errors.Errorf("internal error: secureStat: expected 1 item but got %d", len(globStats))
-	}
-
-	stat, exists := globStats[0].Results[glob] // only one glob passed, so that's okay
-	if !exists {
-		return nil, copy.ErrENOENT
-	}
-
-	var statErr error
-	if stat.Error != "" {
-		statErr = errors.New(stat.Error)
-	}
-	return stat, statErr
+	return nil, err
 }

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -212,6 +212,7 @@ var _ = Describe("Podman cp", func() {
 
 	// Copy the root dir "/" of a container to the host.
 	It("podman cp the root directory from the ctr to an existing directory on the host ", func() {
+		SkipIfRootless("cannot copy tty devices in rootless mode")
 		container := "copyroottohost"
 		session := podmanTest.RunTopContainer(container)
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Traditionally, the path resolution for containers has been resolved on
the *host*; relative to the container's mount point or relative to
specified bind mounts or volumes.

While this works nicely for non-running containers, it poses a problem
for running ones.  In that case, certain kinds of mounts (e.g., tmpfs)
will not resolve correctly.  A tmpfs is held in memory and hence cannot
be resolved relatively to the container's mount point.  A copy operation
will succeed but the data will not show up inside the container.

To support these kinds of mounts, we need to join the *running*
container's mount namespace (and PID namespace) when copying.

Note that this change implies moving the copy and stat logic into
`libpod` since we need to keep the container locked to avoid race
conditions.  The immediate benefit is that all logic is now inside
`libpod`; the code isn't scattered anymore.

Further note that Docker does not support copying to tmpfs mounts.

Tests have been extended to cover *both* path resolutions for running
and created containers.  New tests have been added to exercise the
tmpfs-mount case.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@containers/podman-maintainers PTAL
@edsantiago, I'd love your input especially on the test changes