### PR TITLE
Check for supportsKVM based on basename of the runtime

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -113,9 +113,11 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 
 	// TODO: probe OCI runtime for feature and enable automatically if
 	// available.
-	runtime.supportsJSON = supportsJSON[name]
-	runtime.supportsNoCgroups = supportsNoCgroups[name]
-	runtime.supportsKVM = supportsKVM[name]
+
+	base := filepath.Base(name)
+	runtime.supportsJSON = supportsJSON[base]
+	runtime.supportsNoCgroups = supportsNoCgroups[base]
+	runtime.supportsKVM = supportsKVM[base]
 
 	foundPath := false
 	for _, path := range paths {


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/9582

This PR also adds tests to make sure SELinux labels match the runtime,
or if init is specified works with the correct label.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
