### PR TITLE
Add tests for selinux kvm/init labels

### DIFF
--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -77,13 +77,14 @@ function check_label() {
 @test "podman selinux: inspect kvm labels" {
     skip_if_no_selinux
     skip_if_remote "runtime flag is not passed over remote"
-    if [ ! -e /usr/bin/kata-runtime ]; then
-        skip "kata-runtime not available"
-    fi
 
-    run_podman create --runtime=kata --name myc $IMAGE
+    tmpdir=$PODMAN_TMPDIR/kata-test
+    mkdir -p $tmpdir
+    KATA=${tmpdir}/kata-runtime
+    ln -s /bin/true ${KATA}
+    run_podman create --runtime=${KATA} --name myc $IMAGE
     run_podman inspect --format='{{ .ProcessLabel }}' myc
-    is "$output" ".*container_kvm_t.*"
+    is "$output" ".*container_kvm_t"
 }
 
 # pr #6752


### PR DESCRIPTION
spc_t tests should be able to run rootless as well.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
