### PR TITLE
Makefile: add install.docker-docs-nobuild for packaging use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -548,10 +548,13 @@ install.docker:
 	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR}  ${DESTDIR}${USERSYSTEMDDIR} ${DESTDIR}${TMPFILESDIR}
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-docker.conf -t ${DESTDIR}${TMPFILESDIR}
 
-.PHONY: install.docker-docs
-install.docker-docs: docker-docs
+.PHONY: install.docker-docs-nobuild
+install.docker-docs-nobuild:
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man1
 	install ${SELINUXOPT} -m 644 docs/build/man/docker*.1 -t $(DESTDIR)$(MANDIR)/man1
+
+.PHONY: install.docker-docs
+install.docker-docs: docker-docs install.docker-docs-nobuild
 
 .PHONY: install.systemd
 ifneq (,$(findstring systemd,$(BUILDTAGS)))


### PR DESCRIPTION
This will allow installation of the manpages without the need to rebuild
them in the installation stage of distro packaging.

[NO TESTS NEEDED]

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->


@mheon @baude @rhatdan @vrothberg @liuming50 PTAL