### PR TITLE
Respect NanoCpus in Compat Create

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/containers/podman/v3/pkg/rootless"
 	"github.com/containers/podman/v3/pkg/specgen"
+	"github.com/pkg/errors"
 )
 
 type ContainerCLIOpts struct {
@@ -394,6 +395,13 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 			}
 			cliOpts.Ulimit = ulimits
 		}
+	}
+	if cc.HostConfig.Resources.NanoCPUs > 0 {
+		if cliOpts.CPUPeriod != 0 || cliOpts.CPUQuota != 0 {
+			return nil, nil, errors.Errorf("NanoCpus conflicts with CpuPeriod and CpuQuota")
+		}
+		cliOpts.CPUPeriod = 100000
+		cliOpts.CPUQuota = cc.HostConfig.Resources.NanoCPUs / 10000
 	}
 
 	// volumes

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -263,3 +263,12 @@ t GET containers/json 200 \
   .[0].Ports[0].Type="tcp"
 
 podman stop bar
+
+# Test CPU limit (NanoCPUs)
+t POST containers/create '"Image":"'$IMAGE'","HostConfig":{"NanoCpus":500000}' 201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .HostConfig.NanoCpus=500000
+
+t DELETE containers/$cid?v=true 204


### PR DESCRIPTION
The NanoCpus field in HostConfig was not wired up. It conflicts with CPU period and quota (it hard-codes period to a specific value and then sets the user-specified value as Quota).

Fixes #9523
