### PR TITLE
Fix images_test using inconsistent alpine:latest

### DIFF
--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -188,23 +188,23 @@ WORKDIR /test
 	})
 
 	It("podman images filter since image", func() {
-		dockerfile := `FROM quay.io/libpod/alpine:latest
+		dockerfile := `FROM quay.io/libpod/alpine:3.2
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "since=quay.io/libpod/alpine:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(len(result.OutputToStringArray())).To(Equal(7))
+		Expect(len(result.OutputToStringArray())).To(Equal(8))
 	})
 
 	It("podman image list filter after image", func() {
-		dockerfile := `FROM quay.io/libpod/alpine:latest
+		dockerfile := `FROM quay.io/libpod/alpine:3.2
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
 		result := podmanTest.Podman([]string{"image", "list", "-q", "-f", "after=quay.io/libpod/alpine:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(result.OutputToStringArray()).Should(HaveLen(7), "list filter output: %q", result.OutputToString())
+		Expect(result.OutputToStringArray()).Should(HaveLen(8), "list filter output: %q", result.OutputToString())
 	})
 
 	It("podman images filter dangling", func() {


### PR DESCRIPTION
At some point, somehow the `quay.io/libpod/apline:latest` image changed.
This is causing integration tests to fail on this branch.  Mainly
these failures are caused by missed-expectations w/ the test image. Fix
these test by using a specific, fixed, named image tag instead of
'latest' (which can change unpredictably).