### PR TITLE
Fix podman network rm (-f) workflow

### DIFF
--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -96,7 +96,15 @@ func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, o
 		}
 		// We need to iterate containers looking to see if they belong to the given network
 		for _, c := range containers {
-			if util.StringInSlice(name, c.Config().Networks) {
+			networks, _, err := c.Networks()
+			// if container vanished or network does not exist, go to next container
+			if errors.Is(err, define.ErrNoSuchNetwork) || errors.Is(err, define.ErrNoSuchCtr) {
+				continue
+			}
+			if err != nil {
+				return reports, err
+			}
+			if util.StringInSlice(name, networks) {
 				// if user passes force, we nuke containers and pods
 				if !options.Force {
 					// Without the force option, we return an error

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -352,6 +352,29 @@ var _ = Describe("Podman network", func() {
 		Expect(rmAll.ExitCode()).To(BeZero())
 	})
 
+	It("podman network remove after disconnect when container initially created with the network", func() {
+		SkipIfRootless("disconnect works only in non rootless container")
+
+		container := "test"
+		network := "foo"
+
+		session := podmanTest.Podman([]string{"network", "create", network})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"run", "--name", container, "--network", network, "-d", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"network", "disconnect", network, container})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"network", "rm", network})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman network remove bogus", func() {
 		session := podmanTest.Podman([]string{"network", "rm", "bogus"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
/kind bug

Fix for issue #9632
/closes #9632

In NetworkRm fields from c.Config().Networks are checked to see associated networks. c.Config().Networks is not referring to the runtime and store initial configuration which can be obsolete. It forces to use -f flag if the container is created with network which is later disconnected. 

A fix proposes the usage of the runtime data from c.Networks() with special handling of 2 errors which may occur: deleted containers and no associated networks.