### PR TITLE
[NO TESTS NEEDED] Bump pre-commit-hooks version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 exclude: ^vendor/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v2.4.0
+    rev: v3.4.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace


### PR DESCRIPTION
Signed-off-by: xatier <xatierlike@gmail.com>

Tested locally, this shouldn't introduce any regressions.

```
$ pre-commit run -av
Fix End of Files.........................................................Passed
- hook id: end-of-file-fixer
- duration: 0.08s
Trim Trailing Whitespace.................................................Passed
- hook id: trailing-whitespace
- duration: 0.09s
Mixed line ending........................................................Passed
- hook id: mixed-line-ending
- duration: 0.07s
check BOM - deprecated: use fix-byte-order-marker........................Passed
- hook id: check-byte-order-marker
- duration: 0.08s
Check that executables have shebangs.....................................Passed
- hook id: check-executables-have-shebangs
- duration: 0.06s
Check for merge conflicts................................................Passed
- hook id: check-merge-conflict
- duration: 0.07s
```