### PR TITLE
podman-remote stop -time 0 does not work

### DIFF
--- a/pkg/api/handlers/compat/containers_stop.go
+++ b/pkg/api/handlers/compat/containers_stop.go
@@ -39,11 +39,11 @@ func StopContainer(w http.ResponseWriter, r *http.Request) {
 		Ignore: query.Ignore,
 	}
 	if utils.IsLibpodRequest(r) {
-		if query.LibpodTimeout > 0 {
+		if _, found := r.URL.Query()["timeout"]; found {
 			options.Timeout = &query.LibpodTimeout
 		}
 	} else {
-		if query.DockerTimeout > 0 {
+		if _, found := r.URL.Query()["t"]; found {
 			options.Timeout = &query.DockerTimeout
 		}
 	}

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Podman stop", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"stop", "--time", "1", "test4"})
+		session = podmanTest.Podman([]string{"stop", "--time", "0", "test4"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		output := session.OutputToString()
@@ -166,7 +166,7 @@ var _ = Describe("Podman stop", func() {
 		session := podmanTest.Podman([]string{"run", "-d", "--name", "test5", ALPINE, "sleep", "100"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"stop", "--timeout", "1", "test5"})
+		session = podmanTest.Podman([]string{"stop", "--timeout", "0", "test5"})
 		// Without timeout container stops in 10 seconds
 		// If not stopped in 5 seconds, then --timeout did not work
 		session.Wait(5)


### PR DESCRIPTION
This patch will allow users to pass in the time 0.
Currently the timeout will take 10 seconds if user passes
in the 0 flag.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
