### PR TITLE
[NO TESTS NEEDED] Podman machine CLI and interface stub

### DIFF
--- a/cmd/podman/machine/config.go
+++ b/cmd/podman/machine/config.go
@@ -1,0 +1,38 @@
+package machine
+
+import "fmt"
+
+type CreateOptions struct {
+	CPUS       uint64
+	Memory     uint64
+	KernelPath string
+	Devices    []VMDevices
+}
+
+type VMDevices struct {
+	Path     string
+	ReadOnly bool
+}
+
+type VM interface {
+	Create(name string, opts CreateOptions) error
+	Start(name string) error
+	Stop(name string) error
+}
+
+type TestVM struct {
+}
+
+func (vm *TestVM) Create(name string, opts CreateOptions) error {
+	fmt.Printf("Created: %s\n", name)
+	return nil
+}
+
+func (vm *TestVM) Start(name string) error {
+	fmt.Printf("Started: %s\n", name)
+	return nil
+}
+func (vm *TestVM) Stop(name string) error {
+	fmt.Printf("Stopped: %s\n", name)
+	return nil
+}

--- a/cmd/podman/machine/create.go
+++ b/cmd/podman/machine/create.go
@@ -1,0 +1,132 @@
+package machine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containers/common/pkg/completion"
+	"github.com/containers/podman/v3/cmd/podman/registry"
+	"github.com/containers/podman/v3/pkg/domain/entities"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	createCmd = &cobra.Command{
+		Use:               "create [options] NAME",
+		Short:             "Create a vm",
+		Long:              "Create a virtual machine for Podman to run on. Virtual machines are used to run Podman on Macs. ",
+		RunE:              create,
+		Args:              cobra.ExactArgs(1),
+		Example:           `podman machine create myvm`,
+		ValidArgsFunction: completion.AutocompleteNone,
+	}
+)
+
+type CreateCLIOptions struct {
+	CPUS       uint64
+	Memory     uint64
+	KernelPath string
+	Devices    []string
+}
+
+var (
+	createOpts = CreateCLIOptions{}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: createCmd,
+		Parent:  machineCmd,
+	})
+	flags := createCmd.Flags()
+
+	cpusFlagName := "cpus"
+	flags.Uint64Var(
+		&createOpts.CPUS,
+		cpusFlagName, 0,
+		"Number of CPUs. The default is 0.000 which means no limit",
+	)
+	_ = createCmd.RegisterFlagCompletionFunc(cpusFlagName, completion.AutocompleteNone)
+
+	memoryFlagName := "memory"
+	flags.Uint64VarP(
+		&createOpts.Memory,
+		memoryFlagName, "m", 0,
+		"Memory (in MB)",
+	)
+	_ = createCmd.RegisterFlagCompletionFunc(memoryFlagName, completion.AutocompleteNone)
+
+	kernelPathFlagName := "kernel-path"
+	flags.StringVar(
+		&createOpts.KernelPath,
+		kernelPathFlagName, "",
+		"Kernel path",
+	)
+	_ = createCmd.RegisterFlagCompletionFunc(kernelPathFlagName, completion.AutocompleteNone)
+
+	deviceFlagName := "device"
+	flags.StringSliceVar(
+		&createOpts.Devices,
+		deviceFlagName, []string{},
+		"Add a device",
+	)
+	_ = createCmd.RegisterFlagCompletionFunc(deviceFlagName, completion.AutocompleteDefault)
+}
+
+func create(cmd *cobra.Command, args []string) error {
+	vmOpts := CreateOptions{
+		CPUS:       createOpts.CPUS,
+		Memory:     createOpts.Memory,
+		KernelPath: createOpts.KernelPath,
+	}
+
+	if cmd.Flags().Changed("device") {
+		devices, err := cmd.Flags().GetStringSlice("device")
+		if err != nil {
+			return err
+		}
+		vmOpts.Devices, err = parseDevices(devices)
+		if err != nil {
+			return err
+		}
+	}
+
+	test := new(TestVM)
+	test.Create(args[0], vmOpts)
+
+	return nil
+}
+
+func parseDevices(devices []string) ([]VMDevices, error) {
+	vmDevices := make([]VMDevices, 0, len(devices))
+
+	for _, dev := range devices {
+		split := strings.Split(dev, ":")
+
+		if len(split) == 1 {
+			vmDevices = append(vmDevices, VMDevices{
+				Path:     split[0],
+				ReadOnly: false,
+			})
+		} else if len(split) == 2 {
+			var readonly bool
+
+			switch split[1] {
+			case "ro", "readonly":
+				readonly = true
+			default:
+				return nil, errors.New(fmt.Sprintf("Invalid readonly value: %s", dev))
+			}
+
+			vmDevices = append(vmDevices, VMDevices{
+				Path:     split[0],
+				ReadOnly: readonly,
+			})
+		} else {
+			return nil, errors.New(fmt.Sprintf("Invalid device format: %s", dev))
+		}
+	}
+	return vmDevices, nil
+}

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -1,0 +1,30 @@
+package machine
+
+import (
+	"github.com/containers/podman/v3/cmd/podman/registry"
+	"github.com/containers/podman/v3/cmd/podman/validate"
+	"github.com/containers/podman/v3/pkg/domain/entities"
+	"github.com/spf13/cobra"
+)
+
+var (
+	noOp = func(cmd *cobra.Command, args []string) error {
+		return nil
+	}
+	// Command: podman _machine_
+	machineCmd = &cobra.Command{
+		Use:                "machine",
+		Short:              "Manage a virtual machine",
+		Long:               "Manage a virtual machine. Virtual machines are used to run Podman on Macs.",
+		PersistentPreRunE:  noOp,
+		PersistentPostRunE: noOp,
+		RunE:               validate.SubCommandExists,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: machineCmd,
+	})
+}

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -1,0 +1,34 @@
+package machine
+
+import (
+	"github.com/containers/common/pkg/completion"
+	"github.com/containers/podman/v3/cmd/podman/registry"
+	"github.com/containers/podman/v3/pkg/domain/entities"
+	"github.com/spf13/cobra"
+)
+
+var (
+	startCmd = &cobra.Command{
+		Use:               "start NAME",
+		Short:             "Start an existing machine",
+		Long:              "Start an existing machine ",
+		RunE:              start,
+		Args:              cobra.ExactArgs(1),
+		Example:           `podman machine start myvm`,
+		ValidArgsFunction: completion.AutocompleteNone,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: startCmd,
+		Parent:  machineCmd,
+	})
+}
+
+func start(cmd *cobra.Command, args []string) error {
+	test := new(TestVM)
+	test.Start(args[0])
+	return nil
+}

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -1,0 +1,34 @@
+package machine
+
+import (
+	"github.com/containers/common/pkg/completion"
+	"github.com/containers/podman/v3/cmd/podman/registry"
+	"github.com/containers/podman/v3/pkg/domain/entities"
+	"github.com/spf13/cobra"
+)
+
+var (
+	stopCmd = &cobra.Command{
+		Use:               "stop NAME",
+		Short:             "Stop an existing machine",
+		Long:              "Stop an existing machine ",
+		RunE:              stop,
+		Args:              cobra.ExactArgs(1),
+		Example:           `podman machine stop myvm`,
+		ValidArgsFunction: completion.AutocompleteNone,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: stopCmd,
+		Parent:  machineCmd,
+	})
+}
+
+func stop(cmd *cobra.Command, args []string) error {
+	test := new(TestVM)
+	test.Stop(args[0])
+	return nil
+}

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/containers/podman/v3/cmd/podman/generate"
 	_ "github.com/containers/podman/v3/cmd/podman/healthcheck"
 	_ "github.com/containers/podman/v3/cmd/podman/images"
+	_ "github.com/containers/podman/v3/cmd/podman/machine"
 	_ "github.com/containers/podman/v3/cmd/podman/manifest"
 	_ "github.com/containers/podman/v3/cmd/podman/networks"
 	_ "github.com/containers/podman/v3/cmd/podman/play"

--- a/docs/source/Commands.rst
+++ b/docs/source/Commands.rst
@@ -55,6 +55,8 @@ Commands
 
 :doc:`logs <markdown/podman-logs.1>` Fetch the logs of a container
 
+:doc:`machine <markdown/podman-machine.1>` Manage podman's virtual machine
+
 :doc:`manifest <manifest>` Create and manipulate manifest lists and image indexes
 
 :doc:`mount <markdown/podman-mount.1>` Mount a working container's root filesystem

--- a/docs/source/machine.rst
+++ b/docs/source/machine.rst
@@ -1,0 +1,7 @@
+Machine
+======
+:doc:`create <markdown/podman-machine-create.1>` Create a new virtual machine
+
+:doc:`start <markdown/podman-machine-start.1>` Start a virtual machine
+
+:doc:`stop <markdown/podman-machine-stop.1>` Stop a virtual machine

--- a/docs/source/markdown/podman-machine-create.1.md
+++ b/docs/source/markdown/podman-machine-create.1.md
@@ -1,0 +1,56 @@
+% podman-machine-create(1)
+
+## NAME
+podman\-machine\-create - Create a new virtual machine
+
+## SYNOPSIS
+**podman machine create** [*options*] *name*
+
+## DESCRIPTION
+
+Creates a new virtual machine for Podman.
+
+Podman on MacOS requires a virtual machine. This is because containers are Linux -
+containers do not run on any other OS because containers' core functionality are
+tied to the Linux kernel.
+
+**podman machine create** creates a new Linux virtual machine where containers are run.
+
+## OPTIONS
+
+#### **--cpus**=*number*
+
+Number of CPUs.
+
+#### **--memory**, **-m**=*number*
+
+Memory (in MB).
+
+#### **--kernel-path**=*path*
+
+Print usage statement.
+
+#### **--device**=_device_[**:**_permissions_]
+
+Add a device to the virtual machine. Optional *permissions* parameter
+can be used to specify device permissions. **ro** means the device is read-only.
+
+Example: **--device=/dev/xvdc:ro**.
+
+#### **--help**
+
+Print usage statement.
+
+## EXAMPLES
+
+```
+$ podman machine create myvm
+$ podman machine create --device=/dev/xvdc:rw myvm
+$ podman machine create --memory=1024 myvm
+```
+
+## SEE ALSO
+podman-machine (1)
+
+## HISTORY
+March 2021, Originally compiled by Ashley Cui <acui@redhat.com>

--- a/docs/source/markdown/podman-machine-start.1.md
+++ b/docs/source/markdown/podman-machine-start.1.md
@@ -1,0 +1,35 @@
+% podman-machine-start(1)
+
+## NAME
+podman\-machine\-start - Start a virtual machine
+
+## SYNOPSIS
+**podman machine start** *name*
+
+## DESCRIPTION
+
+Starts a virtual machine for Podman.
+
+Podman on MacOS requires a virtual machine. This is because containers are Linux -
+containers do not run on any other OS because containers' core functionality are
+tied to the Linux kernel.
+
+**podman machine start** starts a Linux virtual machine where containers are run.
+
+## OPTIONS
+
+#### **--help**
+
+Print usage statement.
+
+## EXAMPLES
+
+```
+$ podman machine start myvm
+```
+
+## SEE ALSO
+podman-machine (1)
+
+## HISTORY
+March 2021, Originally compiled by Ashley Cui <acui@redhat.com>

--- a/docs/source/markdown/podman-machine-stop.1.md
+++ b/docs/source/markdown/podman-machine-stop.1.md
@@ -1,0 +1,35 @@
+% podman-machine-stop(1)
+
+## NAME
+podman\-machine\-stop - Stop a virtual machine
+
+## SYNOPSIS
+**podman machine stop** *name*
+
+## DESCRIPTION
+
+Stops a virtual machine.
+
+Podman on MacOS requires a virtual machine. This is because containers are Linux -
+containers do not run on any other OS because containers' core functionality are
+tied to the Linux kernel.
+
+**podman machine stop** stops a Linux virtual machine where containers are run.
+
+## OPTIONS
+
+#### **--help**
+
+Print usage statement.
+
+## EXAMPLES
+
+```
+$ podman machine stop myvm
+```
+
+## SEE ALSO
+podman-machine (1)
+
+## HISTORY
+March 2021, Originally compiled by Ashley Cui <acui@redhat.com>

--- a/docs/source/markdown/podman-machine.1.md
+++ b/docs/source/markdown/podman-machine.1.md
@@ -1,0 +1,24 @@
+% podman-machine(1)
+
+## NAME
+podman\-machine - Manage Podman's virtual machine
+
+## SYNOPSIS
+**podman machine** *subcommand*
+
+## DESCRIPTION
+`podman machine` is a set of subcommands that manage Podman's virtual machine on MacOS.
+
+## SUBCOMMANDS
+
+| Command | Man Page                                                | Description                   |
+| ------- | ------------------------------------------------------- | ----------------------------- |
+| create  | [podman-machine-create(1)](podman-machine-create.1.md)  | Create a new virtual machine  |
+| start   | [podman-machine-start(1)](podman-machine-start.1.md)    | Start a virtual machine       |
+| stop    | [podman-machine-stop(1)](podman-machine-stop.1.md)      | Stop a virtual machine        |
+
+## SEE ALSO
+podman(1)
+
+## HISTORY
+March 2021, Originally compiled by Ashley Cui <acui@redhat.com>

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -237,6 +237,7 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-login(1)](podman-login.1.md)             | Login to a container registry.                                              |
 | [podman-logout(1)](podman-logout.1.md)           | Logout of a container registry.                                             |
 | [podman-logs(1)](podman-logs.1.md)               | Display the logs of one or more containers.                                 |
+| [podman-machine(1)](podman-machine.1.md)         | Manage Podman's virtual machine                                             |
 | [podman-manifest(1)](podman-manifest.1.md)       | Create and manipulate manifest lists and image indexes.                     |
 | [podman-mount(1)](podman-mount.1.md)             | Mount a working container's root filesystem.                                |
 | [podman-network(1)](podman-network.1.md)         | Manage Podman CNI networks.                                                 |


### PR DESCRIPTION
Podman machine will be a mac-only command that manages the VM where
containers are run. Currently, only the CLI is written and the interface
function for the VM management is stub for future developement

The podman machine cli is only built on mac builds.

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
