### PR TITLE
[ci skip] Bad formatting fix in build documentation

### DIFF
--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -821,9 +821,13 @@ $ podman build --no-cache --rm=false -t imageName .
 
 ### Building an multi-architecture image using a --manifest option (Requires emulation software)
 
-podman build --arch arm --manifest myimage /tmp/mysrc
-podman build --arch amd64 --manifest myimage /tmp/mysrc
-podman build --arch s390x --manifest myimage /tmp/mysrc
+```
+$ podman build --arch arm --manifest myimage /tmp/mysrc
+
+$ podman build --arch amd64 --manifest myimage /tmp/mysrc
+
+$ podman build --arch s390x --manifest myimage /tmp/mysrc
+```
 
 ### Building an image using a URL, Git repo, or archive
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

Spotted bad formatting when searching in podman build doc. Visible here (grep for Building an multi-architecture image ...):
http://docs.podman.io/en/latest/markdown/podman-build.1.html
