### PR TITLE
Allow users to generate a kubernetes yaml off non running containers

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -676,8 +676,18 @@ func generateKubeSecurityContext(c *Container) (*v1.SecurityContext, error) {
 			return nil, errors.Wrapf(err, "unable to sync container during YAML generation")
 		}
 
+		mountpoint := c.state.Mountpoint
+		if mountpoint == "" {
+			var err error
+			mountpoint, err = c.mount()
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to mount %s mountpoint", c.ID())
+			}
+			defer c.unmount(false)
+		}
 		logrus.Debugf("Looking in container for user: %s", c.User())
-		execUser, err := lookup.GetUserGroupInfo(c.state.Mountpoint, c.User(), nil)
+
+		execUser, err := lookup.GetUserGroupInfo(mountpoint, c.User(), nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Currently if you attempt to create a kube.yaml file off of a non running
container where the container runs as a specific User, the creation
fails because the storage container is not mounted. Podman is supposed to
read the /etc/passwd entry inside of the container but since the
container is not mounted, the c.State.Mountpoint == "".  Podman
incorrectly attempts to read /etc/passwd on the host, and fails if the
specified user is not in the hosts /etc/passwd.

This PR mounts the storage container, if it was not mounted so the read
succeeds.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
