### PR TITLE
[NO TESTS NEEDED] podman-remote build does not support volumes

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -170,6 +170,7 @@ func buildFlags(cmd *cobra.Command) {
 		_ = flags.MarkHidden("signature-policy")
 		_ = flags.MarkHidden("tls-verify")
 		_ = flags.MarkHidden("compress")
+		_ = flags.MarkHidden("volume")
 	}
 }
 

--- a/docs/source/markdown/podman-attach.1.md
+++ b/docs/source/markdown/podman-attach.1.md
@@ -25,9 +25,7 @@ Specify the key sequence for detaching a container. Format is a single character
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--no-stdin**
 

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -86,7 +86,7 @@ resulting image's configuration.
 #### **--cache-from**
 
 Images to utilize as potential cache sources. Podman does not currently support
-caching so this is a NOOP.
+caching so this is a NOOP. (This option is not available with the remote Podman client)
 
 #### **--cap-add**=*CAP\_xxx*
 
@@ -111,8 +111,7 @@ given.
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_. (Not available for
-remote commands)
+Default certificates directory is _/etc/containers/certs.d_. (This option is not available with the remote Podman client)
 
 #### **--cgroup-parent**=*path*
 
@@ -124,7 +123,7 @@ of the init process. Cgroups will be created if they do not already exist.
 
 This option is added to be aligned with other containers CLIs.
 Podman doesn't communicate with a daemon or a remote server.
-Thus, compressing the data before sending it is irrelevant to Podman.
+Thus, compressing the data before sending it is irrelevant to Podman. (This option is not available with the remote Podman client)
 
 #### **--cni-config-dir**=*directory*
 
@@ -255,7 +254,7 @@ specifying **--disable-compression=false**.
 
 This is a Docker specific option to disable image verification to a Docker
 registry and is not supported by Podman.  This flag is a NOOP and provided
-solely for scripting compatibility.
+solely for scripting compatibility. (This option is not available with the remote Podman client)
 
 #### **--dns**=*dns*
 
@@ -521,7 +520,7 @@ size entirely, the system uses `64m`.
 
 #### **--sign-by**=*fingerprint*
 
-Sign the image using a GPG key with the specified FINGERPRINT.
+Sign the image using a GPG key with the specified FINGERPRINT. (This option is not available with the remote Podman client)
 
 #### **--squash**
 
@@ -566,7 +565,7 @@ timestamp.
 #### **--tls-verify**=*true|false*
 
 Require HTTPS and verify certificates when talking to container registries
-(defaults to true).
+(defaults to true). (This option is not available with the remote Podman client)
 
 #### **--ulimit**=*type*=*soft-limit*[:*hard-limit*]
 
@@ -679,7 +678,9 @@ Set the architecture variant of the image to be pulled.
 
    Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Podman
    bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the Podman
-   container. The `OPTIONS` are a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
+   container. (This option is not available with the remote Podman client)
+
+   The `OPTIONS` are a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
 
    * [rw|ro]
    * [z|Z|O]

--- a/docs/source/markdown/podman-container-checkpoint.1.md
+++ b/docs/source/markdown/podman-container-checkpoint.1.md
@@ -23,9 +23,7 @@ Checkpoint all running containers.
 
 #### **--latest**, **-l**
 
-Instead of providing the container name or ID, checkpoint the last created container.
-
-The latest option is not supported on the remote client.
+Instead of providing the container name or ID, checkpoint the last created container. (This option is not available with the remote Podman client)
 
 #### **--leave-running**, **-R**
 

--- a/docs/source/markdown/podman-container-cleanup.1.md
+++ b/docs/source/markdown/podman-container-cleanup.1.md
@@ -25,9 +25,7 @@ Conflicts with **--rmi** as the container is not being cleaned up so the image c
 
 #### **--latest**, **-l**
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--rm**
 

--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -30,9 +30,7 @@ Restore all checkpointed containers.
 
 #### **--latest**, **-l**
 
-Instead of providing the container name or ID, restore the last created container.
-
-The latest option is not supported on the remote client.
+Instead of providing the container name or ID, restore the last created container. (This option is not available with the remote Podman client)
 
 #### **--tcp-established**
 

--- a/docs/source/markdown/podman-container-runlabel.1.md
+++ b/docs/source/markdown/podman-container-runlabel.1.md
@@ -57,7 +57,7 @@ The runlabel command will not execute if --display is specified.
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
+Default certificates directory is _/etc/containers/certs.d_. (This option is not available with the remote Podman client)
 
 #### **--creds**=*[username[:password]]*
 

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -343,7 +343,7 @@ See [**Environment**](#environment) note below for precedence and examples.
 
 #### **--env-host**=*true|false*
 
-Use host environment inside of the container. See **Environment** note below for precedence. (Not available for remote commands)
+Use host environment inside of the container. See **Environment** note below for precedence. (This option is not available with the remote Podman client)
 
 #### **--env-file**=*file*
 
@@ -412,7 +412,7 @@ the container should not use any proxy. Proxy environment variables specified
 for the container in any other way will override the values that would have
 been passed through from the host. (Other ways to specify the proxy for the
 container include passing the values with the `--env` flag, or hard coding the
-proxy environment at container build time.)  (Not available for remote commands)
+proxy environment at container build time.)  (This option is not available with the remote Podman client)
 
 For example, to disable passing these environment variables from host to
 container:

--- a/docs/source/markdown/podman-diff.1.md
+++ b/docs/source/markdown/podman-diff.1.md
@@ -20,9 +20,7 @@ Alter the output into a different format.  The only valid format for diff is `js
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-exec.1.md
+++ b/docs/source/markdown/podman-exec.1.md
@@ -37,9 +37,7 @@ When set to true, keep stdin open even if not attached. The default is *false*.
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--preserve-fds**=*N*
 

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -1,7 +1,7 @@
 % podman-generate-systemd(1)
 
 ## NAME
-podman\-generate\-systemd - Generate systemd unit file(s) for a container or pod. Not supported for the remote client
+podman\-generate\-systemd - Generate systemd unit file(s) for a container or pod
 
 ## SYNOPSIS
 **podman generate systemd** [*options*] *container|pod*

--- a/docs/source/markdown/podman-generate.1.md
+++ b/docs/source/markdown/podman-generate.1.md
@@ -14,7 +14,7 @@ The generate command will create structured output (like YAML) based on a contai
 | Command | Man Page                                                   | Description                                                                         |
 |---------|------------------------------------------------------------|-------------------------------------------------------------------------------------|
 | kube    | [podman-generate-kube(1)](podman-generate-kube.1.md)       | Generate Kubernetes YAML based on a pod or container.                               |
-| systemd | [podman-generate-systemd(1)](podman-generate-systemd.1.md) | Generate systemd unit file(s) for a container or pod. Not supported for the remote client. |
+| systemd | [podman-generate-systemd(1)](podman-generate-systemd.1.md) | Generate systemd unit file(s) for a container or pod.                               |
 
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-image-sign.1.md
+++ b/docs/source/markdown/podman-image-sign.1.md
@@ -26,7 +26,7 @@ Sign all the manifests of the multi-architecture image (default false).
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
+Default certificates directory is _/etc/containers/certs.d_. (This option is not available with the remote Podman client)
 
 #### **--directory**, **-d**=*dir*
 

--- a/docs/source/markdown/podman-image-trust.1.md
+++ b/docs/source/markdown/podman-image-trust.1.md
@@ -8,7 +8,7 @@ podman\-image\-trust - Manage container registry image trust policy
 **podman image trust** set|show [*options*] *registry[/repository]*
 
 ## DESCRIPTION
-Manages which registries you trust as a source of container images  based on its location. (Not available for remote commands)
+Manages which registries you trust as a source of container images  based on its location. (This option is not available with the remote Podman client)
 
 The location is determined
 by the transport and the registry host of the image.  Using this container image `docker://docker.io/library/busybox`

--- a/docs/source/markdown/podman-init.1.md
+++ b/docs/source/markdown/podman-init.1.md
@@ -25,9 +25,7 @@ Initialize all containers. Containers that have already initialized (including c
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-inspect.1.md
+++ b/docs/source/markdown/podman-inspect.1.md
@@ -39,9 +39,7 @@ The keys of the returned JSON can be used as the values for the --format flag (s
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods.
 
-This option can be used to inspect the latest pod created when used with --type pod
-
-The latest option is not supported on the remote client or when invoked as *podman image inspect*.
+This option can be used to inspect the latest pod created when used with --type pod. (This option is not available with the remote Podman client or when invoked as *podman image inspect*.)
 
 #### **--size**, **-s**
 

--- a/docs/source/markdown/podman-kill.1.md
+++ b/docs/source/markdown/podman-kill.1.md
@@ -23,9 +23,7 @@ Read container ID from the specified file and remove the container.  Can be spec
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--signal**, **-s**
 

--- a/docs/source/markdown/podman-login.1.md
+++ b/docs/source/markdown/podman-login.1.md
@@ -54,7 +54,7 @@ Return the logged-in user for the registry.  Return error if no login is found.
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
+Default certificates directory is _/etc/containers/certs.d_. (This option is not available with the remote Podman client)
 
 #### **--tls-verify**=*true|false*
 

--- a/docs/source/markdown/podman-logs.1.md
+++ b/docs/source/markdown/podman-logs.1.md
@@ -26,9 +26,7 @@ file will be removed before `podman logs` reads the final content.
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--names**, **-n**
 

--- a/docs/source/markdown/podman-manifest-add.1.md
+++ b/docs/source/markdown/podman-manifest-add.1.md
@@ -44,7 +44,7 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
+Default certificates directory is _/etc/containers/certs.d_. (This option is not available with the remote Podman client)
 
 #### **--creds**=*creds*
 

--- a/docs/source/markdown/podman-manifest-push.1.md
+++ b/docs/source/markdown/podman-manifest-push.1.md
@@ -30,7 +30,7 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
+Default certificates directory is _/etc/containers/certs.d_. (This option is not available with the remote Podman client)
 
 #### **--creds**=*creds*
 

--- a/docs/source/markdown/podman-mount.1.md
+++ b/docs/source/markdown/podman-mount.1.md
@@ -38,9 +38,7 @@ Print the mounted containers in specified format (json).
 
 Instead of providing the container name or ID, use the last created container.
 If you use methods other than Podman to run containers such as CRI-O, the last
-started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--notruncate**
 

--- a/docs/source/markdown/podman-network-reload.1.md
+++ b/docs/source/markdown/podman-network-reload.1.md
@@ -23,9 +23,7 @@ Reload network configuration of all containers.
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -28,7 +28,7 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
+Default certificates directory is _/etc/containers/certs.d_. (This option is not available with the remote Podman client)
 
 #### **--configmap**=*path*
 
@@ -56,7 +56,7 @@ Suppress output information when pulling images
 
 #### **--seccomp-profile-root**=*path*
 
-Directory path for seccomp profiles (default: "/var/lib/kubelet/seccomp"). (Not available for remote commands)
+Directory path for seccomp profiles (default: "/var/lib/kubelet/seccomp"). (This option is not available with the remote Podman client)
 
 #### **--start**=*true|false*
 

--- a/docs/source/markdown/podman-pod-inspect.1.md
+++ b/docs/source/markdown/podman-pod-inspect.1.md
@@ -14,9 +14,7 @@ that belong to the pod.
 #### **--latest**, **-l**
 
 Instead of providing the pod name or ID, use the last created pod. If you use methods other than Podman
-to run pods such as CRI-O, the last started pod could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run pods such as CRI-O, the last started pod could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--format**=*format*, **-f**
 

--- a/docs/source/markdown/podman-pod-kill.1.md
+++ b/docs/source/markdown/podman-pod-kill.1.md
@@ -17,9 +17,7 @@ Sends signal to all containers associated with a pod.
 #### **--latest**, **-l**
 
 Instead of providing the pod name or ID, use the last created pod. If you use methods other than Podman
-to run pods such as CRI-O, the last started pod could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run pods such as CRI-O, the last started pod could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--signal**, **-s**
 

--- a/docs/source/markdown/podman-pod-pause.1.md
+++ b/docs/source/markdown/podman-pod-pause.1.md
@@ -17,9 +17,7 @@ Pause all pods.
 
 #### **--latest**, **-l**
 
-Instead of providing the pod name or ID, pause the last created pod.
-
-The latest option is not supported on the remote client.
+Instead of providing the pod name or ID, pause the last created pod. (This option is not available with the remote Podman client)
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-pod-ps.1.md
+++ b/docs/source/markdown/podman-pod-ps.1.md
@@ -40,9 +40,7 @@ Includes the container statuses in the container info field
 
 #### **--latest**, **-l**
 
-Show the latest pod created (all states)
-
-The latest option is not supported on the remote client.
+Show the latest pod created (all states) (This option is not available with the remote Podman client)
 
 #### **--no-trunc**
 

--- a/docs/source/markdown/podman-pod-restart.1.md
+++ b/docs/source/markdown/podman-pod-restart.1.md
@@ -20,9 +20,7 @@ Restarts all pods
 
 #### **--latest**, **-l**
 
-Instead of providing the pod name or ID, restart the last created pod.
-
-The latest option is not supported on the remote client.
+Instead of providing the pod name or ID, restart the last created pod. (This option is not available with the remote Podman client)
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-pod-rm.1.md
+++ b/docs/source/markdown/podman-pod-rm.1.md
@@ -23,9 +23,7 @@ ExecStop directive of a systemd service referencing that pod.
 
 #### **--latest**, **-l**
 
-Instead of providing the pod name or ID, remove the last created pod.
-
-The latest option is not supported on the remote client.
+Instead of providing the pod name or ID, remove the last created pod. (This option is not available with the remote Podman client)
 
 #### **--force**, **-f**
 

--- a/docs/source/markdown/podman-pod-start.1.md
+++ b/docs/source/markdown/podman-pod-start.1.md
@@ -18,9 +18,7 @@ Starts all pods
 
 #### **--latest**, **-l**
 
-Instead of providing the pod name or ID, start the last created pod.
-
-The latest option is not supported on the remote client.
+Instead of providing the pod name or ID, start the last created pod. (This option is not available with the remote Podman client)
 
 #### **--pod-id-file**
 

--- a/docs/source/markdown/podman-pod-stats.1.md
+++ b/docs/source/markdown/podman-pod-stats.1.md
@@ -17,9 +17,7 @@ Show all containers.  Only running containers are shown by default
 
 #### **--latest**, **-l**
 
-Instead of providing the pod name or ID, use the last created pod.
-
-The latest option is not supported on the remote client.
+Instead of providing the pod name or ID, use the last created pod. (This option is not available with the remote Podman client)
 
 #### **--no-reset**
 

--- a/docs/source/markdown/podman-pod-stop.1.md
+++ b/docs/source/markdown/podman-pod-stop.1.md
@@ -23,9 +23,7 @@ ExecStop directive of a systemd service referencing that pod.
 
 #### **--latest**, **-l**
 
-Instead of providing the pod name or ID, stop the last created pod.
-
-The latest option is not supported on the remote client.
+Instead of providing the pod name or ID, stop the last created pod. (This option is not available with the remote Podman client)
 
 #### **--time**, **-t**=*time*
 

--- a/docs/source/markdown/podman-pod-top.1.md
+++ b/docs/source/markdown/podman-pod-top.1.md
@@ -17,9 +17,7 @@ Display the running processes of containers in a pod. The *format-descriptors* a
 
 #### **--latest**, **-l**
 
-Instead of providing the pod name or ID, use the last created pod.
-
-The latest option is not supported on the remote client.
+Instead of providing the pod name or ID, use the last created pod. (This option is not available with the remote Podman client)
 
 ## FORMAT DESCRIPTORS
 

--- a/docs/source/markdown/podman-pod-unpause.1.md
+++ b/docs/source/markdown/podman-pod-unpause.1.md
@@ -17,9 +17,7 @@ Unpause all pods.
 
 #### **--latest**, **-l**
 
-Instead of providing the pod name or ID, unpause the last created pod.
-
-The latest option is not supported on the remote client.
+Instead of providing the pod name or ID, unpause the last created pod. (This option is not available with the remote Podman client)
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-port.1.md
+++ b/docs/source/markdown/podman-port.1.md
@@ -21,9 +21,7 @@ or private ports/protocols as filters.
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -94,9 +94,7 @@ Print the n last created containers (all states)
 
 #### **--latest**, **-l**
 
-Show the latest container created (all states)
-
-The latest option is not supported on the remote client.
+Show the latest container created (all states) (This option is not available with the remote Podman client)
 
 #### **--namespace**, **--ns**
 

--- a/docs/source/markdown/podman-pull.1.md
+++ b/docs/source/markdown/podman-pull.1.md
@@ -85,7 +85,7 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
+Default certificates directory is _/etc/containers/certs.d_. (This option is not available with the remote Podman client)
 
 #### **--creds**=*[username[:password]]*
 

--- a/docs/source/markdown/podman-push.1.md
+++ b/docs/source/markdown/podman-push.1.md
@@ -71,7 +71,7 @@ value can be entered.  The password is entered without echo.
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
+Default certificates directory is _/etc/containers/certs.d_. (This option is not available with the remote Podman client)
 
 #### **--compress**
 
@@ -80,7 +80,7 @@ Note: This flag can only be set when using the **dir** transport
 
 #### **--digestfile** *Digestfile*
 
-After copying the image, write the digest of the resulting image to the file.  (Not available for remote commands)
+After copying the image, write the digest of the resulting image to the file.  (This option is not available with the remote Podman client)
 
 #### **--disable-content-trust**
 
@@ -98,11 +98,11 @@ When writing the output image, suppress progress output
 
 #### **--remove-signatures**
 
-Discard any pre-existing signatures in the image. (Not available for remote commands)
+Discard any pre-existing signatures in the image. (This option is not available with the remote Podman client)
 
 #### **--sign-by**=*key*
 
-Add a signature at the destination using the specified key. (Not available for remote commands)
+Add a signature at the destination using the specified key. (This option is not available with the remote Podman client)
 
 #### **--tls-verify**=*true|false*
 

--- a/docs/source/markdown/podman-restart.1.md
+++ b/docs/source/markdown/podman-restart.1.md
@@ -19,9 +19,7 @@ Restart all containers regardless of their current state.
 
 #### **--latest**, **-l**
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--running**
 Restart all containers that are already in the *running* state.

--- a/docs/source/markdown/podman-rm.1.md
+++ b/docs/source/markdown/podman-rm.1.md
@@ -39,9 +39,7 @@ during the ExecStop directive of a systemd service referencing that container.
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--volumes**, **-v**
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -380,7 +380,7 @@ See [**Environment**](#environment) note below for precedence and examples.
 
 #### **--env-host**=**true**|**false**
 
-Use host environment inside of the container. See **Environment** note below for precedence. (Not available for remote commands)
+Use host environment inside of the container. See **Environment** note below for precedence. (This option is not available with the remote Podman client)
 
 #### **--env-file**=*file*
 
@@ -456,7 +456,7 @@ the container should not use any proxy. Proxy environment variables specified
 for the container in any other way will override the values that would have
 been passed through from the host. (Other ways to specify the proxy for the
 container include passing the values with the **--env** flag, or hard coding the
-proxy environment at container build time.) (Not available for remote commands)
+proxy environment at container build time.) (This option is not available with the remote Podman client)
 
 Defaults to **true**.
 

--- a/docs/source/markdown/podman-start.1.md
+++ b/docs/source/markdown/podman-start.1.md
@@ -32,9 +32,7 @@ Attach container's STDIN. The default is false.
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--sig-proxy**=*true|false*
 

--- a/docs/source/markdown/podman-stats.1.md
+++ b/docs/source/markdown/podman-stats.1.md
@@ -27,9 +27,7 @@ Show all containers.  Only running containers are shown by default
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--no-reset**
 

--- a/docs/source/markdown/podman-stop.1.md
+++ b/docs/source/markdown/podman-stop.1.md
@@ -34,9 +34,7 @@ during the ExecStop directive of a systemd service referencing that container.
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 #### **--time**, **-t**=*time*
 

--- a/docs/source/markdown/podman-top.1.md
+++ b/docs/source/markdown/podman-top.1.md
@@ -20,9 +20,7 @@ Print usage statement
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+to run containers such as CRI-O, the last started container could be from either of those methods.(This option is not available with the remote Podman client)
 
 ## FORMAT DESCRIPTORS
 

--- a/docs/source/markdown/podman-unmount.1.md
+++ b/docs/source/markdown/podman-unmount.1.md
@@ -43,9 +43,7 @@ as the mount point could be removed without their knowledge.
 
 Instead of providing the container name or ID, use the last created container.
 If you use methods other than Podman to run containers such as CRI-O, the last
-started container could be from either of those methods.
-
-The latest option is not supported on the remote client.
+started container could be from either of those methods. (This option is not available with the remote Podman client)
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-wait.1.md
+++ b/docs/source/markdown/podman-wait.1.md
@@ -29,9 +29,8 @@ Condition to wait on (default "stopped")
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods.
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
-The latest option is not supported on the remote client.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Remove --volume option from podman-remote since it is
not supported, also add information to podman-build man page
indicating options not supported over remote connections.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
