### PR TITLE
apiv2 tests: add helpers to start/stop a local registry

### DIFF
--- a/test/apiv2/60-auth.at
+++ b/test/apiv2/60-auth.at
@@ -1,0 +1,29 @@
+# -*- sh -*-
+#
+# registry-related tests
+#
+
+start_registry
+
+# FIXME FIXME FIXME: remove the 'if false' for use with PR 9589
+if false; then
+
+# FIXME FIXME: please forgive the horrible POST params format; I have an
+#              upcoming PR which should fix that.
+
+# Test with wrong password. Confirm bad status and appropriate error message
+t POST /v1.40/auth "\"username\":\"${REGISTRY_USERNAME}\",\"password\":\"WrOnGPassWord\",\"serveraddress\":\"localhost:$REGISTRY_PORT/\"" \
+  400 \
+  .Status~'.* invalid username/password'
+
+# Test with the right password. Confirm status message and reasonable token
+t POST /v1.40/auth "\"username\":\"${REGISTRY_USERNAME}\",\"password\":\"${REGISTRY_PASSWORD}\",\"serveraddress\":\"localhost:$REGISTRY_PORT/\"" \
+  200 \
+  .Status="Login Succeeded" \
+  .IdentityToken~[a-zA-Z0-9]
+
+# FIXME: now what? Try something-something using that token?
+token=$(jq -r .IdentityToken <<<"$output")
+# ...
+
+fi    # FIXME FIXME FIXME: remove when working

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -17,6 +17,8 @@ PODMAN_TEST_IMAGE_FQN="$PODMAN_TEST_IMAGE_REGISTRY/$PODMAN_TEST_IMAGE_USER/$PODM
 
 IMAGE=$PODMAN_TEST_IMAGE_FQN
 
+REGISTRY_IMAGE="${PODMAN_TEST_IMAGE_REGISTRY}/${PODMAN_TEST_IMAGE_USER}/registry:2.7"
+
 # END   stuff you can but probably shouldn't customize
 ###############################################################################
 # BEGIN setup
@@ -313,11 +315,113 @@ function start_service() {
         die "Cannot start service on non-localhost ($HOST)"
     fi
 
-    $PODMAN_BIN --root $WORKDIR system service --time 15 tcp:127.0.0.1:$PORT \
+    $PODMAN_BIN --root $WORKDIR/server_root system service \
+                --time 15 \
+                tcp:127.0.0.1:$PORT \
         &> $WORKDIR/server.log &
     service_pid=$!
 
     wait_for_port $HOST $PORT
+}
+
+function stop_service() {
+    # Stop the server
+    if [[ -n $service_pid ]]; then
+        kill $service_pid
+        wait $service_pid
+    fi
+}
+
+####################
+#  start_registry  #  Run a local registry
+####################
+REGISTRY_PORT=
+REGISTRY_USERNAME=
+REGISTRY_PASSWORD=
+function start_registry() {
+    # We can be invoked multiple times, e.g. from different subtests, but
+    # let's assume that once started we only kill it at the end of tests.
+    if [[ -n "$REGISTRY_PORT" ]]; then
+        return
+    fi
+
+    REGISTRY_PORT=$(random_port)
+    REGISTRY_USERNAME=u$(random_string 7)
+    REGISTRY_PASSWORD=p$(random_string 7)
+
+    local REGDIR=$WORKDIR/registry
+    local AUTHDIR=$REGDIR/auth
+    mkdir -p $AUTHDIR
+
+    mkdir -p ${REGDIR}/{root,runroot}
+    local PODMAN_REGISTRY_ARGS="--root ${REGDIR}/root --runroot ${REGDIR}/runroot"
+
+    # Give it three tries, to compensate for network flakes
+    podman ${PODMAN_REGISTRY_ARGS} pull $REGISTRY_IMAGE ||
+        podman ${PODMAN_REGISTRY_ARGS} pull $REGISTRY_IMAGE ||
+        podman ${PODMAN_REGISTRY_ARGS} pull $REGISTRY_IMAGE
+
+    # Create a local cert and credentials
+    # FIXME: is there a hidden "--quiet" flag? This is too noisy.
+    openssl req -newkey rsa:4096 -nodes -sha256 \
+            -keyout $AUTHDIR/domain.key -x509 -days 2 \
+            -out $AUTHDIR/domain.crt \
+            -subj "/C=US/ST=Foo/L=Bar/O=Red Hat, Inc./CN=registry host certificate" \
+            -addext subjectAltName=DNS:localhost
+    htpasswd -Bbn ${REGISTRY_USERNAME} ${REGISTRY_PASSWORD} \
+             > $AUTHDIR/htpasswd
+
+    # Run the registry, and wait for it to come up
+    podman ${PODMAN_REGISTRY_ARGS} run -d \
+           -p ${REGISTRY_PORT}:5000 \
+           --name registry \
+           -v $AUTHDIR:/auth:Z \
+           -e "REGISTRY_AUTH=htpasswd" \
+           -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
+           -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+           -e REGISTRY_HTTP_TLS_CERTIFICATE=/auth/domain.crt \
+           -e REGISTRY_HTTP_TLS_KEY=/auth/domain.key \
+           ${REGISTRY_IMAGE}
+
+    wait_for_port localhost $REGISTRY_PORT
+}
+
+function stop_registry() {
+    local REGDIR=${WORKDIR}/registry
+    if [[ -d $REGDIR ]]; then
+        local OPTS="--root ${REGDIR}/root --runroot ${REGDIR}/runroot"
+        podman $OPTS stop -f -t 0 -a
+
+        # rm/rmi are important when running rootless: without them we
+        # get EPERMS in tmpdir cleanup because files are owned by subuids.
+        podman $OPTS rm -f -a
+        podman $OPTS rmi -f -a
+    fi
+}
+
+#################
+#  random_port  #  Random open port; arg is range (min-max), default 5000-5999
+#################
+function random_port() {
+    local range=${1:-5000-5999}
+
+    local port
+    for port in $(shuf -i ${range}); do
+        if ! { exec 5<> /dev/tcp/127.0.0.1/$port; } &>/dev/null; then
+            echo $port
+            return
+        fi
+    done
+
+    die "Could not find open port in range $range"
+}
+
+###################
+#  random_string  #  Pseudorandom alphanumeric string of given length
+###################
+function random_string() {
+    local length=${1:-10}
+    head /dev/urandom | tr -dc a-zA-Z0-9 | head -c$length
 }
 
 ###################
@@ -341,8 +445,8 @@ function wait_for_port() {
 #  podman  #  Needed by some test scripts to invoke the actual podman binary
 ############
 function podman() {
-    echo "\$ $PODMAN_BIN $*"           >>$WORKDIR/output.log
-    $PODMAN_BIN --root $WORKDIR "$@"   >>$WORKDIR/output.log 2>&1
+    echo "\$ $PODMAN_BIN $*"                       >>$WORKDIR/output.log
+    $PODMAN_BIN --root $WORKDIR/server_root "$@"   >>$WORKDIR/output.log 2>&1
 }
 
 ####################
@@ -412,9 +516,8 @@ if [ -n "$service_pid" ]; then
     podman rm -a
     podman rmi -af
 
-    # Stop the server
-    kill $service_pid
-    wait $service_pid
+    stop_registry
+    stop_service
 fi
 
 test_count=$(<$testcounter_file)


### PR DESCRIPTION
...and a rudimentary set of /auth tests for PR#9589 (disabled).

This simply adds a new start_registry() helper function that
allocates a random unused port, pulls a registry image, creates
a local certificate + random username + random password, and
fires everything up. Since none of this is (yet) used in CI,
this is very low risk.

The only infinitessimally-risky change is using a dedicated
subdirectory of $WORKDIR (instead of $WORKDIR itself) as
the podman root. This fixes a dumb oversight on my part:
the workdir has grown to be used for much more than just
podman root; this change removes clutter and makes it
easier for humans to debug in cases of problems.

Signed-off-by: Ed Santiago <santiago@redhat.com>
