### PR TITLE
options: append CLI graph driver options

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -64,15 +64,22 @@ func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
 			setField = true
 		}
 
+		graphDriverChanged := false
 		if config.GraphDriverName != "" {
 			rt.storageConfig.GraphDriverName = config.GraphDriverName
 			rt.storageSet.GraphDriverNameSet = true
 			setField = true
+			graphDriverChanged = true
 		}
 
 		if config.GraphDriverOptions != nil {
-			rt.storageConfig.GraphDriverOptions = make([]string, len(config.GraphDriverOptions))
-			copy(rt.storageConfig.GraphDriverOptions, config.GraphDriverOptions)
+			if graphDriverChanged {
+				rt.storageConfig.GraphDriverOptions = make([]string, len(config.GraphDriverOptions))
+				copy(rt.storageConfig.GraphDriverOptions, config.GraphDriverOptions)
+			} else {
+				// append new options after what is specified in the config files
+				rt.storageConfig.GraphDriverOptions = append(rt.storageConfig.GraphDriverOptions, config.GraphDriverOptions...)
+			}
 			setField = true
 		}
 


### PR DESCRIPTION
if --storage-opt are specified on the CLI append them after what is
specified in the configuration files instead of overriding it.

Closes: https://github.com/containers/podman/issues/9657

[NO TESTS NEEDED]

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
