### PR TITLE
podman load: fix error handling

### DIFF
--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -316,7 +316,8 @@ func (r *Runtime) LoadImageFromSingleImageArchive(ctx context.Context, writer io
 	} {
 		src, err := referenceFn()
 		if err == nil && src != nil {
-			if newImages, err := r.ImageRuntime().LoadFromArchiveReference(ctx, src, signaturePolicy, writer); err == nil {
+			newImages, err := r.ImageRuntime().LoadFromArchiveReference(ctx, src, signaturePolicy, writer)
+			if err == nil {
 				return getImageNames(newImages), nil
 			}
 			saveErr = err

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -26,6 +26,13 @@ verify_iid_and_name() {
     is "$new_img_name" "$1"   "Name & tag of restored image"
 }
 
+@test "podman load invalid file" {
+    # Regression test for #9672 to make sure invalid input yields errors.
+    invalid=$PODMAN_TMPDIR/invalid
+    echo "I am an invalid file and should cause a podman-load error" > $invalid
+    run_podman 125 load -i $invalid
+}
+
 @test "podman save to pipe and load" {
     # Generate a random name and tag (must be lower-case)
     local random_name=x0$(random_string 12 | tr A-Z a-z)


### PR DESCRIPTION
Make sure to properly return loading errors and to set the exit code
accordingly.

Fixes: #9672
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
