### PR TITLE
Fix array instead of one elem network http api

### DIFF
--- a/pkg/api/handlers/libpod/networks.go
+++ b/pkg/api/handlers/libpod/networks.go
@@ -128,7 +128,7 @@ func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
-	utils.WriteResponse(w, http.StatusOK, reports)
+	utils.WriteResponse(w, http.StatusOK, reports[0])
 }
 
 // Connect adds a container to a network

--- a/pkg/api/handlers/libpod/swagger.go
+++ b/pkg/api/handlers/libpod/swagger.go
@@ -102,7 +102,7 @@ type swagNetworkRmReport struct {
 // swagger:response NetworkInspectReport
 type swagNetworkInspectReport struct {
 	// in:body
-	Body []entities.NetworkInspectReport
+	Body entities.NetworkInspectReport
 }
 
 // Network list

--- a/pkg/bindings/network/network.go
+++ b/pkg/bindings/network/network.go
@@ -40,6 +40,7 @@ func Create(ctx context.Context, options *CreateOptions) (*entities.NetworkCreat
 // Inspect returns low level information about a CNI network configuration
 func Inspect(ctx context.Context, nameOrID string, options *InspectOptions) ([]entities.NetworkInspectReport, error) {
 	var reports []entities.NetworkInspectReport
+	reports = append(reports, entities.NetworkInspectReport{})
 	if options == nil {
 		options = new(InspectOptions)
 	}
@@ -52,7 +53,7 @@ func Inspect(ctx context.Context, nameOrID string, options *InspectOptions) ([]e
 	if err != nil {
 		return nil, err
 	}
-	return reports, response.Process(&reports)
+	return reports, response.Process(&reports[0])
 }
 
 // Remove deletes a defined CNI network configuration by name.  The optional force boolean

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -27,6 +27,10 @@ t GET libpod/networks/json?filters='{"name":["network1"]}' 200 \
   .[0].Name=network1
 t GET networks 200
 
+#inspect network
+t GET libpod/networks/network1/json 200 \
+  .name="network1"
+
 #network list docker endpoint
 t GET networks?filters='{"name":["network1","network2"]}' 200 \
   length=2


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
Closes #9690
Fixes  #9690

curl -v --unix-socket /run/podman/podman.sock http://d/v3.0.0/libpod/networks/podman/json
**Describe the results you received:**
the array of one of network report objects.
**Describe the results you expected:**
One report object, since input guarantees there will only ever be one output.

This PR fixes the above issue.