### PR TITLE
Bump containers/image to v5.10.5 in the v3.0.1-rhel branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containers/buildah v1.19.7
 	github.com/containers/common v0.33.4
 	github.com/containers/conmon v2.0.20+incompatible
-	github.com/containers/image/v5 v5.10.3
+	github.com/containers/image/v5 v5.10.5
 	github.com/containers/ocicrypt v1.0.3
 	github.com/containers/psgo v1.5.2
 	github.com/containers/storage v1.24.8

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOB
 github.com/containers/image/v5 v5.10.1 h1:tHhGQ8RCMxJfJLD/PEW1qrOKX8nndledW9qz6UiAxns=
 github.com/containers/image/v5 v5.10.1/go.mod h1:JlRLJZv7elVbtHaaaR6Kz8i6G3k2ttj4t7fubwxD9Hs=
 github.com/containers/image/v5 v5.10.2/go.mod h1:JlRLJZv7elVbtHaaaR6Kz8i6G3k2ttj4t7fubwxD9Hs=
-github.com/containers/image/v5 v5.10.3 h1:DHgdrNkiBVav/ca/5EdAzn682Zuy1gp6PQgK83fiAkw=
-github.com/containers/image/v5 v5.10.3/go.mod h1:SgIbWEedCNBbn2FI5cH0/jed1Ecy2s8XK5zTxvJTzII=
+github.com/containers/image/v5 v5.10.5 h1:VK1UbsZMzjdw5Xqr3Im9h4iOqHWU0naFs+I78kavc7I=
+github.com/containers/image/v5 v5.10.5/go.mod h1:SgIbWEedCNBbn2FI5cH0/jed1Ecy2s8XK5zTxvJTzII=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.3 h1:vYgl+RZ9Q3DPMuTfxmN+qp0X2Bj52uuY2vnt6GzVe1c=

--- a/vendor/github.com/containers/image/v5/storage/storage_image.go
+++ b/vendor/github.com/containers/image/v5/storage/storage_image.go
@@ -246,8 +246,7 @@ func (s *storageImageSource) LayerInfosForCopy(ctx context.Context, instanceDige
 	case imgspecv1.MediaTypeImageManifest:
 		uncompressedLayerType = imgspecv1.MediaTypeImageLayer
 	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType, manifest.DockerV2Schema2MediaType:
-		// This is actually a compressed type, but there's no uncompressed type defined
-		uncompressedLayerType = manifest.DockerV2Schema2LayerMediaType
+		uncompressedLayerType = manifest.DockerV2SchemaLayerMediaTypeUncompressed
 	}
 
 	physicalBlobInfos := []types.BlobInfo{}

--- a/vendor/github.com/containers/image/v5/version/version.go
+++ b/vendor/github.com/containers/image/v5/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 10
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 3
+	VersionPatch = 5
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,7 +108,7 @@ github.com/containers/common/pkg/umask
 github.com/containers/common/version
 # github.com/containers/conmon v2.0.20+incompatible
 github.com/containers/conmon/runner/config
-# github.com/containers/image/v5 v5.10.3
+# github.com/containers/image/v5 v5.10.5
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory
 github.com/containers/image/v5/directory/explicitfilepath


### PR DESCRIPTION
As the title says.

No c/storage bump Podman is already at v1.24.8.  
Also, Buildah is at c/storage v1.24.8 and c/image v5.10.5 so no bumps inbound for it for RHEL 8.4.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
