### PR TITLE
Fix for volumes prune in http compat api when using filters

### DIFF
--- a/test/apiv2/30-volumes.at
+++ b/test/apiv2/30-volumes.at
@@ -86,6 +86,10 @@ t DELETE libpod/volumes/foo1 404 \
     .message~.* \
     .response=404
 
+# Prune volumes - bad filter input
+t POST volumes/prune?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+
 ## Prune volumes with label matching 'testlabel1=testonly'
 t POST libpod/volumes/prune?filters='{"label":["testlabel1=testonly"]}' 200
 t GET libpod/volumes/json?filters='{"label":["testlabel1=testonly"]}' 200 length=0


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
/kind bug

1. Docker: scenario => when the user makes mistake when using filters, then no negative consequences
```
$ docker volume create v1
v1
$ docker volume create v2
v2
$ curl -gG -XPOST --unix-socket /var/run/docker.sock  http://localhost/v1.41/volumes/prune?filters=dssd21 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    67  100    67    0     0  67000      0 --:--:-- --:--:-- --:--:-- 67000
{
  "message": "invalid character 'd' looking for beginning of value"
}


```

2. Podman (compat API): scenario => mistake, then there are negative consequences
```
$ bin/podman volume create v1
v1
$ bin/podman volume create v2
v2
$ curl -gG -XPOST --unix-socket /run/user/1000/podman/podman.sock  http://d/v3.0.0/volumes/prune?filters=dssd21 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    50  100    50    0     0   2173      0 --:--:-- --:--:-- --:--:--  2173
{
  "VolumesDeleted": [
    "v1",
    "v2"
  ],
  "SpaceReclaimed": 0
}
$ bin/podman volume create v1bis
v1bis
$ bin/podman volume create v2bis
v2bis
$ curl -gG -XPOST --unix-socket /run/user/1000/podman/podman.sock  http://d/v3.0.0/volumes/prune?filters={garba1ge | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    56  100    56    0     0   2666      0 --:--:-- --:--:-- --:--:--  2666
{
  "VolumesDeleted": [
    "v1bis",
    "v2bis"
  ],
  "SpaceReclaimed": 0
}

```
3. After fix:
```
$ curl -gG -XPOST --unix-socket /run/user/1000/podman/podman.sock  http://d/v3.0.0/volumes/prune?filters=dssd21 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   155  100   155    0     0   151k      0 --:--:-- --:--:-- --:--:--  151k
{
  "cause": "invalid character 'd' looking for beginning of value",
  "message": "Decode(): invalid character 'd' looking for beginning of value",
  "response": 500
}

```

Generally, this code:
```
	query := struct {
		Filters map[string][]string `schema:"filters"`
	}{
		// override any golang type defaults
	}

	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
```
Is very broken in similar situations. Sometimes it does not have negative consequences (for GET list, just inconsistency) but for prune user instead of 500 user receives 200 with success... having all things wiped out.

I can do similar PRs for compat API (images, containers, etc). Libpod is also affected, but since there are no compat constraints there, maybe this is by design?

I also added fixes for HTTP codes, according to this: https://docs.docker.com/engine/api/v1.41/ . There are many 400 (StatusBadRequest) while there is no example of 400 in docker API. Another story is that current flow never gets to if conditions in questions since `if err := decoder.Decode(&query, r.URL.Query()); err != nil....` is broken. Probably it returns nil instead of error when analyzing garbage filter input.

