### PR TITLE
System test cleanup

### DIFF
--- a/test/apiv2/44-mounts.at
+++ b/test/apiv2/44-mounts.at
@@ -6,7 +6,7 @@ podman pull $IMAGE &>/dev/null
 tmpfs_name="/mytmpfs"
 t POST containers/create?name=hostconfig_test \
   Image=$IMAGE \
-  Cmd='["df"]' \
+  Cmd='["df","-P","'$tmpfs_name'"]' \
   HostConfig='{"Binds":["/tmp/doesnotexist:/test1"]' \
   TmpFs="{\"$tmpfs_name\":\"rw\"}}" \
   201 \
@@ -22,5 +22,10 @@ t POST containers/${cid}/start 204
 t POST containers/${cid}/wait  200
 t GET  containers/${cid}/logs?stdout=true  200
 
-like "$(<$WORKDIR/curl.result.out)" ".* ${tmpfs_name}" \
+# /logs returns application/octet-stream, which our test helper saves in
+# an outfile rather than returning in $output. That's why we can't test
+# this directly in the /logs test above; instead, we rely on knowing the
+# path to the stored results. The 'tr' is needed because there may be
+# null bytes in the outfile.
+like "$(tr -d \\0 <$WORKDIR/curl.result.out)" ".* ${tmpfs_name}" \
      "'df' output includes tmpfs name"

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -370,6 +370,7 @@ load helpers
     is "${lines[0]}" "${randomcontent[0]}" "eval symlink - created container"
     is "${lines[1]}" "${randomcontent[1]}" "eval symlink - created container"
     run_podman rm -f cpcontainer
+    run_podman rmi $cpimage
 }
 
 

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -31,6 +31,9 @@ verify_iid_and_name() {
     invalid=$PODMAN_TMPDIR/invalid
     echo "I am an invalid file and should cause a podman-load error" > $invalid
     run_podman 125 load -i $invalid
+    # podman and podman-remote emit different messages; this is a common string
+    is "$output" ".*error pulling image: unable to pull .*" \
+       "load -i INVALID fails with expected diagnostic"
 }
 
 @test "podman save to pipe and load" {

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -5,6 +5,20 @@
 
 load helpers
 
+# This is a long ugly way to clean up pods and remove the pause image
+function teardown() {
+    run_podman pod rm -f -a
+    run_podman rm -f -a
+    run_podman image list --format '{{.ID}} {{.Repository}}'
+    while read id name; do
+        if [[ "$name" =~ /pause ]]; then
+            run_podman rmi $id
+        fi
+    done <<<"$output"
+
+    basic_teardown
+}
+
 testYaml="
 apiVersion: v1
 kind: Pod
@@ -24,7 +38,7 @@ spec:
       value: xterm
     - name: container
       value: podman
-    image: quay.io/libpod/alpine:latest
+    image: $IMAGE
     name: test
     resources: {}
     securityContext:


### PR DESCRIPTION
- cp test: clean up stray image

- build test: add workaround for #9567 (ultra-slow ubuntu).
  We're seeing CI flakes (timeouts) due to ubuntu 2004 being
  absurdly slow. Workaround: double our timeout on one specific
  test when ubuntu + remote.

- build test: clean up new copy-from test (from #9275).
  The test was copy-pasted from buildah system tests, without
  really adapting for podman environment (e.g. it was using
  images that we don't use here, and would cause pulls, which
  will cause flakes). Rewrite test so it references only $IMAGE,
  remove some confusing/unnecessary stuff, selectively run
  parts of it even when rootless or remote, and add a
  test to confirm that copy-from succeeded.

- load test: add error-message test to new load-invalid (#9672).
  Basically, make sure the command fails for the right reason.

- play test (kube): use $IMAGE, not alpine; and add pause-image
  cleanup to teardown()

- apiv2 mounts test: add a maintainability comment in a tricky
  section of code; and tighten up the mount point test.

Signed-off-by: Ed Santiago <santiago@redhat.com>
