### PR TITLE
[CI:DOCS] removing secrets is safe for in-use secrets

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -833,6 +833,11 @@ A secret is a blob of sensitive data which a container needs at runtime but
 should not be stored in the image or in source control, such as usernames and passwords,
 TLS certificates and keys, SSH keys or other important generic strings or binary content (up to 500 kb in size).
 
+Secrets are copied and mounted into the container when a container is created. If a secret is deleted using
+`podman secret rm`, the container will still have access to the secret. If a secret is deleted and
+another secret is created with the same name, the secret inside the container will not change; the old
+secret value will still remain.
+
 Secrets are managed using the `podman secret` command.
 
 #### **--security-opt**=*option*

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -885,6 +885,11 @@ A secret is a blob of sensitive data which a container needs at runtime but
 should not be stored in the image or in source control, such as usernames and passwords,
 TLS certificates and keys, SSH keys or other important generic strings or binary content (up to 500 kb in size).
 
+Secrets are copied and mounted into the container when a container is created. If a secret is deleted using
+`podman secret rm`, the container will still have access to the secret. If a secret is deleted and
+another secret is created with the same name, the secret inside the container will not change; the old
+secret value will still remain.
+
 Secrets are managed using the `podman secret` command
 
 #### **--security-opt**=*option*

--- a/docs/source/markdown/podman-secret-rm.1.md
+++ b/docs/source/markdown/podman-secret-rm.1.md
@@ -10,6 +10,12 @@ podman\-secret\-rm - Remove one or more secrets
 
 Removes one or more secrets.
 
+`podman secret rm` is safe to use on secrets that are in use by a container.
+The created container will still have access to the secret data because secrets are
+copied and mounted into the container when a container is created. If a secret is deleted and
+another secret is created with the same name, the secret inside the container will not change;
+the old secret value will still remain.
+
 ## OPTIONS
 
 #### **--all**, **-a**


### PR DESCRIPTION
Add docs explaining that it is safe to remove a secret that is in use by
a container: secrets are copied and mounted into the container at
creation

Signed-off-by: Ashley Cui <acui@redhat.com>

Closes #9712

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
