### PR TITLE
fix user message image prune --all

### DIFF
--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -53,9 +53,7 @@ func init() {
 func prune(cmd *cobra.Command, args []string) error {
 	if !force {
 		reader := bufio.NewReader(os.Stdin)
-		fmt.Printf(`
-WARNING! This will remove all dangling images.
-Are you sure you want to continue? [y/N] `)
+		fmt.Printf("%s", createPruneWarningMessage(pruneOpts))
 		answer, err := reader.ReadString('\n')
 		if err != nil {
 			return err
@@ -71,4 +69,12 @@ Are you sure you want to continue? [y/N] `)
 	}
 
 	return utils.PrintImagePruneResults(results, false)
+}
+
+func createPruneWarningMessage(pruneOpts entities.ImagePruneOptions) string {
+	question := "Are you sure you want to continue? [y/N] "
+	if pruneOpts.All {
+		return "WARNING! This will remove all images without at least one container associated to them.\n" + question
+	}
+	return "WARNING! This will remove all dangling images.\n" + question
 }


### PR DESCRIPTION
User message was the same as in the case of no flag provided.
This commit aligns message with the one used in docker.

[NO TESTS NEEDED]

Signed-off-by: Jakub Guzik <jakubmguzik@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
/kind bug

Docker:
```
$ docker image prune 
WARNING! This will remove all dangling images.
Are you sure you want to continue? [y/N] ^C
$ docker image prune -a
WARNING! This will remove all images without at least one container associated to them.
Are you sure you want to continue? [y/N] ^C
```
Podman:
```
$podman image prune 

WARNING! This will remove all dangling images.
Are you sure you want to continue? [y/N] ^C
$ podman image prune -a

WARNING! This will remove all dangling images.
Are you sure you want to continue? [y/N] ^C
```
Podman after fix:
```
$ bin/podman image prune 
WARNING! This will remove all dangling images.
Are you sure you want to continue? [y/N] ^C 
$ bin/podman image prune -a
WARNING! This will remove all images without at least one container associated to them.
Are you sure you want to continue? [y/N] ^C
```