### PR TITLE
Delete all containers and pods between tests

### DIFF
--- a/test/apiv2/rest_api/__init__.py
+++ b/test/apiv2/rest_api/__init__.py
@@ -3,6 +3,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 
 
@@ -114,13 +115,20 @@ class Podman(object):
         check = kwargs.get("check", False)
         shell = kwargs.get("shell", False)
 
-        return subprocess.run(
-            cmd,
-            shell=shell,
-            check=check,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        try:
+            return subprocess.run(
+                cmd,
+                shell=shell,
+                check=check,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except subprocess.CalledProcessError as e:
+            if e.stdout:
+                sys.stdout.write("\nRun Stdout:\n" + e.stdout.decode("utf-8"))
+            if e.stderr:
+                sys.stderr.write("\nRun Stderr:\n" + e.stderr.decode("utf-8"))
+            raise
 
     def tear_down(self):
         shutil.rmtree(self.anchor_directory, ignore_errors=True)


### PR DESCRIPTION
New tearDown() deletes all pods and containers between tests

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
