### PR TITLE
Check if stdin is a term in --interactive --tty mode

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var (
@@ -104,6 +105,11 @@ func run(cmd *cobra.Command, args []string) error {
 	cliVals.Net, err = common.NetFlagsToNetOptions(cmd)
 	if err != nil {
 		return err
+	}
+
+	// TODO: Breaking change should be made fatal in next major Release
+	if cliVals.TTY && cliVals.Interactive && !terminal.IsTerminal(int(os.Stdin.Fd())) {
+		logrus.Warnf("The input device is not a TTY. The --tty and --interactive flags might not work properly")
 	}
 
 	if af := cliVals.Authfile; len(af) > 0 {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -668,4 +668,15 @@ json-file | f
     is "$output" ".*HOME=/.*"
 }
 
+@test "podman run --tty -i failure with no tty" {
+    run_podman run --tty -i --rm $IMAGE echo hello < /dev/null
+    is "$output" ".*The input device is not a TTY.*"
+
+    run_podman run --tty=false -i --rm $IMAGE echo hello < /dev/null
+    is "$output" "hello"
+
+    run_podman run --tty -i=false --rm $IMAGE echo hello < /dev/null
+    is "$output" "hello"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
If you are attempting to run a container in interactive mode, and want
a --tty, then there must be a terminal in use.

Docker exits right away when a user specifies to use a --interactive and
--TTY but the stdin is not a tty.

Currently podman will pull the image and then fail much later.

Discussion in : https://github.com/containers/podman/issues/8916

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
