### PR TITLE
Cleanup /libpod/images/load handler

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -810,11 +810,14 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// summary: Load image
 	// description: Load an image (oci-archive or docker-archive) stream.
 	// parameters:
-	//   - in: formData
+	//   - in: body
 	//     name: upload
-	//     description: tarball of container image
-	//     type: file
 	//     required: true
+	//     description: tarball of container image
+	//     schema:
+	//       type: string
+	// consumes:
+	// - application/x-tar
 	// produces:
 	// - application/json
 	// responses:

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -32,7 +32,7 @@ verify_iid_and_name() {
     echo "I am an invalid file and should cause a podman-load error" > $invalid
     run_podman 125 load -i $invalid
     # podman and podman-remote emit different messages; this is a common string
-    is "$output" ".*error pulling image: unable to pull .*" \
+    is "$output" ".*payload does not match any of the supported image formats .*" \
        "load -i INVALID fails with expected diagnostic"
 }
 
@@ -135,6 +135,13 @@ verify_iid_and_name() {
     is "$output" \
        "Error: cannot read from terminal. Use command-line redirection" \
        "Diagnostic from 'podman load' without redirection or -i"
+}
+
+@test "podman load - redirect corrupt payload" {
+    run_podman 125 load <<< "Danger, Will Robinson!! This is a corrupt tarball!"
+    is "$output" \
+        ".*payload does not match any of the supported image formats .*" \
+        "Diagnostic from 'podman load' unknown/corrupt payload"
 }
 
 @test "podman load - multi-image archive" {


### PR DESCRIPTION
* Remove orphaned code
* Add meaningful error from LoadImageFromSingleImageArchive() when
  heuristic fails to determine payload format
* Correct swagger to output correct types and headers

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
