### PR TITLE
Fix volumes and networks list/prune filters in http api

### DIFF
--- a/pkg/util/filters.go
+++ b/pkg/util/filters.go
@@ -1,6 +1,10 @@
 package util
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/containers/podman/v3/pkg/timetype"
@@ -22,4 +26,70 @@ func ComputeUntilTimestamp(filter string, filterValues []string) (time.Time, err
 		return invalid, err
 	}
 	return time.Unix(seconds, nanoseconds), nil
+}
+
+// filtersFromRequests extracts the "filters" parameter from the specified
+// http.Request.  The parameter can either be a `map[string][]string` as done
+// in new versions of Docker and libpod, or a `map[string]map[string]bool` as
+// done in older versions of Docker.  We have to do a bit of Yoga to support
+// both - just as Docker does as well.
+//
+// Please refer to https://github.com/containers/podman/issues/6899 for some
+// background.
+func FiltersFromRequest(r *http.Request) ([]string, error) {
+	var (
+		compatFilters map[string]map[string]bool
+		filters       map[string][]string
+		libpodFilters []string
+		raw           []byte
+	)
+
+	if _, found := r.URL.Query()["filters"]; found {
+		raw = []byte(r.Form.Get("filters"))
+	} else if _, found := r.URL.Query()["Filters"]; found {
+		raw = []byte(r.Form.Get("Filters"))
+	} else {
+		return []string{}, nil
+	}
+
+	// Backwards compat with older versions of Docker.
+	if err := json.Unmarshal(raw, &compatFilters); err == nil {
+		for filterKey, filterMap := range compatFilters {
+			for filterValue, toAdd := range filterMap {
+				if toAdd {
+					libpodFilters = append(libpodFilters, fmt.Sprintf("%s=%s", filterKey, filterValue))
+				}
+			}
+		}
+		return libpodFilters, nil
+	}
+
+	if err := json.Unmarshal(raw, &filters); err != nil {
+		return nil, err
+	}
+
+	for filterKey, filterSlice := range filters {
+		for _, filterValue := range filterSlice {
+			libpodFilters = append(libpodFilters, fmt.Sprintf("%s=%s", filterKey, filterValue))
+		}
+	}
+
+	return libpodFilters, nil
+}
+
+// PrepareFilters prepares a *map[string][]string of filters to be later searched
+// in lipod and compat API to get desired filters
+func PrepareFilters(r *http.Request) (*map[string][]string, error) {
+	filtersList, err := FiltersFromRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	filterMap := map[string][]string{}
+	for _, filter := range filtersList {
+		split := strings.SplitN(filter, "=", 2)
+		if len(split) > 1 {
+			filterMap[split[0]] = append(filterMap[split[0]], split[1])
+		}
+	}
+	return &filterMap, nil
 }

--- a/test/apiv2/30-volumes.at
+++ b/test/apiv2/30-volumes.at
@@ -86,13 +86,33 @@ t DELETE libpod/volumes/foo1 404 \
     .message~.* \
     .response=404
 
+#compat api list volumes sanity checks
+t GET volumes?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t GET volumes?filters='{"label":["testl' 500 \
+    .cause="unexpected end of JSON input"
+
+#libpod api list volumes sanity checks
+t GET libpod/volumes/json?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t GET libpod/volumes/json?filters='{"label":["testl' 500 \
+    .cause="unexpected end of JSON input"
+
 # Prune volumes - bad filter input
 t POST volumes/prune?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t POST libpod/volumes/prune?filters='garb1age}' 500 \
     .cause="invalid character 'g' looking for beginning of value"
 
 ## Prune volumes with label matching 'testlabel1=testonly'
 t POST libpod/volumes/prune?filters='{"label":["testlabel1=testonly"]}' 200
 t GET libpod/volumes/json?filters='{"label":["testlabel1=testonly"]}' 200 length=0
+
+## Prune volumes with label illformed label
+t POST volumes/prune?filters='{"label":["tes' 500 \
+    .cause="unexpected end of JSON input"
+t POST libpod/volumes/prune?filters='{"label":["tes' 500 \
+    .cause="unexpected end of JSON input"
 
 ## Prune volumes with label matching 'testlabel'
 t POST libpod/volumes/prune?filters='{"label":["testlabel"]}' 200

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -80,9 +80,29 @@ t POST networks/create Name=net3\ IPAM='{"Config":[]}' 201
 # network delete docker
 t DELETE networks/net3 204
 
-# Prune networks compat api - bad filter input
+#compat api list networks sanity checks
+t GET networks?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t GET networks?filters='{"label":["testl' 500 \
+    .cause="unexpected end of JSON input"
+
+#libpod api list networks sanity checks
+t GET libpod/networks/json?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t GET libpod/networks/json?filters='{"label":["testl' 500 \
+    .cause="unexpected end of JSON input"
+
+# Prune networks compat api
 t POST networks/prune?filters='garb1age}' 500 \
     .cause="invalid character 'g' looking for beginning of value"
+t POST networks/prune?filters='{"label":["tes' 500 \
+    .cause="unexpected end of JSON input"
+
+# Prune networks libpod api
+t POST libpod/networks/prune?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t POST libpod/networks/prune?filters='{"label":["tes' 500 \
+    .cause="unexpected end of JSON input"
 
 # prune networks using filter - compat api
 t POST networks/prune?filters='{"label":["xyz"]}' 200


### PR DESCRIPTION
This is the continuation of work started in #9711. It turns out
that list/prune commands for volumes in libpod/compat api have
very dangerous error handling when broken filter input is supplied.
Problem also affects network list/prune in libpod. This commit
unifies filter handling across libpod/compat api and adds sanity
apiv2 testcases.

Signed-off-by: Jakub Guzik <jakubmguzik@gmail.com>

/kind bug
/kind cleanup

Below applies to libpod HTTP network prune, volume prune and volume list (both libpod and compat http)
1. Docker: scenario => when the user makes mistake when using filters, then no negative consequences
```
$ docker volume create v1
v1
$ docker volume create v2
v2
$ curl -gG -XPOST --unix-socket /var/run/docker.sock  http://localhost/v1.41/volumes/prune?filters=dssd21 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    67  100    67    0     0  67000      0 --:--:-- --:--:-- --:--:-- 67000
{
  "message": "invalid character 'd' looking for beginning of value"
}


```

2. Podman (compat API): scenario => mistake, then there are negative consequences
```
$ bin/podman volume create v1
v1
$ bin/podman volume create v2
v2
$ curl -gG -XPOST --unix-socket /run/user/1000/podman/podman.sock  http://d/v3.0.0/volumes/prune?filters=dssd21 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    50  100    50    0     0   2173      0 --:--:-- --:--:-- --:--:--  2173
{
  "VolumesDeleted": [
    "v1",
    "v2"
  ],
  "SpaceReclaimed": 0
}
$ bin/podman volume create v1bis
v1bis
$ bin/podman volume create v2bis
v2bis
$ curl -gG -XPOST --unix-socket /run/user/1000/podman/podman.sock  http://d/v3.0.0/volumes/prune?filters={garba1ge | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    56  100    56    0     0   2666      0 --:--:-- --:--:-- --:--:--  2666
{
  "VolumesDeleted": [
    "v1bis",
    "v2bis"
  ],
  "SpaceReclaimed": 0
}

```
3. After fix:
```
$ curl -gG -XPOST --unix-socket /run/user/1000/podman/podman.sock  http://d/v3.0.0/volumes/prune?filters=dssd21 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   155  100   155    0     0   151k      0 --:--:-- --:--:-- --:--:--  151k
{
  "cause": "invalid character 'd' looking for beginning of value",
  "message": "Decode(): invalid character 'd' looking for beginning of value",
  "response": 500
}
