### PR TITLE
security: use the bounding caps with --privileged

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
 	github.com/containers/buildah v1.19.8
-	github.com/containers/common v0.35.0
+	github.com/containers/common v0.35.3
 	github.com/containers/conmon v2.0.20+incompatible
-	github.com/containers/image/v5 v5.10.2
+	github.com/containers/image/v5 v5.10.5
 	github.com/containers/ocicrypt v1.1.0
 	github.com/containers/psgo v1.5.2
 	github.com/containers/storage v1.28.0
@@ -42,7 +42,7 @@ require (
 	github.com/moby/term v0.0.0-20201110203204-bea5bbe245bf
 	github.com/mrunalp/fileutils v0.5.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/onsi/ginkgo v1.15.1
+	github.com/onsi/ginkgo v1.15.2
 	github.com/onsi/gomega v1.11.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6

--- a/go.mod
+++ b/go.mod
@@ -70,5 +70,3 @@ require (
 	k8s.io/api v0.20.1
 	k8s.io/apimachinery v0.20.5
 )
-
-replace github.com/syndtr/gocapability => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2

--- a/go.sum
+++ b/go.sum
@@ -179,13 +179,14 @@ github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRD
 github.com/containers/buildah v1.19.8 h1:4TzmetfKPQF5hh6GgMwbAfrD50j+PAcsRiWDnx+gCI8=
 github.com/containers/buildah v1.19.8/go.mod h1:VnyHWgNmfR1d89/zJ/F4cbwOzaQS+6sBky46W7dCo3E=
 github.com/containers/common v0.33.4/go.mod h1:PhgL71XuC4jJ/1BIqeP7doke3aMFkCP90YBXwDeUr9g=
-github.com/containers/common v0.35.0 h1:1OLZ2v+Tj/CN9BTQkKZ5VOriOiArJedinMMqfJRUI38=
-github.com/containers/common v0.35.0/go.mod h1:gs1th7XFTOvVUl4LDPdQjOfOeNiVRDbQ7CNrZ0wS6F8=
+github.com/containers/common v0.35.3 h1:6tEBSIHlJzpmt35zA1ZcjBqbtUilAHDWaa7buPvaqWY=
+github.com/containers/common v0.35.3/go.mod h1:rMzxgD7nMGw++cEbsp+NZv0UJO4rgXbm7F7IbJPTwIE=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.10.1/go.mod h1:JlRLJZv7elVbtHaaaR6Kz8i6G3k2ttj4t7fubwxD9Hs=
-github.com/containers/image/v5 v5.10.2 h1:STD9GYR9p/X0qTLmBYsyx8dEM7zQW+qZ8KHoL/64fkg=
 github.com/containers/image/v5 v5.10.2/go.mod h1:JlRLJZv7elVbtHaaaR6Kz8i6G3k2ttj4t7fubwxD9Hs=
+github.com/containers/image/v5 v5.10.5 h1:VK1UbsZMzjdw5Xqr3Im9h4iOqHWU0naFs+I78kavc7I=
+github.com/containers/image/v5 v5.10.5/go.mod h1:SgIbWEedCNBbn2FI5cH0/jed1Ecy2s8XK5zTxvJTzII=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=
@@ -197,7 +198,7 @@ github.com/containers/psgo v1.5.2/go.mod h1:2ubh0SsreMZjSXW1Hif58JrEcFudQyIy9EzP
 github.com/containers/storage v1.23.5/go.mod h1:ha26Q6ngehFNhf3AWoXldvAvwI4jFe3ETQAf/CeZPyM=
 github.com/containers/storage v1.24.5/go.mod h1:YC+2pY8SkfEAcZkwycxYbpK8EiRbx5soPPwz9dxe4IQ=
 github.com/containers/storage v1.24.6/go.mod h1:YC+2pY8SkfEAcZkwycxYbpK8EiRbx5soPPwz9dxe4IQ=
-github.com/containers/storage v1.25.0/go.mod h1:UxTYd5F4mPVqmDRcRL0PBS8+HP74aBn96eahnhEvPtk=
+github.com/containers/storage v1.24.8/go.mod h1:YC+2pY8SkfEAcZkwycxYbpK8EiRbx5soPPwz9dxe4IQ=
 github.com/containers/storage v1.28.0 h1:lA/9i9BIjfmIRxCI8GuzasYHmU4IUXVcfZZiDceD0Eg=
 github.com/containers/storage v1.28.0/go.mod h1:ixAwO7Bj31cigqPEG7aCz+PYmxkDxbIFdUFioYdxbzI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -583,8 +584,8 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
-github.com/onsi/ginkgo v1.15.1 h1:DsXNrKujDlkMS9Rsxmd+Fg7S6Kc5lhE+qX8tY6laOxc=
-github.com/onsi/ginkgo v1.15.1/go.mod h1:Dd6YFfwBW84ETqqtL0CPyPXillHgY6XhQH3uuCCTr/o=
+github.com/onsi/ginkgo v1.15.2 h1:l77YT15o814C2qVL47NOyjV/6RbaP7kKdrvZnxQ3Org=
+github.com/onsi/ginkgo v1.15.2/go.mod h1:Dd6YFfwBW84ETqqtL0CPyPXillHgY6XhQH3uuCCTr/o=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/go.sum
+++ b/go.sum
@@ -748,8 +748,11 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tchap/go-patricia v2.3.0+incompatible h1:GkY4dP3cEfEASBPPkWd+AmjYxhmDkqO9/zg7R0lSQRs=
 github.com/tchap/go-patricia v2.3.0+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1268,7 +1268,10 @@ func prepareProcessExec(c *Container, options *ExecOptions, env []string, sessio
 		return nil, err
 	}
 
-	allCaps := capabilities.AllCapabilities()
+	allCaps, err := capabilities.BoundingSet()
+	if err != nil {
+		return nil, err
+	}
 	if options.Privileged {
 		pspec.Capabilities.Bounding = allCaps
 	} else {

--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -89,11 +89,27 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 	// NOTE: Must happen before SECCOMP
 	if s.Privileged {
 		g.SetupPrivileged(true)
-		caplist = capabilities.AllCapabilities()
-	} else {
-		caplist, err = capabilities.MergeCapabilities(rtc.Containers.DefaultCapabilities, s.CapAdd, s.CapDrop)
+		caplist, err = capabilities.BoundingSet()
 		if err != nil {
 			return err
+		}
+	} else {
+		mergedCaps, err := capabilities.MergeCapabilities(rtc.Containers.DefaultCapabilities, s.CapAdd, s.CapDrop)
+		if err != nil {
+			return err
+		}
+		boundingSet, err := capabilities.BoundingSet()
+		if err != nil {
+			return err
+		}
+		boundingCaps := make(map[string]interface{})
+		for _, b := range boundingSet {
+			boundingCaps[b] = b
+		}
+		for _, c := range mergedCaps {
+			if _, ok := boundingCaps[c]; ok {
+				caplist = append(caplist, c)
+			}
 		}
 
 		privCapsRequired := []string{}
@@ -139,9 +155,23 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 		configSpec.Process.Capabilities.Permitted = caplist
 		configSpec.Process.Capabilities.Inheritable = caplist
 	} else {
-		userCaps, err := capabilities.MergeCapabilities(nil, s.CapAdd, nil)
+		mergedCaps, err := capabilities.MergeCapabilities(nil, s.CapAdd, nil)
 		if err != nil {
 			return errors.Wrapf(err, "capabilities requested by user are not valid: %q", strings.Join(s.CapAdd, ","))
+		}
+		boundingSet, err := capabilities.BoundingSet()
+		if err != nil {
+			return err
+		}
+		boundingCaps := make(map[string]interface{})
+		for _, b := range boundingSet {
+			boundingCaps[b] = b
+		}
+		var userCaps []string
+		for _, c := range mergedCaps {
+			if _, ok := boundingCaps[c]; ok {
+				userCaps = append(userCaps, c)
+			}
 		}
 		configSpec.Process.Capabilities.Effective = userCaps
 		configSpec.Process.Capabilities.Permitted = userCaps

--- a/vendor/github.com/containers/common/pkg/auth/auth.go
+++ b/vendor/github.com/containers/common/pkg/auth/auth.go
@@ -22,9 +22,7 @@ import (
 func GetDefaultAuthFile() string {
 	authfile := os.Getenv("REGISTRY_AUTH_FILE")
 	if authfile == "" {
-		if authfile, ok := os.LookupEnv("DOCKER_CONFIG"); ok {
-			logrus.Infof("Using DOCKER_CONFIG environment variable for authfile path %s", authfile)
-		}
+		authfile = os.Getenv("DOCKER_CONFIG")
 	}
 	return authfile
 }

--- a/vendor/github.com/containers/common/pkg/chown/chown.go
+++ b/vendor/github.com/containers/common/pkg/chown/chown.go
@@ -4,10 +4,8 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"syscall"
 
 	"github.com/containers/storage/pkg/homedir"
-	"github.com/pkg/errors"
 )
 
 // DangerousHostPath validates if a host path is dangerous and should not be modified
@@ -64,59 +62,4 @@ func DangerousHostPath(path string) (bool, error) {
 	}
 
 	return false, nil
-}
-
-// ChangeHostPathOwnership changes the uid and gid ownership of a directory or file within the host.
-// This is used by the volume U flag to change source volumes ownership
-func ChangeHostPathOwnership(path string, recursive bool, uid, gid int) error {
-	// Validate if host path can be chowned
-	isDangerous, err := DangerousHostPath(path)
-	if err != nil {
-		return errors.Wrapf(err, "failed to validate if host path is dangerous")
-	}
-
-	if isDangerous {
-		return errors.Errorf("chowning host path %q is not allowed. You can manually `chown -R %d:%d %s`", path, uid, gid, path)
-	}
-
-	// Chown host path
-	if recursive {
-		err := filepath.Walk(path, func(filePath string, f os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-
-			// Get current ownership
-			currentUID := int(f.Sys().(*syscall.Stat_t).Uid)
-			currentGID := int(f.Sys().(*syscall.Stat_t).Gid)
-
-			if uid != currentUID || gid != currentGID {
-				return os.Lchown(filePath, uid, gid)
-			}
-
-			return nil
-		})
-
-		if err != nil {
-			return errors.Wrapf(err, "failed to chown recursively host path")
-		}
-	} else {
-		// Get host path info
-		f, err := os.Lstat(path)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get host path information")
-		}
-
-		// Get current ownership
-		currentUID := int(f.Sys().(*syscall.Stat_t).Uid)
-		currentGID := int(f.Sys().(*syscall.Stat_t).Gid)
-
-		if uid != currentUID || gid != currentGID {
-			if err := os.Lchown(path, uid, gid); err != nil {
-				return errors.Wrapf(err, "failed to chown host path")
-			}
-		}
-	}
-
-	return nil
 }

--- a/vendor/github.com/containers/common/pkg/chown/chown_unix.go
+++ b/vendor/github.com/containers/common/pkg/chown/chown_unix.go
@@ -1,0 +1,66 @@
+// +build !windows
+
+package chown
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+// ChangeHostPathOwnership changes the uid and gid ownership of a directory or file within the host.
+// This is used by the volume U flag to change source volumes ownership
+func ChangeHostPathOwnership(path string, recursive bool, uid, gid int) error {
+	// Validate if host path can be chowned
+	isDangerous, err := DangerousHostPath(path)
+	if err != nil {
+		return errors.Wrapf(err, "failed to validate if host path is dangerous")
+	}
+
+	if isDangerous {
+		return errors.Errorf("chowning host path %q is not allowed. You can manually `chown -R %d:%d %s`", path, uid, gid, path)
+	}
+
+	// Chown host path
+	if recursive {
+		err := filepath.Walk(path, func(filePath string, f os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// Get current ownership
+			currentUID := int(f.Sys().(*syscall.Stat_t).Uid)
+			currentGID := int(f.Sys().(*syscall.Stat_t).Gid)
+
+			if uid != currentUID || gid != currentGID {
+				return os.Lchown(filePath, uid, gid)
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return errors.Wrapf(err, "failed to chown recursively host path")
+		}
+	} else {
+		// Get host path info
+		f, err := os.Lstat(path)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get host path information")
+		}
+
+		// Get current ownership
+		currentUID := int(f.Sys().(*syscall.Stat_t).Uid)
+		currentGID := int(f.Sys().(*syscall.Stat_t).Gid)
+
+		if uid != currentUID || gid != currentGID {
+			if err := os.Lchown(path, uid, gid); err != nil {
+				return errors.Wrapf(err, "failed to chown host path")
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/containers/common/pkg/chown/chown_windows.go
+++ b/vendor/github.com/containers/common/pkg/chown/chown_windows.go
@@ -1,0 +1,11 @@
+package chown
+
+import (
+	"github.com/pkg/errors"
+)
+
+// ChangeHostPathOwnership changes the uid and gid ownership of a directory or file within the host.
+// This is used by the volume U flag to change source volumes ownership
+func ChangeHostPathOwnership(path string, recursive bool, uid, gid int) error {
+	return errors.Errorf("windows not supported")
+}

--- a/vendor/github.com/containers/common/pkg/completion/completion.go
+++ b/vendor/github.com/containers/common/pkg/completion/completion.go
@@ -139,3 +139,17 @@ func AutocompleteOS(cmd *cobra.Command, args []string, toComplete string) ([]str
 	completions := []string{"linux", "windows"}
 	return completions, cobra.ShellCompDirectiveNoFileComp
 }
+
+// AutocompleteJSONFormat - Autocomplete format flag option.
+// -> "json"
+func AutocompleteJSONFormat(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
+}
+
+// AutocompleteOneArg - Autocomplete one random arg
+func AutocompleteOneArg(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 1 {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/containers/common/pkg/apparmor"
 	"github.com/containers/common/pkg/cgroupv2"
-	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/containers/storage/pkg/unshare"
+	"github.com/containers/storage/types"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -224,9 +224,9 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	c.EventsLogFilePath = filepath.Join(c.TmpDir, "events", "events.log")
 
 	if path, ok := os.LookupEnv("CONTAINERS_STORAGE_CONF"); ok {
-		storage.SetDefaultConfigFilePath(path)
+		types.SetDefaultConfigFilePath(path)
 	}
-	storeOpts, err := storage.DefaultStoreOptions(unshare.IsRootless(), unshare.GetRootlessUID())
+	storeOpts, err := types.DefaultStoreOptions(unshare.IsRootless(), unshare.GetRootlessUID())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/common/pkg/parse/parse_unix.go
+++ b/vendor/github.com/containers/common/pkg/parse/parse_unix.go
@@ -7,13 +7,12 @@ import (
 	"path/filepath"
 
 	"github.com/containers/storage/pkg/unshare"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/pkg/errors"
 )
 
-func DeviceFromPath(device string) ([]configs.Device, error) {
-	var devs []configs.Device
+func DeviceFromPath(device string) ([]devices.Device, error) {
+	var devs []devices.Device
 	src, dst, permissions, err := Device(device)
 	if err != nil {
 		return nil, err
@@ -44,7 +43,7 @@ func DeviceFromPath(device string) ([]configs.Device, error) {
 	}
 	for _, d := range srcDevices {
 		d.Path = filepath.Join(dst, filepath.Base(d.Path))
-		d.Permissions = configs.DevicePermissions(permissions)
+		d.Permissions = devices.Permissions(permissions)
 		devs = append(devs, *d)
 	}
 	return devs, nil

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.35.0"
+const Version = "0.35.3"

--- a/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/shortnames.go
+++ b/vendor/github.com/containers/image/v5/pkg/sysregistriesv2/shortnames.go
@@ -34,15 +34,9 @@ func shortNameAliasesConfPath(ctx *types.SystemContext) (string, error) {
 	}
 
 	// Rootless user
-	var cacheRoot string
-	if xdgCache := os.Getenv("XDG_CACHE_HOME"); xdgCache != "" {
-		cacheRoot = xdgCache
-	} else {
-		configHome, err := homedir.GetConfigHome()
-		if err != nil {
-			return "", err
-		}
-		cacheRoot = filepath.Join(configHome, ".cache")
+	cacheRoot, err := homedir.GetCacheHome()
+	if err != nil {
+		return "", err
 	}
 
 	return filepath.Join(cacheRoot, userShortNamesFile), nil

--- a/vendor/github.com/containers/image/v5/storage/storage_image.go
+++ b/vendor/github.com/containers/image/v5/storage/storage_image.go
@@ -246,8 +246,7 @@ func (s *storageImageSource) LayerInfosForCopy(ctx context.Context, instanceDige
 	case imgspecv1.MediaTypeImageManifest:
 		uncompressedLayerType = imgspecv1.MediaTypeImageLayer
 	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType, manifest.DockerV2Schema2MediaType:
-		// This is actually a compressed type, but there's no uncompressed type defined
-		uncompressedLayerType = manifest.DockerV2Schema2LayerMediaType
+		uncompressedLayerType = manifest.DockerV2SchemaLayerMediaTypeUncompressed
 	}
 
 	physicalBlobInfos := []types.BlobInfo{}

--- a/vendor/github.com/containers/image/v5/version/version.go
+++ b/vendor/github.com/containers/image/v5/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 10
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 5
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""

--- a/vendor/github.com/onsi/ginkgo/CHANGELOG.md
+++ b/vendor/github.com/onsi/ginkgo/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.15.2
+
+### Fixes
+- ignore blank `-focus` and `-skip` flags (#780) [e90a4a0]
+
 ## 1.15.1
 
 ### Fixes

--- a/vendor/github.com/onsi/ginkgo/README.md
+++ b/vendor/github.com/onsi/ginkgo/README.md
@@ -62,6 +62,8 @@ Describe("the strings package", func() {
 
 - [Completions for VSCode](https://github.com/onsi/vscode-ginkgo): just use VSCode's extension installer to install `vscode-ginkgo`.
 
+- [Ginkgo tools for VSCode](https://marketplace.visualstudio.com/items?itemName=joselitofilho.ginkgotestexplorer): just use VSCode's extension installer to install `ginkgoTestExplorer`.
+
 - Straightforward support for third-party testing libraries such as [Gomock](https://code.google.com/p/gomock/) and [Testify](https://github.com/stretchr/testify).  Check out the [docs](https://onsi.github.io/ginkgo/#third-party-integrations) for details.
 
 - A modular architecture that lets you easily:

--- a/vendor/github.com/onsi/ginkgo/config/config.go
+++ b/vendor/github.com/onsi/ginkgo/config/config.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 )
 
-const VERSION = "1.15.1"
+const VERSION = "1.15.2"
 
 type GinkgoConfigType struct {
 	RandomSeed         int64
@@ -219,10 +219,14 @@ func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultRepor
 
 // flagFocus implements the -focus flag.
 func flagFocus(arg string) {
-	GinkgoConfig.FocusStrings = append(GinkgoConfig.FocusStrings, arg)
+	if arg != "" {
+		GinkgoConfig.FocusStrings = append(GinkgoConfig.FocusStrings, arg)
+	}
 }
 
 // flagSkip implements the -skip flag.
 func flagSkip(arg string) {
-	GinkgoConfig.SkipStrings = append(GinkgoConfig.SkipStrings, arg)
+	if arg != "" {
+		GinkgoConfig.SkipStrings = append(GinkgoConfig.SkipStrings, arg)
+	}
 }

--- a/vendor/github.com/syndtr/gocapability/capability/enum.go
+++ b/vendor/github.com/syndtr/gocapability/capability/enum.go
@@ -41,7 +41,9 @@ const (
 //go:generate go run enumgen/gen.go
 type Cap int
 
-// POSIX-draft defined capabilities.
+// POSIX-draft defined capabilities and Linux extensions.
+//
+// Defined in https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
 const (
 	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
 	// overrides the restriction of changing file ownership and group
@@ -187,6 +189,7 @@ const (
 	// arbitrary SCSI commands
 	// Allow setting encryption key on loopback filesystem
 	// Allow setting zone reclaim policy
+	// Allow everything under CAP_BPF and CAP_PERFMON for backward compatibility
 	CAP_SYS_ADMIN = Cap(21)
 
 	// Allow use of reboot()
@@ -211,6 +214,7 @@ const (
 	// Allow more than 64hz interrupts from the real-time clock
 	// Override max number of consoles on console allocation
 	// Override max number of keymaps
+	// Control memory reclaim behavior
 	CAP_SYS_RESOURCE = Cap(24)
 
 	// Allow manipulation of system clock
@@ -256,8 +260,45 @@ const (
 	// Allow preventing system suspends
 	CAP_BLOCK_SUSPEND = Cap(36)
 
-	// Allow reading audit messages from the kernel
+	// Allow reading the audit log via multicast netlink socket
 	CAP_AUDIT_READ = Cap(37)
+
+	// Allow system performance and observability privileged operations
+	// using perf_events, i915_perf and other kernel subsystems
+	CAP_PERFMON = Cap(38)
+
+	// CAP_BPF allows the following BPF operations:
+	// - Creating all types of BPF maps
+	// - Advanced verifier features
+	//   - Indirect variable access
+	//   - Bounded loops
+	//   - BPF to BPF function calls
+	//   - Scalar precision tracking
+	//   - Larger complexity limits
+	//   - Dead code elimination
+	//   - And potentially other features
+	// - Loading BPF Type Format (BTF) data
+	// - Retrieve xlated and JITed code of BPF programs
+	// - Use bpf_spin_lock() helper
+	//
+	// CAP_PERFMON relaxes the verifier checks further:
+	// - BPF progs can use of pointer-to-integer conversions
+	// - speculation attack hardening measures are bypassed
+	// - bpf_probe_read to read arbitrary kernel memory is allowed
+	// - bpf_trace_printk to print kernel memory is allowed
+	//
+	// CAP_SYS_ADMIN is required to use bpf_probe_write_user.
+	//
+	// CAP_SYS_ADMIN is required to iterate system wide loaded
+	// programs, maps, links, BTFs and convert their IDs to file descriptors.
+	//
+	// CAP_PERFMON and CAP_BPF are required to load tracing programs.
+	// CAP_NET_ADMIN and CAP_BPF are required to load networking programs.
+	CAP_BPF = Cap(39)
+
+	// Allow checkpoint/restore related operations.
+	// Introduced in kernel 5.9
+	CAP_CHECKPOINT_RESTORE = Cap(40)
 )
 
 var (

--- a/vendor/github.com/syndtr/gocapability/capability/enum_gen.go
+++ b/vendor/github.com/syndtr/gocapability/capability/enum_gen.go
@@ -80,6 +80,12 @@ func (c Cap) String() string {
 		return "block_suspend"
 	case CAP_AUDIT_READ:
 		return "audit_read"
+	case CAP_PERFMON:
+		return "perfmon"
+	case CAP_BPF:
+		return "bpf"
+	case CAP_CHECKPOINT_RESTORE:
+		return "checkpoint_restore"
 	}
 	return "unknown"
 }
@@ -125,5 +131,8 @@ func List() []Cap {
 		CAP_WAKE_ALARM,
 		CAP_BLOCK_SUSPEND,
 		CAP_AUDIT_READ,
+		CAP_PERFMON,
+		CAP_BPF,
+		CAP_CHECKPOINT_RESTORE,
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -93,7 +93,7 @@ github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/supplemented
 github.com/containers/buildah/util
-# github.com/containers/common v0.35.0
+# github.com/containers/common v0.35.3
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/apparmor/internal/supported
 github.com/containers/common/pkg/auth
@@ -115,7 +115,7 @@ github.com/containers/common/pkg/umask
 github.com/containers/common/version
 # github.com/containers/conmon v2.0.20+incompatible
 github.com/containers/conmon/runner/config
-# github.com/containers/image/v5 v5.10.2
+# github.com/containers/image/v5 v5.10.5
 github.com/containers/image/v5/copy
 github.com/containers/image/v5/directory
 github.com/containers/image/v5/directory/explicitfilepath
@@ -413,7 +413,7 @@ github.com/nxadm/tail/ratelimiter
 github.com/nxadm/tail/util
 github.com/nxadm/tail/watch
 github.com/nxadm/tail/winfile
-# github.com/onsi/ginkgo v1.15.1
+# github.com/onsi/ginkgo v1.15.2
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/extensions/table

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -547,7 +547,7 @@ github.com/stefanberger/go-pkcs11uri
 # github.com/stretchr/testify v1.7.0
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+# github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 github.com/syndtr/gocapability/capability
 # github.com/tchap/go-patricia v2.3.0+incompatible
 github.com/tchap/go-patricia/patricia


### PR DESCRIPTION
when --privileged is used, make sure to not request more capabilities
than currently available in the current context.

[NO TESTS NEEDED] since it fixes existing tests.

Replaces: https://github.com/containers/podman/pull/9761

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>