### PR TITLE
Ensure manually-created volumes have correct ownership

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1627,19 +1627,6 @@ func WithVolumeGID(gid int) VolumeCreateOption {
 	}
 }
 
-// WithVolumeNeedsChown sets the NeedsChown flag for the volume.
-func WithVolumeNeedsChown() VolumeCreateOption {
-	return func(volume *Volume) error {
-		if volume.valid {
-			return define.ErrVolumeFinalized
-		}
-
-		volume.state.NeedsChown = true
-
-		return nil
-	}
-}
-
 // withSetAnon sets a bool notifying libpod that this volume is anonymous and
 // should be removed when containers using it are removed and volumes are
 // specified for removal.

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -392,7 +392,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		logrus.Debugf("Creating new volume %s for container", vol.Name)
 
 		// The volume does not exist, so we need to create it.
-		volOptions := []VolumeCreateOption{WithVolumeName(vol.Name), WithVolumeUID(ctr.RootUID()), WithVolumeGID(ctr.RootGID()), WithVolumeNeedsChown()}
+		volOptions := []VolumeCreateOption{WithVolumeName(vol.Name), WithVolumeUID(ctr.RootUID()), WithVolumeGID(ctr.RootGID())}
 		if isAnonymous {
 			volOptions = append(volOptions, withSetAnon())
 		}

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -17,6 +17,7 @@ func newVolume(runtime *Runtime) *Volume {
 	volume.config.Labels = make(map[string]string)
 	volume.config.Options = make(map[string]string)
 	volume.state.NeedsCopyUp = true
+	volume.state.NeedsChown = true
 	return volume
 }
 


### PR DESCRIPTION
As part of a fix for an earlier bug (#5698) we added the ability for Podman to chown volumes to correctly match the user running in the container, even in adverse circumstances (where we don't know the right UID/GID until very late in the process). However, we only did this for volumes created automatically by a `podman run` or `podman create`. Volumes made by `podman volume create` do not get this chown, so their permissions may not be correct. I've looked, and I don't think there's a good reason not to do this chwon for all volumes the first time the container is started.

I would prefer to do this as part of volume copy-up, but I don't think that's really possible (copy-up happens earlier in the process and we don't have a spec). There is a small chance, as things stand, that a copy-up happens for one container and then a chown for a second, unrelated container, but the odds of this are astronomically small (we'd need a very close race between two starting containers).

Fixes #9608
