### PR TITLE
System tests: reenable a bunch of skipped tests

### DIFF
--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -18,10 +18,6 @@ function teardown() {
 
 
 @test "podman pod top - containers in different PID namespaces" {
-    if is_remote && is_rootless; then
-        skip "FIXME: pending #7139"
-    fi
-
     # With infra=false, we don't get a /pause container (we also
     # don't pull k8s.gcr.io/pause )
     no_infra='--infra=false'
@@ -55,10 +51,6 @@ function teardown() {
 
 
 @test "podman pod - communicating between pods" {
-    if is_remote && is_rootless; then
-        skip "FIXME: pending #7139"
-    fi
-
     podname=pod$(random_string)
     run_podman 1 pod exists $podname
     run_podman pod create --infra=true --name=$podname
@@ -117,10 +109,6 @@ function teardown() {
 }
 
 @test "podman pod - communicating via /dev/shm " {
-    if is_remote && is_rootless; then
-        skip "FIXME: pending #7139"
-    fi
-
     podname=pod$(random_string)
     run_podman 1 pod exists $podname
     run_podman pod create --infra=true --name=$podname
@@ -168,10 +156,6 @@ function random_ip() {
 }
 
 @test "podman pod create - hashtag AllTheOptions" {
-    if is_remote && is_rootless; then
-        skip "FIXME: pending #7139"
-    fi
-
     mac=$(random_mac)
     add_host_ip=$(random_ip)
     add_host_n=$(random_string | tr A-Z a-z).$(random_string | tr A-Z a-z).xyz

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -25,8 +25,6 @@ function _check_health {
 
 
 @test "podman healthcheck" {
-    skip_if_remote "FIXME: pending #7137"
-
     # Create an image with a healthcheck script; said script will
     # pass until the file /uh-oh gets created (by us, via exec)
     cat >${PODMAN_TMPDIR}/healthcheck <<EOF

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -61,9 +61,6 @@ function check_label() {
             # SELinux not enabled on Ubuntu, so we should never get here
             die "WHOA! SELinux enabled, but no /usr/bin/rpm!"
         fi
-        if [[ "$cs_version" < "2.146" ]]; then
-            skip "FIXME: #7939: requires container-selinux-2.146.0 (currently installed: $cs_version)"
-        fi
     fi
     # FIXME FIXME FIXME: delete up to here, leaving just check_label
 

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -97,7 +97,6 @@ load helpers
 
 # "network create" now works rootless, with the help of a special container
 @test "podman network create" {
-    skip_if_remote "FIXME: pending #7808"
     myport=54322
 
     local mynetname=testnet-$(random_string 10)


### PR DESCRIPTION
Checking for 'skip.*[0-9]{4,5}', and checking status on said
issues, finds several that have been closed. Let's see if
they're really fixed.

Signed-off-by: Ed Santiago <santiago@redhat.com>
