### PR TITLE
Fix containers list/prune http api filter behaviour

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -280,6 +280,32 @@ t GET containers/json 200 \
 
 podman stop bar
 
+#compat api list containers sanity checks
+t GET containers/json?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t GET containers/json?filters='{"label":["testl' 500 \
+    .cause="unexpected end of JSON input"
+
+#libpod api list containers sanity checks
+t GET libpod/containers/json?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t GET libpod/containers/json?filters='{"label":["testl' 500 \
+    .cause="unexpected end of JSON input"
+
+# Prune containers - bad filter input
+t POST containers/prune?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t POST libpod/containers/prune?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+
+## Prune containers with illformed label
+t POST containers/prune?filters='{"label":["tes' 500 \
+    .cause="unexpected end of JSON input"
+t POST libpod/containers/prune?filters='{"label":["tes' 500 \
+    .cause="unexpected end of JSON input"
+
+t GET libpod/containers/json?filters='{"label":["testlabel"]}' 200 length=0
+
 # Test CPU limit (NanoCPUs)
 t POST containers/create Image=$IMAGE HostConfig='{"NanoCpus":500000}' 201 \
   .Id~[0-9a-f]\\{64\\}


### PR DESCRIPTION
The problem described in #9711 and followed by #9758 affects
containers as well. When user provides wrong filter input, error
message should occur, not fallback to full list/prune command.
This change fixes the issue. Additionally, there are error message
fixes for docker http api compat.

Signed-off-by: Jakub Guzik <jakubmguzik@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
