### PR TITLE
Fix system prune cmd user message with options

### DIFF
--- a/cmd/podman/system/prune.go
+++ b/cmd/podman/system/prune.go
@@ -55,22 +55,17 @@ func init() {
 
 func prune(cmd *cobra.Command, args []string) error {
 	var err error
-
 	// Prompt for confirmation if --force is not set
 	if !force {
 		reader := bufio.NewReader(os.Stdin)
 		volumeString := ""
 		if pruneOptions.Volume {
 			volumeString = `
-        - all volumes not used by at least one container`
+	- all volumes not used by at least one container`
 		}
-		fmt.Printf(`
-WARNING! This will remove:
-        - all stopped containers%s
-        - all stopped pods
-        - all dangling images
-        - all build cache
-Are you sure you want to continue? [y/N] `, volumeString)
+
+		fmt.Printf(createPruneWarningMessage(pruneOptions), volumeString, "Are you sure you want to continue? [y/N] ")
+
 		answer, err := reader.ReadString('\n')
 		if err != nil {
 			return err
@@ -114,4 +109,23 @@ Are you sure you want to continue? [y/N] `, volumeString)
 
 	fmt.Printf("Total reclaimed space: %s\n", units.HumanSize((float64)(response.ReclaimedSpace)))
 	return nil
+}
+
+func createPruneWarningMessage(pruneOpts entities.SystemPruneOptions) string {
+	if pruneOpts.All {
+		return `WARNING! This will remove:
+	- all stopped containers
+	- all networks not used by at least one container%s
+	- all images without at least one container associated to them
+	- all build cache
+
+%s`
+	}
+	return `WARNING! This will remove:
+	- all stopped containers
+	- all networks not used by at least one container%s
+	- all dangling images
+	- all dangling build cache
+
+%s`
 }


### PR DESCRIPTION
[NO TESTS NEEDED]

Signed-off-by: Jakub Guzik <jakubmguzik@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
/kind bug

1. Podman before fix (the same message):
```
$ podman system prune 

WARNING! This will remove:
        - all stopped containers
        - all stopped pods
        - all dangling images
        - all build cache
Are you sure you want to continue? [y/N] ^C
$ podman system prune -a

WARNING! This will remove:
        - all stopped containers
        - all stopped pods
        - all dangling images
        - all build cache
Are you sure you want to continue? [y/N] ^C
$ podman system prune -a --volumes 

WARNING! This will remove:
        - all stopped containers
        - all volumes not used by at least one container
        - all stopped pods
        - all dangling images
        - all build cache
Are you sure you want to continue? [y/N] ^C
$ podman system prune --volumes 

WARNING! This will remove:
        - all stopped containers
        - all volumes not used by at least one container
        - all stopped pods
        - all dangling images
        - all build cache
Are you sure you want to continue? [y/N] 

```
2. Docker:
```
$ docker system prune
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all dangling images
  - all dangling build cache

Are you sure you want to continue? [y/N] ^C
$ docker system prune -a
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all images without at least one container associated to them
  - all build cache

Are you sure you want to continue? [y/N] ^C
$ docker system prune -a --volumes 
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all volumes not used by at least one container
  - all images without at least one container associated to them
  - all build cache

Are you sure you want to continue? [y/N] ^C
$ docker system prune --volumes 
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all volumes not used by at least one container
  - all dangling images
  - all dangling build cache

Are you sure you want to continue? [y/N] ^C
```
3. podman after fix:
```
$ bin/podman system prune 
WARNING! This will remove:
        - all stopped containers
        - all networks not used by at least one container
        - all dangling images
        - all dangling build cache

Are you sure you want to continue? [y/N] ^C
$ bin/podman system prune -a
WARNING! This will remove:
        - all stopped containers
        - all networks not used by at least one container
        - all images without at least one container associated to them
        - all build cache

Are you sure you want to continue? [y/N] ^C
$ bin/podman system prune -a --volumes 
WARNING! This will remove:
        - all stopped containers
        - all networks not used by at least one container
        - all volumes not used by at least one container
        - all images without at least one container associated to them
        - all build cache

Are you sure you want to continue? [y/N] ^C
$ bin/podman system prune  --volumes   
WARNING! This will remove:
        - all stopped containers
        - all networks not used by at least one container
        - all volumes not used by at least one container
        - all dangling images
        - all dangling build cache

Are you sure you want to continue? [y/N] ^C
```

I kept original tabs in podman, but the message content is now the same as in docker.