### PR TITLE
[CI:DOCS] rootless: Tell the user what was led to the error, not just what it is

### DIFF
--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -116,7 +116,7 @@ func tryMappingTool(uid bool, pid int, hostID int, mappings []idtools.IDMap) err
 	}
 	path, err := exec.LookPath(tool)
 	if err != nil {
-		return errors.Wrapf(err, "cannot find %s", tool)
+		return errors.Wrapf(err, "command required for rootless mode with multiple IDs")
 	}
 
 	appendTriplet := func(l []string, a, b, c int) []string {

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -203,12 +203,12 @@ Rootless Podman requires the newuidmap and newgidmap programs to be installed.
 
 #### Symptom
 
-If you are running Podman or buildah as a not root user, you get an error complaining about
+If you are running Podman or Buildah as a rootless user, you get an error complaining about
 a missing newuidmap executable.
 
 ```
 podman run -ti fedora sh
-cannot find newuidmap: exec: "newuidmap": executable file not found in $PATH
+command required for rootless mode with multiple IDs: exec: "newuidmap": executable file not found in $PATH
 ```
 
 #### Solution


### PR DESCRIPTION
Users coming e.g. from Docker do not always read the manual and expect podman to not require sudo or uidmap, for them the default message is not very helpful:

    Error: Cannot connect to the Podman socket, make sure there is a Podman REST API service running.:
    cannot find newuidmap: exec: "newuidmap": executable file not found in $PATH

Adding a bit more context to this would help to nudge them into the right direction and tell them what to look for in the documentation:

    cannot find newuidmap required for rootless mode (try running as root?): exec: "newuidmap": executable file not found in $PATH

Signed-off-by: Andrej Shadura `<andrew.shadura@collabora.co.uk>`