### PR TITLE
Updated schema:resource to schema:network to comply with JSON API

### DIFF
--- a/pkg/api/handlers/libpod/play.go
+++ b/pkg/api/handlers/libpod/play.go
@@ -20,7 +20,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
-		Network   string `schema:"reference"`
+		Network   string `schema:"network"`
 		TLSVerify bool   `schema:"tlsVerify"`
 		LogDriver string `schema:"logDriver"`
 		Start     bool   `schema:"start"`


### PR DESCRIPTION
The libpod JSON API handler for play kube was not decoding the URL query parameters correctly as per the API spec. Changing "reference" to "network" fixed the issue.
