### PR TITLE
Cirrus: Reduce to bare-minimum testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,13 +62,12 @@ timeout_in: 60m
 gcp_credentials: ENCRYPTED[a28959877b2c9c36f151781b0a05407218cda646c7d047fc556e42f55e097e897ab63ee78369dae141dcf0b46a9d0cdd]
 
 
-# Attempt to prevent flakes by confirming all required external/3rd-party
-# services are available and functional.
-ext_svc_check_task:
-    alias: 'ext_svc_check'  # int. ref. name - required for depends_on reference
-    name: "Ext. services"  # Displayed Title - has no other significance
-    skip: &tags "$CIRRUS_TAG != ''"  # Don't run on tags
-    # Default/small container image to execute tasks with
+# Execute some quick checks to confirm this YAML file and all
+# automation-related shell scripts are sane.
+automation_task:
+    alias: 'automation'
+    name: "Check Automation"
+    skip: &branches_and_tags "$CIRRUS_PR == '' || $CIRRUS_TAG != ''" # Don't run on branches/tags
     container: &smallcontainer
         image: ${CTR_FQIN}
         # Resources are limited across ALL currently executing tasks
@@ -76,12 +75,9 @@ ext_svc_check_task:
         cpu: 2
         memory: 2
     env:
-        TEST_FLAVOR: ext_svc
+        TEST_FLAVOR: automation
         CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-    # NOTE: The default way Cirrus-CI clones is *NOT* compatible with
-    #       environment expectations in contrib/cirrus/lib.sh.  Specifically
-    #       the 'origin' remote must be defined, and all remote branches/tags
-    #       must be available for reference from CI scripts.
+        TEST_ENVIRON: container
     clone_script: &full_clone |
           cd /
           rm -rf $CIRRUS_WORKING_DIR
@@ -96,30 +92,12 @@ ext_svc_check_task:
               git reset --hard $CIRRUS_CHANGE_IN_REPO
           fi
           make install.tools
-
     setup_script: &setup '$GOSRC/$SCRIPT_BASE/setup_environment.sh'
     main_script: &main '/usr/bin/time --verbose --output="$STATS_LOGFILE" $GOSRC/$SCRIPT_BASE/runner.sh'
     always: &runner_stats
         runner_stats_artifacts:
             path: ./*-${STATS_LOGFILE_SFX}
             type: text/plain
-
-
-# Execute some quick checks to confirm this YAML file and all
-# automation-related shell scripts are sane.
-automation_task:
-    alias: 'automation'
-    name: "Check Automation"
-    skip: &branches_and_tags "$CIRRUS_PR == '' || $CIRRUS_TAG != ''" # Don't run on branches/tags
-    container: *smallcontainer
-    env:
-        TEST_FLAVOR: automation
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-        TEST_ENVIRON: container
-    clone_script: *full_clone
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
 
 
 # N/B: This task is critical.  It builds all binaries and release archives
@@ -201,7 +179,6 @@ validate_task:
     # build or test task failures.
     skip: *branches_and_tags
     depends_on:
-        - ext_svc_check
         - automation
         - build
     # golangci-lint is a very, very hungry beast.
@@ -219,374 +196,6 @@ validate_task:
     setup_script: *setup
     main_script: *main
     always: *runner_stats
-
-
-# Exercise the "libpod" API with a small set of common
-# operations to ensure they are functional.
-bindings_task:
-    name: "Test Bindings"
-    alias: bindings
-    only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
-    skip: *branches_and_tags
-    depends_on:
-        - build
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: bindings
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
-
-
-# Build the "libpod" API documentation `swagger.yaml` for eventual
-# publishing along side the official podman documentation.
-swagger_task:
-    name: "Test Swagger"
-    alias: swagger
-    depends_on:
-        - build
-    container: *smallcontainer
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: swagger
-        TEST_ENVIRON: container
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-    clone_script: *full_clone  # build-cache not available to container tasks
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts
-
-
-# Check that all included go modules from other sources match
-# what is expected in `vendor/modules.txt` vs `go.mod`.  Also
-# make sure that the generated bindings in pkg/bindings/...
-# are in sync with the code.
-consistency_task:
-    name: "Test Code Consistency"
-    alias: consistency
-    skip: *tags
-    depends_on:
-        - build
-    container: *smallcontainer
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: consistency
-        TEST_ENVIRON: container
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-    clone_script: *full_clone  # build-cache not available to container tasks
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
-
-
-# There are several other important variations of podman which
-# must always build successfully.  Most of them are handled in
-# this task, though a few need dedicated tasks which follow.
-alt_build_task:
-    name: "$ALT_NAME"
-    alias: alt_build
-    only_if: *not_docs
-    depends_on:
-        - build
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: "altbuild"
-    gce_instance: *standardvm
-    matrix:
-      - env:
-            ALT_NAME: 'Build Each Commit'
-      - env:
-            ALT_NAME: 'Windows Cross'
-      - env:
-            ALT_NAME: 'Build Without CGO'
-      - env:
-            ALT_NAME: 'Test build RPM'
-      - env:
-            ALT_NAME: 'Alt Arch. Cross'
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts
-
-
-# Confirm building a statically-linked binary is successful
-static_alt_build_task:
-    name: "Static Build"
-    alias: static_alt_build
-    only_if: *not_docs
-    depends_on:
-        - build
-    # Community-maintained task, may fail on occasion.  If so, uncomment
-    # the next line and file an issue with details about the failure.
-    # allow_failures: $CI == $CI
-    gce_instance: *bigvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: "altbuild"
-        # gce_instance variation prevents this being included in alt_build_task
-        ALT_NAME: 'Static build'
-        # Do not use 'latest', fixed-version tag for runtime stability.
-        CTR_FQIN: "docker.io/nixos/nix:2.3.6"
-        # Authentication token for pushing the build cache to cachix.
-        # This is critical, it helps to avoid a very lengthy process of
-        # statically building every dependency needed to build podman.
-        # Assuming the pinned nix dependencies in nix/nixpkgs.json have not
-        # changed, this cache will ensure that only the static podman binary is
-        # built.
-        CACHIX_AUTH_TOKEN: ENCRYPTED[df0d4d0a67474e8ea49cc503221dcb912b7e2ba45c8ec4bf2e5fd9c49a18ac21c24bacee59b5393355ed9e4358d2baef]
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts
-
-
-# Confirm building the remote client, natively on a Mac OS-X VM.
-osx_alt_build_task:
-    name: "OSX Cross"
-    alias: osx_alt_build
-    depends_on:
-        - build
-    env:
-        <<: *stdenvars
-        # OSX platform variation prevents this being included in alt_build_task
-        TEST_FLAVOR: "altbuild"
-        ALT_NAME: 'OSX Cross'
-    osx_instance:
-        image: 'catalina-base'
-    script:
-        - brew install go
-        - brew install go-md2man
-        - make podman-remote-darwin
-        - make install-podman-remote-darwin-docs
-    always: *binary_artifacts
-
-
-# This task is a stub: In the future it will be used to verify
-# podman is compatible with the docker python-module.
-docker-py_test_task:
-    name: Docker-py Compat.
-    alias: docker-py_test
-    skip: *tags
-    only_if: *not_docs
-    depends_on:
-        - build
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: docker-py
-        TEST_ENVIRON: container
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
-
-
-# Does exactly what it says, execute the podman unit-tests on all primary
-# platforms and release versions.
-unit_test_task:
-    name: "Unit tests on $DISTRO_NV"
-    alias: unit_test
-    skip: *tags
-    only_if: *not_docs
-    depends_on:
-        - validate
-    matrix: *platform_axis
-    gce_instance: *standardvm
-    env:
-        TEST_FLAVOR: unit
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
-
-
-apiv2_test_task:
-    name: "APIv2 test on $DISTRO_NV"
-    alias: apiv2_test
-    skip: *tags
-    depends_on:
-        - validate
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: apiv2
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: &logs_artifacts
-        <<: *runner_stats
-        # Required for `contrib/cirrus/logformatter` to work properly
-        html_artifacts:
-            path: ./*.html
-            type: text/html
-        package_versions_script: '$SCRIPT_BASE/logcollector.sh packages'
-        ginkgo_node_logs_script: '$SCRIPT_BASE/logcollector.sh ginkgo'
-        df_script: '$SCRIPT_BASE/logcollector.sh df'
-        audit_log_script: '$SCRIPT_BASE/logcollector.sh audit'
-        journal_script: '$SCRIPT_BASE/logcollector.sh journal'
-        podman_system_info_script: '$SCRIPT_BASE/logcollector.sh podman'
-        time_script: '$SCRIPT_BASE/logcollector.sh time'
-
-compose_test_task:
-    name: "compose test on $DISTRO_NV"
-    alias: compose_test
-    only_if: *not_docs
-    skip: *tags
-    depends_on:
-        - validate
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: compose
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
-
-
-# Execute the podman integration tests on all primary platforms and release
-# versions, as root, without involving the podman-remote client.
-local_integration_test_task: &local_integration_test_task
-    # Integration-test task name convention:
-    # <int.|sys.> <podman|remote> <Distro NV> <root|rootless>
-    name: &std_name_fmt "$TEST_FLAVOR $PODBIN_NAME $DISTRO_NV $PRIV_NAME $TEST_ENVIRON"
-    alias: local_integration_test
-    only_if: *not_docs
-    skip: *branches_and_tags
-    depends_on:
-        - unit_test
-    matrix: *platform_axis
-    gce_instance: *standardvm
-    timeout_in: 90m
-    env:
-        TEST_FLAVOR: int
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
-
-
-# Nearly identical to `local_integration_test` except all operations
-# are performed through the podman-remote client vs a podman "server"
-# running on the same host.
-remote_integration_test_task:
-    <<: *local_integration_test_task
-    alias: remote_integration_test
-    env:
-        TEST_FLAVOR: int
-        PODBIN_NAME: remote
-
-
-# Run the complete set of integration tests from inside a container.
-# This verifies all/most operations function with "podman-in-podman".
-container_integration_test_task:
-    name: *std_name_fmt
-    alias: container_integration_test
-    only_if: *not_docs
-    skip: *branches_and_tags
-    depends_on:
-        - unit_test
-    matrix: &fedora_vm_axis
-        - env:
-              DISTRO_NV: ${FEDORA_NAME}
-              _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-              VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-        - env:
-              DISTRO_NV: ${PRIOR_FEDORA_NAME}
-              _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-              VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
-    gce_instance: *standardvm
-    timeout_in: 90m
-    env:
-        TEST_FLAVOR: int
-        TEST_ENVIRON: container
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
-
-
-# Execute most integration tests as a regular (non-root) user.
-rootless_integration_test_task:
-    name: *std_name_fmt
-    alias: rootless_integration_test
-    only_if: *not_docs
-    skip: *branches_and_tags
-    depends_on:
-        - unit_test
-    matrix: *fedora_vm_axis
-    gce_instance: *standardvm
-    timeout_in: 90m
-    env:
-        TEST_FLAVOR: int
-        PRIV_NAME: rootless
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
-
-
-# Always run subsequent to integration tests.  While parallelism is lost
-# with runtime, debugging system-test failures can be more challenging
-# for some golang developers.  Otherwise the following tasks run across
-# the same matrix as the integration-tests (above).
-local_system_test_task: &local_system_test_task
-    name: *std_name_fmt
-    alias: local_system_test
-    skip: *tags
-    only_if: *not_docs
-    depends_on:
-      - local_integration_test
-    matrix: *platform_axis
-    gce_instance: *standardvm
-    env:
-        TEST_FLAVOR: sys
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
-
-
-remote_system_test_task:
-    <<: *local_system_test_task
-    alias: remote_system_test
-    depends_on:
-      - remote_integration_test
-    env:
-        TEST_FLAVOR: sys
-        PODBIN_NAME: remote
-
-
-rootless_system_test_task:
-    name: *std_name_fmt
-    alias: rootless_system_test
-    skip: *tags
-    only_if: *not_docs
-    depends_on:
-      - rootless_integration_test
-    matrix: *fedora_vm_axis
-    gce_instance: *standardvm
-    env:
-        TEST_FLAVOR: sys
-        PRIV_NAME: rootless
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
 
 
 # This task is critical.  It updates the "last-used by" timestamp stored
@@ -623,27 +232,9 @@ success_task:
     alias: success
     # N/B: ALL tasks must be listed here, minus their '_task' suffix.
     depends_on:
-        - ext_svc_check
         - automation
         - build
         - validate
-        - bindings
-        - swagger
-        - consistency
-        - alt_build
-        - static_alt_build
-        - osx_alt_build
-        - docker-py_test
-        - unit_test
-        - apiv2_test
-        - compose_test
-        - local_integration_test
-        - remote_integration_test
-        - rootless_integration_test
-        - container_integration_test
-        - local_system_test
-        - remote_system_test
-        - rootless_system_test
         - meta
     container: *smallcontainer
     env:
@@ -651,46 +242,3 @@ success_task:
         TEST_ENVIRON: container
     clone_script: *noop
     script: /bin/true
-
-
-# When a new tag is pushed, confirm that the code and commits
-# meet criteria for an official release.
-release_task:
-    name: "Verify Release"
-    alias: release
-    only_if: *tags
-    depends_on:
-        - success
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: release
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts
-
-
-# When preparing to release a new version, this task may be manually
-# activated at the PR stage to verify the build is proper for a potential
-# podman release.
-#
-# Note: This cannot use a YAML alias on 'release_task' as of this
-# comment, it is incompatible with 'trigger_type: manual'
-release_test_task:
-    name: "Optional Release Test"
-    alias: release_test
-    only_if: $CIRRUS_PR != ''
-    trigger_type: manual
-    depends_on:
-        - success
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: release
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts


### PR DESCRIPTION
Now that the v3.1 branch is in process, there is no need for extensive
testing of v3.0.  Dial it down to the bare-minimum to reduce overall
maintenance burden.