### PR TITLE
[NO TESTS NEEDED] Fix rootless volume plugins

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1577,8 +1577,6 @@ func WithVolumeLabels(labels map[string]string) VolumeCreateOption {
 }
 
 // WithVolumeOptions sets the options of the volume.
-// If the "local" driver has been selected, options will be validated. There are
-// currently 3 valid options for the "local" driver - o, type, and device.
 func WithVolumeOptions(options map[string]string) VolumeCreateOption {
 	return func(volume *Volume) error {
 		if volume.valid {
@@ -1587,13 +1585,6 @@ func WithVolumeOptions(options map[string]string) VolumeCreateOption {
 
 		volume.config.Options = make(map[string]string)
 		for key, value := range options {
-			switch key {
-			case "type", "device", "o", "UID", "GID":
-				volume.config.Options[key] = value
-			default:
-				return errors.Wrapf(define.ErrInvalidArg, "unrecognized volume option %q is not supported with local driver", key)
-			}
-
 			volume.config.Options[key] = value
 		}
 

--- a/libpod/volume_internal_linux.go
+++ b/libpod/volume_internal_linux.go
@@ -32,8 +32,10 @@ func (v *Volume) mount() error {
 		return nil
 	}
 
-	// We cannot mount volumes as rootless.
-	if rootless.IsRootless() {
+	// We cannot mount 'local' volumes as rootless.
+	if !v.UsesVolumeDriver() && rootless.IsRootless() {
+		// This check should only be applied to 'local' driver
+		// so Volume Drivers must be excluded
 		return errors.Wrapf(define.ErrRootless, "cannot mount volumes without root privileges")
 	}
 
@@ -137,8 +139,8 @@ func (v *Volume) unmount(force bool) error {
 		return nil
 	}
 
-	// We cannot unmount volumes as rootless.
-	if rootless.IsRootless() {
+	// We cannot unmount 'local' volumes as rootless.
+	if !v.UsesVolumeDriver() && rootless.IsRootless() {
 		// If force is set, just clear the counter and bail without
 		// error, so we can remove volumes from the state if they are in
 		// an awkward configuration.


### PR DESCRIPTION
According to https://github.com/containers/podman/issues/9650 there are few issues when using volume plugins with rootless containers.

The reason behind these is local-driver-specific code being executed for all cases. This is a minimal fix to address these issues.

Please also note that:
1. In fact, there is a need to clearly separate local-driver-specific code from plugin-related, because there are little to none logic that should be executed in both cases.
2. The removed check is actually already correctly implemented here
https://github.com/containers/podman/blob/d92b94677cc816a1e157802836195430b731d015/libpod/runtime_volume_linux.go#L66-L77
3. These kind of checks is actually implementation specific, so it seems natural to keep them close to the implementation.

At this point no new tests are needed, because there is no reliable and stable volume plugin yet. Using unstable volume plugin is rather harmful, as such test is much more likely to break due to unrelated issue, than due to regression of this fix. 