### PR TITLE
[NO TESTS NEEDED] Remove /tmp/containers-users-* files on reboot

### DIFF
--- a/contrib/tmpfile/podman.conf
+++ b/contrib/tmpfile/podman.conf
@@ -1,5 +1,6 @@
 # /tmp/podman-run-* directory can contain content for Podman containers that have run
 # for many days. This following line prevents systemd from removing this content.
 x /tmp/podman-run-*
+x /tmp/containers-user-*
 D! /run/podman 0700 root root
 D! /var/lib/cni/networks


### PR DESCRIPTION
Helps Fix https://github.com/containers/podman/issues/9765

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
