### PR TITLE
Fix filters list/prune in image http compat/libpod api endpoints

### DIFF
--- a/libpod/image/prune.go
+++ b/libpod/image/prune.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	"github.com/containers/podman/v3/libpod/events"
@@ -34,6 +35,12 @@ func generatePruneFilterFuncs(filter, filterValue string) (ImageFilter, error) {
 			}
 			return false
 		}, nil
+	case "dangling":
+		danglingImages, err := strconv.ParseBool(filterValue)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid filter dangling=%s", filterValue)
+		}
+		return ImageFilter(DanglingFilter(danglingImages)), nil
 	}
 	return nil, nil
 }

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -77,6 +77,55 @@ for i in $iid ${iid:0:12} $PODMAN_TEST_IMAGE_NAME; do
   t GET "libpod/images/$i/get?compress=false" 200 '[POSIX tar archive]'
 done
 
+#compat api list images sanity checks
+t GET images/json?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t GET images/json?filters='{"label":["testl' 500 \
+    .cause="unexpected end of JSON input"
+
+#libpod api list images sanity checks
+t GET libpod/images/json?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t GET libpod/images/json?filters='{"label":["testl' 500 \
+    .cause="unexpected end of JSON input"
+
+# Prune images - bad filter input
+t POST images/prune?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+t POST libpod/images/prune?filters='garb1age}' 500 \
+    .cause="invalid character 'g' looking for beginning of value"
+
+## Prune images with illformed label
+t POST images/prune?filters='{"label":["tes' 500 \
+    .cause="unexpected end of JSON input"
+t POST libpod/images/prune?filters='{"label":["tes' 500 \
+    .cause="unexpected end of JSON input"
+
+
+#create, list and remove dangling image
+podman image build -t test:test -<<EOF
+from alpine
+RUN >file1
+EOF
+
+podman image build -t test:test --label xyz -<<EOF
+from alpine
+RUN >file2
+EOF
+
+t GET images/json?filters='{"dangling":["true"]}' 200 length=1
+t POST images/prune?filters='{"dangling":["true"]}' 200
+t GET images/json?filters='{"dangling":["true"]}' 200 length=0
+
+#label filter check in libpod and compat
+t GET images/json?filters='{"label":["xyz"]}' 200 length=1
+t GET libpod/images/json?filters='{"label":["xyz"]}' 200 length=1
+
+t DELETE libpod/images/test:test 200
+
+t GET images/json?filters='{"label":["xyz"]}' 200 length=0
+t GET libpod/images/json?filters='{"label":["xyz"]}' 200 length=0
+
 # Export more than one image
 # FIXME FIXME FIXME, this doesn't work:
 #   not ok 64 [10-images] GET images/get?names=alpine,busybox : status


### PR DESCRIPTION
Signed-off-by: Jakub Guzik <jakubmguzik@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
/kind bug
As described in previous commits and PRs, in certain situations prune/list filter handling is broken (see #9773, #9711 and #9758 ). The problem affects images as well. This is an attempt to fix it.

Adding also handling of dangling filter in compat API (was unimplemented).


