### PR TITLE
Correct json encoding field name for Namespace type

### DIFF
--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -54,7 +54,7 @@ const (
 // Namespace describes the namespace
 type Namespace struct {
 	NSMode NamespaceMode `json:"nsmode,omitempty"`
-	Value  string        `json:"string,omitempty"`
+	Value  string        `json:"value,omitempty"`
 }
 
 // IsDefault returns whether the namespace is set to the default setting (which


### PR DESCRIPTION
[NO TESTS NEEDED]

* When using the **Namespace** type, the field Value was json encoded
  with the name "string" vs "value"
* No tests included as fields are not reported via API

Signed-off-by: Jhon Honce <jhonce@redhat.com>
