### PR TITLE
image unit tests - make them pass on F34 with enforced short-name mode

### DIFF
--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -106,7 +107,7 @@ func TestImage_NewFromLocal(t *testing.T) {
 		assert.NoError(t, err)
 		for _, name := range image.names {
 			newImage, err := ir.NewFromLocal(name)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, newImage.ID(), image.img.ID())
 		}
 	}
@@ -141,7 +142,7 @@ func TestImage_New(t *testing.T) {
 	// after the pull
 	for _, img := range names {
 		newImage, err := ir.New(context.Background(), img, "", "", writer, nil, SigningOptions{}, nil, util.PullImageMissing, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEqual(t, newImage.ID(), "")
 		err = newImage.Remove(context.Background(), false)
 		assert.NoError(t, err)
@@ -167,14 +168,14 @@ func TestImage_MatchRepoTag(t *testing.T) {
 		GraphRoot: workdir,
 	}
 	ir, err := NewImageRuntimeFromOptions(so)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ir.Eventer = events.NewNullEventer()
 	newImage, err := ir.New(context.Background(), "busybox", "", "", os.Stdout, nil, SigningOptions{}, nil, util.PullImageMissing, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = newImage.TagImage("foo:latest")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = newImage.TagImage("foo:bar")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Tests start here.
 	for _, name := range bbNames {
@@ -187,12 +188,12 @@ func TestImage_MatchRepoTag(t *testing.T) {
 
 	// foo should resolve to foo:latest
 	repoTag, err := newImage.MatchRepoTag("foo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "localhost/foo:latest", repoTag)
 
 	// foo:bar should resolve to foo:bar
 	repoTag, err = newImage.MatchRepoTag("foo:bar")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "localhost/foo:bar", repoTag)
 	// Shutdown the runtime and remove the temporary storage
 	cleanup(workdir, ir)
@@ -201,9 +202,7 @@ func TestImage_MatchRepoTag(t *testing.T) {
 // TestImage_RepoDigests tests RepoDigest generation.
 func TestImage_RepoDigests(t *testing.T) {
 	dgst, err := digest.Parse("sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	for _, tt := range []struct {
 		name     string
@@ -235,10 +234,7 @@ func TestImage_RepoDigests(t *testing.T) {
 				},
 			}
 			actual, err := image.RepoDigests()
-			if err != nil {
-				t.Fatal(err)
-			}
-
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, actual)
 
 			image = &Image{
@@ -248,10 +244,7 @@ func TestImage_RepoDigests(t *testing.T) {
 				},
 			}
 			actual, err = image.RepoDigests()
-			if err != nil {
-				t.Fatal(err)
-			}
-
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -94,6 +94,8 @@ func TestImage_NewFromLocal(t *testing.T) {
 	// Need images to be present for this test
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
+	defer cleanup(workdir, ir)
+
 	ir.Eventer = events.NewNullEventer()
 	bb, err := ir.New(context.Background(), "docker.io/library/busybox:latest", "", "", writer, nil, SigningOptions{}, nil, util.PullImageMissing, nil)
 	assert.NoError(t, err)
@@ -111,9 +113,6 @@ func TestImage_NewFromLocal(t *testing.T) {
 			assert.Equal(t, newImage.ID(), image.img.ID())
 		}
 	}
-
-	// Shutdown the runtime and remove the temporary storage
-	cleanup(workdir, ir)
 }
 
 // TestImage_New tests pulling the image by various names, tags, and from
@@ -126,13 +125,14 @@ func TestImage_New(t *testing.T) {
 	var names []string
 	workdir, err := mkWorkDir()
 	assert.NoError(t, err)
-
 	so := storage.StoreOptions{
 		RunRoot:   workdir,
 		GraphRoot: workdir,
 	}
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
+	defer cleanup(workdir, ir)
+
 	ir.Eventer = events.NewNullEventer()
 	// Build the list of pull names
 	names = append(names, bbNames...)
@@ -147,9 +147,6 @@ func TestImage_New(t *testing.T) {
 		err = newImage.Remove(context.Background(), false)
 		assert.NoError(t, err)
 	}
-
-	// Shutdown the runtime and remove the temporary storage
-	cleanup(workdir, ir)
 }
 
 // TestImage_MatchRepoTag tests the various inputs we need to match
@@ -162,13 +159,14 @@ func TestImage_MatchRepoTag(t *testing.T) {
 	//Set up
 	workdir, err := mkWorkDir()
 	assert.NoError(t, err)
-
 	so := storage.StoreOptions{
 		RunRoot:   workdir,
 		GraphRoot: workdir,
 	}
 	ir, err := NewImageRuntimeFromOptions(so)
 	require.NoError(t, err)
+	defer cleanup(workdir, ir)
+
 	ir.Eventer = events.NewNullEventer()
 	newImage, err := ir.New(context.Background(), "busybox", "", "", os.Stdout, nil, SigningOptions{}, nil, util.PullImageMissing, nil)
 	require.NoError(t, err)
@@ -195,8 +193,6 @@ func TestImage_MatchRepoTag(t *testing.T) {
 	repoTag, err = newImage.MatchRepoTag("foo:bar")
 	require.NoError(t, err)
 	assert.Equal(t, "localhost/foo:bar", repoTag)
-	// Shutdown the runtime and remove the temporary storage
-	cleanup(workdir, ir)
 }
 
 // TestImage_RepoDigests tests RepoDigest generation.

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -138,11 +138,14 @@ func TestImage_New(t *testing.T) {
 	names = append(names, bbNames...)
 	writer := os.Stdout
 
+	opts := DockerRegistryOptions{
+		RegistriesConfPath: "testdata/registries.conf",
+	}
 	// Iterate over the names and delete the image
 	// after the pull
 	for _, img := range names {
-		newImage, err := ir.New(context.Background(), img, "", "", writer, nil, SigningOptions{}, nil, util.PullImageMissing, nil)
-		require.NoError(t, err)
+		newImage, err := ir.New(context.Background(), img, "", "", writer, &opts, SigningOptions{}, nil, util.PullImageMissing, nil)
+		require.NoError(t, err, img)
 		assert.NotEqual(t, newImage.ID(), "")
 		err = newImage.Remove(context.Background(), false)
 		assert.NoError(t, err)
@@ -167,8 +170,11 @@ func TestImage_MatchRepoTag(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup(workdir, ir)
 
+	opts := DockerRegistryOptions{
+		RegistriesConfPath: "testdata/registries.conf",
+	}
 	ir.Eventer = events.NewNullEventer()
-	newImage, err := ir.New(context.Background(), "busybox", "", "", os.Stdout, nil, SigningOptions{}, nil, util.PullImageMissing, nil)
+	newImage, err := ir.New(context.Background(), "busybox", "", "", os.Stdout, &opts, SigningOptions{}, nil, util.PullImageMissing, nil)
 	require.NoError(t, err)
 	err = newImage.TagImage("foo:latest")
 	require.NoError(t, err)

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -245,6 +245,7 @@ func (ir *Runtime) pullImageFromHeuristicSource(ctx context.Context, inputName s
 		sc.OSChoice = dockerOptions.OSChoice
 		sc.ArchitectureChoice = dockerOptions.ArchitectureChoice
 		sc.VariantChoice = dockerOptions.VariantChoice
+		sc.SystemRegistriesConfPath = dockerOptions.RegistriesConfPath
 	}
 	if signaturePolicyPath == "" {
 		sc.SignaturePolicyPath = ir.SignaturePolicyPath
@@ -306,7 +307,12 @@ func (ir *Runtime) doPullImage(ctx context.Context, sc *types.SystemContext, goa
 		}
 	}()
 
-	systemRegistriesConfPath := registries.SystemRegistriesConfPath()
+	var systemRegistriesConfPath string
+	if dockerOptions != nil && dockerOptions.RegistriesConfPath != "" {
+		systemRegistriesConfPath = dockerOptions.RegistriesConfPath
+	} else {
+		systemRegistriesConfPath = registries.SystemRegistriesConfPath()
+	}
 
 	var (
 		images     []string

--- a/libpod/image/testdata/registries.conf
+++ b/libpod/image/testdata/registries.conf
@@ -1,0 +1,4 @@
+short-name-mode="enforcing"
+
+[aliases]
+"busybox"="docker.io/library/busybox"


### PR DESCRIPTION
Helps bring https://github.com/containers/podman/pull/9554 forward. Please refer to the individual commits.

@containers/podman-maintainers PTAL