### PR TITLE
system tests: new interactive tests

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -668,15 +668,4 @@ json-file | f
     is "$output" ".*HOME=/.*"
 }
 
-@test "podman run --tty -i failure with no tty" {
-    run_podman run --tty -i --rm $IMAGE echo hello < /dev/null
-    is "$output" ".*The input device is not a TTY.*"
-
-    run_podman run --tty=false -i --rm $IMAGE echo hello < /dev/null
-    is "$output" "hello"
-
-    run_podman run --tty -i=false --rm $IMAGE echo hello < /dev/null
-    is "$output" "hello"
-}
-
 # vim: filetype=sh

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -126,17 +126,6 @@ verify_iid_and_name() {
     verify_iid_and_name $img_name
 }
 
-@test "podman load - will not read from tty" {
-    if [ ! -t 0 ]; then
-        skip "STDIN is not a tty"
-    fi
-
-    run_podman 125 load
-    is "$output" \
-       "Error: cannot read from terminal. Use command-line redirection" \
-       "Diagnostic from 'podman load' without redirection or -i"
-}
-
 @test "podman load - redirect corrupt payload" {
     run_podman 125 load <<< "Danger, Will Robinson!! This is a corrupt tarball!"
     is "$output" \

--- a/test/system/450-interactive.bats
+++ b/test/system/450-interactive.bats
@@ -1,0 +1,92 @@
+# -*- bats -*-
+#
+# tests of podman commands that require an interactive pty
+#
+
+load helpers
+
+###############################################################################
+# BEGIN setup/teardown
+
+# Each test runs with its own PTY, managed by socat.
+PODMAN_TEST_PTY=$(mktemp -u --tmpdir=${BATS_TMPDIR:-/tmp} podman_pty.XXXXXX)
+PODMAN_DUMMY=$(mktemp -u --tmpdir=${BATS_TMPDIR:-/tmp} podman_dummy.XXXXXX)
+PODMAN_SOCAT_PID=
+
+function setup() {
+    basic_setup
+
+    # Create a pty. Run under 'timeout' because BATS reaps child processes
+    # and if we exit before killing socat, bats will hang forever.
+    timeout 10 socat \
+            PTY,link=$PODMAN_TEST_PTY,raw,echo=0 \
+            PTY,link=$PODMAN_DUMMY,raw,echo=0 &
+    PODMAN_SOCAT_PID=$!
+
+    # Wait for pty
+    retries=5
+    while [[ ! -e $PODMAN_TEST_PTY ]]; do
+        retries=$(( retries - 1 ))
+        if [[ $retries -eq 0 ]]; then
+            die "Timed out waiting for $PODMAN_TEST_PTY"
+        fi
+        sleep 0.5
+    done
+}
+
+function teardown() {
+    if [[ -n $PODMAN_SOCAT_PID ]]; then
+        kill $PODMAN_SOCAT_PID
+        PODMAN_SOCAT_PID=
+    fi
+    rm -f $PODMAN_TEST_PTY $PODMAN_DUMMY_PTY
+
+    basic_teardown
+}
+
+# END   setup/teardown
+###############################################################################
+# BEGIN tests
+
+@test "podman detects correct tty size" {
+    skip_if_remote "FIXME: resolved in #9782"
+
+    # Set the pty to a random size. Make rows/columns odd/even, to guarantee
+    # that they can never be the same
+    rows=$(( 15 + RANDOM % 60 |   1 ))
+    cols=$(( 15 + RANDOM % 60 & 126 ))
+    stty rows $rows cols $cols <$PODMAN_TEST_PTY
+
+    # ...and make sure stty under podman reads that.
+    # FIXME: 'sleep 1' is needed for podman-remote; without it, there's
+    # a race condition resulting in the following warning:
+    #   WARN[0000] failed to resize TTY: container "xx" in wrong state "stopped"
+    # (also "created")
+    run_podman run -it --name mystty $IMAGE sh -c 'sleep 1;stty size' <$PODMAN_TEST_PTY
+    is "$output" "$rows $cols" "stty under podman reads the correct dimensions"
+}
+
+
+@test "podman load - will not read from tty" {
+    run_podman 125 load <$PODMAN_TEST_PTY
+    is "$output" \
+       "Error: cannot read from terminal. Use command-line redirection" \
+       "Diagnostic from 'podman load' without redirection or -i"
+}
+
+
+@test "podman run --tty -i failure with no tty" {
+    run_podman run --tty -i --rm $IMAGE echo hello < /dev/null
+    is "$output" ".*The input device is not a TTY.*" "-it _without_ a tty"
+
+    run_podman run --tty -i --rm $IMAGE echo hello <$PODMAN_TEST_PTY
+    is "$output" "hello" "-it _with_ a pty"
+
+    run_podman run --tty=false -i --rm $IMAGE echo hello < /dev/null
+    is "$output" "hello" "-tty=false: no warning"
+
+    run_podman run --tty -i=false --rm $IMAGE echo hello < /dev/null
+    is "$output" "hello" "-i=false: no warning"
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
socat can create a dummy PTY that we can manipulate. This
lets us run a variety of tests that we couldn't before,
involving "run -it", and stty, and even "load" with no args.

Signed-off-by: Ed Santiago <santiago@redhat.com>
