### PR TITLE
Fix list pods filter handling in libpod api

### DIFF
--- a/test/apiv2/40-pods.at
+++ b/test/apiv2/40-pods.at
@@ -116,6 +116,12 @@ t GET libpod/pods/foo/top?ps_args=args,pid 200 \
   .Titles[0]="COMMAND" \
   .Titles[1]="PID" \
 
+#api list pods sanity checks
+t GET libpod/pods/json?filters='garb1age}' 400 \
+    .cause="invalid character 'g' looking for beginning of value"
+t GET libpod/pods/json?filters='{"label":["testl' 400 \
+    .cause="unexpected end of JSON input"
+
 # FIXME: I'm not sure what 'prune' is supposed to do; as of 20200224 it
 # just returns 200 (ok) with empty result list.
 #t POST libpod/pods/prune       200     # FIXME: 2020-02-24 returns 200 {}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
/kind bug

I found one more affected by wrong filter handling in case of bad input. Its pods list HTTP API. I think this could be the last one in regards to the issue described in previous commits (see #9773, #9711, #9758, #9810).
