### PR TITLE
Use TMPDIR when commiting images

### DIFF
--- a/libpod/image/docker_registry_options.go
+++ b/libpod/image/docker_registry_options.go
@@ -69,6 +69,7 @@ func GetSystemContext(signaturePolicyPath, authFilePath string, forceCompress bo
 	sc.AuthFilePath = authFilePath
 	sc.DirForceCompress = forceCompress
 	sc.DockerRegistryUserAgent = fmt.Sprintf("libpod/%s", podmanVersion.Version)
+	sc.BigFilesTemporaryDir = parse.GetTempDir()
 
 	return sc
 }

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/podman/v3/libpod/events"
 	"github.com/containers/podman/v3/pkg/util"
+	podmanVersion "github.com/containers/podman/v3/version"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/opencontainers/go-digest"
@@ -291,5 +292,27 @@ func TestNormalizedTag(t *testing.T) {
 			assert.NoError(t, err, c.input)
 			assert.Equal(t, c.expected, res.String())
 		}
+	}
+}
+
+func TestGetSystemContext(t *testing.T) {
+	sc := GetSystemContext("", "", false)
+	assert.Equal(t, sc.SignaturePolicyPath, "")
+	assert.Equal(t, sc.AuthFilePath, "")
+	assert.Equal(t, sc.DirForceCompress, false)
+	assert.Equal(t, sc.DockerRegistryUserAgent, fmt.Sprintf("libpod/%s", podmanVersion.Version))
+	assert.Equal(t, sc.BigFilesTemporaryDir, "/var/tmp")
+
+	oldtmpdir := os.Getenv("TMPDIR")
+	os.Setenv("TMPDIR", "/mnt")
+	sc = GetSystemContext("/tmp/foo", "/tmp/bar", true)
+	assert.Equal(t, sc.SignaturePolicyPath, "/tmp/foo")
+	assert.Equal(t, sc.AuthFilePath, "/tmp/bar")
+	assert.Equal(t, sc.DirForceCompress, true)
+	assert.Equal(t, sc.BigFilesTemporaryDir, "/mnt")
+	if oldtmpdir != "" {
+		os.Setenv("TMPDIR", oldtmpdir)
+	} else {
+		os.Unsetenv("TMPDIR")
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/9825

Currently we are using TMPDIR for storaing temporary files
when building images, but not when you directly commit the images.

This change simply uses the TMPDIR environment variable if set
to store temporary files.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
