### PR TITLE
Remove resize race condition

### DIFF
--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -587,6 +587,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    type: integer
 	//    required: false
 	//    description: Width to set for the terminal, in characters
+	//  - in: query
+	//    name: running
+	//    type: boolean
+	//    required: false
+	//    description: Ignore containers not running errors
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/api/server/register_exec.go
+++ b/pkg/api/server/register_exec.go
@@ -136,6 +136,11 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//    name: w
 	//    type: integer
 	//    description: Width of the TTY session in characters
+	//  - in: query
+	//    name: running
+	//    type: boolean
+	//    required: false
+	//    description: Ignore containers not running errors
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -307,6 +307,7 @@ func resizeTTY(ctx context.Context, endpoint string, height *int, width *int) er
 	if width != nil {
 		params.Set("w", strconv.Itoa(*width))
 	}
+	params.Set("running", "true")
 	rsp, err := conn.DoRequest(nil, http.MethodPost, endpoint, params, nil)
 	if err != nil {
 		return err

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -210,8 +210,9 @@ type RenameOptions struct {
 // ResizeTTYOptions are optional options for resizing
 // container TTYs
 type ResizeTTYOptions struct {
-	Height *int
-	Width  *int
+	Height  *int
+	Width   *int
+	Running *bool
 }
 
 //go:generate go run ../generator/generator.go ResizeExecTTYOptions

--- a/pkg/bindings/containers/types_resizetty_options.go
+++ b/pkg/bindings/containers/types_resizetty_options.go
@@ -51,3 +51,19 @@ func (o *ResizeTTYOptions) GetWidth() int {
 	}
 	return *o.Width
 }
+
+// WithRunning
+func (o *ResizeTTYOptions) WithRunning(value bool) *ResizeTTYOptions {
+	v := &value
+	o.Running = v
+	return o
+}
+
+// GetRunning
+func (o *ResizeTTYOptions) GetRunning() bool {
+	var running bool
+	if o.Running == nil {
+		return running
+	}
+	return *o.Running
+}

--- a/test/system/450-interactive.bats
+++ b/test/system/450-interactive.bats
@@ -57,9 +57,6 @@ function teardown() {
 
     # ...and make sure stty under podman reads that.
     # FIXME: 'sleep 1' is needed for podman-remote; without it, there's
-    # a race condition resulting in the following warning:
-    #   WARN[0000] failed to resize TTY: container "xx" in wrong state "stopped"
-    # (also "created")
     run_podman run -it --name mystty $IMAGE sh -c 'sleep 1;stty size' <$PODMAN_TEST_PTY
     is "$output" "$rows $cols" "stty under podman reads the correct dimensions"
 }


### PR DESCRIPTION
Since podman-remote resize requests can come in at random times, this
generates a real potential for race conditions. We should only be
attempting to resize TTY on running containers, but the containers can
go from running to stopped at any time, and returning an error to the
caller is just causing noice.

This change will basically ignore requests to resize terminals if the
container is not running and return the caller to success.  All other
callers will still return failure.

Fixes: https://github.com/containers/podman/issues/9831

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
