### PR TITLE
Podman machine enhancements

### DIFF
--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -14,11 +14,11 @@ import (
 
 var (
 	sshCmd = &cobra.Command{
-		Use:   "ssh [options] NAME [COMMAND [ARG ...]]",
+		Use:   "ssh [options] [NAME] [COMMAND [ARG ...]]",
 		Short: "SSH into a virtual machine",
 		Long:  "SSH into a virtual machine ",
 		RunE:  ssh,
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		Example: `podman machine ssh myvm
   podman machine ssh -e  myvm echo hello`,
 
@@ -48,6 +48,10 @@ func ssh(cmd *cobra.Command, args []string) error {
 		vm     machine.VM
 		vmType string
 	)
+	vmName := defaultMachineName
+	if len(args) > 0 && len(args[0]) > 1 {
+		vmName = args[0]
+	}
 	sshOpts.Args = args[1:]
 
 	// Error if no execute but args given
@@ -61,10 +65,10 @@ func ssh(cmd *cobra.Command, args []string) error {
 
 	switch vmType {
 	default:
-		vm, err = qemu.LoadVMByName(args[0])
+		vm, err = qemu.LoadVMByName(vmName)
 	}
 	if err != nil {
 		return errors.Wrapf(err, "vm %s not found", args[0])
 	}
-	return vm.SSH(args[0], sshOpts)
+	return vm.SSH(vmName, sshOpts)
 }

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -13,11 +13,11 @@ import (
 
 var (
 	startCmd = &cobra.Command{
-		Use:               "start NAME",
+		Use:               "start [NAME]",
 		Short:             "Start an existing machine",
 		Long:              "Start an existing machine ",
 		RunE:              start,
-		Args:              cobra.ExactArgs(1),
+		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine start myvm`,
 		ValidArgsFunction: completion.AutocompleteNone,
 	}
@@ -37,12 +37,16 @@ func start(cmd *cobra.Command, args []string) error {
 		vm     machine.VM
 		vmType string
 	)
+	vmName := defaultMachineName
+	if len(args) > 0 && len(args[0]) > 0 {
+		vmName = args[0]
+	}
 	switch vmType {
 	default:
-		vm, err = qemu.LoadVMByName(args[0])
+		vm, err = qemu.LoadVMByName(vmName)
 	}
 	if err != nil {
 		return err
 	}
-	return vm.Start(args[0], machine.StartOptions{})
+	return vm.Start(vmName, machine.StartOptions{})
 }

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -13,11 +13,11 @@ import (
 
 var (
 	stopCmd = &cobra.Command{
-		Use:               "stop NAME",
+		Use:               "stop [NAME]",
 		Short:             "Stop an existing machine",
 		Long:              "Stop an existing machine ",
 		RunE:              stop,
-		Args:              cobra.ExactArgs(1),
+		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine stop myvm`,
 		ValidArgsFunction: completion.AutocompleteNone,
 	}
@@ -38,12 +38,16 @@ func stop(cmd *cobra.Command, args []string) error {
 		vm     machine.VM
 		vmType string
 	)
+	vmName := defaultMachineName
+	if len(args) > 0 && len(args[0]) > 0 {
+		vmName = args[0]
+	}
 	switch vmType {
 	default:
-		vm, err = qemu.LoadVMByName(args[0])
+		vm, err = qemu.LoadVMByName(vmName)
 	}
 	if err != nil {
 		return err
 	}
-	return vm.Stop(args[0], machine.StopOptions{})
+	return vm.Stop(vmName, machine.StopOptions{})
 }

--- a/docs/source/machine.rst
+++ b/docs/source/machine.rst
@@ -3,7 +3,7 @@ Machine
 
 
 :doc:`init <markdown/podman-machine-init.1>` Initialize a new virtual machine
-:doc:`remove <markdown/podman-machine-remove.1>` Remove a virtual machine
+:doc:`rm <markdown/podman-machine-rm.1>` Remove a virtual machine
 :doc:`ssh <markdown/podman-machine-ssh.1>` SSH into a virtual machine
 :doc:`start <markdown/podman-machine-start.1>` Start a virtual machine
 :doc:`stop <markdown/podman-machine-stop.1>` Stop a virtual machine

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -22,6 +22,10 @@ tied to the Linux kernel.
 
 Number of CPUs.
 
+#### **--disk-size**=*number*
+
+Size of the disk for the guest VM in GB.
+
 #### **--ignition-path**
 
 Fully qualified path of the ignition file

--- a/docs/source/markdown/podman-machine-rm.1.md
+++ b/docs/source/markdown/podman-machine-rm.1.md
@@ -1,17 +1,17 @@
-% podman-machine-remove(1)
+% podman-machine-rm(1)
 
 ## NAME
-podman\-machine\-remove - Remove a virtual machine
+podman\-machine\-rm - Remove a virtual machine
 
 ## SYNOPSIS
-**podman machine remove** [*options*] *name*
+**podman machine rm** [*options*] [*name*]
 
 ## DESCRIPTION
 
 Remove a virtual machine and its related files.  What is actually deleted
 depends on the virtual machine type.  For all virtual machines, the generated
 SSH keys and the podman system connection are deleted.  The ignition files
-generated for that VM are also removeed as is its image file on the filesystem.
+generated for that VM are also removed as is its image file on the filesystem.
 
 Users get a display of what will be deleted and are required to confirm unless the option `--force`
 is used.
@@ -45,7 +45,7 @@ deleted.
 Remove a VM named "test1"
 
 ```
-$ podman machine remove test1
+$ podman machine rm test1
 
 The following files will be deleted:
 

--- a/docs/source/markdown/podman-machine-ssh.1.md
+++ b/docs/source/markdown/podman-machine-ssh.1.md
@@ -4,7 +4,7 @@
 podman\-machine\-ssh - SSH into a virtual machine
 
 ## SYNOPSIS
-**podman machine ssh** [*options*] *name* [*command* [*arg* ...]]
+**podman machine ssh** [*options*] [*name*] [*command* [*arg* ...]]
 
 ## DESCRIPTION
 

--- a/docs/source/markdown/podman-machine-start.1.md
+++ b/docs/source/markdown/podman-machine-start.1.md
@@ -4,7 +4,7 @@
 podman\-machine\-start - Start a virtual machine
 
 ## SYNOPSIS
-**podman machine start** *name*
+**podman machine start** [*name*]
 
 ## DESCRIPTION
 

--- a/docs/source/markdown/podman-machine-stop.1.md
+++ b/docs/source/markdown/podman-machine-stop.1.md
@@ -4,7 +4,7 @@
 podman\-machine\-stop - Stop a virtual machine
 
 ## SYNOPSIS
-**podman machine stop** *name*
+**podman machine stop** [*name*]
 
 ## DESCRIPTION
 

--- a/docs/source/markdown/podman-machine.1.md
+++ b/docs/source/markdown/podman-machine.1.md
@@ -14,10 +14,10 @@ podman\-machine - Manage Podman's virtual machine
 | Command | Man Page                                                | Description                       |
 | ------- | ------------------------------------------------------- | --------------------------------- |
 | init    | [podman-machine-init(1)](podman-machine-init.1.md)      | Initialize a new virtual machine  |
-| remove  | [podman-machine-remove(1)](podman-machine-remove.1.md)  | Remove a virtual machine          |
-| ssh     | [podman-machine-ssh(1)](podman-machine-ssh.1.md)        | SSH into a virtual machine        |
-| start   | [podman-machine-start(1)](podman-machine-start.1.md)    | Start a virtual machine           |
-| stop    | [podman-machine-stop(1)](podman-machine-stop.1.md)      | Stop a virtual machine            |
+| rm | [podman-machine-rm(1)](podman-machine-rm.1.md)| Remove a virtual machine     |
+| ssh     | [podman-machine-ssh(1)](podman-machine-ssh.1.md)   | SSH into a virtual machine    |
+| start   | [podman-machine-start(1)](podman-machine-start.1.md)    | Start a virtual machine       |
+| stop    | [podman-machine-stop(1)](podman-machine-stop.1.md)      | Stop a virtual machine        |
 
 ## SEE ALSO
 podman(1)

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -7,19 +7,19 @@ import (
 	"path/filepath"
 
 	"github.com/containers/storage/pkg/homedir"
+	"github.com/pkg/errors"
 )
 
 type InitOptions struct {
-	Name         string
 	CPUS         uint64
-	Memory       uint64
+	DiskSize     uint64
 	IgnitionPath string
 	ImagePath    string
-	Username     string
-	URI          url.URL
 	IsDefault    bool
-	//KernelPath string
-	//Devices    []VMDevices
+	Memory       uint64
+	Name         string
+	URI          url.URL
+	Username     string
 }
 
 type RemoteConnectionType string
@@ -27,6 +27,8 @@ type RemoteConnectionType string
 var (
 	SSHRemoteConnection     RemoteConnectionType = "ssh"
 	DefaultIgnitionUserName                      = "core"
+	ErrNoSuchVM                                  = errors.New("VM does not exist")
+	ErrVMAlreadyExists                           = errors.New("VM already exists")
 )
 
 type Download struct {


### PR DESCRIPTION
Podman machine remove is now called `rm`.

Podman machine create now supports resizing the image to the value of
--disk-size as provided.  The default is to 10G.

Added systemd unit file on guest via ignition that sends a Ready message
to the host over a virtio-socket so that we know when the VM is booted
and ready for use.

Podman machine commands no longer require a VM name as an argument.  A
default VM name is defined and if no VM name is provided as a arg, the
default will be used.

[NO TESTS NEEDED]

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
