### PR TITLE
Add support for env from secrets in play kube

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -2,11 +2,13 @@ package kube
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
 
 	"github.com/containers/common/pkg/parse"
+	"github.com/containers/common/pkg/secrets"
 	"github.com/containers/podman/v3/libpod/image"
 	ann "github.com/containers/podman/v3/pkg/annotations"
 	"github.com/containers/podman/v3/pkg/specgen"
@@ -94,6 +96,8 @@ type CtrSpecGenOptions struct {
 	RestartPolicy string
 	// NetNSIsHost tells the container to use the host netns
 	NetNSIsHost bool
+	// SecretManager to access the secrets
+	SecretsManager *secrets.SecretsManager
 }
 
 func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGenerator, error) {
@@ -331,7 +335,21 @@ func quantityToInt64(quantity *resource.Quantity) (int64, error) {
 	return 0, errors.Errorf("Quantity cannot be represented as int64: %v", quantity)
 }
 
-// envVarsFrom returns all key-value pairs as env vars from a configMap that matches the envFrom setting of a container
+// read a k8s secret in JSON format from the secret manager
+func k8sSecretFromSecretManager(name string, secretsManager *secrets.SecretsManager) (map[string][]byte, error) {
+	_, jsonSecret, err := secretsManager.LookupSecretData(name)
+	if err != nil {
+		return nil, err
+	}
+
+	var secrets map[string][]byte
+	if err := json.Unmarshal(jsonSecret, &secrets); err != nil {
+		return nil, errors.Errorf("Secret %v is not valid JSON: %v", name, err)
+	}
+	return secrets, nil
+}
+
+// envVarsFrom returns all key-value pairs as env vars from a configMap or secret that matches the envFrom setting of a container
 func envVarsFrom(envFrom v1.EnvFromSource, opts *CtrSpecGenOptions) (map[string]string, error) {
 	envs := map[string]string{}
 
@@ -352,11 +370,23 @@ func envVarsFrom(envFrom v1.EnvFromSource, opts *CtrSpecGenOptions) (map[string]
 		}
 	}
 
+	if envFrom.SecretRef != nil {
+		secRef := envFrom.SecretRef
+		secret, err := k8sSecretFromSecretManager(secRef.Name, opts.SecretsManager)
+		if err == nil {
+			for k, v := range secret {
+				envs[k] = string(v)
+			}
+		} else if secRef.Optional == nil || !*secRef.Optional {
+			return nil, err
+		}
+	}
+
 	return envs, nil
 }
 
 // envVarValue returns the environment variable value configured within the container's env setting.
-// It gets the value from a configMap if specified, otherwise returns env.Value
+// It gets the value from a configMap or secret if specified, otherwise returns env.Value
 func envVarValue(env v1.EnvVar, opts *CtrSpecGenOptions) (string, error) {
 	if env.ValueFrom != nil {
 		if env.ValueFrom.ConfigMapKeyRef != nil {
@@ -374,6 +404,21 @@ func envVarValue(env v1.EnvVar, opts *CtrSpecGenOptions) (string, error) {
 			}
 			if cmKeyRef.Optional == nil || !*cmKeyRef.Optional {
 				return "", err
+			}
+			return "", nil
+		}
+
+		if env.ValueFrom.SecretKeyRef != nil {
+			secKeyRef := env.ValueFrom.SecretKeyRef
+			secret, err := k8sSecretFromSecretManager(secKeyRef.Name, opts.SecretsManager)
+			if err == nil {
+				if val, ok := secret[secKeyRef.Key]; ok {
+					return string(val), nil
+				}
+				err = errors.Errorf("Secret %v has not %v key", secKeyRef.Name, secKeyRef.Key)
+			}
+			if secKeyRef.Optional == nil || !*secKeyRef.Optional {
+				return "", errors.Errorf("Cannot set env %v: %v", env.Name, err)
 			}
 			return "", nil
 		}

--- a/pkg/specgen/generate/kube/play_test.go
+++ b/pkg/specgen/generate/kube/play_test.go
@@ -8,12 +8,12 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestEnvVarsFromConfigMap(t *testing.T) {
+func TestEnvVarsFrom(t *testing.T) {
 	tests := []struct {
-		name          string
-		envFrom       v1.EnvFromSource
-		configMapList []v1.ConfigMap
-		expected      map[string]string
+		name     string
+		envFrom  v1.EnvFromSource
+		options  CtrSpecGenOptions
+		expected map[string]string
 	}{
 		{
 			"ConfigMapExists",
@@ -24,7 +24,9 @@ func TestEnvVarsFromConfigMap(t *testing.T) {
 					},
 				},
 			},
-			configMapList,
+			CtrSpecGenOptions{
+				ConfigMaps: configMapList,
+			},
 			map[string]string{
 				"myvar": "foo",
 			},
@@ -38,7 +40,9 @@ func TestEnvVarsFromConfigMap(t *testing.T) {
 					},
 				},
 			},
-			configMapList,
+			CtrSpecGenOptions{
+				ConfigMaps: configMapList,
+			},
 			map[string]string{},
 		},
 		{
@@ -50,7 +54,9 @@ func TestEnvVarsFromConfigMap(t *testing.T) {
 					},
 				},
 			},
-			[]v1.ConfigMap{},
+			CtrSpecGenOptions{
+				ConfigMaps: []v1.ConfigMap{},
+			},
 			map[string]string{},
 		},
 	}
@@ -58,7 +64,7 @@ func TestEnvVarsFromConfigMap(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			result := envVarsFromConfigMap(test.envFrom, test.configMapList)
+			result := envVarsFrom(test.envFrom, &test.options)
 			assert.Equal(t, test.expected, result)
 		})
 	}
@@ -66,10 +72,10 @@ func TestEnvVarsFromConfigMap(t *testing.T) {
 
 func TestEnvVarValue(t *testing.T) {
 	tests := []struct {
-		name          string
-		envVar        v1.EnvVar
-		configMapList []v1.ConfigMap
-		expected      string
+		name     string
+		envVar   v1.EnvVar
+		options  CtrSpecGenOptions
+		expected string
 	}{
 		{
 			"ConfigMapExists",
@@ -84,7 +90,9 @@ func TestEnvVarValue(t *testing.T) {
 					},
 				},
 			},
-			configMapList,
+			CtrSpecGenOptions{
+				ConfigMaps: configMapList,
+			},
 			"foo",
 		},
 		{
@@ -100,7 +108,9 @@ func TestEnvVarValue(t *testing.T) {
 					},
 				},
 			},
-			configMapList,
+			CtrSpecGenOptions{
+				ConfigMaps: configMapList,
+			},
 			"",
 		},
 		{
@@ -116,7 +126,9 @@ func TestEnvVarValue(t *testing.T) {
 					},
 				},
 			},
-			configMapList,
+			CtrSpecGenOptions{
+				ConfigMaps: configMapList,
+			},
 			"",
 		},
 		{
@@ -132,7 +144,9 @@ func TestEnvVarValue(t *testing.T) {
 					},
 				},
 			},
-			[]v1.ConfigMap{},
+			CtrSpecGenOptions{
+				ConfigMaps: []v1.ConfigMap{},
+			},
 			"",
 		},
 	}
@@ -140,7 +154,7 @@ func TestEnvVarValue(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			result := envVarValue(test.envVar, test.configMapList)
+			result := envVarValue(test.envVar, &test.options)
 			assert.Equal(t, test.expected, result)
 		})
 	}


### PR DESCRIPTION
This serie add support for the `env.valueFrom.secretKeyRef` and `envFrom.secretRef` elements in play kube. While at it I noticed that podman treat env references as optional, but K8S treat them as mandatory unless the `optional` parameter if set true. So this serie also add support for the `optional` parameter in configMapRef and fix the behavior when it is not present to match K8S.

Note that K8S secrets are dictionaries of binary data, so the value stored in the secret must be a JSON object that contain values in base64 encoding. This match the data type of the `data` field in a K8S secret object.