### PR TITLE
Add machine support for more Linux distros

### DIFF
--- a/pkg/machine/qemu/options_linux_amd64.go
+++ b/pkg/machine/qemu/options_linux_amd64.go
@@ -1,11 +1,14 @@
 package qemu
 
 var (
-	QemuCommand = "qemu-kvm"
+	QemuCommand = "qemu-system-x86_64"
 )
 
 func (v *MachineVM) addArchOptions() []string {
-	opts := []string{"-cpu", "host"}
+	opts := []string{
+		"-accel", "kvm",
+		"-cpu", "host",
+	}
 	return opts
 }
 


### PR DESCRIPTION
Since `qemu-kvm` symlink is only available in Fedora

Fixes:

```
Error: exec: "qemu-kvm": executable file not found in $PATH
```

KVM is still hard-coded.