### PR TITLE
[NO TESTS NEEDED] Add machine support for qemu-system-aarch64 on linux

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -1,4 +1,4 @@
-// +build amd64,linux amd64,darwin arm64,darwin
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
 
 package machine
 

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -1,4 +1,4 @@
-// +build amd64,linux amd64,darwin arm64,darwin
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
 
 package machine
 

--- a/cmd/podman/machine/machine_unsupported.go
+++ b/cmd/podman/machine/machine_unsupported.go
@@ -1,4 +1,4 @@
-// +build !amd64 arm64,linux amd64,windows
+// +build !amd64 amd64,windows
 
 package machine
 

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -1,4 +1,4 @@
-// +build amd64,linux amd64,darwin arm64,darwin
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
 
 package machine
 

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -1,4 +1,4 @@
-// +build amd64,linux amd64,darwin arm64,darwin
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
 
 package machine
 

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -1,4 +1,4 @@
-// +build amd64,linux amd64,darwin arm64,darwin
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
 
 package machine
 

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -1,4 +1,4 @@
-// +build amd64,linux amd64,darwin arm64,darwin
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
 
 package machine
 

--- a/pkg/machine/fcos_arm64.go
+++ b/pkg/machine/fcos_arm64.go
@@ -34,7 +34,7 @@ func getFCOSDownload() (*fcosDownloadInfo, error) {
 		return nil, err
 	}
 	return &fcosDownloadInfo{
-		Location:  "https://fedorapeople.org/groups/fcos-images/builds/latest/aarch64/fedora-coreos-33.20210310.dev.0-qemu.aarch64.qcow2",
+		Location:  aarchBaseURL + "/" + meta.BuildArtifacts.Qemu.Path,
 		Release:   "",
 		Sha256Sum: meta.BuildArtifacts.Qemu.Sha256,
 	}, nil

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -38,7 +38,7 @@ func DownloadVMImage(downloadURL fmt.Stringer, localImagePath string) error {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("error downloading VM image: %s", resp.Status)
+		return fmt.Errorf("error downloading VM image %s: %s", downloadURL, resp.Status)
 	}
 	size := resp.ContentLength
 	urlSplit := strings.Split(downloadURL.String(), "/")

--- a/pkg/machine/qemu/options_linux_arm64.go
+++ b/pkg/machine/qemu/options_linux_arm64.go
@@ -1,0 +1,41 @@
+package qemu
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var (
+	QemuCommand = "qemu-system-aarch64"
+)
+
+func (v *MachineVM) addArchOptions() []string {
+	opts := []string{
+		"-accel", "kvm",
+		"-cpu", "host",
+		"-M", "virt,gic-version=max",
+		"-bios", getQemuUefiFile("QEMU_EFI.fd"),
+	}
+	return opts
+}
+
+func (v *MachineVM) prepare() error {
+	return nil
+}
+
+func (v *MachineVM) archRemovalFiles() []string {
+	return []string{}
+}
+
+func getQemuUefiFile(name string) string {
+	dirs := []string{
+		"/usr/share/qemu-efi-aarch64",
+		"/usr/share/edk2/aarch64",
+	}
+	for _, dir := range dirs {
+		if _, err := os.Stat(dir); err == nil {
+			return filepath.Join(dir, name)
+		}
+	}
+	return name
+}


### PR DESCRIPTION
Didn't boot after fixing the build and the url, but found some notes at https://fedorapeople.org/groups/fcos-images/readme.txt

Tested on a Raspberry Pi 4, running Ubuntu 20.04 with Xfce. (regular installation, https://ubuntu.com/download/raspberry-pi)

![Screenshot_2021-03-28_13-36-52](https://user-images.githubusercontent.com/10364051/112754289-b14aa100-8fdb-11eb-8631-42a9af1bceec.jpg)

The main reason for running "machine" there (linux-arm64), is to be able to test the ARM image on inexpensive hardware ($100).

It should be possible to test this on Fedora Workstation aarch64 as well, but there is no Xfce spin. <https://alt.fedoraproject.org/alt/>