### PR TITLE
An improvement for is() function in case of missing testname

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -384,7 +384,11 @@ function die() {
 function is() {
     local actual="$1"
     local expect="$2"
-    local testname="${3:-FIXME}"
+    #FUNCNAME is used to determine function caller to be utilized in case of missing testname.
+    #sed substitutes are used for cosmetic corrections.	
+    local callerchain="${FUNCNAME[1]}"
+    local caller="$(echo FIXME - Caller: $callerchain|sed -e 's/-3a/:/g' -e 's/-2d/-/g' -e 's/_/ /g')"
+    local testname="${3:-$caller}"
 
     if [ -z "$expect" ]; then
         if [ -z "$actual" ]; then


### PR DESCRIPTION
Change is an improvement and cosmetic correction. 

Previously error returning from is() would print as (FAIL line in particular):
![image](https://user-images.githubusercontent.com/80413463/112767506-c6492380-901f-11eb-9746-c344a5116fa0.png)

Improvement changes the FIXME text as (without cosmetic corrections):
![image](https://user-images.githubusercontent.com/80413463/112767570-1e802580-9020-11eb-9e29-472ec3d44eac.png)

Finally with cosmetic corrections:
![image](https://user-images.githubusercontent.com/80413463/112767586-3f487b00-9020-11eb-9cf0-bcb428e552df.png)

PersonalNote:  I think [CI:DOCS] would be required. However, I am trying to learn and adjust. Any suggestion/criticism/edit is welcomed. :)

Signed-off-by: Ali Aslanturk <ilaaslanturk@gmail.com>
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
