### PR TITLE
[CI:DOCS] Fix long option format in man pages

### DIFF
--- a/docs/remote-docs.sh
+++ b/docs/remote-docs.sh
@@ -70,7 +70,7 @@ function html_fn() {
         local link=$(sed -e 's?.so man1/\(.*\)?\1?' <$dir/links/${file%.md})
         markdown=$dir/$link.md
     fi
-    pandoc --ascii --lua-filter=docs/links-to-html.lua -o $TARGET/${file%%.*}.html $markdown
+    pandoc --ascii -f gfm --lua-filter=docs/links-to-html.lua -o $TARGET/${file%%.*}.html $markdown
 }
 
 # Run 'podman help' (possibly against a subcommand, e.g. 'podman help image')


### PR DESCRIPTION
Currently long options like `--tag` look to have only one long
dash instead of two dashes in the man pages on docs.podman.io.

When cut/pasted, only one dash is included, and worse yet, searches
for two dashes fail.

@eriksjolund discovered this probable fix, unfortunately it's not
easy to test without merging.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
