### PR TITLE
system tests: friendier messages for 2-arg is()

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -72,6 +72,9 @@ function basic_setup() {
     # on cleanup.
     # TODO: do this outside of setup, so it carries across tests?
     PODMAN_TMPDIR=$(mktemp -d --tmpdir=${BATS_TMPDIR:-/tmp} podman_bats.XXXXXX)
+
+    # In the unlikely event that a test runs is() before a run_podman()
+    MOST_RECENT_PODMAN_COMMAND=
 }
 
 # Basic teardown: remove all pods and containers
@@ -149,6 +152,9 @@ function run_podman() {
         [12][0-9][0-9])  expected_rc=$1; shift;;
         '?')             expected_rc=  ; shift;;  # ignore exit code
     esac
+
+    # Remember command args, for possible use in later diagnostic messages
+    MOST_RECENT_PODMAN_COMMAND="podman $*"
 
     # stdout is only emitted upon error; this echo is to help a debugger
     echo "$_LOG_PROMPT $PODMAN $*"
@@ -384,7 +390,7 @@ function die() {
 function is() {
     local actual="$1"
     local expect="$2"
-    local testname="${3:-FIXME}"
+    local testname="${3:-${MOST_RECENT_PODMAN_COMMAND:-[no test name given]}}"
 
     if [ -z "$expect" ]; then
         if [ -z "$actual" ]; then


### PR DESCRIPTION
The 'is' check was intended to be called with three arguments,
the last one being a nice helpful test name. There's a fallback
for two-argument calls, but it was a horrible FIXME.

New fallback: the most recently run podman command. We keep
track of it in each run_podman() invocation.

This is not ideal, because it's theoretically possible to
invoke 'is' on something other than the output of run_podman,
but this at least fixes the by-far-most-common case.

Signed-off-by: Ed Santiago <santiago@redhat.com>
