### PR TITLE
[CI:DOCS] swagger: update system version response body

### DIFF
--- a/pkg/api/server/swagger.go
+++ b/pkg/api/server/swagger.go
@@ -205,7 +205,7 @@ type swagHealthCheckRunResponse struct {
 type swagVersion struct {
 	// in:body
 	Body struct {
-		entities.SystemVersionReport
+		entities.ComponentVersion
 	}
 }
 


### PR DESCRIPTION
This change updates the swagger documentation of the
system version response body to match with the actual
response.

Fixes: #9522
Signed-off-by: Tristan Cacqueray <tdecacqu@redhat.com>