### PR TITLE
APIv2 basic test: relax APIVersion check

### DIFF
--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -16,13 +16,13 @@ t GET  libpod/_ping 200 OK
 t HEAD libpod/_ping 200
 
 for i in /version version; do
-    t GET  $i      200                           \
-      .Components[0].Name="Podman Engine"        \
-      .Components[0].Details.APIVersion=3.2.0-dev    \
-      .Components[0].Details.MinAPIVersion=3.1.0 \
-      .Components[0].Details.Os=linux            \
-      .ApiVersion=1.40                          \
-      .MinAPIVersion=1.24                       \
+    t GET  $i      200                               \
+      .Components[0].Name="Podman Engine"            \
+      .Components[0].Details.APIVersion~3[0-9.-]\\+  \
+      .Components[0].Details.MinAPIVersion=3.1.0     \
+      .Components[0].Details.Os=linux                \
+      .ApiVersion=1.40                               \
+      .MinAPIVersion=1.24                            \
       .Os=linux
 done
 


### PR DESCRIPTION
It is tedious and error-prone to update the 'APIVersion=<exact>'
test every time there's a minor bump. Change the test so it
confirms only the major version.

Signed-off-by: Ed Santiago <santiago@redhat.com>
