### PR TITLE
Document --volume from podman-remote run/create client

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -765,11 +765,15 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	)
 	_ = cmd.RegisterFlagCompletionFunc(mountFlagName, AutocompleteMountFlag)
 
+	volumeDesciption := "Bind mount a volume into the container"
+	if registry.IsRemote() {
+		volumeDesciption = "Bind mount a volume into the container. Volume src will be on the server machine, not the client"
+	}
 	volumeFlagName := "volume"
 	createFlags.StringArrayVarP(
 		&cf.Volume,
 		volumeFlagName, "v", volumes(),
-		"Bind mount a volume into the container",
+		volumeDesciption,
 	)
 	_ = cmd.RegisterFlagCompletionFunc(volumeFlagName, AutocompleteVolumeFlag)
 
@@ -804,4 +808,10 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 		"Configure cgroup v2 (key=value)",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(cgroupConfFlagName, completion.AutocompleteNone)
+
+	_ = createFlags.MarkHidden("signature-policy")
+	if registry.IsRemote() {
+		_ = createFlags.MarkHidden("env-host")
+		_ = createFlags.MarkHidden("http-proxy")
+	}
 }

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -63,11 +63,6 @@ func createFlags(cmd *cobra.Command) {
 	common.DefineNetFlags(cmd)
 
 	flags.SetNormalizeFunc(utils.AliasFlags)
-
-	_ = flags.MarkHidden("signature-policy")
-	if registry.IsRemote() {
-		_ = flags.MarkHidden("http-proxy")
-	}
 }
 
 func init() {

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -76,13 +76,11 @@ func runFlags(cmd *cobra.Command) {
 	detachKeysFlagName := "detach-keys"
 	flags.StringVar(&runOpts.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-cf`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 	_ = cmd.RegisterFlagCompletionFunc(detachKeysFlagName, common.AutocompleteDetachKeys)
-
-	_ = flags.MarkHidden("signature-policy")
 	if registry.IsRemote() {
-		_ = flags.MarkHidden("http-proxy")
 		_ = flags.MarkHidden("preserve-fds")
 	}
 }
+
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1029,7 +1029,7 @@ Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Podman
 bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the Podman
 container. Similarly, `-v SOURCE-VOLUME:/CONTAINER-DIR` will mount the volume
 in the host to the container. If no such named volume exists, Podman will
-create one. The `OPTIONS` are a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
+create one. The `OPTIONS` are a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>  (Note when using the remote client, the volumes will be mounted from the remote server, not necessarly the client machine.)
 
 The _options_ is a comma delimited list and can be:
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -744,7 +744,7 @@ If a container is run within a pod, and the pod has an infra-container, the infr
 #### **\-\-preserve-fds**=*N*
 
 Pass down to the process N additional file descriptors (in addition to 0, 1, 2).
-The total FDs will be 3+N.
+The total FDs will be 3+N. (This option is not available with the remote Podman client)
 
 #### **\-\-privileged**=**true**|**false**
 
@@ -1104,7 +1104,7 @@ Create a bind mount. If you specify _/HOST-DIR_:_/CONTAINER-DIR_, Podman
 bind mounts _host-dir_ in the host to _CONTAINER-DIR_ in the Podman
 container. Similarly, _SOURCE-VOLUME_:_/CONTAINER-DIR_ will mount the volume
 in the host to the container. If no such named volume exists, Podman will
-create one.
+create one. (Note when using the remote client, the volumes will be mounted from the remote server, not necessarly the client machine.)
 
 The _options_ is a comma delimited list and can be: <sup>[[1]](#Footnote1)</sup>
 


### PR DESCRIPTION
[NO TESTS NEEDED] This PR is mainly documentation and some code cleanup.

Also cleanup and consolidate handling of other hanlding of podman-remote
hidden options.

Fixes: #9874

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>