### PR TITLE
Trim white space from /top endpoint results

### DIFF
--- a/pkg/api/handlers/compat/containers_top.go
+++ b/pkg/api/handlers/compat/containers_top.go
@@ -46,8 +46,16 @@ func TopContainer(w http.ResponseWriter, r *http.Request) {
 	var body = handlers.ContainerTopOKBody{}
 	if len(output) > 0 {
 		body.Titles = strings.Split(output[0], "\t")
+		for i := range body.Titles {
+			body.Titles[i] = strings.TrimSpace(body.Titles[i])
+		}
+
 		for _, line := range output[1:] {
-			body.Processes = append(body.Processes, strings.Split(line, "\t"))
+			process := strings.Split(line, "\t")
+			for i := range process {
+				process[i] = strings.TrimSpace(process[i])
+			}
+			body.Processes = append(body.Processes, process)
 		}
 	}
 	utils.WriteJSON(w, http.StatusOK, body)

--- a/test/apiv2/25-containersMore.at
+++ b/test/apiv2/25-containersMore.at
@@ -38,7 +38,8 @@ t GET libpod/containers/foo/json 200 \
 
 # List processes of the container
 t GET libpod/containers/foo/top 200 \
-  length=2
+  length=2 \
+  .Processes[0][7]="top"
 
 # List processes of none such
 t GET libpod/containers/nonesuch/top 404


### PR DESCRIPTION
Versions of the ps command have additional spaces between fields, this
manifests as the container asking to run "top" and API reporting "top "
as a process.

Endpoint and tests updated to check that "top" is reported.

There is no libpod specialized endpoint to update.

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
