### PR TITLE
Remove --execute from podman machine ssh

### DIFF
--- a/docs/source/markdown/podman-machine-ssh.1.md
+++ b/docs/source/markdown/podman-machine-ssh.1.md
@@ -4,21 +4,18 @@
 podman\-machine\-ssh - SSH into a virtual machine
 
 ## SYNOPSIS
-**podman machine ssh** [*options*] [*name*] [*command* [*arg* ...]]
+**podman machine ssh** [*name*] [*command* [*arg* ...]]
 
 ## DESCRIPTION
 
-SSH into a Podman-managed virtual machine.
+SSH into a Podman-managed virtual machine and optionally execute a command
+on the virtual machine.  Unless using the default virtual machine, the
+first argument must be the virtual machine name. The optional command to
+execute can then follow. If no command is provided, an interactive session
+with the virtual machine is established.
 
-Podman on MacOS requires a virtual machine. This is because containers are Linux -
-containers do not run on any other OS because containers' core functionality are
-tied to the Linux kernel.
 
 ## OPTIONS
-
-#### **\-\-execute**, **-e**
-
-Execute the given command on the VM
 
 #### **\-\-help**
 
@@ -26,14 +23,25 @@ Print usage statement.
 
 ## EXAMPLES
 
+To get an interactive session with the default virtual machine:
+
+```
+$ podman machine ssh
+```
+
 To get an interactive session with a VM called `myvm`:
 ```
 $ podman machine ssh myvm
 ```
 
+To run a command on the default virtual machine:
+```
+$ podman machine ssh rpm -q podman
+```
+
 To run a command on a VM called `myvm`:
 ```
-$ podman machine ssh -e myvm -- rpm -q podman
+$ podman machine ssh  myvm rpm -q podman
 ```
 
 ## SEE ALSO

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -56,8 +56,7 @@ type ListResponse struct {
 }
 
 type SSHOptions struct {
-	Execute bool
-	Args    []string
+	Args []string
 }
 type StartOptions struct{}
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -400,7 +400,7 @@ func (v *MachineVM) SSH(name string, opts machine.SSHOptions) error {
 	port := strconv.Itoa(v.Port)
 
 	args := []string{"-i", v.IdentityPath, "-p", port, sshDestination}
-	if opts.Execute {
+	if len(opts.Args) > 0 {
 		args = append(args, opts.Args...)
 	} else {
 		fmt.Printf("Connecting to vm %s. To close connection, use `~.` or `exit`\n", v.Name)
@@ -446,7 +446,11 @@ func getDiskSize(path string) (uint64, error) {
 }
 
 // List lists all vm's that use qemu virtualization
-func List(opts machine.ListOptions) ([]*machine.ListResponse, error) {
+func List(_ machine.ListOptions) ([]*machine.ListResponse, error) {
+	return GetVMInfos()
+}
+
+func GetVMInfos() ([]*machine.ListResponse, error) {
 	vmConfigDir, err := machine.GetConfDir(vmtype)
 	if err != nil {
 		return nil, err
@@ -492,4 +496,17 @@ func List(opts machine.ListOptions) ([]*machine.ListResponse, error) {
 		return nil, err
 	}
 	return listed, err
+}
+
+func IsValidVMName(name string) (bool, error) {
+	infos, err := GetVMInfos()
+	if err != nil {
+		return false, err
+	}
+	for _, vm := range infos {
+		if vm.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
The --execute flag ended up serving no purpose.  It was removed and
documentation was updated.

Fixed a panic when no VM name was provided.

[NO TESTS NEEDED]

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
