### PR TITLE
Don't relabel volumes if running in a privileged container

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -376,8 +376,14 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 			case "z":
 				fallthrough
 			case "Z":
-				if err := label.Relabel(m.Source, c.MountLabel(), label.IsShared(o)); err != nil {
-					return nil, err
+				if c.MountLabel() != "" {
+					if c.ProcessLabel() != "" {
+						if err := label.Relabel(m.Source, c.MountLabel(), label.IsShared(o)); err != nil {
+							return nil, err
+						}
+					} else {
+						logrus.Infof("Not relabeling volume %q in container %s as SELinux is disabled", m.Source, c.ID())
+					}
 				}
 
 			default:


### PR DESCRIPTION
Docker does not relabel this content, and openstack is running
containers in this manner.  There is a penalty for doing this
on each container, that is not worth taking on a disable SELinux
container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>