### PR TITLE
Handle podman-remote --arch, --platform, --os

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/checkpoint-restore/go-criu v0.0.0-20190109184317-bdb7599cd87b
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
-	github.com/containers/buildah v1.20.0
+	github.com/containers/buildah v1.20.1-0.20210402144408-36a37402d0c8
 	github.com/containers/common v0.35.4
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.10.5

--- a/go.sum
+++ b/go.sum
@@ -174,9 +174,8 @@ github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHV
 github.com/containernetworking/plugins v0.8.7/go.mod h1:R7lXeZaBzpfqapcAbHRW8/CYwm0dHzbz0XEjofx0uB0=
 github.com/containernetworking/plugins v0.9.1 h1:FD1tADPls2EEi3flPc2OegIY1M9pUa9r2Quag7HMLV8=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
-github.com/containers/buildah v1.20.0 h1:H8db/d2uSGm947mqjX0Iup6F0T9AnK3kS/ff9RCemZA=
-github.com/containers/buildah v1.20.0/go.mod h1:8V3UBoTKBWU9AxNHb1MAKnZZ9oSoz/IsYyjeymrpl1s=
-github.com/containers/common v0.35.3/go.mod h1:rMzxgD7nMGw++cEbsp+NZv0UJO4rgXbm7F7IbJPTwIE=
+github.com/containers/buildah v1.20.1-0.20210402144408-36a37402d0c8 h1:RlqbDlfE3+qrq4bNTZG7NVPqCDzfZrgE/yicu0VAykQ=
+github.com/containers/buildah v1.20.1-0.20210402144408-36a37402d0c8/go.mod h1:iowyscoAC5jwNDhs3c5CLGdBZ9FJk5UOoN2I5TdmXFs=
 github.com/containers/common v0.35.4 h1:szyWRncsHkBwCVpu1dkEOXUjkwCetlfcLmKJTwo1Sp8=
 github.com/containers/common v0.35.4/go.mod h1:rMzxgD7nMGw++cEbsp+NZv0UJO4rgXbm7F7IbJPTwIE=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/containers/buildah"
 	buildahDefine "github.com/containers/buildah/define"
+	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v3/libpod"
@@ -445,6 +446,17 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	if len(query.Platform) > 0 {
+		variant := ""
+		buildOptions.OS, buildOptions.Architecture, variant, err = parse.Platform(query.Platform)
+		if err != nil {
+			utils.BadRequest(w, "platform", query.Platform, err)
+			return
+		}
+		buildOptions.SystemContext.OSChoice = buildOptions.OS
+		buildOptions.SystemContext.ArchitectureChoice = buildOptions.Architecture
+		buildOptions.SystemContext.VariantChoice = variant
+	}
 	if _, found := r.URL.Query()["timestamp"]; found {
 		ts := time.Unix(query.Timestamp, 0)
 		buildOptions.Timestamp = &ts

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -190,6 +191,10 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 			platform = "linux"
 		}
 		platform += "/" + options.Architecture
+	} else {
+		if len(platform) > 0 {
+			platform += "/" + runtime.GOARCH
+		}
 	}
 	if len(platform) > 0 {
 		params.Set("platform", platform)

--- a/test/buildah-bud/buildah-tests.diff
+++ b/test/buildah-bud/buildah-tests.diff
@@ -1,16 +1,22 @@
-From a49a2e48421c6f3bb1a56ae372de1f3d1a45d1f1 Mon Sep 17 00:00:00 2001
+From 9f6396ad848f4c0221e0469fb272d57ccd635384 Mon Sep 17 00:00:00 2001
 From: Ed Santiago <santiago@redhat.com>
 Date: Tue, 9 Feb 2021 17:28:05 -0700
 Subject: [PATCH] tweaks for running buildah tests under podman
 
 Signed-off-by: Ed Santiago <santiago@redhat.com>
 ---
- tests/bud.bats     | 26 ++++++++++++++++----------
- tests/helpers.bash | 28 ++++++++++++++++++++++++----
- 2 files changed, 40 insertions(+), 14 deletions(-)
+ tests/bud.bats         |  23 ++-
+ tests/bud.bats.rej     |  12 ++
+ tests/helpers.bash     |  28 ++-
+ tests/helpers.bash.rej |  10 ++
+ tests/helpers.bash~    | 378 +++++++++++++++++++++++++++++++++++++++++
+ 5 files changed, 438 insertions(+), 13 deletions(-)
+ create mode 100644 tests/bud.bats.rej
+ create mode 100644 tests/helpers.bash.rej
+ create mode 100644 tests/helpers.bash~
 
 diff --git a/tests/bud.bats b/tests/bud.bats
-index cf55d9a4..60cb6f96 100644
+index fe3af27a..07fc727e 100644
 --- a/tests/bud.bats
 +++ b/tests/bud.bats
 @@ -4,7 +4,7 @@ load helpers
@@ -30,7 +36,7 @@ index cf55d9a4..60cb6f96 100644
    run_buildah 125 bud /tmp/tmpdockerfile/ -t blabla
    check_options_flag_err "-t"
 
-@@ -1416,13 +1417,13 @@ function _test_http() {
+@@ -1436,13 +1437,13 @@ function _test_http() {
  @test "bud with dir for file but no Dockerfile in dir" {
    target=alpine-image
    run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json -t ${target} -f ${TESTSDIR}/bud/empty-dir ${TESTSDIR}/bud/empty-dir
@@ -46,18 +52,7 @@ index cf55d9a4..60cb6f96 100644
  }
 
  @test "bud with ARG before FROM default value" {
-@@ -1834,7 +1835,9 @@ _EOF
-   run_buildah bud --signature-policy ${TESTSDIR}/policy.json --layers -t test-img-2 --build-arg TEST=foo -f Dockerfile4 ${TESTSDIR}/bud/build-arg
-   run_buildah inspect -f '{{.FromImageID}}' test-img-2
-   argsid="$output"
--  [[ "$argsid" != "$initialid" ]]
-+  if [[ "$argsid" == "$initialid" ]]; then
-+      die ".FromImageID of test-img-2 ($argsid) == same as test-img, it should be different"
-+  fi
-
-   # Set the build-arg via an ENV in the local environment and verify that the cached layers are not used
-   export TEST=bar
-@@ -1887,6 +1890,7 @@ _EOF
+@@ -1913,6 +1914,7 @@ _EOF
  }
 
  @test "bud without any arguments should succeed" {
@@ -65,7 +60,7 @@ index cf55d9a4..60cb6f96 100644
    cd ${TESTSDIR}/bud/from-scratch
    run_buildah bud --signature-policy ${TESTSDIR}/policy.json
  }
-@@ -1894,7 +1898,7 @@ _EOF
+@@ -1920,7 +1922,7 @@ _EOF
  @test "bud without any arguments should fail when no Dockerfile exist" {
    cd $(mktemp -d)
    run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json
@@ -74,7 +69,7 @@ index cf55d9a4..60cb6f96 100644
  }
 
  @test "bud with specified context should fail if directory contains no Dockerfile" {
-@@ -1907,16 +1911,17 @@ _EOF
+@@ -1933,16 +1935,17 @@ _EOF
    DIR=$(mktemp -d)
    mkdir -p "$DIR"/Dockerfile
    run_buildah 125 bud --signature-policy ${TESTSDIR}/policy.json "$DIR"
@@ -94,7 +89,7 @@ index cf55d9a4..60cb6f96 100644
    DIR=$(mktemp -d)
    echo "FROM alpine" > "$DIR"/Dockerfile
    run_buildah 0 bud --signature-policy ${TESTSDIR}/policy.json "$DIR"/Dockerfile
-@@ -1968,7 +1973,7 @@ _EOF
+@@ -1994,7 +1997,7 @@ _EOF
 
  @test "bud-squash-hardlinks" {
    _prefetch busybox
@@ -103,7 +98,7 @@ index cf55d9a4..60cb6f96 100644
  }
 
  @test "bud with additional directory of devices" {
-@@ -2134,6 +2139,7 @@ _EOF
+@@ -2159,6 +2162,7 @@ _EOF
  }
 
  @test "bud with Containerfile should fail with nonexistent authfile" {
@@ -111,7 +106,7 @@ index cf55d9a4..60cb6f96 100644
    target=alpine-image
    run_buildah 125 bud --authfile /tmp/nonexistent --signature-policy ${TESTSDIR}/policy.json -t ${target} ${TESTSDIR}/bud/containerfile
  }
-@@ -2261,6 +2267,7 @@ EOM
+@@ -2286,6 +2290,7 @@ EOM
  }
 
  @test "bud with encrypted FROM image" {
@@ -119,7 +114,7 @@ index cf55d9a4..60cb6f96 100644
    _prefetch busybox
    mkdir ${TESTDIR}/tmp
    openssl genrsa -out ${TESTDIR}/tmp/mykey.pem 1024
-@@ -2333,8 +2340,6 @@ EOM
+@@ -2358,8 +2363,6 @@ EOM
    _prefetch alpine
    run_buildah bud --timestamp=0 --quiet --pull=false --signature-policy ${TESTSDIR}/policy.json -t timestamp -f Dockerfile.1 ${TESTSDIR}/bud/cache-stages
    cid=$output
@@ -128,7 +123,7 @@ index cf55d9a4..60cb6f96 100644
    run_buildah inspect --format '{{ .OCIv1.Created }}' timestamp
    expect_output --substring "1970-01-01"
    run_buildah inspect --format '{{ .History }}' timestamp
-@@ -2594,6 +2599,7 @@ _EOF
+@@ -2619,6 +2622,7 @@ _EOF
  }
 
  @test "bud with --arch flag" {
@@ -136,20 +131,28 @@ index cf55d9a4..60cb6f96 100644
    _prefetch alpine
    mytmpdir=${TESTDIR}/my-dir
    mkdir -p ${mytmpdir}
+@@ -2729,1 +2733,1 @@ _EOF
+ }
+
+ @test "bud --pull=false --arch test" {
++  skip "N/A under podman"
+   mytmpdir=${TESTDIR}/my-dir
+   mkdir -p ${mytmpdir}
+ cat > $mytmpdir/Containerfile << _EOF
 diff --git a/tests/helpers.bash b/tests/helpers.bash
-index b28fd2c3..d42a6b82 100644
+index 99c290af..c5572840 100644
 --- a/tests/helpers.bash
 +++ b/tests/helpers.bash
 @@ -70,7 +70,7 @@ function _prefetch() {
-             mkdir -p ${_BUILDAH_IMAGE_CACHEDIR}
-         fi
+         mkdir -p ${_BUILDAH_IMAGE_CACHEDIR}
+     fi
 
--        local _podman_opts="--root ${TESTDIR}/root --storage-driver ${STORAGE_DRIVER}"
-+        local _podman_opts="--root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver ${STORAGE_DRIVER}"
+-    local _podman_opts="--root ${TESTDIR}/root --storage-driver ${STORAGE_DRIVER}"
++    local _podman_opts="--root ${TESTDIR}/root --runroot ${TESTDIR}/runroot --storage-driver ${STORAGE_DRIVER}"
 
-         for img in "$@"; do
-             echo "# [checking for: $img]" >&2
-@@ -138,15 +138,35 @@ function run_buildah() {
+     for img in "$@"; do
+         echo "# [checking for: $img]" >&2
+@@ -138,16 +138,35 @@ function run_buildah() {
          --retry)         retry=3;        shift;;  # retry network flakes
      esac
 

--- a/test/buildah-bud/make-new-buildah-diffs
+++ b/test/buildah-bud/make-new-buildah-diffs
@@ -17,7 +17,7 @@ if [[ ! $whereami =~ test-buildah-v ]]; then
 fi
 
 # FIXME: check that git repo is buildah
-git remote -v | grep -q [BUILDAHREPO] \
+git remote -v | grep -q github.com/containers/buildah \
     || die "This does not look like a buildah repo (git remote -v)"
 
 # We could do the commit automatically, but it's prudent to require human
@@ -32,13 +32,13 @@ fi
 rm -f 0001-*.patch
 
 # Check count of commits, barf if need to squash
-n_commits=$(git log --pretty=format:%h [BASETAG]..HEAD | wc -l)
+n_commits=$(git log --pretty=format:%h buildah-bud-in-podman..HEAD | wc -l)
 if [[ $n_commits -gt 1 ]]; then
     die "Please squash your commits"
 fi
 
 # Scope check: make sure the only files changed are under tests/
-changes=$(git diff --name-status [BASETAG]..HEAD | egrep -v '\stests/')
+changes=$(git diff --name-status buildah-bud-in-podman..HEAD | egrep -v '\stests/')
 if [[ -n "$changes" ]]; then
     echo $changes
     die "Found modified files other than under 'tests/'"
@@ -47,7 +47,7 @@ fi
 ###############################################################################
 # All right - things look good. Generate the patch, and copy it into place.
 
-git format-patch [BASETAG]
+git format-patch buildah-bud-in-podman
 
 # Once again, make sure there's exactly one and only one commit
 shopt -s nullglob

--- a/test/buildah-bud/run-buildah-bud-tests
+++ b/test/buildah-bud/run-buildah-bud-tests
@@ -72,7 +72,7 @@ function die() {
 
 # From here on out, any unexpected abort will try to offer helpful hints
 failhint=
-trap 'if [[ $? != 0 ]]; then if [[ -n $failhint ]]; then echo;echo "***************************************";echo $failhint;echo;echo "Please see $BUD_TEST_DIR_REL/README.md for advice";fi;fi' 0
+trap 'if [[ $? != 0 ]]; then if [[ -n $failhint ]]; then echo;echo "***************************************";echo "$failhint";echo;echo "Please see $BUD_TEST_DIR_REL/README.md for advice";fi;fi' 0
 
 # Find the version of buildah we've vendored in, so we can run the right tests
 buildah_version=$(awk "\$1 == \"$BUILDAH_REPO\" { print \$2 }" <go.mod)
@@ -110,10 +110,27 @@ if [[ -n $do_checkout ]]; then
         die "Directory already exists: $buildah_dir"
     fi
 
+    # buildah_version should usually be vX.Y, but sometimes a PR under test
+    # will need a special unreleased version (go calls then "pseudoversions").
+    # In the usual case, we can do a shallow git clone:
+    shallow_checkout="--branch $buildah_version"
+    if [[ $buildah_version =~ .*-.*\.[0-9]{14}-.* ]]; then
+        # ...but with a pseudoversion, we must git-clone the entire repo,
+        # then do a git checkout within it
+        shallow_checkout=
+    fi
+
     failhint="'git clone' failed - this should never happen!"
-    (set -x;git clone -q --branch $buildah_version https://$BUILDAH_REPO $buildah_dir)
+    (set -x;git clone -q $shallow_checkout https://$BUILDAH_REPO $buildah_dir)
 
     cd $buildah_dir
+    if [[ -z $shallow_checkout ]]; then
+        # extract the SHA (rightmost field) from, e.g., v1.2-YYYMMDD-<sha>
+        sha=${buildah_version##*-}
+
+        failhint="'git checkout $sha' failed - this should never happen!"
+        (set -x;git checkout -q $sha)
+    fi
 
     # Give it a recognizable tag; this will be useful if we need to update
     # the set of patches
@@ -126,8 +143,10 @@ if [[ -n $do_checkout ]]; then
     # Apply custom patches. We do this _after_ building, although it shouldn't
     # matter because these patches should only apply to test scripts.
     failhint="
-Error applying patch file. This can happen when you vendor in a new buildah."
-    (set -x;git am <$PATCHES)
+Error applying patch file. This can happen when you vendor in a new buildah.
+
+Look for '*.rej' files to resolve the conflict(s) manually."
+    (set -x;git am --reject <$PATCHES)
 
     failhint=
     sed -e "s,\[BASETAG\],${BASE_TAG},g" \

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -566,4 +566,42 @@ RUN echo hello`, ALPINE)
 		Expect(session.OutputToString()).To(ContainSubstring("(user)"))
 		Expect(session.OutputToString()).To(ContainSubstring("(elapsed)"))
 	})
+
+	It("podman build --arch --os flag", func() {
+		containerfile := `FROM scratch`
+		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
+		err := ioutil.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		Expect(err).To(BeNil())
+		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--arch", "foo", "--os", "bar", "--file", containerfilePath, podmanTest.TempDir})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"image", "inspect", "--format", "{{ .Architecture }}", "test"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.OutputToString()).To(Equal("foo"))
+
+		inspect = podmanTest.Podman([]string{"image", "inspect", "--format", "{{ .Os }}", "test"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.OutputToString()).To(Equal("bar"))
+
+	})
+
+	It("podman build --os windows flag", func() {
+		containerfile := `FROM scratch`
+		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
+		err := ioutil.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		Expect(err).To(BeNil())
+		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--os", "windows", "--file", containerfilePath, podmanTest.TempDir})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"image", "inspect", "--format", "{{ .Architecture }}", "test"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.OutputToString()).To(Equal(runtime.GOARCH))
+
+		inspect = podmanTest.Podman([]string{"image", "inspect", "--format", "{{ .Os }}", "test"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.OutputToString()).To(Equal("windows"))
+
+	})
 })

--- a/vendor/github.com/containers/buildah/.cirrus.yml
+++ b/vendor/github.com/containers/buildah/.cirrus.yml
@@ -164,7 +164,7 @@ conformance_task:
     gce_instance:
         image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
 
-    timeout_in: 20m
+    timeout_in: 25m
 
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
     conformance_test_script: '${SCRIPT_BASE}/test.sh conformance |& ${_TIMESTAMP}'

--- a/vendor/github.com/containers/buildah/Makefile
+++ b/vendor/github.com/containers/buildah/Makefile
@@ -149,7 +149,7 @@ install.runc:
 
 .PHONY: test-conformance
 test-conformance:
-	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover -timeout 15m ./tests/conformance
+	$(GO_TEST) -v -tags "$(STORAGETAGS) $(SECURITYTAGS)" -cover -timeout 20m ./tests/conformance
 
 .PHONY: test-integration
 test-integration: install.tools

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -28,7 +28,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.20.0"
+	Version = "1.20.1-dev"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"
@@ -166,7 +166,7 @@ func cloneToDirectory(url, dir string) error {
 		cmd = exec.Command("git", "clone", url, dir)
 	} else {
 		logrus.Debugf("cloning repo %q and branch %q to %q", gitBranch[0], gitBranch[1], dir)
-		cmd = exec.Command("git", "clone", "-b", gitBranch[1], gitBranch[0], dir)
+		cmd = exec.Command("git", "clone", "--recurse-submodules", "-b", gitBranch[1], gitBranch[0], dir)
 	}
 	return cmd.Run()
 }

--- a/vendor/github.com/containers/buildah/go.mod
+++ b/vendor/github.com/containers/buildah/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/containernetworking/cni v0.8.1
-	github.com/containers/common v0.35.3
+	github.com/containers/common v0.35.4
 	github.com/containers/image/v5 v5.10.5
 	github.com/containers/ocicrypt v1.1.0
 	github.com/containers/storage v1.28.1

--- a/vendor/github.com/containers/buildah/go.sum
+++ b/vendor/github.com/containers/buildah/go.sum
@@ -165,8 +165,8 @@ github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/containernetworking/cni v0.8.1 h1:7zpDnQ3T3s4ucOuJ/ZCLrYBxzkg0AELFfII3Epo9TmI=
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
-github.com/containers/common v0.35.3 h1:6tEBSIHlJzpmt35zA1ZcjBqbtUilAHDWaa7buPvaqWY=
-github.com/containers/common v0.35.3/go.mod h1:rMzxgD7nMGw++cEbsp+NZv0UJO4rgXbm7F7IbJPTwIE=
+github.com/containers/common v0.35.4 h1:szyWRncsHkBwCVpu1dkEOXUjkwCetlfcLmKJTwo1Sp8=
+github.com/containers/common v0.35.4/go.mod h1:rMzxgD7nMGw++cEbsp+NZv0UJO4rgXbm7F7IbJPTwIE=
 github.com/containers/image/v5 v5.10.5 h1:VK1UbsZMzjdw5Xqr3Im9h4iOqHWU0naFs+I78kavc7I=
 github.com/containers/image/v5 v5.10.5/go.mod h1:SgIbWEedCNBbn2FI5cH0/jed1Ecy2s8XK5zTxvJTzII=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=

--- a/vendor/github.com/containers/buildah/pkg/blobcache/blobcache.go
+++ b/vendor/github.com/containers/buildah/pkg/blobcache/blobcache.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/pkg/archive"
@@ -301,25 +302,32 @@ func (s *blobCacheSource) LayerInfosForCopy(ctx context.Context, instanceDigest 
 				alternate = filepath.Join(filepath.Dir(alternate), makeFilename(digest.Digest(replaceDigest), false))
 				fileInfo, err := os.Stat(alternate)
 				if err == nil {
-					logrus.Debugf("suggesting cached blob with digest %q and compression %v in place of blob with digest %q", string(replaceDigest), s.reference.compress, info.Digest.String())
-					info.Digest = digest.Digest(replaceDigest)
-					info.Size = fileInfo.Size()
 					switch info.MediaType {
 					case v1.MediaTypeImageLayer, v1.MediaTypeImageLayerGzip:
 						switch s.reference.compress {
 						case types.Compress:
 							info.MediaType = v1.MediaTypeImageLayerGzip
+							info.CompressionAlgorithm = &compression.Gzip
 						case types.Decompress:
 							info.MediaType = v1.MediaTypeImageLayer
+							info.CompressionAlgorithm = nil
 						}
 					case docker.V2S2MediaTypeUncompressedLayer, manifest.DockerV2Schema2LayerMediaType:
 						switch s.reference.compress {
 						case types.Compress:
 							info.MediaType = manifest.DockerV2Schema2LayerMediaType
+							info.CompressionAlgorithm = &compression.Gzip
 						case types.Decompress:
-							info.MediaType = docker.V2S2MediaTypeUncompressedLayer
+							// nope, not going to suggest anything, it's not allowed by the spec
+							replacedInfos = append(replacedInfos, info)
+							continue
 						}
 					}
+					logrus.Debugf("suggesting cached blob with digest %q, type %q, and compression %v in place of blob with digest %q", string(replaceDigest), info.MediaType, s.reference.compress, info.Digest.String())
+					info.CompressionOperation = s.reference.compress
+					info.Digest = digest.Digest(replaceDigest)
+					info.Size = fileInfo.Size()
+					logrus.Debugf("info = %#v", info)
 				}
 			}
 			replacedInfos = append(replacedInfos, info)
@@ -422,8 +430,9 @@ func (d *blobCacheDestination) PutBlob(ctx context.Context, stream io.Reader, in
 	var err error
 	var n int
 	var alternateDigest digest.Digest
+	var closer io.Closer
 	wg := new(sync.WaitGroup)
-	defer wg.Wait()
+	needToWait := false
 	compression := archive.Uncompressed
 	if inputInfo.Digest != "" {
 		filename := filepath.Join(d.reference.directory, makeFilename(inputInfo.Digest, isConfig))
@@ -458,7 +467,7 @@ func (d *blobCacheDestination) PutBlob(ctx context.Context, stream io.Reader, in
 				if n >= len(initial) {
 					compression = archive.DetectCompression(initial[:n])
 				}
-				if compression != archive.Uncompressed {
+				if compression == archive.Gzip {
 					// The stream is compressed, so create a file which we'll
 					// use to store a decompressed copy.
 					decompressedTemp, err2 := ioutil.TempFile(d.reference.directory, makeFilename(inputInfo.Digest, isConfig))
@@ -470,10 +479,11 @@ func (d *blobCacheDestination) PutBlob(ctx context.Context, stream io.Reader, in
 						// closing the writing end of the pipe after
 						// PutBlob() returns.
 						decompressReader, decompressWriter := io.Pipe()
-						defer decompressWriter.Close()
+						closer = decompressWriter
 						stream = io.TeeReader(stream, decompressWriter)
 						// Let saveStream() close the reading end and handle the temporary file.
 						wg.Add(1)
+						needToWait = true
 						go saveStream(wg, decompressReader, decompressedTemp, filename, inputInfo.Digest, isConfig, &alternateDigest)
 					}
 				}
@@ -481,6 +491,12 @@ func (d *blobCacheDestination) PutBlob(ctx context.Context, stream io.Reader, in
 		}
 	}
 	newBlobInfo, err := d.destination.PutBlob(ctx, stream, inputInfo, cache, isConfig)
+	if closer != nil {
+		closer.Close()
+	}
+	if needToWait {
+		wg.Wait()
+	}
 	if err != nil {
 		return newBlobInfo, errors.Wrapf(err, "error storing blob to image destination for cache %q", transports.ImageName(d.reference))
 	}

--- a/vendor/github.com/containers/buildah/pkg/parse/parse.go
+++ b/vendor/github.com/containers/buildah/pkg/parse/parse.go
@@ -629,7 +629,7 @@ func SystemContextFromOptions(c *cobra.Command) (*types.SystemContext, error) {
 	}
 	if c.Flag("platform") != nil && c.Flag("platform").Changed {
 		if platform, err := c.Flags().GetString("platform"); err == nil {
-			os, arch, variant, err := parsePlatform(platform)
+			os, arch, variant, err := Platform(platform)
 			if err != nil {
 				return nil, err
 			}
@@ -672,7 +672,7 @@ func PlatformFromOptions(c *cobra.Command) (os, arch string, err error) {
 
 	if c.Flag("platform").Changed {
 		if pf, err := c.Flags().GetString("platform"); err == nil {
-			selectedOS, selectedArch, _, err := parsePlatform(pf)
+			selectedOS, selectedArch, _, err := Platform(pf)
 			if err != nil {
 				return "", "", errors.Wrap(err, "unable to parse platform")
 			}
@@ -691,7 +691,8 @@ func DefaultPlatform() string {
 	return runtime.GOOS + platformSep + runtime.GOARCH
 }
 
-func parsePlatform(platform string) (os, arch, variant string, err error) {
+// Platform separates the platform string into os, arch and variant
+func Platform(platform string) (os, arch, variant string, err error) {
 	split := strings.Split(platform, platformSep)
 	if len(split) < 2 {
 		return "", "", "", errors.Errorf("invalid platform syntax for %q (use OS/ARCH)", platform)

--- a/vendor/github.com/containers/buildah/run_linux.go
+++ b/vendor/github.com/containers/buildah/run_linux.go
@@ -359,7 +359,17 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, builtin
 			}
 			initializeVolume = true
 		}
-		stat, err := os.Stat(srcPath)
+		// Check if srcPath is a symlink
+		stat, err := os.Lstat(srcPath)
+		// If srcPath is a symlink, follow the link and ensure the destination exists
+		if err == nil && stat != nil && (stat.Mode()&os.ModeSymlink != 0) {
+			srcPath, err = copier.Eval(mountPoint, volume, copier.EvalOptions{})
+			if err != nil {
+				return nil, errors.Wrapf(err, "evaluating symlink %q", srcPath)
+			}
+			// Stat the destination of the evaluated symlink
+			stat, err = os.Stat(srcPath)
+		}
 		if err != nil {
 			if !os.IsNotExist(err) {
 				return nil, err
@@ -519,8 +529,9 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 		return err
 	}
 
+	allMounts := util.SortMounts(append(append(append(append(append(volumes, builtins...), secretMounts...), bindFileMounts...), specMounts...), sysfsMount...))
 	// Add them all, in the preferred order, except where they conflict with something that was previously added.
-	for _, mount := range append(append(append(append(append(volumes, builtins...), secretMounts...), bindFileMounts...), specMounts...), sysfsMount...) {
+	for _, mount := range allMounts {
 		if haveMount(mount.Destination) {
 			// Already mounting something there, no need to bother with this one.
 			continue

--- a/vendor/github.com/containers/buildah/util/util.go
+++ b/vendor/github.com/containers/buildah/util/util.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -473,4 +475,27 @@ func MergeEnv(defaults, overrides []string) []string {
 		index[envVar[0]] = len(s) - 1
 	}
 	return s
+}
+
+type byDestination []specs.Mount
+
+func (m byDestination) Len() int {
+	return len(m)
+}
+
+func (m byDestination) Less(i, j int) bool {
+	return m.parts(i) < m.parts(j)
+}
+
+func (m byDestination) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
+}
+
+func (m byDestination) parts(i int) int {
+	return strings.Count(filepath.Clean(m[i].Destination), string(os.PathSeparator))
+}
+
+func SortMounts(m []specs.Mount) []specs.Mount {
+	sort.Sort(byDestination(m))
+	return m
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/containernetworking/plugins/pkg/utils/hwaddr
 github.com/containernetworking/plugins/pkg/utils/sysctl
 github.com/containernetworking/plugins/plugins/ipam/host-local/backend
 github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator
-# github.com/containers/buildah v1.20.0
+# github.com/containers/buildah v1.20.1-0.20210402144408-36a37402d0c8
 github.com/containers/buildah
 github.com/containers/buildah/bind
 github.com/containers/buildah/chroot


### PR DESCRIPTION
Podman remote should be able to handle remote specification of
arches.

Requires: https://github.com/containers/buildah/pull/3116

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
