### PR TITLE
[CI:DOCS] Makefile: Fix make install.docker regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -558,6 +558,9 @@ install.docker-docs-nobuild:
 .PHONY: install.docker-docs
 install.docker-docs: docker-docs install.docker-docs-nobuild
 
+.PHONY: install.docker-full
+install.docker-full: install.docker install.docker-docs
+
 .PHONY: install.systemd
 ifneq (,$(findstring systemd,$(BUILDTAGS)))
 install.systemd:

--- a/Makefile
+++ b/Makefile
@@ -545,13 +545,14 @@ install.cni:
 
 .PHONY: install.docker
 install.docker:
+	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 docker $(DESTDIR)$(BINDIR)/docker
 	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR}  ${DESTDIR}${USERSYSTEMDDIR} ${DESTDIR}${TMPFILESDIR}
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-docker.conf -t ${DESTDIR}${TMPFILESDIR}
 
 .PHONY: install.docker-docs-nobuild
 install.docker-docs-nobuild:
-	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man1
+	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(MANDIR)/man1
 	install ${SELINUXOPT} -m 644 docs/build/man/docker*.1 -t $(DESTDIR)$(MANDIR)/man1
 
 .PHONY: install.docker-docs


### PR DESCRIPTION
This should fix the fact that `make install.docker` would fail as `$(BINDIR)` was never created after splitting up the routine in 3908c00799fe2af1a12c9c4f4be8b49dbdecd9be.

I also introduced a `install.docker-full` to install the binary and documentation. But I can remove that commit if upstream thinks it's not needed.