### PR TITLE
[CI:DOCS] Fix unmount doc reference in image.rst

### DIFF
--- a/docs/source/image.rst
+++ b/docs/source/image.rst
@@ -40,6 +40,6 @@ Image
 
 :doc:`trust <markdown/podman-image-trust.1>` Manage container image trust policy
 
-:doc:`unmount <markdown/podman-unmount.1>` Unmount an image's root filesystem
+:doc:`unmount <markdown/podman-image-unmount.1>` Unmount an image's root filesystem
 
 :doc:`untag <markdown/podman-untag.1>` Removes one or more names from a locally-stored image


### PR DESCRIPTION
This pointed to the container-unmount doc page. It now points to the
expected podman-image-unmount doc page.

Currently deployed version with wrong link: http://docs.podman.io/en/latest/image.html