### PR TITLE
Fix bindings prune containers flaky test

### DIFF
--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -568,15 +568,6 @@ var _ = Describe("Podman containers ", func() {
 		Expect(err).To(BeNil())
 		Expect(len(reports.PruneReportsIds(pruneResponse))).To(Equal(0))
 		Expect(len(reports.PruneReportsErrs(pruneResponse))).To(Equal(0))
-
-		// Valid filter params container should be pruned now.
-		filters := map[string][]string{
-			"until": {"0s"},
-		}
-		pruneResponse, err = containers.Prune(bt.conn, new(containers.PruneOptions).WithFilters(filters))
-		Expect(err).To(BeNil())
-		Expect(len(reports.PruneReportsErrs(pruneResponse))).To(Equal(0))
-		Expect(len(reports.PruneReportsIds(pruneResponse))).To(Equal(1))
 	})
 
 	It("podman prune running containers", func() {


### PR DESCRIPTION
In #9863 prune containers filter params were narrowed to support only those
required by http API. name filter in bindings was replaced by until filter,
which is not a good match, as until filters are causing tests to be flaky.

Signed-off-by: Jakub Guzik <jakubmguzik@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
