### PR TITLE
podman machine shell completion

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1092,11 +1092,3 @@ func AutocompleteVolumeFilters(cmd *cobra.Command, args []string, toComplete str
 	}
 	return completeKeyValues(toComplete, kv)
 }
-
-// AutocompleteMachineSSH - Autocomplete machine ssh command.
-func AutocompleteMachineSSH(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	if len(args) == 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	return nil, cobra.ShellCompDirectiveDefault
-}

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -3,9 +3,13 @@
 package machine
 
 import (
+	"strings"
+
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/cmd/podman/validate"
 	"github.com/containers/podman/v3/pkg/domain/entities"
+	"github.com/containers/podman/v3/pkg/machine"
+	"github.com/containers/podman/v3/pkg/machine/qemu"
 	"github.com/spf13/cobra"
 )
 
@@ -29,4 +33,35 @@ func init() {
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
 		Command: machineCmd,
 	})
+}
+
+// autocompleteMachineSSH - Autocomplete machine ssh command.
+func autocompleteMachineSSH(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return getMachines(toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveDefault
+}
+
+// autocompleteMachine - Autocomplete machines.
+func autocompleteMachine(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return getMachines(toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}
+
+func getMachines(toComplete string) ([]string, cobra.ShellCompDirective) {
+	suggestions := []string{}
+	machines, err := qemu.List(machine.ListOptions{})
+	if err != nil {
+		cobra.CompErrorln(err.Error())
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	for _, m := range machines {
+		if strings.HasPrefix(m.Name, toComplete) {
+			suggestions = append(suggestions, m.Name)
+		}
+	}
+	return suggestions, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/containers/podman/v3/pkg/machine"
@@ -18,13 +17,13 @@ import (
 
 var (
 	rmCmd = &cobra.Command{
-		Use:               "rm [options] [NAME]",
+		Use:               "rm [options] [MACHINE]",
 		Short:             "Remove an existing machine",
 		Long:              "Remove an existing machine ",
 		RunE:              rm,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine rm myvm`,
-		ValidArgsFunction: completion.AutocompleteNone,
+		ValidArgsFunction: autocompleteMachine,
 	}
 )
 

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -3,7 +3,6 @@
 package machine
 
 import (
-	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/containers/podman/v3/pkg/machine"
@@ -14,7 +13,7 @@ import (
 
 var (
 	sshCmd = &cobra.Command{
-		Use:   "ssh [options] [NAME] [COMMAND [ARG ...]]",
+		Use:   "ssh [options] [MACHINE] [COMMAND [ARG ...]]",
 		Short: "SSH into a virtual machine",
 		Long:  "SSH into a virtual machine ",
 		RunE:  ssh,
@@ -22,7 +21,7 @@ var (
 		Example: `podman machine ssh myvm
   podman machine ssh -e  myvm echo hello`,
 
-		ValidArgsFunction: common.AutocompleteMachineSSH,
+		ValidArgsFunction: autocompleteMachineSSH,
 	}
 )
 

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -3,7 +3,6 @@
 package machine
 
 import (
-	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/containers/podman/v3/pkg/machine"
@@ -13,13 +12,13 @@ import (
 
 var (
 	startCmd = &cobra.Command{
-		Use:               "start [NAME]",
+		Use:               "start [MACHINE]",
 		Short:             "Start an existing machine",
 		Long:              "Start an existing machine ",
 		RunE:              start,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine start myvm`,
-		ValidArgsFunction: completion.AutocompleteNone,
+		ValidArgsFunction: autocompleteMachine,
 	}
 )
 

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -3,7 +3,6 @@
 package machine
 
 import (
-	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/containers/podman/v3/pkg/machine"
@@ -13,13 +12,13 @@ import (
 
 var (
 	stopCmd = &cobra.Command{
-		Use:               "stop [NAME]",
+		Use:               "stop [MACHINE]",
 		Short:             "Stop an existing machine",
 		Long:              "Stop an existing machine ",
 		RunE:              stop,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine stop myvm`,
-		ValidArgsFunction: completion.AutocompleteNone,
+		ValidArgsFunction: autocompleteMachine,
 	}
 )
 


### PR DESCRIPTION
Add shell completion for machine names.

[NO TESTS NEEDED]
I would like to add one to the shell completion test however
using podman machine init is to expensive.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
