### PR TITLE
Should send the OCI runtime path not just the name to buildah

### DIFF
--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -168,9 +168,7 @@ func (r *Runtime) newImageBuildCompleteEvent(idOrName string) {
 // Build adds the runtime to the imagebuildah call
 func (r *Runtime) Build(ctx context.Context, options buildahDefine.BuildOptions, dockerfiles ...string) (string, reference.Canonical, error) {
 	if options.Runtime == "" {
-		// Make sure that build containers use the same runtime as Podman (see #9365).
-		conf := util.DefaultContainerConfig()
-		options.Runtime = conf.Engine.OCIRuntime
+		options.Runtime = r.GetOCIRuntimePath()
 	}
 	id, ref, err := imagebuildah.BuildDockerfiles(ctx, r.store, options, dockerfiles...)
 	// Write event for build completion


### PR DESCRIPTION
[NO TESTS NEEDED] Mainly because I have no idea how we would test
this.

Fixes: https://github.com/containers/podman/issues/9459

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
