### PR TITLE
Add support for podman --context default

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -180,6 +180,10 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 		os.Setenv("TMPDIR", "/var/tmp")
 	}
 
+	context := cmd.Root().LocalFlags().Lookup("context")
+	if context.Value.String() != "default" {
+		return errors.New("Podman does not support swarm, the only --context value allowed is \"default\"")
+	}
 	if !registry.IsRemote() {
 		if cmd.Flag("cpu-profile").Changed {
 			f, err := os.Create(cfg.CPUProfile)
@@ -268,6 +272,10 @@ func rootFlags(cmd *cobra.Command, opts *entities.PodmanConfig) {
 	urlFlagName := "url"
 	lFlags.StringVar(&opts.URI, urlFlagName, uri, "URL to access Podman service (CONTAINER_HOST)")
 	_ = cmd.RegisterFlagCompletionFunc(urlFlagName, completion.AutocompleteDefault)
+
+	// Context option added just for compatibility with DockerCLI.
+	lFlags.String("context", "default", "Name of the context to use to connect to the daemon (This flag is a NOOP and provided solely for scripting compatibility.)")
+	_ = lFlags.MarkHidden("context")
 
 	identityFlagName := "identity"
 	lFlags.StringVar(&opts.Identity, identityFlagName, ident, "path to SSH identity file, (CONTAINER_SSHKEY)")

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -10,6 +10,13 @@ function setup() {
     :
 }
 
+@test "podman --context emits reasonable output" {
+    run_podman 125 --context=swarm version
+    is "$output" "Error: Podman does not support swarm, the only --context value allowed is \"default\"" "--context=default or fail"
+
+    run_podman --context=default version
+}
+
 @test "podman version emits reasonable output" {
     run_podman version
 


### PR DESCRIPTION
This is a noop but helps with scripting and docker-compose.

Fixes: https://github.com/containers/podman/issues/9806

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
