### PR TITLE
[CI:DOCS] Add transport and destination info to manifest doc

### DIFF
--- a/docs/source/markdown/podman-manifest-add.1.md
+++ b/docs/source/markdown/podman-manifest-add.1.md
@@ -4,7 +4,7 @@
 podman\-manifest\-add - Add an image to a manifest list or image index
 
 ## SYNOPSIS
-**podman manifest add** [*options*] *listnameorindexname* *imagename*
+**podman manifest add** [*options*] *listnameorindexname* [*transport*]:*imagename*
 
 ## DESCRIPTION
 
@@ -78,6 +78,20 @@ Require HTTPS and verify certificates when talking to container registries (defa
 Specify the variant which the list or index records for the image.  This option
 is typically used to distinguish between multiple entries which share the same
 architecture value, but which expect different versions of its instruction set.
+
+## Transport
+
+ Multiple transports are supported:
+
+  **docker://**_docker-reference_ _(default)_
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
+
+    $ podman manifest add mylist:v1.11 docker://quay.io/username/myimage
+
+  **containers-storage:**_oci-reference_
+  An image in _oci-reference_ format stored in the local container storage. _oci-reference_ must contain a tag.
+
+    $ podman manifest add mylist:v1.11 containers-storage:quay.io/username/myimage
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-manifest-push.1.md
+++ b/docs/source/markdown/podman-manifest-push.1.md
@@ -4,7 +4,7 @@
 podman\-manifest\-push - Push a manifest list or image index to a registry
 
 ## SYNOPSIS
-**podman manifest push** [*options*] *listnameorindexname* *transport:details*
+**podman manifest push** [*options*] *listnameorindexname* [*destination*]
 
 ## DESCRIPTION
 Pushes a manifest list or image index to a registry.
@@ -65,6 +65,40 @@ Sign the pushed images using the GPG key that matches the specified fingerprint.
 #### **\-\-tls-verify**
 
 Require HTTPS and verify certificates when talking to container registries. (defaults to true)
+
+## DESTINATION
+
+ The DESTINATION is a location to store container images
+ The Image "DESTINATION" uses a "transport":"details" format.
+ If a transport is not given, podman push will attempt to push
+ to a registry.
+
+ Multiple transports are supported:
+
+  **dir:**_path_
+  An existing local directory _path_ storing the manifest, layer tarballs and signatures as individual files. This is a non-standardized format, primarily useful for debugging or noninvasive container inspection.
+
+    $ podman manfiest push mylist:v1.11 dir:/tmp/mylist
+
+  **docker://**_docker-reference_
+  An image in a registry implementing the "Docker Registry HTTP API V2". By default, uses the authorization state in `$XDG_RUNTIME_DIR/containers/auth.json`, which is set using `(podman login)`. If the authorization state is not found there, `$HOME/.docker/config.json` is checked, which is set using `(docker login)`.
+
+    $ podman manfiest push mylist:v1.11 docker://registry.example.org/mylist:v1.11
+
+  **docker-archive:**_path_[**:**_docker-reference_]
+  An image is stored in the `docker save` formatted file.  _docker-reference_ is only used when creating such a file, and it must not contain a digest.
+
+    $ podman manfiest push mylist:v1.11 docker-archive:/tmp/mylist
+
+  **docker-daemon:**_docker-reference_
+  An image in _docker-reference_ format stored in the docker daemon internal storage. _docker-reference_ must contain a tag.
+
+    $ podman manfiest push mylist:v1.11 docker-daemon:registry.example.org/mylist:v1.11
+
+  **oci-archive:**_path_**:**_tag_
+  An image _tag_ in a directory compliant with "Open Container Image Layout Specification" at _path_.
+
+    $ podman manifest push mylist:v1.11 oci-archive:/tmp/mylist
 
 ## EXAMPLE
 


### PR DESCRIPTION
Initially I was missing transport information on podman manifest add.
Especially the `containers-storage` transport which references the
local image store. Had a use case where this came in quite handy and it
is not stated anywhere else in the docs. Suppose it does not make sense
for podman pull & push.

I've only added containers-storage and docker transports for
manifest add since I know those work. Maybe others work too.

I then also added the destination section to manifest push as it is done
in podman push & pull. I've added all transports here, but I don't know
if all are supported. Please review.

I feel the podman manifest documentation is a bit *underwhelming*. I hope
this is a step to improve this situation also for others.