### PR TITLE
Allow users to override default storage opts with --storage-opt

### DIFF
--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -148,7 +148,7 @@ specify additional options via the `--storage-opt` flag.
 
 #### **\-\-storage-opt**=*value*
 
-Storage driver option, Default storage driver options are configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode). The `STORAGE_OPTS` environment variable overrides the default. The --storage-opt specified options overrides all.
+Storage driver option, Default storage driver options are configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode). The `STORAGE_OPTS` environment variable overrides the default. The --storage-opt specified options overrides all. If you specify --storage-opt="", no storage options will be used.
 
 #### **\-\-syslog**=*true|false*
 

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -77,8 +77,7 @@ func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
 				rt.storageConfig.GraphDriverOptions = make([]string, len(config.GraphDriverOptions))
 				copy(rt.storageConfig.GraphDriverOptions, config.GraphDriverOptions)
 			} else {
-				// append new options after what is specified in the config files
-				rt.storageConfig.GraphDriverOptions = append(rt.storageConfig.GraphDriverOptions, config.GraphDriverOptions...)
+				rt.storageConfig.GraphDriverOptions = config.GraphDriverOptions
 			}
 			setField = true
 		}

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -146,7 +146,11 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 	// This should always be checked after storage-driver is checked
 	if len(cfg.StorageOpts) > 0 {
 		storageSet = true
-		storageOpts.GraphDriverOptions = cfg.StorageOpts
+		if len(cfg.StorageOpts) == 1 && cfg.StorageOpts[0] == "" {
+			storageOpts.GraphDriverOptions = []string{}
+		} else {
+			storageOpts.GraphDriverOptions = cfg.StorageOpts
+		}
 	}
 	if opts.migrate {
 		options = append(options, libpod.WithMigrate())

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -53,4 +53,13 @@ store.imageStore.number   | 1
 
 }
 
+@test "podman info --storage-opt='' " {
+    skip_if_remote "--storage-opt flag is not supported for remote"
+    skip_if_rootless "storage opts are required for rootless running"
+    run_podman --storage-opt='' info
+    # Note this will not work in rootless mode, unless you specify
+    # storage-driver=vfs, until we have kernels that support rootless overlay
+    # mounts.
+    is "$output" ".*graphOptions: {}" "output includes graphOptions: {}"
+}
 # vim: filetype=sh


### PR DESCRIPTION
We define in the man page that this overrides the default storage
options, but the code was appending to the existing options.

This PR also makes a change to allow users to specify --storage-opt="".
This will turn off all storage options.

https://github.com/containers/podman/issues/9852

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
