### PR TITLE
Recreate until container prune tests for bindings

### DIFF
--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -568,6 +568,35 @@ var _ = Describe("Podman containers ", func() {
 		Expect(err).To(BeNil())
 		Expect(len(reports.PruneReportsIds(pruneResponse))).To(Equal(0))
 		Expect(len(reports.PruneReportsErrs(pruneResponse))).To(Equal(0))
+
+		// Valid filter params container should be pruned now.
+		filters := map[string][]string{
+			"until": {"5000000000"}, //Friday, June 11, 2128
+		}
+		pruneResponse, err = containers.Prune(bt.conn, new(containers.PruneOptions).WithFilters(filters))
+		Expect(err).To(BeNil())
+		Expect(len(reports.PruneReportsErrs(pruneResponse))).To(Equal(0))
+		Expect(len(reports.PruneReportsIds(pruneResponse))).To(Equal(1))
+	})
+
+	It("podman list containers with until filter", func() {
+		var name = "top"
+		_, err := bt.RunTopContainer(&name, nil)
+		Expect(err).To(BeNil())
+
+		filters := map[string][]string{
+			"until": {"5000000000"}, //Friday, June 11, 2128
+		}
+		c, err := containers.List(bt.conn, new(containers.ListOptions).WithFilters(filters).WithAll(true))
+		Expect(err).To(BeNil())
+		Expect(len(c)).To(Equal(1))
+
+		filters = map[string][]string{
+			"until": {"500000"}, // Tuesday, January 6, 1970
+		}
+		c, err = containers.List(bt.conn, new(containers.ListOptions).WithFilters(filters).WithAll(true))
+		Expect(err).To(BeNil())
+		Expect(len(c)).To(Equal(0))
 	})
 
 	It("podman prune running containers", func() {

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -237,7 +237,7 @@ func prepareUntilFilterFunc(filterValues []string) (func(container *libpod.Conta
 		return nil, err
 	}
 	return func(c *libpod.Container) bool {
-		if !until.IsZero() && c.CreatedTime().After((until)) {
+		if !until.IsZero() && c.CreatedTime().Before(until) {
 			return true
 		}
 		return false


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
#9902 follow-up.
/kind bug
**Please double-check that, but it seems until filter was wrongly implemented.**

Docker API https://docs.docker.com/engine/api/v1.41/#operation/ContainerPrune states:
```
until=<timestamp> Prune containers created before this timestamp. 
The <timestamp> can be Unix timestamps, date formatted
timestamps, or Go duration strings (e.g. 10m, 1h30m) computed 
relative to the daemon machine’s time.
```
More or less the same can be found in podman API. In the code, after was used instead of until. That caused tests to flake heavily.
If you approve the code change, I will look for similar errors, because until is probably badly implemented in other places.

Added also test for list containers with until filter. Dates are now set as Unix timestamp way in future and in past, so tests should not flake.