### PR TITLE
Utilising is() function instead of [[. Avoiding wildcard for comparison

### DIFF
--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -236,9 +236,16 @@ Labels.created_at | 20[0-9-]\\\+T[0-9:]\\\+Z
     iid=$output
 
     run_podman manifest create test:1.0
-    run_podman images --format '{{.ID}}' --no-trunc
-    [[ "$output" == *"sha256:$iid"* ]]
-
+     # Check sha256 ID of test:1.0 and $IMAGE
+    run_podman images --format '{{.ID}}' --no-trunc $IMAGE
+    is  "$output" \
+        "sha256:$iid" \
+        "podman images - bare manifest list (old image)"
+    run_podman images --format '{{.ID}}' --no-trunc test:1.0
+    iid_new=$output
+    is  "$output" \
+        "$iid_new" \
+        "podman images - bare manifest list (new image)"
     run_podman rmi test:1.0
 }
 # vim: filetype=sh


### PR DESCRIPTION
This PR is basically an alternation for legibility and minor improvement.
### Short history
According to reported bug #8931, `podman images` fails after `buildah manifest create multi:1.0`.
In response to the bug, #8934 was merged with accompanying system test on test/system/010-images.bats.

### Need for the PR
Proposed system test uses '[[' for output comparison.
Main goal of this PR was to utilise is() instead of '[['. However, there was a room for improvement and legibility. 
Current commit checks `podman images` output for IDs of both **old (default image)** and **new (new manifest test:1.0)**. 

#### The good
`is()` function is utilised. No wildcards are used for output comparison. Even though this makes the test fragile, it provides small robustness. Also, it uses two different types of expected patterns, namely, "`sha256:$iid`" and "`$iid_new`", which would break if `--format {{.ID}}` output style were to change. 

#### The bad
Test is more fragile. It may break in case of cosmetic output change. (However, could be fixed easily.)

#### The ugly
Commit replaces 1 line with 8 lines.

Note: I want to avoid triggering CI with tags . However, I have not learn the CI flow fully, I am reluctant to include no test hooks. 


Signed-off-by: Ali Aslanturk <ilaaslanturk@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
