### PR TITLE
fix machine naming conventions

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -15,8 +15,8 @@ import (
 var (
 	initCmd = &cobra.Command{
 		Use:               "init [options] [NAME]",
-		Short:             "initialize a vm",
-		Long:              "initialize a virtual machine for Podman to run on. Virtual machines are used to run Podman.",
+		Short:             "Initialize a virtual machine",
+		Long:              "initialize a virtual machine ",
 		RunE:              initMachine,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine init myvm`,

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -28,7 +28,7 @@ var (
 		Use:     "list [options]",
 		Aliases: []string{"ls"},
 		Short:   "List machines",
-		Long:    "List Podman managed virtual machines.",
+		Long:    "List managed virtual machines.",
 		RunE:    list,
 		Args:    validate.NoArgs,
 		Example: `podman machine list,

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -19,7 +19,7 @@ var (
 	rmCmd = &cobra.Command{
 		Use:               "rm [options] [MACHINE]",
 		Short:             "Remove an existing machine",
-		Long:              "Remove an existing machine ",
+		Long:              "Remove a managed virtual machine ",
 		RunE:              rm,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine rm myvm`,

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -14,11 +14,11 @@ import (
 var (
 	sshCmd = &cobra.Command{
 		Use:   "ssh [NAME] [COMMAND [ARG ...]]",
-		Short: "SSH into a virtual machine",
-		Long:  "SSH into a virtual machine ",
+		Short: "SSH into an existing machine",
+		Long:  "SSH into a managed virtual machine ",
 		RunE:  ssh,
 		Example: `podman machine ssh myvm
-  podman machine ssh -e  myvm echo hello`,
+  podman machine ssh myvm echo hello`,
 		ValidArgsFunction: autocompleteMachineSSH,
 	}
 )

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -14,7 +14,7 @@ var (
 	startCmd = &cobra.Command{
 		Use:               "start [MACHINE]",
 		Short:             "Start an existing machine",
-		Long:              "Start an existing machine ",
+		Long:              "Start a managed virtual machine ",
 		RunE:              start,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine start myvm`,

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -14,7 +14,7 @@ var (
 	stopCmd = &cobra.Command{
 		Use:               "stop [MACHINE]",
 		Short:             "Stop an existing machine",
-		Long:              "Stop an existing machine ",
+		Long:              "Stop a managed virtual machine ",
 		RunE:              stop,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine stop myvm`,


### PR DESCRIPTION
try to align the machine commands and their usage descriptions.

[NO TESTS NEEDED]

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
