### PR TITLE
[NO TESTS NEEDED] Add ssh connection to root user

### DIFF
--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -15,6 +15,8 @@ containers do not run on any other OS because containers' core functionality are
 tied to the Linux kernel.
 
 **podman machine init** initializes a new Linux virtual machine where containers are run.
+SSH keys are automatically generated to access the VM, and system connections to the root account
+and a user account inside the VM are added.
 
 ## OPTIONS
 

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -55,10 +55,16 @@ func NewIgnitionFile(ign DynamicIgnition) error {
 	}
 
 	ignPassword := Passwd{
-		Users: []PasswdUser{{
-			Name:              ign.Name,
-			SSHAuthorizedKeys: []SSHAuthorizedKey{SSHAuthorizedKey(ign.Key)},
-		}},
+		Users: []PasswdUser{
+			{
+				Name:              ign.Name,
+				SSHAuthorizedKeys: []SSHAuthorizedKey{SSHAuthorizedKey(ign.Key)},
+			},
+			{
+				Name:              "root",
+				SSHAuthorizedKeys: []SSHAuthorizedKey{SSHAuthorizedKey(ign.Key)},
+			},
+		},
 	}
 
 	ignStorage := Storage{

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -168,6 +168,11 @@ func (v *MachineVM) Init(opts machine.InitOptions) error {
 		if err := machine.AddConnection(&uri, v.Name, filepath.Join(sshDir, v.Name), opts.IsDefault); err != nil {
 			return err
 		}
+
+		uriRoot := machine.SSHRemoteConnection.MakeSSHURL("localhost", "/run/podman/podman.sock", strconv.Itoa(v.Port), "root")
+		if err := machine.AddConnection(&uriRoot, v.Name+"-root", filepath.Join(sshDir, v.Name), opts.IsDefault); err != nil {
+			return err
+		}
 	} else {
 		fmt.Println("An ignition path was provided.  No SSH connection was added to Podman")
 	}
@@ -357,6 +362,10 @@ func (v *MachineVM) Remove(name string, opts machine.RemoveOptions) (string, fun
 	if err := machine.RemoveConnection(v.Name); err != nil {
 		logrus.Error(err)
 	}
+	if err := machine.RemoveConnection(v.Name + "-root"); err != nil {
+		logrus.Error(err)
+	}
+
 	vmConfigDir, err := machine.GetConfDir(vmtype)
 	if err != nil {
 		return "", nil, err


### PR DESCRIPTION
When initing a VM, create two add connections - one to user, one to
root.
podman machine remove removes both connections as well.

[NO TESTS NEEDED]

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
