### PR TITLE
[CI:DOCS] Fix typos --uidmapping and --gidmapping and adjust Markdown layout for --userns

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -989,24 +989,21 @@ The following examples are all valid:
 
 Without this argument the command will be run as root in the container.
 
-#### **\-\-userns**=*auto*[:OPTIONS]
-#### **\-\-userns**=*host*
-#### **\-\-userns**=*keep-id*
-#### **\-\-userns**=container:container
-#### **\-\-userns**=private
-#### **\-\-userns**=*ns:my_namespace*
+#### **\-\-userns**=*mode*
 
 Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with the **\-\-uidmap** and **\-\-gidmap** options.
 
-- `auto`: automatically create a namespace. It is possible to specify other options to `auto`. The supported options are
-  **size=SIZE** to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will guess a size for the user namespace.
-  **uidmapping=HOST_UID:CONTAINER_UID:SIZE** to force a UID mapping to be present in the user namespace.
-  **gidmapping=HOST_UID:CONTAINER_UID:SIZE** to force a GID mapping to be present in the user namespace.
-- `container`: join the user namespace of the specified container.
-- `host`: run in the user namespace of the caller. This is the default if no user namespace options are set. The processes running in the container will have the same privileges on the host as any other process launched by the calling user.
-- `keep-id`: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is ignored for containers created by the root user.
-- `ns`: run the container in the given existing user namespace.
-- `private`: create a new namespace for the container (default)
+Valid _mode_ values are:
+
+- **auto[:**_OPTIONS,..._**]**: automatically create a namespace. It is possible to specify these options to `auto`:
+  - **gidmapping=**_HOST_GID:CONTAINER_GID:SIZE_: to force a GID mapping to be present in the user namespace.
+  - **size=**_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will estimate a size for the user namespace.
+  - **uidmapping=**_HOST_UID:CONTAINER_UID:SIZE_: to force a UID mapping to be present in the user namespace.
+- **container:**_id_: join the user namespace of the specified container.
+- **host**: run in the user namespace of the caller. The processes running in the container will have the same privileges on the host as any other process launched by the calling user (default).
+- **keep-id**: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is ignored for containers created by the root user.
+- **ns:**_namespace_: run the container in the given existing user namespace.
+- **private**: create a new namespace for the container.
 
 This option is incompatible with **\-\-gidmap**, **\-\-uidmap**, **\-\-subuidname** and **\-\-subgidname**.
 

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -996,8 +996,7 @@ Without this argument the command will be run as root in the container.
 #### **\-\-userns**=private
 #### **\-\-userns**=*ns:my_namespace*
 
-Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value means user namespaces are disabled.
-
+Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with the **\-\-uidmap** and **\-\-gidmap** options.
 
 - `auto`: automatically create a namespace. It is possible to specify other options to `auto`. The supported options are
   **size=SIZE** to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will guess a size for the user namespace.

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1070,21 +1070,21 @@ Without this argument, the command will run as the user specified in the contain
 
 When a user namespace is not in use, the UID and GID used within the container and on the host will match. When user namespaces are in use, however, the UID and GID in the container may correspond to another UID and GID on the host. In rootless containers, for example, a user namespace is always used, and root in the container will by default correspond to the UID and GID of the user invoking Podman.
 
-#### **\-\-userns**=**auto**|**host**|**keep-id**|**container:**_id_|**ns:**_namespace_
+#### **\-\-userns**=*mode*
 
 Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with the **\-\-uidmap** and **\-\-gidmap** options.
 
 Valid _mode_ values are:
 
-- **auto**: automatically create a namespace. It is possible to specify other options to `auto`. The supported options are
-  **size=SIZE** to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will guess a size for the user namespace.
-  **uidmapping=HOST_UID:CONTAINER_UID:SIZE** to force a UID mapping to be present in the user namespace.
-  **gidmapping=HOST_UID:CONTAINER_UID:SIZE** to force a GID mapping to be present in the user namespace.
+- **auto[:**_OPTIONS,..._**]**: automatically create a namespace. It is possible to specify these options to `auto`:
+  - **gidmapping=**_HOST_GID:CONTAINER_GID:SIZE_: to force a GID mapping to be present in the user namespace.
+  - **size=**_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will estimate a size for the user namespace.
+  - **uidmapping=**_HOST_UID:CONTAINER_UID:SIZE_: to force a UID mapping to be present in the user namespace.
+- **container:**_id_: join the user namespace of the specified container.
 - **host**: run in the user namespace of the caller. The processes running in the container will have the same privileges on the host as any other process launched by the calling user (default).
 - **keep-id**: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is ignored for containers created by the root user.
-- **ns**: run the container in the given existing user namespace.
+- **ns:**_namespace_: run the container in the given existing user namespace.
 - **private**: create a new namespace for the container.
-- **container**: join the user namespace of the specified container.
 
 This option is incompatible with **\-\-gidmap**, **\-\-uidmap**, **\-\-subuidname** and **\-\-subgidname**.
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1072,7 +1072,9 @@ When a user namespace is not in use, the UID and GID used within the container a
 
 #### **\-\-userns**=**auto**|**host**|**keep-id**|**container:**_id_|**ns:**_namespace_
 
-Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with they `--uidmapping` and `--gidmapping` options.
+Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with the **\-\-uidmap** and **\-\-gidmap** options.
+
+Valid _mode_ values are:
 
 - **auto**: automatically create a namespace. It is possible to specify other options to `auto`. The supported options are
   **size=SIZE** to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will guess a size for the user namespace.


### PR DESCRIPTION
I guess `--uidmapping` and `--gidmapping` are typos and
should be `--uidmap` and `--gidmap`. (I'm not 100% sure so please check this).

In the PR I also rearranged the layout of the `--userns` documenation to make it easier to read.

Let the user provided input that is variable (e.g. _id_) be shown in italics.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
