### PR TITLE
[CI:DOCS] Fix spelling rootfull -> rootful

### DIFF
--- a/docs/tutorials/basic_networking.md
+++ b/docs/tutorials/basic_networking.md
@@ -7,15 +7,15 @@
 It seems once people master the basics of containers, networking is one of the first
 aspects they begin experimenting with.  And in regards to networking, it takes very
 little experimentation before ending up on the deep end of the pool.  The following
-guide shows the most common network setups for Podman rootfull and rootless containers.
+guide shows the most common network setups for Podman rootful and rootless containers.
 Each setup is supported with an example.
 
 
-## Differences between rootfull and rootless container networking
+## Differences between rootful and rootless container networking
 
 One of the guiding factors on networking for containers with Podman is going to be
 whether or not the container is run by a root user or not.  This is because unprivileged
-users cannot create networking interfaces on the host.  Therefore, with rootfull
+users cannot create networking interfaces on the host.  Therefore, with rootful
 containers, the default networking mode is to use the Container Network Interface
 (CNI) plugins and specifically the bridge plugin.  For rootless, the default network
 mode is slirp4netns. Because of the limited privileges, slirp4netns lacks some of
@@ -38,7 +38,7 @@ network reload command to restore this without having to restart the container.
 ## Basic Network Setups
 
 Most containers and pods being run with Podman adhere to a couple of simple scenarios.
-By default, rootfull Podman will create a bridged network.  This is the most straightforward
+By default, rootful Podman will create a bridged network.  This is the most straightforward
 and preferred network setup for Podman. Bridge networking creates an interface for
 the container on an internal bridge network, which is then connected to the internet
 via Network Address Translation(NAT).  We also see users wanting to use `macvlan`
@@ -79,7 +79,7 @@ command. Containers can be joined to a CNI network when they are created with th
 
 As mentioned earlier, slirp4netns is the default network configuration for rootless
 users.  But as of Podman version 3.0, rootless users can also use CNI networking.
-The user experience of rootless CNI is very akin to a rootfull CNI, except that
+The user experience of rootless CNI is very akin to a rootful CNI, except that
 there is no default network configuration provided.  You simply need to create a
 network, and the one will be created as a bridge network.
 
@@ -92,23 +92,23 @@ container for running CNI is also run. Do not remove this container while your r
 containers are running.  if you remove this container (e.g by accident) all attached
 containers lose network connectivity. In order to restore the network connectivity
 all containers with networks must be restarted. This will automatically recreate
-the "side-car" container. For rootfull containers, there is no “side-car” container
-as rootfull users have the permissions to create and modify network interfaces on
+the "side-car" container. For rootful containers, there is no “side-car” container
+as rootful users have the permissions to create and modify network interfaces on
 the host.
 
 #### Example
 
-By default, rootfull containers use the CNI bridge plugin for its default configuration.
+By default, rootful containers use the CNI bridge plugin for its default configuration.
 In this case, no network name must be passed to Podman.  However, you can create
 additional bridged networks with the podman create command.  In that case, you will
 have to set the network name.
 
 The following example shows how to set up a web server and expose it to the network
-outside the host as both rootfull and rootless.  It will also show how an outside
+outside the host as both rootful and rootless.  It will also show how an outside
 client can connect to the container.
 
 ```
-(rootfull) $ sudo podman run -dt --name webserver -p 8080:80 quay.io/libpod/banner
+(rootful) $ sudo podman run -dt --name webserver -p 8080:80 quay.io/libpod/banner
 00f3440c7576aae2d5b193c40513c29c7964e96bf797cf0cc352c2b68ccbe66a
 ```
 
@@ -129,7 +129,7 @@ how the host and container ports can be mapped for external access.  The port co
 very well have been 80 as well (except for rootless users).
 
 To connect from an outside client to the webserver, simply point an HTTP client to
-the host’s IP address at port 8080 for rootfull and port 8081 for rootless.
+the host’s IP address at port 8080 for rootful and port 8081 for rootless.
 ```
 (outside_host): $ curl 192.168.99.109:8080
    ___           __
@@ -233,7 +233,7 @@ port like 8080.
 $ podman run -dt --name webserver -p 8080:80 quay.io/libpod/banner
 17ea33ccd7f55ff45766b3ec596b990a5f2ba66eb9159cb89748a85dc3cebfe0
 ```
-Because rootfull containers cannot communicate with each other directly with TCP/IP
+Because rootful containers cannot communicate with each other directly with TCP/IP
 via IP addresses, the host and the port mapping are used.  To do so, the IP address
 of the host (interface) must be known.
 ```


### PR DESCRIPTION
If I understand correctly the spelling "rootful" should be prefered over "rootfull" (see
https://github.com/containers/podman/pull/8787#issuecomment-749026276).

This PR fixes
./docs/tutorials/basic_networking.md

There is one file that still has the wrong spelling 
./vendor/github.com/containers/common/pkg/config/containers.conf

```
[esjolund@laptop podman]$ grep rootfull ./vendor/github.com/containers/common/pkg/config/containers.conf
#       rootfull "unix://run/podman/podman.sock (Default)
#       remote rootfull ssh://root@10.10.1.136:22/run/podman/podman.sock
[esjolund@laptop podman]$ 
```
But I leave those out because they are in vendored code.

The recommendation "_Do not change vendored code._" can be seen here:
https://github.com/containers/podman/pull/8787#discussion_r546678504

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
