### PR TITLE
[CI:DOCS] Set all swagger operation id's to be compatible

### DIFF
--- a/pkg/api/server/docs.go
+++ b/pkg/api/server/docs.go
@@ -1,4 +1,4 @@
-// Package api Provides a container compatible interface.
+// Package api Provides an API for the  Libpod library
 //
 // This documentation describes the Podman v2.0 RESTful API.
 // It replaces the Podman v1.0 API and was initially delivered
@@ -21,22 +21,22 @@
 //
 //   'podman info'
 //
-//      curl --unix-socket /run/podman/podman.sock http://d/v1.0.0/libpod/info
+//      curl --unix-socket /run/podman/podman.sock http://d/v3.0.0/libpod/info
 //
 //   'podman pull quay.io/containers/podman'
 //
-//      curl -XPOST --unix-socket /run/podman/podman.sock -v 'http://d/v1.0.0/images/create?fromImage=quay.io%2Fcontainers%2Fpodman'
+//      curl -XPOST --unix-socket /run/podman/podman.sock -v 'http://d/v3.0.0/images/create?fromImage=quay.io%2Fcontainers%2Fpodman'
 //
 //   'podman list images'
 //
-//      curl --unix-socket /run/podman/podman.sock -v 'http://d/v1.0.0/libpod/images/json' | jq
+//      curl --unix-socket /run/podman/podman.sock -v 'http://d/v3.0.0/libpod/images/json' | jq
 //
 // Terms Of Service:
 //
 //     Schemes: http, https
 //     Host: podman.io
 //     BasePath: /
-//     Version: 0.0.1
+//     Version: 3.2.0
 //     License: Apache-2.0 https://opensource.org/licenses/Apache-2.0
 //     Contact: Podman <podman@lists.podman.io> https://podman.io/community/
 //
@@ -47,8 +47,8 @@
 //
 //     Produces:
 //     - application/json
+//     - application/octet-stream
 //     - text/plain
-//     - text/html
 //
 //     Consumes:
 //     - application/json

--- a/pkg/api/server/register_archive.go
+++ b/pkg/api/server/register_archive.go
@@ -8,10 +8,9 @@ import (
 )
 
 func (s *APIServer) registerArchiveHandlers(r *mux.Router) error {
-	// swagger:operation PUT /containers/{name}/archive compat putArchive
+	// swagger:operation PUT /containers/{name}/archive compat PutContainerArchive
 	// ---
 	//  summary: Put files into a container
-	//  operationId: PutContainerArchive
 	//  description: Put a tar archive of files into a container
 	//  tags:
 	//   - containers (compat)
@@ -53,10 +52,9 @@ func (s *APIServer) registerArchiveHandlers(r *mux.Router) error {
 	//    500:
 	//      $ref: "#/responses/InternalError"
 
-	// swagger:operation GET /containers/{name}/archive compat getArchive
+	// swagger:operation GET /containers/{name}/archive compat ContainerArchive
 	// ---
 	//  summary: Get files from a container
-	//  operationId: ContainerArchive
 	//  description: Get a tar archive of files from a container
 	//  tags:
 	//   - containers (compat)

--- a/pkg/api/server/register_archive.go
+++ b/pkg/api/server/register_archive.go
@@ -11,6 +11,7 @@ func (s *APIServer) registerArchiveHandlers(r *mux.Router) error {
 	// swagger:operation PUT /containers/{name}/archive compat putArchive
 	// ---
 	//  summary: Put files into a container
+	//  operationId: PutContainerArchive
 	//  description: Put a tar archive of files into a container
 	//  tags:
 	//   - containers (compat)
@@ -55,6 +56,7 @@ func (s *APIServer) registerArchiveHandlers(r *mux.Router) error {
 	// swagger:operation GET /containers/{name}/archive compat getArchive
 	// ---
 	//  summary: Get files from a container
+	//  operationId: ContainerArchive
 	//  description: Get a tar archive of files from a container
 	//  tags:
 	//   - containers (compat)

--- a/pkg/api/server/register_archive.go
+++ b/pkg/api/server/register_archive.go
@@ -91,7 +91,7 @@ func (s *APIServer) registerArchiveHandlers(r *mux.Router) error {
 		Libpod
 	*/
 
-	// swagger:operation PUT /libpod/containers/{name}/archive libpod libpodPutArchive
+	// swagger:operation PUT /libpod/containers/{name}/archive libpod PutContainerArchiveLibpod
 	// ---
 	//  summary: Copy files into a container
 	//  description: Copy a tar archive of files into a container
@@ -132,7 +132,7 @@ func (s *APIServer) registerArchiveHandlers(r *mux.Router) error {
 	//    500:
 	//      $ref: "#/responses/InternalError"
 
-	// swagger:operation GET /libpod/containers/{name}/archive libpod libpodGetArchive
+	// swagger:operation GET /libpod/containers/{name}/archive libpod ContainerArchiveLibpod
 	// ---
 	//  summary: Copy files from a container
 	//  description: Copy a tar archive of files from a container

--- a/pkg/api/server/register_auth.go
+++ b/pkg/api/server/register_auth.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *APIServer) registerAuthHandlers(r *mux.Router) error {
-	// swagger:operation POST /auth compat auth
+	// swagger:operation POST /auth compat SystemAuth
 	// ---
 	//   summary: Check auth configuration
 	//   tags:

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -9,10 +9,9 @@ import (
 )
 
 func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
-	// swagger:operation POST /containers/create compat createContainer
+	// swagger:operation POST /containers/create compat ContainerCreate
 	// ---
 	//   summary: Create a container
-	//   operationId: ContainerCreate
 	//   tags:
 	//    - containers (compat)
 	//   produces:
@@ -36,12 +35,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/create"), s.APIHandler(compat.CreateContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/create", s.APIHandler(compat.CreateContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/json compat listContainers
+	// swagger:operation GET /containers/json compat ContainerList
 	// ---
 	// tags:
 	//  - containers (compat)
 	// summary: List containers
-	// operationId: ContainerList
 	// description: Returns a list of containers
 	// parameters:
 	//  - in: query
@@ -94,12 +92,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/json"), s.APIHandler(compat.ListContainers)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/json", s.APIHandler(compat.ListContainers)).Methods(http.MethodGet)
-	// swagger:operation POST  /containers/prune compat pruneContainers
+	// swagger:operation POST  /containers/prune compat ContainerPrune
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Delete stopped containers
-	// operationId: ContainerPrune
 	// description: Remove containers not in use
 	// parameters:
 	//  - in: query
@@ -119,12 +116,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/prune"), s.APIHandler(compat.PruneContainers)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/prune", s.APIHandler(compat.PruneContainers)).Methods(http.MethodPost)
-	// swagger:operation DELETE /containers/{name} compat removeContainer
+	// swagger:operation DELETE /containers/{name} compat ContainerDelete
 	// ---
 	// tags:
 	//  - containers (compat)
 	// summary: Remove a container
-	// operationId: ContainerDelete
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -161,12 +157,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}"), s.APIHandler(compat.RemoveContainer)).Methods(http.MethodDelete)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}", s.APIHandler(compat.RemoveContainer)).Methods(http.MethodDelete)
-	// swagger:operation GET /containers/{name}/json compat getContainer
+	// swagger:operation GET /containers/{name}/json compat ContainerInspect
 	// ---
 	// tags:
 	//  - containers (compat)
 	// summary: Inspect container
-	// operationId: ContainerInspect
 	// description: Return low-level information about a container.
 	// parameters:
 	//  - in: path
@@ -191,12 +186,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/json"), s.APIHandler(compat.GetContainer)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/json", s.APIHandler(compat.GetContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /containers/{name}/kill compat killContainer
+	// swagger:operation POST /containers/{name}/kill compat ContainerKill
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Kill container
-	// operationId: ContainerKill
 	// description: Signal to send to the container as an integer or string (e.g. SIGINT)
 	// parameters:
 	//  - in: path
@@ -229,12 +223,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/kill"), s.APIHandler(compat.KillContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/kill", s.APIHandler(compat.KillContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{name}/logs compat logsFromContainer
+	// swagger:operation GET /containers/{name}/logs compat ContainerLogs
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Get container logs
-	// operationId: ContainerLogs
 	// description: Get stdout and stderr logs from a container.
 	// parameters:
 	//  - in: path
@@ -284,12 +277,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/logs"), s.APIHandler(compat.LogsFromContainer)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/logs", s.APIHandler(compat.LogsFromContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /containers/{name}/pause compat pauseContainer
+	// swagger:operation POST /containers/{name}/pause compat ContainerPause
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Pause container
-	// operationId: ContainerPause
 	// description: Use the cgroups freezer to suspend all processes in a container.
 	// parameters:
 	//  - in: path
@@ -309,12 +301,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/pause"), s.APIHandler(compat.PauseContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/pause", s.APIHandler(compat.PauseContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{name}/restart compat restartContainer
+	// swagger:operation POST /containers/{name}/restart compat ContainerRestart
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Restart container
-	// operationId: ContainerRestart
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -337,12 +328,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/restart"), s.APIHandler(compat.RestartContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/restart", s.APIHandler(compat.RestartContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{name}/start compat startContainer
+	// swagger:operation POST /containers/{name}/start compat ContainerStart
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Start a container
-	// operationId: ContainerStart
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -368,12 +358,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/start"), s.APIHandler(compat.StartContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/start", s.APIHandler(compat.StartContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{name}/stats compat statsContainer
+	// swagger:operation GET /containers/{name}/stats compat ContainerStats
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Get stats for a container
-	// operationId: ContainerStats
 	// description: This returns a live stream of a container’s resource usage statistics.
 	// parameters:
 	//  - in: path
@@ -398,12 +387,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/stats"), s.APIHandler(compat.StatsContainer)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/stats", s.APIHandler(compat.StatsContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /containers/{name}/stop compat stopContainer
+	// swagger:operation POST /containers/{name}/stop compat ContainerStop
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Stop a container
-	// operationId: ContainerStop
 	// description: Stop a container
 	// parameters:
 	//  - in: path
@@ -429,12 +417,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/stop"), s.APIHandler(compat.StopContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/stop", s.APIHandler(compat.StopContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{name}/top compat topContainer
+	// swagger:operation GET /containers/{name}/top compat ContainerTop
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: List processes running inside a container
-	// operationId: ContainerTop
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -457,12 +444,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/top"), s.APIHandler(compat.TopContainer)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/top", s.APIHandler(compat.TopContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /containers/{name}/unpause compat unpauseContainer
+	// swagger:operation POST /containers/{name}/unpause compat ContainerUnpause
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Unpause container
-	// operationId: ContainerUnpause
 	// description: Resume a paused container
 	// parameters:
 	//  - in: path
@@ -482,12 +468,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/unpause"), s.APIHandler(compat.UnpauseContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/unpause", s.APIHandler(compat.UnpauseContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{name}/wait compat waitContainer
+	// swagger:operation POST /containers/{name}/wait compat ContainerWait
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Wait on a container
-	// operationId: ContainerWait
 	// description: Block until a container stops or given condition is met.
 	// parameters:
 	//  - in: path
@@ -523,12 +508,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/wait"), s.APIHandler(compat.WaitContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/wait", s.APIHandler(compat.WaitContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{name}/attach compat attachContainer
+	// swagger:operation POST /containers/{name}/attach compat ContainerAttach
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Attach to a container
-	// operationId: ContainerAttach
 	// description: Hijacks the connection to forward the container's standard streams to the client.
 	// parameters:
 	//  - in: path
@@ -581,12 +565,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/attach"), s.APIHandler(compat.AttachContainer)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/attach", s.APIHandler(compat.AttachContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{name}/resize compat resizeContainer
+	// swagger:operation POST /containers/{name}/resize compat ContainerResize
 	// ---
 	// tags:
 	//  - containers (compat)
 	// summary: Resize a container's TTY
-	// operationId: ContainerResize
 	// description: Resize the terminal attached to a container (for use with Attach).
 	// parameters:
 	//  - in: path
@@ -621,12 +604,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/resize"), s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.HandleFunc("/containers/{name}/resize", s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{name}/export compat exportContainer
+	// swagger:operation GET /containers/{name}/export compat ContainerExport
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Export a container
-	// operationId: ContainerExport
 	// description: Export the contents of a container as a tarball.
 	// parameters:
 	//  - in: path
@@ -645,12 +627,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/export"), s.APIHandler(compat.ExportContainer)).Methods(http.MethodGet)
 	r.HandleFunc("/containers/{name}/export", s.APIHandler(compat.ExportContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /containers/{name}/rename compat renameContainer
+	// swagger:operation POST /containers/{name}/rename compat ContainerRename
 	// ---
 	// tags:
 	//   - containers (compat)
 	// summary: Rename an existing container
-	// operationId: ContainerRename
 	// description: Change the name of an existing container.
 	// parameters:
 	//  - in: path
@@ -1487,14 +1468,13 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/restore"), s.APIHandler(libpod.Restore)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{name}/changes libpod libpodChangesContainer
+	// swagger:operation GET /containers/{name}/changes libpod ContainerChanges
 	// swagger:operation GET /libpod/containers/{name}/changes compat changesContainer
 	// ---
 	// tags:
 	//   - containers
 	//   - containers (compat)
 	// summary: Report on changes to container's filesystem; adds, deletes or modifications.
-	// operationId: ContainerChanges
 	// description: |
 	//   Returns which files in a container's filesystem have been added, deleted, or modified. The Kind of modification can be one of:
 	//

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -12,6 +12,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// swagger:operation POST /containers/create compat createContainer
 	// ---
 	//   summary: Create a container
+	//   operationId: ContainerCreate
 	//   tags:
 	//    - containers (compat)
 	//   produces:
@@ -40,6 +41,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//  - containers (compat)
 	// summary: List containers
+	// operationId: ContainerList
 	// description: Returns a list of containers
 	// parameters:
 	//  - in: query
@@ -97,6 +99,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Delete stopped containers
+	// operationId: ContainerPrune
 	// description: Remove containers not in use
 	// parameters:
 	//  - in: query
@@ -121,6 +124,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//  - containers (compat)
 	// summary: Remove a container
+	// operationId: ContainerDelete
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -162,6 +166,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//  - containers (compat)
 	// summary: Inspect container
+	// operationId: ContainerInspect
 	// description: Return low-level information about a container.
 	// parameters:
 	//  - in: path
@@ -191,6 +196,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Kill container
+	// operationId: ContainerKill
 	// description: Signal to send to the container as an integer or string (e.g. SIGINT)
 	// parameters:
 	//  - in: path
@@ -228,6 +234,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Get container logs
+	// operationId: ContainerLogs
 	// description: Get stdout and stderr logs from a container.
 	// parameters:
 	//  - in: path
@@ -282,6 +289,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Pause container
+	// operationId: ContainerPause
 	// description: Use the cgroups freezer to suspend all processes in a container.
 	// parameters:
 	//  - in: path
@@ -306,6 +314,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Restart container
+	// operationId: ContainerRestart
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -333,6 +342,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Start a container
+	// operationId: ContainerStart
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -363,6 +373,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Get stats for a container
+	// operationId: ContainerStats
 	// description: This returns a live stream of a container’s resource usage statistics.
 	// parameters:
 	//  - in: path
@@ -392,6 +403,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Stop a container
+	// operationId: ContainerStop
 	// description: Stop a container
 	// parameters:
 	//  - in: path
@@ -422,6 +434,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: List processes running inside a container
+	// operationId: ContainerTop
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -449,6 +462,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Unpause container
+	// operationId: ContainerUnpause
 	// description: Resume a paused container
 	// parameters:
 	//  - in: path
@@ -473,6 +487,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Wait on a container
+	// operationId: ContainerWait
 	// description: Block until a container stops or given condition is met.
 	// parameters:
 	//  - in: path
@@ -513,6 +528,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Attach to a container
+	// operationId: ContainerAttach
 	// description: Hijacks the connection to forward the container's standard streams to the client.
 	// parameters:
 	//  - in: path
@@ -570,6 +586,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//  - containers (compat)
 	// summary: Resize a container's TTY
+	// operationId: ContainerResize
 	// description: Resize the terminal attached to a container (for use with Attach).
 	// parameters:
 	//  - in: path
@@ -609,6 +626,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Export a container
+	// operationId: ContainerExport
 	// description: Export the contents of a container as a tarball.
 	// parameters:
 	//  - in: path
@@ -632,6 +650,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// tags:
 	//   - containers (compat)
 	// summary: Rename an existing container
+	// operationId: ContainerRename
 	// description: Change the name of an existing container.
 	// parameters:
 	//  - in: path
@@ -1475,6 +1494,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   - containers
 	//   - containers (compat)
 	// summary: Report on changes to container's filesystem; adds, deletes or modifications.
+	// operationId: ContainerChanges
 	// description: |
 	//   Returns which files in a container's filesystem have been added, deleted, or modified. The Kind of modification can be one of:
 	//

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -662,7 +662,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 		libpod endpoints
 	*/
 
-	// swagger:operation POST /libpod/containers/create libpod libpodCreateContainer
+	// swagger:operation POST /libpod/containers/create libpod ContainerCreateLibpod
 	// ---
 	//   summary: Create a container
 	//   tags:
@@ -687,7 +687,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//     500:
 	//       $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/create"), s.APIHandler(libpod.CreateContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/containers/json libpod libpodListContainers
+	// swagger:operation GET /libpod/containers/json libpod ContainerListLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -752,7 +752,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/json"), s.APIHandler(libpod.ListContainers)).Methods(http.MethodGet)
-	// swagger:operation POST  /libpod/containers/prune libpod libpodPruneContainers
+	// swagger:operation POST  /libpod/containers/prune libpod ContainerPruneLibpod
 	// ---
 	// tags:
 	//   - containers
@@ -774,7 +774,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/prune"), s.APIHandler(compat.PruneContainers)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/containers/showmounted libpod libpodShowMountedContainers
+	// swagger:operation GET /libpod/containers/showmounted libpod ShowMountedContainersLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -792,7 +792,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//      $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/showmounted"), s.APIHandler(libpod.ShowMountedContainers)).Methods(http.MethodGet)
-	// swagger:operation DELETE /libpod/containers/{name} libpod libpodRemoveContainer
+	// swagger:operation DELETE /libpod/containers/{name} libpod ContainerDeleteLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -826,7 +826,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}"), s.APIHandler(compat.RemoveContainer)).Methods(http.MethodDelete)
-	// swagger:operation GET /libpod/containers/{name}/json libpod libpodGetContainer
+	// swagger:operation GET /libpod/containers/{name}/json libpod ContainerInspectLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -852,7 +852,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/json"), s.APIHandler(libpod.GetContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/containers/{name}/kill libpod libpodKillContainer
+	// swagger:operation POST /libpod/containers/{name}/kill libpod ContainerKillLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -881,7 +881,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/kill"), s.APIHandler(compat.KillContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{name}/mount libpod libpodMountContainer
+	// swagger:operation POST /libpod/containers/{name}/mount libpod ContainerMountLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -907,7 +907,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/mount"), s.APIHandler(libpod.MountContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{name}/unmount libpod libpodUnmountContainer
+	// swagger:operation POST /libpod/containers/{name}/unmount libpod ContainerUnmountLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -929,7 +929,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/unmount"), s.APIHandler(libpod.UnmountContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/containers/{name}/logs libpod libpodLogsFromContainer
+	// swagger:operation GET /libpod/containers/{name}/logs libpod ContainerLogsLibpod
 	// ---
 	// tags:
 	//   - containers
@@ -981,7 +981,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//      $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/logs"), s.APIHandler(compat.LogsFromContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/containers/{name}/pause libpod libpodPauseContainer
+	// swagger:operation POST /libpod/containers/{name}/pause libpod ContainerPauseLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1003,7 +1003,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/pause"), s.APIHandler(compat.PauseContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{name}/restart libpod libpodRestartContainer
+	// swagger:operation POST /libpod/containers/{name}/restart libpod ContainerRestartLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1028,7 +1028,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/restart"), s.APIHandler(compat.RestartContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{name}/start libpod libpodStartContainer
+	// swagger:operation POST /libpod/containers/{name}/start libpod ContainerStartLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1056,7 +1056,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/start"), s.APIHandler(compat.StartContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/containers/{name}/stats libpod libpodStatsContainer
+	// swagger:operation GET /libpod/containers/{name}/stats libpod ContainerStatsLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1083,7 +1083,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/stats"), s.APIHandler(compat.StatsContainer)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/containers/stats libpod libpodStatsContainers
+	// swagger:operation GET /libpod/containers/stats libpod ContainersStatsAllLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1112,7 +1112,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/stats"), s.APIHandler(libpod.StatsContainer)).Methods(http.MethodGet)
 
-	// swagger:operation GET /libpod/containers/{name}/top libpod libpodTopContainer
+	// swagger:operation GET /libpod/containers/{name}/top libpod ContainerTopLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1146,7 +1146,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/top"), s.APIHandler(compat.TopContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/containers/{name}/unpause libpod libpodUnpauseContainer
+	// swagger:operation POST /libpod/containers/{name}/unpause libpod ContainerUnpauseLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1167,7 +1167,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/unpause"), s.APIHandler(compat.UnpauseContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{name}/wait libpod libpodWaitContainer
+	// swagger:operation POST /libpod/containers/{name}/wait libpod ContainerWaitLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1204,7 +1204,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/wait"), s.APIHandler(libpod.WaitContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/containers/{name}/exists libpod libpodContainerExists
+	// swagger:operation GET /libpod/containers/{name}/exists libpod ContainerExistsLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1226,7 +1226,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/exists"), s.APIHandler(libpod.ContainerExists)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/containers/{name}/stop libpod libpodStopContainer
+	// swagger:operation POST /libpod/containers/{name}/stop libpod ContainerStopLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1264,7 +1264,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/stop"), s.APIHandler(compat.StopContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{name}/attach libpod libpodAttachContainer
+	// swagger:operation POST /libpod/containers/{name}/attach libpod ContainerAttachLibpod
 	// ---
 	// tags:
 	//   - containers
@@ -1319,7 +1319,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/attach"), s.APIHandler(compat.AttachContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{name}/resize libpod libpodResizeContainer
+	// swagger:operation POST /libpod/containers/{name}/resize libpod ContainerResizeLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1351,7 +1351,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/resize"), s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/containers/{name}/export libpod libpodExportContainer
+	// swagger:operation GET /libpod/containers/{name}/export libpod ContainerExportLibpod
 	// ---
 	// tags:
 	//   - containers
@@ -1373,7 +1373,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/export"), s.APIHandler(compat.ExportContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/containers/{name}/checkpoint libpod libpodCheckpointContainer
+	// swagger:operation POST /libpod/containers/{name}/checkpoint libpod ContainerCheckpointLibpod
 	// ---
 	// tags:
 	//   - containers
@@ -1414,7 +1414,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/checkpoint"), s.APIHandler(libpod.Checkpoint)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{name}/restore libpod libpodRestoreContainer
+	// swagger:operation POST /libpod/containers/{name}/restore libpod ContainerRestoreLibpod
 	// ---
 	// tags:
 	//   - containers
@@ -1468,8 +1468,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/restore"), s.APIHandler(libpod.Restore)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{name}/changes libpod ContainerChanges
-	// swagger:operation GET /libpod/containers/{name}/changes compat changesContainer
+	// swagger:operation GET /containers/{name}/changes libpod ContainerChangesLibpod
+	// swagger:operation GET /libpod/containers/{name}/changes compat ContainerChanges
 	// ---
 	// tags:
 	//   - containers
@@ -1501,7 +1501,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/containers/{name}/changes"), s.APIHandler(compat.Changes)).Methods(http.MethodGet)
 	r.HandleFunc("/containers/{name}/changes", s.APIHandler(compat.Changes)).Methods(http.MethodGet)
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/changes"), s.APIHandler(compat.Changes)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/containers/{name}/init libpod libpodInitContainer
+	// swagger:operation POST /libpod/containers/{name}/init libpod ContainerInitLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1525,7 +1525,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/init"), s.APIHandler(libpod.InitContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{name}/rename libpod libpodRenameContainer
+	// swagger:operation POST /libpod/containers/{name}/rename libpod ContainerRenameLibpod
 	// ---
 	// tags:
 	//   - containers

--- a/pkg/api/server/register_events.go
+++ b/pkg/api/server/register_events.go
@@ -8,12 +8,11 @@ import (
 )
 
 func (s *APIServer) registerEventsHandlers(r *mux.Router) error {
-	// swagger:operation GET /events system getEvents
+	// swagger:operation GET /events system SystemEvents
 	// ---
 	// tags:
 	//   - system (compat)
 	// summary: Get events
-	// operationId: SystemEvents
 	// description: Returns events filtered on query parameters
 	// produces:
 	// - application/json

--- a/pkg/api/server/register_events.go
+++ b/pkg/api/server/register_events.go
@@ -13,6 +13,7 @@ func (s *APIServer) registerEventsHandlers(r *mux.Router) error {
 	// tags:
 	//   - system (compat)
 	// summary: Get events
+	// operationId: SystemEvents
 	// description: Returns events filtered on query parameters
 	// produces:
 	// - application/json

--- a/pkg/api/server/register_events.go
+++ b/pkg/api/server/register_events.go
@@ -37,7 +37,7 @@ func (s *APIServer) registerEventsHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/events"), s.APIHandler(compat.GetEvents)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/events", s.APIHandler(compat.GetEvents)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/events system libpodGetEvents
+	// swagger:operation GET /libpod/events system SystemEventsLibpod
 	// ---
 	// tags:
 	//   - system

--- a/pkg/api/server/register_exec.go
+++ b/pkg/api/server/register_exec.go
@@ -102,7 +102,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//          type: boolean
 	//          description: Allocate a pseudo-TTY. Presently ignored.
 	// produces:
-	// - application/json
+	// - application/octet-stream
 	// responses:
 	//   200:
 	//     description: no error
@@ -182,7 +182,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 		libpod api follows
 	*/
 
-	// swagger:operation POST /libpod/containers/{name}/exec libpod libpodCreateExec
+	// swagger:operation POST /libpod/containers/{name}/exec libpod ContainerExecLibpod
 	// ---
 	// tags:
 	//   - exec
@@ -249,7 +249,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/containers/{name}/exec"), s.APIHandler(compat.ExecCreateHandler)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/exec/{id}/start libpod libpodStartExec
+	// swagger:operation POST /libpod/exec/{id}/start libpod ExecStartLibpod
 	// ---
 	// tags:
 	//   - exec
@@ -285,7 +285,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/exec/{id}/start"), s.APIHandler(compat.ExecStartHandler)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/exec/{id}/resize libpod libpodResizeExec
+	// swagger:operation POST /libpod/exec/{id}/resize libpod ExecResizeLibpod
 	// ---
 	// tags:
 	//   - exec
@@ -316,7 +316,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/exec/{id}/resize"), s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/exec/{id}/json libpod libpodInspectExec
+	// swagger:operation GET /libpod/exec/{id}/json libpod ExecInspectLibpod
 	// ---
 	// tags:
 	//   - exec

--- a/pkg/api/server/register_exec.go
+++ b/pkg/api/server/register_exec.go
@@ -8,12 +8,11 @@ import (
 )
 
 func (s *APIServer) registerExecHandlers(r *mux.Router) error {
-	// swagger:operation POST /containers/{name}/exec compat createExec
+	// swagger:operation POST /containers/{name}/exec compat ContainerExec
 	// ---
 	// tags:
 	//   - exec (compat)
 	// summary: Create an exec instance
-	// operationId: ContainerExec
 	// description: Create an exec session to run a command inside a running container. Exec sessions will be automatically removed 5 minutes after they exit.
 	// parameters:
 	//  - in: path
@@ -78,12 +77,11 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/containers/{name}/exec"), s.APIHandler(compat.ExecCreateHandler)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/containers/{name}/exec", s.APIHandler(compat.ExecCreateHandler)).Methods(http.MethodPost)
-	// swagger:operation POST /exec/{id}/start compat startExec
+	// swagger:operation POST /exec/{id}/start compat ExecStart
 	// ---
 	// tags:
 	//   - exec (compat)
 	// summary: Start an exec instance
-	// operationId: ExecStart
 	// description: Starts a previously set up exec instance. If detach is true, this endpoint returns immediately after starting the command. Otherwise, it sets up an interactive session with the command.
 	// parameters:
 	//  - in: path
@@ -117,12 +115,11 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/exec/{id}/start"), s.APIHandler(compat.ExecStartHandler)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/exec/{id}/start", s.APIHandler(compat.ExecStartHandler)).Methods(http.MethodPost)
-	// swagger:operation POST /exec/{id}/resize compat resizeExec
+	// swagger:operation POST /exec/{id}/resize compat ExecResize
 	// ---
 	// tags:
 	//   - exec (compat)
 	// summary: Resize an exec instance
-	// operationId: ExecResize
 	// description: |
 	//  Resize the TTY session used by an exec instance. This endpoint only works if tty was specified as part of creating and starting the exec instance.
 	// parameters:
@@ -156,12 +153,11 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/exec/{id}/resize"), s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/exec/{id}/resize", s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
-	// swagger:operation GET /exec/{id}/json compat inspectExec
+	// swagger:operation GET /exec/{id}/json compat ExecInspect
 	// ---
 	// tags:
 	//   - exec (compat)
 	// summary: Inspect an exec instance
-	// operationId: ExecInspect
 	// description: Return low-level information about an exec instance.
 	// parameters:
 	//  - in: path

--- a/pkg/api/server/register_exec.go
+++ b/pkg/api/server/register_exec.go
@@ -13,6 +13,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	// tags:
 	//   - exec (compat)
 	// summary: Create an exec instance
+	// operationId: ContainerExec
 	// description: Create an exec session to run a command inside a running container. Exec sessions will be automatically removed 5 minutes after they exit.
 	// parameters:
 	//  - in: path
@@ -82,6 +83,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	// tags:
 	//   - exec (compat)
 	// summary: Start an exec instance
+	// operationId: ExecStart
 	// description: Starts a previously set up exec instance. If detach is true, this endpoint returns immediately after starting the command. Otherwise, it sets up an interactive session with the command.
 	// parameters:
 	//  - in: path
@@ -120,6 +122,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	// tags:
 	//   - exec (compat)
 	// summary: Resize an exec instance
+	// operationId: ExecResize
 	// description: |
 	//  Resize the TTY session used by an exec instance. This endpoint only works if tty was specified as part of creating and starting the exec instance.
 	// parameters:
@@ -158,6 +161,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	// tags:
 	//   - exec (compat)
 	// summary: Inspect an exec instance
+	// operationId: ExecInspect
 	// description: Return low-level information about an exec instance.
 	// parameters:
 	//  - in: path

--- a/pkg/api/server/register_generate.go
+++ b/pkg/api/server/register_generate.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *APIServer) registerGenerateHandlers(r *mux.Router) error {
-	// swagger:operation GET /libpod/generate/{name:.*}/systemd libpod libpodGenerateSystemd
+	// swagger:operation GET /libpod/generate/{name:.*}/systemd libpod GenerateSystemdLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -75,7 +75,7 @@ func (s *APIServer) registerGenerateHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/generate/{name:.*}/systemd"), s.APIHandler(libpod.GenerateSystemd)).Methods(http.MethodGet)
 
-	// swagger:operation GET /libpod/generate/kube libpod libpodGenerateKube
+	// swagger:operation GET /libpod/generate/kube libpod GenerateKubeLibpod
 	// ---
 	// tags:
 	//  - containers

--- a/pkg/api/server/register_healthcheck.go
+++ b/pkg/api/server/register_healthcheck.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *APIServer) registerHealthCheckHandlers(r *mux.Router) error {
-	// swagger:operation GET /libpod/containers/{name:.*}/healthcheck libpod libpodRunHealthCheck
+	// swagger:operation GET /libpod/containers/{name:.*}/healthcheck libpod ContainerHealthcheckLibpod
 	// ---
 	// tags:
 	//  - containers

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -13,12 +13,11 @@ import (
 // * /images/create is missing the "message" and "platform" parameters
 
 func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
-	// swagger:operation POST /images/create compat createImage
+	// swagger:operation POST /images/create compat ImageCreate
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Create an image
-	// operationId: ImageCreate
 	// description: Create an image by either pulling it from a registry or importing it.
 	// produces:
 	// - application/json
@@ -57,12 +56,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/create"), s.APIHandler(compat.CreateImageFromSrc)).Methods(http.MethodPost).Queries("fromSrc", "{fromSrc}")
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/create", s.APIHandler(compat.CreateImageFromSrc)).Methods(http.MethodPost).Queries("fromSrc", "{fromSrc}")
-	// swagger:operation GET /images/json compat listImages
+	// swagger:operation GET /images/json compat ImageList
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: List Images
-	// operationId: ImageList
 	// description: Returns a list of images on the server. Note that it uses a different, smaller representation of an image than inspecting a single image.
 	// parameters:
 	//   - name: all
@@ -95,12 +93,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/json"), s.APIHandler(compat.GetImages)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/json", s.APIHandler(compat.GetImages)).Methods(http.MethodGet)
-	// swagger:operation POST /images/load compat importImage
+	// swagger:operation POST /images/load compat ImageLoad
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Import image
-	// operationId: ImageLoad
 	// description: Load a set of images and tags into a repository.
 	// parameters:
 	//  - in: query
@@ -122,12 +119,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/load"), s.APIHandler(compat.LoadImages)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/load", s.APIHandler(compat.LoadImages)).Methods(http.MethodPost)
-	// swagger:operation POST /images/prune compat pruneImages
+	// swagger:operation POST /images/prune compat ImagePrune
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Prune unused images
-	// operationId: ImagePrune
 	// description: Remove images from local storage that are not being used by a container
 	// parameters:
 	//  - in: query
@@ -150,12 +146,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/prune"), s.APIHandler(compat.PruneImages)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/prune", s.APIHandler(compat.PruneImages)).Methods(http.MethodPost)
-	// swagger:operation GET /images/search compat searchImages
+	// swagger:operation GET /images/search compat ImageSearch
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Search images
-	// operationId: ImageSearch
 	// description: Search registries for an image
 	// parameters:
 	//  - in: query
@@ -190,12 +185,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/search"), s.APIHandler(compat.SearchImages)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/search", s.APIHandler(compat.SearchImages)).Methods(http.MethodGet)
-	// swagger:operation DELETE /images/{name:.*} compat removeImage
+	// swagger:operation DELETE /images/{name:.*} compat ImageDelete
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Remove Image
-	// operationId: ImageDelete
 	// description: Delete an image from local storage
 	// parameters:
 	//  - in: path
@@ -225,12 +219,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}"), s.APIHandler(compat.RemoveImage)).Methods(http.MethodDelete)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}", s.APIHandler(compat.RemoveImage)).Methods(http.MethodDelete)
-	// swagger:operation POST /images/{name:.*}/push compat pushImage
+	// swagger:operation POST /images/{name:.*}/push compat ImagePush
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Push Image
-	// operationId: ImagePush
 	// description: Push an image to a container registry
 	// parameters:
 	//  - in: path
@@ -273,12 +266,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}/push"), s.APIHandler(compat.PushImage)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}/push", s.APIHandler(compat.PushImage)).Methods(http.MethodPost)
-	// swagger:operation GET /images/{name:.*}/get compat exportImage
+	// swagger:operation GET /images/{name:.*}/get compat ImageGet
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Export an image
-	// operationId: ImageGet
 	// description: Export an image in tarball format
 	// parameters:
 	//  - in: path
@@ -299,12 +291,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}/get"), s.APIHandler(compat.ExportImage)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}/get", s.APIHandler(compat.ExportImage)).Methods(http.MethodGet)
-	// swagger:operation GET /images/get compat get
+	// swagger:operation GET /images/get compat ImageGetAll
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Export several images
-	// operationId: ImageGetAll
 	// description: Get a tarball containing all images and metadata for several image repositories
 	// parameters:
 	//  - in:  query
@@ -325,12 +316,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/get"), s.APIHandler(compat.ExportImages)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/get", s.APIHandler(compat.ExportImages)).Methods(http.MethodGet)
-	// swagger:operation GET /images/{name:.*}/history compat imageHistory
+	// swagger:operation GET /images/{name:.*}/history compat ImageHistory
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: History of an image
-	// operationId: ImageHistory
 	// description: Return parent layers of an image.
 	// parameters:
 	//  - in: path
@@ -350,12 +340,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}/history"), s.APIHandler(compat.HistoryImage)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}/history", s.APIHandler(compat.HistoryImage)).Methods(http.MethodGet)
-	// swagger:operation GET /images/{name:.*}/json compat inspectImage
+	// swagger:operation GET /images/{name:.*}/json compat ImageInspect
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Inspect an image
-	// operationId: ImageInspect
 	// description: Return low-level information about an image.
 	// parameters:
 	//  - in: path
@@ -375,12 +364,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}/json"), s.APIHandler(compat.GetImage)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}/json", s.APIHandler(compat.GetImage)).Methods(http.MethodGet)
-	// swagger:operation POST /images/{name:.*}/tag compat tagImage
+	// swagger:operation POST /images/{name:.*}/tag compat ImageTag
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Tag an image
-	// operationId: ImageTag
 	// description: Tag an image so that it becomes part of a repository.
 	// parameters:
 	//  - in: path
@@ -412,12 +400,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/images/{name:.*}/tag"), s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/images/{name:.*}/tag", s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
-	// swagger:operation POST /commit compat commitContainer
+	// swagger:operation POST /commit compat ImageCommit
 	// ---
 	// tags:
 	//  - containers (compat)
 	// summary: New Image
-	// operationId: ImageCommit
 	// description: Create a new image from a container
 	// parameters:
 	//  - in: query
@@ -461,12 +448,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/commit", s.APIHandler(compat.CommitContainer)).Methods(http.MethodPost)
 
-	// swagger:operation POST /build compat buildImage
+	// swagger:operation POST /build compat ImageBuild
 	// ---
 	// tags:
 	//  - images (compat)
 	// summary: Create image
-	// operationId: ImageBuild
 	// description: Build an image from the given Dockerfile(s)
 	// parameters:
 	//  - in: query

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -18,6 +18,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Create an image
+	// operationId: ImageCreate
 	// description: Create an image by either pulling it from a registry or importing it.
 	// produces:
 	// - application/json
@@ -61,6 +62,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: List Images
+	// operationId: ImageList
 	// description: Returns a list of images on the server. Note that it uses a different, smaller representation of an image than inspecting a single image.
 	// parameters:
 	//   - name: all
@@ -98,6 +100,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Import image
+	// operationId: ImageLoad
 	// description: Load a set of images and tags into a repository.
 	// parameters:
 	//  - in: query
@@ -124,6 +127,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Prune unused images
+	// operationId: ImagePrune
 	// description: Remove images from local storage that are not being used by a container
 	// parameters:
 	//  - in: query
@@ -151,6 +155,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Search images
+	// operationId: ImageSearch
 	// description: Search registries for an image
 	// parameters:
 	//  - in: query
@@ -190,6 +195,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Remove Image
+	// operationId: ImageDelete
 	// description: Delete an image from local storage
 	// parameters:
 	//  - in: path
@@ -224,6 +230,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Push Image
+	// operationId: ImagePush
 	// description: Push an image to a container registry
 	// parameters:
 	//  - in: path
@@ -271,6 +278,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Export an image
+	// operationId: ImageGet
 	// description: Export an image in tarball format
 	// parameters:
 	//  - in: path
@@ -296,6 +304,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Export several images
+	// operationId: ImageGetAll
 	// description: Get a tarball containing all images and metadata for several image repositories
 	// parameters:
 	//  - in:  query
@@ -321,6 +330,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: History of an image
+	// operationId: ImageHistory
 	// description: Return parent layers of an image.
 	// parameters:
 	//  - in: path
@@ -345,6 +355,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Inspect an image
+	// operationId: ImageInspect
 	// description: Return low-level information about an image.
 	// parameters:
 	//  - in: path
@@ -369,6 +380,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Tag an image
+	// operationId: ImageTag
 	// description: Tag an image so that it becomes part of a repository.
 	// parameters:
 	//  - in: path
@@ -405,6 +417,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - containers (compat)
 	// summary: New Image
+	// operationId: ImageCommit
 	// description: Create a new image from a container
 	// parameters:
 	//  - in: query
@@ -453,6 +466,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// tags:
 	//  - images (compat)
 	// summary: Create image
+	// operationId: ImageBuild
 	// description: Build an image from the given Dockerfile(s)
 	// parameters:
 	//  - in: query

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -19,6 +19,9 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//  - images (compat)
 	// summary: Create an image
 	// description: Create an image by either pulling it from a registry or importing it.
+	// consumes:
+	// - text/plain
+	// - application/octet-stream
 	// produces:
 	// - application/json
 	// parameters:
@@ -279,7 +282,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    required: true
 	//    description: the name or ID of the container
 	// produces:
-	//  - application/json
+	//  - application/x-tar
 	// responses:
 	//   200:
 	//     description: no error
@@ -664,7 +667,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 		libpod endpoints
 	*/
 
-	// swagger:operation POST /libpod/images/{name:.*}/push libpod libpodPushImage
+	// swagger:operation POST /libpod/images/{name:.*}/push libpod ImagePushLibpod
 	// ---
 	// tags:
 	//  - images
@@ -702,7 +705,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:.*}/push"), s.APIHandler(libpod.PushImage)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/images/{name:.*}/exists libpod libpodImageExists
+	// swagger:operation GET /libpod/images/{name:.*}/exists libpod ImageExistsLibpod
 	// ---
 	// tags:
 	//  - images
@@ -724,7 +727,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:.*}/exists"), s.APIHandler(libpod.ImageExists)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/images/{name:.*}/tree libpod libpodImageTree
+	// swagger:operation GET /libpod/images/{name:.*}/tree libpod ImageTreeLibpod
 	// ---
 	// tags:
 	//  - images
@@ -750,7 +753,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:.*}/tree"), s.APIHandler(libpod.ImageTree)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/images/{name:.*}/history libpod libpodImageHistory
+	// swagger:operation GET /libpod/images/{name:.*}/history libpod ImageHistoryLibpod
 	// ---
 	// tags:
 	//  - images
@@ -772,7 +775,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:.*}/history"), s.APIHandler(compat.HistoryImage)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/images/json libpod libpodListImages
+	// swagger:operation GET /libpod/images/json libpod ImageListLibpod
 	// ---
 	// tags:
 	//  - images
@@ -803,7 +806,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/json"), s.APIHandler(libpod.GetImages)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/images/load libpod libpodImagesLoad
+	// swagger:operation POST /libpod/images/load libpod ImageLoadLibpod
 	// ---
 	// tags:
 	//  - images
@@ -828,7 +831,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/load"), s.APIHandler(libpod.ImagesLoad)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/images/import libpod libpodImagesImport
+	// swagger:operation POST /libpod/images/import libpod ImageImportLibpod
 	// ---
 	// tags:
 	//  - images
@@ -871,7 +874,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/import"), s.APIHandler(libpod.ImagesImport)).Methods(http.MethodPost)
-	// swagger:operation DELETE /libpod/images/remove libpod libpodImagesRemove
+	// swagger:operation DELETE /libpod/images/remove libpod ImageDeleteAllLibpod
 	// ---
 	// tags:
 	//  - images
@@ -903,7 +906,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/remove"), s.APIHandler(libpod.ImagesBatchRemove)).Methods(http.MethodDelete)
-	// swagger:operation DELETE /libpod/images/{name:.*} libpod libpodRemoveImage
+	// swagger:operation DELETE /libpod/images/{name:.*} libpod ImageDeleteLibpod
 	// ---
 	// tags:
 	//  - images
@@ -933,7 +936,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:.*}"), s.APIHandler(libpod.ImagesRemove)).Methods(http.MethodDelete)
-	// swagger:operation POST /libpod/images/pull libpod libpodImagesPull
+	// swagger:operation POST /libpod/images/pull libpod ImagePullLibpod
 	// ---
 	// tags:
 	//  - images
@@ -979,7 +982,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/pull"), s.APIHandler(libpod.ImagesPull)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/images/prune libpod libpodPruneImages
+	// swagger:operation POST /libpod/images/prune libpod ImagePruneLibpod
 	// ---
 	// tags:
 	//  - images
@@ -1004,7 +1007,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/prune"), s.APIHandler(libpod.PruneImages)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/images/search libpod libpodSearchImages
+	// swagger:operation GET /libpod/images/search libpod ImageSearchLibpod
 	// ---
 	// tags:
 	//  - images
@@ -1039,7 +1042,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//      $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/search"), s.APIHandler(compat.SearchImages)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/images/{name:.*}/get libpod libpodExportImage
+	// swagger:operation GET /libpod/images/{name:.*}/get libpod ImageGetLibpod
 	// ---
 	// tags:
 	//  - images
@@ -1060,7 +1063,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    type: boolean
 	//    description: use compression on image
 	// produces:
-	// - application/json
+	// - application/x-tar
 	// responses:
 	//   200:
 	//     description: no error
@@ -1072,7 +1075,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:.*}/get"), s.APIHandler(libpod.ExportImage)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/images/export libpod libpodExportImages
+	// swagger:operation GET /libpod/images/export libpod ImageExportLibpod
 	// ---
 	// tags:
 	//  - images
@@ -1106,7 +1109,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/export"), s.APIHandler(libpod.ExportImages)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/images/{name:.*}/json libpod libpodInspectImage
+	// swagger:operation GET /libpod/images/{name:.*}/json libpod ImageInspectLibpod
 	// ---
 	// tags:
 	//  - images
@@ -1128,7 +1131,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:.*}/json"), s.APIHandler(libpod.GetImage)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/images/{name:.*}/tag libpod libpodTagImage
+	// swagger:operation POST /libpod/images/{name:.*}/tag libpod ImageTagLibpod
 	// ---
 	// tags:
 	//  - images
@@ -1162,7 +1165,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:.*}/tag"), s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/commit libpod libpodCommitContainer
+	// swagger:operation POST /libpod/commit libpod ImageCommitLibpod
 	// ---
 	// tags:
 	//  - containers
@@ -1214,7 +1217,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/commit"), s.APIHandler(libpod.CommitContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/images/{name:.*}/untag libpod libpodUntagImage
+	// swagger:operation POST /libpod/images/{name:.*}/untag libpod ImageUntagLibpod
 	// ---
 	// tags:
 	//  - images
@@ -1249,7 +1252,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:.*}/untag"), s.APIHandler(libpod.UntagImage)).Methods(http.MethodPost)
 
-	// swagger:operation GET /libpod/images/{name}/changes libpod libpodChangesImages
+	// swagger:operation GET /libpod/images/{name}/changes libpod ImageChangesLibpod
 	// ---
 	// tags:
 	//   - images
@@ -1279,7 +1282,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/images/{name}/changes"), s.APIHandler(compat.Changes)).Methods(http.MethodGet)
 
-	// swagger:operation POST /libpod/build libpod libpodBuildImage
+	// swagger:operation POST /libpod/build libpod ImageBuildLibpod
 	// ---
 	// tags:
 	//  - images

--- a/pkg/api/server/register_info.go
+++ b/pkg/api/server/register_info.go
@@ -25,7 +25,7 @@ func (s *APIServer) registerInfoHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/info"), s.APIHandler(compat.GetInfo)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/info", s.APIHandler(compat.GetInfo)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/info libpod libpodGetInfo
+	// swagger:operation GET /libpod/info libpod SystemInfoLibpod
 	// ---
 	// tags:
 	//  - system

--- a/pkg/api/server/register_info.go
+++ b/pkg/api/server/register_info.go
@@ -9,12 +9,11 @@ import (
 )
 
 func (s *APIServer) registerInfoHandlers(r *mux.Router) error {
-	// swagger:operation GET /info compat getInfo
+	// swagger:operation GET /info compat SystemInfo
 	// ---
 	// tags:
 	//  - system (compat)
 	// summary: Get info
-	// operationId: SystemInfo
 	// description: Returns information on the system and libpod configuration
 	// produces:
 	// - application/json

--- a/pkg/api/server/register_info.go
+++ b/pkg/api/server/register_info.go
@@ -14,6 +14,7 @@ func (s *APIServer) registerInfoHandlers(r *mux.Router) error {
 	// tags:
 	//  - system (compat)
 	// summary: Get info
+	// operationId: SystemInfo
 	// description: Returns information on the system and libpod configuration
 	// produces:
 	// - application/json

--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
-	// swagger:operation POST /libpod/manifests/create manifests Create
+	// swagger:operation POST /libpod/manifests/create manifests ManifestCreateLibpod
 	// ---
 	// summary: Create
 	// description: Create a manifest list
@@ -39,7 +39,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/manifests/create"), s.APIHandler(libpod.ManifestCreate)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/manifests/{name}/exists manifests Exists
+	// swagger:operation GET /libpod/manifests/{name}/exists manifests ManifestExistsLibpod
 	// ---
 	// summary: Exists
 	// description: Check if manifest list exists
@@ -59,7 +59,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/manifests/{name}/exists"), s.APIHandler(libpod.ExistsManifest)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/manifests/{name:.*}/json manifests Inspect
+	// swagger:operation GET /libpod/manifests/{name:.*}/json manifests ManifestInspectLibpod
 	// ---
 	// summary: Inspect
 	// description: Display a manifest list
@@ -79,7 +79,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/manifests/{name:.*}/json"), s.APIHandler(libpod.ManifestInspect)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/manifests/{name:.*}/add manifests AddManifest
+	// swagger:operation POST /libpod/manifests/{name:.*}/add manifests ManifestAddLibpod
 	// ---
 	// description: Add an image to a manifest list
 	// produces:
@@ -106,7 +106,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/manifests/{name:.*}/add"), s.APIHandler(libpod.ManifestAdd)).Methods(http.MethodPost)
-	// swagger:operation DELETE /libpod/manifests/{name:.*} manifests RemoveManifest
+	// swagger:operation DELETE /libpod/manifests/{name:.*} manifests ManifestDeleteLibpod
 	// ---
 	// summary: Remove
 	// description: Remove an image from a manifest list
@@ -133,7 +133,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/manifests/{name:.*}"), s.APIHandler(libpod.ManifestRemove)).Methods(http.MethodDelete)
-	// swagger:operation POST /libpod/manifests/{name}/push manifests PushManifest
+	// swagger:operation POST /libpod/manifests/{name}/push manifests ManifestPushLibpod
 	// ---
 	// summary: Push
 	// description: Push a manifest list or image index to a registry

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -9,11 +9,26 @@ import (
 )
 
 func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
+	// swagger:operation POST /networks/prune compat compatPruneNetwork
+	// ---
+	// tags:
+	// - networks (compat)
+	// Summary: Delete unused networks
+	// operationId: NetworkPrune
+	// description: Not supported
+	// produces:
+	// - application/json
+	// responses:
+	//   404:
+	//     $ref: "#/responses/NoSuchNetwork"
+	r.HandleFunc(VersionedPath("/networks/prune"), compat.UnsupportedHandler).Methods(http.MethodPost)
+	r.HandleFunc("/networks/prune", compat.UnsupportedHandler).Methods(http.MethodPost)
 	// swagger:operation DELETE /networks/{name} compat compatRemoveNetwork
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: Remove a network
+	// operationId: NetworkDelete
 	// description: Remove a network
 	// parameters:
 	//  - in: path
@@ -37,6 +52,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Inspect a network
+	// operationId: NetworkInspect
 	// description: Display low level configuration network
 	// parameters:
 	//  - in: path
@@ -60,6 +76,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: List networks
+	// operationId: NetworkList
 	// description: Display summary of network configurations
 	// parameters:
 	//  - in: query
@@ -85,6 +102,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Create network
+	// operationId: NetworkCreate
 	// description: Create a network configuration
 	// produces:
 	// - application/json
@@ -108,6 +126,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Connect container to network
+	// operationId: NetworkConnect
 	// description: Connect a container to a network.  This endpoint is current a no-op
 	// produces:
 	// - application/json
@@ -136,6 +155,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks (compat)
 	// summary: Disconnect container from network
+	// operationId: NetworkDisconnect
 	// description: Disconnect a container from a network.  This endpoint is current a no-op
 	// produces:
 	// - application/json
@@ -219,6 +239,28 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	*/
 
 	r.HandleFunc(VersionedPath("/libpod/networks/{name}"), s.APIHandler(libpod.RemoveNetwork)).Methods(http.MethodDelete)
+	// swagger:operation GET /libpod/networks/{name}/json libpod libpodInspectNetwork
+	// ---
+	// tags:
+	//  - networks
+	// summary: Inspect a network
+	// description: Display low level configuration for a CNI network
+	// parameters:
+	//  - in: path
+	//    name: name
+	//    type: string
+	//    required: true
+	//    description: the name of the network
+	// produces:
+	// - application/json
+	// responses:
+	//   200:
+	//     $ref: "#/responses/NetworkInspectReport"
+	//   404:
+	//     $ref: "#/responses/NoSuchNetwork"
+	//   500:
+	//     $ref: "#/responses/InternalError"
+	r.HandleFunc(VersionedPath("/libpod/networks/{name}/json"), s.APIHandler(libpod.InspectNetwork)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/networks/{name}/exists libpod libpodExistsNetwork
 	// ---
 	// tags:

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -9,12 +9,11 @@ import (
 )
 
 func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
-	// swagger:operation POST /networks/prune compat compatPruneNetwork
+	// swagger:operation POST /networks/prune compat NetworkPrune
 	// ---
 	// tags:
 	// - networks (compat)
 	// Summary: Delete unused networks
-	// operationId: NetworkPrune
 	// description: Not supported
 	// produces:
 	// - application/json
@@ -23,12 +22,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchNetwork"
 	r.HandleFunc(VersionedPath("/networks/prune"), compat.UnsupportedHandler).Methods(http.MethodPost)
 	r.HandleFunc("/networks/prune", compat.UnsupportedHandler).Methods(http.MethodPost)
-	// swagger:operation DELETE /networks/{name} compat compatRemoveNetwork
+	// swagger:operation DELETE /networks/{name} compat NetworkDelete
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: Remove a network
-	// operationId: NetworkDelete
 	// description: Remove a network
 	// parameters:
 	//  - in: path
@@ -47,12 +45,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks/{name}"), s.APIHandler(compat.RemoveNetwork)).Methods(http.MethodDelete)
 	r.HandleFunc("/networks/{name}", s.APIHandler(compat.RemoveNetwork)).Methods(http.MethodDelete)
-	// swagger:operation GET /networks/{name} compat compatInspectNetwork
+	// swagger:operation GET /networks/{name} compat NetworkInspect
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: Inspect a network
-	// operationId: NetworkInspect
 	// description: Display low level configuration network
 	// parameters:
 	//  - in: path
@@ -71,12 +68,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks/{name}"), s.APIHandler(compat.InspectNetwork)).Methods(http.MethodGet)
 	r.HandleFunc("/networks/{name}", s.APIHandler(compat.InspectNetwork)).Methods(http.MethodGet)
-	// swagger:operation GET /networks compat compatListNetwork
+	// swagger:operation GET /networks compat NetworkList
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: List networks
-	// operationId: NetworkList
 	// description: Display summary of network configurations
 	// parameters:
 	//  - in: query
@@ -97,12 +93,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks"), s.APIHandler(compat.ListNetworks)).Methods(http.MethodGet)
 	r.HandleFunc("/networks", s.APIHandler(compat.ListNetworks)).Methods(http.MethodGet)
-	// swagger:operation POST /networks/create compat compatCreateNetwork
+	// swagger:operation POST /networks/create compat NetworkCreate
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: Create network
-	// operationId: NetworkCreate
 	// description: Create a network configuration
 	// produces:
 	// - application/json
@@ -121,12 +116,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks/create"), s.APIHandler(compat.CreateNetwork)).Methods(http.MethodPost)
 	r.HandleFunc("/networks/create", s.APIHandler(compat.CreateNetwork)).Methods(http.MethodPost)
-	// swagger:operation POST /networks/{name}/connect compat compatConnectNetwork
+	// swagger:operation POST /networks/{name}/connect compat NetworkConnect
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: Connect container to network
-	// operationId: NetworkConnect
 	// description: Connect a container to a network.  This endpoint is current a no-op
 	// produces:
 	// - application/json
@@ -150,12 +144,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks/{name}/connect"), s.APIHandler(compat.Connect)).Methods(http.MethodPost)
 	r.HandleFunc("/networks/{name}/connect", s.APIHandler(compat.Connect)).Methods(http.MethodPost)
-	// swagger:operation POST /networks/{name}/disconnect compat compatDisconnectNetwork
+	// swagger:operation POST /networks/{name}/disconnect compat NetworkDisconnect
 	// ---
 	// tags:
 	//  - networks (compat)
 	// summary: Disconnect container from network
-	// operationId: NetworkDisconnect
 	// description: Disconnect a container from a network.  This endpoint is current a no-op
 	// produces:
 	// - application/json

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -9,19 +9,6 @@ import (
 )
 
 func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
-	// swagger:operation POST /networks/prune compat NetworkPrune
-	// ---
-	// tags:
-	// - networks (compat)
-	// Summary: Delete unused networks
-	// description: Not supported
-	// produces:
-	// - application/json
-	// responses:
-	//   404:
-	//     $ref: "#/responses/NoSuchNetwork"
-	r.HandleFunc(VersionedPath("/networks/prune"), compat.UnsupportedHandler).Methods(http.MethodPost)
-	r.HandleFunc("/networks/prune", compat.UnsupportedHandler).Methods(http.MethodPost)
 	// swagger:operation DELETE /networks/{name} compat NetworkDelete
 	// ---
 	// tags:
@@ -172,7 +159,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks/{name}/disconnect"), s.APIHandler(compat.Disconnect)).Methods(http.MethodPost)
 	r.HandleFunc("/networks/{name}/disconnect", s.APIHandler(compat.Disconnect)).Methods(http.MethodPost)
-	// swagger:operation POST /networks/prune compat compatPruneNetwork
+	// swagger:operation POST /networks/prune compat NetworkPrune
 	// ---
 	// tags:
 	//  - networks (compat)
@@ -201,7 +188,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/networks/prune"), s.APIHandler(compat.Prune)).Methods(http.MethodPost)
 	r.HandleFunc("/networks/prune", s.APIHandler(compat.Prune)).Methods(http.MethodPost)
 
-	// swagger:operation DELETE /libpod/networks/{name} libpod libpodRemoveNetwork
+	// swagger:operation DELETE /libpod/networks/{name} libpod NetworkDeleteLibpod
 	// ---
 	// tags:
 	//  - networks
@@ -226,35 +213,8 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchNetwork"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-
-	/*
-		Libpod
-	*/
-
 	r.HandleFunc(VersionedPath("/libpod/networks/{name}"), s.APIHandler(libpod.RemoveNetwork)).Methods(http.MethodDelete)
-	// swagger:operation GET /libpod/networks/{name}/json libpod libpodInspectNetwork
-	// ---
-	// tags:
-	//  - networks
-	// summary: Inspect a network
-	// description: Display low level configuration for a CNI network
-	// parameters:
-	//  - in: path
-	//    name: name
-	//    type: string
-	//    required: true
-	//    description: the name of the network
-	// produces:
-	// - application/json
-	// responses:
-	//   200:
-	//     $ref: "#/responses/NetworkInspectReport"
-	//   404:
-	//     $ref: "#/responses/NoSuchNetwork"
-	//   500:
-	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/networks/{name}/json"), s.APIHandler(libpod.InspectNetwork)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/networks/{name}/exists libpod libpodExistsNetwork
+	// swagger:operation GET /libpod/networks/{name}/exists libpod NetworkExistsLibpod
 	// ---
 	// tags:
 	//  - networks
@@ -276,7 +236,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/networks/{name}/exists"), s.APIHandler(libpod.ExistsNetwork)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/networks/json libpod libpodListNetwork
+	// swagger:operation GET /libpod/networks/json libpod NetworkListLibpod
 	// ---
 	// tags:
 	//  - networks
@@ -301,7 +261,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/networks/json"), s.APIHandler(libpod.ListNetworks)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/networks/{name}/json libpod libpodInspectNetwork
+	// swagger:operation GET /libpod/networks/{name}/json libpod NetworkInspectLibpod
 	// ---
 	// tags:
 	//  - networks
@@ -324,7 +284,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/networks/{name}/json"), s.APIHandler(libpod.InspectNetwork)).Methods(http.MethodGet)
 	r.HandleFunc(VersionedPath("/libpod/networks/{name}"), s.APIHandler(libpod.InspectNetwork)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/networks/create libpod libpodCreateNetwork
+	// swagger:operation POST /libpod/networks/create libpod NetworkCreateLibpod
 	// ---
 	// tags:
 	//  - networks
@@ -350,7 +310,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/networks/create"), s.APIHandler(libpod.CreateNetwork)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/networks/{name}/connect libpod libpodConnectNetwork
+	// swagger:operation POST /libpod/networks/{name}/connect libpod NetworkConnectLibpod
 	// ---
 	// tags:
 	//  - networks
@@ -377,7 +337,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/networks/{name}/connect"), s.APIHandler(libpod.Connect)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/networks/{name}/disconnect libpod libpodDisconnectNetwork
+	// swagger:operation POST /libpod/networks/{name}/disconnect libpod NetworkDisconnectLibpod
 	// ---
 	// tags:
 	//  - networks
@@ -404,7 +364,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/networks/{name}/disconnect"), s.APIHandler(compat.Disconnect)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/networks/prune libpod libpodPruneNetwork
+	// swagger:operation POST /libpod/networks/prune libpod NetworkPruneLibpod
 	// ---
 	// tags:
 	//  - networks

--- a/pkg/api/server/register_ping.go
+++ b/pkg/api/server/register_ping.go
@@ -10,7 +10,7 @@ import (
 func (s *APIServer) registerPingHandlers(r *mux.Router) error {
 	r.Handle("/_ping", s.APIHandler(compat.Ping)).Methods(http.MethodGet, http.MethodHead)
 	r.Handle(VersionedPath("/_ping"), s.APIHandler(compat.Ping)).Methods(http.MethodGet, http.MethodHead)
-	// swagger:operation GET /libpod/_ping libpod libpodPingGet
+	// swagger:operation GET /libpod/_ping libpod SystemPing
 	// ---
 	//   summary: Ping service
 	//   description: |

--- a/pkg/api/server/register_play.go
+++ b/pkg/api/server/register_play.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *APIServer) registerPlayHandlers(r *mux.Router) error {
-	// swagger:operation POST /libpod/play/kube libpod libpodPlayKube
+	// swagger:operation POST /libpod/play/kube libpod KubePlayLibpod
 	// ---
 	// tags:
 	//  - containers

--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
-	// swagger:operation GET /libpod/pods/json pods ListPods
+	// swagger:operation GET /libpod/pods/json pods PodListLibpod
 	// ---
 	// summary: List pods
 	// produces:
@@ -26,7 +26,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/json"), s.APIHandler(libpod.Pods)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/pods/create pods CreatePod
+	// swagger:operation POST /libpod/pods/create pods PodCreateLibpod
 	// ---
 	// summary: Create a pod
 	// produces:
@@ -51,7 +51,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/create"), s.APIHandler(libpod.PodCreate)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/prune pods PrunePods
+	// swagger:operation POST /libpod/pods/prune pods PodPruneLibpod
 	// ---
 	// summary: Prune unused pods
 	// produces:
@@ -66,7 +66,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/prune"), s.APIHandler(libpod.PodPrune)).Methods(http.MethodPost)
-	// swagger:operation DELETE /libpod/pods/{name} pods removePod
+	// swagger:operation DELETE /libpod/pods/{name} pods PodDeleteLibpod
 	// ---
 	// summary: Remove pod
 	// produces:
@@ -91,7 +91,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}"), s.APIHandler(libpod.PodDelete)).Methods(http.MethodDelete)
-	// swagger:operation GET /libpod/pods/{name}/json pods inspectPod
+	// swagger:operation GET /libpod/pods/{name}/json pods PodInspectLibpod
 	// ---
 	// summary: Inspect pod
 	// produces:
@@ -110,7 +110,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//      $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/json"), s.APIHandler(libpod.PodInspect)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/pods/{name}/exists pods podExists
+	// swagger:operation GET /libpod/pods/{name}/exists pods PodExistsLibpod
 	// ---
 	// summary: Pod exists
 	// description: Check if a pod exists by name or ID
@@ -130,7 +130,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/exists"), s.APIHandler(libpod.PodExists)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/pods/{name}/kill pods killPod
+	// swagger:operation POST /libpod/pods/{name}/kill pods PodKillLibpod
 	// ---
 	// summary: Kill a pod
 	// produces:
@@ -158,7 +158,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/kill"), s.APIHandler(libpod.PodKill)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/{name}/pause pods pausePod
+	// swagger:operation POST /libpod/pods/{name}/pause pods PodPauseLibpod
 	// ---
 	// summary: Pause a pod
 	// description: Pause a pod
@@ -180,7 +180,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/pause"), s.APIHandler(libpod.PodPause)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/{name}/restart pods restartPod
+	// swagger:operation POST /libpod/pods/{name}/restart pods PodRestartLibpod
 	// ---
 	// summary: Restart a pod
 	// produces:
@@ -201,7 +201,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/restart"), s.APIHandler(libpod.PodRestart)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/{name}/start pods startPod
+	// swagger:operation POST /libpod/pods/{name}/start pods PodStartLibpod
 	// ---
 	// summary: Start a pod
 	// produces:
@@ -224,7 +224,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/start"), s.APIHandler(libpod.PodStart)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/{name}/stop pods stopPod
+	// swagger:operation POST /libpod/pods/{name}/stop pods PodStopLibpod
 	// ---
 	// summary: Stop a pod
 	// produces:
@@ -253,7 +253,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/stop"), s.APIHandler(libpod.PodStop)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/{name}/unpause pods unpausePod
+	// swagger:operation POST /libpod/pods/{name}/unpause pods PodUnpauseLibpod
 	// ---
 	// summary: Unpause a pod
 	// produces:
@@ -274,7 +274,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/unpause"), s.APIHandler(libpod.PodUnpause)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/pods/{name}/top pods topPod
+	// swagger:operation GET /libpod/pods/{name}/top pods PodTopLibpod
 	// ---
 	// summary: List processes
 	// description: List processes running inside a pod
@@ -305,7 +305,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name}/top"), s.APIHandler(libpod.PodTop)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/pods/stats pods statsPod
+	// swagger:operation GET /libpod/pods/stats pods PodStatsLibpod
 	// ---
 	// tags:
 	//  - pods

--- a/pkg/api/server/register_secrets.go
+++ b/pkg/api/server/register_secrets.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
-	// swagger:operation POST /libpod/secrets/create libpod libpodCreateSecret
+	// swagger:operation POST /libpod/secrets/create libpod SecretCreateLibpod
 	// ---
 	// tags:
 	//  - secrets
@@ -38,7 +38,7 @@ func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/secrets/create"), s.APIHandler(libpod.CreateSecret)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/secrets/json libpod libpodListSecret
+	// swagger:operation GET /libpod/secrets/json libpod SecretListLibpod
 	// ---
 	// tags:
 	//  - secrets
@@ -53,7 +53,7 @@ func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/secrets/json"), s.APIHandler(compat.ListSecrets)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/secrets/{name}/json libpod libpodInspectSecret
+	// swagger:operation GET /libpod/secrets/{name}/json libpod SecretInspectLibpod
 	// ---
 	// tags:
 	//  - secrets
@@ -74,7 +74,7 @@ func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
 	//   '500':
 	//     "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/secrets/{name}/json"), s.APIHandler(compat.InspectSecret)).Methods(http.MethodGet)
-	// swagger:operation DELETE /libpod/secrets/{name} libpod libpodRemoveSecret
+	// swagger:operation DELETE /libpod/secrets/{name} libpod SecretDeleteLibpod
 	// ---
 	// tags:
 	//  - secrets
@@ -104,7 +104,7 @@ func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
 	/*
 	 * Docker compatibility endpoints
 	 */
-	// swagger:operation GET /secrets compat ListSecret
+	// swagger:operation GET /secrets compat SecretList
 	// ---
 	// tags:
 	//  - secrets (compat)
@@ -120,7 +120,7 @@ func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
 	//      "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/secrets"), s.APIHandler(compat.ListSecrets)).Methods(http.MethodGet)
 	r.Handle("/secrets", s.APIHandler(compat.ListSecrets)).Methods(http.MethodGet)
-	// swagger:operation POST /secrets/create compat CreateSecret
+	// swagger:operation POST /secrets/create compat SecretCreate
 	// ---
 	// tags:
 	//  - secrets (compat)
@@ -143,7 +143,7 @@ func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
 	//      "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/secrets/create"), s.APIHandler(compat.CreateSecret)).Methods(http.MethodPost)
 	r.Handle("/secrets/create", s.APIHandler(compat.CreateSecret)).Methods(http.MethodPost)
-	// swagger:operation GET /secrets/{name} compat InspectSecret
+	// swagger:operation GET /secrets/{name} compat SecretInspect
 	// ---
 	// tags:
 	//  - secrets (compat)
@@ -165,7 +165,7 @@ func (s *APIServer) registerSecretHandlers(r *mux.Router) error {
 	//     "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/secrets/{name}"), s.APIHandler(compat.InspectSecret)).Methods(http.MethodGet)
 	r.Handle("/secrets/{name}", s.APIHandler(compat.InspectSecret)).Methods(http.MethodGet)
-	// swagger:operation DELETE /secrets/{name} compat RemoveSecret
+	// swagger:operation DELETE /secrets/{name} compat SecretDelete
 	// ---
 	// tags:
 	//  - secrets (compat)

--- a/pkg/api/server/register_system.go
+++ b/pkg/api/server/register_system.go
@@ -9,10 +9,23 @@ import (
 )
 
 func (s *APIServer) registerSystemHandlers(r *mux.Router) error {
+	// swagger:operation GET /system/df compat SystemDataUsage
+	// ---
+	// tags:
+	//   - system (compat)
+	// summary: Show disk usage
+	// description: Return information about disk usage for containers, images, and volumes
+	// produces:
+	// - application/json
+	// responses:
+	//   200:
+	//     $ref: '#/responses/SystemDiskUse'
+	//   500:
+	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/system/df"), s.APIHandler(compat.GetDiskUsage)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
 	r.Handle("/system/df", s.APIHandler(compat.GetDiskUsage)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/system/prune libpod pruneSystem
+	// swagger:operation POST /libpod/system/prune libpod SystemPruneLibpod
 	// ---
 	// tags:
 	//   - system
@@ -27,7 +40,7 @@ func (s *APIServer) registerSystemHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/system/prune"), s.APIHandler(libpod.SystemPrune)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/system/df libpod df
+	// swagger:operation GET /libpod/system/df libpod SystemDataUsageLibpod
 	// ---
 	// tags:
 	//   - system

--- a/pkg/api/server/register_version.go
+++ b/pkg/api/server/register_version.go
@@ -8,10 +8,9 @@ import (
 )
 
 func (s *APIServer) registerVersionHandlers(r *mux.Router) error {
-	// swagger:operation GET /version compat CompatSystemVersion
+	// swagger:operation GET /version compat SystemVersion
 	// ---
 	// summary: Component Version information
-	// operationId: SystemVersion
 	// tags:
 	// - system (compat)
 	// produces:

--- a/pkg/api/server/register_version.go
+++ b/pkg/api/server/register_version.go
@@ -20,7 +20,7 @@ func (s *APIServer) registerVersionHandlers(r *mux.Router) error {
 	//    $ref: "#/responses/Version"
 	r.Handle("/version", s.APIHandler(compat.VersionHandler)).Methods(http.MethodGet)
 	r.Handle(VersionedPath("/version"), s.APIHandler(compat.VersionHandler)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/version libpod SystemVersion
+	// swagger:operation GET /libpod/version libpod SystemVersionLibpod
 	// ---
 	// summary: Component Version information
 	// tags:

--- a/pkg/api/server/register_version.go
+++ b/pkg/api/server/register_version.go
@@ -11,6 +11,7 @@ func (s *APIServer) registerVersionHandlers(r *mux.Router) error {
 	// swagger:operation GET /version compat CompatSystemVersion
 	// ---
 	// summary: Component Version information
+	// operationId: SystemVersion
 	// tags:
 	// - system (compat)
 	// produces:

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
-	// swagger:operation POST /libpod/volumes/create libpod libpodCreateVolume
+	// swagger:operation POST /libpod/volumes/create libpod VolumeCreateLibpod
 	// ---
 	// tags:
 	//  - volumes
@@ -28,7 +28,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/volumes/create"), s.APIHandler(libpod.CreateVolume)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/volumes/{name}/exists libpod libpodExistsVolume
+	// swagger:operation GET /libpod/volumes/{name}/exists libpod VolumeExistsLibpod
 	// ---
 	// tags:
 	//  - volumes
@@ -50,7 +50,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/volumes/{name}/exists"), s.APIHandler(libpod.ExistsVolume)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/volumes/json libpod libpodListVolumes
+	// swagger:operation GET /libpod/volumes/json libpod VolumeListLibpod
 	// ---
 	// tags:
 	//  - volumes
@@ -74,7 +74,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/volumes/json"), s.APIHandler(libpod.ListVolumes)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/volumes/prune libpod libpodPruneVolumes
+	// swagger:operation POST /libpod/volumes/prune libpod VolumePruneLibpod
 	// ---
 	// tags:
 	//  - volumes
@@ -87,7 +87,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/volumes/prune"), s.APIHandler(libpod.PruneVolumes)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/volumes/{name}/json libpod libpodInspectVolume
+	// swagger:operation GET /libpod/volumes/{name}/json libpod VolumeInspectLibpod
 	// ---
 	// tags:
 	//  - volumes
@@ -108,7 +108,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//   '500':
 	//     "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/volumes/{name}/json"), s.APIHandler(libpod.InspectVolume)).Methods(http.MethodGet)
-	// swagger:operation DELETE /libpod/volumes/{name} libpod libpodRemoveVolume
+	// swagger:operation DELETE /libpod/volumes/{name} libpod VolumeDeleteLibpod
 	// ---
 	// tags:
 	//  - volumes

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -140,12 +140,11 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	 * Docker compatibility endpoints
 	 */
 
-	// swagger:operation GET /volumes compat listVolumes
+	// swagger:operation GET /volumes compat VolumeList
 	// ---
 	// tags:
 	//  - volumes (compat)
 	// summary: List volumes
-	// operationId: VolumeList
 	// description: Returns a list of volume
 	// produces:
 	// - application/json
@@ -169,12 +168,11 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/volumes"), s.APIHandler(compat.ListVolumes)).Methods(http.MethodGet)
 	r.Handle("/volumes", s.APIHandler(compat.ListVolumes)).Methods(http.MethodGet)
 
-	// swagger:operation POST /volumes/create compat createVolume
+	// swagger:operation POST /volumes/create compat VolumeCreate
 	// ---
 	// tags:
 	//  - volumes (compat)
 	// summary: Create a volume
-	// operationId: VolumeCreate
 	// parameters:
 	//  - in: body
 	//    name: create
@@ -193,12 +191,11 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/volumes/create"), s.APIHandler(compat.CreateVolume)).Methods(http.MethodPost)
 	r.Handle("/volumes/create", s.APIHandler(compat.CreateVolume)).Methods(http.MethodPost)
 
-	// swagger:operation GET /volumes/{name} compat inspectVolume
+	// swagger:operation GET /volumes/{name} compat VolumeInspect
 	// ---
 	// tags:
 	//  - volumes (compat)
 	// summary: Inspect volume
-	// operationId: VolumeInspect
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -217,12 +214,11 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/volumes/{name}"), s.APIHandler(compat.InspectVolume)).Methods(http.MethodGet)
 	r.Handle("/volumes/{name}", s.APIHandler(compat.InspectVolume)).Methods(http.MethodGet)
 
-	// swagger:operation DELETE /volumes/{name} compat removeVolume
+	// swagger:operation DELETE /volumes/{name} compat VolumeDelete
 	// ---
 	// tags:
 	//  - volumes (compat)
 	// summary: Remove volume
-	// operationId: VolumeDelete
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -250,12 +246,11 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/volumes/{name}"), s.APIHandler(compat.RemoveVolume)).Methods(http.MethodDelete)
 	r.Handle("/volumes/{name}", s.APIHandler(compat.RemoveVolume)).Methods(http.MethodDelete)
 
-	// swagger:operation POST /volumes/prune compat pruneVolumes
+	// swagger:operation POST /volumes/prune compat VolumePrune
 	// ---
 	// tags:
 	//  - volumes (compat)
 	// summary: Prune volumes
-	// operationId: VolumePrune
 	// produces:
 	// - application/json
 	// parameters:

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -145,6 +145,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// tags:
 	//  - volumes (compat)
 	// summary: List volumes
+	// operationId: VolumeList
 	// description: Returns a list of volume
 	// produces:
 	// - application/json
@@ -173,6 +174,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// tags:
 	//  - volumes (compat)
 	// summary: Create a volume
+	// operationId: VolumeCreate
 	// parameters:
 	//  - in: body
 	//    name: create
@@ -196,6 +198,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// tags:
 	//  - volumes (compat)
 	// summary: Inspect volume
+	// operationId: VolumeInspect
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -219,6 +222,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// tags:
 	//  - volumes (compat)
 	// summary: Remove volume
+	// operationId: VolumeDelete
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -251,6 +255,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// tags:
 	//  - volumes (compat)
 	// summary: Prune volumes
+	// operationId: VolumePrune
 	// produces:
 	// - application/json
 	// parameters:

--- a/pkg/api/tags.yaml
+++ b/pkg/api/tags.yaml
@@ -24,7 +24,7 @@ tags:
     - name: images (compat)
       description: Actions related to images for the compatibility endpoints
     - name: networks (compat)
-      description: Actions related to compatibility networks
+      description: Actions related to networks for the compatibility endpoints
     - name: volumes (compat)
       description: Actions related to volumes for the compatibility endpoints
     - name: secrets (compat)


### PR DESCRIPTION
* Libpod operation id's changed to better match compatible id

Supersedes #9123 by included all commits. 

Additionally, corrects a duplicated ID that prevented that PR#9123 from merging, and rebased to current master.

Signed-off-by: Tom Deseyn <tom.deseyn@gmail.com>
Signed-off-by: Jhon Honce <jhonce@redhat.com>