### PR TITLE
podman unshare: add --rootless-cni to join the ns

### DIFF
--- a/cmd/podman/system/unshare.go
+++ b/cmd/podman/system/unshare.go
@@ -12,9 +12,10 @@ import (
 )
 
 var (
+	unshareOptions     = entities.SystemUnshareOptions{}
 	unshareDescription = "Runs a command in a modified user namespace."
 	unshareCommand     = &cobra.Command{
-		Use:                   "unshare [COMMAND [ARG...]]",
+		Use:                   "unshare [options] [COMMAND [ARG...]]",
 		DisableFlagsInUseLine: true,
 		Short:                 "Run a command in a modified user namespace",
 		Long:                  unshareDescription,
@@ -33,6 +34,7 @@ func init() {
 	})
 	flags := unshareCommand.Flags()
 	flags.SetInterspersed(false)
+	flags.BoolVar(&unshareOptions.RootlessCNI, "rootless-cni", false, "Join the rootless network namespace used for CNI networking")
 }
 
 func unshare(cmd *cobra.Command, args []string) error {
@@ -49,5 +51,5 @@ func unshare(cmd *cobra.Command, args []string) error {
 		args = []string{shell}
 	}
 
-	return registry.ContainerEngine().Unshare(registry.Context(), args)
+	return registry.ContainerEngine().Unshare(registry.Context(), args, unshareOptions)
 }

--- a/docs/source/markdown/podman-unshare.1.md
+++ b/docs/source/markdown/podman-unshare.1.md
@@ -24,6 +24,19 @@ The unshare session defines two environment variables:
 - **CONTAINERS_GRAPHROOT**: the path to the persistent container's data.
 - **CONTAINERS_RUNROOT**: the path to the volatile container's data.
 
+## OPTIONS
+
+#### **\-\-help**, **-h**
+
+Print usage statement
+
+#### **\-\-rootless-cni**
+
+Join the rootless network namespace used for CNI networking. It can be used to
+connect to a rootless container via IP address (CNI networking). This is otherwise
+not possible from the host network namespace.
+_Note: Using this option with more than one unshare session can have unexpected results._
+
 ## EXAMPLE
 
 ```
@@ -35,6 +48,30 @@ $ podman unshare cat /proc/self/uid_map /proc/self/gid_map
          1      10000      65536
          0       1000          1
          1      10000      65536
+
+$ podman unshare --rootless-cni ip addr
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host
+       valid_lft forever preferred_lft forever
+2: tap0: <BROADCAST,UP,LOWER_UP> mtu 65520 qdisc fq_codel state UNKNOWN group default qlen 1000
+    link/ether 36:0e:4a:c7:45:7e brd ff:ff:ff:ff:ff:ff
+    inet 10.0.2.100/24 brd 10.0.2.255 scope global tap0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::340e:4aff:fec7:457e/64 scope link
+       valid_lft forever preferred_lft forever
+3: cni-podman2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+    link/ether 5e:3a:71:d2:b4:3a brd ff:ff:ff:ff:ff:ff
+    inet 10.89.1.1/24 brd 10.89.1.255 scope global cni-podman2
+       valid_lft forever preferred_lft forever
+    inet6 fe80::5c3a:71ff:fed2:b43a/64 scope link
+       valid_lft forever preferred_lft forever
+4: vethd4ba3a2f@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master cni-podman2 state UP group default
+    link/ether 8a:c9:56:32:17:0c brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet6 fe80::88c9:56ff:fe32:170c/64 scope link
+       valid_lft forever preferred_lft forever
 ```
 
 

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -88,7 +88,7 @@ type ContainerEngine interface {
 	SecretRm(ctx context.Context, nameOrID []string, opts SecretRmOptions) ([]*SecretRmReport, error)
 	Shutdown(ctx context.Context)
 	SystemDf(ctx context.Context, options SystemDfOptions) (*SystemDfReport, error)
-	Unshare(ctx context.Context, args []string) error
+	Unshare(ctx context.Context, args []string, options SystemUnshareOptions) error
 	Version(ctx context.Context) (*SystemVersionReport, error)
 	VolumeCreate(ctx context.Context, opts VolumeCreateOptions) (*IDOrNameResponse, error)
 	VolumeExists(ctx context.Context, namesOrID string) (*BoolReport, error)

--- a/pkg/domain/entities/system.go
+++ b/pkg/domain/entities/system.go
@@ -98,6 +98,11 @@ type SystemVersionReport struct {
 	Server *define.Version `json:",omitempty"`
 }
 
+// SystemUnshareOptions describes the options for the unshare command
+type SystemUnshareOptions struct {
+	RootlessCNI bool
+}
+
 type ComponentVersion struct {
 	types.Version
 }

--- a/pkg/domain/infra/tunnel/system.go
+++ b/pkg/domain/infra/tunnel/system.go
@@ -28,7 +28,7 @@ func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.System
 	return system.DiskUsage(ic.ClientCtx, nil)
 }
 
-func (ic *ContainerEngine) Unshare(ctx context.Context, args []string) error {
+func (ic *ContainerEngine) Unshare(ctx context.Context, args []string, options entities.SystemUnshareOptions) error {
 	return errors.New("unshare is not supported on remote clients")
 }
 

--- a/test/e2e/unshare_test.go
+++ b/test/e2e/unshare_test.go
@@ -49,4 +49,11 @@ var _ = Describe("Podman unshare", func() {
 		ok, _ := session.GrepString(userNS)
 		Expect(ok).To(BeFalse())
 	})
+
+	It("podman unshare --rootles-cni", func() {
+		session := podmanTest.Podman([]string{"unshare", "--rootless-cni", "ip", "addr"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("tap0"))
+	})
 })


### PR DESCRIPTION
Add a new --rootless-cni option to podman unshare to also join the
rootless-cni network namespace. This is useful if you want to connect
to a rootless container via IP address. This is only possible from the
rootless-cni namespace and not from the host namespace. This option also
helps to debug problems in the rootless-cni namespace.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
