### PR TITLE
System tests: special case for RHEL: require runc

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -53,6 +53,27 @@ store.imageStore.number   | 1
 
 }
 
+# 2021-04-06 discussed in watercooler: RHEL must never use crun, even if
+# using cgroups v2.
+@test "podman info - RHEL8 must use runc" {
+    local osrelease=/etc/os-release
+    test -e $osrelease || skip "Not a RHEL system (no $osrelease)"
+
+    local osname=$(source $osrelease; echo $NAME)
+    if [[ $osname =~ Red.Hat || $osname =~ CentOS ]]; then
+        # Version can include minor; strip off first dot an all beyond it
+        local osver=$(source $osrelease; echo $VERSION_ID)
+        test ${osver%%.*} -le 8 || skip "$osname $osver > RHEL8"
+
+        # RHEL or CentOS 8.
+        # FIXME: what does 'CentOS 8' even mean? What is $VERSION_ID in CentOS?
+        run_podman info --format '{{.Host.OCIRuntime.Name}}'
+        is "$output" "runc" "$osname only supports OCI Runtime = runc"
+    else
+        skip "only applicable on RHEL, this is $osname"
+    fi
+}
+
 @test "podman info --storage-opt='' " {
     skip_if_remote "--storage-opt flag is not supported for remote"
     skip_if_rootless "storage opts are required for rootless running"


### PR DESCRIPTION
As discussed in watercooler 2021-04-06: make sure that RHEL
and CentOS are using runc. Using crun is probably a packaging
error that should be caught early.

Signed-off-by: Ed Santiago <santiago@redhat.com>
