### PR TITLE
Volumes prune endpoint should use only prune filters

### DIFF
--- a/pkg/api/handlers/compat/volumes.go
+++ b/pkg/api/handlers/compat/volumes.go
@@ -266,7 +266,7 @@ func PruneVolumes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	f := (url.Values)(*filterMap)
-	filterFuncs, err := filters.GenerateVolumeFilters(f)
+	filterFuncs, err := filters.GeneratePruneVolumeFilters(f)
 	if err != nil {
 		utils.Error(w, "Something when wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to parse filters for %s", f.Encode()))
 		return

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -150,7 +150,7 @@ func pruneVolumesHelper(r *http.Request) ([]*reports.PruneReport, error) {
 	}
 
 	f := (url.Values)(*filterMap)
-	filterFuncs, err := filters.GenerateVolumeFilters(f)
+	filterFuncs, err := filters.GeneratePruneVolumeFilters(f)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -75,7 +75,25 @@ func GenerateVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, error) {
 					return dangling
 				})
 			default:
-				return nil, errors.Errorf("%q is in an invalid volume filter", filter)
+				return nil, errors.Errorf("%q is an invalid volume filter", filter)
+			}
+		}
+	}
+	return vf, nil
+}
+
+func GeneratePruneVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, error) {
+	var vf []libpod.VolumeFilter
+	for filter, v := range filters {
+		for _, val := range v {
+			switch filter {
+			case "label":
+				filter := val
+				vf = append(vf, func(v *libpod.Volume) bool {
+					return util.MatchLabelFilters([]string{filter}, v.Labels())
+				})
+			default:
+				return nil, errors.Errorf("%q is an invalid volume filter", filter)
 			}
 		}
 	}

--- a/test/apiv2/30-volumes.at
+++ b/test/apiv2/30-volumes.at
@@ -123,4 +123,20 @@ t POST libpod/volumes/prune 200
 #After prune volumes, there should be no volume existing
 t GET libpod/volumes/json 200 length=0
 
+# libpod api: do not use list filters for prune
+t POST libpod/volumes/prune?filters='{"name":["anyname"]}' 500 \
+    .cause="\"name\" is an invalid volume filter"
+t POST libpod/volumes/prune?filters='{"driver":["anydriver"]}' 500 \
+    .cause="\"driver\" is an invalid volume filter"
+t POST libpod/volumes/prune?filters='{"scope":["anyscope"]}' 500 \
+    .cause="\"scope\" is an invalid volume filter"
+
+# compat api: do not use list filters for prune
+t POST volumes/prune?filters='{"name":["anyname"]}' 500 \
+    .cause="\"name\" is an invalid volume filter"
+t POST volumes/prune?filters='{"driver":["anydriver"]}' 500 \
+    .cause="\"driver\" is an invalid volume filter"
+t POST volumes/prune?filters='{"scope":["anyscope"]}' 500 \
+    .cause="\"scope\" is an invalid volume filter"
+
 # vim: filetype=sh


### PR DESCRIPTION
Volumes endpoints for HTTP compat and libpod APIs allowed
usage of list HTTP endpoint filter funcs. Documentation in
case of compat API does not allow that. This commit aligns
code with the documentation and also ligns libpod with compat API.

Signed-off-by: Jakub Guzik <jakubmguzik@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
/kind bug