### PR TITLE
rootless cni add /usr/sbin to PATH if not present

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -411,6 +411,16 @@ func (r *Runtime) getRootlessCNINetNs(new bool) (*rootlessCNI, error) {
 			}
 		}
 
+		// The CNI plugins need access to iptables in $PATH. As it turns out debian doesn't put
+		// /usr/sbin in $PATH for rootless users. This will break rootless cni completely.
+		// We might break existing users and we cannot expect everyone to change their $PATH so
+		// lets add /usr/sbin to $PATH ourselves.
+		path = os.Getenv("PATH")
+		if !strings.Contains(path, "/usr/sbin") {
+			path = path + ":/usr/sbin"
+			os.Setenv("PATH", path)
+		}
+
 		rootlessCNINS = &rootlessCNI{
 			ns:   ns,
 			dir:  cniDir,

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -209,4 +209,19 @@ load helpers
     run_podman rm -f $cid
 }
 
+@test "podman rootless cni adds /usr/sbin to PATH" {
+    is_rootless || skip "only meaningful for rootless"
+
+    local mynetname=testnet-$(random_string 10)
+    run_podman network create $mynetname
+
+    # Test that rootless cni adds /usr/sbin to $PATH
+    # iptables is located under /usr/sbin and is needed for the CNI plugins.
+    # Debian doesn't add /usr/sbin to $PATH for rootless users so we have to add it.
+    PATH=/usr/local/bin:/usr/bin run_podman run --rm --network $mynetname $IMAGE ip addr
+    is "$output" ".*eth0.*" "Interface eth0 not found in ip addr output"
+
+    run_podman network rm -f $mynetname
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
The CNI plugins need access to iptables in $PATH. On debian /usr/sbin
is not added to $PATH for rootless users. This will break rootless
cni completely. To prevent breaking existing users add /usr/sbin to
$PATH in podman if needed.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
