### PR TITLE
Fix flaking rootless compose test

### DIFF
--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -163,7 +163,13 @@ function test_port() {
     local op="$2"                # '=' or '~'
     local expect="$3"            # what to expect from curl output
 
-    local actual=$(curl --retry 10 --retry-all-errors -s http://127.0.0.1:$port/)
+    local actual=$(curl --retry 3 --retry-all-errors -s http://127.0.0.1:$port/)
+    # The test is flaking with an empty result. The curl retry doesn't solve this.
+    # If the result is empty sleep one second and try again.
+    if [[ "$actual" == "" ]]; then
+        sleep 1
+        local actual=$(curl --retry 3 --retry-all-errors -s http://127.0.0.1:$port/)
+    fi
     local curl_rc=$?
     if [ $curl_rc -ne 0 ]; then
         _show_ok 0 "$testname - curl failed with status $curl_rc"


### PR DESCRIPTION
The compose port test is flaking with an empty curl result. The curl retry
does not work properly. Given the the tests never expect an empty result
lets just wait one second and retry again.
Unfortunately there is no way for me to actually verify if this will fix
the flake.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
