### PR TITLE
[CI:DOCS] Update swagger definition of inspect manifest

### DIFF
--- a/pkg/api/Makefile
+++ b/pkg/api/Makefile
@@ -5,6 +5,9 @@ SWAGGER_OUT ?= swagger.yaml
 validate: ${SWAGGER_OUT}
 	swagger validate ${SWAGGER_OUT}
 
+serve: ${SWAGGER_OUT}
+	swagger serve -F redoc -p=8080 swagger.yaml
+
 .PHONY: ${SWAGGER_OUT}
 ${SWAGGER_OUT}:
 	# generate doesn't remove file on error

--- a/pkg/api/handlers/libpod/swagger.go
+++ b/pkg/api/handlers/libpod/swagger.go
@@ -25,7 +25,7 @@ type swagInspectPodResponse struct {
 // swagger:response InspectManifest
 type swagInspectManifestResponse struct {
 	// in:body
-	Body manifest.List
+	Body manifest.Schema2List
 }
 
 // Kill Pod

--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -81,6 +81,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/libpod/manifests/{name:.*}/json"), s.APIHandler(libpod.ManifestInspect)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/manifests/{name:.*}/add manifests ManifestAddLibpod
 	// ---
+	// summary: Add image
 	// description: Add an image to a manifest list
 	// produces:
 	// - application/json


### PR DESCRIPTION
* Changed reference in swagger to correct struture that was being
  returned.
* Added summary to ManifestAddLibpod to clean up generated web site
* Added serve target to Makefile, to aid in debugging generated
  web site

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
