### PR TITLE
[CI:DOCS] Adjust libpod API Container Wait documentation to the code

### DIFF
--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -1194,11 +1194,22 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//       - removing
 	//       - stopping
 	//    description: "Conditions to wait for. If no condition provided the 'exited' condition is assumed."
+	//  - in: query
+	//    name: interval
+	//    type: string
+	//    default: "250ms"
+	//    description: Time Interval to wait before polling for completion.
 	// produces:
 	// - application/json
+	// - text/plain
 	// responses:
 	//   200:
-	//     $ref: "#/responses/ContainerWaitResponse"
+	//     description: Status code
+	//     schema:
+	//       type: integer
+	//       format: int32
+	//     examples:
+	//       text/plain: 137
 	//   404:
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:


### PR DESCRIPTION
Closes #9960

As of the issue, what is currently documented as the response for `/libpod/containers/{name}/wait` is not actually what the code is doing. At the same time, `interval` property was left undocumented.
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
