### PR TITLE
Update manifest API endpoints

### DIFF
--- a/test/apiv2/rest_api/test_rest_v2_0_0.py
+++ b/test/apiv2/rest_api/test_rest_v2_0_0.py
@@ -727,10 +727,13 @@ class TestApi(unittest.TestCase):
         start = json.loads(r.text)
         self.assertGreater(len(start["Errs"]), 0, r.text)
 
+    def test_manifest_409(self):
+        r = requests.post(_url("/manifests/create"), params={"name": "ThisIsAnInvalidImage"})
+        self.assertEqual(r.status_code, 400, r.text)
+
     def test_df(self):
         r = requests.get(_url("/system/df"))
         self.assertEqual(r.status_code, 200, r.text)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* Add validation for manifest name
* Always return an array for manifests even if empty

When c/image is refactored to include manifests, these endpoints should
be revisited.

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
