### PR TITLE
speed up CI handling of images

### DIFF
--- a/test/e2e/config_amd64.go
+++ b/test/e2e/config_amd64.go
@@ -5,7 +5,7 @@ var (
 	STORAGE_OPTIONS          = "--storage-driver vfs"
 	ROOTLESS_STORAGE_FS      = "vfs"
 	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"
-	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, registry, infra, labels, healthcheck, ubi_init, ubi_minimal}
+	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, registry, infra, labels, healthcheck, ubi_init, ubi_minimal, fedoraToolbox}
 	nginx                    = "quay.io/libpod/alpine_nginx:latest"
 	BB_GLIBC                 = "docker.io/library/busybox:glibc"
 	registry                 = "quay.io/libpod/registry:2.6"

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Podman images", func() {
 		session = podmanTest.Podman([]string{"images", "-qn"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(len(session.OutputToStringArray())).To(BeNumerically("==", 11))
+		Expect(len(session.OutputToStringArray())).To(BeNumerically("==", len(CACHE_IMAGES)))
 	})
 
 	It("podman images with digests", func() {
@@ -194,7 +194,7 @@ WORKDIR /test
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "since=quay.io/libpod/alpine:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(len(result.OutputToStringArray())).To(Equal(8))
+		Expect(len(result.OutputToStringArray())).To(Equal(9))
 	})
 
 	It("podman image list filter after image", func() {
@@ -204,7 +204,7 @@ WORKDIR /test
 		result := podmanTest.Podman([]string{"image", "list", "-q", "-f", "after=quay.io/libpod/alpine:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(result.OutputToStringArray()).Should(HaveLen(8), "list filter output: %q", result.OutputToString())
+		Expect(result.OutputToStringArray()).Should(HaveLen(9), "list filter output: %q", result.OutputToString())
 	})
 
 	It("podman images filter dangling", func() {

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Podman rmi", func() {
 		session = podmanTest.Podman([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(len(session.OutputToStringArray())).To(Equal(12))
+		Expect(len(session.OutputToStringArray())).To(Equal(len(CACHE_IMAGES) + 1))
 
 		podmanTest.BuildImage(dockerfile, "test3", "true")
 
@@ -236,7 +236,7 @@ var _ = Describe("Podman rmi", func() {
 		session = podmanTest.Podman([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(len(session.OutputToString())).To(Equal(142))
+		Expect(len(session.OutputToString())).To(Equal(155))
 	})
 
 	It("podman rmi -a with no images should be exit 0", func() {

--- a/test/e2e/toolbox_test.go
+++ b/test/e2e/toolbox_test.go
@@ -215,7 +215,6 @@ var _ = Describe("Toolbox-specific testing", func() {
 		useradd := fmt.Sprintf("useradd --home-dir %s --shell %s --uid %s %s",
 			homeDir, shell, uid, username)
 		passwd := fmt.Sprintf("passwd --delete %s", username)
-		podmanTest.AddImageToRWStore(fedoraToolbox)
 		session = podmanTest.Podman([]string{"create", "--name", "test", "--userns=keep-id", "--user", "root:root", fedoraToolbox, "sh", "-c",
 			fmt.Sprintf("%s; %s; echo READY; sleep 1000", useradd, passwd)})
 		session.WaitWithDefaultTimeout()
@@ -251,7 +250,6 @@ var _ = Describe("Toolbox-specific testing", func() {
 
 		groupadd := fmt.Sprintf("groupadd --gid %s %s", gid, groupName)
 
-		podmanTest.AddImageToRWStore(fedoraToolbox)
 		session = podmanTest.Podman([]string{"create", "--name", "test", "--userns=keep-id", "--user", "root:root", fedoraToolbox, "sh", "-c",
 			fmt.Sprintf("%s; echo READY; sleep 1000", groupadd)})
 		session.WaitWithDefaultTimeout()
@@ -296,7 +294,6 @@ var _ = Describe("Toolbox-specific testing", func() {
 		usermod := fmt.Sprintf("usermod --append --groups wheel --home %s --shell %s --uid %s --gid %s %s",
 			homeDir, shell, uid, gid, username)
 
-		podmanTest.AddImageToRWStore(fedoraToolbox)
 		session = podmanTest.Podman([]string{"create", "--name", "test", "--userns=keep-id", "--user", "root:root", fedoraToolbox, "sh", "-c",
 			fmt.Sprintf("%s; %s; %s; echo READY; sleep 1000", useradd, groupadd, usermod)})
 		session.WaitWithDefaultTimeout()
@@ -341,7 +338,6 @@ var _ = Describe("Toolbox-specific testing", func() {
 
 		// These should be most of the switches that Toolbox uses to create a "toolbox" container
 		// https://github.com/containers/toolbox/blob/master/src/cmd/create.go
-		podmanTest.AddImageToRWStore(fedoraToolbox)
 		session = podmanTest.Podman([]string{"create",
 			"--dns", "none",
 			"--hostname", "toolbox",
@@ -378,7 +374,6 @@ var _ = Describe("Toolbox-specific testing", func() {
 		currentUser, err := user.Current()
 		Expect(err).To(BeNil())
 
-		podmanTest.AddImageToRWStore(fedoraToolbox)
 		session = podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:%s", currentUser.HomeDir, currentUser.HomeDir), "--userns=keep-id", fedoraToolbox, "sh", "-c", "echo $HOME"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))


### PR DESCRIPTION
now that ci uses cached images, putting the large toolbox image into
cache should help speed up tests.

Signed-off-by: baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
