### PR TITLE
Add missing return

### DIFF
--- a/pkg/api/handlers/libpod/system.go
+++ b/pkg/api/handlers/libpod/system.go
@@ -72,6 +72,7 @@ func DiskUsage(w http.ResponseWriter, r *http.Request) {
 	response, err := ic.SystemDf(r.Context(), options)
 	if err != nil {
 		utils.InternalServerError(w, err)
+		return
 	}
 	utils.WriteResponse(w, http.StatusOK, response)
 }

--- a/test/apiv2/rest_api/test_rest_v2_0_0.py
+++ b/test/apiv2/rest_api/test_rest_v2_0_0.py
@@ -727,6 +727,10 @@ class TestApi(unittest.TestCase):
         start = json.loads(r.text)
         self.assertGreater(len(start["Errs"]), 0, r.text)
 
+    def test_df(self):
+        r = requests.get(_url("/system/df"))
+        self.assertEqual(r.status_code, 200, r.text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
libpod df handler missing a return after writing error to client. This
caused a null to be appended to JSON and crashed python decoder.

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
