### PR TITLE
[CI:DOCS] Fix formatting of podman-build man page

### DIFF
--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -12,8 +12,8 @@ podman\-build - Build a container image using a Containerfile
 **podman build** Builds an image using instructions from one or more
 Containerfiles or Dockerfiles and a specified build context directory. A
 Containerfile uses the same syntax as a Dockerfile internally. For this
-document, a file referred to as a Containerfile can be a file named either
-'Containerfile' or 'Dockerfile'.
+document, a file referred to as a Containerfile can be a file named
+either 'Containerfile' or 'Dockerfile'.
 
 The build context directory can be specified as the http(s) URL of an archive,
 git repository or Containerfile.


### PR DESCRIPTION
An apostrophe as the first character of the line is a formatting request
in troff, so the words "'Containerfile' or 'Dockerfile'" are not
visible when viewing 'man podman-build'.

Signed-off-by: Jonathan Wakely <jwakely@redhat.com>
