### PR TITLE
cgroups: force 64 bits to ParseUint

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -265,7 +265,7 @@ func readFileAsUint64(path string) (uint64, error) {
 	if v == "max" {
 		return math.MaxUint64, nil
 	}
-	ret, err := strconv.ParseUint(v, 10, 0)
+	ret, err := strconv.ParseUint(v, 10, 64)
 	if err != nil {
 		return ret, errors.Wrapf(err, "parse %s from %s", v, path)
 	}

--- a/pkg/cgroups/cpu.go
+++ b/pkg/cgroups/cpu.go
@@ -40,7 +40,7 @@ func readAcctList(ctr *CgroupControl, name string) ([]uint64, error) {
 		if s == "" {
 			break
 		}
-		v, err := strconv.ParseUint(s, 10, 0)
+		v, err := strconv.ParseUint(s, 10, 64)
 		if err != nil {
 			return nil, errors.Wrapf(err, "parsing %s", s)
 		}
@@ -80,14 +80,14 @@ func (c *cpuHandler) Stat(ctr *CgroupControl, m *Metrics) error {
 			return err
 		}
 		if val, found := values["usage_usec"]; found {
-			usage.Total, err = strconv.ParseUint(cleanString(val[0]), 10, 0)
+			usage.Total, err = strconv.ParseUint(cleanString(val[0]), 10, 64)
 			if err != nil {
 				return err
 			}
 			usage.Kernel *= 1000
 		}
 		if val, found := values["system_usec"]; found {
-			usage.Kernel, err = strconv.ParseUint(cleanString(val[0]), 10, 0)
+			usage.Kernel, err = strconv.ParseUint(cleanString(val[0]), 10, 64)
 			if err != nil {
 				return err
 			}
@@ -149,7 +149,7 @@ func GetSystemCPUUsage() (uint64, error) {
 		}
 
 		if val, found := values["usage_usec"]; found {
-			v, err := strconv.ParseUint(cleanString(val[0]), 10, 0)
+			v, err := strconv.ParseUint(cleanString(val[0]), 10, 64)
 			if err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
[NO TESTS NEEDED]

force bitsSize==64 so that the string is always parsed to a uint64
instead of using the native int size, that could be not big enough on
32 bits arches.

Closes: https://github.com/containers/podman/issues/9979

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
