### PR TITLE
[NO TESTS NEEDED] Fix panic when not giving a machine name for ssh

### DIFF
--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -78,7 +78,7 @@ func ssh(cmd *cobra.Command, args []string) error {
 		vm, err = qemu.LoadVMByName(vmName)
 	}
 	if err != nil {
-		return errors.Wrapf(err, "vm %s not found", args[0])
+		return errors.Wrapf(err, "vm %s not found", vmName)
 	}
 	return vm.SSH(vmName, sshOpts)
 }


### PR DESCRIPTION
BEFORE

$ ./bin/podman machine ssh
panic: runtime error: index out of range [0] with length 0

AFTER

$ ./bin/podman machine ssh
Error: vm podman-machine-default not found: podman-machine-default: VM does not exist

Closes #9865