### PR TITLE
Add network prune filters support to bindings

### DIFF
--- a/pkg/bindings/network/network.go
+++ b/pkg/bindings/network/network.go
@@ -184,7 +184,13 @@ func Exists(ctx context.Context, nameOrID string, options *ExistsOptions) (bool,
 
 // Prune removes unused CNI networks
 func Prune(ctx context.Context, options *PruneOptions) ([]*entities.NetworkPruneReport, error) {
-	// TODO Filters is not implemented
+	if options == nil {
+		options = new(PruneOptions)
+	}
+	params, err := options.ToParams()
+	if err != nil {
+		return nil, err
+	}
 	var (
 		prunedNetworks []*entities.NetworkPruneReport
 	)
@@ -193,7 +199,7 @@ func Prune(ctx context.Context, options *PruneOptions) ([]*entities.NetworkPrune
 		return nil, err
 	}
 
-	response, err := conn.DoRequest(nil, http.MethodPost, "/networks/prune", nil, nil)
+	response, err := conn.DoRequest(nil, http.MethodPost, "/networks/prune", params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/network/types.go
+++ b/pkg/bindings/network/types.go
@@ -79,4 +79,7 @@ type ExistsOptions struct {
 // PruneOptions are optional options for removing unused
 // CNI networks
 type PruneOptions struct {
+	// Filters are applied to the prune of networks to be more
+	// specific on choosing
+	Filters map[string][]string
 }

--- a/pkg/bindings/network/types_prune_options.go
+++ b/pkg/bindings/network/types_prune_options.go
@@ -19,3 +19,19 @@ func (o *PruneOptions) Changed(fieldName string) bool {
 func (o *PruneOptions) ToParams() (url.Values, error) {
 	return util.ToParams(o)
 }
+
+// WithFilters
+func (o *PruneOptions) WithFilters(value map[string][]string) *PruneOptions {
+	v := value
+	o.Filters = v
+	return o
+}
+
+// GetFilters
+func (o *PruneOptions) GetFilters() map[string][]string {
+	var filters map[string][]string
+	if o.Filters == nil {
+		return filters
+	}
+	return o.Filters
+}

--- a/pkg/bindings/test/networks_test.go
+++ b/pkg/bindings/test/networks_test.go
@@ -37,6 +37,53 @@ var _ = Describe("Podman networks", func() {
 		bt.cleanup()
 	})
 
+	It("podman prune unused networks with filters", func() {
+		name := "foobar"
+		opts := network.CreateOptions{
+			Name: &name,
+		}
+		_, err = network.Create(connText, &opts)
+		Expect(err).To(BeNil())
+
+		// Invalid filters should return error
+		filtersIncorrect := map[string][]string{
+			"status": {"dummy"},
+		}
+		_, err = network.Prune(connText, new(network.PruneOptions).WithFilters(filtersIncorrect))
+		Expect(err).ToNot(BeNil())
+
+		// List filter params should not work with prune.
+		filtersIncorrect = map[string][]string{
+			"name": {name},
+		}
+		_, err = network.Prune(connText, new(network.PruneOptions).WithFilters(filtersIncorrect))
+		Expect(err).ToNot(BeNil())
+
+		// Mismatched label, correct filter params => no network should be pruned.
+		filtersIncorrect = map[string][]string{
+			"label": {"xyz"},
+		}
+		pruneResponse, err := network.Prune(connText, new(network.PruneOptions).WithFilters(filtersIncorrect))
+		Expect(err).To(BeNil())
+		Expect(len(pruneResponse)).To(Equal(0))
+
+		// Mismatched until, correct filter params => no network should be pruned.
+		filters := map[string][]string{
+			"until": {"50"}, // January 1, 1970
+		}
+		pruneResponse, err = network.Prune(connText, new(network.PruneOptions).WithFilters(filters))
+		Expect(err).To(BeNil())
+		Expect(len(pruneResponse)).To(Equal(0))
+
+		// Valid filter params => network should be pruned now.
+		filters = map[string][]string{
+			"until": {"5000000000"}, //June 11, 2128
+		}
+		pruneResponse, err = network.Prune(connText, new(network.PruneOptions).WithFilters(filters))
+		Expect(err).To(BeNil())
+		Expect(len(pruneResponse)).To(Equal(1))
+	})
+
 	It("create network", func() {
 		// create a network with blank config should work
 		_, err = network.Create(connText, &network.CreateOptions{})

--- a/pkg/domain/infra/tunnel/network.go
+++ b/pkg/domain/infra/tunnel/network.go
@@ -92,5 +92,6 @@ func (ic *ContainerEngine) NetworkExists(ctx context.Context, networkname string
 
 // Network prune removes unused cni networks
 func (ic *ContainerEngine) NetworkPrune(ctx context.Context, options entities.NetworkPruneOptions) ([]*entities.NetworkPruneReport, error) {
-	return network.Prune(ic.ClientCtx, nil)
+	opts := new(network.PruneOptions).WithFilters(options.Filters)
+	return network.Prune(ic.ClientCtx, opts)
 }


### PR DESCRIPTION
Signed-off-by: Jakub Guzik <jakubmguzik@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

Support present on the server-side for several weeks. Now, I added it to bindings.