### PR TITLE
Fix message about runtime to show only the actual runtime

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -130,8 +130,8 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 			continue
 		}
 		foundPath = true
+		logrus.Tracef("found runtime %q", runtime.path)
 		runtime.path = path
-		logrus.Debugf("using runtime %q", path)
 		break
 	}
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -389,7 +389,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 			// This will allow us to ship configs including optional
 			// runtimes that might not be installed (crun, kata).
 			// Only a infof so default configs don't spec errors.
-			logrus.Infof("Error initializing configured OCI runtime %s: %v", name, err)
+			logrus.Debugf("configured OCI runtime %s initialization failed: %v", name, err)
 			continue
 		}
 
@@ -416,6 +416,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 			runtime.defaultOCIRuntime = ociRuntime
 		}
 	}
+	logrus.Debugf("Using OCI runtime %q", runtime.defaultOCIRuntime.Path())
 
 	// Do we have at least one valid OCI runtime?
 	if len(runtime.ociRuntimes) == 0 {


### PR DESCRIPTION
Currently the debug line shows every runtime up until it finds
the correct one, confusing users on which runtime it is using.

[NO TESTS NEEDED] Since this is just debug.

Triggered by https://github.com/containers/podman/issues/4854

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
