### PR TITLE
cgroup: do not set cgroup parent when rootless and cgroupfs

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2216,7 +2216,7 @@ func (c *Container) getOCICgroupPath() (string, error) {
 	}
 	cgroupManager := c.CgroupManager()
 	switch {
-	case (rootless.IsRootless() && !unified) || c.config.NoCgroups:
+	case (rootless.IsRootless() && (cgroupManager == config.CgroupfsCgroupsManager || !unified)) || c.config.NoCgroups:
 		return "", nil
 	case c.config.CgroupsMode == cgroupSplit:
 		if c.config.CgroupParent != "" {

--- a/test/system/420-cgroups.bats
+++ b/test/system/420-cgroups.bats
@@ -24,6 +24,11 @@ load helpers
     run_podman container inspect --format '{{.HostConfig.CgroupManager}}' myc
     is "$output" "$other" "podman preserved .HostConfig.CgroupManager"
 
+    if is_rootless && test $other = cgroupfs ; then
+        run_podman container inspect --format '{{.HostConfig.CgroupParent}}' myc
+        is "$output" "" "podman didn't set .HostConfig.CgroupParent for cgroupfs and rootless"
+    fi
+
     # Restart the container, without --cgroup-manager option (ie use default)
     # Prior to #7970, this would fail with an OCI runtime error
     run_podman start myc


### PR DESCRIPTION
do not set the cgroup parent when running as rootless with cgroupfs,
even if cgroup v2 is used.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1947999

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
