### PR TITLE
[CI:DOCS] Correct status code for /pods/create

### DIFF
--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -38,7 +38,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   schema:
 	//     $ref: "#/definitions/PodSpecGenerator"
 	// responses:
-	//   200:
+	//   201:
 	//     schema:
 	//       $ref: "#/definitions/IdResponse"
 	//   400:

--- a/test/apiv2/rest_api/test_rest_v2_0_0.py
+++ b/test/apiv2/rest_api/test_rest_v2_0_0.py
@@ -735,5 +735,6 @@ class TestApi(unittest.TestCase):
         r = requests.get(_url("/system/df"))
         self.assertEqual(r.status_code, 200, r.text)
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Swagger documentation reported that the API endpoint /pods/create
returned 200 while the as-built code returned 201. 201 is more
correct so documentation updated.

Tests already checked for 201 so no updated needed.

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
