### PR TITLE
Do not delete container twice

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -616,20 +616,6 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 		}
 	}
 
-	// Delete the container.
-	// Not needed in Configured and Exited states, where the container
-	// doesn't exist in the runtime
-	if c.state.State != define.ContainerStateConfigured &&
-		c.state.State != define.ContainerStateExited {
-		if err := c.delete(ctx); err != nil {
-			if cleanupErr == nil {
-				cleanupErr = err
-			} else {
-				logrus.Errorf("delete container: %v", err)
-			}
-		}
-	}
-
 	// Remove the container from the state
 	if c.config.Pod != "" {
 		// If we're removing the pod, the container will be evicted


### PR DESCRIPTION
10 lines above we had

	// Set ContainerStateRemoving
	c.state.State = define.ContainerStateRemoving

Which causes the state to not be the two checked states.  Since the
c.cleanup call already deleted the OCI state, this meant that we were
calling cleanup, and hence the postHook hook twice.

Fixes: https://github.com/containers/podman/issues/9983

[NO TESTS NEEDED] Since it would be difficult to tests this.  Main tests
should handle that the container is being deleted successfully.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
