### PR TITLE
Reflect current state of prune implementation in docs

### DIFF
--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -377,7 +377,6 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    name: filters
 	//    type: string
 	//    description: |
-	//      NOT IMPLEMENTED
 	//      Filters to process on the prune list, encoded as JSON (a map[string][]string).
 	//      Available filters:
 	//        - until=<timestamp> Prune networks created before this timestamp. The <timestamp> can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. 10m, 1h30m) computed relative to the daemon machine’s time.

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -81,6 +81,14 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// summary: Prune volumes
 	// produces:
 	// - application/json
+	// parameters:
+	//  - in: query
+	//    name: filters
+	//    type: string
+	//    description: |
+	//      JSON encoded value of filters (a map[string][]string) to match volumes against before pruning.
+	//      Available filters:
+	//	      - label (label=<key>, label=<key>=<value>, label!=<key>, or label!=<key>=<value>) Prune volumes with (or without, in case label!=... is used) the specified labels.
 	// responses:
 	//   '200':
 	//      "$ref": "#/responses/VolumePruneResponse"
@@ -259,8 +267,8 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//    type: string
 	//    description: |
 	//      JSON encoded value of filters (a map[string][]string) to match volumes against before pruning.
-	//
-	//      Note: No filters are currently supported and any filters specified will cause an error response.
+	//      Available filters:
+	//	      - label (label=<key>, label=<key>=<value>, label!=<key>, or label!=<key>=<value>) Prune volumes with (or without, in case label!=... is used) the specified labels.
 	// responses:
 	//   '200':
 	//      "$ref": "#/responses/DockerVolumePruneResponse"


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
[NO TESTS NEEDED]

I am changing only comments, but maybe you have generate job somewhere so I skip the ci docs flag.
This commit aligns comments with the current state of the implementation.