### PR TITLE
System tests: fix racy podman-inspect

### DIFF
--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -132,6 +132,7 @@ load helpers
     is "$output" "stopping" "Status of container should be 'stopping'"
 
     run_podman kill stopme
+    run_podman wait stopme
 
     # Exit code should be 137 as it was killed
     run_podman inspect --format '{{.State.ExitCode}}' stopme


### PR DESCRIPTION
Add 'podman wait' between kill & inspect.

Fixes: #9751

Signed-off-by: Ed Santiago <santiago@redhat.com>
