### PR TITLE
Recognize "trace" logging, and use it for lone errors at exit

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -21,7 +21,7 @@ var (
 	// ChangeCmds is the list of valid Change commands to passed to the Commit call
 	ChangeCmds = []string{"CMD", "ENTRYPOINT", "ENV", "EXPOSE", "LABEL", "ONBUILD", "STOPSIGNAL", "USER", "VOLUME", "WORKDIR"}
 	// LogLevels supported by podman
-	LogLevels = []string{"debug", "info", "warn", "warning", "error", "fatal", "panic"}
+	LogLevels = []string{"trace", "debug", "info", "warn", "warning", "error", "fatal", "panic"}
 )
 
 type completeType int
@@ -1009,7 +1009,7 @@ func AutocompleteEventBackend(cmd *cobra.Command, args []string, toComplete stri
 }
 
 // AutocompleteLogLevel - Autocomplete log level options.
-// -> "debug", "info", "warn", "error", "fatal", "panic"
+// -> "trace", "debug", "info", "warn", "error", "fatal", "panic"
 func AutocompleteLogLevel(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return LogLevels, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -416,7 +416,11 @@ func formatError(err error) string {
 			strings.TrimSuffix(err.Error(), ": "+define.ErrOCIRuntime.Error()),
 		)
 	} else {
-		message = "Error: " + err.Error()
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
+			message = fmt.Sprintf("Error: %+v", err)
+		} else {
+			message = fmt.Sprintf("Error: %v", err)
+		}
 	}
 	return message
 }

--- a/pkg/errorhandling/errorhandling.go
+++ b/pkg/errorhandling/errorhandling.go
@@ -24,6 +24,9 @@ func JoinErrors(errs []error) error {
 	if finalErr == nil {
 		return finalErr
 	}
+	if len(multiE.WrappedErrors()) == 1 && logrus.IsLevelEnabled(logrus.TraceLevel) {
+		return multiE.WrappedErrors()[0]
+	}
 	return errors.New(strings.TrimSpace(finalErr.Error()))
 }
 

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -111,4 +111,17 @@ function setup() {
     is "$output" "you found me" "sample invocation of 'jq'"
 }
 
+@test "podman --log-level recognizes log levels" {
+    run_podman 1 --log-level=telepathic info
+    is "$output" 'Log Level "telepathic" is not supported.*'
+    run_podman --log-level=trace   info
+    run_podman --log-level=debug   info
+    run_podman --log-level=info    info
+    run_podman --log-level=warn    info
+    run_podman --log-level=warning info
+    run_podman --log-level=error   info
+    run_podman --log-level=fatal   info
+    run_podman --log-level=panic   info
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
* "trace" is a valid logrus debugging level, so we should be able to tell the library to display messages logged at that level.
* change `pkg/errorhandling.JoinErrors()` to not throw away the backtrace info in errors that were wrapped using `github.com/pkg/errors` if the `go-multierror` it's formatting only contains one error
* if we're printing an error at exit, and we're at trace level or higher, use %+v instead of %v when formatting the error for display, which will show the stack trace if there is one.

The net result is that `./bin/podman rmi no-such-image` still produces
```
Error: 1 error occurred:
	* unable to find a name and tag match for no-such-image in repotags: no such image
```
but `./bin/podman --log-level=trace rmi no-such-image` now ends with
```
Error: no such image
unable to find a name and tag match for no-such-image in repotags
github.com/containers/podman/v3/libpod/image.findImageInRepotags
	libpod/image/utils.go:48
github.com/containers/podman/v3/libpod/image.(*Runtime).getLocalImage
	libpod/image/image.go:489
github.com/containers/podman/v3/libpod/image.(*Runtime).NewFromLocal
	libpod/image/image.go:136
github.com/containers/podman/v3/pkg/domain/infra/abi.(*ImageEngine).Remove
	pkg/domain/infra/abi/images.go:641
github.com/containers/podman/v3/cmd/podman/images.rm
	cmd/podman/images/rm.go:56
github.com/spf13/cobra.(*Command).execute
	vendor/github.com/spf13/cobra/command.go:852
github.com/spf13/cobra.(*Command).ExecuteC
	vendor/github.com/spf13/cobra/command.go:960
github.com/spf13/cobra.(*Command).Execute
	vendor/github.com/spf13/cobra/command.go:897
github.com/spf13/cobra.(*Command).ExecuteContext
	vendor/github.com/spf13/cobra/command.go:890
main.Execute
	cmd/podman/root.go:90
main.main
	cmd/podman/main.go:38
runtime.main
	/usr/lib/golang/src/runtime/proc.go:225
runtime.goexit
	/usr/lib/golang/src/runtime/asm_amd64.s:1371
```