### PR TITLE
Fix flake on failed podman-remote build : try 2

### DIFF
--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -340,6 +340,7 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 	re := regexp.MustCompile(`[0-9a-f]{12}`)
 
 	var id string
+	var mErr error
 	for {
 		var s struct {
 			Stream string `json:"stream,omitempty"`
@@ -347,9 +348,19 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		}
 		if err := dec.Decode(&s); err != nil {
 			if errors.Is(err, io.EOF) {
-				return &entities.BuildReport{ID: id}, nil
+				if mErr == nil && id == "" {
+					mErr = errors.New("stream dropped, unexpected failure")
+				}
+				break
 			}
 			s.Error = err.Error() + "\n"
+		}
+
+		select {
+		case <-response.Request.Context().Done():
+			return &entities.BuildReport{ID: id}, mErr
+		default:
+			// non-blocking select
 		}
 
 		switch {
@@ -359,11 +370,12 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 				id = strings.TrimSuffix(s.Stream, "\n")
 			}
 		case s.Error != "":
-			return nil, errors.New(s.Error)
+			mErr = errors.New(s.Error)
 		default:
 			return &entities.BuildReport{ID: id}, errors.New("failed to parse build results stream, unexpected input")
 		}
 	}
+	return &entities.BuildReport{ID: id}, mErr
 }
 
 func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {


### PR DESCRIPTION
This time we are checking if the function actually succeeded,
otherwise we will report an error.

Also if we did not get the id, report unexpected failure.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
