### PR TITLE
[CI:DOCS] Update documentation of podman-run to reflect volume "U" option

### DIFF
--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -692,6 +692,7 @@ Set the architecture variant of the image to be pulled.
 
    * [rw|ro]
    * [z|Z|O]
+   * [U]
    * [`[r]shared`|`[r]slave`|`[r]private`]
 
 The `CONTAINER-DIR` must be an absolute path such as `/src/docs`. The `HOST-DIR`
@@ -706,6 +707,18 @@ container.
 You can add the `:ro` or `:rw` suffix to a volume to mount it read-only or
 read-write mode, respectively. By default, the volumes are mounted read-write.
 See examples.
+
+  `Chowning Volume Mounts`
+
+By default, Podman does not change the owner and group of source volume
+directories mounted. When running using user namespaces, the UID and GID inside
+the namespace may correspond to another UID and GID on the host.
+
+The `:U` suffix tells Podman to use the correct host UID and GID based on the
+UID and GID within the namespace, to change recursively the owner and group of
+the source volume.
+
+**Warning** use with caution since this will modify the host filesystem.
 
   `Labeling Volume Mounts`
 

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1075,9 +1075,14 @@ See examples.
 
   `Chowning Volume Mounts`
 
-By default, Podman does not change the owner and group of source volume directories mounted into containers. If a container is created in a new user namespace, the UID and GID in the container may correspond to another UID and GID on the host.
+By default, Podman does not change the owner and group of source volume
+directories mounted into containers. If a container is created in a new user
+namespace, the UID and GID in the container may correspond to another UID and
+GID on the host.
 
-The `:U` suffix tells Podman to use the correct host UID and GID based on the UID and GID within the container, to change recursively the owner and group of the source volume.
+The `:U` suffix tells Podman to use the correct host UID and GID based on the
+UID and GID within the container, to change recursively the owner and group of
+the source volume.
 
 **Warning** use with caution since this will modify the host filesystem.
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1155,9 +1155,14 @@ read-write mode, respectively. By default, the volumes are mounted read-write.
 
   `Chowning Volume Mounts`
 
-By default, Podman does not change the owner and group of source volume directories mounted into containers. If a container is created in a new user namespace, the UID and GID in the container may correspond to another UID and GID on the host.
+By default, Podman does not change the owner and group of source volume
+directories mounted into containers. If a container is created in a new user
+namespace, the UID and GID in the container may correspond to another UID and
+GID on the host.
 
-The `:U` suffix tells Podman to use the correct host UID and GID based on the UID and GID within the container, to change recursively the owner and group of the source volume.
+The `:U` suffix tells Podman to use the correct host UID and GID based on the
+UID and GID within the container, to change recursively the owner and group of
+the source volume.
 
 **Warning** use with caution since this will modify the host filesystem.
 


### PR DESCRIPTION
The "U" option is accepted by `--volume` in `podman-build`,
but documentation is missing

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
