### PR TITLE
Add flag "--pidfile" for podman create/run

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -817,6 +817,12 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	)
 	_ = cmd.RegisterFlagCompletionFunc(cgroupConfFlagName, completion.AutocompleteNone)
 
+	pidFileFlagName := "pidfile"
+	createFlags.StringVar(
+		&cf.PidFile,
+		pidFileFlagName, "",
+		"Write the container process ID to the file")
+
 	_ = createFlags.MarkHidden("signature-policy")
 	if registry.IsRemote() {
 		_ = createFlags.MarkHidden("env-host")

--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -822,6 +822,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 		&cf.PidFile,
 		pidFileFlagName, "",
 		"Write the container process ID to the file")
+	_ = cmd.RegisterFlagCompletionFunc(pidFileFlagName, completion.AutocompleteDefault)
 
 	_ = createFlags.MarkHidden("signature-policy")
 	if registry.IsRemote() {

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -122,6 +122,7 @@ type ContainerCLIOpts struct {
 	VolumesFrom       []string
 	Workdir           string
 	SeccompPolicy     string
+	PidFile           string
 
 	Net *entities.NetOptions
 

--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -644,6 +644,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	s.Timezone = c.Timezone
 	s.Umask = c.Umask
 	s.Secrets = c.Secrets
+	s.PidFile = c.PidFile
 
 	return nil
 }

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -63,6 +63,10 @@ func createFlags(cmd *cobra.Command) {
 	common.DefineNetFlags(cmd)
 
 	flags.SetNormalizeFunc(utils.AliasFlags)
+
+	if registry.IsRemote() {
+		_ = flags.MarkHidden("pidfile")
+	}
 }
 
 func init() {

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -65,6 +65,7 @@ func createFlags(cmd *cobra.Command) {
 	flags.SetNormalizeFunc(utils.AliasFlags)
 
 	if registry.IsRemote() {
+		_ = flags.MarkHidden("conmon-pidfile")
 		_ = flags.MarkHidden("pidfile")
 	}
 }

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -79,6 +79,7 @@ func runFlags(cmd *cobra.Command) {
 
 	if registry.IsRemote() {
 		_ = flags.MarkHidden("preserve-fds")
+		_ = flags.MarkHidden("conmon-pidfile")
 		_ = flags.MarkHidden("pidfile")
 	}
 }

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -76,8 +76,10 @@ func runFlags(cmd *cobra.Command) {
 	detachKeysFlagName := "detach-keys"
 	flags.StringVar(&runOpts.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-cf`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 	_ = cmd.RegisterFlagCompletionFunc(detachKeysFlagName, common.AutocompleteDetachKeys)
+
 	if registry.IsRemote() {
 		_ = flags.MarkHidden("preserve-fds")
+		_ = flags.MarkHidden("pidfile")
 	}
 }
 

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1228,14 +1228,12 @@ can override the working directory by using the **-w** option.
 #### **\-\-pidfile**=*path*
 
 When the pidfile location is specified, the container process' PID will be written to the pidfile. (This option is not available with the remote Podman client)
+If the pidfile option is not specified, the container process' PID will be written to /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
+
 After the container is started, the location for the pidfile can be discovered with the following `podman inspect` command:
 
-    $ podman inspect --format '{{ .Config.CreateCommand }}' $CID
-    podman run --pidfile $pidfilepath image
-
-If the pidfile option is not specified, the container process' PID will be written to
-/run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
-The default pidfile location is not listed in the `podman inspect` output.
+    $ podman inspect --format '{{ .PidFile }}' $CID
+    /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile
 
 
 ## EXAMPLES

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -149,6 +149,7 @@ Write the container ID to the file
 #### **\-\-conmon-pidfile**=*path*
 
 Write the pid of the `conmon` process to a file. `conmon` runs in a separate process than Podman, so this is necessary when using systemd to restart Podman containers.
+(This option is not available with the remote Podman client)
 
 #### **\-\-cpu-period**=*limit*
 
@@ -1226,9 +1227,15 @@ can override the working directory by using the **-w** option.
 
 #### **\-\-pidfile**=*path*
 
-Write the pid of the container process to a file.
+When the pidfile location is specified, the container process' PID will be written to the pidfile. (This option is not available with the remote Podman client)
+After the container is started, the location for the pidfile can be discovered with the following `podman inspect` command:
 
-The default pidfile is RunDir/pidfile.
+    $ podman inspect --format '{{ .Config.CreateCommand }}' $CID
+    podman run --pidfile $pidfilepath image
+
+If the pidfile option is not specified, the container process' PID will be written to
+/run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
+The default pidfile location is not listed in the `podman inspect` output.
 
 
 ## EXAMPLES

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1224,6 +1224,13 @@ The default working directory for running binaries within a container is the roo
 The image developer can set a different default with the WORKDIR instruction. The operator
 can override the working directory by using the **-w** option.
 
+#### **\-\-pidfile**=*path*
+
+Write the pid of the container process to a file.
+
+The default pidfile is RunDir/pidfile.
+
+
 ## EXAMPLES
 
 ### Create a container using a local image

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -167,6 +167,7 @@ Write the container ID to *file*.
 #### **\-\-conmon-pidfile**=*file*
 
 Write the pid of the **conmon** process to a file. As **conmon** runs in a separate process than Podman, this is necessary when using systemd to restart Podman containers.
+(This option is not available with the remote Podman client)
 
 #### **\-\-cpu-period**=*limit*
 
@@ -1307,9 +1308,16 @@ can override the working directory by using the **-w** option.
 
 #### **\-\-pidfile**=*path*
 
-Write the pid of the container process to a file.
+When the pidfile location is specified, the container process' PID will be written to the pidfile. (This option is not available with the remote Podman client)
+After the container is started, the location for the pidfile can be discovered with the following `podman inspect` command:
 
-The default pidfile is RunDir/pidfile.
+    $ podman inspect --format '{{ .Config.CreateCommand }}' $CID
+    podman run --pidfile $pidfilepath image
+
+If the pidfile option is not specified, the container process' PID will be written to
+/run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
+The default pidfile location is not listed in the `podman inspect` output.
+
 
 ## Exit Status
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1305,6 +1305,12 @@ The default working directory for running binaries within a container is the roo
 The image developer can set a different default with the WORKDIR instruction. The operator
 can override the working directory by using the **-w** option.
 
+#### **\-\-pidfile**=*path*
+
+Write the pid of the container process to a file.
+
+The default pidfile is RunDir/pidfile.
+
 ## Exit Status
 
 The exit code from **podman run** gives information about why the container

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1309,15 +1309,12 @@ can override the working directory by using the **-w** option.
 #### **\-\-pidfile**=*path*
 
 When the pidfile location is specified, the container process' PID will be written to the pidfile. (This option is not available with the remote Podman client)
+If the pidfile option is not specified, the container process' PID will be written to /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
+
 After the container is started, the location for the pidfile can be discovered with the following `podman inspect` command:
 
-    $ podman inspect --format '{{ .Config.CreateCommand }}' $CID
-    podman run --pidfile $pidfilepath image
-
-If the pidfile option is not specified, the container process' PID will be written to
-/run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
-The default pidfile location is not listed in the `podman inspect` output.
-
+    $ podman inspect --format '{{ .PidFile }}' $CID
+    /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile
 
 ## Exit Status
 

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -364,4 +364,6 @@ type ContainerMiscConfig struct {
 	Timezone string `json:"timezone,omitempty"`
 	// Umask is the umask inside the container.
 	Umask string `json:"umask,omitempty"`
+	// PidFile is the file that saves the pid of the container process
+	PidFile string `json:"pid_file,omitempty"`
 }

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -141,6 +141,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 		Mounts:          inspectMounts,
 		Dependencies:    c.Dependencies(),
 		IsInfra:         c.IsInfra(),
+		PidFile:         config.PidFile,
 	}
 
 	if c.state.ConfigPath != "" {

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -128,6 +128,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 		StaticDir:       config.StaticDir,
 		OCIRuntime:      config.OCIRuntime,
 		ConmonPidFile:   config.ConmonPidFile,
+		PidFile:         config.PidFile,
 		Name:            config.Name,
 		RestartCount:    int32(runtimeInfo.RestartCount),
 		Driver:          driverData.Name,
@@ -141,7 +142,6 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 		Mounts:          inspectMounts,
 		Dependencies:    c.Dependencies(),
 		IsInfra:         c.IsInfra(),
-		PidFile:         config.PidFile,
 	}
 
 	if c.state.ConfigPath != "" {

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -627,6 +627,7 @@ type InspectContainerData struct {
 	OCIConfigPath   string                      `json:"OCIConfigPath,omitempty"`
 	OCIRuntime      string                      `json:"OCIRuntime,omitempty"`
 	ConmonPidFile   string                      `json:"ConmonPidFile"`
+	PidFile         string                      `json:"PidFile"`
 	Name            string                      `json:"Name"`
 	RestartCount    int32                       `json:"RestartCount"`
 	Driver          string                      `json:"Driver"`
@@ -647,7 +648,6 @@ type InspectContainerData struct {
 	IsInfra         bool                        `json:"IsInfra"`
 	Config          *InspectContainerConfig     `json:"Config"`
 	HostConfig      *InspectContainerHostConfig `json:"HostConfig"`
-	PidFile         string                      `json:"PidFile"`
 }
 
 // InspectExecSession contains information about a given exec session.

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -647,6 +647,7 @@ type InspectContainerData struct {
 	IsInfra         bool                        `json:"IsInfra"`
 	Config          *InspectContainerConfig     `json:"Config"`
 	HostConfig      *InspectContainerHostConfig `json:"HostConfig"`
+	PidFile         string                      `json:"PidFile"`
 }
 
 // InspectExecSession contains information about a given exec session.

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1025,12 +1025,7 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 		}
 	}
 
-	pidfile := ctr.config.PidFile
-	if pidfile == "" {
-		pidfile = filepath.Join(ctr.state.RunDir, "pidfile")
-	}
-
-	args := r.sharedConmonArgs(ctr, ctr.ID(), ctr.bundlePath(), pidfile, ctr.LogPath(), r.exitsDir, ociLog, ctr.LogDriver(), logTag)
+	args := r.sharedConmonArgs(ctr, ctr.ID(), ctr.bundlePath(), ctr.config.PidFile, ctr.LogPath(), r.exitsDir, ociLog, ctr.LogDriver(), logTag)
 
 	if ctr.config.Spec.Process.Terminal {
 		args = append(args, "-t")

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1025,7 +1025,12 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 		}
 	}
 
-	args := r.sharedConmonArgs(ctr, ctr.ID(), ctr.bundlePath(), filepath.Join(ctr.state.RunDir, "pidfile"), ctr.LogPath(), r.exitsDir, ociLog, ctr.LogDriver(), logTag)
+	pidfile := ctr.config.PidFile
+	if pidfile == "" {
+		pidfile = filepath.Join(ctr.state.RunDir, "pidfile")
+	}
+
+	args := r.sharedConmonArgs(ctr, ctr.ID(), ctr.bundlePath(), pidfile, ctr.LogPath(), r.exitsDir, ociLog, ctr.LogDriver(), logTag)
 
 	if ctr.config.Spec.Process.Terminal {
 		args = append(args, "-t")

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1692,6 +1692,17 @@ func WithSecrets(secretNames []string) CtrCreateOption {
 	}
 }
 
+// WithPidFile adds pidFile to the container
+func WithPidFile(pidFile string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+		ctr.config.PidFile = pidFile
+		return nil
+	}
+}
+
 // Pod Creation Options
 
 // WithInfraImage sets the infra image for libpod.

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -69,6 +69,13 @@ func (r *Runtime) RestoreContainer(ctx context.Context, rSpec *spec.Spec, config
 		ctr.config.ConmonPidFile = ""
 	}
 
+	// If the path to PidFile starts with the default value (RunRoot), then
+	// the user has not specified '--pidfile' during run or create (probably).
+	// In that case reset PidFile to be set to the default value later.
+	if strings.HasPrefix(ctr.config.PidFile, r.storageConfig.RunRoot) {
+		ctr.config.PidFile = ""
+	}
+
 	return r.setupContainer(ctx, ctr)
 }
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -366,6 +366,10 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		ctr.config.ConmonPidFile = filepath.Join(ctr.state.RunDir, "conmon.pid")
 	}
 
+	if ctr.config.PidFile == "" {
+		ctr.config.PidFile = filepath.Join(ctr.state.RunDir, "pidfile")
+	}
+
 	// Go through named volumes and add them.
 	// If they don't exist they will be created using basic options.
 	// Maintain an array of them - we need to lock them later.

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -375,6 +375,9 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 		}
 		options = append(options, libpod.WithDependencyCtrs(deps))
 	}
+	if s.PidFile != "" {
+		options = append(options, libpod.WithPidFile(s.PidFile))
+	}
 	return options, nil
 }
 

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -171,6 +171,10 @@ type ContainerBasicConfig struct {
 	// container. Dependencies can be specified by name or full/partial ID.
 	// Optional.
 	DependencyContainers []string `json:"dependencyContainers,omitempty"`
+	// PidFile is the file that saves container process id.
+	// set tags as `json:"-"` for not supported remote
+	// Optional.
+	PidFile string `json:"-"`
 }
 
 // ContainerStorageConfig contains information on the storage configuration of a

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -508,4 +508,14 @@ var _ = Describe("Podman inspect", func() {
 		Expect(data[0].HostConfig.CapDrop[1]).To(Equal("CAP_MKNOD"))
 		Expect(data[0].HostConfig.CapDrop[2]).To(Equal("CAP_NET_RAW"))
 	})
+
+	It("podman inspect container with GO format for PidFile", func() {
+		SkipIfRemote("pidfile not handled by remote")
+		session, ec, _ := podmanTest.RunLsContainer("test1")
+		Expect(ec).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"inspect", "--format", "{{.PidFile}}", "test1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1613,4 +1613,12 @@ WORKDIR /madethis`, BB)
 		Expect(running.ExitCode()).To(Equal(0))
 		Expect(len(running.OutputToStringArray())).To(Equal(2))
 	})
+
+	It("podman run with pidfile", func() {
+		session := podmanTest.Podman([]string{"run", "--pidfile", tempdir + "pidfile", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		err := os.Remove(tempdir + "pidfile")
+		Expect(err).To(BeNil())
+	})
 })

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1615,10 +1615,18 @@ WORKDIR /madethis`, BB)
 	})
 
 	It("podman run with pidfile", func() {
-		session := podmanTest.Podman([]string{"run", "--pidfile", tempdir + "pidfile", ALPINE, "ls"})
+		SkipIfRemote("pidfile not handled by remote")
+		pidfile := tempdir + "pidfile"
+		session := podmanTest.Podman([]string{"run", "--pidfile", pidfile, ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		err := os.Remove(tempdir + "pidfile")
+		readFirstLine := func(path string) string {
+			content, err := ioutil.ReadFile(path)
+			Expect(err).To(BeNil())
+			return strings.Split(string(content), "\n")[0]
+		}
+		containerPID := readFirstLine(pidfile)
+		_, err = strconv.Atoi(containerPID) // Make sure it's a proper integer
 		Expect(err).To(BeNil())
 	})
 })

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -211,6 +211,7 @@ var _ = Describe("Podman start", func() {
 	})
 
 	It("podman start container with special pidfile", func() {
+		SkipIfRemote("pidfile not handled by remote")
 		pidfile := tempdir + "pidfile"
 		session := podmanTest.Podman([]string{"create", "--pidfile", pidfile, ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -1,7 +1,10 @@
 package integration
 
 import (
+	"io/ioutil"
 	"os"
+	"strconv"
+	"strings"
 
 	. "github.com/containers/podman/v3/test/utils"
 	. "github.com/onsi/ginkgo"
@@ -205,5 +208,24 @@ var _ = Describe("Podman start", func() {
 		session = podmanTest.Podman([]string{"start", "-l", "--sig-proxy"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(125))
+	})
+
+	It("podman start container with special pidfile", func() {
+		pidfile := tempdir + "pidfile"
+		session := podmanTest.Podman([]string{"create", "--pidfile", pidfile, ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+
+		session = podmanTest.Podman([]string{"start", cid})
+		Expect(session.ExitCode()).To(Equal(0))
+		readFirstLine := func(path string) string {
+			content, err := ioutil.ReadFile(path)
+			Expect(err).To(BeNil())
+			return strings.Split(string(content), "\n")[0]
+		}
+		containerPID := readFirstLine(pidfile)
+		_, err = strconv.Atoi(containerPID) // Make sure it's a proper integer
+		Expect(err).To(BeNil())
 	})
 })

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -219,6 +219,7 @@ var _ = Describe("Podman start", func() {
 		cid := session.OutputToString()
 
 		session = podmanTest.Podman([]string{"start", cid})
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		readFirstLine := func(path string) string {
 			content, err := ioutil.ReadFile(path)


### PR DESCRIPTION
Default the container process id will be writen into `/run/containers/storage/overlay-containers/$containerId/userdata/pidfile`

This change adds flag "--pidfile" for podman create/run. When specify pidfile, after podman creates or runs container successfully, the container process id will be writen into this file.

Closes #9992