### PR TITLE
add --ip to podman play kube

### DIFF
--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -65,6 +65,10 @@ func init() {
 	flags.StringVar(&kubeOptions.Network, networkFlagName, "", "Connect pod to CNI network(s)")
 	_ = kubeCmd.RegisterFlagCompletionFunc(networkFlagName, common.AutocompleteNetworkFlag)
 
+	staticIPFlagName := "ip"
+	flags.IPSliceVar(&kubeOptions.StaticIPs, staticIPFlagName, nil, "Static IP addresses to assign to the pods")
+	_ = kubeCmd.RegisterFlagCompletionFunc(staticIPFlagName, completion.AutocompleteNone)
+
 	logDriverFlagName := "log-driver"
 	flags.StringVar(&kubeOptions.LogDriver, logDriverFlagName, "", "Logging driver for the container")
 	_ = kubeCmd.RegisterFlagCompletionFunc(logDriverFlagName, common.AutocompleteLogDriver)

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -62,6 +62,10 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
+#### **\-\-ip**=*IP address*
+
+Assign a static ip address to the pod. This option can be specified several times when play kube creates more than one pod.
+
 #### **\-\-log-driver**=driver
 
 Set logging driver for all created containers.

--- a/pkg/api/server/register_play.go
+++ b/pkg/api/server/register_play.go
@@ -34,6 +34,12 @@ func (s *APIServer) registerPlayHandlers(r *mux.Router) error {
 	//    type: boolean
 	//    default: true
 	//    description: Start the pod after creating it.
+	//  - in: query
+	//    name: staticIPs
+	//    type: array
+	//    description: Static IPs used for the pods.
+	//    items:
+	//      type: string
 	//  - in: body
 	//    name: request
 	//    description: Kubernetes YAML file.

--- a/pkg/bindings/play/types.go
+++ b/pkg/bindings/play/types.go
@@ -1,5 +1,7 @@
 package play
 
+import "net"
+
 //go:generate go run ../generator/generator.go KubeOptions
 // KubeOptions are optional options for replaying kube YAML files
 type KubeOptions struct {
@@ -23,6 +25,8 @@ type KubeOptions struct {
 	// SeccompProfileRoot - path to a directory containing seccomp
 	// profiles.
 	SeccompProfileRoot *string
+	// StaticIPs - Static IP address used by the pod(s).
+	StaticIPs *[]net.IP
 	// ConfigMaps - slice of pathnames to kubernetes configmap YAMLs.
 	ConfigMaps *[]string
 	// LogDriver for the container. For example: journald

--- a/pkg/bindings/play/types_kube_options.go
+++ b/pkg/bindings/play/types_kube_options.go
@@ -1,6 +1,7 @@
 package play
 
 import (
+	"net"
 	"net/url"
 
 	"github.com/containers/podman/v3/pkg/bindings/internal/util"
@@ -162,6 +163,22 @@ func (o *KubeOptions) GetSeccompProfileRoot() string {
 		return seccompProfileRoot
 	}
 	return *o.SeccompProfileRoot
+}
+
+// WithStaticIPs
+func (o *KubeOptions) WithStaticIPs(value []net.IP) *KubeOptions {
+	v := &value
+	o.StaticIPs = v
+	return o
+}
+
+// GetStaticIPs
+func (o *KubeOptions) GetStaticIPs() []net.IP {
+	var staticIPs []net.IP
+	if o.StaticIPs == nil {
+		return staticIPs
+	}
+	return *o.StaticIPs
 }
 
 // WithConfigMaps

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -1,6 +1,10 @@
 package entities
 
-import "github.com/containers/image/v5/types"
+import (
+	"net"
+
+	"github.com/containers/image/v5/types"
+)
 
 // PlayKubeOptions controls playing kube YAML files.
 type PlayKubeOptions struct {
@@ -24,6 +28,8 @@ type PlayKubeOptions struct {
 	// SeccompProfileRoot - path to a directory containing seccomp
 	// profiles.
 	SeccompProfileRoot string
+	// StaticIPs - Static IP address used by the pod(s).
+	StaticIPs []net.IP
 	// ConfigMaps - slice of pathnames to kubernetes configmap YAMLs.
 	ConfigMaps []string
 	// LogDriver for the container. For example: journald

--- a/pkg/domain/infra/tunnel/play.go
+++ b/pkg/domain/infra/tunnel/play.go
@@ -11,7 +11,7 @@ import (
 func (ic *ContainerEngine) PlayKube(ctx context.Context, path string, opts entities.PlayKubeOptions) (*entities.PlayKubeReport, error) {
 	options := new(play.KubeOptions).WithAuthfile(opts.Authfile).WithUsername(opts.Username).WithPassword(opts.Password)
 	options.WithCertDir(opts.CertDir).WithQuiet(opts.Quiet).WithSignaturePolicy(opts.SignaturePolicy).WithConfigMaps(opts.ConfigMaps)
-	options.WithLogDriver(opts.LogDriver).WithNetwork(opts.Network).WithSeccompProfileRoot(opts.SeccompProfileRoot)
+	options.WithLogDriver(opts.LogDriver).WithNetwork(opts.Network).WithSeccompProfileRoot(opts.SeccompProfileRoot).WithStaticIPs(opts.StaticIPs)
 
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		options.WithSkipTLSVerify(s == types.OptionalBoolTrue)


### PR DESCRIPTION
Add a new --ip flag to podman play kube. This is used to specify a
static IP address which should be used for the pod. This option can be
specified several times because play kube can create more than pod.

Fixes #8442

Replaces #8617

Signed-off-by: Paul Holzinger <paul.holzinger@web.de>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
