### PR TITLE
podman play kube apply correct log driver

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -300,6 +300,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			RestartPolicy:  ctrRestartPolicy,
 			NetNSIsHost:    p.NetNS.IsHost(),
 			SecretsManager: secretsManager,
+			LogDriver:      options.LogDriver,
 		}
 		specGen, err := kube.ToSpecGen(ctx, &specgenOpts)
 		if err != nil {

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -98,6 +98,8 @@ type CtrSpecGenOptions struct {
 	NetNSIsHost bool
 	// SecretManager to access the secrets
 	SecretsManager *secrets.SecretsManager
+	// LogDriver which should be used for the container
+	LogDriver string
 }
 
 func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGenerator, error) {
@@ -114,6 +116,10 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	s.Terminal = opts.Container.TTY
 
 	s.Pod = opts.PodID
+
+	s.LogConfiguration = &specgen.LogConfig{
+		Driver: opts.LogDriver,
+	}
 
 	setupSecurityContext(s, opts.Container)
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1970,7 +1970,6 @@ MemoryReservation: {{ .HostConfig.MemoryReservation }}`})
 	})
 
 	It("podman play kube applies log driver to containers", func() {
-		Skip("need to verify images have correct packages for journald")
 		pod := getPod()
 		err := generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
The --log-driver flag was silently ignored by podman play kube. This
regression got introduced during the play kube rework.
Unfortunately the test for this was skipped for no good reason.

Fixes #10015

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
