### PR TITLE
Fix possible panic in libpod/image/prune.go

### DIFF
--- a/libpod/image/prune.go
+++ b/libpod/image/prune.go
@@ -134,10 +134,11 @@ func (ir *Runtime) PruneImages(ctx context.Context, all bool, filter []string) (
 			}
 			nameOrID := img.ID()
 			s, err := img.Size(ctx)
-			imgSize := *s
+			imgSize := uint64(0)
 			if err != nil {
 				logrus.Warnf("Failed to collect image size for: %s, %s", nameOrID, err)
-				imgSize = 0
+			} else {
+				imgSize = *s
 			}
 			if err := img.Remove(ctx, false); err != nil {
 				if errors.Cause(err) == storage.ErrImageUsedByContainer {


### PR DESCRIPTION
podman image prune paniced locally for me. The error handling was not
done correctly and we could end up with a nil pointer dereference.

[NO TEST NEEDED] I have no idea how I could force an error in img.Size().

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
