### PR TITLE
[NO TESTS NEEDED] Make an advanced layer diff function private

### DIFF
--- a/libpod/diff.go
+++ b/libpod/diff.go
@@ -1,8 +1,6 @@
 package libpod
 
 import (
-	"io"
-
 	"github.com/containers/podman/v3/libpod/layers"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/pkg/errors"
@@ -44,16 +42,6 @@ func (r *Runtime) GetDiff(from, to string) ([]archive.Change, error) {
 		}
 	}
 	return rchanges, err
-}
-
-// ApplyDiffTarStream applies the changes stored in 'diff' to the layer 'to'
-func (r *Runtime) ApplyDiffTarStream(to string, diff io.Reader) error {
-	toLayer, err := r.getLayerID(to)
-	if err != nil {
-		return err
-	}
-	_, err = r.store.ApplyDiff(toLayer, diff)
-	return err
 }
 
 // GetLayerID gets a full layer id given a full or partial id


### PR DESCRIPTION
Noticed this while I was poking around in the runtime doing DB work. The signature of this function makes me a bit uncomfortable (why should we let people apply arbitrary diffs to layers? Seems like a good way to break things...) and it's completely unused, so make it private to remove from our public API.
