### PR TITLE
Change log message in findRuntime()

### DIFF
--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -606,7 +606,7 @@ func (c *EngineConfig) findRuntime() string {
 			}
 		}
 		if path, err := exec.LookPath(name); err == nil {
-			logrus.Warningf("Found default OCIruntime %s path which is missing from [engine.runtimes] in containers.conf", path)
+			logrus.Tracef("Found default OCIruntime %s path via PATH environment variable", path)
 			return name
 		}
 	}


### PR DESCRIPTION
Rephrase the log message and change the log level from
"warning" to "trace".

My comment https://github.com/containers/podman/issues/9389#issuecomment-782888578
explains why the log message
```
logrus.Warningf("Found default OCIruntime %s path which is missing from [engine.runtimes] in containers.conf", path)
```

 does not make sense.

(I don't know if it should be %s or %q in the format string. It was %s before so I left it like that)

Fixes #9389

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
