### PR TITLE
[CI:DOCS] Add support for `podman login --verbose`

### DIFF
--- a/docs/source/markdown/podman-login.1.md
+++ b/docs/source/markdown/podman-login.1.md
@@ -111,6 +111,14 @@ $ echo $testpassword | podman login -u testuser --password-stdin docker.io
 Login Succeeded!
 ```
 
+```
+$ podman login quay.io --verbose
+Username: myusername
+Password:
+Used: /run/user/1000/containers/auth.json
+Login Succeeded!
+```
+
 ## SEE ALSO
 podman(1), podman-logout(1), containers-auth.json(5), containers-certs.d(5), containers-registries.conf(5)
 


### PR DESCRIPTION
Reference Issue: https://github.com/containers/podman/issues/6717
Depends on PR:  https://github.com/containers/image/pull/1204 and https://github.com/containers/common/pull/607

**NOTE**: Following PR should be only merged when https://github.com/containers/image/pull/1204 & https://github.com/containers/common/pull/607 is merged in upstream and master is rebased.

Sample output
```bash
./podman login quay.io -v
Username: flouthoc
Password: 
Modified: /run/user/1000/containers/auth.json
Login Succeeded!
```