### PR TITLE
Ensure mount destination is clean, no trailing slash

### DIFF
--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -57,10 +57,13 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 	}
 
 	for _, m := range s.Mounts {
-		if _, ok := unifiedMounts[m.Destination]; ok {
-			return nil, nil, nil, errors.Wrapf(errDuplicateDest, "conflict in specified mounts - multiple mounts at %q", m.Destination)
+		// Ensure that mount dest is clean, so that it can be
+		// compared against named volumes and avoid duplicate mounts.
+		cleanDestination := filepath.Clean(m.Destination)
+		if _, ok := unifiedMounts[cleanDestination]; ok {
+			return nil, nil, nil, errors.Wrapf(errDuplicateDest, "conflict in specified mounts - multiple mounts at %q", cleanDestination)
 		}
-		unifiedMounts[m.Destination] = m
+		unifiedMounts[cleanDestination] = m
 	}
 
 	for _, m := range commonMounts {


### PR DESCRIPTION
HostPath volumes specified in kube Pod YAMLs were not being cleaned (remove trailing slash), while named volumes specified in Dockerfiles / Containerfiles with the VOLUME instruction were being cleaned. This provoked that two volumes were mounted because the destination was not the same due to the trailing slash.

Fix #9618 

Signed-off-by: Eduardo Vega <edvegavalerio@gmail.com>
