### PR TITLE
Fix podman ps --filter ancestor to match exact ImageName/ImageID

### DIFF
--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -83,7 +83,19 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 		return func(c *libpod.Container) bool {
 			for _, filterValue := range filterValues {
 				containerConfig := c.Config()
-				if strings.Contains(containerConfig.RootfsImageID, filterValue) || strings.Contains(containerConfig.RootfsImageName, filterValue) {
+				var imageTag string
+				var imageNameWithoutTag string
+				// Compare with ImageID, ImageName
+				// Will match ImageName if running image has tag latest for other tags exact complete filter must be given
+				imageNameSlice := strings.SplitN(containerConfig.RootfsImageName, ":", 2)
+				if len(imageNameSlice) == 2 {
+					imageNameWithoutTag = imageNameSlice[0]
+					imageTag = imageNameSlice[1]
+				}
+
+				if (containerConfig.RootfsImageID == filterValue) ||
+					(containerConfig.RootfsImageName == filterValue) ||
+					(imageNameWithoutTag == filterValue && imageTag == "latest") {
 					return true
 				}
 			}

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -269,6 +269,12 @@ var _ = Describe("Podman ps", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(result.OutputToString()).To(Equal(cid))
+
+		// Query by trunctated image name should not match ( should return empty output )
+		result = podmanTest.Podman([]string{"ps", "-q", "--no-trunc", "-a", "--filter", "ancestor=quay.io/libpod/alpi"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(result.OutputToString()).To(Equal(""))
 	})
 
 	It("podman ps id filter flag", func() {


### PR DESCRIPTION
Reference Issue: https://github.com/containers/podman/issues/10066

Following PR brings parity between how `docker` and `podman` behaves to `ps --filter ancestor=`. Fix for https://github.com/containers/podman/issues/10066

