### PR TITLE
podman-remote should show podman.sock info

### DIFF
--- a/pkg/api/handlers/libpod/info.go
+++ b/pkg/api/handlers/libpod/info.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/containers/podman/v3/libpod"
 	"github.com/containers/podman/v3/pkg/api/handlers/utils"
+	"github.com/containers/podman/v3/pkg/domain/infra/abi"
 )
 
 func GetInfo(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
-	info, err := runtime.Info()
+	containerEngine := abi.ContainerEngine{Libpod: runtime}
+	info, err := containerEngine.Info(r.Context())
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -32,17 +32,11 @@ func (ic *ContainerEngine) Info(ctx context.Context) (*define.Info, error) {
 	if err != nil {
 		return nil, err
 	}
-	xdg, err := util.GetRuntimeDir()
+
+	socketPath, err := util.SocketPath()
 	if err != nil {
 		return nil, err
 	}
-	if len(xdg) == 0 {
-		// If no xdg is returned, assume root socket
-		xdg = "/run"
-	}
-
-	// Glue the socket path together
-	socketPath := filepath.Join(xdg, "podman", "podman.sock")
 	rs := define.RemoteSocket{
 		Path:   socketPath,
 		Exists: false,

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -706,3 +706,26 @@ func IDtoolsToRuntimeSpec(idMaps []idtools.IDMap) (convertedIDMap []specs.LinuxI
 	}
 	return convertedIDMap
 }
+
+var socketPath string
+
+func SetSocketPath(path string) {
+	socketPath = path
+}
+
+func SocketPath() (string, error) {
+	if socketPath != "" {
+		return socketPath, nil
+	}
+	xdg, err := GetRuntimeDir()
+	if err != nil {
+		return "", err
+	}
+	if len(xdg) == 0 {
+		// If no xdg is returned, assume root socket
+		xdg = "/run"
+	}
+
+	// Glue the socket path together
+	return filepath.Join(xdg, "podman", "podman.sock"), nil
+}

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -109,4 +109,19 @@ var _ = Describe("Podman Info", func() {
 		Expect(err).To(BeNil())
 		Expect(string(out)).To(Equal(expect))
 	})
+
+	It("podman info check RemoteSocket", func() {
+		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.RemoteSocket.Path}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(MatchRegexp("/run/.*podman.*sock"))
+
+		if IsRemote() {
+			session = podmanTest.Podman([]string{"info", "--format", "{{.Host.RemoteSocket.Exists}}"})
+			session.WaitWithDefaultTimeout()
+			Expect(session.ExitCode()).To(Equal(0))
+			Expect(session.OutputToString()).To(ContainSubstring("true"))
+		}
+	})
+
 })


### PR DESCRIPTION
Currently podman-remote info does not show socket information.

Fixes: https://github.com/containers/podman/issues/10077

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
