### PR TITLE
[CI:DOCS] Add missing dash to verbose option

### DIFF
--- a/docs/source/markdown/podman-import.1.md
+++ b/docs/source/markdown/podman-import.1.md
@@ -34,7 +34,7 @@ Set commit message for imported image
 
 Shows progress on the import
 
-**-verbose**
+**\-\-verbose**
 
 Print additional debugging information
 


### PR DESCRIPTION
The `--verbose` option in the import man page was
missing a dash, this corrects it.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
