### PR TITLE
Add --noheading flag to all list commands

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -97,6 +97,7 @@ func listFlagSet(cmd *cobra.Command) {
 	flags.BoolVar(&noTrunc, "no-trunc", false, "Display the extended information")
 	flags.BoolVarP(&listOpts.Pod, "pod", "p", false, "Print the ID and name of the pod the containers are associated with")
 	flags.BoolVarP(&listOpts.Quiet, "quiet", "q", false, "Print the numeric IDs of the containers only")
+	flags.Bool("noheading", false, "Do not print headers")
 	flags.BoolVarP(&listOpts.Size, "size", "s", false, "Display the total file sizes")
 	flags.BoolVar(&listOpts.Sync, "sync", false, "Sync container state with OCI runtime")
 
@@ -242,7 +243,8 @@ func ps(cmd *cobra.Command, _ []string) error {
 	defer w.Flush()
 
 	headers := func() error { return nil }
-	if !(listOpts.Quiet || cmd.Flags().Changed("format")) {
+	noHeading, _ := cmd.Flags().GetBool("noheading")
+	if !(noHeading || listOpts.Quiet || cmd.Flags().Changed("format")) {
 		headers = func() error {
 			return tmpl.Execute(w, hdrs)
 		}

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -61,6 +61,7 @@ func init() {
 	formatFlagName := "format"
 	flags.StringVar(&listFlag.format, formatFlagName, "{{.Name}}\t{{.VMType}}\t{{.Created}}\t{{.LastUp}}\n", "Format volume output using Go template")
 	_ = lsCmd.RegisterFlagCompletionFunc(formatFlagName, completion.AutocompleteNone)
+	flags.BoolVar(&listFlag.noHeading, "noheading", false, "Do not print headers")
 }
 
 func list(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -48,6 +48,7 @@ func networkListFlags(flags *pflag.FlagSet) {
 
 	filterFlagName := "filter"
 	flags.StringArrayVarP(&filters, filterFlagName, "f", nil, "Provide filter values (e.g. 'name=podman')")
+	flags.Bool("noheading", false, "Do not print headers")
 	_ = networklistCommand.RegisterFlagCompletionFunc(filterFlagName, common.AutocompleteNetworkFilters)
 }
 
@@ -140,7 +141,8 @@ func templateOut(responses []*entities.NetworkListReport, cmd *cobra.Command) er
 	w := tabwriter.NewWriter(os.Stdout, 8, 2, 2, ' ', 0)
 	defer w.Flush()
 
-	if renderHeaders {
+	noHeading, _ := cmd.Flags().GetBool("noheading")
+	if !noHeading && renderHeaders {
 		if err := tmpl.Execute(w, headers); err != nil {
 			return err
 		}

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -63,6 +63,7 @@ func init() {
 	flags.StringVar(&psInput.Format, formatFlagName, "", "Pretty-print pods to JSON or using a Go template")
 	_ = psCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteJSONFormat)
 
+	flags.Bool("noheading", false, "Do not print headers")
 	flags.BoolVar(&psInput.Namespace, "namespace", false, "Display namespace information of the pod")
 	flags.BoolVar(&psInput.Namespace, "ns", false, "Display namespace information of the pod")
 	flags.BoolVar(&noTrunc, "no-trunc", false, "Do not truncate pod and container IDs")
@@ -133,6 +134,10 @@ func pods(cmd *cobra.Command, _ []string) error {
 	if cmd.Flags().Changed("format") {
 		renderHeaders = parse.HasTable(psInput.Format)
 		row = report.NormalizeFormat(psInput.Format)
+	}
+	noHeading, _ := cmd.Flags().GetBool("noheading")
+	if noHeading {
+		renderHeaders = false
 	}
 	format := parse.EnforceRange(row)
 

--- a/cmd/podman/secrets/list.go
+++ b/cmd/podman/secrets/list.go
@@ -48,6 +48,7 @@ func init() {
 	formatFlagName := "format"
 	flags.StringVar(&listFlag.format, formatFlagName, "{{.ID}}\t{{.Name}}\t{{.Driver}}\t{{.CreatedAt}}\t{{.UpdatedAt}}\t\n", "Format volume output using Go template")
 	_ = lsCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteJSONFormat)
+	flags.BoolVar(&listFlag.noHeading, "noheading", false, "Do not print headers")
 }
 
 func ls(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -62,6 +62,7 @@ func init() {
 	flags.StringVar(&cliOpts.Format, formatFlagName, "{{.Driver}}\t{{.Name}}\n", "Format volume output using Go template")
 	_ = lsCommand.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteJSONFormat)
 
+	flags.Bool("noheading", false, "Do not print headers")
 	flags.BoolVarP(&cliOpts.Quiet, "quiet", "q", false, "Print volume output in quiet mode")
 }
 
@@ -94,6 +95,7 @@ func list(cmd *cobra.Command, args []string) error {
 }
 
 func outputTemplate(cmd *cobra.Command, responses []*entities.VolumeListReport) error {
+	noHeading, _ := cmd.Flags().GetBool("noheading")
 	headers := report.Headers(entities.VolumeListReport{}, map[string]string{
 		"Name": "VOLUME NAME",
 	})
@@ -111,7 +113,7 @@ func outputTemplate(cmd *cobra.Command, responses []*entities.VolumeListReport) 
 	w := tabwriter.NewWriter(os.Stdout, 12, 2, 2, ' ', 0)
 	defer w.Flush()
 
-	if !cliOpts.Quiet && !cmd.Flag("format").Changed {
+	if !(noHeading || cliOpts.Quiet || cmd.Flag("format").Changed) {
 		if err := tmpl.Execute(w, headers); err != nil {
 			return errors.Wrapf(err, "failed to write report column headers")
 		}

--- a/docs/source/markdown/podman-machine-list.1.md
+++ b/docs/source/markdown/podman-machine-list.1.md
@@ -35,6 +35,10 @@ Valid placeholders for the Go template are listed below:
 
 Print usage statement.
 
+#### **\-\-noheading**
+
+Omit the table headings from the listing of pods.
+
 ## EXAMPLES
 
 ```

--- a/docs/source/markdown/podman-network-ls.1.md
+++ b/docs/source/markdown/podman-network-ls.1.md
@@ -41,6 +41,10 @@ Valid placeholders for the Go template are listed below:
 | .Labels         | Network labels                  |
 | .Version        | CNI Version of the config file	|
 
+#### **\-\-noheading**
+
+Omit the table headings from the listing of networks.
+
 #### **\-\-no-trunc**
 
 Do not truncate the network ID. The network ID is not displayed by default and must be specified with **\-\-format**.

--- a/docs/source/markdown/podman-pod-ps.1.md
+++ b/docs/source/markdown/podman-pod-ps.1.md
@@ -42,6 +42,10 @@ Includes the container statuses in the container info field
 
 Show the latest pod created (all states) (This option is not available with the remote Podman client)
 
+#### **\-\-noheading**
+
+Omit the table headings from the listing of pods.
+
 #### **\-\-no-trunc**
 
 Display the extended information

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -100,6 +100,10 @@ Show the latest container created (all states) (This option is not available wit
 
 Display namespace information
 
+#### **\-\-noheading**
+
+Omit the table headings from the listing of containers.
+
 #### **\-\-no-trunc**
 
 Display the extended information

--- a/docs/source/markdown/podman-secret-ls.1.md
+++ b/docs/source/markdown/podman-secret-ls.1.md
@@ -16,6 +16,10 @@ Lists all the secrets that exist. The output can be formatted to a Go template u
 
 Format secret output using Go template.
 
+#### **\-\-noheading**
+
+Omit the table headings from the listing of secrets.	.
+
 ## EXAMPLES
 
 ```

--- a/docs/source/markdown/podman-volume-ls.1.md
+++ b/docs/source/markdown/podman-volume-ls.1.md
@@ -26,6 +26,10 @@ Format volume output using Go template.
 
 Print usage statement.
 
+#### **\-\-noheading**
+
+Omit the table headings from the listing of volumes.
+
 #### **\-\-quiet**, **-q**
 
 Print volume output in quiet mode. Only print the volume names.

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -5,6 +5,9 @@ load helpers
 @test "podman ps - basic tests" {
     rand_name=$(random_string 30)
 
+    run_podman ps --noheading
+    is "$output" "" "baseline: empty results from ps --noheading"
+
     run_podman run -d --name $rand_name $IMAGE sleep 5
     cid=$output
     is "$cid" "[0-9a-f]\{64\}$"
@@ -29,8 +32,6 @@ load helpers
     is "${lines[1]}" \
        "${cid:0:12} \+$IMAGE *sleep .* Exited .* $rand_name" \
        "podman ps -a"
-
-
 
     run_podman rm $cid
 }

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -23,6 +23,9 @@ function teardown() {
 @test "podman run --volumes : basic" {
     skip_if_remote "volumes cannot be shared across hosts"
 
+    run_podman volume list --noheading
+    is "$output" "" "baseline: empty results from list --noheading"
+
     # Create three temporary directories
     vol1=${PODMAN_TMPDIR}/v1_$(random_string)
     vol2=${PODMAN_TMPDIR}/v2_$(random_string)

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -17,6 +17,17 @@ function teardown() {
 }
 
 
+@test "podman pod - basic tests" {
+    run_podman pod list --noheading
+    is "$output" "" "baseline: empty results from list --noheading"
+
+    run_podman pod ls --noheading
+    is "$output" "" "baseline: empty results from ls --noheading"
+
+    run_podman pod ps --noheading
+    is "$output" "" "baseline: empty results from ps --noheading"
+}
+
 @test "podman pod top - containers in different PID namespaces" {
     # With infra=false, we don't get a /pause container (we also
     # don't pull k8s.gcr.io/pause )

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -5,6 +5,19 @@
 
 load helpers
 
+@test "podman network - basic tests" {
+    heading="*NETWORK*ID*NAME*VERSION*PLUGINS*"
+    run_podman network ls
+    if  [[ ${output} != ${heading} ]]; then
+       die "network ls expected heading is not available"
+    fi
+
+    run_podman network ls --noheading
+    if  [[ ${output} = ${heading} ]]; then
+       die "network ls --noheading did not remove heading: $output"
+    fi
+}
+
 # Copied from tsweeney's https://github.com/containers/podman/issues/4827
 @test "podman networking: port on localhost" {
     skip_if_remote "FIXME: reevaluate this one after #7360 is fixed"
@@ -20,9 +33,9 @@ load helpers
 
     # Bind-mount this file with a different name to a container running httpd
     run_podman run -d --name myweb -p "$HOST_PORT:80" \
-               -v $INDEX1:/var/www/index.txt \
-               -w /var/www \
-               $IMAGE /bin/busybox-extras httpd -f -p 80
+	       -v $INDEX1:/var/www/index.txt \
+	       -w /var/www \
+	       $IMAGE /bin/busybox-extras httpd -f -p 80
     cid=$output
 
     # In that container, create a second file, using exec and redirection
@@ -71,7 +84,7 @@ load helpers
     # We could get more parseable output by using $NCAT_REMOTE_ADDR,
     # but busybox nc doesn't support that.
     run_podman run -d --userns=keep-id -p 127.0.0.1:$myport:$myport \
-               $IMAGE nc -l -n -v -p $myport
+	       $IMAGE nc -l -n -v -p $myport
     cid="$output"
 
     # emit random string, and check it
@@ -108,7 +121,7 @@ load helpers
     # (Assert that output is formatted, not a one-line blob: #8011)
     run_podman network inspect $mynetname
     if [[ "${#lines[*]}" -lt 5 ]]; then
-        die "Output from 'pod inspect' is only ${#lines[*]} lines; see #8011"
+	die "Output from 'pod inspect' is only ${#lines[*]} lines; see #8011"
     fi
 
     run_podman run --rm --network $mynetname $IMAGE ip a
@@ -116,7 +129,7 @@ load helpers
        "sdfsdf"
 
     run_podman run --rm -d --network $mynetname -p 127.0.0.1:$myport:$myport \
-               $IMAGE nc -l -n -v -p $myport
+	       $IMAGE nc -l -n -v -p $myport
     cid="$output"
 
     # emit random string, and check it
@@ -159,9 +172,9 @@ load helpers
 
     # Bind-mount this file with a different name to a container running httpd
     run_podman run -d --name myweb -p "$HOST_PORT:80" \
-               -v $INDEX1:/var/www/index.txt \
-               -w /var/www \
-               $IMAGE /bin/busybox-extras httpd -f -p 80
+	       -v $INDEX1:/var/www/index.txt \
+	       -w /var/www \
+	       $IMAGE /bin/busybox-extras httpd -f -p 80
     cid=$output
 
     run_podman inspect $cid --format "{{.NetworkSettings.IPAddress}}"
@@ -179,7 +192,7 @@ load helpers
     # check that we cannot curl (timeout after 5 sec)
     run timeout 5 curl -s $SERVER/index.txt
     if [ "$status" -ne 124 ]; then
-        die "curl did not timeout, status code: $status"
+	die "curl did not timeout, status code: $status"
     fi
 
     # reload the network to recreate the iptables rules


### PR DESCRIPTION
Currently we have only podman images list --noheading.
This PR Adds this option to volumes, containers, pods, networks,
machines, and secrets.

Fixes: https://github.com/containers/podman/issues/10065

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
