### PR TITLE
corrupt-image test: fix an oops

### DIFF
--- a/test/system/330-corrupt-images.bats
+++ b/test/system/330-corrupt-images.bats
@@ -77,7 +77,7 @@ function _corrupt_image_test() {
 
         # Run the requested command. Confirm it succeeds, with suitable warnings
         run_podman $*
-        is "$output" ".*error determining parent of image" \
+        is "$output" ".*error determining parent of image.*ignoring the error" \
            "$* with missing $what_to_rm"
 
         run_podman images -a --noheading
@@ -117,7 +117,7 @@ function _corrupt_image_test() {
 }
 
 @test "podman corrupt images - system reset" {
-    _corrupt_image_test "image prune -a -f"
+    _corrupt_image_test "system reset -f"
 }
 
 # END   actual tests


### PR DESCRIPTION
Followup to #10033: actually implement the system reset test.
And, just out of paranoia, extend the warning-message check.

Signed-off-by: Ed Santiago <santiago@redhat.com>
