### PR TITLE
[CI:DOCS] Typo fix to usage text of --compress option

### DIFF
--- a/docs/source/markdown/podman-save.1.md
+++ b/docs/source/markdown/podman-save.1.md
@@ -27,7 +27,7 @@ Note: `:` is a restricted character and cannot be part of the file name.
 #### **\-\-compress**
 
 Compress tarball image layers when pushing to a directory using the 'dir' transport. (default is same compression type, compressed or uncompressed, as source)
-Note: This flag can only be set when using the **dir** transport i.e --format=oci-dir or --format-docker-dir
+Note: This flag can only be set when using the **dir** transport i.e --format=oci-dir or --format=docker-dir
 
 #### **\-\-output**, **-o**=*file*
 


### PR DESCRIPTION
Correction of `--format-docker-dir` in to `--format=docker-dir`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
