### PR TITLE
Add podman run --timeout option

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -651,7 +651,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	createFlags.UintVar(
 		&cf.StopTimeout,
 		stopTimeoutFlagName, containerConfig.Engine.StopTimeout,
-		"Timeout (in seconds) to stop a container. Default is 10",
+		"Timeout (in seconds) that containers stopped by user command have to exit. If exceeded, the container will be forcibly stopped via SIGKILL.",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(stopTimeoutFlagName, completion.AutocompleteNone)
 
@@ -696,6 +696,14 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 		`Run container in systemd mode ("true"|"false"|"always")`,
 	)
 	_ = cmd.RegisterFlagCompletionFunc(systemdFlagName, AutocompleteSystemdFlag)
+
+	timeoutFlagName := "timeout"
+	createFlags.UintVar(
+		&cf.Timeout,
+		timeoutFlagName, 0,
+		"Maximum length of time a container is allowed to run. The container will be killed automatically after the time expires.",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(timeoutFlagName, completion.AutocompleteNone)
 
 	tmpfsFlagName := "tmpfs"
 	createFlags.StringArrayVar(

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -108,6 +108,7 @@ type ContainerCLIOpts struct {
 	SubGIDName        string
 	Sysctl            []string
 	Systemd           string
+	Timeout           uint
 	TmpFS             []string
 	TTY               bool
 	Timezone          string

--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -641,6 +641,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	}
 	s.Remove = c.Rm
 	s.StopTimeout = &c.StopTimeout
+	s.Timeout = c.Timeout
 	s.Timezone = c.Timezone
 	s.Umask = c.Umask
 	s.Secrets = c.Secrets

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -72,7 +72,8 @@ func stopFlags(cmd *cobra.Command) {
 		_ = flags.MarkHidden("cidfile")
 		_ = flags.MarkHidden("ignore")
 	}
-	flags.SetNormalizeFunc(utils.AliasFlags)
+
+	flags.SetNormalizeFunc(utils.TimeoutAliasFlags)
 }
 
 func init() {

--- a/cmd/podman/generate/systemd.go
+++ b/cmd/podman/generate/systemd.go
@@ -74,7 +74,7 @@ func init() {
 	flags.StringVar(&format, formatFlagName, "", "Print the created units in specified format (json)")
 	_ = systemdCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(nil))
 
-	flags.SetNormalizeFunc(utils.AliasFlags)
+	flags.SetNormalizeFunc(utils.TimeoutAliasFlags)
 }
 
 func systemd(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/utils/alias.go
+++ b/cmd/podman/utils/alias.go
@@ -17,8 +17,6 @@ func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "health-timeout"
 	case "net":
 		name = "network"
-	case "timeout":
-		name = "time"
 	case "namespace":
 		name = "ns"
 	case "storage":
@@ -31,6 +29,15 @@ func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "os"
 	case "override-variant":
 		name = "variant"
+	}
+	return pflag.NormalizedName(name)
+}
+
+// TimeoutAliasFlags is a function to handle backwards compatibility with old timeout flags
+func TimeoutAliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	switch name {
+	case "timeout":
+		name = "time"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -951,6 +951,12 @@ The `container_manage_cgroup` boolean must be enabled for this to be allowed on 
 
 `setsebool -P container_manage_cgroup true`
 
+#### **\-\-timeout**=*seconds*
+
+Maximimum time a container is allowed to run before conmon sends it the kill
+signal.  By default containers will run until they exit or are stopped by
+`podman stop`.
+
 #### **\-\-tmpfs**=*fs*
 
 Create a tmpfs mount

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1024,6 +1024,12 @@ The **container_manage_cgroup** boolean must be enabled for this to be allowed o
 setsebool -P container_manage_cgroup true
 ```
 
+#### **\-\-timeout**=*seconds*
+
+Maximimum time a container is allowed to run before conmon sends it the kill
+signal.  By default containers will run until they exit or are stopped by
+`podman stop`.
+
 #### **\-\-tmpfs**=*fs*
 
 Create a tmpfs mount.

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -298,6 +298,8 @@ type ContainerMiscConfig struct {
 	StopSignal uint `json:"stopSignal,omitempty"`
 	// StopTimeout is the signal that will be used to stop the container
 	StopTimeout uint `json:"stopTimeout,omitempty"`
+	// Timeout is maximimum time a container will run before getting the kill signal
+	Timeout uint `json:"timeout,omitempty"`
 	// Time container was created
 	CreatedTime time.Time `json:"createdTime"`
 	// CgroupManager is the cgroup manager used to create this container.

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -304,6 +304,8 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 		ctrConfig.WorkingDir = spec.Process.Cwd
 	}
 
+	ctrConfig.StopTimeout = c.config.StopTimeout
+	ctrConfig.Timeout = c.config.Timeout
 	ctrConfig.OpenStdin = c.config.Stdin
 	ctrConfig.Image = c.config.RootfsImageName
 	ctrConfig.SystemdMode = c.config.Systemd

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -64,6 +64,10 @@ type InspectContainerConfig struct {
 	Umask string `json:"Umask,omitempty"`
 	// Secrets are the secrets mounted in the container
 	Secrets []*InspectSecret `json:"Secrets,omitempty"`
+	// Timeout is time before container is killed by conmon
+	Timeout uint `json:"Timeout"`
+	// StopTimeout is time before container is stoped when calling stop
+	StopTimeout uint `json:"StopTimeout"`
 }
 
 // InspectRestartPolicy holds information about the container's restart policy.

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1024,6 +1024,10 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 		args = append(args, "-i")
 	}
 
+	if ctr.config.Timeout > 0 {
+		args = append(args, fmt.Sprintf("--timeout=%d", ctr.config.Timeout))
+	}
+
 	if !r.enableKeyring {
 		args = append(args, "--no-new-keyring")
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -758,6 +758,19 @@ func WithStopTimeout(timeout uint) CtrCreateOption {
 	}
 }
 
+// WithTimeout sets the maximum time a container is allowed to run"
+func WithTimeout(timeout uint) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.Timeout = timeout
+
+		return nil
+	}
+}
+
 // WithIDMappings sets the idmappings for the container
 func WithIDMappings(idmappings storage.IDMappingOptions) CtrCreateOption {
 	return func(ctr *Container) error {

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -292,6 +292,9 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 	if s.StopTimeout != nil {
 		options = append(options, libpod.WithStopTimeout(*s.StopTimeout))
 	}
+	if s.Timeout != 0 {
+		options = append(options, libpod.WithTimeout(s.Timeout))
+	}
 	if s.LogConfiguration != nil {
 		if len(s.LogConfiguration.Path) > 0 {
 			options = append(options, libpod.WithLogPath(s.LogConfiguration.Path))

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -83,6 +83,11 @@ type ContainerBasicConfig struct {
 	// instead.
 	// Optional.
 	StopTimeout *uint `json:"stop_timeout,omitempty"`
+	// Timeout is a maximum time in seconds the container will run before
+	// main process is sent SIGKILL.
+	// If 0 is used, signal will not be sent. Container can run indefinitely
+	// Optional.
+	Timeout uint `json:"timeout,omitempty"`
 	// LogConfiguration describes the logging for a container including
 	// driver, path, and options.
 	// Optional

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Podman generate systemd", func() {
 		n.WaitWithDefaultTimeout()
 		Expect(n.ExitCode()).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"generate", "systemd", "--timeout", "42", "--name", "--new", "foo"})
+		session := podmanTest.Podman([]string{"generate", "systemd", "--time", "42", "--name", "--new", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 


### PR DESCRIPTION
This option allows users to specify the maximum amount of time to run
before conmon sends the kill signal to the container.

Fixes: https://github.com/containers/podman/issues/6412

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
