### PR TITLE
Parse slirp4netns net options with compat api

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -252,21 +252,24 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, cgroup
 		return nil, nil, err
 	}
 
-	netNS := specgen.Namespace{
-		NSMode: nsmode.NSMode,
-		Value:  nsmode.Value,
+	var netOpts map[string][]string
+	parts := strings.SplitN(string(cc.HostConfig.NetworkMode), ":", 2)
+	if len(parts) > 1 {
+		netOpts = make(map[string][]string)
+		netOpts[parts[0]] = strings.Split(parts[1], ",")
 	}
 
 	// network
 	// Note: we cannot emulate compat exactly here. we only allow specifics of networks to be
 	// defined when there is only one network.
 	netInfo := entities.NetOptions{
-		AddHosts:     cc.HostConfig.ExtraHosts,
-		DNSOptions:   cc.HostConfig.DNSOptions,
-		DNSSearch:    cc.HostConfig.DNSSearch,
-		DNSServers:   dns,
-		Network:      netNS,
-		PublishPorts: specPorts,
+		AddHosts:       cc.HostConfig.ExtraHosts,
+		DNSOptions:     cc.HostConfig.DNSOptions,
+		DNSSearch:      cc.HostConfig.DNSSearch,
+		DNSServers:     dns,
+		Network:        nsmode,
+		PublishPorts:   specPorts,
+		NetworkOptions: netOpts,
 	}
 
 	// network names

--- a/test/compose/slirp4netns_opts/docker-compose.yml
+++ b/test/compose/slirp4netns_opts/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  alpine:
+    image: alpine
+    network_mode: "slirp4netns:allow_host_loopback=true"
+    command: sh -c "echo teststring | nc 10.0.2.2 5001"

--- a/test/compose/slirp4netns_opts/setup.sh
+++ b/test/compose/slirp4netns_opts/setup.sh
@@ -1,0 +1,8 @@
+# -*- bash -*-
+
+# create tempfile to store nc output
+OUTFILE=$(mktemp)
+# listen on a port, the container will try to connect to it
+nc -l 5001 > $OUTFILE &
+
+nc_pid=$!

--- a/test/compose/slirp4netns_opts/teardown.sh
+++ b/test/compose/slirp4netns_opts/teardown.sh
@@ -1,0 +1,4 @@
+# -*- bash -*-
+
+kill $nc_pid &> /dev/null
+rm -f $OUTFILE

--- a/test/compose/slirp4netns_opts/tests.sh
+++ b/test/compose/slirp4netns_opts/tests.sh
@@ -1,0 +1,6 @@
+# -*- bash -*-
+
+output="$(cat $OUTFILE)"
+expected="teststring"
+
+is "$output" "$expected" "$testname : nc received teststring"


### PR DESCRIPTION
Parse the slirp4netns network options when called via compat api. The
options must be extracted from the NetworkMode string.

Fixes #10110

Signed-off-by: Paul Holzinger <paul.holzinger@web.de>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
