### PR TITLE
[NO TESTS NEEDED] Add machine-enabled to containers.conf for machine 

### DIFF
--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -168,6 +168,22 @@ func getFiles(usrName string) []File {
 		},
 		FileEmbedded1: FileEmbedded1{Mode: intToPtr(420)},
 	})
+
+	// Set machine_enabled to true to indicate we're in a VM
+	files = append(files, File{
+		Node: Node{
+			Group: getNodeGrp("root"),
+			Path:  "/etc/containers/containers.conf",
+			User:  getNodeUsr("root"),
+		},
+		FileEmbedded1: FileEmbedded1{
+			Append: nil,
+			Contents: Resource{
+				Source: strToPtr("data:,%5Bengine%5D%0Amachine_enabled%3Dtrue%0A"),
+			},
+			Mode: intToPtr(420),
+		},
+	})
 	return files
 }
 


### PR DESCRIPTION
Add machine-enabled=true into /etc/containers/containers.conf when
initing a VM. This field should tell Podman it's being run in a
podman-machine and it will be used in future to tell podman to set up
other necessary machine stuff such as networking

Signed-off-by: Ashley Cui <acui@redhat.com>

