### PR TITLE
[CI:DOCS] Restore missing content to manpages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,8 +425,8 @@ pkg/api/swagger.yaml: .gopathok
 	make -C pkg/api
 
 $(MANPAGES): %: %.md .install.md2man docdir
-	@sed -e 's/\((podman.*\.md)\)//' -e 's/\[\(podman.*\)\]/\1/' \
-		-e 's;<\(/\)\?\(a[^>]*\|sup\)>;;g' $<  | \
+	@sed -e 's/\((podman[^)]*\.md)\)//g' -e 's/\[\(podman[^]]*\)\]/\1/g' \
+		-e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g' $<  | \
 	$(GOMD2MAN) -in /dev/stdin -out $(subst source/markdown,build/man,$@)
 
 .PHONY: docdir


### PR DESCRIPTION
Looking into the sed preprocess in the manpage build, I noticed some content was being lost:
- Text after the first markdown link on a line to the end of the last (in lines with multiple markdown links)
- Email addresses of the form <a...@...>

For example, the reference to `podman-container(1)` in the [HTML podman-generate-systemd docs](http://docs.podman.io/en/latest/markdown/podman-generate-systemd.1.html#see-also) is missing from `man podman-generate-systemd`. Also, the last line of the [HTML podman-container-restore docs](http://docs.podman.io/en/latest/markdown/podman-container-restore.1.html#history) has an email address that is missing in the equivalent manpage.

This PR changes the sed regexes to prevent these issues. I diffed the output manpages (in docs/build/man) against the previous versions to confirm the fix worked and there were no unexpected changes.