### PR TITLE
Fixes generate kube incorrect when bind-mounting "/" and "/root"

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"fmt"
 	"math/rand"
 	"os"
 	"strconv"
@@ -539,11 +540,17 @@ func libpodMountsToKubeVolumeMounts(c *Container) ([]v1.VolumeMount, []v1.Volume
 	namedVolumes, mounts := c.sortUserVolumes(c.config.Spec)
 	vms := make([]v1.VolumeMount, 0, len(mounts))
 	vos := make([]v1.Volume, 0, len(mounts))
-	for _, m := range mounts {
+
+	var suffix string
+	for index, m := range mounts {
 		vm, vo, err := generateKubeVolumeMount(m)
 		if err != nil {
 			return vms, vos, err
 		}
+		// Name will be the same, so use the index as suffix
+		suffix = fmt.Sprintf("-%d", index)
+		vm.Name += suffix
+		vo.Name += suffix
 		vms = append(vms, vm)
 		vos = append(vos, vo)
 	}


### PR DESCRIPTION
Fixes https://github.com/containers/podman/issues/9764
Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
