### PR TITLE
Cirrus: Update Ubuntu images to 21.04

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,11 +26,11 @@ env:
     ####
     FEDORA_NAME: "fedora-34beta"
     PRIOR_FEDORA_NAME: "fedora-33"
-    UBUNTU_NAME: "ubuntu-2010"
-    PRIOR_UBUNTU_NAME: "ubuntu-2004"
+    UBUNTU_NAME: "ubuntu-2104"
+    PRIOR_UBUNTU_NAME: "ubuntu-2010"
 
     # Google-cloud VM Images
-    IMAGE_SUFFIX: "c5032481331085312"
+    IMAGE_SUFFIX: "c6731272010596352"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -10,27 +10,17 @@ set -a
 # handling of the (otherwise) default shell setup is non-uniform.  Rather
 # than attempt to workaround differences, simply force-load/set required
 # items every time this library is utilized.
-_waserrexit=0
-if [[ "$SHELLOPTS" =~ errexit ]]; then _waserrexit=1; fi
-set +e  # Assumed in F33 for setting global vars
-if [[ -r "/etc/automation_environment" ]]; then
-    source /etc/automation_environment
-else # prior to automation library v2.0, this was necessary
-    source /etc/profile
-    source /etc/environment
-fi
-if [[ -r "/etc/ci_environment" ]]; then source /etc/ci_environment; fi
 USER="$(whoami)"
 HOME="$(getent passwd $USER | cut -d : -f 6)"
 # Some platforms set and make this read-only
 [[ -n "$UID" ]] || \
     UID=$(getent passwd $USER | cut -d : -f 3)
-if ((_waserrexit)); then set -e; fi
 
-# During VM Image build, the 'containers/automation' installation
-# was performed.  The final step of installation sets the library
-# location $AUTOMATION_LIB_PATH in /etc/environment or in the
-# default shell profile depending on distribution.
+# Automation library installed at image-build time,
+# defining $AUTOMATION_LIB_PATH in this file.
+if [[ -r "/etc/automation_environment" ]]; then
+    source /etc/automation_environment
+fi
 # shellcheck disable=SC2154
 if [[ -n "$AUTOMATION_LIB_PATH" ]]; then
         # shellcheck source=/usr/share/automation/lib/common_lib.sh
@@ -42,6 +32,9 @@ else
     echo "         This ${BASH_SOURCE[0]} was loaded by ${BASH_SOURCE[1]}"
     ) > /dev/stderr
 fi
+
+# Managed by setup_environment.sh; holds task-specific definitions.
+if [[ -r "/etc/ci_environment" ]]; then source /etc/ci_environment; fi
 
 OS_RELEASE_ID="$(source /etc/os-release; echo $ID)"
 # GCE image-name compatible string representation of distribution _major_ version

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -582,6 +582,9 @@ USER bin`, BB)
 			if _, err := os.Stat("/sys/fs/cgroup/io.stat"); os.IsNotExist(err) {
 				Skip("Kernel does not have io.stat")
 			}
+			if _, err := os.Stat("/sys/fs/cgroup/system.slice/io.bfq.weight"); os.IsNotExist(err) {
+				Skip("Kernel does not support BFQ IO scheduler")
+			}
 			session := podmanTest.Podman([]string{"run", "--rm", "--blkio-weight=15", ALPINE, "sh", "-c", "cat /sys/fs/cgroup/io.bfq.weight"})
 			session.WaitWithDefaultTimeout()
 			Expect(session.ExitCode()).To(Equal(0))


### PR DESCRIPTION
Fixes: #10143

Also simplify `lib.sh` after supporting changes incorporated
into automation library 2.x+ (present in all VM and container images).

* No need to force-load `/etc/profile` and handle it's expectation
  to **not** being in `errexit` mode.
* Slightly re-arrange loading of automation library files for
  clarity.
* Update comments.

Ref: https://github.com/containers/automation_images/pull/62