### PR TITLE
[CI:DOCS] Add troubleshooting advice about the --userns option.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -67,7 +67,8 @@ Briefly describe the problem you are having in a few paragraphs.
 (paste your output here)
 ```
 
-**Have you tested with the latest version of Podman and have you checked the Podman Troubleshooting Guide?**
+**Have you tested with the latest version of Podman and have you checked the Podman Troubleshooting Guide? (https://github.com/containers/podman/blob/master/troubleshooting.md)**
+
 
 Yes/No
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -23,7 +23,7 @@ touch: cannot touch '/content/file': Permission denied
 
 #### Solution
 
-This is usually caused by SELinux.
+This is sometimes caused by SELinux, and sometimes by user namespaces.
 
 Labeling systems like SELinux require that proper labels are placed on volume
 content mounted into a container. Without a label, the security system might
@@ -46,6 +46,14 @@ types of containers we recommend that disable SELinux separation.  The option `-
 will disable SELinux separation for the container.
 
 $ podman run --security-opt label=disable -v ~:/home/user fedora touch /home/user/file
+
+In cases where the container image runs as a specific, non-root user, though, the
+solution is to fix the user namespace.  This would include container images such as
+the Jupyter Notebook image (which runs as "jovyan") and the Postgres image (which runs
+as "postgres").  In either case, use the `--userns` switch to map user namespaces,
+most of the time by using keep_id option.
+
+$ podman run -v "$PWD":/home/jovyan/work --userns=keep_id jupyter/scipy-notebook
 
 ---
 ### 3) No such image or Bare keys cannot contain ':'


### PR DESCRIPTION
Also a link to the troubleshooting guide into the issue template.

Replaces: https://github.com/containers/podman/pull/9770

Signed-off-by: Josh Berkus <josh@agliodbs.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
