### PR TITLE
libpod/image: unit tests: don't use system's registries.conf.d

### DIFF
--- a/libpod/image/pull_test.go
+++ b/libpod/image/pull_test.go
@@ -308,6 +308,12 @@ func TestPullGoalFromPossiblyUnqualifiedName(t *testing.T) {
 	sc.UserShortNameAliasConfPath = aliasesConf.Name()
 	sc.SystemRegistriesConfPath = registriesConf.Name()
 
+	// Make sure to not sure the system's registries.conf.d
+	dir, err := ioutil.TempDir("", "example")
+	require.NoError(t, err)
+	sc.SystemRegistriesConfDirPath = dir
+	defer os.RemoveAll(dir) // clean up
+
 	for _, c := range []struct {
 		input    string
 		expected []pullRefStrings


### PR DESCRIPTION
This should make the unit tests pass on updated CI images.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@cevich PTAL