### PR TITLE
[CI:DOCS] Fix logic for pushing stable multi-arch images

### DIFF
--- a/.github/workflows/multi-arch-build.yaml
+++ b/.github/workflows/multi-arch-build.yaml
@@ -77,7 +77,7 @@ jobs:
                       docker://$PODMAN_QUAY_REGISTRY/stable | \
                       jq -r '.Tags[]')
             PUSH="false"
-            if fgrep -qx "$VERSION" <<<"$ALLTAGS"; then
+            if ! fgrep -qx "$VERSION" <<<"$ALLTAGS"; then
                 PUSH="true"
             fi
 
@@ -85,7 +85,7 @@ jobs:
             # Only push if version tag does not exist
             if [[ "$PUSH" == "true" ]]; then
               echo "Will push $FQIN"
-              echo "::set-output name=podman_push::${PUSH}"
+              echo "::set-output name=podman_push::true"
               echo "::set-output name=podman_fqin::${FQIN}"
             else
               echo "Not pushing, $FQIN already exists."
@@ -97,7 +97,7 @@ jobs:
                       docker://$CONTAINERS_QUAY_REGISTRY/podman | \
                       jq -r '.Tags[]')
             PUSH="false"
-            if fgrep -qx "$VERSION" <<<"$ALLTAGS"; then
+            if ! fgrep -qx "$VERSION" <<<"$ALLTAGS"; then
                 PUSH="true"
             fi
 
@@ -105,7 +105,7 @@ jobs:
             # Only push if version tag does not exist
             if [[ "$PUSH" == "true" ]]; then
               echo "Will push $FQIN"
-              echo "::set-output name=containers_push::${PUSH}"
+              echo "::set-output name=containers_push::true"
               echo "::set-output name=containers_fqin::$FQIN"
             else
               echo "Not pushing, $FQIN already exists."


### PR DESCRIPTION
The intention is to only push an image if there is ***NOT*** an existing
tag.  The original logic for this condition was inverted.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
