### PR TITLE
Fix images prune filter until

### DIFF
--- a/libpod/image/prune.go
+++ b/libpod/image/prune.go
@@ -30,7 +30,7 @@ func generatePruneFilterFuncs(filter, filterValue string) (ImageFilter, error) {
 			return nil, err
 		}
 		return func(i *Image) bool {
-			if !until.IsZero() && i.Created().After((until)) {
+			if !until.IsZero() && i.Created().Before(until) {
 				return true
 			}
 			return false

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -126,6 +126,20 @@ t DELETE libpod/images/test:test 200
 t GET images/json?filters='{"label":["xyz"]}' 200 length=0
 t GET libpod/images/json?filters='{"label":["xyz"]}' 200 length=0
 
+
+# to be used in prune until filter tests
+podman image build -t test1:latest -<<EOF
+from alpine
+RUN >file3
+EOF
+
+# image should not be deleted
+t GET images/json?filters='{"reference":["test1"]}' 200 length=1
+t POST images/prune?filters='{"until":["500000"]}' 200
+t GET images/json?filters='{"reference":["test1"]}' 200 length=1
+
+t DELETE libpod/images/test1:latest 200
+
 # Export more than one image
 # FIXME FIXME FIXME, this doesn't work:
 #   not ok 64 [10-images] GET images/get?names=alpine,busybox : status


### PR DESCRIPTION
This commits fixes until filter. It is now checking if the created
timestamp is before until filter value as expected in the docs.

Signed-off-by: Jakub Guzik <jakubmguzik@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
