### PR TITLE
Allow docker volume create API to pass without name

### DIFF
--- a/pkg/api/handlers/compat/volumes.go
+++ b/pkg/api/handlers/compat/volumes.go
@@ -96,11 +96,17 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// See if the volume exists already
-	existingVolume, err := runtime.GetVolume(input.Name)
-	if err != nil && errors.Cause(err) != define.ErrNoSuchVolume {
-		utils.InternalServerError(w, err)
-		return
+	var (
+		existingVolume *libpod.Volume
+		err            error
+	)
+	if len(input.Name) != 0 {
+		// See if the volume exists already
+		existingVolume, err = runtime.GetVolume(input.Name)
+		if err != nil && errors.Cause(err) != define.ErrNoSuchVolume {
+			utils.InternalServerError(w, err)
+			return
+		}
 	}
 
 	// if using the compat layer and the volume already exists, we

--- a/test/apiv2/30-volumes.at
+++ b/test/apiv2/30-volumes.at
@@ -13,6 +13,13 @@ t POST libpod/volumes/create name=foo1  201 \
     .CreatedAt~[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}.* \
     .Labels={} \
     .Options={}
+t POST volumes/create 201 \
+    .Name~[0-9a-f]\\{64\\}
+    .Driver=local \
+    .Mountpoint=$volumepath/~[0-9a-f]\\{64\\}/_data \
+    .CreatedAt~[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}.* \
+    .Labels={} \
+    .Options={}
 t POST libpod/volumes/create 201
 t POST libpod/volumes/create \
   Name=foo2 \


### PR DESCRIPTION
The Docker API does not require Volume name to be specified when
creating a volume.

Fixes: https://github.com/containers/podman/issues/9803

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
