### PR TITLE
Use seccomp_profile as default profile if defined in containers.conf

### DIFF
--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -17,6 +17,7 @@ type SecurityInfo struct {
 	DefaultCapabilities string `json:"capabilities"`
 	Rootless            bool   `json:"rootless"`
 	SECCOMPEnabled      bool   `json:"seccompEnabled"`
+	SECCOMPProfilePath  string `json:"seccompProfilePath"`
 	SELinuxEnabled      bool   `json:"selinuxEnabled"`
 }
 

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -87,6 +87,12 @@ func (r *Runtime) hostInfo() (*define.HostInfo, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "error getting hostname")
 	}
+
+	seccompProfilePath, err := DefaultSeccompPath()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting Seccomp profile path")
+	}
+
 	info := define.HostInfo{
 		Arch:           runtime.GOARCH,
 		BuildahVersion: buildah.Version,
@@ -106,6 +112,7 @@ func (r *Runtime) hostInfo() (*define.HostInfo, error) {
 			DefaultCapabilities: strings.Join(r.config.Containers.DefaultCapabilities, ","),
 			Rootless:            rootless.IsRootless(),
 			SECCOMPEnabled:      seccomp.IsEnabled(),
+			SECCOMPProfilePath:  seccompProfilePath,
 			SELinuxEnabled:      selinux.GetEnabled(),
 		},
 		Slirp4NetNS: define.SlirpInfo{},

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -194,7 +194,15 @@ func programVersion(mountProgram string) (string, error) {
 // if it exists, first it checks OverrideSeccomp and then default.
 // If neither exist function returns ""
 func DefaultSeccompPath() (string, error) {
-	_, err := os.Stat(config.SeccompOverridePath)
+	def, err := config.Default()
+	if err != nil {
+		return "", err
+	}
+	if def.Containers.SeccompProfile != "" {
+		return def.Containers.SeccompProfile, nil
+	}
+
+	_, err = os.Stat(config.SeccompOverridePath)
 	if err == nil {
 		return config.SeccompOverridePath, nil
 	}

--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -353,4 +353,23 @@ var _ = Describe("Podman run", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("test"))
 	})
+
+	It("podman info seccomp profile path", func() {
+		configPath := filepath.Join(podmanTest.TempDir, "containers.conf")
+		os.Setenv("CONTAINERS_CONF", configPath)
+
+		profile := filepath.Join(podmanTest.TempDir, "seccomp.json")
+		containersConf := []byte(fmt.Sprintf("[containers]\nseccomp_profile=\"%s\"", profile))
+		err = ioutil.WriteFile(configPath, containersConf, os.ModePerm)
+		Expect(err).To(BeNil())
+
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+		}
+
+		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.Security.SECCOMPProfilePath}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal(profile))
+	})
 })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

I bumped into the issue that pointing `seccomp_profile` in containers.conf to a user-defined profile completely ignored my settings. Instead, podman kept using the profile in `/usr/share/containers/seccomp.json`. This PR fixes that issue, by considering the runtime configuration of higher priority than the default settings.
