### PR TITLE
System tests: fix two race conditions

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -501,6 +501,7 @@ json-file | f
     run_podman inspect --format '{{.OCIRuntime}}' $cid
     is "$output" "$new_runtime" "podman inspect shows configured runtime"
     run_podman kill $cid
+    run_podman wait $cid
     run_podman rm $cid
     rm -f $new_runtime
 }

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -116,6 +116,7 @@ load helpers
         is "$output" ".*${teststring}.*" "test string received on container"
 
         # Clean up
+        run_podman wait $cid
         run_podman rm $cid
     done
 }


### PR DESCRIPTION
Basically, add 'podman wait' before 'podman rm'. See if this
fixes gating tests run on ppc64le (possibly very very slow hosts)

Signed-off-by: Ed Santiago <santiago@redhat.com>
