### PR TITLE
[CI:DOCS] Improve titles of command HTML pages

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,8 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import re
+from recommonmark.transform import AutoStructify
 
 # -- Project information -----------------------------------------------------
 
@@ -59,3 +61,27 @@ html_css_files = [
 ]
 
 # -- Extension configuration -------------------------------------------------
+
+def convert_markdown_title(app, docname, source):
+    # Process markdown files only
+    docpath = app.env.doc2path(docname)
+    if docpath.endswith(".md"):
+        # Convert pandoc title line into eval_rst block for recommonmark
+        source[0] = re.sub(
+            r"^% (.*)",
+            r"```eval_rst\n.. title:: \g<1>\n```",
+            source[0])
+
+
+def setup(app):
+    app.connect("source-read", convert_markdown_title)
+
+    app.add_config_value(
+        "recommonmark_config", {
+            "enable_eval_rst": True,
+            "enable_auto_doc_ref": False,
+            "enable_auto_toc_tree": False,
+            "enable_math": False,
+            "enable_inline_math": False,
+        }, True)
+    app.add_transform(AutoStructify)


### PR DESCRIPTION
As detailed in containers/podman.io#385, the titles of the command HTML pages were all set to "NAME - Podman documentation". This made search results confusing.

This PR gives command HTML pages the same title as the equivalent manpage. The existing pandoc-style title lines are converted at build time into the format supported by recommonmark.

This also removes the `% pandoc-<command name>(1)` line from the top of each command's HTML page.