### PR TITLE
[NO TESTS NEEDED] Check if another VM is running on machine start

### DIFF
--- a/docs/source/markdown/podman-machine-start.1.md
+++ b/docs/source/markdown/podman-machine-start.1.md
@@ -14,6 +14,9 @@ Podman on MacOS requires a virtual machine. This is because containers are Linux
 containers do not run on any other OS because containers' core functionality are
 tied to the Linux kernel.
 
+Only one Podman managed VM can be active at a time. If a VM is already running,
+`podman machine start` will return an error.
+
 **podman machine start** starts a Linux virtual machine where containers are run.
 
 ## OPTIONS

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -30,6 +30,8 @@ var (
 	DefaultIgnitionUserName                      = "core"
 	ErrNoSuchVM                                  = errors.New("VM does not exist")
 	ErrVMAlreadyExists                           = errors.New("VM already exists")
+	ErrVMAlreadyRunning                          = errors.New("VM already running")
+	ErrMultipleActiveVM                          = errors.New("only one VM can be active at a time")
 )
 
 type Download struct {

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -519,3 +519,17 @@ func IsValidVMName(name string) (bool, error) {
 	}
 	return false, nil
 }
+
+// CheckActiveVM checks if there is a VM already running
+func CheckActiveVM() (bool, string, error) {
+	vms, err := GetVMInfos()
+	if err != nil {
+		return false, "", errors.Wrap(err, "error checking VM active")
+	}
+	for _, vm := range vms {
+		if vm.Running {
+			return true, vm.Name, nil
+		}
+	}
+	return false, "", nil
+}


### PR DESCRIPTION
Only one VM can be up at a time. If another VM is running, or the current VM is running, error out on a podman machine start

[NO TESTS NEEDED]

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
