### PR TITLE
Docker returns 'die' status rather then 'died' status

### DIFF
--- a/pkg/api/handlers/compat/events.go
+++ b/pkg/api/handlers/compat/events.go
@@ -89,6 +89,10 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 			}
 
 			e := entities.ConvertToEntitiesEvent(*evt)
+			if !utils.IsLibpodRequest(r) && e.Status == "died" {
+				e.Status = "die"
+			}
+
 			if err := coder.Encode(e); err != nil {
 				logrus.Errorf("unable to write json: %q", err)
 			}


### PR DESCRIPTION
In order to be more compatible with Docker, we should return a
container die status rather then a "container died", Too late to
change this for Podman.

Partially fixes: https://github.com/containers/podman/issues/10168

[NO TESTS NEEDED] No easy way to test this.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
