### PR TITLE
[CI:DOCS] Add titles to remote docs (windows)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ link on that page.
 | ------------------------------------ | --------------------------- |
 | docs/remote-docs.sh | Read the docs/source/markdown files and format for each platform |
 | docs/links-to-html.lua | pandoc filter to do aliases for html files |
+| docs/use-pagetitle.lua | pandoc filter to set html document title |
 
 ## API Reference
 

--- a/docs/remote-docs.sh
+++ b/docs/remote-docs.sh
@@ -80,7 +80,10 @@ function html_fn() {
         local link=$(sed -e 's?.so man1/\(.*\)?\1?' <$dir/links/${file%.md})
         markdown=$dir/$link.md
     fi
-    pandoc --ascii --lua-filter=docs/links-to-html.lua -o $TARGET/${file%%.*}.html $markdown
+    pandoc --ascii --standalone \
+        --lua-filter=docs/links-to-html.lua \
+        --lua-filter=docs/use-pagetitle.lua \
+        -o $TARGET/${file%%.*}.html $markdown
 }
 
 # Run 'podman help' (possibly against a subcommand, e.g. 'podman help image')

--- a/docs/use-pagetitle.lua
+++ b/docs/use-pagetitle.lua
@@ -1,0 +1,14 @@
+local List = require("pandoc.List")
+
+function Meta(m)
+  -- Use pagetitle instead of title (prevents pandoc inserting a <H1> title)
+  m.pagetitle = m.title
+  m.title = nil
+
+  if m.pagetitle ~= nil and m.pagetitle.t == "MetaInlines" then
+    -- Add suffix to match the Sphinx HTML documentation
+    List.extend(m.pagetitle, {pandoc.Str" \u{2014} Podman documentation"})
+  end
+
+  return m
+end


### PR DESCRIPTION
As mentioned in containers/podman.io#385, the podman-remote windows docs don't have HTML titles.

This PR gives them the same titles as the equivalent Sphinx HTML pages.

