### PR TITLE
Fix multi-arch image workflow typo

### DIFF
--- a/.github/workflows/multi-arch-build.yaml
+++ b/.github/workflows/multi-arch-build.yaml
@@ -62,7 +62,7 @@ jobs:
       # Simple verification that stable images work, and
       # also grab version number use in forming the FQIN.
       - name: amd64 container sniff test
-        if: matrix.source = 'stable'
+        if: matrix.source == 'stable'
         id: sniff_test
         run: |
           VERSION_OUTPUT="$(docker run localhost:5000/podman/${{ matrix.source }} \

--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -39,6 +39,7 @@ filtered_changes=$(git diff --name-status $base $head |
                        fgrep -vx go.mod               |
                        fgrep -vx go.sum               |
                        egrep -v  '^[^/]+\.md$'        |
+                       egrep -v  '^.github'           |
                        egrep -v  '^contrib/'          |
                        egrep -v  '^docs/'             |
                        egrep -v  '^hack/'             |


### PR DESCRIPTION
Fixes error Introduced in #10150 

There's no easy way to test this, it literally has to run from the master-branch due to github-actions design :disappointed: 