### PR TITLE
Add filepath glob support to --security-opt unmask

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -540,7 +540,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 					return fmt.Errorf("invalid systempaths option %q, only `unconfined` is supported", con[1])
 				}
 			case "unmask":
-				s.ContainerSecurityConfig.Unmask = append(s.ContainerSecurityConfig.Unmask, strings.Split(con[1], ":")...)
+				s.ContainerSecurityConfig.Unmask = append(s.ContainerSecurityConfig.Unmask, con[1:]...)
 			default:
 				return fmt.Errorf("invalid --security-opt 2: %q", opt)
 			}

--- a/contrib/podmanimage/stable/containers.conf
+++ b/contrib/podmanimage/stable/containers.conf
@@ -5,6 +5,7 @@ ipcns="host"
 utsns="host"
 cgroupns="host"
 cgroups="disabled"
+log_driver = "k8s_file"
 [engine]
 cgroup_manager = "cgroupfs"
 events_logger="file"

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -882,8 +882,7 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 - `proc-opts=OPTIONS` : Comma-separated list of options to use for the /proc mount. More details for the
   possible mount options are specified in the **proc(5)** man page.
 
-- `unmask=ALL or /path/1:/path/2` : Paths to unmask separated by a colon. If set to **ALL**, it will
-  unmask all the paths that are masked or made read only by default.
+- **unmask**=_ALL_ or _/path/1:/path/2_, or shell expanded paths (/proc/*): Paths to unmask separated by a colon. If set to **ALL**, it will unmask all the paths that are masked or made read only by default.
   The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.**  The default paths that are read only are **/proc/asound, /proc/bus, /proc/fs, /proc/irq, /proc/sys, /proc/sysrq-trigger, /sys/fs/cgroup**.
 
 Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -934,8 +934,7 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 - **proc-opts**=_OPTIONS_ : Comma-separated list of options to use for the /proc mount. More details
   for the possible mount options are specified in the **proc(5)** man page.
 
-- **unmask**=_ALL_ or _/path/1:/path/2_: Paths to unmask separated by a colon. If set to **ALL**, it will
-  unmask all the paths that are masked or made read only by default.
+- **unmask**=_ALL_ or _/path/1:/path/2_, or shell expanded paths (/proc/*): Paths to unmask separated by a colon. If set to **ALL**, it will unmask all the paths that are masked or made read only by default.
   The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.**.  The default paths that are read only are **/proc/asound**, **/proc/bus**, **/proc/fs**, **/proc/irq**, **/proc/sys**, **/proc/sysrq-trigger**, **/sys/fs/cgroup**.
 
 Note: Labeling can be disabled for all containers by setting **label=false** in the **containers.conf**(5) file.
@@ -1642,6 +1641,13 @@ the **mask** option.
 
 ```
 $ podman run --security-opt unmask=ALL fedora bash
+```
+
+To unmask all the paths that start with /proc, set the **unmask** option to
+**/proc/***.
+
+```
+$ podman run --security-opt unmask=/proc/* fedora bash
 ```
 
 ```

--- a/pkg/specgen/generate/config_linux_test.go
+++ b/pkg/specgen/generate/config_linux_test.go
@@ -1,0 +1,28 @@
+package generate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldMask(t *testing.T) {
+	tests := []struct {
+		mask       string
+		unmask     []string
+		shouldMask bool
+	}{
+		{"/proc/foo", []string{"all"}, false},
+		{"/proc/foo", []string{"ALL"}, false},
+		{"/proc/foo", []string{"/proc/foo"}, false},
+		{"/proc/foo", []string{"/proc/*"}, false},
+		{"/proc/foo", []string{"/proc/bar", "all"}, false},
+		{"/proc/foo", []string{"/proc/f*"}, false},
+		{"/proc/foo", []string{"/proc/b*"}, true},
+		{"/proc/foo", []string{}, true},
+	}
+	for _, test := range tests {
+		val := shouldMask(test.mask, test.unmask)
+		assert.Equal(t, val, test.shouldMask)
+	}
+}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -299,9 +299,17 @@ var _ = Describe("Podman run", func() {
 		session = podmanTest.Podman([]string{"run", "-d", "--name=maskCtr5", "--security-opt", "systempaths=unconfined", ALPINE, "grep", "/proc", "/proc/self/mounts"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		stdoutLines := session.OutputToStringArray()
-		Expect(stdoutLines).Should(HaveLen(1))
+		Expect(session.OutputToStringArray()).Should(HaveLen(1))
 
+		session = podmanTest.Podman([]string{"run", "-d", "--security-opt", "unmask=/proc/*", ALPINE, "grep", "/proc", "/proc/self/mounts"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToStringArray()).Should(HaveLen(1))
+
+		session = podmanTest.Podman([]string{"run", "--security-opt", "unmask=/proc/a*", ALPINE, "ls", "/proc/acpi"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Not(BeEmpty()))
 	})
 
 	It("podman run security-opt unmask on /sys/fs/cgroup", func() {


### PR DESCRIPTION
Want to allow users to specify --security-opt unmask=/proc/*.
This allows us to run podman within podman more securely, then
specifing umask=all, also gives the user more flexibilty.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
