### PR TITLE
[CI:DOCS] Fix variable reference typo. in multi-arch image action

### DIFF
--- a/.github/workflows/multi-arch-build.yaml
+++ b/.github/workflows/multi-arch-build.yaml
@@ -24,6 +24,8 @@ jobs:
 
     # build several images (upstream, testing, stable) in parallel
     strategy:
+      # By default, failure of one matrix item cancels all others
+      fail-fast: false
       matrix:
         # Builds are located under contrib/podmanimage/<source> directory
         source:
@@ -178,7 +180,7 @@ jobs:
           file: ./contrib/podmanimage/${{ matrix.source }}/Dockerfile
           platforms: ${{ env.PLATFORMS }}
           push: true
-          tags: ${{ steps.podman_push.outputs.fqin }}
+          tags: ${{ steps.podman_reg.outputs.fqin }}
           labels: |
             ${{ env.LABELS }}
 


### PR DESCRIPTION
Bug introduced by #10150

Also, in case of failure of one matrix-leg, do not terminate execution
of all others.  There are many reasons why an item could fail (i.e.
temporary networking problem).  Since the job runs periodically,
we can simply allow the subsequent run to cover for any missed images
pushes due to sporadic job failures.

Ref: https://github.com/containers/podman/runs/2490406959?check_suite_focus=true#step:12:27