### PR TITLE
System tests: honor $OCI_RUNTIME (for CI)

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -67,8 +67,7 @@ store.imageStore.number   | 1
 
         # RHEL or CentOS 8.
         # FIXME: what does 'CentOS 8' even mean? What is $VERSION_ID in CentOS?
-        run_podman info --format '{{.Host.OCIRuntime.Name}}'
-        is "$output" "runc" "$osname only supports OCI Runtime = runc"
+        is "$(podman_runtime)" "runc" "$osname only supports OCI Runtime = runc"
     else
         skip "only applicable on RHEL, this is $osname"
     fi

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -123,8 +123,7 @@ EOF
     # ARGH. Unfortunately, runc (used for cgroups v1) produces a different error
     local expect_rc=126
     local expect_msg='.* OCI permission denied.*'
-    run_podman info --format '{{ .Host.OCIRuntime.Path }}'
-    if expr "$output" : ".*/runc"; then
+    if [[ $(podman_runtime) = "runc" ]]; then
         expect_rc=1
         expect_msg='.* exec user process caused.*permission denied'
     fi

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -6,22 +6,31 @@
 
 load helpers
 
+function _require_crun() {
+    runtime=$(podman_runtime)
+    if [[ $runtime != "crun" ]]; then
+        skip "runtime is $runtime; keep-groups requires crun"
+    fi
+}
+
 @test "podman --group-add keep-groups while in a userns" {
-    skip_if_rootless "choot is not allowed in rootless mode"
+    skip_if_rootless "chroot is not allowed in rootless mode"
     skip_if_remote "--group-add keep-groups not supported in remote mode"
+    _require_crun
     run chroot --groups 1234 / ${PODMAN} run --uidmap 0:200000:5000 --group-add keep-groups $IMAGE id
     is "$output" ".*65534(nobody)" "Check group leaked into user namespace"
 }
 
 @test "podman --group-add keep-groups while not in a userns" {
-    skip_if_rootless "choot is not allowed in rootless mode"
+    skip_if_rootless "chroot is not allowed in rootless mode"
     skip_if_remote "--group-add keep-groups not supported in remote mode"
+    _require_crun
     run chroot --groups 1234,5678 / ${PODMAN} run --group-add keep-groups $IMAGE id
     is "$output" ".*1234" "Check group leaked into container"
 }
 
 @test "podman --group-add without keep-groups while in a userns" {
-    skip_if_rootless "choot is not allowed in rootless mode"
+    skip_if_rootless "chroot is not allowed in rootless mode"
     skip_if_remote "--group-add keep-groups not supported in remote mode"
     run chroot --groups 1234,5678 / ${PODMAN} run --uidmap 0:200000:5000 --group-add 457 $IMAGE id
     is "$output" ".*457" "Check group leaked into container"

--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -17,9 +17,9 @@ function setup() {
 
     # sdnotify fails with runc 1.0.0-3-dev2 on Ubuntu. Let's just
     # assume that we work only with crun, nothing else.
-    run_podman info --format '{{ .Host.OCIRuntime.Name }}'
-    if [[ "$output" != "crun" ]]; then
-        skip "this test only works with crun, not '$output'"
+    runtime=$(podman_runtime)
+    if [[ "$runtime" != "crun" ]]; then
+        skip "this test only works with crun, not $runtime"
     fi
 
     basic_setup


### PR DESCRIPTION
Some CI systems set $OCI_RUNTIME as a way to override the
default crun. Integration (e2e) tests honor this, but system
tests were not aware of the convention; this means we haven't
been testing system tests with runc, which means RHEL gating
tests are now failing.

The proper solution would be to edit containers.conf on CI
systems. Sorry, that would involve too much CI-VM work.
Instead, this PR detects $OCI_RUNTIME and creates a dummy
containers.conf file using that runtime.

Add: various skips for tests that don't work with runc.

Refactor: add a helper function so we don't need to do
the complicated 'podman info blah blah .OCIRuntime.blah'
thing in many places.

BUG: we leave a tmp file behind on exit.

Signed-off-by: Ed Santiago <santiago@redhat.com>
