### PR TITLE
Add support to preserve auto-update labels in play / generate kube

### DIFF
--- a/docs/source/markdown/podman-auto-update.1.md
+++ b/docs/source/markdown/podman-auto-update.1.md
@@ -14,7 +14,7 @@ The label "image" is an alternative to "registry" maintained for backwards compa
 An image is considered updated if the digest in the local storage is different than the one of the remote image.
 If an image must be updated, Podman pulls it down and restarts the systemd unit executing the container.
 
-The registry policy requires a requires a fully-qualified image reference (e.g., quay.io/podman/stable:latest) to be used to create the container.
+The registry policy requires a fully-qualified image reference (e.g., quay.io/podman/stable:latest) to be used to create the container.
 This enforcement is necessary to know which image to actually check and pull.
 If an image ID was used, Podman would not know which image to check/pull anymore.
 

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -100,6 +100,8 @@ type CtrSpecGenOptions struct {
 	SecretsManager *secrets.SecretsManager
 	// LogDriver which should be used for the container
 	LogDriver string
+	// Labels define key-value pairs of metadata
+	Labels map[string]string
 }
 
 func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGenerator, error) {
@@ -276,6 +278,19 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 
 	if opts.NetNSIsHost {
 		s.NetNS.NSMode = specgen.Host
+	}
+
+	// Add labels that come from kube
+	if len(s.Labels) == 0 {
+		// If there are no labels, let's use the map that comes
+		// from kube
+		s.Labels = opts.Labels
+	} else {
+		// If there are already labels in the map, append the ones
+		// obtained from kube
+		for k, v := range opts.Labels {
+			s.Labels[k] = v
+		}
 	}
 
 	return s, nil


### PR DESCRIPTION
Fixes #9763 

This provides the ability to preserve auto-update labels in containers when using `podman generate / play kube`. In the case of `generate kube` the auto-update labels will be converted into kube annotations and for `play kube` they will be converted back to labels since that's what podman understands.
