### PR TITLE
compat api: Networks must be empty instead of null

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containers/podman/v3/pkg/util"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
 	"github.com/gorilla/schema"
@@ -525,6 +526,10 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 	networkSettings := types.NetworkSettings{}
 	if err := json.Unmarshal(n, &networkSettings); err != nil {
 		return nil, err
+	}
+	// do not report null instead use an empty map
+	if networkSettings.Networks == nil {
+		networkSettings.Networks = map[string]*network.EndpointSettings{}
 	}
 
 	c := types.ContainerJSON{

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -205,10 +205,15 @@ t GET containers/$cid/json 200 \
 t POST containers/create Image=$IMAGE Entrypoint='["top"]' 201 \
   .Id~[0-9a-f]\\{64\\}
 cid_top=$(jq -r '.Id' <<<"$output")
+network_expect="{}"
+if root; then
+    network_expect='.podman.NetworkID=podman'
+fi
 t GET containers/${cid_top}/json 200 \
   .Config.Entrypoint[0]="top" \
   .Config.Cmd='[]' \
   .Path="top"
+  .NetworkSettings.Networks="$network_expect"
 t POST  containers/${cid_top}/start 204
 # make sure the container is running
 t GET containers/${cid_top}/json 200 \


### PR DESCRIPTION
The compat endpoint for container inspect must return {} instead of null
for NetworkSettings.Networks.

Fixes #9837

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
