### PR TITLE
add libimage events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
 	github.com/containers/buildah v1.20.2-0.20210519094241-c3a3fe847ee1
-	github.com/containers/common v0.38.4-0.20210519112800-40a1e9ee42fb
+	github.com/containers/common v0.38.4
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.12.0
 	github.com/containers/ocicrypt v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRD
 github.com/containers/buildah v1.20.2-0.20210519094241-c3a3fe847ee1 h1:XrHrbHwkTMmZCNhRglW4H3k8ApOWyupsSp5snJmsb24=
 github.com/containers/buildah v1.20.2-0.20210519094241-c3a3fe847ee1/go.mod h1:7qXQ9hVQxgkE3XCoCjtzrV0VKh5GzgugkQDfvFxcVus=
 github.com/containers/common v0.38.3/go.mod h1:egfpX/Y3+19Dz4Wa1eRZDdgzoEOeneieF9CQppKzLBg=
-github.com/containers/common v0.38.4-0.20210519112800-40a1e9ee42fb h1:KEwgtZFf3o/Dk8oLkYrh+CrKENV2fRbZHfcJwgpA9i4=
-github.com/containers/common v0.38.4-0.20210519112800-40a1e9ee42fb/go.mod h1:egfpX/Y3+19Dz4Wa1eRZDdgzoEOeneieF9CQppKzLBg=
+github.com/containers/common v0.38.4 h1:WYv4R6Sw1qiOPZtBNbKglrmisXdPcq3fZ3bGy4prrjo=
+github.com/containers/common v0.38.4/go.mod h1:egfpX/Y3+19Dz4Wa1eRZDdgzoEOeneieF9CQppKzLBg=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.12.0 h1:1hNS2QkzFQ4lH3GYQLyAXB0acRMhS1Ubm6oV++8vw4w=

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/containers/common/libimage"
 	"github.com/containers/common/pkg/config"
@@ -68,17 +69,18 @@ type Runtime struct {
 	storageConfig storage.StoreOptions
 	storageSet    storageSet
 
-	state             State
-	store             storage.Store
-	storageService    *storageService
-	imageContext      *types.SystemContext
-	defaultOCIRuntime OCIRuntime
-	ociRuntimes       map[string]OCIRuntime
-	runtimeFlags      []string
-	netPlugin         ocicni.CNIPlugin
-	conmonPath        string
-	libimageRuntime   *libimage.Runtime
-	lockManager       lock.Manager
+	state                  State
+	store                  storage.Store
+	storageService         *storageService
+	imageContext           *types.SystemContext
+	defaultOCIRuntime      OCIRuntime
+	ociRuntimes            map[string]OCIRuntime
+	runtimeFlags           []string
+	netPlugin              ocicni.CNIPlugin
+	conmonPath             string
+	libimageRuntime        *libimage.Runtime
+	libimageEventsShutdown chan bool
+	lockManager            lock.Manager
 
 	// doRenumber indicates that the runtime should perform a lock renumber
 	// during initialization.
@@ -214,6 +216,8 @@ func newRuntimeFromConfig(ctx context.Context, conf *config.Config, options ...R
 	if err := makeRuntime(ctx, runtime); err != nil {
 		return nil, err
 	}
+
+	runtime.libimageEventsShutdown = make(chan bool)
 
 	return runtime, nil
 }
@@ -680,6 +684,62 @@ func (r *Runtime) GetConfig() (*config.Config, error) {
 	return config, nil
 }
 
+// libimageEventsMap translates a libimage event type to a libpod event status.
+var libimageEventsMap = map[libimage.EventType]events.Status{
+	libimage.EventTypeImagePull:    events.Pull,
+	libimage.EventTypeImagePush:    events.Push,
+	libimage.EventTypeImageRemove:  events.Remove,
+	libimage.EventTypeImageLoad:    events.LoadFromArchive,
+	libimage.EventTypeImageSave:    events.Save,
+	libimage.EventTypeImageTag:     events.Tag,
+	libimage.EventTypeImageUntag:   events.Untag,
+	libimage.EventTypeImageMount:   events.Mount,
+	libimage.EventTypeImageUnmount: events.Unmount,
+}
+
+// libimageEvents spawns a goroutine in the background which is listenting for
+// events on the libimage.Runtime.  The gourtine will be cleaned up implicitly
+// when the main() exists.
+func (r *Runtime) libimageEvents() {
+	toLibpodEventStatus := func(e *libimage.Event) events.Status {
+		status, found := libimageEventsMap[e.Type]
+		if !found {
+			return "Unknown"
+		}
+		return status
+	}
+
+	go func() {
+		eventChannel := r.libimageRuntime.EventChannel()
+
+		for {
+			// Make sure to read and write all events before
+			// checking if we're about to shutdown.
+			for len(eventChannel) > 0 {
+				libimageEvent := <-eventChannel
+				e := events.Event{
+					ID:     libimageEvent.ID,
+					Name:   libimageEvent.Name,
+					Status: toLibpodEventStatus(libimageEvent),
+					Time:   libimageEvent.Time,
+					Type:   events.Image,
+				}
+				if err := r.eventer.Write(e); err != nil {
+					logrus.Errorf("unable to write image event: %q", err)
+				}
+			}
+
+			select {
+			case <-r.libimageEventsShutdown:
+				return
+
+			default:
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}()
+}
+
 // DeferredShutdown shuts down the runtime without exposing any
 // errors. This is only meant to be used when the runtime is being
 // shutdown within a defer statement; else use Shutdown
@@ -719,7 +779,11 @@ func (r *Runtime) Shutdown(force bool) error {
 	// If no store was requested, it can be nil and there is no need to
 	// attempt to shut it down
 	if r.store != nil {
-		if _, err := r.store.Shutdown(force); err != nil {
+		// Wait for the events to be written.
+		r.libimageEventsShutdown <- true
+
+		// Note that the libimage runtime shuts down the store.
+		if err := r.libimageRuntime.Shutdown(force); err != nil {
 			lastError = errors.Wrapf(err, "error shutting down container storage")
 		}
 	}
@@ -845,6 +909,8 @@ func (r *Runtime) configureStore() error {
 		return err
 	}
 	r.libimageRuntime = libimageRuntime
+	// Run the libimage events routine.
+	r.libimageEvents()
 
 	return nil
 }

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.38.4-dev"
+const Version = "0.38.4"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -91,7 +91,7 @@ github.com/containers/buildah/pkg/overlay
 github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/util
-# github.com/containers/common v0.38.4-0.20210519112800-40a1e9ee42fb
+# github.com/containers/common v0.38.4
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
 github.com/containers/common/pkg/apparmor


### PR DESCRIPTION
libimage now supports events which `libpod.Runtime` now uses for image
events.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

Need to merge https://github.com/containers/common/pull/524 first.