### PR TITLE
podman: set volatile storage flag for --rm containers

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -646,6 +646,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	s.Umask = c.Umask
 	s.Secrets = c.Secrets
 	s.PidFile = c.PidFile
+	s.Volatile = c.Rm
 
 	return nil
 }

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -151,6 +151,9 @@ type ContainerRootFSConfig struct {
 	Secrets []*secrets.Secret `json:"secrets,omitempty"`
 	// SecretPath is the secrets location in storage
 	SecretsPath string `json:"secretsPath"`
+	// Volatile specifies whether the container storage can be optimized
+	// at the cost of not syncing all the dirty files in memory.
+	Volatile bool `json:"volatile,omitempty"`
 }
 
 // ContainerSecurityConfig is an embedded sub-config providing security configuration

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -451,6 +451,8 @@ func (c *Container) setupStorage(ctx context.Context) error {
 		options.MountOpts = newOptions
 	}
 
+	options.Volatile = c.config.Volatile
+
 	c.setupStorageMapping(&options.IDMappingOptions, &c.config.IDMappings)
 
 	containerInfo, err := c.runtime.storageService.CreateContainerStorage(ctx, c.runtime.imageContext, c.config.RootfsImageName, c.config.RootfsImageID, c.config.Name, c.config.ID, options)

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -2318,3 +2318,16 @@ func WithPodSlirp4netns(networkOptions map[string][]string) PodCreateOption {
 		return nil
 	}
 }
+
+// WithVolatile sets the volatile flag for the container storage.
+// The option can potentially cause data loss when used on a container that must survive a machine reboot.
+func WithVolatile() CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.Volatile = true
+		return nil
+	}
+}

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -194,6 +194,9 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 	if s.Umask != "" {
 		options = append(options, libpod.WithUmask(s.Umask))
 	}
+	if s.Volatile {
+		options = append(options, libpod.WithVolatile())
+	}
 
 	useSystemd := false
 	switch s.Systemd {

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -256,6 +256,9 @@ type ContainerStorageConfig struct {
 	// Secrets are the secrets that will be added to the container
 	// Optional.
 	Secrets []string `json:"secrets,omitempty"`
+	// Volatile specifies whether the container storage can be optimized
+	// at the cost of not syncing all the dirty files in memory.
+	Volatile bool `json:"volatile,omitempty"`
 }
 
 // ContainerSecurityConfig is a container's security features, including


### PR DESCRIPTION
volatile containers are a storage optimization that disables *sync()
syscalls for the container rootfs.

If a container is created with --rm, then automatically set the
volatile storage flag as anyway the container won't persist after a
reboot or machine crash.

[NO TESTS NEEDED]

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
