### PR TITLE
rootless: improve automatic range split

### DIFF
--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -137,7 +137,7 @@ func GetAvailableGids() (int64, error) {
 // It assumes availableMappings is sorted by ID.
 func findIDInMappings(id int64, availableMappings []user.IDMap) *user.IDMap {
 	i := sort.Search(len(availableMappings), func(i int) bool {
-		return availableMappings[i].ID >= id
+		return availableMappings[i].ID <= id
 	})
 	if i < 0 || i >= len(availableMappings) {
 		return nil
@@ -157,7 +157,7 @@ func MaybeSplitMappings(mappings []spec.LinuxIDMapping, availableMappings []user
 	overflow.Size = 0
 	consumed := 0
 	sort.Slice(availableMappings, func(i, j int) bool {
-		return availableMappings[i].ID < availableMappings[j].ID
+		return availableMappings[i].ID > availableMappings[j].ID
 	})
 	for {
 		cur := overflow

--- a/pkg/rootless/rootless_test.go
+++ b/pkg/rootless/rootless_test.go
@@ -98,4 +98,61 @@ func TestMaybeSplitMappings(t *testing.T) {
 	if !reflect.DeepEqual(newMappings, desiredMappings) {
 		t.Fatal("wrong mappings generated")
 	}
+
+	mappings = []spec.LinuxIDMapping{
+		{
+			ContainerID: 0,
+			HostID:      0,
+			Size:        4,
+		},
+	}
+	desiredMappings = []spec.LinuxIDMapping{
+		{
+			ContainerID: 0,
+			HostID:      0,
+			Size:        1,
+		},
+		{
+			ContainerID: 1,
+			HostID:      1,
+			Size:        1,
+		},
+		{
+			ContainerID: 2,
+			HostID:      2,
+			Size:        1,
+		},
+		{
+			ContainerID: 3,
+			HostID:      3,
+			Size:        1,
+		},
+	}
+	availableMappings = []user.IDMap{
+		{
+			ID:       0,
+			ParentID: 0,
+			Count:    1,
+		},
+		{
+			ID:       1,
+			ParentID: 1,
+			Count:    1,
+		},
+		{
+			ID:       2,
+			ParentID: 2,
+			Count:    1,
+		},
+		{
+			ID:       3,
+			ParentID: 3,
+			Count:    1,
+		},
+	}
+
+	newMappings = MaybeSplitMappings(mappings, availableMappings)
+	if !reflect.DeepEqual(newMappings, desiredMappings) {
+		t.Fatal("wrong mappings generated")
+	}
 }


### PR DESCRIPTION
sort.Search returns the smallest index, so provide the available IDs
in decreasing order.

It fixes an issue when splitting the current mappings over multiple
available IDs.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
