### PR TITLE
fix: docker APIv2 `images/get`

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -466,7 +466,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 
-	saveOptions := entities.ImageSaveOptions{Output: tmpfile.Name()}
+	saveOptions := entities.ImageSaveOptions{Format: "docker-archive", Output: tmpfile.Name()}
 	if err := imageEngine.Save(r.Context(), images[0], images[1:], saveOptions); err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -443,7 +443,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 
 	query := struct {
-		Names string `schema:"names"`
+		Names []string `schema:"names"`
 	}{
 		// This is where you can override the golang default value for one of fields
 	}
@@ -451,8 +451,16 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
-	images := make([]string, 0)
-	images = append(images, strings.Split(query.Names, ",")...)
+	if len(query.Names) <= 0 {
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, fmt.Errorf("no images to download"))
+		return
+	}
+	if len(query.Names) > 1 {
+		utils.Error(w, "Something went wrong.", http.StatusNotImplemented, fmt.Errorf("getting multiple image is not supported yet"))
+		return
+	}
+
+	images := query.Names
 	tmpfile, err := ioutil.TempFile("", "api.tar")
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -151,5 +151,6 @@ t DELETE libpod/images/test1:latest 200
 #      actual: {"cause":"no such image","message":"unable to find a name and tag match for busybox in repotags: no such image","response":500}
 #
 #t GET images/get?names=alpine,busybox 200 '[POSIX tar archive]'
+t GET "images/get?names=alpine" 200 '[POSIX tar archive]'
 
 # vim: filetype=sh

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -148,6 +148,7 @@ podman pull busybox
 #is "$img_cnt" 2 "number of images in tar archive"
 # TODO getting multiple images is not supported yet
 # once it is supported replace the test below by the tests above
-t GET "images/get?names=alpine&names=busybox" 501
+t GET "images/get?names=alpine&names=busybox" 501 \
+  .cause="getting multiple image is not supported yet"
 
 # vim: filetype=sh

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -140,17 +140,14 @@ t GET images/json?filters='{"reference":["test1"]}' 200 length=1
 
 t DELETE libpod/images/test1:latest 200
 
-# Export more than one image
-# FIXME FIXME FIXME, this doesn't work:
-#   not ok 64 [10-images] GET images/get?names=alpine,busybox : status
-#    expected: 200
-#      actual: 500
-#    expected: 200
-#  not ok 65 [10-images] GET images/get?names=alpine,busybox : output
-  #  expected: [POSIX tar archive]
-#      actual: {"cause":"no such image","message":"unable to find a name and tag match for busybox in repotags: no such image","response":500}
-#
-#t GET images/get?names=alpine,busybox 200 '[POSIX tar archive]'
 t GET "images/get?names=alpine" 200 '[POSIX tar archive]'
+
+podman pull busybox
+#t GET "images/get?names=alpine&names=busybox" 200 '[POSIX tar archive]'
+#img_cnt=$(tar xf "$WORKDIR/curl.result.out" manifest.json -O | jq "length")
+#is "$img_cnt" 2 "number of images in tar archive"
+# TODO getting multiple images is not supported yet
+# once it is supported replace the test below by the tests above
+t GET "images/get?names=alpine&names=busybox" 501
 
 # vim: filetype=sh


### PR DESCRIPTION
Fixing docker APIv2 `images/get/` endpoint.
Image format must be set to "docker-archive" not empty string.

resolves #10229