### PR TITLE
codespell cleanup

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -277,7 +277,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	createFlags.StringSliceVar(
 		&cf.GroupAdd,
 		groupAddFlagName, []string{},
-		"Add additional groups to the primary container process. 'keep-groups' allows container processes to use suplementary groups.",
+		"Add additional groups to the primary container process. 'keep-groups' allows container processes to use supplementary groups.",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(groupAddFlagName, completion.AutocompleteNone)
 

--- a/contrib/dependabot-dance
+++ b/contrib/dependabot-dance
@@ -55,8 +55,8 @@ function branch_dance() {
         echo
         echo "Commit author is '$author' (expected 'dependabot')"
         echo -n "Continue? [y/N] "
-        read ans
-        case "$ans" in
+        read answer
+        case "$answer" in
             [yY]*) ;;
             *) exit 1;;
         esac

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -952,7 +952,7 @@ The `container_manage_cgroup` boolean must be enabled for this to be allowed on 
 
 #### **\-\-timeout**=*seconds*
 
-Maximimum time a container is allowed to run before conmon sends it the kill
+Maximum time a container is allowed to run before conmon sends it the kill
 signal.  By default containers will run until they exit or are stopped by
 `podman stop`.
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1025,7 +1025,7 @@ setsebool -P container_manage_cgroup true
 
 #### **\-\-timeout**=*seconds*
 
-Maximimum time a container is allowed to run before conmon sends it the kill
+Maximum time a container is allowed to run before conmon sends it the kill
 signal.  By default containers will run until they exit or are stopped by
 `podman stop`.
 

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -301,7 +301,7 @@ type ContainerMiscConfig struct {
 	StopSignal uint `json:"stopSignal,omitempty"`
 	// StopTimeout is the signal that will be used to stop the container
 	StopTimeout uint `json:"stopTimeout,omitempty"`
-	// Timeout is maximimum time a container will run before getting the kill signal
+	// Timeout is maximum time a container will run before getting the kill signal
 	Timeout uint `json:"timeout,omitempty"`
 	// Time container was created
 	CreatedTime time.Time `json:"createdTime"`

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -66,7 +66,7 @@ type InspectContainerConfig struct {
 	Secrets []*InspectSecret `json:"Secrets,omitempty"`
 	// Timeout is time before container is killed by conmon
 	Timeout uint `json:"Timeout"`
-	// StopTimeout is time before container is stoped when calling stop
+	// StopTimeout is time before container is stopped when calling stop
 	StopTimeout uint `json:"StopTimeout"`
 }
 

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -270,7 +270,7 @@ var _ = Describe("Podman ps", func() {
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(result.OutputToString()).To(Equal(cid))
 
-		// Query by trunctated image name should not match ( should return empty output )
+		// Query by truncated image name should not match ( should return empty output )
 		result = podmanTest.Podman([]string{"ps", "-q", "--no-trunc", "-a", "--filter", "ancestor=quay.io/libpod/alpi"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))

--- a/test/upgrade/README.md
+++ b/test/upgrade/README.md
@@ -84,4 +84,4 @@ Where To Go From Here
 
 * Figuring out how/if to run variations with different config files
   (e.g. running OLD-PODMAN that creates a user libpod.conf, tweaking
-  that in the test, then running NEW-PODMAN upgrate tests)
+  that in the test, then running NEW-PODMAN upgrade tests)


### PR DESCRIPTION
[NO TESTS NEEDED] This is just running codespell on podman

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
