### PR TITLE
cgroup: fix rootless --cgroup-parent with pods

### DIFF
--- a/libpod/pod_internal.go
+++ b/libpod/pod_internal.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v3/libpod/define"
+	"github.com/containers/podman/v3/pkg/rootless"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -74,9 +75,11 @@ func (p *Pod) refresh() error {
 			}
 			p.state.CgroupPath = cgroupPath
 		case config.CgroupfsCgroupsManager:
-			p.state.CgroupPath = filepath.Join(p.config.CgroupParent, p.ID())
+			if rootless.IsRootless() && isRootlessCgroupSet(p.config.CgroupParent) {
+				p.state.CgroupPath = filepath.Join(p.config.CgroupParent, p.ID())
 
-			logrus.Debugf("setting pod cgroup to %s", p.state.CgroupPath)
+				logrus.Debugf("setting pod cgroup to %s", p.state.CgroupPath)
+			}
 		default:
 			return errors.Wrapf(define.ErrInvalidArg, "unknown cgroups manager %s specified", p.runtime.config.Engine.CgroupManager)
 		}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -295,7 +295,10 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 					if podCgroup == "" {
 						return nil, errors.Wrapf(define.ErrInternal, "pod %s cgroup is not set", pod.ID())
 					}
-					ctr.config.CgroupParent = podCgroup
+					canUseCgroup := !rootless.IsRootless() || isRootlessCgroupSet(podCgroup)
+					if canUseCgroup {
+						ctr.config.CgroupParent = podCgroup
+					}
 				} else if !rootless.IsRootless() {
 					ctr.config.CgroupParent = CgroupfsDefaultCgroupParent
 				}


### PR DESCRIPTION
extend to pods the existing check whether the cgroup is usable when
running as rootless with cgroupfs.

commit 17ce567c6827abdcd517699bc07e82ccf48f7619 introduced the
regression.

[NO TESTS NEEDED] -- we already have tests, they're just not being run. #10237 hopes to fix that.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
