### PR TITLE
Add support for podman manifest rm command

### DIFF
--- a/cmd/podman/manifest/manifest.go
+++ b/cmd/podman/manifest/manifest.go
@@ -19,7 +19,8 @@ var (
   podman manifest inspect localhost/list
   podman manifest annotate --annotation left=right mylist:v1.11 image:v1.11-amd64
   podman manifest push mylist:v1.11 docker://quay.io/myuser/image:v1.11
-  podman manifest remove mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736`,
+  podman manifest remove mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736
+  podman manifest rm mylist:v1.11`,
 	}
 )
 

--- a/cmd/podman/manifest/rm.go
+++ b/cmd/podman/manifest/rm.go
@@ -1,0 +1,51 @@
+package manifest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containers/podman/v3/cmd/podman/common"
+	"github.com/containers/podman/v3/cmd/podman/registry"
+	"github.com/containers/podman/v3/pkg/domain/entities"
+	"github.com/containers/podman/v3/pkg/errorhandling"
+	"github.com/spf13/cobra"
+)
+
+var (
+	rmCmd = &cobra.Command{
+		Use:                   "rm LIST",
+		Short:                 "Remove manifest list or image index from local storage",
+		Long:                  "Remove manifest list or image index from local storage.",
+		RunE:                  rm,
+		ValidArgsFunction:     common.AutocompleteImages,
+		Example:               `podman manifest rm mylist:v1.11`,
+		Args:                  cobra.ExactArgs(1),
+		DisableFlagsInUseLine: true,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: rmCmd,
+		Parent:  manifestCmd,
+	})
+}
+
+func rm(cmd *cobra.Command, args []string) error {
+	report, rmErrors := registry.ImageEngine().ManifestRm(context.Background(), args)
+	if report != nil {
+		for _, u := range report.Untagged {
+			fmt.Println("Untagged: " + u)
+		}
+		for _, d := range report.Deleted {
+			// Make sure an image was deleted (and not just untagged); else print it
+			if len(d) > 0 {
+				fmt.Println("Deleted: " + d)
+			}
+		}
+		registry.SetExitCode(report.ExitCode)
+	}
+
+	return errorhandling.JoinErrors(rmErrors)
+}

--- a/docs/source/manifest.rst
+++ b/docs/source/manifest.rst
@@ -14,3 +14,5 @@ Create and manipulate manifest lists and image indexes
 :doc:`push <markdown/podman-manifest-push.1>` Push a manifest list or image index to a registry
 
 :doc:`remove <markdown/podman-manifest-remove.1>` Remove an image from a manifest list or image index
+
+:doc:`rm <markdown/podman-manifest-rm.1>` Remove manifest list or image index from local storage

--- a/docs/source/markdown/podman-manifest-rm.1.md
+++ b/docs/source/markdown/podman-manifest-rm.1.md
@@ -1,0 +1,25 @@
+# podman-manifest-rm "1" "April 2021" "podman"
+
+## NAME
+podman\-manifest\-rm - Remove manifest list or image index from local storage
+
+## SYNOPSIS
+**podman manifest rm** *list-or-index* [...]
+
+## DESCRIPTION
+Removes one or more locally stored manifest lists.
+
+## EXAMPLE
+
+podman manifest rm <list>
+
+podman manifest rm listid1 listid2
+
+**storage.conf** (`/etc/containers/storage.conf`)
+
+storage.conf is the storage configuration file for all tools using containers/storage
+
+The storage configuration file specifies all of the available container storage options for tools using shared container storage.
+
+## SEE ALSO
+podman(1), containers-storage.conf(5), podman-manifest(1)

--- a/docs/source/markdown/podman-manifest.1.md
+++ b/docs/source/markdown/podman-manifest.1.md
@@ -22,6 +22,7 @@ The `podman manifest` command provides subcommands which can be used to:
 | inspect  | [podman-manifest-inspect(1)](podman-manifest-inspect.1.md)   | Display a manifest list or image index.                                     |
 | push     | [podman-manifest-push(1)](podman-manifest-push.1.md)         | Push a manifest list or image index to a registry.                          |
 | remove   | [podman-manifest-remove(1)](podman-manifest-remove.1.md)     | Remove an image from a manifest list or image index.                        |
+| rm       | [podman-manifest-rme(1)](podman-manifest-rm.1.md)            | Remove manifest list or image index from local storage.                |
 
 ## SEE ALSO
 podman(1), podman-manifest-add(1), podman-manifest-annotate(1), podman-manifest-create(1), podman-manifest-inspect(1), podman-manifest-push(1), podman-manifest-remove(1)

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -37,6 +37,7 @@ type ImageEngine interface {
 	ManifestAdd(ctx context.Context, opts ManifestAddOptions) (string, error)
 	ManifestAnnotate(ctx context.Context, names []string, opts ManifestAnnotateOptions) (string, error)
 	ManifestRemove(ctx context.Context, names []string) (string, error)
+	ManifestRm(ctx context.Context, names []string) (*ImageRemoveReport, []error)
 	ManifestPush(ctx context.Context, name, destination string, imagePushOpts ImagePushOptions) (string, error)
 	Sign(ctx context.Context, names []string, options SignOptions) (*SignReport, error)
 }

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -320,6 +320,11 @@ func (ir *ImageEngine) ManifestRemove(ctx context.Context, names []string) (stri
 	return manifestList.ID(), nil
 }
 
+// ManifestRm removes the specified manifest list from storage
+func (ir *ImageEngine) ManifestRm(ctx context.Context, names []string) (report *entities.ImageRemoveReport, rmErrors []error) {
+	return ir.Remove(ctx, names, entities.ImageRemoveOptions{})
+}
+
 // ManifestPush pushes a manifest list or image index to the destination
 func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination string, opts entities.ImagePushOptions) (string, error) {
 	manifestList, err := ir.Libpod.LibimageRuntime().LookupManifestList(name)

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -83,6 +83,11 @@ func (ir *ImageEngine) ManifestRemove(ctx context.Context, names []string) (stri
 	return fmt.Sprintf("%s :%s\n", updatedListID, names[1]), nil
 }
 
+// ManifestRm removes the specified manifest list from storage
+func (ir *ImageEngine) ManifestRm(ctx context.Context, names []string) (*entities.ImageRemoveReport, []error) {
+	return ir.Remove(ctx, names, entities.ImageRemoveOptions{})
+}
+
 // ManifestPush pushes a manifest list or image index to the destination
 func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination string, opts entities.ImagePushOptions) (string, error) {
 	options := new(images.PushOptions)

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -168,6 +168,10 @@ var _ = Describe("Podman manifest", func() {
 		session = podmanTest.Podman([]string{"manifest", "remove", "foo", "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
+
+		session = podmanTest.Podman([]string{"manifest", "rm", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	It("podman manifest push", func() {
@@ -248,6 +252,10 @@ var _ = Describe("Podman manifest", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"manifest", "inspect", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+
+		session = podmanTest.Podman([]string{"manifest", "rm", "foo1", "foo2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})


### PR DESCRIPTION
This is mainly to match command line of Docker.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
