### PR TITLE
CI: run rootless tests under ubuntu

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -539,7 +539,7 @@ rootless_integration_test_task:
     skip: *branches_and_tags
     depends_on:
         - unit_test
-    matrix: *fedora_vm_axis
+    matrix: *platform_axis
     gce_instance: *standardvm
     timeout_in: 90m
     env:
@@ -614,7 +614,7 @@ rootless_system_test_task:
     only_if: *not_docs
     depends_on:
       - rootless_integration_test
-    matrix: *fedora_vm_axis
+    matrix: *platform_axis
     gce_instance: *standardvm
     env:
         TEST_FLAVOR: sys

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -605,13 +605,6 @@ func SkipIfRootlessCgroupsV1(reason string) {
 	}
 }
 
-func SkipIfUnprivilegedCPULimits() {
-	info := GetHostDistributionInfo()
-	if isRootless() && info.Distribution == "fedora" {
-		ginkgo.Skip("Rootless Fedora doesn't have permission to set CPU limits")
-	}
-}
-
 func SkipIfRootless(reason string) {
 	checkReason(reason)
 	if os.Geteuid() != 0 {

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1999,8 +1999,7 @@ VOLUME %s`, ALPINE, hostPathDir+"/")
 
 	It("podman play kube allows setting resource limits", func() {
 		SkipIfContainerized("Resource limits require a running systemd")
-		SkipIfRootlessCgroupsV1("Limits require root or cgroups v2")
-		SkipIfUnprivilegedCPULimits()
+		SkipIfRootless("CPU limits require root")
 		podmanTest.CgroupManager = "systemd"
 
 		var (

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -10,15 +10,17 @@ function setup() {
     :
 }
 
-@test "podman --context emits reasonable output" {
-    run_podman 125 --context=swarm version
-    is "$output" "Error: Podman does not support swarm, the only --context value allowed is \"default\"" "--context=default or fail"
-
-    run_podman --context=default version
-}
+#### DO NOT ADD ANY TESTS HERE! ADD NEW TESTS AT BOTTOM!
 
 @test "podman version emits reasonable output" {
     run_podman version
+
+    # FIXME FIXME FIXME: #10248: nasty message on Ubuntu cgroups v1, rootless
+    if [[ "$output" =~ "overlay test mount with multiple lowers failed" ]]; then
+        if is_rootless; then
+            lines=("${lines[@]:1}")
+        fi
+    fi
 
     # First line of podman-remote is "Client:<blank>".
     # Just delete it (i.e. remove the first entry from the 'lines' array)
@@ -40,6 +42,17 @@ function setup() {
     fi
 }
 
+
+@test "podman --context emits reasonable output" {
+    # All we care about here is that the command passes
+    run_podman --context=default version
+
+    # This one must fail
+    run_podman 125 --context=swarm version
+    is "$output" \
+       "Error: Podman does not support swarm, the only --context value allowed is \"default\"" \
+       "--context=default or fail"
+}
 
 @test "podman can pull an image" {
     run_podman pull $IMAGE


### PR DESCRIPTION
Reason: to catch errors before they surface in RHEL.

One of the Ubuntus is specially crafted to run with cgroups v1
and runc. Although this isn't quite the same as RHEL, it's as
close as we can come in our CI environment, and I suspect it
would have caught #10234 (a regression).

Sorry, team.

[NO TESTS NEEDED] - we already have tests, this PR will make them run

Signed-off-by: Ed Santiago <santiago@redhat.com>
