### PR TITLE
Fix infinite loop in isPathOnVolume

### DIFF
--- a/libpod/container_path_resolution.go
+++ b/libpod/container_path_resolution.go
@@ -128,7 +128,7 @@ func isPathOnVolume(c *Container, containerPath string) bool {
 		if cleanedContainerPath == filepath.Clean(vol.Dest) {
 			return true
 		}
-		for dest := vol.Dest; dest != "/"; dest = filepath.Dir(dest) {
+		for dest := vol.Dest; dest != "/" && dest != "."; dest = filepath.Dir(dest) {
 			if cleanedContainerPath == dest {
 				return true
 			}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -921,6 +921,17 @@ USER mail`, BB)
 		Expect(session.OutputToString()).To(ContainSubstring("mail root"))
 	})
 
+	It("podman run with incorect VOLUME", func() {
+		dockerfile := fmt.Sprintf(`FROM %s
+VOLUME ['/etc/foo']
+WORKDIR /etc/foo`, BB)
+		podmanTest.BuildImage(dockerfile, "test", "false")
+		session := podmanTest.Podman([]string{"run", "--rm", "test", "echo", "test"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("test"))
+	})
+
 	It("podman run --volumes-from flag", func() {
 		vol := filepath.Join(podmanTest.TempDir, "vol-test")
 		err := os.MkdirAll(vol, 0755)


### PR DESCRIPTION
[filepath.Dir](https://golang.org/pkg/path/filepath/#Dir) in some cases returns `.` symbol and calling this function again returns same result. In such cases this function never returns and causes some operations to stuck forever.

Closes #10216