### PR TITLE
build: improve regex for iidfile

### DIFF
--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -28,6 +28,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var (
+	iidRegex = regexp.MustCompile(`^[0-9a-f]{12}`)
+)
+
 // Build creates an image using a containerfile reference
 func Build(ctx context.Context, containerFiles []string, options entities.BuildOptions) (*entities.BuildReport, error) {
 	params := url.Values{}
@@ -337,7 +341,6 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 	}
 
 	dec := json.NewDecoder(body)
-	re := regexp.MustCompile(`[0-9a-f]{12}`)
 
 	var id string
 	var mErr error
@@ -366,7 +369,7 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		switch {
 		case s.Stream != "":
 			stdout.Write([]byte(s.Stream))
-			if re.Match([]byte(s.Stream)) {
+			if iidRegex.Match([]byte(s.Stream)) {
 				id = strings.TrimSuffix(s.Stream, "\n")
 			}
 		case s.Error != "":

--- a/pkg/bindings/images/build_test.go
+++ b/pkg/bindings/images/build_test.go
@@ -1,0 +1,17 @@
+package images
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildMatchIID(t *testing.T) {
+	assert.True(t, iidRegex.MatchString("a883dafc480d466ee04e0d6da986bd78eb1fdd2178d04693723da3a8f95d42f4"))
+	assert.True(t, iidRegex.MatchString("3da3a8f95d42"))
+	assert.False(t, iidRegex.MatchString("3da3"))
+}
+
+func TestBuildNotMatchStatusMessage(t *testing.T) {
+	assert.False(t, iidRegex.MatchString("Copying config a883dafc480d466ee04e0d6da986bd78eb1fdd2178d04693723da3a8f95d42f4"))
+}


### PR DESCRIPTION
improve the regex to match only at the beginning of the line.

It prevents matching "Copying %s $CHECKSUM" messages returned by the
containers/image copy process.

Closes: https://github.com/containers/podman/issues/10233

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
