### PR TITLE
[CI:DOCS] Fix wrong macvlan PNG in networking tutorial doc.

### DIFF
--- a/docs/tutorials/basic_networking.md
+++ b/docs/tutorials/basic_networking.md
@@ -151,7 +151,7 @@ host. This interface can configure multiple subinterfaces.  And each subinterfac
 is capable of having its own MAC and IP address.  In the case of Podman containers,
 the container will present itself as if it is on the same network as the host.
 
-![macvlan_network](podman_bridge.png)
+![macvlan_network](podman_macvlan.png)
 
 In the illustration, outside clients will be able to access the web container by
 its IP address directly.  Usually the network information, including IP address,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
