### PR TITLE
Revert Patch to relabel if selinux not enabled

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -377,14 +377,8 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 			case "z":
 				fallthrough
 			case "Z":
-				if c.MountLabel() != "" {
-					if c.ProcessLabel() != "" {
-						if err := label.Relabel(m.Source, c.MountLabel(), label.IsShared(o)); err != nil {
-							return nil, err
-						}
-					} else {
-						logrus.Infof("Not relabeling volume %q in container %s as SELinux is disabled", m.Source, c.ID())
-					}
+				if err := label.Relabel(m.Source, c.MountLabel(), label.IsShared(o)); err != nil {
+					return nil, err
 				}
 
 			default:


### PR DESCRIPTION
Revert : https://github.com/containers/podman/pull/9895

Turns out that if Docker is in --selinux-enabeled, it still relabels if
the user tells the system to, even if running a --privileged container
or if the selinux separation is disabled --security-opt label=disable.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
