### PR TITLE
[CI:DOCS] Stop conversion of `--` into en dash

### DIFF
--- a/docs/remote-docs.sh
+++ b/docs/remote-docs.sh
@@ -80,7 +80,7 @@ function html_fn() {
         local link=$(sed -e 's?.so man1/\(.*\)?\1?' <$dir/links/${file%.md})
         markdown=$dir/$link.md
     fi
-    pandoc --ascii --standalone \
+    pandoc --ascii --standalone --from markdown-smart \
         --lua-filter=docs/links-to-html.lua \
         --lua-filter=docs/use-pagetitle.lua \
         -o $TARGET/${file%%.*}.html $markdown

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,10 @@ exclude_patterns = []
 
 master_doc = "index"
 
+# Configure smartquotes to only transform quotes and ellipses, not dashes
+smartquotes_action = "qe"
+
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
This turns off the "smartquotes" dash transform, which converts unescaped `--`/`---` into en/em dash characters.

The conversion is a problem because it makes long option names appear to start with a single en dash (–example-option) instead of two dashes (--example-option). There are around a hundred such cases in the source currently (see: containers/podman.io#389)

Escaping as `\-\-` works around this, but that can't be applied globally because escape codes aren't processed inside code blocks.

Checking in the documentation source I can only find `--` used in long option names or console output. `---` is only used once, in console output. Since there are no cases where these sequences are deliberately used to create en/em dashes I think it makes sense to switch off the transformation.

The Sphinx build (which makes http://docs.podman.io/en/latest) has a configuration option to turn off just the dash transform. The quote/apostrophe and ellipsis transforms can be left enabled.

The pandoc build (podman remote-windows docs) only has the option to turn off the entire smart extension. Since the equivalent Linux/Darwin manpages are processed without smartquotes it seems reasonable to make the windows docs match.

Setting those options makes it unnecessary to wrap `--` in a code block or escape them as `\-\-`. Note that `\-\-` still works exactly as before, so I haven't converted those back to `--` in the source.