### PR TITLE
fix: compat API "images/get" for multiple images

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -455,10 +455,6 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusBadRequest, fmt.Errorf("no images to download"))
 		return
 	}
-	if len(query.Names) > 1 {
-		utils.Error(w, "Something went wrong.", http.StatusNotImplemented, fmt.Errorf("getting multiple image is not supported yet"))
-		return
-	}
 
 	images := query.Names
 	tmpfile, err := ioutil.TempFile("", "api.tar")
@@ -474,7 +470,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 
-	saveOptions := entities.ImageSaveOptions{Format: "docker-archive", Output: tmpfile.Name()}
+	saveOptions := entities.ImageSaveOptions{Format: "docker-archive", Output: tmpfile.Name(), MultiImageArchive: true}
 	if err := imageEngine.Save(r.Context(), images[0], images[1:], saveOptions); err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -143,12 +143,8 @@ t DELETE libpod/images/test1:latest 200
 t GET "images/get?names=alpine" 200 '[POSIX tar archive]'
 
 podman pull busybox
-#t GET "images/get?names=alpine&names=busybox" 200 '[POSIX tar archive]'
-#img_cnt=$(tar xf "$WORKDIR/curl.result.out" manifest.json -O | jq "length")
-#is "$img_cnt" 2 "number of images in tar archive"
-# TODO getting multiple images is not supported yet
-# once it is supported replace the test below by the tests above
-t GET "images/get?names=alpine&names=busybox" 501 \
-  .cause="getting multiple image is not supported yet"
+t GET "images/get?names=alpine&names=busybox" 200 '[POSIX tar archive]'
+img_cnt=$(tar xf "$WORKDIR/curl.result.out" manifest.json -O | jq "length")
+is "$img_cnt" 2 "number of images in tar archive"
 
 # vim: filetype=sh


### PR DESCRIPTION
Fix Docker APIv2 `images/get` endpoint to be able to download multiple images.