### PR TITLE
Create the /etc/mtab file if does not exists

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1530,6 +1530,16 @@ func (c *Container) mountStorage() (_ string, deferredErr error) {
 		}()
 	}
 
+	// If /etc/mtab does not exist in container image, then we need to
+	// create it, so that mount command within the container will work.
+	mtab := filepath.Join(mountPoint, "/etc/mtab")
+	if err := os.MkdirAll(filepath.Dir(mtab), 0755); err != nil {
+		return "", errors.Wrap(err, "error creating mtab directory")
+	}
+	if err = os.Symlink("/proc/mounts", mtab); err != nil && !os.IsExist(err) {
+		return "", err
+	}
+
 	// Request a mount of all named volumes
 	for _, v := range c.config.NamedVolumes {
 		vol, err := c.mountNamedVolume(v, mountPoint)

--- a/libpod/diff.go
+++ b/libpod/diff.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var containerMounts = map[string]bool{
+var initInodes = map[string]bool{
 	"/dev":               true,
 	"/etc/hostname":      true,
 	"/etc/hosts":         true,
@@ -17,6 +17,7 @@ var containerMounts = map[string]bool{
 	"/run/.containerenv": true,
 	"/run/secrets":       true,
 	"/sys":               true,
+	"/etc/mtab":          true,
 }
 
 // GetDiff returns the differences between the two images, layers, or containers
@@ -36,7 +37,7 @@ func (r *Runtime) GetDiff(from, to string) ([]archive.Change, error) {
 	changes, err := r.store.Changes(fromLayer, toLayer)
 	if err == nil {
 		for _, c := range changes {
-			if containerMounts[c.Path] {
+			if initInodes[c.Path] {
 				continue
 			}
 			rchanges = append(rchanges, c)

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -690,4 +690,18 @@ json-file | f
     run_podman rm $cid
 }
 
+@test "podman run no /etc/mtab " {
+    tmpdir=$PODMAN_TMPDIR/build-test
+    mkdir -p $tmpdir
+
+    cat >$tmpdir/Dockerfile <<EOF
+FROM $IMAGE
+RUN rm /etc/mtab
+EOF
+    expected="'/etc/mtab' -> '/proc/mounts'"
+    run_podman build -t nomtab $tmpdir
+    run_podman run --rm nomtab stat -c %N /etc/mtab
+    is "$output" "$expected" "/etc/mtab should be created"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
We should create the /etc/mtab->/proc/mountinfo link
so that mount command will work within the container.

Docker does this by default.

Fixes: https://github.com/containers/podman/issues/10263

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
