### PR TITLE
fix: use UTC for `containers/{name}/json` endpoint

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -379,6 +379,11 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 	if err != nil {
 		return nil, err
 	}
+	// Docker uses UTC
+	if inspect != nil && inspect.State != nil {
+		inspect.State.StartedAt = inspect.State.StartedAt.UTC()
+		inspect.State.FinishedAt = inspect.State.FinishedAt.UTC()
+	}
 	i, err := json.Marshal(inspect.State)
 	if err != nil {
 		return nil, err
@@ -425,7 +430,7 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 
 	cb := types.ContainerJSONBase{
 		ID:              l.ID(),
-		Created:         l.CreatedTime().Format(time.RFC3339Nano),
+		Created:         l.CreatedTime().UTC().Format(time.RFC3339Nano), // Docker uses UTC
 		Path:            inspect.Path,
 		Args:            inspect.Args,
 		State:           &state,

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -161,6 +161,12 @@ t GET libpod/containers/myctr/json 200 \
   .OCIConfigPath~.*config\.json \
   .GraphDriver.Data.MergedDir~.*merged
 
+# Test TS are in UTC
+t GET containers/myctr/json 200 \
+  .Created~.*Z \
+  .State.StartedAt~.*Z \
+  .State.FinishedAt~.*Z
+
 t DELETE images/localhost/newrepo:latest?force=true 200
 t DELETE images/localhost/newrepo:v1?force=true 200
 t DELETE images/localhost/newrepo:v2?force=true 200


### PR DESCRIPTION
Reason: docker daemon uses timestamps in UTC not local date.

resolves: #10267