### PR TITLE
Add host.serviceIsRemote to podman info results

### DIFF
--- a/cmd/podman/system/info.go
+++ b/cmd/podman/system/info.go
@@ -78,6 +78,8 @@ func info(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	info.Host.ServiceIsRemote = registry.IsRemote()
+
 	switch {
 	case report.IsJSON(inFormat):
 		b, err := json.MarshalIndent(info, "", "  ")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,10 +29,7 @@ author = "team"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    "sphinx_markdown_tables",
-    "recommonmark"
-]
+extensions = ["sphinx_markdown_tables", "recommonmark"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -66,26 +63,27 @@ html_css_files = [
 
 # -- Extension configuration -------------------------------------------------
 
+
 def convert_markdown_title(app, docname, source):
     # Process markdown files only
     docpath = app.env.doc2path(docname)
     if docpath.endswith(".md"):
         # Convert pandoc title line into eval_rst block for recommonmark
-        source[0] = re.sub(
-            r"^% (.*)",
-            r"```eval_rst\n.. title:: \g<1>\n```",
-            source[0])
+        source[0] = re.sub(r"^% (.*)", r"```eval_rst\n.. title:: \g<1>\n```", source[0])
 
 
 def setup(app):
     app.connect("source-read", convert_markdown_title)
 
     app.add_config_value(
-        "recommonmark_config", {
+        "recommonmark_config",
+        {
             "enable_eval_rst": True,
             "enable_auto_doc_ref": False,
             "enable_auto_toc_tree": False,
             "enable_math": False,
             "enable_inline_math": False,
-        }, True)
+        },
+        True,
+    )
     app.add_transform(AutoStructify)

--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -21,31 +21,34 @@ type SecurityInfo struct {
 	SELinuxEnabled      bool   `json:"selinuxEnabled"`
 }
 
-//HostInfo describes the libpod host
+// HostInfo describes the libpod host
 type HostInfo struct {
-	Arch           string                 `json:"arch"`
-	BuildahVersion string                 `json:"buildahVersion"`
-	CgroupManager  string                 `json:"cgroupManager"`
-	CGroupsVersion string                 `json:"cgroupVersion"`
-	Conmon         *ConmonInfo            `json:"conmon"`
-	CPUs           int                    `json:"cpus"`
-	Distribution   DistributionInfo       `json:"distribution"`
-	EventLogger    string                 `json:"eventLogger"`
-	Hostname       string                 `json:"hostname"`
-	IDMappings     IDMappings             `json:"idMappings,omitempty"`
-	Kernel         string                 `json:"kernel"`
-	MemFree        int64                  `json:"memFree"`
-	MemTotal       int64                  `json:"memTotal"`
-	OCIRuntime     *OCIRuntimeInfo        `json:"ociRuntime"`
-	OS             string                 `json:"os"`
-	RemoteSocket   *RemoteSocket          `json:"remoteSocket,omitempty"`
-	RuntimeInfo    map[string]interface{} `json:"runtimeInfo,omitempty"`
-	Security       SecurityInfo           `json:"security"`
-	Slirp4NetNS    SlirpInfo              `json:"slirp4netns,omitempty"`
-	SwapFree       int64                  `json:"swapFree"`
-	SwapTotal      int64                  `json:"swapTotal"`
-	Uptime         string                 `json:"uptime"`
-	Linkmode       string                 `json:"linkmode"`
+	Arch           string           `json:"arch"`
+	BuildahVersion string           `json:"buildahVersion"`
+	CgroupManager  string           `json:"cgroupManager"`
+	CGroupsVersion string           `json:"cgroupVersion"`
+	Conmon         *ConmonInfo      `json:"conmon"`
+	CPUs           int              `json:"cpus"`
+	Distribution   DistributionInfo `json:"distribution"`
+	EventLogger    string           `json:"eventLogger"`
+	Hostname       string           `json:"hostname"`
+	IDMappings     IDMappings       `json:"idMappings,omitempty"`
+	Kernel         string           `json:"kernel"`
+	MemFree        int64            `json:"memFree"`
+	MemTotal       int64            `json:"memTotal"`
+	OCIRuntime     *OCIRuntimeInfo  `json:"ociRuntime"`
+	OS             string           `json:"os"`
+	// RemoteSocket returns the UNIX domain socket the Podman service is listening on
+	RemoteSocket *RemoteSocket          `json:"remoteSocket,omitempty"`
+	RuntimeInfo  map[string]interface{} `json:"runtimeInfo,omitempty"`
+	// ServiceIsRemote is true when the podman/libpod service is remote to the client
+	ServiceIsRemote bool         `json:"serviceIsRemote"`
+	Security        SecurityInfo `json:"security"`
+	Slirp4NetNS     SlirpInfo    `json:"slirp4netns,omitempty"`
+	SwapFree        int64        `json:"swapFree"`
+	SwapTotal       int64        `json:"swapTotal"`
+	Uptime          string       `json:"uptime"`
+	Linkmode        string       `json:"linkmode"`
 }
 
 // RemoteSocket describes information about the API socket

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -124,4 +124,15 @@ var _ = Describe("Podman Info", func() {
 		}
 	})
 
+	It("verify ServiceIsRemote", func() {
+		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.ServiceIsRemote}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(Exit(0))
+
+		if podmanTest.RemoteTest {
+			Expect(session.OutputToString()).To(ContainSubstring("true"))
+		} else {
+			Expect(session.OutputToString()).To(ContainSubstring("false"))
+		}
+	})
 })


### PR DESCRIPTION
Developers asked for a deterministic field to verify if podman is running via API or linked directly to libpod library.

```
$ podman info --format '{{.Host.ServiceIsRemote}}'
false
$ podman-remote info --format '{{.Host.ServiceIsRemote}}'
true
$ podman --remote info --format '{{.Host.ServiceIsRemote}}'
true
```

* `docs/conf.py` formatted via black

Fixes: #10289
Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
