### PR TITLE
fix restart always with slirp4netns

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
+github.com/coreos/go-systemd/v22 v22.3.1/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -283,6 +283,14 @@ func (c *Container) handleRestartPolicy(ctx context.Context) (_ bool, retErr err
 		return false, err
 	}
 
+	// setup slirp4netns again because slirp4netns will die when conmon exits
+	if c.config.NetMode.IsSlirp4netns() {
+		err := c.runtime.setupSlirp4netns(c)
+		if err != nil {
+			return false, err
+		}
+	}
+
 	if c.state.State == define.ContainerStateStopped {
 		// Reinitialize the container if we need to
 		if err := c.reinit(ctx, true); err != nil {

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -33,9 +33,10 @@ load helpers
 
     # Bind-mount this file with a different name to a container running httpd
     run_podman run -d --name myweb -p "$HOST_PORT:80" \
-	       -v $INDEX1:/var/www/index.txt \
-	       -w /var/www \
-	       $IMAGE /bin/busybox-extras httpd -f -p 80
+            --restart always \
+            -v $INDEX1:/var/www/index.txt \
+            -w /var/www \
+            $IMAGE /bin/busybox-extras httpd -f -p 80
     cid=$output
 
     # In that container, create a second file, using exec and redirection
@@ -66,6 +67,45 @@ load helpers
 
     run_podman 125 port myweb 99/tcp
     is "$output" 'Error: failed to find published port "99/tcp"'
+
+    # Tests #10310: podman will restart slirp4netns on container restart
+    run_podman container inspect --format "{{.State.Pid}}" $cid
+    pid=$output
+
+    # Kill the process; podman restart policy will bring up a new container.
+    # -9 is crucial: busybox httpd ignores all other signals.
+    kill -9 $pid
+    # Wait for process to exit
+    retries=30
+    while kill -0 $pid; do
+        sleep 0.5
+        retries=$((retries - 1))
+        if [[ $retries -eq 0 ]]; then
+            die "Process $pid (container $cid) refused to die"
+        fi
+    done
+
+    # Wait for container to restart
+    retries=20
+    while :;do
+        run_podman '?' container inspect --format "{{.State.Pid}}" myweb
+        if [[ $status -eq 0 ]]; then
+            if [[ $output == $pid ]]; then
+                die "This should never happen! Restarted container has same PID ($output) as killed one!"
+            fi
+            break
+        fi
+        sleep 0.5
+        retries=$((retries - 1))
+        if [[ $retries -eq 0 ]]; then
+            die "Timed out waiting for container to restart"
+        fi
+    done
+
+    # Verify http contents again: curl from localhost
+    # Use retry since it can take a moment until the new container is ready
+    run curl --retry 2 -s $SERVER/index.txt
+    is "$output" "$random_1" "curl 127.0.0.1:/index.txt after restart"
 
     # Clean up
     run_podman stop -t 1 myweb


### PR DESCRIPTION
When a container is automatically restarted due its restart policy and
the container used the slirp4netns netmode, the slirp4netns process
died. This caused the container to lose network connectivity.

To fix this we have to start a new slirp4netns process.

Fixes #8047

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
