### PR TITLE
fix incorrect log driver in podman container image

### DIFF
--- a/contrib/podmanimage/stable/containers.conf
+++ b/contrib/podmanimage/stable/containers.conf
@@ -5,7 +5,7 @@ ipcns="host"
 utsns="host"
 cgroupns="host"
 cgroups="disabled"
-log_driver = "k8s_file"
+log_driver = "k8s-file"
 [engine]
 cgroup_manager = "cgroupfs"
 events_logger="file"


### PR DESCRIPTION
Commit 7f2c27d43fc5 added an invalid value for the log_driver in the
containers.conf file inside the podman image.

Fixes #10312

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
