### PR TITLE
fix network restart always test

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -88,8 +88,9 @@ load helpers
     # Wait for container to restart
     retries=20
     while :;do
-        run_podman '?' container inspect --format "{{.State.Pid}}" myweb
-        if [[ $status -eq 0 ]]; then
+        run_podman container inspect --format "{{.State.Pid}}" myweb
+        # pid is 0 as long as the container is not running
+        if [[ $output -ne 0 ]]; then
             if [[ $output == $pid ]]; then
                 die "This should never happen! Restarted container has same PID ($output) as killed one!"
             fi


### PR DESCRIPTION
The added test in 30544f225e73 is flaking. Podman inspect is always
working so we have to check the pid instead.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
