### PR TITLE
Fix problem copying files when container is in host pid namespace

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -892,3 +892,26 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 
 	return hostConfig, nil
 }
+
+// Return true if the container is running in the host's PID NS.
+func (c *Container) inHostPidNS() (bool, error) {
+	if c.config.PIDNsCtr != "" {
+		return false, nil
+	}
+	ctrSpec, err := c.specFromState()
+	if err != nil {
+		return false, err
+	}
+	if ctrSpec.Linux != nil {
+		// Locate the spec's PID namespace.
+		// If there is none, it's pid=host.
+		// If there is one and it has a path, it's "ns:".
+		// If there is no path, it's default - the empty string.
+		for _, ns := range ctrSpec.Linux.Namespaces {
+			if ns.Type == spec.PIDNamespace {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -130,6 +130,22 @@ load helpers
 }
 
 
+@test "podman cp file from/to host while --pid=host" {
+    if is_rootless && ! is_cgroupsv2; then
+        skip "'podman cp --pid=host' (rootless) only works with cgroups v2"
+    fi
+
+    srcdir=$PODMAN_TMPDIR/cp-pid-equals-host
+    mkdir -p $srcdir
+    touch $srcdir/hostfile
+
+    run_podman run --pid=host -d --name cpcontainer $IMAGE sleep infinity
+    run_podman cp $srcdir/hostfile cpcontainer:/tmp/hostfile
+    run_podman cp cpcontainer:/tmp/hostfile $srcdir/hostfile1
+    run_podman kill cpcontainer
+    run_podman rm -f cpcontainer
+}
+
 @test "podman cp file from container to host" {
     srcdir=$PODMAN_TMPDIR/cp-test-file-ctr-to-host
     mkdir -p $srcdir


### PR DESCRIPTION
When attempting to copy files into and out of running containers
within the host pidnamespace, the code was attempting to join the
host pidns again, and getting an error. This was causing the podman
cp command to fail. Since we are already in the host pid namespace,
we should not be attempting to join.  This PR adds a check to see if
the container is in NOT host pid namespace, and only then attempts to
join.

Fixes: https://github.com/containers/podman/issues/9985

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
