### PR TITLE
[CI:DOCS] Update first line in intro page

### DIFF
--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -2,7 +2,7 @@
 
 Introduction
 ==================================
-Containers_ simplify the consumption of applications with all of their dependencies and default configuration files. Users test drive or deploy a new application with one or two commands instead of following pages of installation instructions. Here's how to find your first `Container Image`_::
+Containers_ simplify the production, distribution, discoverability, and usage of applications with all of their dependencies and default configuration files. Users test drive or deploy a new application with one or two commands instead of following pages of installation instructions. Here's how to find your first `Container Image`_::
 
     podman search busybox
 


### PR DESCRIPTION
Remove the word `consumption` and give a better description for the
first line of the introduction page.

Fixes: #10325

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
