### PR TITLE
Ensure that :Z/:z/:U can be used with named volumes

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -359,6 +359,25 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 		return nil, err
 	}
 
+	// Add named volumes
+	for _, namedVol := range c.config.NamedVolumes {
+		volume, err := c.runtime.GetVolume(namedVol.Name)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error retrieving volume %s to add to container %s", namedVol.Name, c.ID())
+		}
+		mountPoint, err := volume.MountPoint()
+		if err != nil {
+			return nil, err
+		}
+		volMount := spec.Mount{
+			Type:        "bind",
+			Source:      mountPoint,
+			Destination: namedVol.Dest,
+			Options:     namedVol.Options,
+		}
+		g.AddMount(volMount)
+	}
+
 	// Check if the spec file mounts contain the options z, Z or U.
 	// If they have z or Z, relabel the source directory and then remove the option.
 	// If they have U, chown the source directory and them remove the option.
@@ -391,25 +410,6 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 
 	g.SetProcessSelinuxLabel(c.ProcessLabel())
 	g.SetLinuxMountLabel(c.MountLabel())
-
-	// Add named volumes
-	for _, namedVol := range c.config.NamedVolumes {
-		volume, err := c.runtime.GetVolume(namedVol.Name)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error retrieving volume %s to add to container %s", namedVol.Name, c.ID())
-		}
-		mountPoint, err := volume.MountPoint()
-		if err != nil {
-			return nil, err
-		}
-		volMount := spec.Mount{
-			Type:        "bind",
-			Source:      mountPoint,
-			Destination: namedVol.Dest,
-			Options:     namedVol.Options,
-		}
-		g.AddMount(volMount)
-	}
 
 	// Add bind mounts to container
 	for dstPath, srcPath := range c.state.BindMounts {

--- a/test/e2e/run_selinux_test.go
+++ b/test/e2e/run_selinux_test.go
@@ -343,4 +343,12 @@ var _ = Describe("Podman run", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.OutputToString()).To(ContainSubstring("container_init_t"))
 	})
+
+	It("podman relabels named volume with :Z", func() {
+		session := podmanTest.Podman([]string{"run", "-v", "testvol:/test1/test:Z", fedoraMinimal, "ls", "-alZ", "/test1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ := session.GrepString(":s0:")
+		Expect(match).Should(BeTrue())
+	})
 })


### PR DESCRIPTION
Docker allows relabeling of any volume passed in via -v, even including named volumes. This normally isn't an issue at all, given named volumes get the right label for container access automatically, but this becomes an issue when volume plugins are involved - these aren't managed by Podman, and may well be unaware of SELinux labelling. We could automatically relabel these volumes on creation, but I'm still reluctant to do that (feels like it could break things). Instead, let's allow :z and :Z to be used with named volumes, so users can explicitly request relabel of a volume plugin-backed volume.

We also get :U at the same time. I don't see any real need for it but it also doesn't seem to hurt, so I didn't bother disabling it.

Fixes #10273
