### PR TITLE
auto-update service: prune images

### DIFF
--- a/contrib/systemd/auto-update/podman-auto-update.service
+++ b/contrib/systemd/auto-update/podman-auto-update.service
@@ -7,6 +7,7 @@ After=network-online.target
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/podman auto-update
+ExecStartPost=/usr/bin/podman image prune -f
 
 [Install]
 WantedBy=multi-user.target default.target


### PR DESCRIPTION
Extend the systemd auto-update service to prune images after an update
has run.  As reported by a user [1], auto updates can over time cause
the disk to run out of space.  With Edge being a target use case, we
need to make sure that systems can run without much supervision, so
let's make sure to run `podman image prune` to clean up dangling images.

[1] https://twitter.com/r_isc_y/status/1388981737011793921

Fixes: #10190
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@containers/podman-maintainers @mrguitar PTAL