### PR TITLE
[CI:DOCS] network tutorial: update with rootless cni changes

### DIFF
--- a/docs/tutorials/basic_networking.md
+++ b/docs/tutorials/basic_networking.md
@@ -87,12 +87,16 @@ network, and the one will be created as a bridge network.
 $ podman network create
 ```
 
-When rootless containers are run with a CNI networking configuration, a “side-car”
-container for running CNI is also run. Do not remove this container while your rootless
-containers are running.  if you remove this container (e.g by accident) all attached
-containers lose network connectivity. In order to restore the network connectivity
-all containers with networks must be restarted. This will automatically recreate
-the "side-car" container. For rootfull containers, there is no “side-car” container
+When rootless containers are run with a CNI networking configuration, CNI operations
+will be executed inside an extra network namespace. To join this namespace, use
+`podman unshare --rootless-cni`. Podman version 3.1 and earlier use a special “side-car”
+container called rootless-cni-infra. Do not remove this container while your rootless
+containers are running. If you remove this container (e.g. by accident), all attached
+containers lose network connectivity. In order to restore the network connectivity, all
+containers with networks must be restarted. This will automatically recreate the "side-car"
+container. When you are using version 3.2 or newer the “side-car” container can be
+safely removed. Therefore, it is no longer used.
+For rootfull containers, there is no extra namespace or “side-car” container
 as rootfull users have the permissions to create and modify network interfaces on
 the host.
 


### PR DESCRIPTION
Starting with podman v3.2 rootless cni will work without the
rootless-cni-infra container. Update the network tutorial to refelct the
latest changes and mention that the infra container can be removed.

Signed-off-by: Paul Holzinger <paul.holzinger@web.de>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
