### PR TITLE
podman network reload add rootless support

### DIFF
--- a/cmd/podman/networks/reload.go
+++ b/cmd/podman/networks/reload.go
@@ -26,9 +26,6 @@ var (
 		Example: `podman network reload --latest
   podman network reload 3c13ef6dd843
   podman network reload test1 test2`,
-		Annotations: map[string]string{
-			registry.ParentNSRequired: "",
-		},
 	}
 )
 

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -179,6 +179,9 @@ var (
 	// ErrNoNetwork indicates that a container has no net namespace, like network=none
 	ErrNoNetwork = errors.New("container has no network namespace")
 
+	// ErrNetworkModeInvalid indicates that a container has the wrong network mode for an operation
+	ErrNetworkModeInvalid = errors.New("invalid network mode")
+
 	// ErrSetSecurityAttribute indicates that a request to set a container's security attribute
 	// was not possible.
 	ErrSetSecurityAttribute = fmt.Errorf("%w: unable to assign security attribute", ErrOCIRuntime)

--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -71,7 +71,9 @@ func (ic *ContainerEngine) NetworkReload(ctx context.Context, names []string, op
 		report := new(entities.NetworkReloadReport)
 		report.Id = ctr.ID()
 		report.Err = ctr.ReloadNetwork()
-		if options.All && errors.Cause(report.Err) == define.ErrCtrStateInvalid {
+		// ignore errors for invalid ctr state and network mode when --all is used
+		if options.All && (errors.Cause(report.Err) == define.ErrCtrStateInvalid ||
+			errors.Cause(report.Err) == define.ErrNetworkModeInvalid) {
 			continue
 		}
 		reports = append(reports, report)

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		con := podmanTest.Podman([]string{"network", "disconnect", netName, "test"})
 		con.WaitWithDefaultTimeout()
 		Expect(con.ExitCode()).ToNot(BeZero())
-		Expect(con.ErrorToString()).To(ContainSubstring(`network mode "slirp4netns" is not supported`))
+		Expect(con.ErrorToString()).To(ContainSubstring(`"slirp4netns" is not supported: invalid network mode`))
 	})
 
 	It("podman network disconnect", func() {
@@ -132,7 +132,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		con := podmanTest.Podman([]string{"network", "connect", netName, "test"})
 		con.WaitWithDefaultTimeout()
 		Expect(con.ExitCode()).ToNot(BeZero())
-		Expect(con.ErrorToString()).To(ContainSubstring(`network mode "slirp4netns" is not supported`))
+		Expect(con.ErrorToString()).To(ContainSubstring(`"slirp4netns" is not supported: invalid network mode`))
 	})
 
 	It("podman connect on a container that already is connected to the network should error", func() {


### PR DESCRIPTION
Allow podman network reload to be run as rootless user. While it is
unlikely that the iptable rules are flushed inside the rootless cni
namespace, it could still happen. Also fix podman network reload --all
to ignore errors when a container does not have the bridge network mode,
e.g. slirp4netns.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
