### PR TITLE
image prune: remove unused images only with `--all`

### DIFF
--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -15,10 +15,8 @@ import (
 )
 
 var (
-	pruneDescription = `Removes all unnamed images from local storage.
-
-  If an image is not being used by a container, it will be removed from the system.`
-	pruneCmd = &cobra.Command{
+	pruneDescription = `Removes dangling or unused images from local storage.`
+	pruneCmd         = &cobra.Command{
 		Use:               "prune [options]",
 		Args:              validate.NoArgs,
 		Short:             "Remove unused images",
@@ -41,7 +39,7 @@ func init() {
 	})
 
 	flags := pruneCmd.Flags()
-	flags.BoolVarP(&pruneOpts.All, "all", "a", false, "Remove all unused images, not just dangling ones")
+	flags.BoolVarP(&pruneOpts.All, "all", "a", false, "Remove all images not in use by containers, not just dangling ones")
 	flags.BoolVarP(&force, "force", "f", false, "Do not prompt for confirmation")
 
 	filterFlagName := "filter"

--- a/docs/source/markdown/podman-image-prune.1.md
+++ b/docs/source/markdown/podman-image-prune.1.md
@@ -8,8 +8,7 @@ podman-image-prune - Remove all unused images from the local store
 
 ## DESCRIPTION
 **podman image prune** removes all dangling images from local storage. With the `all` option,
-you can delete all unused images.  Unused images are dangling images as well as any image that
-does not have any containers based on it.
+you can delete all unused images (i.e., images not in use by any container).
 
 The image prune command does not prune cache images that only use layers that are necessary for other images.
 


### PR DESCRIPTION
Fix a regression in `podman image prune` where unused images were
accidentally removed even when `--all=false`.  Extend and partially
rewrite the e2e tests to make sure we're not regressing again in the
future.

Fixing the aforementioned issue revealed another issue in the default
prune filter.  While prune should remove all "dangling" images (i.e.,
those without tag), it removed only "intermediate" ones; dangling images
without children.  Remove the mistaken comment from the libimage
migration.

Also clarify the help message and man page.

Fixes: #10350
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
