### PR TITLE
Match swagger to "as built" output

### DIFF
--- a/pkg/api/handlers/swagger/swagger.go
+++ b/pkg/api/handlers/swagger/swagger.go
@@ -8,6 +8,15 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
+// Tree response
+// swagger:response TreeResponse
+type swagTree struct {
+	// in:body
+	Body struct {
+		entities.ImageTreeReport
+	}
+}
+
 // History response
 // swagger:response DocsHistory
 type swagHistory struct {
@@ -181,14 +190,5 @@ type swagInspectVolumeResponse struct {
 	// in:body
 	Body struct {
 		define.InspectVolumeData
-	}
-}
-
-// Image tree response
-// swagger:response LibpodImageTreeResponse
-type swagImageTreeResponse struct {
-	// in:body
-	Body struct {
-		handlers.ImageTreeResponse
 	}
 }

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -148,15 +148,6 @@ type HistoryResponse struct {
 	Comment   string
 }
 
-type ImageLayer struct{}
-
-type ImageTreeResponse struct {
-	ID     string       `json:"id"`
-	Tags   []string     `json:"tags"`
-	Size   string       `json:"size"`
-	Layers []ImageLayer `json:"layers"`
-}
-
 type ExecCreateConfig struct {
 	docker.ExecConfig
 }

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -747,7 +747,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// - application/json
 	// responses:
 	//   200:
-	//     $ref: '#/responses/LibpodImageTreeResponse'
+	//     $ref: "#/responses/TreeResponse"
 	//   404:
 	//     $ref: '#/responses/NoSuchImage'
 	//   500:

--- a/test/apiv2/python/rest_api/test_v2_0_0_image.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_image.py
@@ -160,6 +160,12 @@ class ImageTestCase(APITestCase):
             for k in required_keys:
                 self.assertIn(k, change)
 
+    def test_tree(self):
+        r = requests.get(self.uri("/images/alpine/tree"))
+        self.assertEqual(r.status_code, 200, r.text)
+        tree = r.json()
+        self.assertTrue(tree["Tree"].startswith("Image ID:"), r.text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* Remove all Types no longer referenced, they were never used

A future API breaking version of Podman API, may restore these Types
and push formatting into presentation layer vs. server.

Fixes #9578

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
