### PR TITLE
Fix formatting and indentation in network http api docs

### DIFF
--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -66,11 +66,11 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    name: filters
 	//    type: string
 	//    description: |
-	//      JSON encoded value of the filters (a map[string][]string) to process on the network list. Currently available filters:
-	//        - name=[name] Matches network name (accepts regex).
-	//        - id=[id] Matches for full or partial ID.
-	//        - driver=[driver] Only bridge is supported.
-	//        - label=[key] or label=[key=value] Matches networks based on the presence of a label alone or a label and a value.
+	//      JSON encoded value of the filters (a `map[string][]string`) to process on the network list. Currently available filters:
+	//        - `name=[name]` Matches network name (accepts regex).
+	//        - `id=[id]` Matches for full or partial ID.
+	//        - `driver=[driver]` Only bridge is supported.
+	//        - `label=[key]` or `label=[key=value]` Matches networks based on the presence of a label alone or a label and a value.
 	// produces:
 	// - application/json
 	// responses:
@@ -174,8 +174,8 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    description: |
 	//      Filters to process on the prune list, encoded as JSON (a map[string][]string).
 	//      Available filters:
-	//        - until=<timestamp> Prune networks created before this timestamp. The <timestamp> can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. 10m, 1h30m) computed relative to the daemon machine’s time.
-	//	      - label (label=<key>, label=<key>=<value>, label!=<key>, or label!=<key>=<value>) Prune networks with (or without, in case label!=... is used) the specified labels.
+	//        - `until=<timestamp>` Prune networks created before this timestamp. The <timestamp> can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+	//        - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune networks with (or without, in case `label!=...` is used) the specified labels.
 	// responses:
 	//   200:
 	//     description: OK
@@ -247,12 +247,12 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    name: filters
 	//    type: string
 	//    description: |
-	//      JSON encoded value of the filters (a map[string][]string) to process on the network list. Available filters:
-	//        - name=[name] Matches network name (accepts regex).
-	//        - id=[id] Matches for full or partial ID.
-	//        - driver=[driver] Only bridge is supported.
-	//        - label=[key] or label=[key=value] Matches networks based on the presence of a label alone or a label and a value.
-	//        - plugin=[plugin] Matches CNI plugins included in a network (e.g `bridge`,`portmap`,`firewall`,`tuning`,`dnsname`,`macvlan`)
+	//      JSON encoded value of the filters (a `map[string][]string`) to process on the network list. Available filters:
+	//        - `name=[name]` Matches network name (accepts regex).
+	//        - `id=[id]` Matches for full or partial ID.
+	//        - `driver=[driver]` Only bridge is supported.
+	//        - `label=[key]` or `label=[key=value]` Matches networks based on the presence of a label alone or a label and a value.
+	//        - `plugin=[plugin]` Matches CNI plugins included in a network (e.g `bridge`,`portmap`,`firewall`,`tuning`,`dnsname`,`macvlan`)
 	// produces:
 	// - application/json
 	// responses:
@@ -377,10 +377,10 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    name: filters
 	//    type: string
 	//    description: |
-	//      Filters to process on the prune list, encoded as JSON (a map[string][]string).
+	//      Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
 	//      Available filters:
-	//        - until=<timestamp> Prune networks created before this timestamp. The <timestamp> can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. 10m, 1h30m) computed relative to the daemon machine’s time.
-	//	      - label (label=<key>, label=<key>=<value>, label!=<key>, or label!=<key>=<value>) Prune networks with (or without, in case label!=... is used) the specified labels.
+	//        - `until=<timestamp>` Prune networks created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+	//        - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune networks with (or without, in case `label!=...` is used) the specified labels.
 	// responses:
 	//   200:
 	//     $ref: "#/responses/NetworkPruneResponse"


### PR DESCRIPTION
Formatting aligned to observed here:
https://docs.docker.com/engine/api/v1.41/#operation/NetworkList
+ fix some indentation issues.

[NO TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
