### PR TITLE
fix: response of containers wait endpoint

### DIFF
--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -98,7 +98,7 @@ type BuildResult struct {
 
 type ContainerWaitOKBody struct {
 	StatusCode int
-	Error      struct {
+	Error      *struct {
 		Message string
 	}
 }

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -75,18 +75,19 @@ func WaitContainerDocker(w http.ResponseWriter, r *http.Request) {
 	}
 
 	exitCode, err := waitDockerCondition(ctx, name, interval, condition)
-	msg := ""
+	var errStruct *struct{ Message string }
 	if err != nil {
 		logrus.Errorf("error while waiting on condition: %q", err)
-		msg = err.Error()
-	}
-	responseData := handlers.ContainerWaitOKBody{
-		StatusCode: int(exitCode),
-		Error: struct {
+		errStruct = &struct {
 			Message string
 		}{
-			Message: msg,
-		},
+			Message: err.Error(),
+		}
+	}
+
+	responseData := handlers.ContainerWaitOKBody{
+		StatusCode: int(exitCode),
+		Error:      errStruct,
 	}
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(true)

--- a/test/apiv2/26-containersWait.at
+++ b/test/apiv2/26-containersWait.at
@@ -21,7 +21,9 @@ t POST "containers/${CTR}/wait?condition=non-existent-cond" 400
 
 t POST "containers/${CTR}/wait?condition=not-running" 200
 
-t POST "containers/${CTR}/wait?condition=next-exit" 200 &
+t POST "containers/${CTR}/wait?condition=next-exit" 200 \
+  .StatusCode=0 \
+  .Error=null &
 child_pid=$!
 podman start "${CTR}"
 wait "${child_pid}"

--- a/test/apiv2/python/rest_api/test_v2_0_0_container.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_container.py
@@ -99,7 +99,7 @@ class ContainerTestCase(APITestCase):
         r = requests.post(self.podman_url + f"/v1.40/containers/{create['Id']}/wait")
         self.assertEqual(r.status_code, 200, r.text)
         wait = r.json()
-        self.assertEqual(wait["StatusCode"], 0, wait["Error"]["Message"])
+        self.assertEqual(wait["StatusCode"], 0, wait["Error"])
 
         prune = requests.post(self.podman_url + "/v1.40/containers/prune")
         self.assertEqual(prune.status_code, 200, prune.status_code)


### PR DESCRIPTION
The `Error` part of response must be nil if no error occurred.
Before this commit a zero value for the struct was returned.

Signed-off-by: Matej Vasek <mvasek@redhat.com>