### PR TITLE
Add --publish to container restore

### DIFF
--- a/cmd/podman/common/netflags.go
+++ b/cmd/podman/common/netflags.go
@@ -170,7 +170,7 @@ func NetFlagsToNetOptions(cmd *cobra.Command, netnsFromConfig bool) (*entities.N
 		return nil, err
 	}
 	if len(inputPorts) > 0 {
-		opts.PublishPorts, err = createPortBindings(inputPorts)
+		opts.PublishPorts, err = CreatePortBindings(inputPorts)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/podman/common/util.go
+++ b/cmd/podman/common/util.go
@@ -89,8 +89,8 @@ func createExpose(expose []string) (map[uint16]string, error) {
 	return toReturn, nil
 }
 
-// createPortBindings iterates ports mappings into SpecGen format.
-func createPortBindings(ports []string) ([]specgen.PortMapping, error) {
+// CreatePortBindings iterates ports mappings into SpecGen format.
+func CreatePortBindings(ports []string) ([]specgen.PortMapping, error) {
 	// --publish is formatted as follows:
 	// [[hostip:]hostport[-endPort]:]containerport[-endPort][/protocol]
 	toReturn := make([]specgen.PortMapping, 0, len(ports))

--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -95,6 +95,19 @@ This option must be used in combination with the **--import, -i** option.
 When restoring containers from a checkpoint tar.gz file with this option,
 the content of associated volumes will not be restored.
 
+#### **--publish**, **-p**
+
+Replaces the ports that the container publishes, as configured during the
+initial container start, with a new set of port forwarding rules.
+
+```
+# podman run --rm -p 2345:80 -d webserver
+# podman container checkpoint -l --export=dump.tar
+# podman container restore -p 5432:8080 --import=dump.tar
+```
+
+For more details please see **podman run --publish**.
+
 ## EXAMPLE
 
 podman container restore mywebserver
@@ -104,7 +117,7 @@ podman container restore 860a4b23
 podman container restore --import-previous pre-checkpoint.tar.gz --import checkpoint.tar.gz
 
 ## SEE ALSO
-podman(1), podman-container-checkpoint(1)
+podman(1), podman-container-checkpoint(1), podman-run(1)
 
 ## HISTORY
 September 2018, Originally compiled by Adrian Reber <areber@redhat.com>

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/podman/v3/libpod"
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/containers/podman/v3/pkg/errorhandling"
+	"github.com/containers/podman/v3/pkg/specgen/generate"
 	"github.com/containers/storage/pkg/archive"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -93,6 +94,14 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 		ctrConfig.ID = ""
 		ctrConfig.Name = restoreOptions.Name
 		newName = true
+	}
+
+	if len(restoreOptions.PublishPorts) > 0 {
+		ports, _, _, err := generate.ParsePortMapping(restoreOptions.PublishPorts)
+		if err != nil {
+			return nil, err
+		}
+		ctrConfig.PortMappings = ports
 	}
 
 	pullOptions := &libimage.PullOptions{}

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -197,6 +197,7 @@ type RestoreOptions struct {
 	Name            string
 	TCPEstablished  bool
 	ImportPrevious  string
+	PublishPorts    []specgen.PortMapping
 }
 
 type RestoreReport struct {

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -125,7 +125,7 @@ func createPodOptions(p *specgen.PodSpecGenerator, rt *libpod.Runtime) ([]libpod
 		options = append(options, libpod.WithPodUseImageHosts())
 	}
 	if len(p.PortMappings) > 0 {
-		ports, _, _, err := parsePortMapping(p.PortMappings)
+		ports, _, _, err := ParsePortMapping(p.PortMappings)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/specgen/generate/ports.go
+++ b/pkg/specgen/generate/ports.go
@@ -24,7 +24,7 @@ const (
 // Parse port maps to OCICNI port mappings.
 // Returns a set of OCICNI port mappings, and maps of utilized container and
 // host ports.
-func parsePortMapping(portMappings []specgen.PortMapping) ([]ocicni.PortMapping, map[string]map[string]map[uint16]uint16, map[string]map[string]map[uint16]uint16, error) {
+func ParsePortMapping(portMappings []specgen.PortMapping) ([]ocicni.PortMapping, map[string]map[string]map[uint16]uint16, map[string]map[string]map[uint16]uint16, error) {
 	// First, we need to validate the ports passed in the specgen, and then
 	// convert them into CNI port mappings.
 	type tempMapping struct {
@@ -254,7 +254,7 @@ func parsePortMapping(portMappings []specgen.PortMapping) ([]ocicni.PortMapping,
 
 // Make final port mappings for the container
 func createPortMappings(ctx context.Context, s *specgen.SpecGenerator, imageData *libimage.ImageData) ([]ocicni.PortMapping, error) {
-	finalMappings, containerPortValidate, hostPortValidate, err := parsePortMapping(s.PortMappings)
+	finalMappings, containerPortValidate, hostPortValidate, err := ParsePortMapping(s.PortMappings)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes: #10338

During container restore the published ports were recreated the same they were during initial container creation. With the changes from this PR it is now possible to change the published ports during restore.

It was already possible to change the published ports during restore by editing the files in the container checkpoint archive. This PR adds the command-line option `--publish` to `restore` with the same semantics as `--publish` during `run`.