### PR TITLE
Handle image user and exposed ports in podman play kube

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/common/pkg/secrets"
 	ann "github.com/containers/podman/v3/pkg/annotations"
 	"github.com/containers/podman/v3/pkg/specgen"
+	"github.com/containers/podman/v3/pkg/specgen/generate"
 	"github.com/containers/podman/v3/pkg/util"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -182,6 +183,19 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		if imageData.Config.WorkingDir != "" {
 			s.WorkDir = imageData.Config.WorkingDir
 		}
+		if s.User == "" {
+			s.User = imageData.Config.User
+		}
+
+		exposed, err := generate.GenExposedPorts(imageData.Config.ExposedPorts)
+		if err != nil {
+			return nil, err
+		}
+
+		for k, v := range s.Expose {
+			exposed[k] = v
+		}
+		s.Expose = exposed
 		// Pull entrypoint and cmd from image
 		s.Entrypoint = imageData.Config.Entrypoint
 		s.Command = imageData.Config.Cmd


### PR DESCRIPTION
Currently if a user runs an image with a user specified or
exposed ports with podman play kube, the fields are ignored.

Fixed: https://github.com/containers/podman/issues/9609

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
