### PR TITLE
Podman info add support for status of standard available cgroup controllers

### DIFF
--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -32,6 +32,12 @@ $ podman info
 host:
   arch: amd64
   buildahVersion: 1.19.0-dev
+  cgroupControllers:
+  - cpuset
+  - cpu
+  - io
+  - memory
+  - pids
   cgroupManager: systemd
   cgroupVersion: v2
   conmon:
@@ -145,6 +151,13 @@ Run podman info with JSON formatted response:
     "buildahVersion": "1.19.0-dev",
     "cgroupManager": "systemd",
     "cgroupVersion": "v2",
+    "cgroupControllers": [
+      "cpuset",
+      "cpu",
+      "io",
+      "memory",
+      "pids"
+    ],
     "conmon": {
       "package": "conmon-2.0.22-2.fc33.x86_64",
       "path": "/usr/bin/conmon",

--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -23,21 +23,22 @@ type SecurityInfo struct {
 
 // HostInfo describes the libpod host
 type HostInfo struct {
-	Arch           string           `json:"arch"`
-	BuildahVersion string           `json:"buildahVersion"`
-	CgroupManager  string           `json:"cgroupManager"`
-	CGroupsVersion string           `json:"cgroupVersion"`
-	Conmon         *ConmonInfo      `json:"conmon"`
-	CPUs           int              `json:"cpus"`
-	Distribution   DistributionInfo `json:"distribution"`
-	EventLogger    string           `json:"eventLogger"`
-	Hostname       string           `json:"hostname"`
-	IDMappings     IDMappings       `json:"idMappings,omitempty"`
-	Kernel         string           `json:"kernel"`
-	MemFree        int64            `json:"memFree"`
-	MemTotal       int64            `json:"memTotal"`
-	OCIRuntime     *OCIRuntimeInfo  `json:"ociRuntime"`
-	OS             string           `json:"os"`
+	Arch              string           `json:"arch"`
+	BuildahVersion    string           `json:"buildahVersion"`
+	CgroupManager     string           `json:"cgroupManager"`
+	CGroupsVersion    string           `json:"cgroupVersion"`
+	CgroupControllers []string         `json:"cgroupControllers"`
+	Conmon            *ConmonInfo      `json:"conmon"`
+	CPUs              int              `json:"cpus"`
+	Distribution      DistributionInfo `json:"distribution"`
+	EventLogger       string           `json:"eventLogger"`
+	Hostname          string           `json:"hostname"`
+	IDMappings        IDMappings       `json:"idMappings,omitempty"`
+	Kernel            string           `json:"kernel"`
+	MemFree           int64            `json:"memFree"`
+	MemTotal          int64            `json:"memTotal"`
+	OCIRuntime        *OCIRuntimeInfo  `json:"ociRuntime"`
+	OS                string           `json:"os"`
 	// RemoteSocket returns the UNIX domain socket the Podman service is listening on
 	RemoteSocket *RemoteSocket          `json:"remoteSocket,omitempty"`
 	RuntimeInfo  map[string]interface{} `json:"runtimeInfo,omitempty"`

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -135,4 +135,14 @@ var _ = Describe("Podman Info", func() {
 			Expect(session.OutputToString()).To(ContainSubstring("false"))
 		}
 	})
+
+	It("Podman info must contain cgroupControllers with ReleventControllers", func() {
+		SkipIfRootless("Hard to tell which controllers are going to be enabled for rootless")
+		SkipIfRootlessCgroupsV1("Disable cgroups not supported on cgroupv1 for rootless users")
+		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.CgroupControllers}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("memory"))
+		Expect(session.OutputToString()).To(ContainSubstring("pids"))
+	})
 })


### PR DESCRIPTION
Following PR adds support for reflecting availability status of cgroup controllers to `info`.  Patch attempts to resolve https://github.com/containers/podman/issues/10306