### PR TITLE
Fix image prune --filter cmd behavior

### DIFF
--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -59,7 +59,15 @@ func prune(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 	}
-
+	filterMap, err := common.ParseFilters(filter)
+	if err != nil {
+		return err
+	}
+	for k, v := range filterMap {
+		for _, val := range v {
+			pruneOpts.Filter = append(pruneOpts.Filter, fmt.Sprintf("%s=%s", k, val))
+		}
+	}
 	results, err := registry.ImageEngine().Prune(registry.GetContext(), pruneOpts)
 	if err != nil {
 		return err

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -425,4 +425,25 @@ LABEL "com.example.vendor"="Example Vendor"
 		Expect(result.OutputToStringArray()).To(Not(Equal(result1.OutputToStringArray())))
 	})
 
+	It("podman image prune --filter", func() {
+		dockerfile := `FROM quay.io/libpod/alpine:latest
+RUN > file
+`
+		dockerfile2 := `FROM quay.io/libpod/alpine:latest
+RUN > file2
+`
+		podmanTest.BuildImageWithLabel(dockerfile, "foobar.com/workdir:latest", "false", "abc")
+		podmanTest.BuildImageWithLabel(dockerfile2, "foobar.com/workdir:latest", "false", "xyz")
+		// --force used to to avoid y/n question
+		result := podmanTest.Podman([]string{"image", "prune", "--filter", "label=abc", "--force"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(len(result.OutputToStringArray())).To(Equal(1))
+
+		//check if really abc is removed
+		result = podmanTest.Podman([]string{"image", "list", "--filter", "label=abc"})
+		Expect(len(result.OutputToStringArray())).To(Equal(0))
+
+	})
+
 })


### PR DESCRIPTION
Glue code added to push filters to the prune image engine method.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
