### PR TITLE
Clear the storage-options from the graphdriver if users specifies --root

### DIFF
--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -120,6 +120,8 @@ Remote connections use local containers.conf for default.
 Storage root dir in which data, including images, is stored (default: "/var/lib/containers/storage" for UID 0, "$HOME/.local/share/containers/storage" for other users).
 Default root dir configured in `/etc/containers/storage.conf`.
 
+Overriding this option will cause the *storage-opt* settings in /etc/containers/storage.conf to be ignored.  The user must specify additional options via the `--storage-opt` flag.
+
 #### **--runroot**=*value*
 
 Storage state directory where all state information is stored (default: "/run/containers/storage" for UID 0, "/run/user/$UID/run" for other users).

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -129,6 +129,7 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 	if fs.Changed("root") {
 		storageSet = true
 		storageOpts.GraphRoot = cfg.Engine.StaticDir
+		storageOpts.GraphDriverOptions = []string{}
 	}
 	if fs.Changed("runroot") {
 		storageSet = true

--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -174,12 +174,12 @@ function test_port() {
     if [ $curl_rc -ne 0 ]; then
         _show_ok 0 "$testname - curl (port $port) failed with status $curl_rc"
         echo "# podman ps -a:"
-        $PODMAN_BIN --root $WORKDIR/root --runroot $WORKDIR/runroot ps -a
+        $PODMAN_BIN --storage-driver=vfs --root $WORKDIR/root --runroot $WORKDIR/runroot ps -a
         if type -p ss; then
             echo "# ss -tulpn:"
             ss -tulpn
             echo "# podman unshare --rootless-cni ss -tulpn:"
-            $PODMAN_BIN --root $WORKDIR/root --runroot $WORKDIR/runroot unshare --rootless-cni ss -tulpn
+            $PODMAN_BIN --storage-driver=vfs --root $WORKDIR/root --runroot $WORKDIR/runroot unshare --rootless-cni ss -tulpn
         fi
         echo "# cat $WORKDIR/server.log:"
         cat $WORKDIR/server.log
@@ -214,6 +214,7 @@ function start_service() {
 
     $PODMAN_BIN \
         --log-level debug \
+	--storage-driver=vfs \
         --root $WORKDIR/root \
         --runroot $WORKDIR/runroot \
         --cgroup-manager=systemd \
@@ -241,6 +242,7 @@ function start_service() {
 function podman() {
     echo "\$ podman $*"           >>$WORKDIR/output.log
     output=$($PODMAN_BIN \
+	--storage-driver=vfs \
         --root    $WORKDIR/root    \
         --runroot $WORKDIR/runroot \
         "$@")

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -82,4 +82,12 @@ store.imageStore.number   | 1
     # mounts.
     is "$output" ".*graphOptions: {}" "output includes graphOptions: {}"
 }
+
+@test "podman --root PATH info - basic output" {
+    if ! is_remote; then
+        run_podman --storage-driver=vfs --root ${PODMAN_TMPDIR}/nothing-here-move-along info --format '{{ .Store.GraphOptions }}'
+        is "$output" "map\[\]" "'podman --root should reset Graphoptions to []"
+    fi
+}
+
 # vim: filetype=sh

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -12,7 +12,7 @@ load helpers
     # 'podman images' should emit headings even if there are no images
     # (but --root only works locally)
     if ! is_remote; then
-        run_podman --root ${PODMAN_TMPDIR}/nothing-here-move-along images
+        run_podman --storage-driver=vfs --root ${PODMAN_TMPDIR}/nothing-here-move-along images
         is "$output" "$headings" "'podman images' emits headings even w/o images"
     fi
 }

--- a/test/system/150-login.bats
+++ b/test/system/150-login.bats
@@ -62,7 +62,7 @@ function setup() {
     # Pull registry image, but into a separate container storage
     mkdir -p ${PODMAN_LOGIN_WORKDIR}/root
     mkdir -p ${PODMAN_LOGIN_WORKDIR}/runroot
-    PODMAN_LOGIN_ARGS="--root ${PODMAN_LOGIN_WORKDIR}/root --runroot ${PODMAN_LOGIN_WORKDIR}/runroot"
+    PODMAN_LOGIN_ARGS="--storage-driver=vfs --root ${PODMAN_LOGIN_WORKDIR}/root --runroot ${PODMAN_LOGIN_WORKDIR}/runroot"
     # Give it three tries, to compensate for flakes
     run_podman ${PODMAN_LOGIN_ARGS} pull $REGISTRY_IMAGE ||
         run_podman ${PODMAN_LOGIN_ARGS} pull $REGISTRY_IMAGE ||
@@ -306,10 +306,10 @@ function _test_skopeo_credential_sharing() {
         skip "[leaving registry running by request]"
     fi
 
-    run_podman --root    ${PODMAN_LOGIN_WORKDIR}/root   \
+    run_podman --storage-driver=vfs --root    ${PODMAN_LOGIN_WORKDIR}/root   \
                --runroot ${PODMAN_LOGIN_WORKDIR}/runroot \
                rm -f registry
-    run_podman --root    ${PODMAN_LOGIN_WORKDIR}/root   \
+    run_podman --storage-driver=vfs --root    ${PODMAN_LOGIN_WORKDIR}/root   \
                --runroot ${PODMAN_LOGIN_WORKDIR}/runroot \
                rmi -a
 

--- a/test/system/330-corrupt-images.bats
+++ b/test/system/330-corrupt-images.bats
@@ -19,7 +19,7 @@ PODMAN_CORRUPT_TEST_IMAGE_ID=961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364b
 # All tests in this file (and ONLY in this file) run with a custom rootdir
 function setup() {
     skip_if_remote "none of these tests run under podman-remote"
-    _PODMAN_TEST_OPTS="--root ${PODMAN_CORRUPT_TEST_WORKDIR}/root"
+    _PODMAN_TEST_OPTS="--storage-driver=vfs --root ${PODMAN_CORRUPT_TEST_WORKDIR}/root"
 }
 
 function teardown() {


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/10393

Currently if a user specifies a --root flag to override the location of
the container storage, we still enforce the storage-opts from
storage.conf. This causes issues with people trying to intereact with
the additional stores feature, and then forces them to use the obscure
--storage-opt="" option. I belive this should be the default and we
already do this when the user specifies the --storage-driver option.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
