### PR TITLE
Always spawn a cleanup process with exec

### DIFF
--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -761,6 +761,9 @@ func (c *Container) Exec(config *ExecConfig, streams *define.AttachStreams, resi
 	}
 	exitCode := session.ExitCode
 	if err := c.ExecRemove(sessionID, false); err != nil {
+		if errors.Cause(err) == define.ErrNoSuchExecSession {
+			return exitCode, nil
+		}
 		return -1, err
 	}
 

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -127,6 +127,8 @@ const (
 	Create Status = "create"
 	// Exec ...
 	Exec Status = "exec"
+	// ExecDied indicates that an exec session in a container died.
+	ExecDied Status = "exec_died"
 	// Exited indicates that a container's process died
 	Exited Status = "died"
 	// Export ...

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -149,6 +149,8 @@ func StringToStatus(name string) (Status, error) {
 		return Create, nil
 	case Exec.String():
 		return Exec, nil
+	case ExecDied.String():
+		return ExecDied, nil
 	case Exited.String():
 		return Exited, nil
 	case Export.String():


### PR DESCRIPTION
We were previously only doing this for detached exec. I don't know why we did that, but I don't see any reason not to extend it to all exec sessions - it guarantees that we will always clean up exec sessions, even if the original `podman exec` process died.

[NO TESTS NEEDED] because I don't really know how to test this one.
