### PR TITLE
[CI:DOCS] Fix multi-arch image build logic and docs

### DIFF
--- a/.github/workflows/multi-arch-build.yaml
+++ b/.github/workflows/multi-arch-build.yaml
@@ -122,11 +122,11 @@ jobs:
                       docker://$CONTAINERS_QUAY_REGISTRY/podman | \
                       jq -r '.Tags[]')
 
-            # New image? Push quay.io/containers/podman:vX.X.X and :latest
+            # New image? Push quay.io/containers/podman:vX.X.X
             if ! fgrep -qx "$VERSION" <<<"$ALLTAGS"; then
-              FQIN="$CONTAINERS_QUAY_REGISTRY/podman:$VERSION,$CONTAINERS_QUAY_REGISTRY/podman:latest"
-            else # Not a new version-tagged image, but contents may be updated
-              FQIN="$CONTAINERS_QUAY_REGISTRY/podman:latest"
+              FQIN="$CONTAINERS_QUAY_REGISTRY/podman:$VERSION"
+            else # Not a new version-tagged image, do nothing.
+              FQIN=""
             fi
           elif [[ "${{ matrix.source }}" == 'upstream' ]]; then
             FQIN="$CONTAINERS_QUAY_REGISTRY/podman:latest"
@@ -134,9 +134,13 @@ jobs:
             echo "::error::Unknown matrix item '${{ matrix.source }}'"
             exit 1
           fi
-          echo "::warning::Pushing $FQIN"
-          echo "::set-output name=fqin::${FQIN}"
-          echo '::set-output name=push::true'
+          if [[ -n "$FQIN" ]]; then
+            echo "::warning::Pushing $FQIN"
+            echo "::set-output name=fqin::${FQIN}"
+            echo '::set-output name=push::true'
+          else
+            echo '::set-output name=push::false'
+          fi
 
       - name: Define LABELS multi-line env. var. value
         run: |

--- a/contrib/podmanimage/README.md
+++ b/contrib/podmanimage/README.md
@@ -23,7 +23,7 @@ The container images are:
     please [see the configuration file](stable/Dockerfile).
   * `quay.io/containers/podman:latest` and `quay.io/podman/stable:latest` -
     Built daily using the same Dockerfile as above.  The Podman version
-    will remain the "latest" available in Fedora, however the other image
+    will remain the "latest" available in Fedora, however the image
     contents may vary compared to the version-tagged images.
   * `quay.io/podman/testing:latest` - This image is built daily, using the
     latest version of Podman that was in the Fedora `updates-testing` repository.


### PR DESCRIPTION
Previously the conditional for both the `stable` and
`upstream` resulted in pushing `quay.io/containers/podman:latest`
(overwriting each other).  Fix this by only pushing `upstream` to the
"latest" tag, and `stable` to the version-named tag.  Also make a small
clarification update to documentation.

Signed-off-by: Chris Evich <cevich@redhat.com>