### PR TITLE
Add podman run --gpus flag for compatibility

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -77,6 +77,11 @@ func runFlags(cmd *cobra.Command) {
 	flags.StringVar(&runOpts.DetachKeys, detachKeysFlagName, containerConfig.DetachKeys(), "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-cf`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 	_ = cmd.RegisterFlagCompletionFunc(detachKeysFlagName, common.AutocompleteDetachKeys)
 
+	gpuFlagName := "gpus"
+	flags.String(gpuFlagName, "", "This is a Docker specific option and is a NOOP")
+	_ = cmd.RegisterFlagCompletionFunc(gpuFlagName, completion.AutocompleteNone)
+	_ = flags.MarkHidden("gpus")
+
 	if registry.IsRemote() {
 		_ = flags.MarkHidden("preserve-fds")
 		_ = flags.MarkHidden("conmon-pidfile")
@@ -203,6 +208,9 @@ func run(cmd *cobra.Command, args []string) error {
 		if len(rmErrors) > 0 {
 			logrus.Errorf("%s", errorhandling.JoinErrors(rmErrors))
 		}
+	}
+	if cmd.Flag("gpus").Changed {
+		logrus.Info("--gpus is a Docker specific option and is a NOOP")
 	}
 	return nil
 }

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -113,4 +113,10 @@ var _ = Describe("Podman run device", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Equal("/dev/kmsg1"))
 	})
+
+	It("podman run --gpus noop", func() {
+		session := podmanTest.Podman([]string{"run", "--gpus", "all", ALPINE, "ls", "/"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
People who use docker scripts with Podman see failures
if they use `podman run --gpus` flag. This is a noop flag.

Resolves https://github.com/containers/podman/issues/10420