### PR TITLE
journald logger: fix race condition

### DIFF
--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Podman logs", func() {
 		})
 
 		It("podman logs on a created container should result in 0 exit code: "+log, func() {
-			session := podmanTest.Podman([]string{"create", "-t", "--name", "log", ALPINE})
+			session := podmanTest.Podman([]string{"create", "--log-driver", log, "-t", "--name", "log", ALPINE})
 			session.WaitWithDefaultTimeout()
 			Expect(session).To(Exit(0))
 

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -73,4 +73,56 @@ ${cid[0]} d"   "Sequential output from logs"
     _log_test_multi journald
 }
 
+@test "podman logs - journald log driver requires journald events backend" {
+    skip_if_remote "remote does not support --events-backend"
+    # We can't use journald on RHEL as rootless: rhbz#1895105
+    skip_if_journald_unavailable
+
+    run_podman --events-backend=file run --log-driver=journald -d --name test --replace $IMAGE ls /
+    run_podman --events-backend=file logs test
+    run_podman 125 --events-backend=file logs --follow test
+    is "$output" "Error: using --follow with the journald --log-driver but without the journald --events-backend (file) is not supported" "journald logger requires journald eventer"
+}
+
+function _log_test_since() {
+    local driver=$1
+
+    s_before="before_$(random_string)_${driver}"
+    s_after="after_$(random_string)_${driver}"
+
+    before=$(date --iso-8601=seconds)
+    run_podman run --log-driver=$driver -d --name test $IMAGE sh -c \
+        "echo $s_before; trap 'echo $s_after; exit' SIGTERM; while :; do sleep 1; done"
+
+    # sleep a second to make sure the date is after the first echo
+    sleep 1
+    after=$(date --iso-8601=seconds)
+    run_podman stop test
+
+    run_podman logs test
+    is "$output" \
+        "$s_before
+$s_after"
+
+    run_podman logs --since $before test
+    is "$output" \
+        "$s_before
+$s_after"
+
+    run_podman logs --since $after test
+    is "$output" "$s_after"
+    run_podman rm -f test
+}
+
+@test "podman logs - since k8s-file" {
+    _log_test_since k8s-file
+}
+
+@test "podman logs - since journald" {
+    # We can't use journald on RHEL as rootless: rhbz#1895105
+    skip_if_journald_unavailable
+
+    _log_test_since journald
+}
+
 # vim: filetype=sh

--- a/test/system/130-kill.bats
+++ b/test/system/130-kill.bats
@@ -8,8 +8,7 @@ load helpers
 @test "podman kill - test signal handling in containers" {
     # Start a container that will handle all signals by emitting 'got: N'
     local -a signals=(1 2 3 4 5 6 8 10 12 13 14 15 16 20 21 22 23 24 25 26 64)
-    # Force the k8s-file driver until #10323 is fixed.
-    run_podman run --log-driver=k8s-file -d $IMAGE sh -c \
+    run_podman run -d $IMAGE sh -c \
         "for i in ${signals[*]}; do trap \"echo got: \$i\" \$i; done;
         echo READY;
         while ! test -e /stop; do sleep 0.05; done;


### PR DESCRIPTION
Fix a race in journald driver.  Following the logs implies streaming
until the container is dead.  Streaming happened in one goroutine,
waiting for the container to exit/die and signaling that event happened
in another goroutine.

The nature of having two goroutines running simultaneously is pretty
much the core of the race condition.  When the streaming goroutines
received the signal that the container has exitted, the routine may not
have read and written all of the container's logs.

Fix this race by reading both, the logs and the events, of the container
and stop streaming when the died/exited event has been read.  The died
event is guaranteed to be after all logs in the journal which guarantees
not only consistencty but also a deterministic behavior.

Note that the journald log driver now requires the journald event
backend to be set.

Fixes: #10323
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
