### PR TITLE
Improve OCI Runtime error

### DIFF
--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -152,7 +152,7 @@ var (
 
 	// ErrOCIRuntimeNotFound indicates the OCI runtime attempted to invoke a command
 	// that was not found
-	ErrOCIRuntimeNotFound = errors.New("OCI not found")
+	ErrOCIRuntimeNotFound = errors.New("OCI runtime attempted to invoke a command that was not found")
 
 	// ErrOCIRuntimeUnavailable indicates that the OCI runtime associated to a container
 	// could not be found in the configuration

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -14,7 +14,7 @@ load helpers
     # ...but check the configured runtime engine, and switch to crun as needed
     run_podman info --format '{{ .Host.OCIRuntime.Path }}'
     if expr "$output" : ".*/crun"; then
-        err_no_such_cmd="Error: executable file.* not found in \$PATH: No such file or directory: OCI not found"
+        err_no_such_cmd="Error: executable file.* not found in \$PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found"
         err_no_exec_dir="Error: open executable: Operation not permitted: OCI permission denied"
     fi
 


### PR DESCRIPTION
ErrOCIRuntimeNotFound error is misleading. Try to make it more
understandable to the user that the OCI Runtime IE crun or runc is not
missing, but the command they attempted to run within the container is
missing.

[NO TESTS NEEDED] Regular tests should handle this.

Fixes: https://github.com/containers/podman/issues/10432

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
