### PR TITLE
Only check for PodStateExited when pruning pods

### DIFF
--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -178,7 +178,7 @@ func (r *Runtime) GetRunningPods() ([]*Pod, error) {
 // PrunePods removes unused pods and their containers from local storage.
 func (r *Runtime) PrunePods(ctx context.Context) (map[string]error, error) {
 	response := make(map[string]error)
-	states := []string{define.PodStateStopped, define.PodStateExited}
+	states := []string{define.PodStateExited}
 	filterFunc := func(p *Pod) bool {
 		state, _ := p.GetPodStatus()
 		for _, status := range states {


### PR DESCRIPTION
[NO TESTS NEEDED] This is an attempt to fix a Race condition
since it is a race it is difficult to ~~fix~~ test.

Helps fix: https://github.com/containers/podman/issues/7139

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
