### PR TITLE
Fix race condition in running ls container in a pod

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -408,7 +408,14 @@ func (p *PodmanTestIntegration) RunLsContainer(name string) (*PodmanSessionInteg
 	podmanArgs = append(podmanArgs, "-d", ALPINE, "ls")
 	session := p.Podman(podmanArgs)
 	session.WaitWithDefaultTimeout()
-	return session, session.ExitCode(), session.OutputToString()
+	if session.ExitCode() != 0 {
+		return session, session.ExitCode(), session.OutputToString()
+	}
+	cid := session.OutputToString()
+
+	wsession := p.Podman([]string{"wait", cid})
+	wsession.WaitWithDefaultTimeout()
+	return session, wsession.ExitCode(), cid
 }
 
 // RunNginxWithHealthCheck runs the alpine nginx container with an optional name and adds a healthcheck into it
@@ -431,7 +438,14 @@ func (p *PodmanTestIntegration) RunLsContainerInPod(name, pod string) (*PodmanSe
 	podmanArgs = append(podmanArgs, "-d", ALPINE, "ls")
 	session := p.Podman(podmanArgs)
 	session.WaitWithDefaultTimeout()
-	return session, session.ExitCode(), session.OutputToString()
+	if session.ExitCode() != 0 {
+		return session, session.ExitCode(), session.OutputToString()
+	}
+	cid := session.OutputToString()
+
+	wsession := p.Podman([]string{"wait", cid})
+	wsession.WaitWithDefaultTimeout()
+	return session, wsession.ExitCode(), cid
 }
 
 // BuildImage uses podman build and buildah to build an image


### PR DESCRIPTION
All of the tests has an assumption that RunLsContainer and RunLsContainerInPod completes
the container before returning.  But since the container is running
in back ground mode, the container could be still running before tools
attempt to remove it. Removing the "-d" from the command fixes the
container to match the assumption.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>