### PR TITLE
Fix race on podman start --all

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -408,7 +408,14 @@ func (p *PodmanTestIntegration) RunLsContainer(name string) (*PodmanSessionInteg
 	podmanArgs = append(podmanArgs, "-d", ALPINE, "ls")
 	session := p.Podman(podmanArgs)
 	session.WaitWithDefaultTimeout()
-	return session, session.ExitCode(), session.OutputToString()
+	if session.ExitCode() != 0 {
+		return session, session.ExitCode(), session.OutputToString()
+	}
+	cid := session.OutputToString()
+
+	wsession := p.Podman([]string{"wait", cid})
+	wsession.WaitWithDefaultTimeout()
+	return session, wsession.ExitCode(), cid
 }
 
 // RunNginxWithHealthCheck runs the alpine nginx container with an optional name and adds a healthcheck into it
@@ -431,7 +438,14 @@ func (p *PodmanTestIntegration) RunLsContainerInPod(name, pod string) (*PodmanSe
 	podmanArgs = append(podmanArgs, "-d", ALPINE, "ls")
 	session := p.Podman(podmanArgs)
 	session.WaitWithDefaultTimeout()
-	return session, session.ExitCode(), session.OutputToString()
+	if session.ExitCode() != 0 {
+		return session, session.ExitCode(), session.OutputToString()
+	}
+	cid := session.OutputToString()
+
+	wsession := p.Podman([]string{"wait", cid})
+	wsession.WaitWithDefaultTimeout()
+	return session, wsession.ExitCode(), cid
 }
 
 // BuildImage uses podman build and buildah to build an image

--- a/test/system/045-start.bats
+++ b/test/system/045-start.bats
@@ -25,6 +25,8 @@ load helpers
         die "podman start --all restarted a running container"
     fi
 
+    run_podman wait $cid_none_implicit $cid_none_explicit $cid_on_failure
+
     run_podman rm $cid_none_implicit $cid_none_explicit $cid_on_failure
     run_podman stop -t 1 $cid_always
     run_podman rm $cid_always


### PR DESCRIPTION
Make sure all containers exit after start

There is a race condition in that container could still be running when
we attempt to remove them.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
