### PR TITLE
Add options to podman machine ssh

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -408,7 +408,7 @@ func (v *MachineVM) SSH(name string, opts machine.SSHOptions) error {
 	sshDestination := v.RemoteUsername + "@localhost"
 	port := strconv.Itoa(v.Port)
 
-	args := []string{"-i", v.IdentityPath, "-p", port, sshDestination}
+	args := []string{"-i", v.IdentityPath, "-p", port, sshDestination, "-o", "UserKnownHostsFile /dev/null", "-o", "StrictHostKeyChecking no"}
 	if len(opts.Args) > 0 {
 		args = append(args, opts.Args...)
 	} else {


### PR DESCRIPTION
Add options to the podman machine ssh command that ignore
hostkeychecking and hosts file

-o 'UserKnownHostsFile /dev/null' -o 'StrictHostKeyChecking no

[NO TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
