### PR TITLE
Enable port forwarding on host

### DIFF
--- a/cmd/podman/common/netflags.go
+++ b/cmd/podman/common/netflags.go
@@ -85,7 +85,10 @@ func DefineNetFlags(cmd *cobra.Command) {
 	)
 }
 
-func NetFlagsToNetOptions(cmd *cobra.Command) (*entities.NetOptions, error) {
+// NetFlagsToNetOptions parses the network flags for the given cmd.
+// The netnsFromConfig bool is used to indicate if the --network flag
+// should always be parsed regardless if it was set on the cli.
+func NetFlagsToNetOptions(cmd *cobra.Command, netnsFromConfig bool) (*entities.NetOptions, error) {
 	var (
 		err error
 	)
@@ -193,7 +196,9 @@ func NetFlagsToNetOptions(cmd *cobra.Command) (*entities.NetOptions, error) {
 		return nil, err
 	}
 
-	if cmd.Flags().Changed("network") {
+	// parse the --network value only when the flag is set or we need to use
+	// the netns config value, e.g. when --pod is not used
+	if netnsFromConfig || cmd.Flag("network").Changed {
 		network, err := cmd.Flags().GetString("network")
 		if err != nil {
 			return nil, err

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -87,7 +87,7 @@ func create(cmd *cobra.Command, args []string) error {
 	var (
 		err error
 	)
-	cliVals.Net, err = common.NetFlagsToNetOptions(cmd)
+	cliVals.Net, err = common.NetFlagsToNetOptions(cmd, cliVals.Pod == "")
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -106,7 +106,7 @@ func init() {
 
 func run(cmd *cobra.Command, args []string) error {
 	var err error
-	cliVals.Net, err = common.NetFlagsToNetOptions(cmd)
+	cliVals.Net, err = common.NetFlagsToNetOptions(cmd, cliVals.Pod == "")
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -166,10 +166,11 @@ func create(cmd *cobra.Command, args []string) error {
 		defer errorhandling.SyncQuiet(podIDFD)
 	}
 
-	createOptions.Net, err = common.NetFlagsToNetOptions(cmd)
+	createOptions.Net, err = common.NetFlagsToNetOptions(cmd, createOptions.Infra)
 	if err != nil {
 		return err
 	}
+
 	if len(createOptions.Net.PublishPorts) > 0 {
 		if !createOptions.Infra {
 			return errors.Errorf("you must have an infra container to publish port bindings to the host")

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -273,7 +273,6 @@ func (r *Runtime) GetRootlessCNINetNs(new bool) (*RootlessCNI, error) {
 				if err != nil {
 					return nil, errors.Wrap(err, "error creating rootless cni network namespace")
 				}
-
 				// setup slirp4netns here
 				path := r.config.Engine.NetworkCmdPath
 				if path == "" {
@@ -437,9 +436,32 @@ func (r *Runtime) GetRootlessCNINetNs(new bool) (*RootlessCNI, error) {
 	return rootlessCNINS, nil
 }
 
+// setPrimaryMachineIP is used for podman-machine and it sets
+// and environment variable with the IP address of the podman-machine
+// host.
+func setPrimaryMachineIP() error {
+	// no connection is actually made here
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			logrus.Error(err)
+		}
+	}()
+	addr := conn.LocalAddr().(*net.UDPAddr)
+	return os.Setenv("PODMAN_MACHINE_HOST", addr.IP.String())
+}
+
 // setUpOCICNIPod will set up the cni networks, on error it will also tear down the cni
 // networks. If rootless it will join/create the rootless cni namespace.
 func (r *Runtime) setUpOCICNIPod(podNetwork ocicni.PodNetwork) ([]ocicni.NetResult, error) {
+	if r.config.MachineEnabled() {
+		if err := setPrimaryMachineIP(); err != nil {
+			return nil, err
+		}
+	}
 	rootlessCNINS, err := r.GetRootlessCNINetNs(true)
 	if err != nil {
 		return nil, err

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -32,6 +32,7 @@ var (
 	ErrVMAlreadyExists                           = errors.New("VM already exists")
 	ErrVMAlreadyRunning                          = errors.New("VM already running")
 	ErrMultipleActiveVM                          = errors.New("only one VM can be active at a time")
+	ForwarderBinaryName                          = "gvproxy"
 )
 
 type Download struct {

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -118,6 +118,7 @@ func getDirs(usrName string) []Directory {
 	// in one swoop, then the leading dirs are creates as root.
 	newDirs := []string{
 		"/home/" + usrName + "/.config",
+		"/home/" + usrName + "/.config/containers",
 		"/home/" + usrName + "/.config/systemd",
 		"/home/" + usrName + "/.config/systemd/user",
 		"/home/" + usrName + "/.config/systemd/user/default.target.wants",
@@ -159,6 +160,22 @@ func getFiles(usrName string) []File {
 		},
 	})
 
+	// Set containers.conf up for core user to use cni networks
+	// by default
+	files = append(files, File{
+		Node: Node{
+			Group: getNodeGrp(usrName),
+			Path:  "/home/" + usrName + "/.config/containers/containers.conf",
+			User:  getNodeUsr(usrName),
+		},
+		FileEmbedded1: FileEmbedded1{
+			Append: nil,
+			Contents: Resource{
+				Source: strToPtr("data:,%5Bcontainers%5D%0D%0Anetns%3D%22bridge%22%0D%0Arootless_networking%3D%22cni%22"),
+			},
+			Mode: intToPtr(484),
+		},
+	})
 	// Add a file into linger
 	files = append(files, File{
 		Node: Node{

--- a/pkg/machine/qemu/options_darwin.go
+++ b/pkg/machine/qemu/options_darwin.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func getSocketDir() (string, error) {
+func getRuntimeDir() (string, error) {
 	tmpDir, ok := os.LookupEnv("TMPDIR")
 	if !ok {
 		return "", errors.New("unable to resolve TMPDIR")

--- a/pkg/machine/qemu/options_darwin_amd64.go
+++ b/pkg/machine/qemu/options_darwin_amd64.go
@@ -5,7 +5,7 @@ var (
 )
 
 func (v *MachineVM) addArchOptions() []string {
-	opts := []string{"-cpu", "host"}
+	opts := []string{"-machine", "q35,accel=hvf:tcg"}
 	return opts
 }
 

--- a/pkg/machine/qemu/options_linux.go
+++ b/pkg/machine/qemu/options_linux.go
@@ -1,7 +1,13 @@
 package qemu
 
-import "github.com/containers/podman/v3/pkg/util"
+import (
+	"github.com/containers/podman/v3/pkg/rootless"
+	"github.com/containers/podman/v3/pkg/util"
+)
 
-func getSocketDir() (string, error) {
+func getRuntimeDir() (string, error) {
+	if !rootless.IsRootless() {
+		return "/run", nil
+	}
 	return util.GetRuntimeDir()
 }


### PR DESCRIPTION
Using the gvproxy application on the host, we can now port forward from
the machine vm on the host.  It requires that 'gvproxy' be installed in
an executable location.  gvproxy can be found in the
containers/gvisor-tap-vsock github repo.

[NO TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
