### PR TITLE
create libimage-events channel in main routine

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -715,9 +715,8 @@ func (r *Runtime) libimageEvents() {
 		return status
 	}
 
+	eventChannel := r.libimageRuntime.EventChannel()
 	go func() {
-		eventChannel := r.libimageRuntime.EventChannel()
-
 		for {
 			// Make sure to read and write all events before
 			// checking if we're about to shutdown.


### PR DESCRIPTION
Move the creation of the channel outside of the sub-routine to fix a
data race between writing the channel (implicitly by calling
EventChannel()) and using that channel in libimage.

[NO TESTS NEEDED]

Fixes: #10459
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@matejvasek @containers/podman-maintainers PTAL
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
