### PR TITLE
[v3.0.1] set version to v3.0.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ import (
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-var Version = semver.MustParse("3.0.2-dev")
+var Version = semver.MustParse("3.0.1")
 
 // APIVersion is the version for the remote
 // client API.  It is used to determine compatibility


### PR DESCRIPTION
The v3.0.1 branch included the bump to v3.0.2-dev which indicates the
state in between two releases.

Fixes: bugzilla.redhat.com/show_bug.cgi?id=1966538
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>