### PR TITLE
API one-shot query implementation/handling

### DIFF
--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -375,6 +375,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    type: boolean
 	//    default: true
 	//    description: Stream the output
+	//  - in: query
+	//    name: one-shot
+	//    type: boolean
+	//    default: false
+	//    description: Provide a one-shot response in which preCPU stats are blank, resulting in a single cycle return.
 	// produces:
 	// - application/json
 	// responses:

--- a/test/apiv2/python/rest_api/test_v2_0_0_container.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_container.py
@@ -30,6 +30,10 @@ class ContainerTestCase(APITestCase):
         self.assertIn(r.status_code, (200, 409), r.text)
         if r.status_code == 200:
             self.assertId(r.content)
+        r = requests.get(self.uri(self.resolve_container("/containers/{}/stats?stream=false&one-shot=true")))
+        self.assertIn(r.status_code, (200, 409), r.text)
+        if r.status_code == 200:
+            self.assertId(r.content)
 
     def test_delete(self):
         r = requests.delete(self.uri(self.resolve_container("/containers/{}")))


### PR DESCRIPTION
containers_stats.go was missing the handling of the one-shot query parameter. Modified the code to handle the incoming query as well as return an error if there is a mismatch of stream and one-shot (stream must be false if one shot is true). One shot skips the preCPU stats and returns a singular cycle's statistics. Also added documentation in register_containers.go 