### PR TITLE
  [NO TESTS NEEDED] Fixes API list networks returns "null" instead of empty array when used with no networks

### DIFF
--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (ic *ContainerEngine) NetworkList(ctx context.Context, options entities.NetworkListOptions) ([]*entities.NetworkListReport, error) {
-	var reports []*entities.NetworkListReport
+	reports := make([]*entities.NetworkListReport, 0)
 
 	config, err := ic.Libpod.GetConfig()
 	if err != nil {


### PR DESCRIPTION
API list networks returns "null" instead of empty array when used with no networks
Fixes: https://github.com/containers/podman/issues/10495

Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>
[NO TESTS NEEDED]
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
