### PR TITLE
[CI:DOCS] Use secrets and machine rst file properly

### DIFF
--- a/docs/source/Commands.rst
+++ b/docs/source/Commands.rst
@@ -55,7 +55,7 @@ Commands
 
 :doc:`logs <markdown/podman-logs.1>` Fetch the logs of a container
 
-:doc:`machine <markdown/podman-machine.1>` Manage podman's virtual machine
+:doc:`machine <machine>` Manage podman's virtual machine
 
 :doc:`manifest <manifest>` Create and manipulate manifest lists and image indexes
 
@@ -91,7 +91,7 @@ Commands
 
 :doc:`search <markdown/podman-search.1>` Search registry for image
 
-:doc:`secret <markdown/podman-secret.1>` Manage podman secrets
+:doc:`secret <secret>` Manage podman secrets
 
 :doc:`start <markdown/podman-start.1>` Start one or more containers
 


### PR DESCRIPTION
This change makes secrets and machine handling match the handling of
other subcommands of Podman.

Possible fixes: https://github.com/containers/podman/issues/10513

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
