### PR TITLE
[v3.2] System tests: add :Z to volume mounts

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -600,12 +600,12 @@ json-file | f
     echo "$randomcontent" > $testdir/content
 
     # Workdir does not exist on the image but is volume mounted.
-    run_podman run --rm --workdir /IamNotOnTheImage -v $testdir:/IamNotOnTheImage $IMAGE cat content
+    run_podman run --rm --workdir /IamNotOnTheImage -v $testdir:/IamNotOnTheImage:Z $IMAGE cat content
     is "$output" "$randomcontent" "cat random content"
 
     # Workdir does not exist on the image but is created by the runtime as it's
     # a subdir of a volume.
-    run_podman run --rm --workdir /IamNotOntheImage -v $testdir/content:/IamNotOntheImage/foo $IMAGE cat foo
+    run_podman run --rm --workdir /IamNotOntheImage -v $testdir/content:/IamNotOntheImage/foo:Z $IMAGE cat foo
     is "$output" "$randomcontent" "cat random content"
 
     # Make sure that running on a read-only rootfs works (#9230).

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -34,7 +34,7 @@ load helpers
     # Bind-mount this file with a different name to a container running httpd
     run_podman run -d --name myweb -p "$HOST_PORT:80" \
             --restart always \
-            -v $INDEX1:/var/www/index.txt \
+            -v $INDEX1:/var/www/index.txt:Z \
             -w /var/www \
             $IMAGE /bin/busybox-extras httpd -f -p 80
     cid=$output
@@ -257,7 +257,7 @@ load helpers
     # Bind-mount this file with a different name to a container running httpd
     run_podman run -d --name myweb -p "$HOST_PORT:80" \
             --network $netname \
-            -v $INDEX1:/var/www/index.txt \
+            -v $INDEX1:/var/www/index.txt:Z \
             -w /var/www \
             $IMAGE /bin/busybox-extras httpd -f -p 80
     cid=$output


### PR DESCRIPTION
selinux-policy-34.9-1.fc34 breaks a behavior we've relied on
since (at least) January 2020:

   - Revert "Add permission open to files_read_inherited_tmp_files()
     interface"

That's probably the correct thing to do, but it breaks our
existing tests. Solution: add ':Z' where needed.

Tested on Ed's laptop, which has the offending selinux-policy
as of 2021-05-31. Tests pass root and rootless. (I mention
this because tests will obviously pass in CI, which has a
much older selinux-policy).

Signed-off-by: Ed Santiago <santiago@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
