### PR TITLE
[v.3.2] events: support disjunctive filters

### DIFF
--- a/libpod/events/filters.go
+++ b/libpod/events/filters.go
@@ -97,18 +97,41 @@ func parseFilter(filter string) (string, string, error) {
 	return filterSplit[0], filterSplit[1], nil
 }
 
-func generateEventOptions(filters []string, since, until string) ([]EventFilter, error) {
-	options := make([]EventFilter, 0, len(filters))
+// applyFilters applies the EventFilter slices in sequence.  Filters under the
+// same key are disjunctive while each key must match (conjuctive).
+func applyFilters(event *Event, filterMap map[string][]EventFilter) bool {
+	for _, filters := range filterMap {
+		success := false
+		for _, filter := range filters {
+			if filter(event) {
+				success = true
+				break
+			}
+		}
+		if !success {
+			return false
+		}
+	}
+	return true
+}
+
+// generateEventFilter parses the specified filters into a filter map that can
+// later on be used to filter events.  Keys are conjunctive, values are
+// disjunctive.
+func generateEventFilters(filters []string, since, until string) (map[string][]EventFilter, error) {
+	filterMap := make(map[string][]EventFilter)
 	for _, filter := range filters {
 		key, val, err := parseFilter(filter)
 		if err != nil {
 			return nil, err
 		}
-		funcFilter, err := generateEventFilter(key, val)
+		filterFunc, err := generateEventFilter(key, val)
 		if err != nil {
 			return nil, err
 		}
-		options = append(options, funcFilter)
+		filterSlice := filterMap[key]
+		filterSlice = append(filterSlice, filterFunc)
+		filterMap[key] = filterSlice
 	}
 
 	if len(since) > 0 {
@@ -116,7 +139,8 @@ func generateEventOptions(filters []string, since, until string) ([]EventFilter,
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to convert since time of %s", since)
 		}
-		options = append(options, generateEventSinceOption(timeSince))
+		filterFunc := generateEventSinceOption(timeSince)
+		filterMap["since"] = []EventFilter{filterFunc}
 	}
 
 	if len(until) > 0 {
@@ -124,7 +148,8 @@ func generateEventOptions(filters []string, since, until string) ([]EventFilter,
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to convert until time of %s", until)
 		}
-		options = append(options, generateEventUntilOption(timeUntil))
+		filterFunc := generateEventUntilOption(timeUntil)
+		filterMap["until"] = []EventFilter{filterFunc}
 	}
-	return options, nil
+	return filterMap, nil
 }

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -44,9 +44,9 @@ func (e EventLogFile) Write(ee Event) error {
 // Reads from the log file
 func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 	defer close(options.EventChannel)
-	eventOptions, err := generateEventOptions(options.Filters, options.Since, options.Until)
+	filterMap, err := generateEventFilters(options.Filters, options.Since, options.Until)
 	if err != nil {
-		return errors.Wrapf(err, "unable to generate event options")
+		return errors.Wrapf(err, "failed to parse event filters")
 	}
 	t, err := e.getTail(options)
 	if err != nil {
@@ -92,11 +92,7 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 		default:
 			return errors.Errorf("event type %s is not valid in %s", event.Type.String(), e.options.LogFilePath)
 		}
-		include := true
-		for _, filter := range eventOptions {
-			include = include && filter(event)
-		}
-		if include && copy {
+		if copy && applyFilters(event, filterMap) {
 			options.EventChannel <- event
 		}
 	}


### PR DESCRIPTION
While different filters are applied in conjunction, the same filter (but
with different values) should be applied in disjunction.  This allows,
for instance, to query the events of two containers.

Fixes: #10507
Backport-of: commit 37f39eefee72ec4fb6c6bd71642e9d384c448387
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
