### PR TITLE
[CI:DOCS] Update podman.1.md, image-(diff, mount, exists) & images

### DIFF
--- a/docs/source/markdown/podman-image-diff.1.md
+++ b/docs/source/markdown/podman-image-diff.1.md
@@ -1,29 +1,44 @@
 % podman-image-diff(1)
 
 ## NAME
+
 podman-image-diff - Inspect changes on an image's filesystem
 
 ## SYNOPSIS
+
 **podman image diff** [*options*] *name*
 
 ## DESCRIPTION
-Displays changes on a container or image's filesystem.  The container or image will be compared to its parent layer
+
+**podman image diff** displays changes on an image's filesystem.  The image will be compared to its parent layer.
+
+The output is prefixed with the following symbols:
+
+| Symbol | Description |
+|--------|-------------|
+| A | A file or directory was added. |
+| D | A file or directory was deleted. |
+| C | A file or directory was changed. |
 
 ## OPTIONS
 
-#### **--format**
+#### **--format**, **-f**=*format*
 
-Alter the output into a different format.  The only valid format for diff is `json`.
+Alter the output into a different format.  The only valid format for diff is `JSON`.
 
 ## EXAMPLE
 
+- Diff of two different python images.
+
 ```
-# podman diff redis:old redis:alpine
+# podman diff python:latest python:alpine
 C /usr
 C /usr/local
 C /usr/local/bin
 A /usr/local/bin/docker-entrypoint.sh
 ```
+
+- `JSON` formatted diff of two different redis images. The returned `JSON` object contains arrays specifying changes in the filesystem. 
 
 ```
 # podman diff --format json redis:old redis:alpine
@@ -40,7 +55,9 @@ A /usr/local/bin/docker-entrypoint.sh
 ```
 
 ## SEE ALSO
-podman(1)
+
+**[podman(1)](podman.1.md)**
 
 ## HISTORY
+
 August 2017, Originally compiled by Ryan Cole <rycole@redhat.com>

--- a/docs/source/markdown/podman-image-exists.1.md
+++ b/docs/source/markdown/podman-image-exists.1.md
@@ -1,43 +1,53 @@
 % podman-image-exists(1)
 
 ## NAME
+
 podman-image-exists - Check if an image exists in local storage
 
 ## SYNOPSIS
-**podman image exists** *image*
+
+**podman image exists** [*options*] *name*
 
 ## DESCRIPTION
-**podman image exists** checks if an image exists in local storage. The **ID** or **Name**
-of the image may be used as input.  Podman will return an exit code
-of `0` when the image is found.  A `1` will be returned otherwise. An exit code of `125` indicates there
-was an issue accessing the local storage.
+
+**podman image exists** checks if an image exists in local storage. The *ID* or *name* of the image may be used as input.
+
+Podman will return the following exit codes:
+
+| Exit Code | Description |
+|-----------|-------------|
+| 0 | Image found. |
+| 1 | Image not found. |
+| 125 | Could not access local storage. |
 
 ## OPTIONS
 
 #### **--help**, **-h**
 
-Print usage statement
+Print usage statement.
 
 ## EXAMPLES
 
-Check if an image called `webclient` exists in local storage (the image does actually exist).
+- Check if an image called `webclient` exists in local storage (the image does actually exist).
+
 ```
 $ podman image exists webclient
 $ echo $?
 0
-$
 ```
 
-Check if an image called `webbackend` exists in local storage (the image does not actually exist).
+- Check if an image called `webbackend` exists in local storage (the image does not actually exist).
+
 ```
 $ podman image exists webbackend
 $ echo $?
 1
-$
 ```
 
 ## SEE ALSO
-podman(1)
+
+**[podman(1)](podman.1.md)**
 
 ## HISTORY
-November 2018, Originally compiled by Brent Baude (bbaude at redhat dot com)
+
+November 2018, Originally compiled by Brent Baude <bbaude@redhat.com>

--- a/docs/source/markdown/podman-image-mount.1.md
+++ b/docs/source/markdown/podman-image-mount.1.md
@@ -1,24 +1,28 @@
 % podman-image-mount(1)
 
 ## NAME
+
 podman\-image\-mount - Mount an image's root filesystem
 
 ## SYNOPSIS
-**podman image mount** [*options*] [*image* ...]
+
+**podman image mount** [*options*] name
 
 ## DESCRIPTION
-Mounts the specified images' root file system in a location which can be
+
+**podman image mount** mounts the specified images' root file system in a location which can be
 accessed from the host, and returns its location.
 
-If you execute the command without any arguments, Podman will list all of the
-currently mounted images.
+If a command is executed without any arguments, Podman will list all of the currently mounted images.
 
-Rootless mode only supports mounting VFS driver, unless you enter the user namespace
+Rootless mode only supports mounting `VFS driver`, unless you enter the user namespace
 via the `podman unshare` command. All other storage drivers will fail to mount.
 
-## RETURN VALUE
-The location of the mounted file system.  On error an empty string and errno is
-returned.
+**Return Value:**
+The location of the mounted file system.  
+
+- **Note:**
+On error an empty string and an errno is returned.
 
 ## OPTIONS
 
@@ -28,26 +32,31 @@ Mount all images.
 
 #### **--format**=*format*
 
-Print the mounted images in specified format (json).
+Print the mounted images in specified format (`JSON`).
 
 ## EXAMPLE
 
-```
-podman image mount fedora ubi8-init
+- Location of the mounted images' root file system on the host is returned.
 
+```
+# podman image mount fedora ubi8-init
 /var/lib/containers/storage/overlay/f3ac502d97b5681989dff84dfedc8354239bcecbdc2692f9a639f4e080a02364/merged
 /var/lib/containers/storage/overlay/0ff7d7ca68bed1ace424f9df154d2dd7b5a125c19d887f17653cbcd5b6e30ba1/merged
 ```
 
+- Currently mounted images.
+
 ```
-podman mount
+# podman mount
 
 registry.fedoraproject.org/fedora:latest /var/lib/containers/storage/overlay/f3ac502d97b5681989dff84dfedc8354239bcecbdc2692f9a639f4e080a02364/merged
 registry.access.redhat.com/ubi8-init:latest /var/lib/containers/storage/overlay/0ff7d7ca68bed1ace424f9df154d2dd7b5a125c19d887f17653cbcd5b6e30ba1/merged
 ```
 
+- Mounted images displayed in `JSON` format.
+
 ```
-podman image mount --format json
+# podman image mount --format json
 [
  {
   "id": "00ff39a8bf19f810a7e641f7eb3ddc47635913a19c4996debd91fafb6b379069",
@@ -73,4 +82,9 @@ podman image mount --format json
 ```
 
 ## SEE ALSO
-podman(1), podman-image-umount(1), mount(8), podman-unshare(1)
+
+**[podman(1)](podman.1.md)**, **[podman-image-unmount(1)](podman-image-unmount.1.md)**, **[podman-unshare(1)](podman-unshare.1.md)**, **mount(8)**
+
+## HISTORY
+
+July 2020, Originally compiled by Daniel Walsh <dwalsh@redhat.com>

--- a/docs/source/markdown/podman-images.1.md
+++ b/docs/source/markdown/podman-images.1.md
@@ -1,9 +1,11 @@
 % podman-images(1)
 
 ## NAME
+
 podman\-images - List images in local storage
 
 ## SYNOPSIS
+
 **podman images** [*options*]
 
 **podman image list** [*options*]
@@ -11,47 +13,40 @@ podman\-images - List images in local storage
 **podman image ls** [*options*]
 
 ## DESCRIPTION
-Displays locally stored images, their names, and their IDs.
+
+**podman images** displays locally stored images, their names, and their IDs.
 
 ## OPTIONS
 
 #### **--all**, **-a**
 
-Show all images (by default filter out the intermediate image layers). The default is false.
+Show all images. If set, itermediate layers are not filtered out.
+
+**Note:**
+
+- Intermediate layers are filtered out by default i.e. when this option is not set.
 
 #### **--digests**
 
-Show image digests
+Show image digests.
 
-#### **--filter**=*filter*, **-f**
+#### **--filter**=, **-f**=*filter*
 
-Filter output based on conditions provided
+| Filter      | Description |
+| ----------- | ----------- |
+| since=IMAGE | Filter on images created after a given IMAGE (name or tag).|
+| before=IMAGE   | Filter on images created before the given IMAGE (name or tag).|
+| dangling=true\|false | Show dangling images. Dangling images refer to file system layers that were used in a previous build of an image and are no longer referenced by any active images. They are denoted with the `<none>` tag, consume disk space and serve no active purpose. |
+| label | Filter by images labels key and/or value. |
+| readonly=true\|false | Show only read only images or read/write images. The default is to show both.  Read only images can be configured by modifying the  `"additionalimagestores"` in the `/etc/containers/storage.conf` file. |
+| reference |  Filter by image name, specified as regular expressions. |
 
-  Filters:
-
-  **since=IMAGE**
-    Filter on images created after the given IMAGE (name or tag).
-
-  **before=IMAGE**
-    Filter on images created before the given IMAGE (name or tag).
-
-  **dangling=true|false**
-    Show dangling images. Dangling images are a file system layer that was used in a previous build of an image and is no longer referenced by any active images. They are denoted with the `<none>` tag, consume disk space and serve no active purpose.
-
-  **label**
-    Filter by images labels key and/or value.
-
-  **readonly=true|false**
-     Show only read only images or Read/Write images. The default is to show both.  Read/Only images can be configured by modifying the  "additionalimagestores" in the /etc/containers/storage.conf file.
-
-  **reference=**
-     Filter by image name, specified as regular expressions.
+Filter output based on conditions provided.
 
 #### **--format**=*format*
 
-Change the default output format.  This can be of a supported type like 'json'
-or a Go template.
-Valid placeholders for the Go template are listed below:
+Change the default output format.  This can be of a supported type like `json` or a `Go` template.
+Valid placeholders for the `Go` template are listed below:
 
 | **Placeholder** | **Description**                                                               |
 | --------------- | ----------------------------------------------------------------------------- |
@@ -59,14 +54,14 @@ Valid placeholders for the Go template are listed below:
 | .Repository     | Image repository                                                              |
 | .Tag            | Image tag                                                                     |
 | .Digest         | Image digest                                                                  |
-| .CreatedSince   | Elapsed time since the image was created			     					  |
+| .CreatedSince   | Elapsed time since the image was created               |
 | .CreatedAt      | Time when the image was created                                               |
 | .Size           | Size of layer on disk                                                         |
 | .History        | History of the image layer                                                    |
 
 #### **--history**
 
-Display the history of image names.  If an image gets re-tagged or untagged, then the image name history gets prepended (latest image first).  This is especially useful when undoing a tag operation or an image does not contain any name because it has been untagged.
+Display the history of image names.  If an image gets re-tagged or untagged, then the image name history gets prepended (latest image first).  This is especially useful when undoing a tag operation or when an image does not contain any name because it has been untagged.
 
 #### **--noheading**, **-n**
 
@@ -80,9 +75,17 @@ Do not truncate output.
 
 Lists only the image IDs.
 
-#### **--sort**=*sort*
+#### **--sort**=**_created_**
 
-Sort by created, id, repository, size or tag (default: created)
+| Criteria     | Description |
+| ----------- | ----------- |
+| **created** | When an image was created. |
+| id   | Alpha-numeric order of id of the created images.|
+| repository | Repository from which the image was pulled.|
+| size | Size of the image. |
+| tag | Alpha-numeric order of tags given to the images.|
+
+Sort by created, id, repository, size or tag. The default is **created**.
 
 ## EXAMPLE
 
@@ -188,7 +191,9 @@ docker.io/library/alpine   latest   3fd9065eaf02   5 months ago    4.41 MB
 ```
 
 ## SEE ALSO
-podman(1), containers-storage.conf(5)
+
+**[podman(1)](podman.1.md)**, **[containers-storage.conf(5)](https://github.com/containers/common/blob/master/docs/containers-mounts.conf.5.md)**
 
 ## HISTORY
-March 2017, Originally compiled by Dan Walsh `<dwalsh@redhat.com>`
+
+March 2017, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -1,12 +1,15 @@
 % podman(1)
 
 ## NAME
-podman - Simple management tool for pods, containers and images
+
+podman - Command to manage pods, containers and images.
 
 ## SYNOPSIS
+
 **podman** [*options*] *command*
 
 ## DESCRIPTION
+
 Podman (Pod Manager) is a fully featured container engine that is a simple daemonless tool.
 Podman provides a Docker-CLI comparable command line that eases the transition from other
 container engines and allows the management of pods, containers and images.  Simply put: `alias docker=podman`.
@@ -21,36 +24,51 @@ Default settings for flags are defined in `containers.conf`. Most settings for
 Remote connections use the server's containers.conf, except when documented in
 man pages.
 
-**podman [GLOBAL OPTIONS]**
+## OPTIONS
 
-## GLOBAL OPTIONS
+#### **--cgroup-manager**=**_systemd_** | *cgroupfs*
 
-#### **--cgroup-manager**=*manager*
+| CGroup Manager| Description|
+| ----------- | ----------- |
+| **systemd**| daemon process for managing services|
+| cgroupfs | pseudo-filesystem for the cgroup interface|
 
-The CGroup manager to use for container cgroups. Supported values are cgroupfs or systemd. Default is systemd unless overridden in the containers.conf file.
+The CGroup manager to use for container cgroups. Default is systemd unless overridden in the `containers.conf` file. The default manager is **systemd**.
 
-Note: Setting this flag can cause certain commands to break when called on containers previously created by the other CGroup manager type.
-Note: CGroup manager is not supported in rootless mode when using CGroups Version V1.
+**Note:**
 
-#### **--cni-config-dir**
-Path of the configuration directory for CNI networks.  (Default: `/etc/cni/net.d`)
+- Setting this flag can cause certain commands to break when called on containers previously created by the other CGroup manager type.
+- CGroup manager is not supported in rootless mode when using CGroups Version V1.
+
+#### **--cni-config-dir**=**_/etc/cni/net.d_**
+
+Path of the configuration directory for CNI networks.
 
 #### **--connection**, **-c**
-Connection to use for remote podman (Default connection is configured in `containers.conf`)
-Remote connections use local containers.conf for default.
+
+Connection to use for remote podman
+
+**Note:**
+
+- Default connection is configured in `containers.conf`.
+- Remote connections use local `containers.conf` for default.
 
 #### **--conmon**
-Path of the conmon binary (Default path is configured in `containers.conf`)
 
-#### **--events-backend**=*type*
+Path of the conmon binary.
 
-Backend to use for storing events. Allowed values are **file**, **journald**, and
-**none**. When *file* is specified, the events are stored under a subdirectory
+**Note:**
+
+Default path is configured in `containers.conf`.
+
+#### **--events-backend**=*file | journald | none*
+
+Backend to use for storing events. When a *file* is specified, the events are stored under a subdirectory
 of the *tmpdir* location (see **--tmpdir** below).
 
 #### **--help**, **-h**
 
-Print usage statement
+Print usage statement.
 
 #### **--hooks-dir**=*path*
 
@@ -66,7 +84,9 @@ If `--hooks-dir` is unset for root callers, Podman and libpod will currently def
 
 Podman and libpod currently support an additional `precreate` state which is called before the runtime's `create` operation.  Unlike the other stages, which receive the container state on their standard input, `precreate` hooks receive the proposed runtime configuration on their standard input.  They may alter that configuration as they see fit, and write the altered form to their standard output.
 
-**WARNING**: the `precreate` hook lets you do powerful things, such as adding additional mounts to the runtime configuration.  That power also makes it easy to break things.  Before reporting libpod errors, try running your container with `precreate` hooks disabled to see if the problem is due to one of your hooks.
+**Warning:**
+
+The `precreate` hook allows additional mounts to the runtime configuration.  This might make it easy to break things.  Before reporting libpod errors, try running the container with `precreate` hooks disabled to see if the problem is due to one of the hooks.
 
 #### **--identity**=*path*
 
@@ -75,110 +95,169 @@ If no identity file is provided and no user is given, podman defaults to the use
 Podman prompts for the login password on the remote server.
 
 Identity value resolution precedence:
- - command line value
- - environment variable `CONTAINER_SSHKEY`, if `CONTAINER_HOST` is found
- - `containers.conf`
-Remote connections use local containers.conf for default.
 
-#### **--log-level**=*level*
+- command line value.
+- environment variable `CONTAINER_SSHKEY`, if `CONTAINER_HOST` is found.
+- `containers.conf`.
+Remote connections use local `containers.conf` for default.
 
-Log messages above specified level: debug, info, warn, error (default), fatal or panic (default: "error")
+#### **--log-level**=**level**
+
+| Level    | Description |
+| ----------- | ----------- |
+| **warn**       | Conditions that might or might not lead to an error.|
+| error  | Runtime/Unexpected error messages.|
+| Debug       | Information that can be used for diagnostic purposes.        |
+| trace | Provides more information than Debug. Useful for pinpointing location of an event.|
+| info       | Runtime messages that highlight the progress of the application.|
+| fatal/panic | Error messages that force a premature termination of the application.|
+
+Log messages above a specified level. The default is **warn**.
 
 #### **--namespace**=*namespace*
 
 Set libpod namespace. Namespaces are used to separate groups of containers and pods in libpod's state.
-When namespace is set, created containers and pods will join the given namespace, and only containers and pods in the given namespace will be visible to Podman.
+When a namespace is set, created containers and pods will join the given namespace, and only containers and pods in the given namespace will be visible to Podman.
 
 #### **--network-cmd-path**=*path*
-Path to the command binary to use for setting up a network.  It is currently only used for setting up a slirp4netns network.  If "" is used then the binary is looked up using the $PATH environment variable.
+
+Path to the command binary to use for setting up a network.  It is currently only used for setting up a slirp4netns network.  If "" is used then the binary is looked up using the `$PATH` environment variable.
 
 #### **--remote**, **-r**
+
 Access Podman service will be remote
-Remote connections use local containers.conf for default.
+Remote connections use local `containers.conf` for default.
 
 #### **--url**=*value*
-URL to access Podman service (default from `containers.conf`, rootless `unix://run/user/$UID/podman/podman.sock` or as root `unix://run/podman/podman.sock`).
 
- - `CONTAINER_HOST` is of the format `<schema>://[<user[:<password>]@]<host>[:<port>][<path>]`
+| User      | Value (Default)|
+| ----------- | ----------- |
+| Root        | `unix://run/user/$UID/podman/podman.sock`|
+| Rootless    | `unix://run/podman/podman.sock`|
 
-Details:
- - `user` will default to either `root` or current running user
- - `password` has no default
- - `host` must be provided and is either the IP or name of the machine hosting the Podman service
- - `port` defaults to 22
- - `path` defaults to either `/run/podman/podman.sock`, or `/run/user/<uid>/podman/podman.sock` if running rootless.
+URL to access Podman service.
+Default in `etc/containers/container.conf`
 
-URL value resolution precedence:
- - command line value
- - environment variable `CONTAINER_HOST`
- - `containers.conf`
- - `unix://run/podman/podman.sock`
-Remote connections use local containers.conf for default.
+**Note:**
+
+- `CONTAINER_HOST` is of the format `<schema>://[<user[:<password>]@]<host>[:<port>][<path>]`.
+- `user` will default to either `root` or current running user.
+- `password` has no default.
+- `host` must be provided and is either the IP or name of the machine hosting the Podman service.
+- `port` defaults to 22.
+- `path` defaults to either `/run/podman/podman.sock`, or `/run/user/<uid>/podman/podman.sock` if running rootless.
+
+**URL value resolution precedence:**
+
+- command line value.
+- environment variable `CONTAINER_HOST`.
+- `containers.conf`.
+- `unix://run/podman/podman.sock`.
+Remote connections use local `containers.conf` for default.
 
 #### **--root**=*value*
 
-Storage root dir in which data, including images, is stored (default: "/var/lib/containers/storage" for UID 0, "$HOME/.local/share/containers/storage" for other users).
-Default root dir configured in `/etc/containers/storage.conf`.
+| UID      | Value (Default)|
+| ----------- | ----------- |
+| 0       | `/var/lib/containers/storage` |
+| Other   | `$HOME/.local/share/containers/storage`|
 
-Overriding this option will cause the *storage-opt* settings in /etc/containers/storage.conf to be ignored.  The user must specify additional options via the `--storage-opt` flag.
+Storage root directory in which data, including images, is stored.
+
+Default root directory is configured in `/etc/containers/storage.conf`.
+
+Overriding this option will cause the *storage-opt* settings in `/etc/containers/storage.conf` to be ignored.  The user must specify additional options via the `--storage-opt` flag.
 
 #### **--runroot**=*value*
 
-Storage state directory where all state information is stored (default: "/run/containers/storage" for UID 0, "/run/user/$UID/run" for other users).
+| UID      | Value (Default)|
+| ----------- | ----------- |
+| 0       | `/run/containers/storage` |
+| Other   | `/run/user/$UID/run`|
+
+Storage state directory where all state information is stored.
+
 Default state dir configured in `/etc/containers/storage.conf`.
 
 #### **--runtime**=*value*
 
-Name of the OCI runtime as specified in containers.conf or absolute path to the OCI compatible binary used to run containers.
+Name of the OCI runtime as specified in `containers.conf` or absolute path to the OCI compatible binary used to run containers.
 
 #### **--runtime-flag**=*flag*
 
-Adds global flags for the container runtime. To list the supported flags, please
-consult the manpages of the selected container runtime (`runc` is the default
+Adds global flags for the container runtime. To list the supported flags.
+Consult the manpages of the selected container runtime (`runc` is the default
 runtime, the manpage to consult is `runc(8)`.  When the machine is configured
 for cgroup V2, the default runtime is `crun`, the manpage to consult is `crun(8)`.).
 
-Note: Do not pass the leading `--` to the flag. To pass the runc flag `--log-format json`
+**Note:**
+
+- Do not pass the leading `--` to the flag. To pass the runc flag `--log-format json`
 to podman build, the option given would be `--runtime-flag log-format=json`.
 
 #### **--storage-driver**=*value*
 
-Storage driver.  The default storage driver for UID 0 is configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode), and is *vfs* for non-root users when *fuse-overlayfs* is not available.  The `STORAGE_DRIVER` environment variable overrides the default.  The --storage-driver specified driver overrides all.
+| UID      | Value (Default)|
+| ----------- | ----------- |
+| 0       | `/etc/containers/storage.conf` |
+| Other   | `$HOME/.config/containers/storage.conf`|
 
-Overriding this option will cause the *storage-opt* settings in /etc/containers/storage.conf to be ignored.  The user must
+Storage driver.
+
+**Note:**
+
+- Default is *vfs* for non-root users when *fuse-overlayfs* is not available.
+
+- The `STORAGE_DRIVER` environment variable overrides the default.  The `--storage-driver` specified driver overrides all.
+
+- Overriding this option will cause the *storage-opt* settings in `/etc/containers/storage.conf` to be ignored.  The user must
 specify additional options via the `--storage-opt` flag.
 
 #### **--storage-opt**=*value*
 
-Storage driver option, Default storage driver options are configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode). The `STORAGE_OPTS` environment variable overrides the default. The --storage-opt specified options overrides all. If you specify --storage-opt="", no storage options will be used.
+| User      | Value (Default)|
+| ----------- | ----------- |
+| Root        | `/etc/containers/storage.conf`|
+| Rootless    | `$HOME/.config/containers/storage.conf`|
 
-#### **--syslog**=*true|false*
+Storage driver option.
 
-Output logging information to syslog as well as the console (default *false*).
+The `STORAGE_OPTS` environment variable overrides the default. The --storage-opt specified options overrides all. If you specify `--storage-opt=""`, no storage options will be used.
 
-On remote clients, logging is directed to the file $HOME/.config/containers/podman.log.
+#### **--syslog**=**_false_**|*true*
+
+| Value      | Description |
+| ----------- | ----------- |
+| **False** | Information is not logged |
+| True   | Information is logged |
+
+Output logging information to syslog as well as the console. The default value is **false**.
+
+On remote clients, logging is directed to the file `$HOME/.config/containers/podman.log`.
 
 #### **--tmpdir**
 
 Path to the tmp directory, for libpod runtime content.
 
-NOTE --tmpdir is not used for the temporary storage of downloaded images.  Use the environment variable `TMPDIR` to change the temporary storage location of downloaded container images. Podman defaults to use `/var/tmp`.
+**Note:**
+
+- **--tmpdir** is not used for the temporary storage of downloaded images.  Use the environment variable `TMPDIR` to change the temporary storage location of downloaded container images. Podman defaults to use `/var/tmp`.
 
 #### **--version**, **-v**
 
-Print the version
+Print the version.
 
 ## Environment Variables
 
-Podman can set up environment variables from env of [engine] table in containers.conf. These variables can be overridden by passing  environment variables before the `podman` commands.
+Podman can set up environment variables from env of [engine] table in `containers.conf`. These variables can be overridden by passing  environment variables before the `podman` commands.
 
 ## Remote Access
 
-The Podman command can be used with remote services using the `--remote` flag. Connections can
+The Podman command can be used with remote services using the **--remote** option. Connections can
 be made using local unix domain sockets, ssh or directly to tcp sockets. When specifying the
 podman --remote flag, only the global options `--url`, `--identity`, `--log-level`, `--connection` are used.
 
-Connection information can also be managed using the containers.conf file.
+Connection information can also be managed using the `containers.conf` file.
 
 ## Exit Codes
 
@@ -199,6 +278,7 @@ the exit codes follow the `chroot` standard, see below:
     126
 
   **127** Executing a _contained command_ and the _command_ cannot be found
+
     $ podman run busybox foo; echo $?
     Error: container_linux.go:346: starting container process caused "exec: \"foo\": executable file not found in $PATH": OCI runtime error
     127
@@ -207,7 +287,6 @@ the exit codes follow the `chroot` standard, see below:
 
     $ podman run busybox /bin/sh -c 'exit 3'; echo $?
     3
-
 
 ## COMMANDS
 
@@ -274,78 +353,116 @@ the exit codes follow the `chroot` standard, see below:
 
 ## CONFIGURATION FILES
 
-**containers.conf** (`/usr/share/containers/containers.conf`, `/etc/containers/containers.conf`, `$HOME/.config/containers/containers.conf`)
+#### containers.conf
 
-    Podman has builtin defaults for command line options. These defaults can be overridden using the containers.conf configuration files.
+**Path(s):**
 
-Distributions ship the `/usr/share/containers/containers.conf` file with their default settings. Administrators can override fields in this file by creating the `/etc/containers/containers.conf` file.  Users can further modify defaults by creating the `$HOME/.config/containers/containers.conf` file. Podman merges its builtin defaults with the specified fields from these files, if they exist. Fields specified in the users file override the administrator's file, which overrides the distribution's file, which override the built-in defaults.
+- `/usr/share/containers/containers.conf`
+- `/etc/containers/containers.conf`
+- `$HOME/.config/containers/containers.conf`
 
-Podman uses builtin defaults if no containers.conf file is found.
+**Info:**
 
-If the **CONTAINERS_CONF** environment variable is set, then its value is used for the containers.conf file rather than the default.
+- Podman has builtin defaults for command line options. These defaults can be overridden using the `containers.conf` configuration files.
 
-**mounts.conf** (`/usr/share/containers/mounts.conf`)
+- Distributions ship the `/usr/share/containers/containers.conf` file with their default settings. Administrators can override fields in this file by creating the `/etc/containers/containers.conf` file.  Rootless users can further modify their own defaults by creating the `$HOME/.config/containers/containers.conf` file.
 
-    The mounts.conf file specifies volume mount directories that are automatically mounted inside containers when executing the `podman run` or `podman start` commands. Administrators can override the defaults file by creating `/etc/containers/mounts.conf`.
+- Podman merges its builtin defaults with the specified fields from these files, if they exist. Fields specified in the users file override the administrator's file, which overrides the distribution's file, which override the built-in defaults.
 
-When Podman runs in rootless mode, the file `$HOME/.config/containers/mounts.conf` will override the default if it exists. Please refer to containers-mounts.conf(5) for further details.
+- Podman uses builtin defaults if there is no `containers.conf` file found.
 
-**policy.json** (`/etc/containers/policy.json`)
+- If the **CONTAINERS_CONF** environment variable is set, then its value is used for the containers.conf file rather than the default.
 
-    Signature verification policy files are used to specify policy, e.g. trusted keys, applicable when deciding whether to accept an image, or individual signatures of that image, as valid.
+#### mounts.conf
 
-**registries.conf** (`/etc/containers/registries.conf`, `$HOME/.config/containers/registries.conf`)
+**Path(s):**
 
-    registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
+- `/usr/share/containers/mounts.conf`
 
-    Non root users of Podman can create the `$HOME/.config/containers/registries.conf` file to be used instead of the system defaults.
+**Info:**
 
-    If the **CONTAINERS_REGISTRIES_CONF** environment variable is set, then its value is used for the registries.conf file rather than the default.
+- The `mounts.conf` file specifies volume mount directories that are automatically mounted inside containers when executing the `podman run` or `podman start` commands. Administrators can override the defaults file by creating `/etc/containers/mounts.conf`.
 
-**storage.conf** (`/etc/containers/storage.conf`, `$HOME/.config/containers/storage.conf`)
+- When Podman runs in rootless mode, the file `$HOME/.config/containers/mounts.conf` will override the default if it exists. Please refer to `containers-mounts.conf(5)` for further details.
 
-    storage.conf is the storage configuration file for all tools using containers/storage
+#### policy.json
 
-    The storage configuration file specifies all of the available container storage options for tools using shared container storage.
+**Path(s):**
 
-    When Podman runs in rootless mode, the file `$HOME/.config/containers/storage.conf` is used instead of the system defaults.
+- `/etc/containers/policy.json`
 
-    If the **CONTAINERS_STORAGE_CONF** environment variable is set, the its value is used for the storage.conf file rather than the default.
+**Info:**
+
+- Signature verification policy files are used to specify policy, e.g. trusted keys, applicable when deciding whether to accept an image, or individual signatures of that image, as valid.
+
+#### registries.conf
+
+**Path(s):**
+
+- `/etc/containers/registries.conf`
+- `$HOME/.config/containers/registries.conf`
+
+**Info:**
+
+- `registries.conf` is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
+
+- Non root users of Podman can create the `$HOME/.config/containers/registries.conf` file to be used instead of the system defaults.
+
+- If the **CONTAINERS_REGISTRIES_CONF** environment variable is set, then its value is used for the registries.conf file rather than the default.
+
+#### storage.conf
+
+**Path(s):**
+
+- `/etc/containers/storage.conf`
+- `$HOME/.config/containers/storage.conf`
+
+**Info:**
+
+- `storage.conf` is the storage configuration file for all tools using containers/storage
+
+- The storage configuration file specifies all of the available container storage options for tools using shared container storage.
+
+- When Podman runs in rootless mode, the file `$HOME/.config/containers/storage.conf` is used instead of the system defaults.
+
+- If the **CONTAINERS_STORAGE_CONF** environment variable is set, the its value is used for the storage.conf file rather than the default.
 
 ## Rootless mode
-Podman can also be used as non-root user. When podman runs in rootless mode, a user namespace is automatically created for the user, defined in /etc/subuid and /etc/subgid.
+
+Podman can also be used as non-root user. When podman runs in rootless mode, a user namespace is automatically created for the user, defined in `/etc/subuid` and `/etc/subgid`.
 
 Containers created by a non-root user are not visible to other users and are not seen or managed by Podman running as root.
 
-It is required to have multiple uids/gids set for an user.  Be sure the user is present in the files `/etc/subuid` and `/etc/subgid`.
+It is required to have multiple `uids/gids` set for an user.  Be sure the user is present in the `/etc/subuid` and `/etc/subgid` files.
 
-If you have a recent version of usermod, you can execute the following
-commands to add the ranges to the files
+Users with a recent version of `usermod` can execute the following commands to add the ranges to the files:
 
-	$ sudo usermod --add-subuids 10000-75535 USERNAME
-	$ sudo usermod --add-subgids 10000-75535 USERNAME
+    sudo usermod --add-subuids 10000-75535 USERNAME
+    sudo usermod --add-subgids 10000-75535 USERNAME
 
-Or just add the content manually.
+Or just add the content manually:
 
-	$ echo USERNAME:10000:65536 >> /etc/subuid
-	$ echo USERNAME:10000:65536 >> /etc/subgid
+    echo USERNAME:10000:65536 >> /etc/subuid
+    echo USERNAME:10000:65536 >> /etc/subgid
 
 See the `subuid(5)` and `subgid(5)` man pages for more information.
 
 Images are pulled under `XDG_DATA_HOME` when specified, otherwise in the home directory of the user under `.local/share/containers/storage`.
 
-Currently the slirp4netns package is required to be installed to create a network device, otherwise rootless containers need to run in the network namespace of the host.
+Currently the `slirp4netns` package is required to be installed to create a network device, otherwise rootless containers need to run in the network namespace of the host.
 
 ### **NOTE:** Unsupported file systems in rootless mode
 
-The Overlay file system (OverlayFS) is not supported in rootless mode.  The fuse-overlayfs package is a tool that provides the functionality of OverlayFS in user namespace that allows mounting file systems in rootless environments.  It is recommended to install the fuse-overlayfs package.  In rootless mode Podman will automatically use the fuse-overlafs program as the mount_program if installed, as long as the $HOME/.config/containers/storage.conf file was not previously created.  If storage.conf exists in the homedir, add `mount_program = "/usr/bin/fuse-overlayfs"` under `[storage.options.overlay]` to enable this feature.
+The `Overlay file system (OverlayFS)` is not supported in rootless mode.  The fuse-overlayfs package is a tool that provides the functionality of OverlayFS in user namespace that allows mounting file systems in rootless environments.  It is recommended to install the fuse-overlayfs package.  In rootless mode Podman will automatically use the `fuse-overlayfs` program as the `mount_program` if installed, as long as the `$HOME/.config/containers/storage.conf` file was not previously created.  If `storage.conf` exists in the homedir, add `mount_program = "/usr/bin/fuse-overlayfs"` under `[storage.options.overlay]` to enable this feature.
 
-The Network File System (NFS) and other distributed file systems (for example: Lustre, Spectrum Scale, the General Parallel File System (GPFS)) are not supported when running in rootless mode as these file systems do not understand user namespace.  However, rootless Podman can make use of an NFS Homedir by modifying the `$HOME/.config/containers/storage.conf` to have the `graphroot` option point to a directory stored on local (Non NFS) storage.
+The `Network File System (NFS)` and other distributed file systems (for example: Lustre, Spectrum Scale, the General Parallel File System (GPFS)) are not supported when running in rootless mode as these file systems do not understand user namespace.  However, rootless Podman can make use of an NFS Homedir by modifying the `$HOME/.config/containers/storage.conf` to have the `graphroot` option point to a directory stored on local (Non NFS) storage.
 
 For more information, please refer to the [Podman Troubleshooting Page](https://github.com/containers/podman/blob/master/troubleshooting.md).
 
 ## SEE ALSO
-**containers-mounts.conf**(5), **containers-registries.conf**(5), **containers-storage.conf**(5), **buildah**(1), **containers.conf**(5), **oci-hooks**(5), **containers-policy.json**(5), **crun**(8), **runc**(8), **subuid**(5), **subgid**(5), **slirp4netns**(1), **conmon**(8).
+
+**[containers-mounts.conf(5)](https://github.com/containers/common/blob/master/docs/containers-mounts.conf.5.md)**, **[containers-registries.conf(5)](https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md)**, **[containers-storage.conf(5)](https://github.com/containers/common/blob/master/docs/containers.conf.5.md)**, **[buildah(1)](https://github.com/containers/buildah/blob/master/docs/buildah.md)**, **[containers.conf(5)](https://github.com/containers/common/blob/master/docs/containers.conf.5.md)**, **[oci-hooks(5)](https://github.com/containers/podman/blob/master/pkg/hooks/docs/oci-hooks.5.md)**, **[containers-policy.json(5)](https://github.com/containers/image/blob/master/docs/containers-policy.json.5.md)**, **[crun(8)](https://github.com/containers/crun/blob/master/crun.1.md)**, **[runc(8)](https://github.com/opencontainers/runc)**, **[slirp4netns(1)](https://github.com/rootless-containers/slirp4netns/blob/master/slirp4netns.1.md)**, **[conmon(8)](https://github.com/containers/conmon/blob/master/docs/conmon.8.md)**, **subuid**(5), **subgid**(5)
 
 ## HISTORY
+
 Dec 2016, Originally compiled by Dan Walsh <dwalsh@redhat.com>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
Hi, so  I just tried to fix the podman.1.md page according to the https://github.com/containers/podman/edit/master/docs/MANPAGE_SYNTAX.md. I was able to do the same for some other pages as well, but before I push the changes I would like to know if this page is okay. I might have made some mistakes, so please do lmk! and I will fix them asap. 

I have a few questions regarding the page:
- I could not find any option named `--runtime-flag` on the version of podman I am using which is 2.0.6. Was this recently introduced? 
```
podman --help | grep -nA 2 -nB 2 runtime
77-      --root string               Path to the root directory in which data, including images, is stored
78-      --runroot string            Path to the 'run directory' where all state information is stored
79:      --runtime string            Path to the OCI-compatible binary used to run containers, default is /usr/bin/runc
80-      --storage-driver string     Select which storage driver is used to manage storage of images and containers (default is overlay)
81-      --storage-opt stringArray   Used to pass an option to the storage driver
```
- For the `--remote` option I am not sure if there is a better way to write it,  "Access Podman service will be remote".
-  Should references to man pages be hyperlinks? 
- For 
```
## Environment Variables
 
Podman can set up environment variables from env of [engine] table in containers.conf. These variables can be overridden by passing  environment variables before the `podman` commands.
```
why is the word in "engine" in square brackets. what would be the correct way to put it? should i just highlight this with backticks?

Thank you so much! Please lmk if there is a better way to put things and if there any related webpages for the commands/options that could be helpful for someone. 

Signed off by: Mehul Arora <aroram18@mcmaster.ca>