### PR TITLE
Update nix pin with `make nixpkgs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,10 +389,10 @@ cross: local-cross
 .PHONY: nixpkgs
 nixpkgs:
 	@nix run \
-		-f channel:nixos-20.09 nix-prefetch-git \
+		-f channel:nixos-21.05 nix-prefetch-git \
 		-c nix-prefetch-git \
 		--no-deepClone \
-		https://github.com/nixos/nixpkgs refs/heads/nixos-20.09 > nix/nixpkgs.json
+		https://github.com/nixos/nixpkgs refs/heads/nixos-21.05 > nix/nixpkgs.json
 
 # Build statically linked binary
 .PHONY: static

--- a/nix/default-arm64.nix
+++ b/nix/default-arm64.nix
@@ -25,6 +25,21 @@ let
               -i "$dev"/include/glib-2.0/gobject/gobjectnotifyqueue.c
           '';
         });
+        pcsclite = (static pkg.pcsclite).overrideAttrs (x: {
+          configureFlags = [
+            "--enable-confdir=/etc"
+            "--enable-usbdropdir=/var/lib/pcsc/drivers"
+            "--disable-libsystemd"
+          ];
+          buildInputs = [ pkgs.python3 pkgs.udev pkgs.dbus pkgs.systemd ];
+        });
+        systemd = (static pkg.systemd).overrideAttrs (x: {
+          outputs = [ "out" "dev" ];
+          mesonFlags = x.mesonFlags ++ [
+            "-Dglib=false"
+            "-Dstatic-libsystemd=true"
+          ];
+        });
       };
     };
   });
@@ -47,8 +62,8 @@ let
     doCheck = false;
     enableParallelBuilding = true;
     outputs = [ "out" ];
-    nativeBuildInputs = [ bash gitMinimal go-md2man installShellFiles makeWrapper pkg-config which ];
-    buildInputs = [ glibc glibc.static gpgme libassuan libgpgerror libseccomp libapparmor libselinux ];
+    nativeBuildInputs = [ bash gitMinimal go-md2man pkg-config which ];
+    buildInputs = [ glibc glibc.static glib gpgme libassuan libgpgerror libseccomp libapparmor libselinux ];
     prePatch = ''
       export CFLAGS='-static -pthread'
       export LDFLAGS='-s -w -static-libgcc -static'

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -23,6 +23,21 @@ let
               -i "$dev"/include/glib-2.0/gobject/gobjectnotifyqueue.c
           '';
         });
+        pcsclite = (static pkg.pcsclite).overrideAttrs (x: {
+          configureFlags = [
+            "--enable-confdir=/etc"
+            "--enable-usbdropdir=/var/lib/pcsc/drivers"
+            "--with-systemdsystemunitdir=${placeholder "bin"}/lib/systemd/system"
+          ];
+          buildInputs = [ pkgs.python3 pkgs.udev pkgs.dbus pkgs.systemd ];
+        });
+        systemd = (static pkg.systemd).overrideAttrs (x: {
+          outputs = [ "out" "dev" ];
+          mesonFlags = x.mesonFlags ++ [
+            "-Dglib=false"
+            "-Dstatic-libsystemd=true"
+          ];
+        });
       };
     };
   });
@@ -45,8 +60,8 @@ let
     doCheck = false;
     enableParallelBuilding = true;
     outputs = [ "out" ];
-    nativeBuildInputs = [ bash gitMinimal go-md2man installShellFiles makeWrapper pkg-config which ];
-    buildInputs = [ glibc glibc.static gpgme libassuan libgpgerror libseccomp libapparmor libselinux ];
+    nativeBuildInputs = [ bash gitMinimal go-md2man pkg-config which ];
+    buildInputs = [ glibc glibc.static glib gpgme libassuan libgpgerror libseccomp libapparmor libselinux ];
     prePatch = ''
       export CFLAGS='-static -pthread'
       export LDFLAGS='-s -w -static-libgcc -static'

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "eb7e1ef185f6c990cda5f71fdc4fb02e76ab06d5",
-  "date": "2021-05-05T23:16:00+02:00",
-  "path": "/nix/store/a98lkhjlsqh32ic2kkrv5kkik6jy25wh-nixpkgs",
-  "sha256": "1ibz204c41g7baqga2iaj11yz9l75cfdylkiqjnk5igm81ivivxg",
+  "rev": "60cce7e5e1fdf62421ef6d4184ee399b46209366",
+  "date": "2021-06-09T01:18:50-04:00",
+  "path": "/nix/store/fixgn194626rb7gf99l9jaqm0hbqn2ix-nixpkgs",
+  "sha256": "100xrb925cana1kfd0c7gwkjjalq891vfgr0rn1gl9j8gp3l3gx6",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -5,4 +5,5 @@ let
     url = "${json.url}/archive/${json.rev}.tar.gz";
     inherit (json) sha256;
   });
-in nixpkgs
+in
+nixpkgs


### PR DESCRIPTION
  - Bugfix `make nixpkgs` which pin with branch `nixos-21.05`
  - Code lint with `nixpkgs-fmt`
  - Code sync between x86\_64 and aarch64

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
