### PR TITLE
API images/create added missing parameters platform, message, repo 

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -169,6 +169,8 @@ func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
 	query := struct {
 		FromSrc string   `schema:"fromSrc"`
 		Changes []string `schema:"changes"`
+		Message string   `schema:"message"`
+		Repo    string   `shchema:"repo"`
 	}{
 		// This is where you can override the golang default value for one of fields
 	}
@@ -185,14 +187,15 @@ func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
 			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to create tempfile"))
 			return
 		}
+
 		source = f.Name()
 		if err := SaveFromBody(f, r); err != nil {
 			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to write temporary file"))
 		}
 	}
-
 	imageEngine := abi.ImageEngine{Libpod: runtime}
-	report, err := imageEngine.Import(r.Context(), entities.ImageImportOptions{Source: source, Changes: query.Changes})
+	// TODO: add support for ImageImportOptions to take a platform parameter. Also import https://github.com/opencontainers/image-spec/tree/master/specs-go/v1 either here or within imageEngine.Import to get default platform
+	report, err := imageEngine.Import(r.Context(), entities.ImageImportOptions{Source: source, Changes: query.Changes, Message: query.Message, Reference: query.Repo})
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to import tarball"))
 		return
@@ -220,10 +223,10 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 	query := struct {
 		FromImage string `schema:"fromImage"`
 		Tag       string `schema:"tag"`
+		Platform  string `schema:"platform"`
 	}{
 		// This is where you can override the golang default value for one of fields
 	}
-
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
@@ -238,12 +241,36 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 	}
 	defer auth.RemoveAuthfile(authfile)
 
+	platformSpecs := strings.Split(query.Platform, "/") // split query into its parts
+
+	addOS := true // default assume true due to structure of if/else below
+	addArch := false
+	addVariant := false
+
+	if len(platformSpecs) > 1 { // if we have two arguments then we have os and arch
+		addArch = true
+		if len(platformSpecs) > 2 { // if we have 3 arguments then we have os arch and variant
+			addVariant = true
+		}
+	} else if len(platformSpecs) == 0 {
+		addOS = false
+	}
+
 	pullOptions := &libimage.PullOptions{}
 	pullOptions.AuthFilePath = authfile
 	if authConf != nil {
 		pullOptions.Username = authConf.Username
 		pullOptions.Password = authConf.Password
 		pullOptions.IdentityToken = authConf.IdentityToken
+		if addOS { // if the len is not 0
+			pullOptions.OS = platformSpecs[0]
+			if addArch {
+				pullOptions.Architecture = platformSpecs[1]
+			}
+			if addVariant {
+				pullOptions.Variant = platformSpecs[2]
+			}
+		}
 	}
 	pullOptions.Writer = os.Stderr // allows for debugging on the server
 
@@ -295,7 +322,6 @@ loop: // break out of for/select infinite loop
 			Error string `json:"error,omitempty"`
 			Id    string `json:"id,omitempty"` // nolint
 		}
-
 		select {
 		case e := <-progress:
 			switch e.Event {

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -28,15 +28,28 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: fromImage
 	//    type: string
-	//    description: needs description
+	//    description: Name of the image to pull. The name may include a tag or digest. This parameter may only be used when pulling an image. The pull is cancelled if the HTTP connection is closed.
 	//  - in: query
 	//    name: fromSrc
 	//    type: string
-	//    description: needs description
+	//    description: Source to import. The value may be a URL from which the image can be retrieved or - to read the image from the request body. This parameter may only be used when importing an image
+	//  - in: query
+	//    name: repo
+	//    type: string
+	//    description: Repository name given to an image when it is imported. The repo may include a tag. This parameter may only be used when importing an image.
 	//  - in: query
 	//    name: tag
 	//    type: string
-	//    description: needs description
+	//    description: Tag or digest. If empty when pulling an image, this causes all tags for the given image to be pulled.
+	//  - in: query
+	//    name: message
+	//    type: string
+	//    description: Set commit message for imported image.
+	//  - in: query
+	//    name: platform
+	//    type: string
+	//    description: Platform in the format os[/arch[/variant]]
+	//    default: ""
 	//  - in: header
 	//    name: X-Registry-Auth
 	//    type: string
@@ -45,6 +58,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    name: request
 	//    schema:
 	//      type: string
+	//      format: binary
 	//    description: Image content if fromSrc parameter was used
 	// responses:
 	//   200:

--- a/test/apiv2/python/rest_api/test_v2_0_0_image.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_image.py
@@ -86,6 +86,11 @@ class ImageTestCase(APITestCase):
         self.assertTrue(keys["id"], "Expected to find id stanza")
         self.assertTrue(keys["images"], "Expected to find images stanza")
         self.assertTrue(keys["stream"], "Expected to find stream progress stanza's")
+    def test_create(self):
+        r = requests.post(self.podman_url + "/v1.40/images/create?fromImage=alpine&platform=linux/amd64/v8", timeout=15)
+        self.assertEqual(r.status_code, 200, r.text)
+        r = requests.post(self.podman_url + "/v1.40/images/create?fromSrc=-&repo=fedora&message=testing123", timeout=15)
+        self.assertEqual(r.status_code, 200, r.text)
 
     def test_search_compat(self):
         url = self.podman_url + "/v1.40/images/search"


### PR DESCRIPTION
Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

Added support for the query parameters platform, message, and repo. Also edited documentation and formatted the request string as binary in register_images.go. CreateImageFromSrc within pkg/api/handlers/compat/images.go has some issues with supporting platform due to imageEngine.Import/the ImageImportOptions struct not supporting a platform parameter. 

I will most likely open a separate issue to handle this as it deals more with our side rather than the docker API. You can see [here](https://github.com/docker/engine/blob/7c6a9484ee37b28fa314f716581bdb268cd78ce2/api/server/router/image/image_routes.go#L26) that Docker supports platform in both the fromSrc and fromImage requests.