### PR TITLE
remote: always send resize before the container starts

### DIFF
--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -1364,6 +1364,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/ok"
 	//   404:
 	//     $ref: "#/responses/NoSuchContainer"
+	//   409:
+	//     $ref: "#/responses/ConflictError"
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name}/resize"), s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)

--- a/test/apiv2/python/rest_api/fixtures/api_testcase.py
+++ b/test/apiv2/python/rest_api/fixtures/api_testcase.py
@@ -49,7 +49,7 @@ class APITestCase(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        APITestCase.podman.run("run", "alpine", "/bin/ls", check=True)
+        APITestCase.podman.run("run", "-d", "alpine", "top", check=True)
 
     def tearDown(self) -> None:
         APITestCase.podman.run("pod", "rm", "--all", "--force", check=True)

--- a/test/apiv2/python/rest_api/test_v2_0_0_container.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_container.py
@@ -12,7 +12,7 @@ class ContainerTestCase(APITestCase):
         r = requests.get(self.uri("/containers/json"), timeout=5)
         self.assertEqual(r.status_code, 200, r.text)
         obj = r.json()
-        self.assertEqual(len(obj), 0)
+        self.assertEqual(len(obj), 1)
 
     def test_list_all(self):
         r = requests.get(self.uri("/containers/json?all=true"))
@@ -36,7 +36,7 @@ class ContainerTestCase(APITestCase):
             self.assertId(r.content)
 
     def test_delete(self):
-        r = requests.delete(self.uri(self.resolve_container("/containers/{}")))
+        r = requests.delete(self.uri(self.resolve_container("/containers/{}?force=true")))
         self.assertEqual(r.status_code, 204, r.text)
 
     def test_stop(self):

--- a/test/system/450-interactive.bats
+++ b/test/system/450-interactive.bats
@@ -56,8 +56,7 @@ function teardown() {
     stty rows $rows cols $cols <$PODMAN_TEST_PTY
 
     # ...and make sure stty under podman reads that.
-    # FIXME: 'sleep 1' is needed for podman-remote; without it, there's
-    run_podman run -it --name mystty $IMAGE sh -c 'sleep 1;stty size' <$PODMAN_TEST_PTY
+    run_podman run -it --name mystty $IMAGE stty size <$PODMAN_TEST_PTY
     is "$output" "$rows $cols" "stty under podman reads the correct dimensions"
 }
 


### PR DESCRIPTION
There is race condition in the remote client attach logic. Because the
resize api call was handled in an extra goroutine the container was
started before the resize call happend. To fix this we have to call
resize in the same goroutine as attach. When the first resize is done
start a goroutine to listen on SIGWINCH in the background and resize
again if the signal is received.

Fixes #9859

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
