### PR TITLE
podman-remote build should handle -f option properly

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -139,6 +139,31 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		addCaps = m
 	}
 
+	// convert addcaps formats
+	containerFiles := []string{}
+	if _, found := r.URL.Query()["dockerfile"]; found {
+		var m = []string{}
+		if err := json.Unmarshal([]byte(query.Dockerfile), &m); err != nil {
+			utils.BadRequest(w, "dockerfile", query.Dockerfile, err)
+			return
+		}
+		containerFiles = m
+	} else {
+		containerFiles = []string{"Dockerfile"}
+		if utils.IsLibpodRequest(r) {
+			containerFiles = []string{"Containerfile"}
+			if _, err = os.Stat(filepath.Join(contextDirectory, "Containerfile")); err != nil {
+				if _, err1 := os.Stat(filepath.Join(contextDirectory, "Dockerfile")); err1 == nil {
+					containerFiles = []string{"Dockerfile"}
+				} else {
+					utils.BadRequest(w, "dockerfile", query.Dockerfile, err)
+				}
+			}
+		} else {
+			containerFiles = []string{"Dockerfile"}
+		}
+	}
+
 	addhosts := []string{}
 	if _, found := r.URL.Query()["extrahosts"]; found {
 		if err := json.Unmarshal([]byte(query.AddHosts), &addhosts); err != nil {
@@ -470,7 +495,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	runCtx, cancel := context.WithCancel(context.Background())
 	go func() {
 		defer cancel()
-		imageID, _, err = runtime.Build(r.Context(), buildOptions, query.Dockerfile)
+		imageID, _, err = runtime.Build(r.Context(), buildOptions, containerFiles...)
 		if err == nil {
 			success = true
 		} else {


### PR DESCRIPTION
podman-remote build has to handle multiple different locations
for the Containerfile.  Currently this works in local mode but not
when using podman-remote.

Fixes: https://github.com/containers/podman/issues/9871

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
