### PR TITLE
remote events: fix --stream=false

### DIFF
--- a/pkg/api/handlers/compat/events.go
+++ b/pkg/api/handlers/compat/events.go
@@ -75,7 +75,7 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 	coder := json.NewEncoder(w)
 	coder.SetEscapeHTML(true)
 
-	for stream := true; stream; stream = query.Stream {
+	for {
 		select {
 		case err := <-errorChannel:
 			if err != nil {

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -27,7 +27,7 @@ load helpers
 }
 
 @test "image events" {
-    skip_if_remote "FIXME: remove events on podman-remote seem to be broken"
+    skip_if_remote "remote does not support --events-backend"
     pushedDir=$PODMAN_TMPDIR/dir
     mkdir -p $pushedDir
 
@@ -86,7 +86,5 @@ function _events_disjunctive_filters() {
 }
 
 @test "events with disjunctive filters - default" {
-    # NOTE: the last event for bar doesn't show up reliably.
-    skip_if_remote "FIXME #10529: remote events lose data"
     _events_disjunctive_filters ""
 }


### PR DESCRIPTION
Fix a bug in remote events where only one event would be sent if when
streaming is turned off.  The source of the bug was that the handler
attempted to implement the streaming logic and did it wrong.  The fix is
rather simple by removing this logic from the handler and let the events
backend handle streaming.

Fixes: #10529
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@containers/podman-maintainers PTAL
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
