### PR TITLE
remote events: support labels

### DIFF
--- a/pkg/domain/entities/events.go
+++ b/pkg/domain/entities/events.go
@@ -30,29 +30,41 @@ func ConvertToLibpodEvent(e Event) *libpodEvents.Event {
 	if err != nil {
 		return nil
 	}
+	image := e.Actor.Attributes["image"]
+	name := e.Actor.Attributes["name"]
+	details := e.Actor.Attributes
+	delete(details, "image")
+	delete(details, "name")
+	delete(details, "containerExitCode")
 	return &libpodEvents.Event{
 		ContainerExitCode: exitCode,
 		ID:                e.Actor.ID,
-		Image:             e.Actor.Attributes["image"],
-		Name:              e.Actor.Attributes["name"],
+		Image:             image,
+		Name:              name,
 		Status:            status,
 		Time:              time.Unix(e.Time, e.TimeNano),
 		Type:              t,
+		Details: libpodEvents.Details{
+			Attributes: details,
+		},
 	}
 }
 
 // ConvertToEntitiesEvent converts a libpod event to an entities one.
 func ConvertToEntitiesEvent(e libpodEvents.Event) *Event {
+	attributes := e.Details.Attributes
+	if attributes == nil {
+		attributes = make(map[string]string)
+	}
+	attributes["image"] = e.Image
+	attributes["name"] = e.Name
+	attributes["containerExitCode"] = strconv.Itoa(e.ContainerExitCode)
 	return &Event{dockerEvents.Message{
 		Type:   e.Type.String(),
 		Action: e.Status.String(),
 		Actor: dockerEvents.Actor{
-			ID: e.ID,
-			Attributes: map[string]string{
-				"image":             e.Image,
-				"name":              e.Name,
-				"containerExitCode": strconv.Itoa(e.ContainerExitCode),
-			},
+			ID:         e.ID,
+			Attributes: attributes,
 		},
 		Scope:    "local",
 		Time:     e.Time.Unix(),

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/containers/podman/v3/libpod/events"
 	. "github.com/containers/podman/v3/test/utils"
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo"
@@ -134,11 +135,9 @@ var _ = Describe("Podman events", func() {
 		jsonArr := test.OutputToStringArray()
 		Expect(test.OutputToStringArray()).ShouldNot(BeEmpty())
 
-		eventsMap := make(map[string]string)
-		err := json.Unmarshal([]byte(jsonArr[0]), &eventsMap)
+		event := events.Event{}
+		err := json.Unmarshal([]byte(jsonArr[0]), &event)
 		Expect(err).ToNot(HaveOccurred())
-
-		Expect(eventsMap).To(HaveKey("Status"))
 
 		test = podmanTest.Podman([]string{"events", "--stream=false", "--format", "{{json.}}"})
 		test.WaitWithDefaultTimeout()
@@ -147,11 +146,9 @@ var _ = Describe("Podman events", func() {
 		jsonArr = test.OutputToStringArray()
 		Expect(test.OutputToStringArray()).ShouldNot(BeEmpty())
 
-		eventsMap = make(map[string]string)
-		err = json.Unmarshal([]byte(jsonArr[0]), &eventsMap)
+		event = events.Event{}
+		err = json.Unmarshal([]byte(jsonArr[0]), &event)
 		Expect(err).ToNot(HaveOccurred())
-
-		Expect(eventsMap).To(HaveKey("Status"))
 	})
 
 	It("podman events --until future", func() {

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -6,7 +6,6 @@
 load helpers
 
 @test "events with a filter by label" {
-    skip_if_remote "FIXME: -remote does not include labels in event output"
     cname=test-$(random_string 30 | tr A-Z a-z)
     labelname=$(random_string 10)
     labelvalue=$(random_string 15)


### PR DESCRIPTION
Certain event meta data was lost when converting the remote events to
libpod events and vice versa.  Enable the skipped system tests for
remote.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
