### PR TITLE
[CI:DOCS] fix incorrect network remove api doc

### DIFF
--- a/pkg/api/handlers/libpod/swagger.go
+++ b/pkg/api/handlers/libpod/swagger.go
@@ -95,7 +95,7 @@ type swagInfoResponse struct {
 // swagger:response NetworkRmReport
 type swagNetworkRmReport struct {
 	// in:body
-	Body entities.NetworkRmReport
+	Body []entities.NetworkRmReport
 }
 
 // Network inspect


### PR DESCRIPTION
The endpoint returns an array and not a single entry.

Fixes #10494
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
