### PR TITLE
Add support for selectable checkpoint archive compression algorithm

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1211,3 +1211,10 @@ func AutocompleteVolumeFilters(cmd *cobra.Command, args []string, toComplete str
 	}
 	return completeKeyValues(toComplete, kv)
 }
+
+// AutocompleteCheckpointCompressType - Autocomplete checkpoint compress type options.
+// -> "gzip", "none", "zstd"
+func AutocompleteCheckpointCompressType(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	types := []string{"gzip", "none", "zstd"}
+	return types, cobra.ShellCompDirectiveNoFileComp
+}

--- a/docs/source/markdown/podman-container-checkpoint.1.md
+++ b/docs/source/markdown/podman-container-checkpoint.1.md
@@ -10,31 +10,9 @@ podman\-container\-checkpoint - Checkpoints one or more running containers
 Checkpoints all the processes in one or more containers. You may use container IDs or names as input.
 
 ## OPTIONS
-#### **--keep**, **-k**
-
-Keep all temporary log and statistics files created by CRIU during checkpointing. These files
-are not deleted if checkpointing fails for further debugging. If checkpointing succeeds these
-files are theoretically not needed, but if these files are needed Podman can keep the files
-for further analysis.
-
 #### **--all**, **-a**
 
 Checkpoint all running containers.
-
-#### **--latest**, **-l**
-
-Instead of providing the container name or ID, checkpoint the last created container. (This option is not available with the remote Podman client)
-
-#### **--leave-running**, **-R**
-
-Leave the container running after checkpointing instead of stopping it.
-
-#### **--tcp-established**
-
-Checkpoint a container with established TCP connections. If the checkpoint
-image contains established TCP connections, this options is required during
-restore. Defaults to not checkpointing containers with established TCP
-connections.
 
 #### **--export**, **-e**
 
@@ -56,10 +34,32 @@ This option must be used in combination with the **--export, -e** option.
 When this option is specified, the content of volumes associated with
 the container will not be included into the checkpoint tar.gz file.
 
+#### **--keep**, **-k**
+
+Keep all temporary log and statistics files created by CRIU during checkpointing. These files
+are not deleted if checkpointing fails for further debugging. If checkpointing succeeds these
+files are theoretically not needed, but if these files are needed Podman can keep the files
+for further analysis.
+
+#### **--latest**, **-l**
+
+Instead of providing the container name or ID, checkpoint the last created container. (This option is not available with the remote Podman client)
+
+#### **--leave-running**, **-R**
+
+Leave the container running after checkpointing instead of stopping it.
+
 #### **--pre-checkpoint**, **-P**
 
 Dump the container's memory information only, leaving the container running. Later
 operations will supersede prior dumps. It only works on runc 1.0-rc3 or higher.
+
+#### **--tcp-established**
+
+Checkpoint a container with established TCP connections. If the checkpoint
+image contains established TCP connections, this options is required during
+restore. Defaults to not checkpointing containers with established TCP
+connections.
 
 #### **--with-previous**
 

--- a/docs/source/markdown/podman-container-checkpoint.1.md
+++ b/docs/source/markdown/podman-container-checkpoint.1.md
@@ -14,6 +14,22 @@ Checkpoints all the processes in one or more containers. You may use container I
 
 Checkpoint all running containers.
 
+#### **--compress**, **-c**
+
+Specify the compression algorithm used for the checkpoint archive created
+with the **--export, -e** option. Possible algorithms are *gzip*, *none*
+and *zstd*. If no compression algorithm is specified Podman will use
+*zstd*.
+
+One possible reason to use *none* is to enable faster creation of checkpoint
+archives. Not compressing the checkpoint archive can result in faster checkpoint
+archive creation.
+
+```
+# podman container checkpoint -l --compress=none --export=dump.tar
+# podman container checkpoint -l --compress=gzip --export=dump.tar.gz
+```
+
 #### **--export**, **-e**
 
 Export the checkpoint to a tar.gz file. The exported checkpoint can be used

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/libpod/events"
 	"github.com/containers/podman/v3/pkg/signal"
+	"github.com/containers/storage/pkg/archive"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -776,6 +777,9 @@ type ContainerCheckpointOptions struct {
 	// ImportPrevious tells the API to restore container with two
 	// images. One is TargetFile, the other is ImportPrevious.
 	ImportPrevious string
+	// Compression tells the API which compression to use for
+	// the exported checkpoint archive.
+	Compression archive.Compression
 }
 
 // Checkpoint checkpoints a container

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -985,7 +985,7 @@ func (c *Container) exportCheckpoint(options ContainerCheckpointOptions) error {
 	}
 
 	input, err := archive.TarWithOptions(c.bundlePath(), &archive.TarOptions{
-		Compression:      archive.Gzip,
+		Compression:      options.Compression,
 		IncludeSourceDir: true,
 		IncludeFiles:     includeFiles,
 	})

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/specgen"
+	"github.com/containers/storage/pkg/archive"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 )
 
@@ -178,6 +179,7 @@ type CheckpointOptions struct {
 	TCPEstablished bool
 	PreCheckPoint  bool
 	WithPrevious   bool
+	Compression    archive.Compression
 }
 
 type CheckpointReport struct {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -483,6 +483,7 @@ func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds [
 		KeepRunning:    options.LeaveRunning,
 		PreCheckPoint:  options.PreCheckPoint,
 		WithPrevious:   options.WithPrevious,
+		Compression:    options.Compression,
 	}
 
 	if options.All {


### PR DESCRIPTION
The checkpoint archive compression was hardcoded to `archive.Gzip`.

There have been requests to make the used compression algorithm selectable. There was especially the request to not compress the checkpoint archive to be able to create faster checkpoints when not compressing it.

This also changes the default from `gzip` to `zstd`. This change should not break anything as the restore code path automatically handles whatever compression the user provides during restore.
