### PR TITLE
[CI:DOCS] Document which CNI fields are encoded

### DIFF
--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -241,7 +241,9 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks
 	// summary: List networks
-	// description: Display summary of network configurations
+	// description: |
+	//   Display summary of network configurations.
+	//     - In a 200 response, all of the fields named Bytes are returned as a Base64 encoded string.
 	// parameters:
 	//  - in: query
 	//    name: filters


### PR DESCRIPTION
The CNI configuration fields named Bytes are typed
[]byte which the GO JSON encoded automatically Base64 encodes.

Note: Future major versions of Podman will refactor the networking
endpoints to encapsulate/abstract the CNI structures which will
allow better documenation and encoding.

Fixes #10562

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
