### PR TITLE
[CI:DOCS] Fix outdated docs

### DIFF
--- a/docs/tutorials/podman-go-bindings.md
+++ b/docs/tutorials/podman-go-bindings.md
@@ -229,7 +229,7 @@ This binding takes three arguments:
 
 ```Go
         // List images
-        imageSummary, err := images.List(connText, nil, nil)
+        imageSummary, err := images.List(connText, &images.ListOptions{})
         if err != nil {
             fmt.Println(err)
             os.Exit(1)

--- a/docs/tutorials/podman-go-bindings.md
+++ b/docs/tutorials/podman-go-bindings.md
@@ -346,7 +346,7 @@ containers.List() takes seven arguments:
 ```Go
         // Container list
         var latestContainers = 1
-        containerLatestList, err := containers.List(connText, nil, nil, &latestContainers, nil, nil, nil)
+        containerLatestList, err := containers.List(connText, &containers.ListOptions{Last: &latestContainers})
         if err != nil {
             fmt.Println(err)
             os.Exit(1)

--- a/docs/tutorials/podman-go-bindings.md
+++ b/docs/tutorials/podman-go-bindings.md
@@ -287,7 +287,7 @@ containers.Wait() takes three arguments:
         // Container create
         s := specgen.NewSpecGenerator(rawImage, false)
         s.Terminal = true
-        r, err := containers.CreateWithSpec(connText, s)
+        r, err := containers.CreateWithSpec(connText, s, nil)
         if err != nil {
                 fmt.Println(err)
                 os.Exit(1)
@@ -302,7 +302,7 @@ containers.Wait() takes three arguments:
         }
 
         running := define.ContainerStateRunning
-        _, err = containers.Wait(connText, r.ID, &running)
+        _, err = containers.Wait(connText, r.ID, &containers.WaitOptions{Condition: []define.ContainerStatus{running}})
         if err != nil {
                 fmt.Println(err)
                 os.Exit(1)

--- a/docs/tutorials/podman-go-bindings.md
+++ b/docs/tutorials/podman-go-bindings.md
@@ -174,7 +174,7 @@ This binding takes three arguments:
 ```Go
         // Pull Busybox image (Sample 1)
         fmt.Println("Pulling Busybox image...")
-        _, err = images.Pull(connText, "docker.io/busybox", entities.ImagePullOptions{})
+        _, err = images.Pull(connText, "docker.io/busybox", &images.PullOptions{})
         if err != nil {
                 fmt.Println(err)
                 os.Exit(1)
@@ -183,7 +183,7 @@ This binding takes three arguments:
         // Pull Fedora image (Sample 2)
         rawImage := "registry.fedoraproject.org/fedora:latest"
         fmt.Println("Pulling Fedora image...")
-        _, err = images.Pull(connText, rawImage, entities.ImagePullOptions{})
+        _, err = images.Pull(connText, rawImage, &images.PullOptions{})
         if err != nil {
                 fmt.Println(err)
                 os.Exit(1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

The imports in the examples mentioned in [go-bindings-tutorial] (https://github.com/containers/podman/blob/master/docs/tutorials/podman-go-bindings.md) are updated to use v3. Nevertheless, if you try to run the examples it will fail due some changes on the package, mainly because of some option parameters that have been grouped into objects.

This PR updates the documentation with the last parameters needed.
