### PR TITLE
[CI:DOCS] converted query parameter for credentials to header parameter.

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -948,10 +948,6 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     description: "Mandatory reference to the image (e.g., quay.io/image/name:tag)"
 	//     type: string
 	//   - in: query
-	//     name: credentials
-	//     description: "username:password for the registry"
-	//     type: string
-	//   - in: query
 	//     name: Arch
 	//     description: Pull image for the specified architecture.
 	//     type: string
@@ -972,6 +968,10 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     name: allTags
 	//     description: Pull all tagged images in the repository.
 	//     type: boolean
+	//   - in: header
+	//     name: X-Registry-Auth
+	//     description: "base-64 encoded auth config. Must include the following four values: username, password, email and server address OR simply just an identity token."
+	//     type: string
 	// produces:
 	// - application/json
 	// responses:


### PR DESCRIPTION
Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

Edited docs based on the fact that [we added support for X-Registry-Auth](https://github.com/containers/podman/pull/6207) and the [libpod pull code](https://github.com/containers/podman/blob/v2.2/pkg/api/handlers/libpod/images_pull.go#L76) seems to only parse the header instead of the credentials query parameter. If interested, we could add handling for a credentials query parameter as well.
