### PR TITLE
Add support for pod inside of user namespace.

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -48,6 +48,7 @@ var (
 	podIDFile         string
 	replace           bool
 	share             string
+	userns            string
 )
 
 func init() {
@@ -71,6 +72,10 @@ func init() {
 	cgroupParentflagName := "cgroup-parent"
 	flags.StringVar(&createOptions.CGroupParent, cgroupParentflagName, "", "Set parent cgroup for the pod")
 	_ = createCommand.RegisterFlagCompletionFunc(cgroupParentflagName, completion.AutocompleteDefault)
+
+	usernsFlagName := "userns"
+	flags.StringVar(&userns, usernsFlagName, os.Getenv("PODMAN_USERNS"), "User namespace to use")
+	_ = createCommand.RegisterFlagCompletionFunc(usernsFlagName, common.AutocompleteUserNamespace)
 
 	flags.BoolVar(&createOptions.Infra, "infra", true, "Create an infra container associated with the pod to share namespaces with")
 
@@ -176,6 +181,11 @@ func create(cmd *cobra.Command, args []string) error {
 				return err
 			}
 		}
+	}
+
+	createOptions.Userns, err = specgen.ParseUserNamespace(userns)
+	if err != nil {
+		return err
 	}
 
 	if cmd.Flag("pod-id-file").Changed {

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1123,9 +1123,9 @@ Podman allocates unique ranges of UIDs and GIDs from the `containers` subpordina
 
   Valid `auto`options:
 
-  - *gidmapping*=_HOST_GID:CONTAINER_GID:SIZE_: to force a GID mapping to be present in the user namespace.
+  - *gidmapping*=_CONTAINER_GID:HOST_GID:SIZE_: to force a GID mapping to be present in the user namespace.
   - *size*=_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will estimate a size for the user namespace.
-  - *uidmapping*=_HOST_UID:CONTAINER_UID:SIZE_: to force a UID mapping to be present in the user namespace.
+  - *uidmapping*=_CONTAINER_UID:HOST_UID:SIZE_: to force a UID mapping to be present in the user namespace.
 
 **container:**_id_: join the user namespace of the specified container.
 

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -164,6 +164,19 @@ podman generates a UUID for each pod, and if a name is not assigned
 to the container with **--name** then a random string name will be generated
 for it. The name is useful any place you need to identify a pod.
 
+#### **--userns**=*mode*
+
+Set the user namespace mode for all the containers in a pod. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled.
+
+Valid _mode_ values are:
+
+- *auto[:*_OPTIONS,..._*]*: automatically create a namespace. It is possible to specify these options to `auto`:
+  - *gidmapping=*_CONTAINER_GID:HOST_GID:SIZE_ to force a GID mapping to be present in the user namespace.
+  - *size=*_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will estimate a size for the user namespace.
+  - *uidmapping=*_CONTAINER_UID:HOST_UID:SIZE_ to force a UID mapping to be present in the user namespace.
+- *host*: run in the user namespace of the caller. The processes running in the container will have the same privileges on the host as any other process launched by the calling user (default).
+- *keep-id*: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is ignored for containers created by the root user.
+
 ## EXAMPLES
 
 ```

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1181,9 +1181,9 @@ Podman allocates unique ranges of UIDs and GIDs from the `containers` subpordina
 
   Valid `auto`options:
 
-  - *gidmapping*=_HOST_GID:CONTAINER_GID:SIZE_: to force a GID mapping to be present in the user namespace.
+  - *gidmapping*=_CONTAINER_GID:HOST_GID:SIZE_: to force a GID mapping to be present in the user namespace.
   - *size*=_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will estimate a size for the user namespace.
-  - *uidmapping*=_HOST_UID:CONTAINER_UID:SIZE_: to force a UID mapping to be present in the user namespace.
+  - *uidmapping*=_CONTAINER_UID:HOST_UID:SIZE_: to force a UID mapping to be present in the user namespace.
 
 **container:**_id_: join the user namespace of the specified container.
 

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1020,8 +1020,8 @@ func (c *Container) RWSize() (int64, error) {
 }
 
 // IDMappings returns the UID/GID mapping used for the container
-func (c *Container) IDMappings() (storage.IDMappingOptions, error) {
-	return c.config.IDMappings, nil
+func (c *Container) IDMappings() storage.IDMappingOptions {
+	return c.config.IDMappings
 }
 
 // RootUID returns the root user mapping from container

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -367,6 +367,12 @@ func (c *Container) setupStorageMapping(dest, from *storage.IDMappingOptions) {
 		return
 	}
 	*dest = *from
+	// If we are creating a container inside a pod, we always want to inherit the
+	// userns settings from the infra container. So clear the auto userns settings
+	// so that we don't request storage for a new uid/gid map.
+	if c.PodID() != "" && !c.IsInfra() {
+		dest.AutoUserNs = false
+	}
 	if dest.AutoUserNs {
 		overrides := c.getUserOverrides()
 		dest.AutoUserNsOpts.PasswdFile = overrides.ContainerEtcPasswdPath

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -659,7 +659,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 		}
 	}
 
-	if c.config.IDMappings.AutoUserNs {
+	if c.config.UserNsCtr == "" && c.config.IDMappings.AutoUserNs {
 		if err := g.AddOrReplaceLinuxNamespace(string(spec.UserNamespace), ""); err != nil {
 			return nil, err
 		}
@@ -1884,7 +1884,7 @@ func (c *Container) generateResolvConf() (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(c.state.RunDir, "resolv.conf"), nil
+	return destPath, nil
 }
 
 // generateHosts creates a containers hosts file

--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -105,6 +105,8 @@ type InspectPodInfraConfig struct {
 	CPUSetCPUs string `json:"cpuset_cpus,omitempty"`
 	// Pid is the PID namespace mode of the pod's infra container
 	PidNS string `json:"pid_ns,omitempty"`
+	// UserNS is the usernamespace that all the containers in the pod will join.
+	UserNS string `json:"userns,omitempty"`
 }
 
 // InspectPodContainerInfo contains information on a container in a pod.

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -117,6 +117,7 @@ type InfraContainerConfig struct {
 	Slirp4netns        bool                  `json:"slirp4netns,omitempty"`
 	NetworkOptions     map[string][]string   `json:"network_options,omitempty"`
 	ResourceLimits     *specs.LinuxResources `json:"resource_limits,omitempty"`
+	Userns             specgen.Namespace     `json:"userns,omitempty"`
 }
 
 // ID retrieves the pod's ID

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -593,6 +593,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		infraConfig.CPUQuota = p.CPUQuota()
 		infraConfig.CPUSetCPUs = p.ResourceLim().CPU.Cpus
 		infraConfig.PidNS = p.PidMode()
+		infraConfig.UserNS = p.config.InfraContainer.Userns.String()
 
 		if len(p.config.InfraContainer.DNSServer) > 0 {
 			infraConfig.DNSServer = make([]string, 0, len(p.config.InfraContainer.DNSServer))

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -30,6 +30,12 @@ func PodCreate(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "failed to decode specgen", http.StatusInternalServerError, errors.Wrap(err, "failed to decode specgen"))
 		return
 	}
+	// parse userns so we get the valid default value of userns
+	psg.Userns, err = specgen.ParseUserNamespace(psg.Userns.String())
+	if err != nil {
+		utils.Error(w, "failed to parse userns", http.StatusInternalServerError, errors.Wrap(err, "failed to parse userns"))
+		return
+	}
 	pod, err := generate.MakePod(&psg, runtime)
 	if err != nil {
 		httpCode := http.StatusInternalServerError

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -122,6 +122,7 @@ type PodCreateOptions struct {
 	Pid                string
 	Cpus               float64
 	CpusetCpus         string
+	Userns             specgen.Namespace
 }
 
 type PodCreateReport struct {
@@ -217,6 +218,7 @@ func (p *PodCreateOptions) ToPodSpecGen(s *specgen.PodSpecGenerator) error {
 			s.CPUQuota = *cpuDat.Quota
 		}
 	}
+	s.Userns = p.Userns
 	return nil
 }
 

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -303,6 +303,8 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	if opts.NetNSIsHost {
 		s.NetNS.NSMode = specgen.Host
 	}
+	// Always set the userns to host since k8s doesn't have support for userns yet
+	s.UserNS.NSMode = specgen.Host
 
 	// Add labels that come from kube
 	if len(s.Labels) == 0 {

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -67,6 +67,10 @@ type PodBasicConfig struct {
 	// Optional (defaults to private if unset). This sets the PID namespace of the infra container
 	// This configuration will then be shared with the entire pod if PID namespace sharing is enabled via --share
 	Pid Namespace `json:"pid,omitempty:"`
+	// Userns is used to indicate which kind of Usernamespace to enter.
+	// Any containers created within the pod will inherit the pod's userns settings.
+	// Optional
+	Userns Namespace `json:"userns,omitempty"`
 }
 
 // PodNetworkConfig contains networking configuration for a pod.

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1114,7 +1114,7 @@ var _ = Describe("Podman play kube", func() {
 	})
 
 	It("podman play kube should share ipc,net,uts when shareProcessNamespace is set", func() {
-		SkipIfRootless("Requires root priviledges for sharing few namespaces")
+		SkipIfRootless("Requires root privileges for sharing few namespaces")
 		err := writeYaml(sharedNamespacePodYaml, kubeYaml)
 		Expect(err).To(BeNil())
 

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -621,4 +622,223 @@ ENTRYPOINT ["sleep","99999"]
 		Expect(podCreate).Should(ExitWithError())
 
 	})
+
+	It("podman pod create with --userns=keep-id", func() {
+		if os.Geteuid() == 0 {
+			Skip("Test only runs without root")
+		}
+
+		podName := "testPod"
+		podCreate := podmanTest.Podman([]string{"pod", "create", "--userns", "keep-id", "--name", podName})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate).Should(Exit(0))
+
+		session := podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "id", "-u"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		uid := fmt.Sprintf("%d", os.Geteuid())
+		ok, _ := session.GrepString(uid)
+		Expect(ok).To(BeTrue())
+
+		// Check passwd
+		session = podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "id", "-un"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		u, err := user.Current()
+		Expect(err).To(BeNil())
+		ok, _ = session.GrepString(u.Name)
+		Expect(ok).To(BeTrue())
+
+		// root owns /usr
+		session = podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "stat", "-c%u", "/usr"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(Equal("0"))
+
+		// fail if --pod and --userns set together
+		session = podmanTest.Podman([]string{"run", "--pod", podName, "--userns", "keep-id", ALPINE, "id", "-u"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(125))
+	})
+
+	It("podman pod create with --userns=keep-id can add users", func() {
+		if os.Geteuid() == 0 {
+			Skip("Test only runs without root")
+		}
+
+		podName := "testPod"
+		podCreate := podmanTest.Podman([]string{"pod", "create", "--userns", "keep-id", "--name", podName})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate).Should(Exit(0))
+
+		ctrName := "ctr-name"
+		session := podmanTest.Podman([]string{"run", "--pod", podName, "-d", "--stop-signal", "9", "--name", ctrName, fedoraMinimal, "sleep", "600"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		// container inside pod inherits user form infra container if --user is not set
+		// etc/passwd entry will look like 1000:*:1000:1000:container user:/:/bin/sh
+		exec1 := podmanTest.Podman([]string{"exec", ctrName, "cat", "/etc/passwd"})
+		exec1.WaitWithDefaultTimeout()
+		Expect(exec1).Should(Exit(0))
+		Expect(exec1.OutputToString()).To(ContainSubstring("container"))
+
+		exec2 := podmanTest.Podman([]string{"exec", ctrName, "useradd", "testuser"})
+		exec2.WaitWithDefaultTimeout()
+		Expect(exec2).Should(Exit(0))
+
+		exec3 := podmanTest.Podman([]string{"exec", ctrName, "cat", "/etc/passwd"})
+		exec3.WaitWithDefaultTimeout()
+		Expect(exec3).Should(Exit(0))
+		Expect(exec3.OutputToString()).To(ContainSubstring("testuser"))
+	})
+
+	It("podman pod create with --userns=auto", func() {
+		u, err := user.Current()
+		Expect(err).To(BeNil())
+		name := u.Name
+		if name == "root" {
+			name = "containers"
+		}
+
+		content, err := ioutil.ReadFile("/etc/subuid")
+		if err != nil {
+			Skip("cannot read /etc/subuid")
+		}
+		if !strings.Contains(string(content), name) {
+			Skip("cannot find mappings for the current user")
+		}
+
+		m := make(map[string]string)
+		for i := 0; i < 5; i++ {
+			podName := "testPod" + strconv.Itoa(i)
+			podCreate := podmanTest.Podman([]string{"pod", "create", "--userns=auto", "--name", podName})
+			podCreate.WaitWithDefaultTimeout()
+			Expect(podCreate).Should(Exit(0))
+
+			session := podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "cat", "/proc/self/uid_map"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(0))
+			l := session.OutputToString()
+			Expect(strings.Contains(l, "1024")).To(BeTrue())
+			m[l] = l
+		}
+		// check for no duplicates
+		Expect(len(m)).To(Equal(5))
+	})
+
+	It("podman pod create --userns=auto:size=%d", func() {
+		u, err := user.Current()
+		Expect(err).To(BeNil())
+
+		name := u.Name
+		if name == "root" {
+			name = "containers"
+		}
+
+		content, err := ioutil.ReadFile("/etc/subuid")
+		if err != nil {
+			Skip("cannot read /etc/subuid")
+		}
+		if !strings.Contains(string(content), name) {
+			Skip("cannot find mappings for the current user")
+		}
+
+		podName := "testPod"
+		podCreate := podmanTest.Podman([]string{"pod", "create", "--userns=auto:size=500", "--name", podName})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate).Should(Exit(0))
+		session := podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "cat", "/proc/self/uid_map"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		ok, _ := session.GrepString("500")
+
+		podName = "testPod-1"
+		podCreate = podmanTest.Podman([]string{"pod", "create", "--userns=auto:size=3000", "--name", podName})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate).Should(Exit(0))
+		session = podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "cat", "/proc/self/uid_map"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		ok, _ = session.GrepString("3000")
+
+		Expect(ok).To(BeTrue())
+	})
+
+	It("podman pod create --userns=auto:uidmapping=", func() {
+		u, err := user.Current()
+		Expect(err).To(BeNil())
+
+		name := u.Name
+		if name == "root" {
+			name = "containers"
+		}
+
+		content, err := ioutil.ReadFile("/etc/subuid")
+		if err != nil {
+			Skip("cannot read /etc/subuid")
+		}
+		if !strings.Contains(string(content), name) {
+			Skip("cannot find mappings for the current user")
+		}
+
+		podName := "testPod"
+		podCreate := podmanTest.Podman([]string{"pod", "create", "--userns=auto:uidmapping=0:0:1", "--name", podName})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate).Should(Exit(0))
+		session := podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "cat", "/proc/self/uid_map"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		output := session.OutputToString()
+		Expect(output).To(MatchRegexp("\\s0\\s0\\s1"))
+
+		podName = "testPod-1"
+		podCreate = podmanTest.Podman([]string{"pod", "create", "--userns=auto:size=8192,uidmapping=0:0:1", "--name", podName})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate).Should(Exit(0))
+		session = podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "cat", "/proc/self/uid_map"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		ok, _ := session.GrepString("8191")
+		Expect(ok).To(BeTrue())
+	})
+
+	It("podman pod create --userns=auto:gidmapping=", func() {
+		u, err := user.Current()
+		Expect(err).To(BeNil())
+
+		name := u.Name
+		if name == "root" {
+			name = "containers"
+		}
+
+		content, err := ioutil.ReadFile("/etc/subuid")
+		if err != nil {
+			Skip("cannot read /etc/subuid")
+		}
+		if !strings.Contains(string(content), name) {
+			Skip("cannot find mappings for the current user")
+		}
+
+		podName := "testPod"
+		podCreate := podmanTest.Podman([]string{"pod", "create", "--userns=auto:gidmapping=0:0:1", "--name", podName})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate).Should(Exit(0))
+		session := podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "cat", "/proc/self/gid_map"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		output := session.OutputToString()
+		Expect(output).To(MatchRegexp("\\s0\\s0\\s1"))
+
+		podName = "testPod-1"
+		podCreate = podmanTest.Podman([]string{"pod", "create", "--userns=auto:size=8192,gidmapping=0:0:1", "--name", podName})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate).Should(Exit(0))
+		session = podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "cat", "/proc/self/gid_map"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		ok, _ := session.GrepString("8191")
+		Expect(ok).To(BeTrue())
+	})
+
 })


### PR DESCRIPTION
Add the --userns flag to podman pod create and keep
track of the userns setting that pod was created with
so that all containers created within the pod will inherit
that userns setting.

Specifically we need to be able to launch a pod with
--userns=keep-id

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
