### PR TITLE
Fix compat create with NetworkMode=default

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -249,7 +249,7 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 	}
 
 	// netMode
-	nsmode, _, err := specgen.ParseNetworkNamespace(string(cc.HostConfig.NetworkMode), true)
+	nsmode, networks, err := specgen.ParseNetworkNamespace(string(cc.HostConfig.NetworkMode), true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -322,7 +322,7 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 		netInfo.Aliases = aliases
 		netInfo.CNINetworks = cniNetworks
 	case len(cc.HostConfig.NetworkMode) > 0:
-		netInfo.CNINetworks = []string{string(cc.HostConfig.NetworkMode)}
+		netInfo.CNINetworks = networks
 	}
 
 	parsedTmp := make([]string, 0, len(cc.HostConfig.Tmpfs))

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -341,3 +341,12 @@ t GET containers/$cid/json 200 \
   .HostConfig.NanoCpus=500000
 
 t DELETE containers/$cid?v=true 204
+
+# Test Compat Create with default network mode (#10569)
+t POST containers/create Image=$IMAGE HostConfig='{"NetworkMode":"default"}' 201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+  .HostConfig.NetworkMode="bridge"
+
+t DELETE containers/$cid?v=true 204


### PR DESCRIPTION
The rework of namespace handling for rootless CNI broke this, as CNI networks were being computed incorrectly. Fix handling of CNI networks for the Compat Create REST API for containers, and add a test so we don't regress again.

Fixes #10569
