### PR TITLE
Fix network prune api docs

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -414,7 +414,7 @@ func Prune(w http.ResponseWriter, r *http.Request) {
 	type response struct {
 		NetworksDeleted []string
 	}
-	var prunedNetworks []string //nolint
+	prunedNetworks := []string{}
 	for _, pr := range pruneReports {
 		if pr.Error != nil {
 			logrus.Error(pr.Error)

--- a/pkg/api/handlers/compat/swagger.go
+++ b/pkg/api/handlers/compat/swagger.go
@@ -77,10 +77,3 @@ type swagCompatNetworkDisconnectRequest struct {
 	// in:body
 	Body struct{ types.NetworkDisconnect }
 }
-
-// Network prune
-// swagger:response NetworkPruneResponse
-type swagCompatNetworkPruneResponse struct {
-	// in:body
-	Body []string
-}

--- a/pkg/api/handlers/libpod/networks.go
+++ b/pkg/api/handlers/libpod/networks.go
@@ -190,5 +190,8 @@ func Prune(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
 		return
 	}
+	if pruneReports == nil {
+		pruneReports = []*entities.NetworkPruneReport{}
+	}
 	utils.WriteResponse(w, http.StatusOK, pruneReports)
 }

--- a/pkg/api/handlers/libpod/swagger.go
+++ b/pkg/api/handlers/libpod/swagger.go
@@ -119,6 +119,13 @@ type swagNetworkCreateReport struct {
 	Body entities.NetworkCreateReport
 }
 
+// Network prune
+// swagger:response NetworkPruneResponse
+type swagNetworkPruneResponse struct {
+	// in:body
+	Body []entities.NetworkPruneReport
+}
+
 func ServeSwagger(w http.ResponseWriter, r *http.Request) {
 	path := DefaultPodmanSwaggerSpec
 	if p, found := os.LookupEnv("PODMAN_SWAGGER_SPEC"); found {

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -180,9 +180,12 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//   200:
 	//     description: OK
 	//     schema:
-	//       type: array
-	//       items:
-	//         type: string
+	//       type: object
+	//       properties:
+	//         NetworksDeleted:
+	//           type: array
+	//           items:
+	//             type: string
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks/prune"), s.APIHandler(compat.Prune)).Methods(http.MethodPost)


### PR DESCRIPTION
The api doc used wrong response examples for both the compat and libpod
network prune endpoints. Change the doc so that it matches the actual
return values. Also fix the endpoints to return an empty array instead
of null when no networks are removed.

Fixes: #10564

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
