### PR TITLE
Improve systemd-resolved detection

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1650,22 +1650,20 @@ func (c *Container) generateResolvConf() (string, error) {
 		}
 	}
 
-	// Determine the endpoint for resolv.conf in case it is a symlink
-	resolvPath, err := filepath.EvalSymlinks(resolvConf)
+	contents, err := ioutil.ReadFile(resolvConf)
 	// resolv.conf doesn't have to exists
 	if err != nil && !os.IsNotExist(err) {
 		return "", err
 	}
 
-	// Determine if symlink points to any of the systemd-resolved files
-	if strings.HasPrefix(resolvPath, "/run/systemd/resolve/") {
-		resolvPath = "/run/systemd/resolve/resolv.conf"
-	}
-
-	contents, err := ioutil.ReadFile(resolvPath)
-	// resolv.conf doesn't have to exists
-	if err != nil && !os.IsNotExist(err) {
-		return "", err
+	ns := resolvconf.GetNameservers(contents)
+	// check if systemd-resolved is used, assume it is used when 127.0.0.53 is the only nameserver
+	if len(ns) == 1 && ns[0] == "127.0.0.53" {
+		// read the actual resolv.conf file for systemd-resolved
+		contents, err = ioutil.ReadFile("/run/systemd/resolve/resolv.conf")
+		if err != nil {
+			return "", errors.Wrapf(err, "detected that systemd-resolved is in use, but could not locate real resolv.conf")
+		}
 	}
 
 	ipv6 := false


### PR DESCRIPTION
When 127.0.0.53 is the only nameserver in /etc/resolv.conf assume
systemd-resolved is used. This is better because /etc/resolv.conf does
not have to be symlinked to /run/systemd/resolve/stub-resolv.conf in
order to use systemd-resolved.

[NO TESTS NEEDED]

Fixes: #10570

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
