### PR TITLE
remote pull: cancel pull when connection is closed

### DIFF
--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -85,7 +85,7 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 
 	var pulledImages []*libimage.Image
 	var pullError error
-	runCtx, cancel := context.WithCancel(context.Background())
+	runCtx, cancel := context.WithCancel(r.Context())
 	go func() {
 		defer cancel()
 		pulledImages, pullError = runtime.LibimageRuntime().Pull(runCtx, query.Reference, config.PullPolicyAlways, pullOptions)


### PR DESCRIPTION
If a client closes the http connection during image pull, the
service should cancel the pull operation.

[NO TESTS NEEDED] I have no idea how we could test this reliable.

Fixes: #7558
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
