### PR TITLE
[CI:DOCS] UPDATE manpages with MANPAGE_SYNTAX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -437,7 +437,7 @@ $(MANPAGES): %: %.md .install.md2man docdir
          -e 's/\[\(podman[^]]*\)\]/\1/g' \
 		 -e 's/\[\([^]]*\)](http[^)]\+)/\1/g' \
          -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g' \
-         -e 's/\\$//  /g' $<  | \
+         -e 's/\\$$/  /g' $<  | \
 	$(GOMD2MAN) -in /dev/stdin -out $(subst source/markdown,build/man,$@)
 
 .PHONY: docdir

--- a/docs/MANPAGE_SYNTAX.md
+++ b/docs/MANPAGE_SYNTAX.md
@@ -4,7 +4,7 @@
 podman\-command - short description
 
 ## SYNOPSIS
-(Shows the command structure.)
+(Shows the command structure. If the command can be written in two different ways, both of them have to be shown.)
 
 **podman command** [*optional*] *mandatory value*
 
@@ -16,7 +16,7 @@ podman\-command - short description
 
 **podman subcommand command** [*optional*] *value1* | *value2*
 
-(If an optinal value follows a mandatory one.)
+(If an optional value follows a mandatory one.)
 
 **podman command** [*optional*] *value1* | *value2* [*optional*]
 
@@ -33,23 +33,23 @@ podman\-command - short description
 Example sentence: The command **podman command** is an example command.
 
 Commands or files that are quoted from other podman manpages or podman repositories have to be linked to those. Non-podman commands are not to be linked.\
-Example sentence: You can use **[podman-run](podman-run.1.md)** or **[containers.conf(5)](https://github.com/containers/common/blob/master/docs/containers.conf.5.md)** for the problem.
+Example sentence: Use **[podman-run](podman-run.1.md)** or **[containers.conf(5)](https://github.com/containers/common/blob/master/docs/containers.conf.5.md)** for the problem.
 
-It should also be specified if the command can only be run as root. In addition, it should be described when a command, OPTION, or other content cannot be executed with the remote client or in combination with other commands, OPTIONS, or content. In this case, the following sentence is put at the end of a command, OPTION, or content: *IMPORTANT: This option/command/other is not available with the command/OPTION/content/remote Podman client*. For a command, this should be done in the DESCRIPTION section. For the OPTIONS, it should be done in the DESCRIPTION of the specified OPTION. Do not use pronouns in the man pages, especially the word `you`.
+It should also be specified if the command can only be run as root. In addition, it should be described when a command, OPTION, or other content cannot be executed with the remote client or in combination with other commands, OPTIONS, or content. In this case, the following sentence is put at the end of a command, OPTION, or content: *IMPORTANT: This OPTION/command/other is not available with the command/OPTION/content/remote Podman client*. For a command, this should be done in the DESCRIPTION section. For the OPTIONS, it should be done in the DESCRIPTION of the specified OPTION. Do not use pronouns in the man pages, especially the word `you`.
 
 ## OPTIONS
 All flags are referred to as OPTIONS. The term flags should not be used. All OPTIONS are listed in this section. OPTIONS that appear in descriptions of other OPTIONS and sections retain their appearance, for example: **--exit**.
 
 OPTIONS that are quoted from other podman manpages or podman repositories have to be linked to those.\
-Example sentence: You can use **[podman-generate-systemd --new](podman-generate-systemd.1.md#--new)** for the problem.
+Example sentence: Use **[podman-generate-systemd --new](podman-generate-systemd.1.md#--new)** for the problem.
 
  Each OPTION should be explained to the fullest extent below the OPTION itself. Each OPTION is behind an H4-header (`####`). If the OPTION has a default argument, it has to be explained in the description of the OPTION. If the OPTION is also not available with the remote client, the sentence about the default argument should the second to last sentence.
 
 
 #### **--version**, **-v**
 
-OPTIONS can be put after the command in two different ways. Eather the long version with **--option** or as the short version **-o**. If there are two ways to write an OPTION they are separated by a comma. If there are two versions of one command the long version is always shown in front.\
-Example: The default is **false**. *IMPORTANT: This option is not available with the remote Podman client*.
+OPTIONS can be put after the command in two different ways. Either the long version with **--option** or as the short version **-o**. If there are two ways to write an OPTION they are separated by a comma. If there are two versions of one command the long version is always shown in front.\
+Example: The default is **false**. *IMPORTANT: This OPTION is not available with the remote Podman client*.
 
 #### **--exit**
 
@@ -57,7 +57,7 @@ An example of an OPTION that has only one possible structure. Thus, it cannot be
 
 #### **--answer**=, **-a**=**active** | *disable*
 
-The "answer" option above is an example of an OPTION that accepts two possible arguments as inputs. If there is a default argument that is selected when the OPTION is not used in the command, it is shown in **bold**. If the OPTION is used it must include an argument afterwards. It must always be ensured that the standard argument is in the first position after the OPTION. In this example, there are two different ways to execute the command. Both possible OPTIONS have to be shown with the arguments following them. The default value is shown as **active**.
+The "answer" OPTION above is an example of an OPTION that accepts two possible arguments as inputs. If there is a default argument that is selected when the OPTION is not used in the command, it is shown in **bold**. If the OPTION is used it must include an argument afterwards. It must always be ensured that the standard argument is in the first position after the OPTION. In this example, there are two different ways to execute the command. Both possible OPTIONS have to be shown with the arguments following them. The default value is shown as **active**.
 
 #### **--status**=**good** | *better* | *best*
 
@@ -65,7 +65,7 @@ This is an example of three arguments following an OPTION. If the number of argu
 
 #### **--test**=**test**
 
-OPTIONS that are followed by an equal sign include an argument after the equal sign in **bold**. If there is a default argument, that is used if the OPTION is not specified in the command, the argument after the eqaul sign is displayed in **bold**. All arguments must be listed and explained in the text below the OPTION.
+OPTIONS that are followed by an equal sign include an argument after the equal sign in **bold**. If there is a default argument, that is used if the OPTION is not specified in the command, the argument after the equal sign is displayed in **bold**. All arguments must be listed and explained in the text below the OPTION.
 
 | Argument           | Description                                                                 |
 | ------------------ | --------------------------------------------------------------------------- |
@@ -102,6 +102,7 @@ All EXAMPLES are listed in this section. This section should be at the end of ea
 
 Description of the EXAMPLE
 ```
+### Example comment
 $ podman command
 
 $ podman command -o
@@ -111,9 +112,16 @@ $ cat $HOME/Dockerfile | podman command --option
 
 Description of the EXAMPLE two
 ```
-$ podman command --redhat
-
-$ podman command --redhat better
-
-$ podman command --redhat=better
+# podman command --status=better
 ```
+## SEE ALSO
+All commands, including commands with OPTIONS, and config-files mentioned in the manpage have to be listed here. Podman commands, including commands with OPTIONS, and config-files have to be linked. If a command is mentioned several times with different OPTIONS it just have to be linked once. All other commands, including commands with OPTIONS, and config-files just have to be mentioned. If a command is mentioned several times with different OPTIONS it just has to be linked once.
+
+Example:
+**[podman(1)](podman.1.md)**, **[podman-run(1)](podman-run.1.md)**, **[podman-create(1)](podman-create.1.md)**
+
+## HISTORY
+Normally, the dates of changes, the content of the changes and the person who provided them is listed here. Most manpages don't keep this record.
+
+Example:\
+December 2021, Originally compiled by Alexander Richter <example@redhat.com>

--- a/docs/source/markdown/podman-attach.1.md
+++ b/docs/source/markdown/podman-attach.1.md
@@ -10,7 +10,7 @@ podman\-attach - Attach to a running container
 
 ## DESCRIPTION
 **podman attach** attaches to a running *container* using the *container's name* or *ID*, to either view its ongoing output or to control it interactively.\
-The *container* can detached from (and leave it running) using a configurable key sequence. The default sequence is `ctrl-p,ctrl-q`. Configure the keys sequence using the **--detach-keys** option, or specifying it in the `containers.conf` file: see **[containers.conf(5)](https://github.com/containers/common/blob/master/docs/containers.conf.5.md)** for more information.
+The *container* can detached from (and leave it running) using a configurable key sequence. The default sequence is `ctrl-p,ctrl-q`. Configure the keys sequence using the **--detach-keys** OPTION, or specifying it in the `containers.conf` file: see **[containers.conf(5)](https://github.com/containers/common/blob/master/docs/containers.conf.5.md)** for more information.
 
 ## OPTIONS
 #### **--detach-keys**=**sequence**
@@ -18,9 +18,8 @@ The *container* can detached from (and leave it running) using a configurable ke
 Specify the key **sequence** for detaching a *container*. Format is a single character `[a-Z]` or one or more `ctrl-<value>` characters where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`. Specifying "" will disable this feature. The default is `ctrl-p,ctrl-q`.
 
 #### **--latest**, **-l**
-
-Instead of providing the *container name* or *ID*, use the last created *container*. If you use methods other than Podman to run containers such as CRI-O, the last started *container* could be from either of those methods. The default is **false**.\
-*IMPORTANT: This option is not available with the remote Podman client*
+Instead of providing the *container name* or *ID*, use the last created *container*. If other methods are used than Podman to run containers such as `CRI-O`, the last started *container* could be from either of those methods. The default is **false**.\
+*IMPORTANT: This OPTION is not available with the remote Podman client.*
 
 #### **--no-stdin**
 

--- a/docs/source/markdown/podman-commit.1.md
+++ b/docs/source/markdown/podman-commit.1.md
@@ -23,7 +23,17 @@ Set the author for the committed image.
 #### **--change**, **-c**=*instruction*
 
 Apply the following possible instructions to the created image:
-**CMD** | **ENTRYPOINT** | **ENV** | **EXPOSE** | **LABEL** | **ONBUILD** | **STOPSIGNAL** | **USER** | **VOLUME** | **WORKDIR**
+
+- *CMD*
+- *ENTRYPOINT*
+- *ENV*
+- *EXPOSE*
+- *LABEL*
+- *ONBUILD*
+- *STOPSIGNAL*
+- *USER*
+- *VOLUME*
+- *WORKDIR*
 
 Can be set multiple times.
 

--- a/docs/source/markdown/podman-completion.1.md
+++ b/docs/source/markdown/podman-completion.1.md
@@ -4,60 +4,60 @@
 podman\-completion - Generate shell completion scripts
 
 ## SYNOPSIS
-**podman completion** [*options*] *bash*|*zsh*|*fish*|*powershell*
+**podman completion** [*options*]   *bash* | *zsh* | *fish* | *powershell*
 
 ## DESCRIPTION
-The completion command generates shell completion scripts for a variety of shells. Supported shells are **bash**, **zsh**, **fish** and **powershell**.
+**podman completion** generates shell completion scripts for a variety of shells. Supported shells are *bash*, *zsh*, *fish* and *powershell*.
 
-These script are used by the shell to provide suggestions and complete commands when you are typing the command and press [TAB].
+These script are used by the shell to provide suggestions and complete commands when the command is typed and `[TAB]` is pressed.
 
 Usually these scripts are automatically installed via the package manager.
 
 ## OPTIONS
-#### **--file**, **-f**
+#### **--file**, **-f**=*file*
 
-Write the generated output to file.
+Write the generated output to a file.
 
 #### **--no-desc**
 
-Do not provide description in the completions.
+Do not provide description in the completions. The default is **false**.
 
 ## Installation
 
 ### BASH
-Make sure you have `bash-completion` installed on the system.
+`bash-completion` has to be installed on the system.
 
-To load the completion script into the current session run:
-`source <(podman completion bash)`
+To load the completion script into the current session run:\
+**source <(podman completion bash)**.
 
-To make it available for all bash sessions run:
-`podman completion bash -f /etc/bash_completion.d/podman`
+To make it available for all bash sessions run:\
+**podman completion -f /etc/bash_completion.d/podman bash**.
 
 
 ### ZSH
-If shell completion is not already enabled in the environment you will need to enable it. You can execute the following once:
-`echo "autoload -U compinit; compinit" >> ~/.zshrc`
+Shell completion needs to be already enabled in the environment. The following can be executed:\
+**echo "autoload -U compinit; compinit" >> ~/.zshrc**
 
-To make it available for all zsh sessions run:
-`podman completion zsh -f "${fpath[1]}/_podman"`
+To make it available for all zsh sessions run:\
+**podman completion -f "${fpath[1]}/_podman zsh"**
 
-Once you reload the shell the auto-completion should be working.
+Once the shell is reloaded the auto-completion should be working.
 
 
 ### FISH
 To load the completion script into the current session run:
-`podman completion fish | source`
+**podman completion fish | source**
 
 To make it available for all fish sessions run:
-`podman completion fish -f ~/.config/fish/completions/podman.fish`
+**podman completion -f ~/.config/fish/completions/podman.fish fish**
 
 ### POWERSHELL
 To load the completion script into the current session run:
-`podman.exe completion powershell | Out-String | Invoke-Expression`
+**podman.exe completion powershell | Out-String | Invoke-Expression**
 
 To make it available in all powershell sessions that a user has, write the
 completion output to a file and source that to the user's powershell profile.
-More information about profiles is available with `Get-Help about_Profiles`.
+More information about profiles is available with **Get-Help about_Profiles**.
 
 ## SEE ALSO
-[podman(1)](podman.1.md)
+**[podman(1)](podman.1.md)**, zsh(1), fish(1), powershell(1)

--- a/docs/source/markdown/podman-container-checkpoint.1.md
+++ b/docs/source/markdown/podman-container-checkpoint.1.md
@@ -4,96 +4,102 @@
 podman\-container\-checkpoint - Checkpoints one or more running containers
 
 ## SYNOPSIS
-**podman container checkpoint** [*options*] *container* ...
+**podman container checkpoint** [*options*] *container* [*container* ...]
 
 ## DESCRIPTION
-Checkpoints all the processes in one or more containers. You may use container IDs or names as input.
+**podman container checkpoint** checkpoints all the processes in one or more *containers*. A *container* can be restored from a checkpoint with **[podman-container-restore](podman-container-restore.1.md)**. The *container IDs* or *names* are used as input.
 
 ## OPTIONS
 #### **--all**, **-a**
 
-Checkpoint all running containers.
+Checkpoint all running *containers*. The default is **false**.
 
-#### **--compress**, **-c**
+#### **--compress**, **-c**=**zstd** | *none* | *gzip*
 
 Specify the compression algorithm used for the checkpoint archive created
-with the **--export, -e** option. Possible algorithms are *gzip*, *none*
-and *zstd*. If no compression algorithm is specified Podman will use
-*zstd*.
+with the **--export, -e** OPTION. Possible algorithms are **zstd**, *none*
+and *gzip*. The default is **zstd**.
 
 One possible reason to use *none* is to enable faster creation of checkpoint
 archives. Not compressing the checkpoint archive can result in faster checkpoint
 archive creation.
 
-```
-# podman container checkpoint -l --compress=none --export=dump.tar
-# podman container checkpoint -l --compress=gzip --export=dump.tar.gz
-```
-
-#### **--export**, **-e**
+#### **--export**, **-e**=*archive*
 
 Export the checkpoint to a tar.gz file. The exported checkpoint can be used
-to import the container on another system and thus enabling container live
-migration. This checkpoint archive also includes all changes to the container's
-root file-system, if not explicitly disabled using **--ignore-rootfs**
+to import the *container* on another system and thus enabling container live
+migration. This checkpoint archive also includes all changes to the *container's*
+root file-system, if not explicitly disabled using **--ignore-rootfs**.
 
 #### **--ignore-rootfs**
 
 This only works in combination with **--export, -e**. If a checkpoint is
 exported to a tar.gz file it is possible with the help of **--ignore-rootfs**
 to explicitly disable including changes to the root file-system into
-the checkpoint archive file.
+the checkpoint archive file. The default is **false**.
 
 #### **--ignore-volumes**
 
-This option must be used in combination with the **--export, -e** option.
-When this option is specified, the content of volumes associated with
-the container will not be included into the checkpoint tar.gz file.
+This OPTION must be used in combination with the **--export, -e** OPTION.
+When this OPTION is specified, the content of volumes associated with
+the *container* will not be included into the checkpoint tar.gz file. The default is **false**.
 
 #### **--keep**, **-k**
 
-Keep all temporary log and statistics files created by CRIU during checkpointing. These files
-are not deleted if checkpointing fails for further debugging. If checkpointing succeeds these
-files are theoretically not needed, but if these files are needed Podman can keep the files
-for further analysis.
+Keep all temporary log and statistics files created by CRIU during checkpointing. These files are not deleted if checkpointing fails for further debugging. If checkpointing succeeds these files are theoretically not needed, but if these files are needed Podman can keep the files for further analysis. The default is **false**.
 
 #### **--latest**, **-l**
 
-Instead of providing the container name or ID, checkpoint the last created container. (This option is not available with the remote Podman client)
+Instead of providing the *container ID* or *name*, use the last created *container*. If you use methods other than Podman to run *containers* such as `CRI-O`, the last started *container* could be from either of those methods. The default is **false**.\
+*IMPORTANT: This OPTION is not available with the remote Podman client.*
 
 #### **--leave-running**, **-R**
 
-Leave the container running after checkpointing instead of stopping it.
+Leave the *container* running after checkpointing instead of stopping it. The default is **false**.
 
 #### **--pre-checkpoint**, **-P**
 
-Dump the container's memory information only, leaving the container running. Later
-operations will supersede prior dumps. It only works on runc 1.0-rc3 or higher.
+Dump the *container's* memory information only, leaving the *container* running. Later
+operations will supersede prior dumps. It only works on `runc 1.0-rc3` or `higher`. The default is **false**.
 
 #### **--tcp-established**
 
-Checkpoint a container with established TCP connections. If the checkpoint
-image contains established TCP connections, this options is required during
-restore. Defaults to not checkpointing containers with established TCP
-connections.
+Checkpoint a *container* with established TCP connections. If the checkpoint
+image contains established TCP connections, this OPTION is required during
+restore. Defaults to not checkpointing *containers* with established TCP
+connections. The default is **false**.
 
 #### **--with-previous**
 
-Check out the container with previous criu image files in pre-dump. It only works
-without **--pre-checkpoint** or **-P**. It only works on runc 1.0-rc3 or higher.
+Check out the *container* with previous criu image files in pre-dump. It only works on `runc 1.0-rc3` or `higher`. The default is **false**.\
+*IMPORTANT: This OPTION is not available with **--pre-checkpoint***.
 
-## EXAMPLE
 
-podman container checkpoint mywebserver
+## EXAMPLES
 
-podman container checkpoint 860a4b23
+Make a checkpoint for the container "mywebserver".
+```
+# podman container checkpoint mywebserver
+```
 
-podman container checkpoint -P -e pre-checkpoint.tar.gz -l
+Dumps the container's memory information of the latest container into an archive.
+```
+# podman container checkpoint -P -e pre-checkpoint.tar.gz -l
+```
 
-podman container checkpoint --with-previous -e checkpoint.tar.gz -l
+Keep the container's memory information from an older dump and add the new container's memory information.
+```
+# podman container checkpoint --with-previous -e checkpoint.tar.gz -l
+```
+
+Dump the container's memory information of the latest container into an archive with the specified compress method.
+```
+# podman container checkpoint -l --compress=none --export=dump.tar
+# podman container checkpoint -l --compress=gzip --export=dump.tar.gz
+```
 
 ## SEE ALSO
-podman(1), podman-container-restore(1)
+**[podman(1)](podman.1.md)**, **[podman-container-restore(1)](podman-container-restore.1.md)**
 
 ## HISTORY
 September 2018, Originally compiled by Adrian Reber <areber@redhat.com>

--- a/docs/source/markdown/podman-container-cleanup.1.md
+++ b/docs/source/markdown/podman-container-cleanup.1.md
@@ -4,51 +4,51 @@
 podman\-container\-cleanup - Cleanup the container's network and mountpoints
 
 ## SYNOPSIS
-**podman container cleanup** [*options*] *container*
+**podman container cleanup** [*options*] *container* [*container* ...]
 
 ## DESCRIPTION
-**podman container cleanup** cleans up exited containers by removing all mountpoints and network configuration from the host.  The container name or ID can be used.  The cleanup command does not remove the containers.  Running containers will not be cleaned up.
-Sometimes container's mount points and network stacks can remain if the podman command was killed or the container ran in daemon mode.  This command is automatically executed when you run containers in daemon mode by the conmon process when the container exits.
+**podman container cleanup** cleans up exited *containers* by removing all mountpoints and network configuration from the host. The *container name* or *ID* can be used. The cleanup command does not remove the *containers*. Running *containers* will not be cleaned up.\
+Sometimes container mount points and network stacks can remain if the podman command was killed or the *container* ran in daemon mode. This command is automatically executed when you run *containers* in daemon mode by the `conmon process` when the *container* exits.
 
 ## OPTIONS
 
 #### **--all**, **-a**
 
-Cleanup all containers.
+Cleanup all *containers*. The default is **false**.
 
-#### **--exec**=_session_
+#### **--exec**=*session*
 
-Clean up an exec session for a single container.
-Can only be specified if a single container is being cleaned up (conflicts with **--all** as such).
-If **--rm** is not specified, temporary files for the exec session will be cleaned up; if it is, the exec session will be removed from the container.
-Conflicts with **--rmi** as the container is not being cleaned up so the image cannot be removed.
+Clean up an exec session for a single *container*.
+Can only be specified if a single *container* is being cleaned up (conflicts with **--all** as such). If **--rm** is not specified, temporary files for the exec session will be cleaned up; if it is, the exec session will be removed from the *container*.\
+*IMPORTANT: Conflicts with **--rmi** as the container is not being cleaned up so the image cannot be removed.*
 
 #### **--latest**, **-l**
-Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
-to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
+
+Instead of providing the *container ID* or *name*, use the last created *container*. If you use methods other than Podman to run *containers* such as `CRI-O`, the last started *container* could be from either of those methods. The default is **false**.\
+*IMPORTANT: This OPTION is not available with the remote Podman client.*
 
 #### **--rm**
 
-After cleanup, remove the container entirely.
+After cleanup, remove the *container* entirely. The default is **false**.
 
 #### **--rmi**
 
-After cleanup, remove the image entirely.
+After cleanup, remove the image entirely. The default is **false**.
 
-## EXAMPLE
+## EXAMPLES
 
-`podman container cleanup mywebserver`
+Cleanup the container "mywebserver".
+```
+$ podman container cleanup mywebserver
+```
 
-`podman container cleanup mywebserver myflaskserver 860a4b23`
-
-`podman container cleanup 860a4b23`
-
-`podman container cleanup -a`
-
-`podman container cleanup --latest`
+Cleanup the containers with the names "mywebserver", "myflaskserver", "860a4b23".
+```
+$ podman container cleanup mywebserver myflaskserver 860a4b23
+```
 
 ## SEE ALSO
-**podman**(1), **podman-container**(1), **conmon**(8).
+**[podman(1)](podman.1.md)**, **[podman-container(1)](podman-container.1.md)**, conmon(8)
 
 ## HISTORY
 Jun 2018, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/docs/source/markdown/podman-container-exists.1.md
+++ b/docs/source/markdown/podman-container-exists.1.md
@@ -1,42 +1,40 @@
 % podman-container-exists(1)
 
 ## NAME
-podman-container-exists - Check if a container exists in local storage
+podman\-container\-exists - Check if a container exists in local storage
 
 ## SYNOPSIS
 **podman container exists** [*options*] *container*
 
 ## DESCRIPTION
-**podman container exists** checks if a container exists in local storage. The **ID** or **Name**
-of the container may be used as input.  Podman will return an exit code
-of `0` when the container is found.  A `1` will be returned otherwise. An exit code of `125` indicates there
-was an issue accessing the local storage.
+**podman container exists** checks if a container exists in local storage. The *container ID* or *name* is used as input. Podman will return an exit code
+of `0` when the container is found.  A `1` will be returned otherwise. An exit code of `125` indicates there was an issue accessing the local storage.
 
 ## OPTIONS
 
-#### **--external**=*true|false*
-Check for external containers as well as Podman containers. These external containers are generally created via other container technology such as Buildah or CRI-O.
+#### **--external**
+Check for external *containers* as well as Podman *containers*. These external *containers* are generally created via other container technology such as `Buildah` or `CRI-O`. The default is **false**.
 
 **-h**, **--help**
-Print usage statement
+Prints usage statement.
 
 ## EXAMPLES
 
-Check if an container called `webclient` exists in local storage (the container does actually exist).
+Check if an container called "webclient" exists in local storage. Here, the container does exist.
 ```
 $ podman container exists webclient
 $ echo $?
 0
 ```
 
-Check if an container called `webbackend` exists in local storage (the container does not actually exist).
+Check if an container called "webbackend" exists in local storage. Here, the container does not exist.
 ```
 $ podman container exists webbackend
 $ echo $?
 1
 ```
 
-Check if an container called `ubi8-working-container` created via Buildah exists in local storage (the container does not actually exist).
+Check if an container called "ubi8-working-container" created via Buildah exists in local storage. Here, the container does not exist.
 ```
 $ podman container exists --external ubi8-working-container
 $ echo $?
@@ -44,7 +42,7 @@ $ echo $?
 ```
 
 ## SEE ALSO
-podman(1)
+**[podman(1)](podman.1.md)**
 
 ## HISTORY
-November 2018, Originally compiled by Brent Baude (bbaude at redhat dot com)
+November 2018, Originally compiled by Brent Baude <bbaude@redhat.com>


### PR DESCRIPTION
The following manpages have been adapted to the MANPAGE_SYNTAX:
- podman-completion
- podman-container-checkpoint
- podman-container-cleanup
- podman-container-exists

The following manpages have had little changes:
- podman-attach
- podman-commit
- MANPAGE_SYNTAX
- Makefile