### PR TITLE
implemented verbose and scope as possible

### DIFF
--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -44,6 +44,16 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//    type: string
 	//    required: true
 	//    description: the name of the network
+	//  - in: query
+	//    name: verbose
+	//    type: boolean
+	//    required: false
+	//    description: Detailed inspect output for troubleshooting
+	//  - in: query
+	//    name: scope
+	//    type: string
+	//    required: false
+	//    description: Filter the network by scope (swarm, global, or local)
 	// produces:
 	// - application/json
 	// responses:


### PR DESCRIPTION
Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
partial implementation of scope and verbose for /networks/{id} query. Not much else is possible for these two. Returns Bad Request is scope is anything other than local. The values docker uses for verbose output are not implemented in podman from what I can tell, and implementing would not save any space/time.