### PR TITLE
[CI:DOCS] Update swagger for inspect network

### DIFF
--- a/pkg/api/handlers/libpod/swagger.go
+++ b/pkg/api/handlers/libpod/swagger.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/containernetworking/cni/libcni"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/api/handlers/utils"
@@ -102,7 +103,7 @@ type swagNetworkRmReport struct {
 // swagger:response NetworkInspectReport
 type swagNetworkInspectReport struct {
 	// in:body
-	Body entities.NetworkInspectReport
+	Body libcni.NetworkConfigList
 }
 
 // Network list

--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -281,7 +281,9 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	// tags:
 	//  - networks
 	// summary: Inspect a network
-	// description: Display low level configuration for a CNI network
+	// description: |
+	//   Display low level configuration for a CNI network.
+	//     - In a 200 response, all of the fields named Bytes are returned as a Base64 encoded string.
 	// parameters:
 	//  - in: path
 	//    name: name

--- a/test/apiv2/python/rest_api/test_v2_0_0_image.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_image.py
@@ -86,10 +86,17 @@ class ImageTestCase(APITestCase):
         self.assertTrue(keys["id"], "Expected to find id stanza")
         self.assertTrue(keys["images"], "Expected to find images stanza")
         self.assertTrue(keys["stream"], "Expected to find stream progress stanza's")
+
     def test_create(self):
-        r = requests.post(self.podman_url + "/v1.40/images/create?fromImage=alpine&platform=linux/amd64/v8", timeout=15)
+        r = requests.post(
+            self.podman_url + "/v1.40/images/create?fromImage=alpine&platform=linux/amd64/v8",
+            timeout=15,
+        )
         self.assertEqual(r.status_code, 200, r.text)
-        r = requests.post(self.podman_url + "/v1.40/images/create?fromSrc=-&repo=fedora&message=testing123", timeout=15)
+        r = requests.post(
+            self.podman_url + "/v1.40/images/create?fromSrc=-&repo=fedora&message=testing123",
+            timeout=15,
+        )
         self.assertEqual(r.status_code, 200, r.text)
 
     def test_search_compat(self):


### PR DESCRIPTION
struct for swagger was pointing to wrong internal type

Fixes #10559

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
