### PR TITLE
container: ignore named hierarchies

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -957,6 +957,12 @@ func (c *Container) cGroupPath() (string, error) {
 	// is the libpod-specific one we're looking for.
 	//
 	// See #8397 on the need for the longest-path look up.
+	//
+	// And another workaround for containers running systemd as the payload.
+	// containers running systemd moves themselves into a child subgroup of
+	// the named systemd cgroup hierarchy.  Ignore any named cgroups during
+	// the lookup.
+	// See #10602 for more details.
 	procPath := fmt.Sprintf("/proc/%d/cgroup", c.state.PID)
 	lines, err := ioutil.ReadFile(procPath)
 	if err != nil {
@@ -970,6 +976,10 @@ func (c *Container) cGroupPath() (string, error) {
 		fields := bytes.Split(line, []byte(":"))
 		if len(fields) != 3 {
 			logrus.Debugf("Error parsing cgroup: expected 3 fields but got %d: %s", len(fields), procPath)
+			continue
+		}
+		// Ignore named cgroups like name=systemd.
+		if bytes.Contains(fields[1], []byte("=")) {
 			continue
 		}
 		path := string(fields[2])

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/podman/v3/pkg/rootless"
 	. "github.com/containers/podman/v3/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -115,6 +116,12 @@ WantedBy=multi-user.target
 		conData := result.InspectContainerToJSON()
 		Expect(len(conData)).To(Equal(1))
 		Expect(conData[0].Config.SystemdMode).To(BeTrue())
+
+		if CGROUPSV2 || !rootless.IsRootless() {
+			stats := podmanTest.Podman([]string{"stats", "--no-stream", ctrName})
+			stats.WaitWithDefaultTimeout()
+			Expect(stats.ExitCode()).To(Equal(0))
+		}
 	})
 
 	It("podman create container with systemd entrypoint triggers systemd mode", func() {


### PR DESCRIPTION
when looking up the container cgroup, ignore named hierarchies since
containers running systemd as payload will create a sub-cgroup and
move themselves there.

Closes: https://github.com/containers/podman/issues/10602

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

