### PR TITLE
Edited compat handling code for containers/json status and added python tests

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -403,6 +403,24 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 		state.Status = define.ContainerStateCreated.String()
 	}
 
+	state.Health = &types.Health{
+		Status:        inspect.State.Healthcheck.Status,
+		FailingStreak: inspect.State.Healthcheck.FailingStreak,
+	}
+
+	log := inspect.State.Healthcheck.Log
+
+	for _, item := range log {
+		res := &types.HealthcheckResult{}
+		s, _ := time.Parse(time.RFC3339Nano, item.Start)
+		e, _ := time.Parse(time.RFC3339Nano, item.End)
+		res.Start = s
+		res.End = e
+		res.ExitCode = item.ExitCode
+		res.Output = item.Output
+		state.Health.Log = append(state.Health.Log, res)
+	}
+
 	formatCapabilities(inspect.HostConfig.CapDrop)
 	formatCapabilities(inspect.HostConfig.CapAdd)
 


### PR DESCRIPTION
Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

Health Check is not handled in the compat LibpodToContainerJSON function within containers.go. Added parsing and handling for this status check and also edited some of the list container filter code.

fixes #10457 
