### PR TITLE
System tests: deal with crun 0.20.1

### DIFF
--- a/docs/source/markdown/podman-manifest-rm.1.md
+++ b/docs/source/markdown/podman-manifest-rm.1.md
@@ -11,7 +11,7 @@ Removes one or more locally stored manifest lists.
 
 ## EXAMPLE
 
-podman manifest rm <list>
+podman manifest rm `<list>`
 
 podman manifest rm listid1 listid2
 

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -9,7 +9,7 @@ podman\-network-create - Create a Podman CNI network
 ## DESCRIPTION
 Create a CNI-network configuration for use with Podman. By default, Podman creates a bridge connection.
 A *Macvlan* connection can be created with the *-d macvlan* option. A parent device for macvlan can
-be designated with the *-o parent=\<device>* option. In the case of *Macvlan* connections, the
+be designated with the *-o parent=`<device>`* option. In the case of *Macvlan* connections, the
 CNI *dhcp* plugin needs to be activated or the container image must have a DHCP client to interact
 with the host network's DHCP server.
 

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -10,8 +10,8 @@ podman\-pod\-create - Create a new pod
 
 Creates an empty pod, or unit of multiple containers, and prepares it to have
 containers added to it. The pod id is printed to STDOUT. You can then use
-**podman create --pod \<pod_id|pod_name\> ...** to add containers to the pod, and
-**podman pod start \<pod_id|pod_name\>** to start the pod.
+**podman create --pod `<pod_id|pod_name>` ...** to add containers to the pod, and
+**podman pod start `<pod_id|pod_name>`** to start the pod.
 
 ## OPTIONS
 

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -183,7 +183,10 @@ function check_label() {
     # runc and crun emit different diagnostics
     runtime=$(podman_runtime)
     case "$runtime" in
-        crun) expect="\`/proc/thread-self/attr/exec\`: OCI runtime error: unable to assign security attribute" ;;
+        # crun 0.20.1 changes the error message
+        #   from /proc/thread-self/attr/exec`: .* unable to assign
+        #   to   /proc/self/attr/keycreate`: .* unable to process
+        crun) expect="\`/proc/.*\`: OCI runtime error: unable to \(assign\|process\) security attribute" ;;
         runc) expect="OCI runtime error: .*: failed to set /proc/self/attr/keycreate on procfs" ;;
         *)    skip "Unknown runtime '$runtime'";;
     esac


### PR DESCRIPTION
crun 0.20.1 changed an error message that we relied on. Deal
with it by accepting the old and new message.

Also (unrelated): sneak in some doc fixes to get rid of
nasty go-md2man warnings that have crept into man pages.

Signed-off-by: Ed Santiago <santiago@redhat.com>
