### PR TITLE
compat import imageFromSrc support for platform query parameter

### DIFF
--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -271,8 +271,10 @@ type ImageLoadReport struct {
 }
 
 type ImageImportOptions struct {
+	Architecture    string
 	Changes         []string
 	Message         string
+	OS              string
 	Quiet           bool
 	Reference       string
 	SignaturePolicy string

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -388,6 +388,8 @@ func (ir *ImageEngine) Import(ctx context.Context, options entities.ImageImportO
 	importOptions.CommitMessage = options.Message
 	importOptions.Tag = options.Reference
 	importOptions.SignaturePolicyPath = options.SignaturePolicy
+	importOptions.OS = options.OS
+	importOptions.Architecture = options.Architecture
 
 	if !options.Quiet {
 		importOptions.Writer = os.Stderr

--- a/test/apiv2/python/rest_api/test_v2_0_0_image.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_image.py
@@ -89,14 +89,9 @@ class ImageTestCase(APITestCase):
 
     def test_create(self):
         r = requests.post(
-            self.podman_url + "/v1.40/images/create?fromImage=alpine&platform=linux/amd64/v8",
-            timeout=15,
-        )
+            self.podman_url + "/v1.40/images/create?fromImage=alpine&platform=linux/amd64/v8", timeout=15)
         self.assertEqual(r.status_code, 200, r.text)
-        r = requests.post(
-            self.podman_url + "/v1.40/images/create?fromSrc=-&repo=fedora&message=testing123",
-            timeout=15,
-        )
+        r = requests.post(self.podman_url + "/v1.40/images/create?fromSrc=-&repo=fedora&message=testing123&platform=linux/amd64", timeout=15)
         self.assertEqual(r.status_code, 200, r.text)
 
     def test_search_compat(self):


### PR DESCRIPTION
Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

Building off of [this PR](https://github.com/containers/common/pull/606) as well as [this](https://github.com/containers/podman/pull/10548) initial addition, made necessary changes in the entities ImageImportOptions struct as well as the compat image.go code in order to pass an OS and Architecture while importing an image from source as [docker does](https://github.com/docker/engine/blob/7c6a9484ee37b28fa314f716581bdb268cd78ce2/api/server/router/image/image_routes.go#L88). Also edited the python tests to pass an os/arch pair in the query.

fixes #10566 

P.S. sorry for the duplicate pr, computer has been having issues today and all of my git repos got scrambled so I had to nuke a lot and start over
