### PR TITLE
[v3.0.1-rhel] rootless: fix fast join userns path

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -302,7 +302,7 @@ static void __attribute__((constructor)) init()
       uid_t uid;
       gid_t gid;
       char path[PATH_MAX];
-      const char *const suffix = "/libpod/pause.pid";
+      const char *const suffix = "/libpod/tmp/pause.pid";
       char *cwd = getcwd (NULL, 0);
       char uid_fmt[16];
       char gid_fmt[16];


### PR DESCRIPTION
commit ab886328357184cd0a8375a5dedf816ba91789f9 changed the path for
the pause.pid file but didn't update the same path in the C code.
This prevented Podman to take the fast path when the userns is already
created and to join it without re-execing itself.

Fix the path in the C code as well so we can join the rootless
user+mount namespace without having to re-exec Podman.

[NO TESTS NEEDED]

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 11badab046d32c0dce40b28707ee3bb72678e36e)

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
