### PR TITLE
Fix build tags for pkg/machine...

### DIFF
--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -1,3 +1,5 @@
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
+
 package machine
 
 import (

--- a/pkg/machine/connection.go
+++ b/pkg/machine/connection.go
@@ -1,3 +1,5 @@
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
+
 package machine
 
 import (

--- a/pkg/machine/fcos.go
+++ b/pkg/machine/fcos.go
@@ -1,3 +1,5 @@
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
+
 package machine
 
 import (

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -1,3 +1,5 @@
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
+
 package machine
 
 import (

--- a/pkg/machine/ignition_schema.go
+++ b/pkg/machine/ignition_schema.go
@@ -1,3 +1,5 @@
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
+
 package machine
 
 /*

--- a/pkg/machine/keys.go
+++ b/pkg/machine/keys.go
@@ -1,3 +1,5 @@
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
+
 package machine
 
 import (

--- a/pkg/machine/libvirt/config.go
+++ b/pkg/machine/libvirt/config.go
@@ -1,3 +1,5 @@
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
+
 package libvirt
 
 type MachineVM struct {

--- a/pkg/machine/libvirt/machine.go
+++ b/pkg/machine/libvirt/machine.go
@@ -1,3 +1,5 @@
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
+
 package libvirt
 
 import "github.com/containers/podman/v3/pkg/machine"

--- a/pkg/machine/libvirt/machine_unsupported.go
+++ b/pkg/machine/libvirt/machine_unsupported.go
@@ -1,0 +1,3 @@
+// +build !amd64 amd64,windows
+
+package libvirt

--- a/pkg/machine/machine_unsupported.go
+++ b/pkg/machine/machine_unsupported.go
@@ -1,0 +1,3 @@
+// +build !amd64 amd64,windows
+
+package machine

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -1,3 +1,5 @@
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
+
 package machine
 
 import (

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -1,3 +1,5 @@
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
+
 package qemu
 
 import "time"

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1,3 +1,5 @@
+// +build amd64,linux arm64,linux amd64,darwin arm64,darwin
+
 package qemu
 
 import (

--- a/pkg/machine/qemu/machine_unsupported.go
+++ b/pkg/machine/qemu/machine_unsupported.go
@@ -1,0 +1,3 @@
+// +build !amd64 amd64,windows
+
+package qemu


### PR DESCRIPTION
Podman machine is only intended for amd64 and arm64 architectures, set
the correct buildtags so that the `pkg/machine`, `pkg/machine/qemu` and
`pkg/machine/libvirt` packages compile correctly.

Fixes #10625

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
