### PR TITLE
Fix restoring of privileged containers

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -427,7 +427,7 @@ func (c *Container) setupStorage(ctx context.Context) error {
 		},
 		LabelOpts: c.config.LabelOpts,
 	}
-	if c.restoreFromCheckpoint {
+	if c.restoreFromCheckpoint && !c.config.Privileged {
 		// If restoring from a checkpoint, the root file-system
 		// needs to be mounted with the same SELinux labels as
 		// it was mounted previously.


### PR DESCRIPTION
Checkpointed containers started with `--privileged` fail during restore with:

 Error: error creating container storage: ProcessLabel and Mountlabel must either not be specified or both specified

This commit fixes it by not setting the labels when restoring a privileged container.

Fixes #10615 