### PR TITLE
[3.0.1-rhel] handle corrupted images

### DIFF
--- a/test/system/335-corrupt-layers.bats
+++ b/test/system/335-corrupt-layers.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# All tests in here perform nasty manipulations on image storage.
+#
+
+load helpers
+
+###############################################################################
+# BEGIN setup/teardown
+
+# Create a scratch directory; this is what we'll use for image store and cache
+if [ -z "${PODMAN_CORRUPT_TEST_WORKDIR}" ]; then
+    export PODMAN_CORRUPT_TEST_WORKDIR=$(mktemp -d --tmpdir=${BATS_TMPDIR:-${TMPDIR:-/tmp}} podman_corrupt_test.XXXXXX)
+fi
+
+# All tests in this file (and ONLY in this file) run with a custom rootdir
+function setup() {
+    skip_if_remote "none of these tests run under podman-remote"
+    _PODMAN_TEST_OPTS="--storage-driver=vfs --root ${PODMAN_CORRUPT_TEST_WORKDIR}/root"
+}
+
+function teardown() {
+    # No other tests should ever run with this custom rootdir
+    unset _PODMAN_TEST_OPTS
+
+    is_remote && return
+
+    # Clean up
+    umount ${PODMAN_CORRUPT_TEST_WORKDIR}/root/overlay || true
+    if is_rootless; then
+        run_podman unshare rm -rf ${PODMAN_CORRUPT_TEST_WORKDIR}/root
+    else
+        rm -rf ${PODMAN_CORRUPT_TEST_WORKDIR}/root
+    fi
+}
+
+# END   setup/teardown
+###############################################################################
+# BEGIN primary test helper
+
+# This is our main action, invoked by every actual test. It:
+#    - creates a new empty rootdir
+#    - populates it with our crafted test image
+#    - removes [ manifest, blob ]
+#    - confirms that "podman images" throws an error
+#    - runs the specified command (rmi -a -f, prune, reset, etc)
+#    - confirms that it succeeds, and also emits expected warnings
+function _corrupt_image_test() {
+    run_podman info --format "{{.Store.GraphRoot}}"
+    indexPath=$output/*-layers/layers.json
+
+    run_podman pull $IMAGE
+    run_podman image exists $IMAGE
+
+    indexTmp="$(realpath $indexPath).tmp.$$"
+    jq 'del(.[0])' $indexPath > $indexTmp
+    mv -f $indexTmp $indexPath
+    # A corrupted image won't be marked as existing.
+    run_podman 1 image exists $IMAGE
+
+    # Run the requested command. Confirm it succeeds, with suitable warnings
+    run_podman $*
+    is "$output" ".*Image $IMAGE exists in local storage but may be corrupted: layer not known.*"
+    run_podman rmi -f $IMAGE
+}
+
+# END   primary test helper
+###############################################################################
+# BEGIN actual tests
+
+@test "podman corrupt images - run --rm" {
+    _corrupt_image_test "run --rm $IMAGE ls"
+}
+
+@test "podman corrupt images - create" {
+    _corrupt_image_test "create $IMAGE ls"
+}
+
+# END   actual tests
+###############################################################################
+# BEGIN final cleanup
+
+@test "podman corrupt images - cleanup" {
+    rm -rf ${PODMAN_CORRUPT_TEST_WORKDIR}
+}
+
+# END   final cleanup
+###############################################################################
+
+# vim: filetype=sh


### PR DESCRIPTION
While various execution paths in Podman already handle corrupted
images, `podman-{create,image exists,run}` did not.

Some corruptions can only be detected when accessing the individual
data.  A reliable way of accessing such data is accessing its layers.
Hence, an image will only be listed to exist if a) it has been found
and b) can be inspected.  If the inspection fails, the image will be
reported to not exists but without an error; the error will only be
logged.  This allows for properly recovering and pull the image, even
in `podman-{create,run}`.

Podman will now behave as follows:
```
$ ./bin/podman run --rm nginx echo "it works!"
ERRO[0000] Image nginx exists in local storage but may be corrupted: layer not known
Resolved "nginx" as an alias (/home/vrothberg/.cache/containers/short-name-aliases.conf)
Trying to pull docker.io/library/nginx:latest...
Getting image source signatures
Copying blob 351ad75a6cfa skipped: already exists
Copying blob febe5bd23e98 skipped: already exists
Copying blob 30afc0b18f67 skipped: already exists
Copying blob 596b1d696923 skipped: already exists
Copying blob 8283eee92e2f skipped: already exists
Copying blob 69692152171a done
Copying config d1a364dc54 done
Writing manifest to image destination
Storing signatures
it works!
```

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1966872
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
