### PR TITLE
Fix pre-checkpointing

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -42,6 +42,7 @@ const (
 	// name of the directory holding the artifacts
 	artifactsDir      = "artifacts"
 	execDirPermission = 0755
+	preCheckpointDir  = "pre-checkpoint"
 )
 
 // rootFsSize gets the size of the container's root filesystem
@@ -141,7 +142,7 @@ func (c *Container) CheckpointPath() string {
 
 // PreCheckpointPath returns the path to the directory containing the pre-checkpoint-images
 func (c *Container) PreCheckPointPath() string {
-	return filepath.Join(c.bundlePath(), "pre-checkpoint")
+	return filepath.Join(c.bundlePath(), preCheckpointDir)
 }
 
 // AttachSocketPath retrieves the path of the container's attach socket

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -909,14 +909,15 @@ func (c *Container) exportCheckpoint(options ContainerCheckpointOptions) error {
 	includeFiles := []string{
 		"artifacts",
 		"ctr.log",
-		metadata.CheckpointDirectory,
 		metadata.ConfigDumpFile,
 		metadata.SpecDumpFile,
 		metadata.NetworkStatusFile,
 	}
 
 	if options.PreCheckPoint {
-		includeFiles[0] = "pre-checkpoint"
+		includeFiles = append(includeFiles, preCheckpointDir)
+	} else {
+		includeFiles = append(includeFiles, metadata.CheckpointDirectory)
 	}
 	// Get root file-system changes included in the checkpoint archive
 	var addToTarFiles []string

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -787,7 +787,11 @@ func (r *ConmonOCIRuntime) CheckpointContainer(ctr *Container, options Container
 		args = append(args, "--pre-dump")
 	}
 	if !options.PreCheckPoint && options.WithPrevious {
-		args = append(args, "--parent-path", ctr.PreCheckPointPath())
+		args = append(
+			args,
+			"--parent-path",
+			filepath.Join("..", preCheckpointDir),
+		)
 	}
 	runtimeDir, err := util.GetRuntimeDir()
 	if err != nil {


### PR DESCRIPTION
Unfortunately --pre-checkpointing never worked as intended and recent
changes to runc have shown that it is broken.

To create a pre-checkpoint CRIU expects the paths between the
pre-checkpoints to be a relative path. If having a previous checkpoint
it needs the be referenced like this: --prev-images-dir ../parent

Unfortunately Podman was giving runc (and CRIU) an absolute path.

Unfortunately, again, until March 2021 CRIU silently ignored if
the path was not relative and switch back to normal checkpointing.

This has been now fixed in CRIU and runc and running pre-checkpoint
with the latest runc fails, because runc already sees that the path is
absolute and returns an error.

This commit fixes this by giving runc a relative path.

This commit also fixes a second pre-checkpointing error which was just
recently introduced.

So summarizing: pre-checkpointing never worked correctly because CRIU
ignored wrong parameters and recent changes broke it even more.

Now both errors should be fixed.