### PR TITLE
Fix network connect race with docker-compose

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1090,7 +1090,7 @@ func (c *Container) NetworkDisconnect(nameOrID, netName string, force bool) erro
 	}
 
 	c.newNetworkEvent(events.NetworkDisconnect, netName)
-	if c.state.State != define.ContainerStateRunning {
+	if !c.ensureState(define.ContainerStateRunning, define.ContainerStateCreated) {
 		return nil
 	}
 
@@ -1145,7 +1145,7 @@ func (c *Container) NetworkConnect(nameOrID, netName string, aliases []string) e
 		return err
 	}
 	c.newNetworkEvent(events.NetworkConnect, netName)
-	if c.state.State != define.ContainerStateRunning {
+	if !c.ensureState(define.ContainerStateRunning, define.ContainerStateCreated) {
 		return nil
 	}
 	if c.state.NetNS == nil {

--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -183,6 +183,8 @@ function test_port() {
         fi
         echo "# cat $WORKDIR/server.log:"
         cat $WORKDIR/server.log
+        echo "# cat $logfile:"
+        cat $logfile
         return
     fi
 


### PR DESCRIPTION
Network connect/disconnect has to call the cni plugins when the network
namespace is already configured. This is the case for `ContainerStateRunning`
and `ContainerStateCreated`. This is important otherwise the network is
not attached to this network namespace and libpod will throw errors like
`network inspection mismatch...` This problem happened when using
`docker-compose up` in attached mode.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
