### PR TITLE
Fall back to string for dockerfile parameter

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -144,8 +144,8 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	if _, found := r.URL.Query()["dockerfile"]; found {
 		var m = []string{}
 		if err := json.Unmarshal([]byte(query.Dockerfile), &m); err != nil {
-			utils.BadRequest(w, "dockerfile", query.Dockerfile, err)
-			return
+			// it's not json, assume just a string
+			m = append(m, query.Dockerfile)
 		}
 		containerFiles = m
 	} else {

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -147,4 +147,39 @@ t GET "images/get?names=alpine&names=busybox" 200 '[POSIX tar archive]'
 img_cnt=$(tar xf "$WORKDIR/curl.result.out" manifest.json -O | jq "length")
 is "$img_cnt" 2 "number of images in tar archive"
 
+# check build works when uploading container file as a tar, see issue #10660
+TMPD=$(mktemp -d podman-apiv2-test.build.XXXXXXXX)
+function cleanBuildTest() {
+    podman rmi -a -f
+    rm -rf "${TMPD}" &> /dev/null
+}
+CONTAINERFILE_TAR="${TMPD}/containerfile.tar"
+cat > $TMPD/containerfile << EOF
+FROM quay.io/libpod/alpine_labels:latest
+EOF
+tar --format=posix -C $TMPD -cvf ${CONTAINERFILE_TAR} containerfile &> /dev/null
+
+curl -XPOST --data-binary @<(cat $CONTAINERFILE_TAR) \
+    -H "content-type: application/x-tar" \
+    --dump-header "${TMPD}/headers.txt" \
+    -o "${TMPD}/response.txt" \
+    "http://$HOST:$PORT/v1.40/libpod/build?dockerfile=containerfile" &> /dev/null
+
+BUILD_TEST_ERROR=""
+
+if ! grep -q '200 OK' "${TMPD}/headers.txt"; then
+    echo -e "${red}NOK: Image build from tar failed response was not 200 OK"
+    BUILD_TEST_ERROR="1"
+fi
+
+if ! grep -q 'quay.io/libpod/alpine_labels' "${TMPD}/response.txt"; then
+    echo -e "${red}NOK: Image build from tar failed image name not in response"
+    BUILD_TEST_ERROR="1"
+fi
+
+cleanBuildTest
+if [[ "${BUILD_TEST_ERROR}" ]]; then
+    exit 1
+fi
+
 # vim: filetype=sh


### PR DESCRIPTION
a9cb824981db3fee6b8445b29e513c89e9b9b00b changed the expectations of the
dockerfile parameter to be json data however it's a string. In order to
support both, let's attempt json and fall back to a string if the json
parsing fails.

Closes #10660

Signed-off-by: Alex Schultz <aschultz@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
