### PR TITLE
podman Image diff between two images

### DIFF
--- a/cmd/podman/common/diffChanges.go
+++ b/cmd/podman/common/diffChanges.go
@@ -29,10 +29,13 @@ func ChangesToJSON(diffs *entities.DiffReport) error {
 			return errors.Errorf("output kind %q not recognized", row.Kind)
 		}
 	}
-
 	// Pull in configured json library
-	enc := json.NewEncoder(os.Stdout)
-	return enc.Encode(body)
+	output, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, string(output))
+	return nil
 }
 
 func ChangesToTable(diffs *entities.DiffReport) error {

--- a/cmd/podman/images/diff.go
+++ b/cmd/podman/images/diff.go
@@ -14,7 +14,7 @@ var (
 	// podman container _inspect_
 	diffCmd = &cobra.Command{
 		Use:               "diff [options] IMAGE",
-		Args:              cobra.ExactArgs(1),
+		Args:              cobra.RangeArgs(1, 2),
 		Short:             "Inspect changes to the image's file systems",
 		Long:              `Displays changes to the image's filesystem.  The image will be compared to its parent layer.`,
 		RunE:              diff,
@@ -46,6 +46,12 @@ func diffFlags(flags *pflag.FlagSet) {
 func diff(cmd *cobra.Command, args []string) error {
 	if diffOpts.Latest {
 		return errors.New("image diff does not support --latest")
+	}
+
+	if len(args) == 2 {
+		diffOpts.OtherImg = args[1]
+	} else {
+		diffOpts.OtherImg = ""
 	}
 
 	results, err := registry.ImageEngine().Diff(registry.GetContext(), args[0], *diffOpts)

--- a/pkg/bindings/images/diff.go
+++ b/pkg/bindings/images/diff.go
@@ -18,8 +18,12 @@ func Diff(ctx context.Context, nameOrID string, options *DiffOptions) ([]archive
 	if err != nil {
 		return nil, err
 	}
+	params, err := options.ToParams()
+	if err != nil {
+		return nil, err
+	}
+	response, err := conn.DoRequest(nil, http.MethodGet, "/images/%s/changes", params, nil, nameOrID)
 
-	response, err := conn.DoRequest(nil, http.MethodGet, "/images/%s/changes", nil, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -16,6 +16,7 @@ type RemoveOptions struct {
 //go:generate go run ../generator/generator.go DiffOptions
 // DiffOptions are optional options image diffs
 type DiffOptions struct {
+	OtherImg string
 }
 
 //go:generate go run ../generator/generator.go ListOptions

--- a/pkg/bindings/images/types_diff_options.go
+++ b/pkg/bindings/images/types_diff_options.go
@@ -19,3 +19,19 @@ func (o *DiffOptions) Changed(fieldName string) bool {
 func (o *DiffOptions) ToParams() (url.Values, error) {
 	return util.ToParams(o)
 }
+
+// WithOtherImg
+func (o *DiffOptions) WithOtherImg(value string) *DiffOptions {
+	v := &value
+	o.OtherImg = v
+	return o
+}
+
+// GetOtherImg
+func (o *DiffOptions) GetOtherImg() string {
+	var otherImg string
+	if o.OtherImg == nil {
+		return otherImg
+	}
+	return *o.OtherImg
+}

--- a/pkg/domain/entities/types.go
+++ b/pkg/domain/entities/types.go
@@ -65,6 +65,7 @@ type DiffOptions struct {
 	Format  string `json:",omitempty"` // CLI only
 	Latest  bool   `json:",omitempty"` // API and CLI, only supported by containers
 	Archive bool   `json:",omitempty"` // CLI only
+	OtherImg string
 }
 
 // DiffReport provides changes for object

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -400,12 +400,22 @@ func (ir *ImageEngine) Import(ctx context.Context, options entities.ImageImportO
 
 	return &entities.ImageImportReport{Id: imageID}, nil
 }
+func (ir *ImageEngine) Diff(_ context.Context, nameOrID string, options entities.DiffOptions) (*entities.DiffReport, error) {
+	var (
+		parent string
+		child string
+	)
+	if options.OtherImg == "" {
+		parent, child = "", nameOrID
+	} else {
+		parent, child = nameOrID, options.OtherImg
+	}
 
-func (ir *ImageEngine) Diff(_ context.Context, nameOrID string, _ entities.DiffOptions) (*entities.DiffReport, error) {
-	changes, err := ir.Libpod.GetDiff("", nameOrID)
+	changes, err := ir.Libpod.GetDiff(parent, child)
 	if err != nil {
 		return nil, err
 	}
+
 	return &entities.DiffReport{Changes: changes}, nil
 }
 

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -300,8 +300,9 @@ func (ir *ImageEngine) Save(ctx context.Context, nameOrID string, tags []string,
 }
 
 // Diff reports the changes to the given image
-func (ir *ImageEngine) Diff(ctx context.Context, nameOrID string, _ entities.DiffOptions) (*entities.DiffReport, error) {
+func (ir *ImageEngine) Diff(ctx context.Context, nameOrID string, opts entities.DiffOptions) (*entities.DiffReport, error) {
 	options := new(images.DiffOptions)
+	options.OtherImg = opts.OtherImg
 	changes, err := images.Diff(ir.ClientCtx, nameOrID, options)
 	if err != nil {
 		return nil, err

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -92,4 +92,32 @@ var _ = Describe("Podman diff", func() {
 		Expect(session.LineInOutputContains("A /tmp/diff-test")).To(BeTrue())
 		Expect(session.ExitCode()).To(Equal(0))
 	})
+
+	It("podman image diff of image", func() {
+		session := podmanTest.Podman([]string{"image", "diff", ALPINE, BB})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 0))
+	})
+
+	It("podman image diff of single image", func() {
+		session := podmanTest.Podman([]string{"image", "diff", BB})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 0))
+	})
+
+	It("podman diff bogus image", func() {
+		session := podmanTest.Podman([]string{"image", "diff", "1234", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
+	})
+
+	It("podman image diff of the same image", func() {
+		session := podmanTest.Podman([]string{"image", "diff", ALPINE, ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(BeNumerically("==", 0))
+	})
+
 })


### PR DESCRIPTION
This adds image diff functionality as mentioned in #10649. This was my first time writing go, so if I made any mistakes or if something is not idiomatic then please let me know and I will fix it. I couldn't find a way to accept optional arguments in go so I just added if else blocks to check for length of args. 
If no image is given then the following error would occur:
```
[mehul@fedora bin]$ ./podman image diff
Error: accepts between 1 and 2 arg(s), received 0
```
If a single image is given then it is compared to the parent layer, retaining the functionality from before. 
```
[mehul@fedora bin]$ ./podman image diff alpine:latest
A /lib
A /lib/apk
A /lib/apk/db
A /lib/apk/db/installed
A /lib/apk/db/lock
.
.
```
If two images are given then they are compared. 

```
[mehul@fedora bin]$ ./podman image diff alpine:latest busybox:latest
C /etc
C /etc/group
A /etc/localtime
C /etc/network
.
.
```
`JSON/json` output is now indented. 

Thanks! 

Signed-off-by: Mehul Arora <aroram18@mcmaster.ca>
