### PR TITLE
Create user storage dir with correct permissions in Dockerfiles

### DIFF
--- a/contrib/podmanimage/stable/Dockerfile
+++ b/contrib/podmanimage/stable/Dockerfile
@@ -21,6 +21,7 @@ echo podman:10000:5000 > /etc/subgid;
 
 VOLUME /var/lib/containers
 VOLUME /home/podman/.local/share/containers
+RUN mkdir -p /home/podman/.local/share/containers
 
 ADD https://raw.githubusercontent.com/containers/libpod/master/contrib/podmanimage/stable/containers.conf /etc/containers/containers.conf
 ADD https://raw.githubusercontent.com/containers/libpod/master/contrib/podmanimage/stable/podman-containers.conf /home/podman/.config/containers/containers.conf

--- a/contrib/podmanimage/testing/Dockerfile
+++ b/contrib/podmanimage/testing/Dockerfile
@@ -21,6 +21,7 @@ echo podman:10000:5000 > /etc/subgid;
 
 VOLUME /var/lib/containers
 VOLUME /home/podman/.local/share/containers
+RUN mkdir -p /home/podman/.local/share/containers
 
 ADD https://raw.githubusercontent.com/containers/libpod/master/contrib/podmanimage/stable/containers.conf /etc/containers/containers.conf
 ADD https://raw.githubusercontent.com/containers/libpod/master/contrib/podmanimage/stable/podman-containers.conf /home/podman/.config/containers/containers.conf

--- a/contrib/podmanimage/upstream/Dockerfile
+++ b/contrib/podmanimage/upstream/Dockerfile
@@ -69,6 +69,7 @@ echo podman:10000:5000 > /etc/subgid;
 
 VOLUME /var/lib/containers
 VOLUME /home/podman/.local/share/containers
+RUN mkdir -p /home/podman/.local/share/containers
 
 ADD https://raw.githubusercontent.com/containers/libpod/master/contrib/podmanimage/stable/containers.conf /etc/containers/containers.conf
 ADD https://raw.githubusercontent.com/containers/libpod/master/contrib/podmanimage/stable/podman-containers.conf /home/podman/.config/containers/containers.conf


### PR DESCRIPTION
Docker VOLUMEs will inherit permissions from an existing directory at the same path. If the path does not exist, the directory will be owned by root which makes this image unusable in rootless mode.

Currently, using quay.io/podman/stable with `--user=podman` fails with a permissions error:
```
$ docker run --rm -ti --security-opt seccomp=unconfined  --env STORAGE_DRIVER=vfs --user=podman quay.io/podman/stable podman run  docker.io/alpine pwd
Error: error creating runtime static files directory: mkdir /home/podman/.local/share/containers/storage: permission denied
```

If you create the directory `/home/podman/.local/share/containers/storage` in the Dockerfile, the anonymous volume will be created with the correct permissions at runtime:

```
$ docker build -t podman-volume-pr .
$ docker run --rm -ti --security-opt seccomp=unconfined  --env STORAGE_DRIVER=vfs --user=podman podman-volume-pr podman run docker.io/alpine pwd
Trying to pull docker.io/library/alpine:latest...
Getting image source signatures
Copying blob 540db60ca938 done  
Copying config 6dbb9cc540 done  
Writing manifest to image destination
Storing signatures
/
```

Tested with Docker Desktop for Mac.
