### PR TITLE
add correct slirp ip to /etc/hosts

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1816,7 +1816,7 @@ func (c *Container) getHosts() string {
 	if c.Hostname() != "" {
 		if c.config.NetMode.IsSlirp4netns() {
 			// When using slirp4netns, the interface gets a static IP
-			slirp4netnsIP, err := GetSlirp4netnsGateway(c.slirp4netnsSubnet)
+			slirp4netnsIP, err := GetSlirp4netnsIP(c.slirp4netnsSubnet)
 			if err != nil {
 				logrus.Warn("failed to determine slirp4netnsIP: ", err.Error())
 			} else {

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -162,23 +162,25 @@ load helpers
     done
 }
 
-@test "podman run with slirp4ns assigns correct gateway address to host.containers.internal" {
+@test "podman run with slirp4ns assigns correct addresses to /etc/hosts" {
     CIDR="$(random_rfc1918_subnet)"
-    run_podman run --network slirp4netns:cidr="${CIDR}.0/24" \
-                $IMAGE grep 'host.containers.internal' /etc/hosts
-    is "$output"   "${CIDR}.2 host.containers.internal"   "host.containers.internal should be the cidr+2 address"
+    local conname=con-$(random_string 10)
+    run_podman run --rm --network slirp4netns:cidr="${CIDR}.0/24" \
+                --name $conname --hostname $conname $IMAGE cat /etc/hosts
+    is "$output"   ".*${CIDR}.2 host.containers.internal"   "host.containers.internal should be the cidr+2 address"
+    is "$output"   ".*${CIDR}.100	$conname $conname"   "$conname should be the cidr+100 address"
 }
 
 @test "podman run with slirp4ns adds correct dns address to resolv.conf" {
     CIDR="$(random_rfc1918_subnet)"
-    run_podman run --network slirp4netns:cidr="${CIDR}.0/24" \
+    run_podman run --rm --network slirp4netns:cidr="${CIDR}.0/24" \
                 $IMAGE grep "${CIDR}" /etc/resolv.conf
     is "$output"   "nameserver ${CIDR}.3"   "resolv.conf should have slirp4netns cidr+3 as a nameserver"
 }
 
 @test "podman run with slirp4ns assigns correct ip address container" {
     CIDR="$(random_rfc1918_subnet)"
-    run_podman run --network slirp4netns:cidr="${CIDR}.0/24" \
+    run_podman run --rm --network slirp4netns:cidr="${CIDR}.0/24" \
                 $IMAGE sh -c "ip address | grep ${CIDR}"
     is "$output"   ".*inet ${CIDR}.100/24 \+"   "container should have slirp4netns cidr+100 assigned to interface"
 }


### PR DESCRIPTION
The container name should have the slirp interface ip set in /etc/hosts
and not the gateway ip. Commit c8dfcce6db0a introduced this regression.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1972073

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
