### PR TITLE
[CI:DOCS] Cirrus: Prevent BZ1965743 workaround pruning

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -673,11 +673,15 @@ meta_task:
         image: quay.io/libpod/imgts:$IMAGE_SUFFIX
     env:
         # Space-separated list of images used by this repository state
+        # TODO: Protect commonly tagged ubuntu images from puning in case
+        # workaround for BZ1965743 remains in use beyond the 30-days.
         IMGNAMES: >-
             ${FEDORA_CACHE_IMAGE_NAME}
             ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
             ${UBUNTU_CACHE_IMAGE_NAME}
             ${PRIOR_UBUNTU_CACHE_IMAGE_NAME}
+            ubuntu-${IMAGE_SUFFIX}
+            prior-ubuntu-${IMAGE_SUFFIX}
         BUILDID: "${CIRRUS_BUILD_ID}"
         REPOREF: "${CIRRUS_REPO_NAME}"
         GCPJSON: ENCRYPTED[3a198350077849c8df14b723c0f4c9fece9ebe6408d35982e7adf2105a33f8e0e166ed3ed614875a0887e1af2b8775f4]

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,17 +30,20 @@ env:
     PRIOR_UBUNTU_NAME: "ubuntu-2010"
 
     # Google-cloud VM Images
+    # TODO: At the time of this comment, an selinux-policy regression is blocking use of updated
+    # Fedora VM images: https://bugzilla.redhat.com/show_bug.cgi?id=1965743
+    IMAGE_SUFFIX_UBUNTU: "c5521575421149184"
     IMAGE_SUFFIX: "c5348179051806720"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
-    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "prior-ubuntu-${IMAGE_SUFFIX}"
+    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX_UBUNTU}"
+    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "prior-ubuntu-${IMAGE_SUFFIX_UBUNTU}"
 
     # Container FQIN's
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
-    UBUNTU_CONTAINER_FQIN: "quay.io/libpod/ubuntu_podman:${IMAGE_SUFFIX}"
-    PRIOR_UBUNTU_CONTAINER_FQIN: "quay.io/libpod/prior-ubuntu_podman:${IMAGE_SUFFIX}"
+    UBUNTU_CONTAINER_FQIN: "quay.io/libpod/ubuntu_podman:${IMAGE_SUFFIX_UBUNTU}"
+    PRIOR_UBUNTU_CONTAINER_FQIN: "quay.io/libpod/prior-ubuntu_podman:${IMAGE_SUFFIX_UBUNTU}"
 
     ####
     #### Control variables that determine what to run and how to run it.

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -921,17 +921,6 @@ USER mail`, BB)
 		Expect(session.OutputToString()).To(ContainSubstring("mail root"))
 	})
 
-	It("podman run with incorect VOLUME", func() {
-		dockerfile := fmt.Sprintf(`FROM %s
-VOLUME ['/etc/foo']
-WORKDIR /etc/foo`, BB)
-		podmanTest.BuildImage(dockerfile, "test", "false")
-		session := podmanTest.Podman([]string{"run", "--rm", "test", "echo", "test"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(ContainSubstring("test"))
-	})
-
 	It("podman run --volumes-from flag", func() {
 		vol := filepath.Join(podmanTest.TempDir, "vol-test")
 		err := os.MkdirAll(vol, 0755)

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -172,7 +172,7 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 		if len(processes) > 0 {
 			for _, pid := range processes {
 				if _, err := f.Write([]byte(fmt.Sprintf("%d\n", pid))); err != nil {
-					logrus.Warnf("Cannot move process %d to cgroup %q", pid, newCgroup)
+					logrus.Warnf("Cannot move process %d to cgroup %q: %v", pid, newCgroup, err)
 				}
 			}
 		} else {
@@ -185,7 +185,7 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 					continue
 				}
 				if _, err := f.Write(pid); err != nil {
-					logrus.Warnf("Cannot move process %s to cgroup %q", string(pid), newCgroup)
+					logrus.Warnf("Cannot move process %s to cgroup %q: %v", string(pid), newCgroup, err)
 				}
 			}
 		}

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -172,7 +172,7 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 		if len(processes) > 0 {
 			for _, pid := range processes {
 				if _, err := f.Write([]byte(fmt.Sprintf("%d\n", pid))); err != nil {
-					logrus.Warnf("Cannot move process %d to cgroup %q: %v", pid, newCgroup, err)
+					logrus.Debugf("Cannot move process %d to cgroup %q: %v", pid, newCgroup, err)
 				}
 			}
 		} else {
@@ -185,7 +185,7 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 					continue
 				}
 				if _, err := f.Write(pid); err != nil {
-					logrus.Warnf("Cannot move process %s to cgroup %q: %v", string(pid), newCgroup, err)
+					logrus.Debugf("Cannot move process %s to cgroup %q: %v", string(pid), newCgroup, err)
 				}
 			}
 		}


### PR DESCRIPTION
A hidden non-obvious corner-case of temporary changes introduced by
https://github.com/containers/podman/pull/10451 could be unintended
pruning of some ubuntu images.  This could be impactful if for some
reason the `.cirrus.yml: use c5521575421149184 for Ubuntu` commit is
reverted beyond 30-days (the disused image-prune interval) and the _old_
images are needed (for an unforeseen reason).

Mitigate this by temporarily including the old images in the timestamp
updating task. This commit may be reverted (and the problem ignored)
if new VM images are built and deployed for all OS's (i.e. replacing
the Fedora/Ubuntu tag split workaround needed for the BZ).