### PR TITLE
[CI:DOCS] Fix multi-arch image build clone:failure

### DIFF
--- a/.github/workflows/multi-arch-build.yaml
+++ b/.github/workflows/multi-arch-build.yaml
@@ -72,7 +72,10 @@ jobs:
         if: matrix.source == 'stable'
         id: sniff_test
         run: |
-          VERSION_OUTPUT="$(docker run localhost:5000/podman/${{ matrix.source }} \
+          podman pull --tls-verify=false \
+                            localhost:5000/podman/${{ matrix.source }}
+          VERSION_OUTPUT="$(podman run \
+                            localhost:5000/podman/${{ matrix.source }} \
                             podman --storage-driver=vfs version)"
           echo "$VERSION_OUTPUT"
           VERSION=$(grep -Em1 '^Version: ' <<<"$VERSION_OUTPUT" | awk '{print $2}')


### PR DESCRIPTION
A suspected recent change in docker (in github-actions Ubuntu
environment) results in a error:

```
cannot clone: Operation not permitted
Error: cannot re-exec process
```

Fix this by using podman to execute the container instead of docker.