### PR TITLE
[CI:DOCS] docs: specify `rmi` removes dangling parents

### DIFF
--- a/docs/source/markdown/podman-rmi.1.md
+++ b/docs/source/markdown/podman-rmi.1.md
@@ -10,6 +10,7 @@ podman\-rmi - Removes one or more locally stored images
 
 ## DESCRIPTION
 Removes one or more locally stored images.
+Passing an argument _image_ deletes it, along with any of its dangling (untagged) parent images.
 
 ## OPTIONS
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

Same documentation change as containers/buildah#3306, resolving containers/buildah#3302.
