### PR TITLE
[CI:DOCS] Cirrus: Prevent BZ1965743 workaround pruning

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -673,11 +673,18 @@ meta_task:
         image: quay.io/libpod/imgts:$IMAGE_SUFFIX
     env:
         # Space-separated list of images used by this repository state
+        # TODO: Protect commonly tagged ubuntu images from puning in case
+        # workaround for BZ1965743 remains in use beyond the 30-days.
+        # Ref sha 404d5edb155
         IMGNAMES: >-
             ${FEDORA_CACHE_IMAGE_NAME}
             ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
             ${UBUNTU_CACHE_IMAGE_NAME}
             ${PRIOR_UBUNTU_CACHE_IMAGE_NAME}
+            fedora-${IMAGE_SUFFIX_UBUNTU}
+            prior-fedora-${IMAGE_SUFFIX_UBUNTU}
+            ubuntu-${IMAGE_SUFFIX}
+            prior-ubuntu-${IMAGE_SUFFIX}
         BUILDID: "${CIRRUS_BUILD_ID}"
         REPOREF: "${CIRRUS_REPO_NAME}"
         GCPJSON: ENCRYPTED[3a198350077849c8df14b723c0f4c9fece9ebe6408d35982e7adf2105a33f8e0e166ed3ed614875a0887e1af2b8775f4]


### PR DESCRIPTION
A hidden non-obvious corner-case of temporary changes introduced by
https://github.com/containers/podman/pull/10451 could be unintended
pruning of some ubuntu images.  This could be impactful if for some
reason the `.cirrus.yml: use c5521575421149184 for Ubuntu` commit is
reverted beyond 30-days (the disused image-prune interval) and the _old_
images are needed (for an unforeseen reason).

Mitigate this by temporarily including the old images in the timestamp
updating task. This commit may be reverted (and the problem ignored)
if new VM images are built and deployed for all OS's (i.e. replacing
the Fedora/Ubuntu tag split workaround needed for the BZ).

Signed-off-by: Chris Evich <cevich@redhat.com>