### PR TITLE
Implement 'networksetup' extension stage

### DIFF
--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -64,9 +64,14 @@ For the bind-mount conditions, only mounts explicitly requested by the caller vi
 
 If `--hooks-dir` is unset for root callers, Podman and libpod will currently default to `/usr/share/containers/oci/hooks.d` and `/etc/containers/oci/hooks.d` in order of increasing precedence.  Using these defaults is deprecated, and callers should migrate to explicitly setting `--hooks-dir`.
 
-Podman and libpod currently support an additional `precreate` state which is called before the runtime's `create` operation.  Unlike the other stages, which receive the container state on their standard input, `precreate` hooks receive the proposed runtime configuration on their standard input.  They may alter that configuration as they see fit, and write the altered form to their standard output.
+Podman and libpod currently support the following additional states:
+* `precreate`
+These hooks are called before the runtime's `create` operation. Unlike the other stages, which receive the container state on their standard input, `precreate` hooks receive the proposed runtime configuration on their standard input.  They may alter that configuration as they see fit and write the altered form to their standard output.
 
 **WARNING**: the `precreate` hook lets you do powerful things, such as adding additional mounts to the runtime configuration.  That power also makes it easy to break things.  Before reporting libpod errors, try running your container with `precreate` hooks disabled to see if the problem is due to one of your hooks.
+
+* `networksetup`
+These hooks are called after Podman finishes setting the network up. The hook path resolves in the runtime namespace, but the hook executes in the container namespace. These hooks are useful to set network restrictions via `iptables(8)` or `nftables(8)` or perform other tasks inside a container with the network ready but before the root is pivoted.
 
 #### **--identity**=*path*
 

--- a/libpod/container_internal_unsupported.go
+++ b/libpod/container_internal_unsupported.go
@@ -62,3 +62,8 @@ func (c *Container) getUserOverrides() *lookup.Overrides {
 func (c *Container) fixVolumePermissions(v *ContainerNamedVolume) error {
 	return define.ErrNotImplemented
 }
+
+// Run network setup hook in network namespace
+func (c *Container) runNetworkSetupHook(ctx context.Context, nspath string, hook *spec.Hook, state []byte, stdout io.Writer, stderr io.Writer, postKillTimeout time.Duration) (hookErr, err error) {
+	return define.ErrNotImplemented
+}


### PR DESCRIPTION
This PR addresses the class of issues described in #10297

The `createContainer` OCI hooks are executed after OCI runtime creates container but it is not guaranteed that the network like Slirp4netns will be ready at the time of hook invocation.

To be able to set `iptables(8)` or `nftables(8)` rules based on gateway provided by Slirp4netns, one needs to hook before the root is pivoted but after network is ready.
