### PR TITLE
Fix documentation of the --format option of podman push

### DIFF
--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -96,7 +96,7 @@ func pushFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(digestfileFlagName, completion.AutocompleteDefault)
 
 	formatFlagName := "format"
-	flags.StringVarP(&pushOptions.Format, formatFlagName, "f", "", "Manifest type (oci, v2s2, or v2s1) to use when pushing an image using the 'dir' transport (default is manifest type of source)")
+	flags.StringVarP(&pushOptions.Format, formatFlagName, "f", "", "Manifest type (oci, v2s2, or v2s1) to use in the destination (default is manifest type of source, with fallbacks)")
 	_ = cmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteManifestFormat)
 
 	flags.BoolVarP(&pushOptions.Quiet, "quiet", "q", false, "Suppress output information when pushing images")

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -184,7 +184,7 @@ type ImagePushOptions struct {
 	// image to the file.  Ignored for remote calls.
 	DigestFile string
 	// Format is the Manifest type (oci, v2s1, or v2s2) to use when pushing an
-	// image using the 'dir' transport. Default is manifest type of source.
+	// image. Default is manifest type of source, with fallbacks.
 	// Ignored for remote calls.
 	Format string
 	// Quiet can be specified to suppress pull progress when pulling.  Ignored


### PR DESCRIPTION
It affects all transports; and without --format, we try several manifest formats.
