### PR TITLE
Podman Pod Create --cpus and --cpuset-cpus flags

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -225,7 +225,6 @@ func createInit(c *cobra.Command) error {
 		}
 		cliVals.Env = env
 	}
-
 	if c.Flag("cgroups").Changed && cliVals.CGroupsMode == "split" && registry.IsRemote() {
 		return errors.Errorf("the option --cgroups=%q is not supported in remote mode", cliVals.CGroupsMode)
 	}
@@ -316,6 +315,8 @@ func createPodIfNecessary(s *specgen.SpecGenerator, netOpts *entities.NetOptions
 		Net:           netOpts,
 		CreateCommand: os.Args,
 		Hostname:      s.ContainerBasicConfig.Hostname,
+		Cpus:          cliVals.CPUS,
+		CpusetCpus:    cliVals.CPUSetCPUs,
 	}
 	// Unset config values we passed to the pod to prevent them being used twice for the container and pod.
 	s.ContainerBasicConfig.Hostname = ""

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -23,6 +23,22 @@ Add a host to the /etc/hosts file shared between all containers in the pod.
 
 Path to cgroups under which the cgroup for the pod will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
+#### **--cpus**=*amount*
+
+Set the total number of CPUs delegated to the pod. Default is 0.000 which indicates that there is no limit on computation power.
+
+#### **--cpuset-cpus**=*amount*
+
+Limit the CPUs to support execution. First CPU is numbered 0. Unlike --cpus this is of type string and parsed as a list of numbers
+
+Format is 0-3,0,1
+
+Examples of the List Format:
+
+0-4,9           # bits 0, 1, 2, 3, 4, and 9 set
+0-2,7,12-14     # bits 0, 1, 2, 7, 12, 13, and 14 set
+
+
 #### **--dns**=*ipaddr*
 
 Set custom DNS servers in the /etc/resolv.conf file that will be shared between all containers in the pod. A special option, "none" is allowed which disables creation of /etc/resolv.conf for the pod.

--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -131,6 +131,5 @@ func (c *Container) validate() error {
 	if c.config.User == "" && (c.config.Spec.Process.User.UID != 0 || c.config.Spec.Process.User.GID != 0) {
 		return errors.Wrapf(define.ErrInvalidArg, "please set User explicitly via WithUser() instead of in OCI spec directly")
 	}
-
 	return nil
 }

--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -51,6 +51,12 @@ type InspectPodData struct {
 	// Containers gives a brief summary of all containers in the pod and
 	// their current status.
 	Containers []InspectPodContainerInfo `json:"Containers,omitempty"`
+	// CPUPeriod contains the CPU period of the pod
+	CPUPeriod uint64 `json:"cpu_period,omitempty"`
+	// CPUQuota contains the CPU quota of the pod
+	CPUQuota int64 `json:"cpu_quota,omitempty"`
+	// CPUSetCPUs contains linux specific CPU data for the pod
+	CPUSetCPUs string `json:"cpuset_cpus,omitempty"`
 }
 
 // InspectPodInfraConfig contains the configuration of the pod's infra
@@ -91,6 +97,12 @@ type InspectPodInfraConfig struct {
 	Networks []string
 	// NetworkOptions are additional options for each network
 	NetworkOptions map[string][]string
+	// CPUPeriod contains the CPU period of the pod
+	CPUPeriod uint64 `json:"cpu_period,omitempty"`
+	// CPUQuota contains the CPU quota of the pod
+	CPUQuota int64 `json:"cpu_quota,omitempty"`
+	// CPUSetCPUs contains linux specific CPU data for the container
+	CPUSetCPUs string `json:"cpuset_cpus,omitempty"`
 }
 
 // InspectPodContainerInfo contains information on a container in a pod.

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/ocicni/pkg/ocicni"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -559,7 +560,6 @@ func WithMaxLogSize(limit int64) CtrCreateOption {
 		if ctr.valid {
 			return define.ErrRuntimeFinalized
 		}
-
 		ctr.config.LogSize = limit
 
 		return nil
@@ -867,7 +867,6 @@ func WithMountNSFrom(nsCtr *Container) CtrCreateOption {
 		if err := checkDependencyContainer(nsCtr, ctr); err != nil {
 			return err
 		}
-
 		ctr.config.MountNsCtr = nsCtr.ID()
 
 		return nil
@@ -2356,6 +2355,45 @@ func WithVolatile() CtrCreateOption {
 		}
 
 		ctr.config.Volatile = true
+		return nil
+	}
+}
+
+// WithPodCPUPAQ takes the given cpu period and quota and inserts them in the proper place.
+func WithPodCPUPAQ(period uint64, quota int64) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return define.ErrPodFinalized
+		}
+		if pod.CPUPeriod() != 0 && pod.CPUQuota() != 0 {
+			pod.config.InfraContainer.ResourceLimits.CPU = &specs.LinuxCPU{
+				Period: &period,
+				Quota:  &quota,
+			}
+		} else {
+			pod.config.InfraContainer.ResourceLimits = &specs.LinuxResources{}
+			pod.config.InfraContainer.ResourceLimits.CPU = &specs.LinuxCPU{
+				Period: &period,
+				Quota:  &quota,
+			}
+		}
+		return nil
+	}
+}
+
+// WithPodCPUSetCPUS computes and sets the Cpus linux resource string which determines the amount of cores, from those available,  we are allowed to execute on
+func WithPodCPUSetCPUs(inp string) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return define.ErrPodFinalized
+		}
+		if pod.ResourceLim().CPU.Period != nil {
+			pod.config.InfraContainer.ResourceLimits.CPU.Cpus = inp
+		} else {
+			pod.config.InfraContainer.ResourceLimits = &specs.LinuxResources{}
+			pod.config.InfraContainer.ResourceLimits.CPU = &specs.LinuxCPU{}
+			pod.config.InfraContainer.ResourceLimits.CPU.Cpus = inp
+		}
 		return nil
 	}
 }

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -538,6 +538,9 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		infraConfig.StaticMAC = p.config.InfraContainer.StaticMAC.String()
 		infraConfig.NoManageResolvConf = p.config.InfraContainer.UseImageResolvConf
 		infraConfig.NoManageHosts = p.config.InfraContainer.UseImageHosts
+		infraConfig.CPUPeriod = p.CPUPeriod()
+		infraConfig.CPUQuota = p.CPUQuota()
+		infraConfig.CPUSetCPUs = p.ResourceLim().CPU.Cpus
 
 		if len(p.config.InfraContainer.DNSServer) > 0 {
 			infraConfig.DNSServer = make([]string, 0, len(p.config.InfraContainer.DNSServer))
@@ -581,6 +584,9 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		SharedNamespaces: sharesNS,
 		NumContainers:    uint(len(containers)),
 		Containers:       ctrs,
+		CPUSetCPUs:       p.ResourceLim().CPU.Cpus,
+		CPUPeriod:        p.CPUPeriod(),
+		CPUQuota:         p.CPUQuota(),
 	}
 
 	return &inspectData, nil

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -146,7 +146,6 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, rawIm
 			options = append(options, WithExitCommand(p.config.InfraContainer.ExitCommand))
 		}
 	}
-
 	g.SetRootReadonly(true)
 	g.SetProcessArgs(infraCtrCommand)
 
@@ -173,7 +172,6 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, rawIm
 		// Ignore mqueue sysctls if not sharing IPC
 		if !p.config.UsePodIPC && strings.HasPrefix(sysctlKey, "fs.mqueue.") {
 			logrus.Infof("Sysctl %s=%s ignored in containers.conf, since IPC Namespace for pod is unused", sysctlKey, sysctlVal)
-
 			continue
 		}
 
@@ -188,7 +186,6 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, rawIm
 			logrus.Infof("Sysctl %s=%s ignored in containers.conf, since UTS Namespace for pod is unused", sysctlKey, sysctlVal)
 			continue
 		}
-
 		g.AddLinuxSysctl(sysctlKey, sysctlVal)
 	}
 
@@ -200,7 +197,11 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, rawIm
 	if len(p.config.InfraContainer.ConmonPidFile) > 0 {
 		options = append(options, WithConmonPidFile(p.config.InfraContainer.ConmonPidFile))
 	}
+	newRes := new(spec.LinuxResources)
+	newRes.CPU = new(spec.LinuxCPU)
+	newRes.CPU = p.ResourceLim().CPU
 
+	g.Config.Linux.Resources.CPU = newRes.CPU
 	return r.newContainer(ctx, g.Config, options...)
 }
 
@@ -211,7 +212,6 @@ func (r *Runtime) createInfraContainer(ctx context.Context, p *Pod) (*Container,
 	if !r.valid {
 		return nil, define.ErrRuntimeStopped
 	}
-
 	imageName := p.config.InfraContainer.InfraImage
 	if imageName == "" {
 		imageName = r.config.Engine.InfraImage

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/specgen"
+	"github.com/containers/podman/v3/pkg/util"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 type PodKillOptions struct {
@@ -116,13 +118,35 @@ type PodCreateOptions struct {
 	Name               string
 	Net                *NetOptions
 	Share              []string
+	Cpus               float64
+	CpusetCpus         string
 }
 
 type PodCreateReport struct {
 	Id string //nolint
 }
 
-func (p PodCreateOptions) ToPodSpecGen(s *specgen.PodSpecGenerator) {
+func (p *PodCreateOptions) CPULimits() *specs.LinuxCPU {
+	cpu := &specs.LinuxCPU{}
+	hasLimits := false
+
+	if p.Cpus != 0 {
+		period, quota := util.CoresToPeriodAndQuota(p.Cpus)
+		cpu.Period = &period
+		cpu.Quota = &quota
+		hasLimits = true
+	}
+	if p.CpusetCpus != "" {
+		cpu.Cpus = p.CpusetCpus
+		hasLimits = true
+	}
+	if !hasLimits {
+		return cpu
+	}
+	return cpu
+}
+
+func (p *PodCreateOptions) ToPodSpecGen(s *specgen.PodSpecGenerator) error {
 	// Basic Config
 	s.Name = p.Name
 	s.Hostname = p.Hostname
@@ -156,6 +180,21 @@ func (p PodCreateOptions) ToPodSpecGen(s *specgen.PodSpecGenerator) {
 
 	// Cgroup
 	s.CgroupParent = p.CGroupParent
+
+	// Resource config
+	cpuDat := p.CPULimits()
+	if s.ResourceLimits == nil {
+		s.ResourceLimits = &specs.LinuxResources{}
+		s.ResourceLimits.CPU = &specs.LinuxCPU{}
+	}
+	if cpuDat != nil {
+		s.ResourceLimits.CPU = cpuDat
+		if p.Cpus != 0 {
+			s.CPUPeriod = *cpuDat.Period
+			s.CPUQuota = *cpuDat.Quota
+		}
+	}
+	return nil
 }
 
 type PodPruneOptions struct {

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -346,7 +346,6 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 			options = append(options, libpod.WithLogDriver(s.LogConfiguration.Driver))
 		}
 	}
-
 	// Security options
 	if len(s.SelinuxOpts) > 0 {
 		options = append(options, libpod.WithSecLabels(s.SelinuxOpts))

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -54,6 +54,14 @@ func createPodOptions(p *specgen.PodSpecGenerator, rt *libpod.Runtime) ([]libpod
 	if len(p.Name) > 0 {
 		options = append(options, libpod.WithPodName(p.Name))
 	}
+	if p.ResourceLimits != nil && p.ResourceLimits.CPU != nil && p.ResourceLimits.CPU.Period != nil && p.ResourceLimits.CPU.Quota != nil {
+		if *p.ResourceLimits.CPU.Period != 0 || *p.ResourceLimits.CPU.Quota != 0 {
+			options = append(options, libpod.WithPodCPUPAQ((*p.ResourceLimits.CPU.Period), (*p.ResourceLimits.CPU.Quota)))
+		}
+	}
+	if p.ResourceLimits != nil && p.ResourceLimits.CPU != nil && p.ResourceLimits.CPU.Cpus != "" {
+		options = append(options, libpod.WithPodCPUSetCPUs(p.ResourceLimits.CPU.Cpus))
+	}
 	if len(p.Hostname) > 0 {
 		options = append(options, libpod.WithPodHostname(p.Hostname))
 	}

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -2,6 +2,8 @@ package specgen
 
 import (
 	"net"
+
+	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // PodBasicConfig contains basic configuration options for pods.
@@ -155,6 +157,16 @@ type PodSpecGenerator struct {
 	PodBasicConfig
 	PodNetworkConfig
 	PodCgroupConfig
+	PodResourceConfig
+}
+
+type PodResourceConfig struct {
+	// ResourceLimits contains linux specific CPU data for the pod
+	ResourceLimits *spec.LinuxResources `json:"resource_limits,omitempty"`
+	// CPU period of the cpuset, determined by --cpus
+	CPUPeriod uint64 `json:"cpu_period,omitempty"`
+	// CPU quota of the cpuset, determined by --cpus
+	CPUQuota int64 `json:"cpu_quota,omitempty"`
 }
 
 // NewPodSpecGenerator creates a new pod spec

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -470,6 +470,10 @@ type ContainerResourceConfig struct {
 	// that are used to configure cgroup v2.
 	// Optional.
 	CgroupConf map[string]string `json:"unified,omitempty"`
+	// CPU period of the cpuset, determined by --cpus
+	CPUPeriod uint64 `json:"cpu_period,omitempty"`
+	// CPU quota of the cpuset, determined by --cpus
+	CPUQuota int64 `json:"cpu_quota,omitempty"`
 }
 
 // ContainerHealthCheckConfig describes a container healthcheck with attributes


### PR DESCRIPTION
Added logic and handling for two new Podman pod create Flags.

--cpus specifies the total number of cores on which the pod can execute, this
is a combination of the period and quota for the CPU.

 --cpuset-cpus is a string value which determines of these available cores,
how many we will truly execute on.

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
