### PR TITLE
fix systemcontext to use correct TMPDIR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
 	github.com/containers/buildah v1.21.1
-	github.com/containers/common v0.40.0
+	github.com/containers/common v0.40.1-0.20210617134614-c6578d76fb0d
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.13.2
 	github.com/containers/ocicrypt v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -221,12 +221,12 @@ github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRD
 github.com/containers/buildah v1.21.1 h1:e9LmTCUKUBLg72v5DnIOT/wc8ffkfB7LbpQBywLZo20=
 github.com/containers/buildah v1.21.1/go.mod h1:yPdlpVd93T+i91yGxrJbW1YOWrqN64j5ZhHOZmHUejs=
 github.com/containers/common v0.38.4/go.mod h1:egfpX/Y3+19Dz4Wa1eRZDdgzoEOeneieF9CQppKzLBg=
-github.com/containers/common v0.40.0 h1:6Q40GoVS3AI2QZbQPLRDS+K7G61JgHqlqvkOYYAJrOo=
-github.com/containers/common v0.40.0/go.mod h1:qLkP2aIaPfiXJS4u/QSSNkUFEEV+dg5d6GOTKsdlZ7g=
+github.com/containers/common v0.40.1-0.20210617134614-c6578d76fb0d h1:PaS/t2XcyxEDOr685T+3HPMyMqN99UPcj6I92nqIDH8=
+github.com/containers/common v0.40.1-0.20210617134614-c6578d76fb0d/go.mod h1:+zxauZzkurY5tbQGDxrCV6rF694RX1olXyYRVJHrzWo=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.12.0/go.mod h1:VasTuHmOw+uD0oHCfApQcMO2+36SfyncoSahU7513Xs=
-github.com/containers/image/v5 v5.13.0/go.mod h1:GkWursKDlDcUIT7L7vZf70tADvZCk/Ga0wgS0MuF0ag=
+github.com/containers/image/v5 v5.13.2-0.20210617132750-db0df5e0cf5e/go.mod h1:GkWursKDlDcUIT7L7vZf70tADvZCk/Ga0wgS0MuF0ag=
 github.com/containers/image/v5 v5.13.2 h1:AgYunV/9d2fRkrmo23wH2MkqeHolFd6oQCkK+1PpuFA=
 github.com/containers/image/v5 v5.13.2/go.mod h1:GkWursKDlDcUIT7L7vZf70tADvZCk/Ga0wgS0MuF0ag=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/secrets"
 	"github.com/containers/image/v5/manifest"
@@ -268,8 +269,11 @@ func WithRegistriesConf(path string) RuntimeOption {
 			return errors.Wrap(err, "error locating specified registries.conf")
 		}
 		if rt.imageContext == nil {
-			rt.imageContext = &types.SystemContext{}
+			rt.imageContext = &types.SystemContext{
+				BigFilesTemporaryDir: parse.GetTempDir(),
+			}
 		}
+
 		rt.imageContext.SystemRegistriesConfPath = path
 		return nil
 	}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/libimage"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/defaultnet"
@@ -381,7 +382,9 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 
 	// Set up containers/image
 	if runtime.imageContext == nil {
-		runtime.imageContext = &types.SystemContext{}
+		runtime.imageContext = &types.SystemContext{
+			BigFilesTemporaryDir: parse.GetTempDir(),
+		}
 	}
 	runtime.imageContext.SignaturePolicyPath = runtime.config.Engine.SignaturePolicyPath
 

--- a/vendor/github.com/containers/common/libimage/download.go
+++ b/vendor/github.com/containers/common/libimage/download.go
@@ -11,7 +11,7 @@ import (
 )
 
 // tmpdir returns a path to a temporary directory.
-func (r *Runtime) tmpdir() string {
+func tmpdir() string {
 	tmpdir := os.Getenv("TMPDIR")
 	if tmpdir == "" {
 		tmpdir = "/var/tmp"
@@ -25,7 +25,7 @@ func (r *Runtime) tmpdir() string {
 func (r *Runtime) downloadFromURL(source string) (string, error) {
 	fmt.Printf("Downloading from %q\n", source)
 
-	outFile, err := ioutil.TempFile(r.tmpdir(), "import")
+	outFile, err := ioutil.TempFile(r.systemContext.BigFilesTemporaryDir, "import")
 	if err != nil {
 		return "", errors.Wrap(err, "error creating file")
 	}

--- a/vendor/github.com/containers/common/libimage/runtime.go
+++ b/vendor/github.com/containers/common/libimage/runtime.go
@@ -84,6 +84,9 @@ func RuntimeFromStore(store storage.Store, options *RuntimeOptions) (*Runtime, e
 	} else {
 		systemContext = types.SystemContext{}
 	}
+	if systemContext.BigFilesTemporaryDir == "" {
+		systemContext.BigFilesTemporaryDir = tmpdir()
+	}
 
 	setRegistriesConfPath(&systemContext)
 

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.40.0"
+const Version = "0.40.1-dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -93,7 +93,7 @@ github.com/containers/buildah/pkg/overlay
 github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/util
-# github.com/containers/common v0.40.0
+# github.com/containers/common v0.40.1-0.20210617134614-c6578d76fb0d
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
 github.com/containers/common/pkg/apparmor


### PR DESCRIPTION
Users are complaining about read/only /var/tmp failing
even if TMPDIR=/tmp is set.

This PR Fixes: https://github.com/containers/podman/issues/10698

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
