### PR TITLE
[CI:DOCS] Add an entry for `/run/user-$UID/libpod` to tmpfiles

### DIFF
--- a/contrib/tmpfile/podman.conf
+++ b/contrib/tmpfile/podman.conf
@@ -2,5 +2,6 @@
 # for many days. This following line prevents systemd from removing this content.
 x /tmp/podman-run-*
 x /tmp/containers-user-*
+x /tmp/run-*/libpod
 D! /run/podman 0700 root root
 D! /var/lib/cni/networks


### PR DESCRIPTION
The systemd-tmpfiles configuration is meant preserve important paths in /tmp that are used by Podman against deletion by systemd. However, not all paths we previously used were included. Some older versions used the `/tmp/run-$UID/libpod` directory instead (when `/run/user/$UID` was unavailable).

Add an entry for these old paths to ensure tmpfiles treats the directory correctly.

CI:DOCS as we don't test this config at all in our CI. Changes worked locally when I made them.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1960948
