### PR TITLE
Add override of SignaturePolicyPath

### DIFF
--- a/cmd/podman/common/overrides.go
+++ b/cmd/podman/common/overrides.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Override path to signature policy if it is not set by shell caller
+func OverrideSignaturePolicyIfEmpty(value *string) {
+	if *value == "" {
+		if envSigPath, ok := os.LookupEnv("CONTAINERS_POLICY_JSON"); ok {
+			if _, err := os.Stat(envSigPath); err == nil {
+				logrus.Debugf("using signature policy file from CONTAINERS_POLICY_JSON environment variable: %s", envSigPath)
+				*value = envSigPath
+			}
+		}
+	}
+}

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -282,6 +282,8 @@ func pullImage(imageName string) (string, error) {
 		if pullPolicy == config.PullPolicyNever {
 			return "", errors.Wrap(storage.ErrImageUnknown, imageName)
 		}
+		// Check for possible override of signature policy setting
+		common.OverrideSignaturePolicyIfEmpty(&cliVals.SignaturePolicy)
 		pullReport, pullErr := registry.ImageEngine().Pull(registry.GetContext(), imageName, entities.ImagePullOptions{
 			Authfile:        cliVals.Authfile,
 			Quiet:           cliVals.Quiet,

--- a/cmd/podman/containers/runlabel.go
+++ b/cmd/podman/containers/runlabel.go
@@ -94,5 +94,7 @@ func runlabel(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+	// Check for possible override of signature policy setting
+	common.OverrideSignaturePolicyIfEmpty(&runlabelOptions.SignaturePolicy)
 	return registry.ContainerEngine().ContainerRunlabel(context.Background(), args[0], args[1], args[2:], runlabelOptions.ContainerRunlabelOptions)
 }

--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -460,6 +460,8 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to obtain decrypt config")
 	}
+	// Check for possible override of signature policy setting
+	common.OverrideSignaturePolicyIfEmpty(&flags.SignaturePolicy)
 
 	opts := buildahDefine.BuildOptions{
 		AddCapabilities:         flags.CapAdd,

--- a/cmd/podman/images/import.go
+++ b/cmd/podman/images/import.go
@@ -109,6 +109,9 @@ func importCon(cmd *cobra.Command, args []string) error {
 	importOpts.Source = source
 	importOpts.Reference = reference
 
+	// Check for possible override of signature policy setting
+	common.OverrideSignaturePolicyIfEmpty(&importOpts.SignaturePolicy)
+
 	response, err := registry.ImageEngine().Import(context.Background(), importOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/images/load.go
+++ b/cmd/podman/images/load.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
+	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/cmd/podman/validate"
 	"github.com/containers/podman/v3/pkg/domain/entities"
@@ -89,6 +90,8 @@ func load(cmd *cobra.Command, args []string) error {
 		}
 		loadOpts.Input = outFile.Name()
 	}
+	// Check for possible override of signature policy setting
+	common.OverrideSignaturePolicyIfEmpty(&loadOpts.SignaturePolicy)
 	response, err := registry.ImageEngine().Load(context.Background(), loadOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -152,6 +152,10 @@ func imagePull(cmd *cobra.Command, args []string) error {
 		pullOptions.Username = creds.Username
 		pullOptions.Password = creds.Password
 	}
+
+	// Check for possible override of signature policy setting
+	common.OverrideSignaturePolicyIfEmpty(&pullOptions.SignaturePolicy)
+
 	// Let's do all the remaining Yoga in the API to prevent us from
 	// scattering logic across (too) many parts of the code.
 	pullReport, err := registry.ImageEngine().Pull(registry.GetContext(), args[0], pullOptions.ImagePullOptions)

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -148,6 +148,9 @@ func imagePush(cmd *cobra.Command, args []string) error {
 		pushOptions.Password = creds.Password
 	}
 
+	// Check for possible override of signature policy setting
+	common.OverrideSignaturePolicyIfEmpty(&pushOptions.SignaturePolicy)
+
 	// Let's do all the remaining Yoga in the API to prevent us from scattering
 	// logic across (too) many parts of the code.
 	return registry.ImageEngine().Push(registry.GetContext(), source, destination, pushOptions.ImagePushOptions)

--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -142,6 +142,9 @@ func kube(cmd *cobra.Command, args []string) error {
 		kubeOptions.StaticMACs = append(kubeOptions.StaticMACs, m)
 	}
 
+	// Check for possible override of signature policy setting
+	common.OverrideSignaturePolicyIfEmpty(&kubeOptions.SignaturePolicy)
+
 	report, err := registry.ContainerEngine().PlayKube(registry.GetContext(), yamlfile, kubeOptions.PlayKubeOptions)
 	if err != nil {
 		return err


### PR DESCRIPTION
Using podman with paths overridden by various CONTAINERS_* environment
variables still requires 'policy.json' to be present in '/etc/containers'
for root and in '$HOME/.config/containers' for rootless set-ups.

This commit adds the environment variable 'CONTAINERS_POLICY_JSON' to
override this path like all other similar paths.
