### PR TITLE
Fix systemd-resolved detection.

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1661,9 +1661,13 @@ func (c *Container) generateResolvConf() (string, error) {
 	// check if systemd-resolved is used, assume it is used when 127.0.0.53 is the only nameserver
 	if len(ns) == 1 && ns[0] == "127.0.0.53" {
 		// read the actual resolv.conf file for systemd-resolved
-		contents, err = ioutil.ReadFile("/run/systemd/resolve/resolv.conf")
+		resolvedContents, err := ioutil.ReadFile("/run/systemd/resolve/resolv.conf")
 		if err != nil {
-			return "", errors.Wrapf(err, "detected that systemd-resolved is in use, but could not locate real resolv.conf")
+			if !os.IsNotExist(err) {
+				return "", errors.Wrapf(err, "detected that systemd-resolved is in use, but could not locate real resolv.conf")
+			}
+		} else {
+			contents = resolvedContents
 		}
 	}
 


### PR DESCRIPTION
Previously podman failed when run in an environment where 127.0.0.53 is
the only nameserver but systemd-resolved is not used directly.
In practice this happened when podman was run within an alpine container
that used the host's network and the host was running systemd-resolved.

This fix makes podman ignore a file not found error when reading /run/systemd/resolve/resolv.conf.

Closes #10733
Follow-up of https://github.com/containers/podman/pull/10598
Relates to https://github.com/mgoltzsche/podman-static/pull/10

To verify that this change really fixes the problem I created a Dockerfile that uses this patch [here](https://github.com/mgoltzsche/podman-static/tree/dns-fix-verification).

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
