### PR TITLE
Do not use inotify for OCICNI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/containers/storage v1.32.3
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/coreos/stream-metadata-go v0.0.0-20210225230131-70edb9eb47b3
-	github.com/cri-o/ocicni v0.2.1-0.20210301205850-541cf7c703cf
+	github.com/cri-o/ocicni v0.2.1-0.20210621164014-d0acc7862283
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/davecgh/go-spew v1.1.1
 	github.com/digitalocean/go-qemu v0.0.0-20210209191958-152a1535e49f

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cri-o/ocicni v0.2.1-0.20210301205850-541cf7c703cf h1:k2wrxBiBseRfOD7h+9fABEuesABBQuUuW5fWwpARbeI=
-github.com/cri-o/ocicni v0.2.1-0.20210301205850-541cf7c703cf/go.mod h1:vingr1ztOAzP2WyTgGbpMov9dFhbjNxdLtDv0+PhAvY=
+github.com/cri-o/ocicni v0.2.1-0.20210621164014-d0acc7862283 h1:7FyIYKksGvRF8XjMkG5T6uIxg8PcgZoPyO+f6kHT5+s=
+github.com/cri-o/ocicni v0.2.1-0.20210621164014-d0acc7862283/go.mod h1:vingr1ztOAzP2WyTgGbpMov9dFhbjNxdLtDv0+PhAvY=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -46,6 +46,9 @@ const (
 
 	// rootlessCNINSName is the file name for the rootless network namespace bind mount
 	rootlessCNINSName = "rootless-cni-ns"
+
+	// persistentCNIDir is the directory where the CNI files are stored
+	persistentCNIDir = "/var/lib/cni"
 )
 
 // Get an OCICNI network config
@@ -150,14 +153,31 @@ func (r *RootlessCNI) Do(toRun func() error) error {
 			}
 		}
 
-		// cni plugins need access to /var and /run
-		runDir := filepath.Join(r.dir, "run")
-		varDir := filepath.Join(r.dir, "var")
-		// make sure to mount var first
-		err = unix.Mount(varDir, "/var", "none", unix.MS_BIND, "")
-		if err != nil {
-			return errors.Wrap(err, "failed to mount /var for rootless cni")
+		// cni plugins need access to /var/lib/cni and /run
+		varDir := ""
+		varTarget := persistentCNIDir
+		// we can only mount to a target dir which exists, check /var/lib/cni recursively
+		// while we could always use /var there are cases where a user might store the cni
+		// configs under /var/custom and this would break
+		for {
+			if _, err := os.Stat(varTarget); err == nil {
+				varDir = filepath.Join(r.dir, strings.TrimPrefix(varTarget, "/"))
+				break
+			}
+			varTarget = filepath.Base(varTarget)
+			if varTarget == "/" {
+				break
+			}
 		}
+		if varDir == "" {
+			return errors.New("failed to stat /var directory")
+		}
+		// make sure to mount var first
+		err = unix.Mount(varDir, varTarget, "none", unix.MS_BIND, "")
+		if err != nil {
+			return errors.Wrapf(err, "failed to mount %s for rootless cni", varTarget)
+		}
+		runDir := filepath.Join(r.dir, "run")
 		// recursive mount to keep the netns mount
 		err = unix.Mount(runDir, "/run", "none", unix.MS_BIND|unix.MS_REC, "")
 		if err != nil {
@@ -385,7 +405,7 @@ func (r *Runtime) GetRootlessCNINetNs(new bool) (*RootlessCNI, error) {
 
 				// create cni directories to store files
 				// they will be bind mounted to the correct location in a extra mount ns
-				err = os.MkdirAll(filepath.Join(cniDir, "var"), 0700)
+				err = os.MkdirAll(filepath.Join(cniDir, strings.TrimPrefix(persistentCNIDir, "/")), 0700)
 				if err != nil {
 					return nil, errors.Wrap(err, "could not create rootless-cni var directory")
 				}
@@ -1043,7 +1063,7 @@ func resultToBasicNetworkConfig(result *cnitypes.Result) (define.InspectBasicNet
 // after itself on an unclean reboot. Return what we're pretty sure is the path
 // to CNI's internal files (it's not really exposed to us).
 func getCNINetworksDir() (string, error) {
-	return "/var/lib/cni/networks", nil
+	return filepath.Join(persistentCNIDir, "networks"), nil
 }
 
 type logrusDebugWriter struct {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -468,7 +468,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 	}
 
 	// Set up the CNI net plugin
-	netPlugin, err := ocicni.InitCNI(runtime.config.Network.DefaultNetwork, runtime.config.Network.NetworkConfigDir, runtime.config.Network.CNIPluginDirs...)
+	netPlugin, err := ocicni.InitCNINoInotify(runtime.config.Network.DefaultNetwork, runtime.config.Network.NetworkConfigDir, "", runtime.config.Network.CNIPluginDirs...)
 	if err != nil {
 		return errors.Wrapf(err, "error configuring CNI network plugin")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -254,7 +254,7 @@ github.com/coreos/stream-metadata-go/fedoracoreos
 github.com/coreos/stream-metadata-go/fedoracoreos/internals
 github.com/coreos/stream-metadata-go/stream
 github.com/coreos/stream-metadata-go/stream/rhcos
-# github.com/cri-o/ocicni v0.2.1-0.20210301205850-541cf7c703cf
+# github.com/cri-o/ocicni v0.2.1-0.20210621164014-d0acc7862283
 github.com/cri-o/ocicni/pkg/ocicni
 # github.com/cyphar/filepath-securejoin v0.2.2
 github.com/cyphar/filepath-securejoin


### PR DESCRIPTION
Podman does not need to watch the cni config directory. If a network is
not found in the cache, OCICNI will reload the networks anyway and thus
even podman system service should work as expected.

Also include a change to not mount a "new" /var by default in the
rootless cni ns, instead try to use /var/lib/cni first and then the
parent dir. This allows users to store cni configs under /var/... which
is the case for the CI compose test.

Fixes #10686

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
