### PR TITLE
[v3.2]  logs: k8s-file: restore poll sleep

### DIFF
--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -74,7 +74,7 @@ func (c *Container) readFromLogFile(ctx context.Context, options *logs.LogOption
 			}
 			nll, err := logs.NewLogLine(line.Text)
 			if err != nil {
-				logrus.Error(err)
+				logrus.Errorf("Error getting new log line: %v", err)
 				continue
 			}
 			if nll.Partial() {
@@ -100,10 +100,10 @@ func (c *Container) readFromLogFile(ctx context.Context, options *logs.LogOption
 			// read the file until EOF.
 			tailError := t.StopAtEOF()
 			if tailError != nil && fmt.Sprintf("%v", tailError) != "tail: stop at eof" {
-				logrus.Error(tailError)
+				logrus.Errorf("Error stopping logger: %v", tailError)
 			}
-			if errors.Cause(err) != define.ErrNoSuchCtr {
-				logrus.Error(err)
+			if err != nil && errors.Cause(err) != define.ErrNoSuchCtr {
+				logrus.Errorf("Error getting container state: %v", err)
 			}
 			return nil
 		}
@@ -126,7 +126,7 @@ func (c *Container) readFromLogFile(ctx context.Context, options *logs.LogOption
 			<-eventChannel
 			tailError := t.StopAtEOF()
 			if tailError != nil && fmt.Sprintf("%v", tailError) != "tail: stop at eof" {
-				logrus.Error(tailError)
+				logrus.Errorf("Error stopping logger: %v", tailError)
 			}
 		}()
 	}


### PR DESCRIPTION
Commit 84b55ee attempted to fix a race waiting for the container
died event.  Previously, Podman slept for duration of the polling
frequency which I considered to be a mistake.  As it turns out, I was
mistaken since the file logger will, in fact, NOT read until EOF and
then stop logging but stop logging immediately _after_ it woke up.

[NO TESTS NEEDED] as the race condition cannot be hit reliably.

Fixes: #10675
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
