### PR TITLE
Add --format to connection list

### DIFF
--- a/docs/source/markdown/podman-system-connection-list.1.md
+++ b/docs/source/markdown/podman-system-connection-list.1.md
@@ -4,12 +4,27 @@
 podman\-system\-connection\-list - List the destination for the Podman service(s)
 
 ## SYNOPSIS
-**podman system connection list**
+**podman system connection list** [*options*]
 
-**podman system connection ls**
+**podman system connection ls** [*options*]
 
 ## DESCRIPTION
 List ssh destination(s) for podman service(s).
+
+## OPTIONS
+
+#### **--format**=*format*
+
+Change the default output format.  This can be of a supported type like 'json' or a Go template.
+Valid placeholders for the Go template listed below:
+
+| **Placeholder** | **Description**                                                               |
+| --------------- | ----------------------------------------------------------------------------- |
+| *.Name*         | Connection Name/Identifier |
+| *.Identity*     | Path to file containing SSH identity |
+| *.URI*          | URI to podman service. Valid schemes are ssh://[user@]*host*[:port]*Unix domain socket*[?secure=True], unix://*Unix domain socket*, and tcp://localhost[:*port*] |
+
+An asterisk is appended to the default connection.
 
 ## EXAMPLE
 ```

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -147,6 +147,12 @@ var _ = Describe("podman system connection", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.Out).Should(Say("Name *Identity *URI"))
+
+		cmd = []string{"system", "connection", "list", "--format", "{{.Name}}"}
+		session = podmanTest.Podman(cmd)
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).Should(Equal("devl* qe"))
 	})
 
 	It("failed default", func() {


### PR DESCRIPTION
Add support for the --format option to podman system connection list.

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
