### PR TITLE
Add CNI rootless networking troubleshooting for v2.2.1

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -156,7 +156,7 @@ When rootless Podman attempts to execute a container on a non exec home director
 
 #### Symptom
 
-If you are running Podman or buildah on a home directory that is mounted noexec,
+If you are running Podman or Buildah on a home directory that is mounted noexec,
 then they will fail. With a message like:
 
 ```
@@ -726,3 +726,23 @@ And then re-add the connection (removing the old one if necessary):
 And now this should work:
 
 `podman-remote info`
+
+---
+### 28) Rootless CNI networking fails in RHEL with Podman v2.2.1 to v3.0.1.
+
+A failure is encountered when trying to use networking on a rootless
+container in Podman v2.2.1 through v3.0.1 on RHEL.  This error does not
+occur on other Linux Distributions.
+
+#### Symptom
+
+A rootless container is created using a CNI network, but the `podman run` command
+returns an error that an image must be built.
+
+#### Solution
+
+In order to use a CNI network in a rootless container on RHEL,
+an Infra container image for CNI-in-slirp4netns must be created.  The
+instructions for building the Infra container image can be found for
+v2.2.1 [here](https://github.com/containers/podman/tree/v2.2.1-rhel/contrib/rootless-cni-infra),
+and for v3.0.1 [here](https://github.com/containers/podman/tree/v3.0.1-rhel/contrib/rootless-cni-infra).


### PR DESCRIPTION
A CNI container image is required for rootless networking
in V2.2.1 (RHEL 8.3.1) and earlier.  Add a note in the
troubleshooting guide with a pointer to the documenation
for that.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
