### PR TITLE
getContainerNetworkInfo: lock netNsCtr before sync

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -888,6 +888,10 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 		if err != nil {
 			return nil, err
 		}
+		// see https://github.com/containers/podman/issues/10090
+		// the container has to be locked for syncContainer()
+		netNsCtr.lock.Lock()
+		defer netNsCtr.lock.Unlock()
 		// Have to sync to ensure that state is populated
 		if err := netNsCtr.syncContainer(); err != nil {
 			return nil, err


### PR DESCRIPTION
`syncContainer()` requires the container to be locked, otherwise we can
end up with undefined behavior.

[NO TESTS NEEDED]
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
