### PR TITLE
Add support for volume prune until filter to http api

### DIFF
--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -88,7 +88,8 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//    description: |
 	//      JSON encoded value of filters (a map[string][]string) to match volumes against before pruning.
 	//      Available filters:
-	//	      - label (label=<key>, label=<key>=<value>, label!=<key>, or label!=<key>=<value>) Prune volumes with (or without, in case label!=... is used) the specified labels.
+	//        - `until=<timestamp>` Prune volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+	//        - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune volumes with (or without, in case `label!=...` is used) the specified labels.
 	// responses:
 	//   '200':
 	//      "$ref": "#/responses/VolumePruneResponse"
@@ -268,7 +269,8 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//    description: |
 	//      JSON encoded value of filters (a map[string][]string) to match volumes against before pruning.
 	//      Available filters:
-	//	      - label (label=<key>, label=<key>=<value>, label!=<key>, or label!=<key>=<value>) Prune volumes with (or without, in case label!=... is used) the specified labels.
+	//        - `until=<timestamp>` Prune volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+	//        - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune volumes with (or without, in case `label!=...` is used) the specified labels.
 	// responses:
 	//   '200':
 	//      "$ref": "#/responses/DockerVolumePruneResponse"

--- a/test/apiv2/30-volumes.at
+++ b/test/apiv2/30-volumes.at
@@ -125,11 +125,6 @@ t POST libpod/volumes/prune?filters='{"label":["tes' 500 \
 t POST libpod/volumes/prune?filters='{"label":["testlabel"]}' 200
 t GET libpod/volumes/json?filters='{"label":["testlabel"]}' 200 length=0
 
-## Prune volumes
-t POST libpod/volumes/prune 200
-#After prune volumes, there should be no volume existing
-t GET libpod/volumes/json 200 length=0
-
 # libpod api: do not use list filters for prune
 t POST libpod/volumes/prune?filters='{"name":["anyname"]}' 500 \
     .cause="\"name\" is an invalid volume filter"
@@ -145,5 +140,47 @@ t POST volumes/prune?filters='{"driver":["anydriver"]}' 500 \
     .cause="\"driver\" is an invalid volume filter"
 t POST volumes/prune?filters='{"scope":["anyscope"]}' 500 \
     .cause="\"scope\" is an invalid volume filter"
+
+## Prune volumes using until filter
+t POST libpod/volumes/create \
+  Name=foo5 \
+  Label='{"testuntil":""}' \
+  Options='{"type":"tmpfs","o":"nodev,noexec"}}' \
+  201 \
+  .Name=foo5 \
+  .Labels.testuntil="" \
+  .Options.type=tmpfs \
+  .Options.o=nodev,noexec
+
+# with date way back in the past, volume should not be deleted
+t POST libpod/volumes/prune?filters='{"until":["500000"]}' 200
+t GET libpod/volumes/json?filters='{"label":["testuntil"]}' 200 length=1
+
+# with date far in the future, volume should be deleted
+t POST libpod/volumes/prune?filters='{"until":["5000000000"]}' 200
+t GET libpod/volumes/json?filters='{"label":["testuntil"]}' 200 length=0
+
+t POST libpod/volumes/create \
+  Name=foo6 \
+  Label='{"testuntilcompat":""}' \
+  Options='{"type":"tmpfs","o":"nodev,noexec"}}' \
+  201 \
+  .Name=foo6 \
+  .Labels.testuntilcompat="" \
+  .Options.type=tmpfs \
+  .Options.o=nodev,noexec
+
+# with date way back in the past, volume should not be deleted (compat api)
+t POST volumes/prune?filters='{"until":["500000"]}' 200
+t GET libpod/volumes/json?filters='{"label":["testuntilcompat"]}' 200 length=1
+
+# with date far in the future, volume should be deleted (compat api)
+t POST volumes/prune?filters='{"until":["5000000000"]}' 200
+t GET libpod/volumes/json?filters='{"label":["testuntilcompat"]}' 200 length=0
+
+## Prune volumes
+t POST libpod/volumes/prune 200
+#After prune volumes, there should be no volume existing
+t GET libpod/volumes/json 200 length=0
 
 # vim: filetype=sh


### PR DESCRIPTION
As stated in #10579 docker silently implements until filter for volume prune.
This commit adds initial support to the HTTP API, both libpod and compat.
It enables further work on that issue, such as adding cli support in the future.

Relates to #10579

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
