### PR TITLE
disable tty-size exec checks in system tests

### DIFF
--- a/test/system/450-interactive.bats
+++ b/test/system/450-interactive.bats
@@ -61,12 +61,14 @@ function teardown() {
 
     run_podman rm -f mystty
 
-    # check that the same works for podman exec
-    run_podman run -d --name mystty $IMAGE top
-    run_podman exec -it mystty stty size <$PODMAN_TEST_PTY
-    is "$output" "$rows $cols" "stty under podman exec reads the correct dimensions"
+    # FIXME: the checks below are flaking a lot (see #10710).
 
-    run_podman rm -f mystty
+    # check that the same works for podman exec
+#    run_podman run -d --name mystty $IMAGE top
+#    run_podman exec -it mystty stty size <$PODMAN_TEST_PTY
+#    is "$output" "$rows $cols" "stty under podman exec reads the correct dimensions"
+#
+#    run_podman rm -f mystty
 }
 
 


### PR DESCRIPTION
As discussed in #10710, the additional checks for podman-exec added by
commit 666f555aa52b are extremely flaky and appear in nearly every PR
I have see this week.

Let's temporarily disable the checks and reenable them once #10710 is
fixed.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
