### PR TITLE
Create /etc/mtab with the correct ownership

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1535,7 +1535,7 @@ func (c *Container) mountStorage() (_ string, deferredErr error) {
 	// If /etc/mtab does not exist in container image, then we need to
 	// create it, so that mount command within the container will work.
 	mtab := filepath.Join(mountPoint, "/etc/mtab")
-	if err := os.MkdirAll(filepath.Dir(mtab), 0755); err != nil {
+	if err := idtools.MkdirAllAs(filepath.Dir(mtab), 0755, c.RootUID(), c.RootGID()); err != nil {
 		return "", errors.Wrap(err, "error creating mtab directory")
 	}
 	if err = os.Symlink("/proc/mounts", mtab); err != nil && !os.IsExist(err) {


### PR DESCRIPTION
Create the /etc and /etc/mtab directories with the
correct ownership based on what the UID and GID is
for the container. This was causing issue when starting
the infra container with userns as the /etc directory
wasn't being created with the correct ownership.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
