### PR TITLE
[NO TESTS NEEDED] Swap private and shared mount relabel options

### DIFF
--- a/cmd/podman/common/volumes.go
+++ b/cmd/podman/common/volumes.go
@@ -337,9 +337,9 @@ func getBindMount(args []string) (spec.Mount, error) {
 			}
 			switch kv[1] {
 			case "private":
-				newMount.Options = append(newMount.Options, "z")
-			case "shared":
 				newMount.Options = append(newMount.Options, "Z")
+			case "shared":
+				newMount.Options = append(newMount.Options, "z")
 			default:
 				return newMount, errors.Wrapf(util.ErrBadMntOption, "%s mount option must be 'private' or 'shared'", kv[0])
 			}


### PR DESCRIPTION
Fixes #10767

`--volume` bind mount relabeling options `z` and `Z` don't behaviour like their `--mount` argument equivalent options `relabel=shared` and `relabel=private`. Specifically, `relabel` code had those options swapped so that `shared` effectively relabeled the mount as a private unshared container and vice versa.

There is more info and a proof of concept in the related issue.