### PR TITLE
[NO TESTS NEEDED]  Suggestions for typos/ incorrect commands for Podman CLI

### DIFF
--- a/cmd/podman/validate/args.go
+++ b/cmd/podman/validate/args.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/pkg/errors"
@@ -20,7 +21,11 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 // SubCommandExists returns an error if no sub command is provided
 func SubCommandExists(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
-		return errors.Errorf("unrecognized command `%[1]s %[2]s`\nTry '%[1]s --help' for more information.", cmd.CommandPath(), args[0])
+		suggestions := cmd.SuggestionsFor(args[0])
+		if len(suggestions) == 0 {
+			return errors.Errorf("unrecognized command `%[1]s %[2]s`\nTry '%[1]s --help' for more information.", cmd.CommandPath(), args[0])
+		}
+		return errors.Errorf("unrecognized command `%[1]s %[2]s`\n\nDid you mean this?\n\t%[3]s\n\nTry '%[1]s --help' for more information.", cmd.CommandPath(), args[0], strings.Join(suggestions, "\n\t"))
 	}
 	return errors.Errorf("missing command '%[1]s COMMAND'\nTry '%[1]s --help' for more information.", cmd.CommandPath())
 }


### PR DESCRIPTION
Fixes #9715 
```
$ bin/podman attacks
Error: unrecognized command `podman attacks`

Did you mean this?
        attach

Try 'podman --help' for more information.
```
```
$ bin/podman containers
Error: unrecognized command `podman containers`

Did you mean this?
        container

Try 'podman --help' for more information.
```

Signed-off-by: Mehul Arora <aroram18@mcmaster.ca>

