### PR TITLE
cp: do not allow dir->file copying

### DIFF
--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -177,6 +177,10 @@ func copyFromContainer(container string, containerPath string, hostPath string) 
 		containerTarget = filepath.Dir(containerTarget)
 	}
 
+	if !isStdout && containerInfo.IsDir && !hostInfo.IsDir {
+		return errors.New("destination must be a directory when copying a directory")
+	}
+
 	reader, writer := io.Pipe()
 	hostCopy := func() error {
 		defer reader.Close()
@@ -332,6 +336,10 @@ func copyToContainer(container string, containerPath string, hostPath string) er
 			return errors.New("source must be a (compressed) tar archive when copying from stdin")
 		}
 		stdinFile = tmpFile.Name()
+	}
+
+	if hostInfo.IsDir && !containerInfo.IsDir {
+		return errors.New("destination must be a directory when copying a directory")
 	}
 
 	reader, writer := io.Pipe()

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -272,6 +272,11 @@ load helpers
         run_podman rm -f cpcontainer
     done < <(parse_table "$tests")
 
+    run_podman create --name cpcontainer --workdir=/srv $cpimage sleep infinity
+    run_podman 125 cp $srcdir cpcontainer:/etc/os-release
+    is "$output" "Error: destination must be a directory when copying a directory" "cannot copy directory to file"
+    run_podman rm -f cpcontainer
+
     run_podman rmi -f $cpimage
 }
 
@@ -343,6 +348,10 @@ load helpers
         is "$(< $destdir$dest_fullname/containerfile1)" "${randomcontent[1]}" "$description"
         rm -rf $destdir/*
     done < <(parse_table "$tests")
+
+    touch $destdir/testfile
+    run_podman 125 cp cpcontainer:/etc/ $destdir/testfile
+    is "$output" "Error: destination must be a directory when copying a directory" "cannot copy directory to file"
     run_podman rm -f cpcontainer
 
     run_podman rmi -f $cpimage


### PR DESCRIPTION
Fix a bug in `podman-cp` to forbid copying directories to files.
Previously, the directory was copied to the parent directory of the file
which is wrong.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
