### PR TITLE
reset: remove external containers on podman system reset

### DIFF
--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -32,6 +32,7 @@ type ContainerEngine interface {
 	ContainerInspect(ctx context.Context, namesOrIds []string, options InspectOptions) ([]*ContainerInspectReport, []error, error)
 	ContainerKill(ctx context.Context, namesOrIds []string, options KillOptions) ([]*KillReport, error)
 	ContainerList(ctx context.Context, options ContainerListOptions) ([]ListContainer, error)
+	ContainerListExternal(ctx context.Context) ([]ListContainer, error)
 	ContainerLogs(ctx context.Context, containers []string, options ContainerLogsOptions) error
 	ContainerMount(ctx context.Context, nameOrIDs []string, options ContainerMountOptions) ([]*ContainerMountReport, error)
 	ContainerPause(ctx context.Context, namesOrIds []string, options PauseUnPauseOptions) ([]*PauseUnpauseReport, error)

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -854,6 +854,10 @@ func (ic *ContainerEngine) ContainerList(ctx context.Context, options entities.C
 	return ps.GetContainerLists(ic.Libpod, options)
 }
 
+func (ic *ContainerEngine) ContainerListExternal(ctx context.Context) ([]entities.ListContainer, error) {
+	return ps.GetExternalContainerLists(ic.Libpod)
+}
+
 // ContainerDiff provides changes to given container
 func (ic *ContainerEngine) ContainerDiff(ctx context.Context, nameOrID string, opts entities.DiffOptions) (*entities.DiffReport, error) {
 	if opts.Latest {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -646,6 +646,12 @@ func (ic *ContainerEngine) ContainerList(ctx context.Context, opts entities.Cont
 	return containers.List(ic.ClientCtx, options)
 }
 
+func (ic *ContainerEngine) ContainerListExternal(ctx context.Context) ([]entities.ListContainer, error) {
+	options := new(containers.ListOptions).WithAll(true)
+	options.WithNamespace(true).WithSize(true).WithSync(true).WithExternal(true)
+	return containers.List(ic.ClientCtx, options)
+}
+
 func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.ContainerRunOptions) (*entities.ContainerRunReport, error) {
 	con, err := containers.CreateWithSpec(ic.ClientCtx, opts.Spec, nil)
 	if err != nil {


### PR DESCRIPTION
Following PR allows `podman system reset` to remove all the external containers with a **safety prompt** when `--force` is not provided. This makes sure that `podman system reset` performs a complete nuke of all the containers.

Attempts a feature patch for issue: https://github.com/containers/podman/issues/10755

Example 
```bash
flouthoc@system:~/src/stable/glibc$ podman system reset
WARNING! This will remove:
        - all containers
        - all pods
        - all images
        - all build cache
WARNING! The following external containers will be purged:
	- dbfc83909cbb (busybox-working-container)
	- c37fb04008bd (busybox-working-container-1)
Are you sure you want to continue? [y/N] y
```
* `--force` silently removes everything without any prompt.
Example 2
```bash
flouthoc@system:~/src/stable/glibc$ podman system reset --force
```

