### PR TITLE
feat(ssh): make debugging ssh show command

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -470,9 +470,7 @@ func (v *MachineVM) SSH(name string, opts machine.SSHOptions) error {
 	}
 
 	cmd := exec.Command("ssh", args...)
-	if logrus.GetLevel() == logrus.DebugLevel {
-		fmt.Printf("The arguments passed to ssh are: %v\n", args)
-	}
+		logrus.Debugf("The arguments passed to ssh are: %v\n", args)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -470,6 +470,9 @@ func (v *MachineVM) SSH(name string, opts machine.SSHOptions) error {
 	}
 
 	cmd := exec.Command("ssh", args...)
+	if logrus.GetLevel() == logrus.DebugLevel {
+		fmt.Printf("The arguments passed to ssh are: %v\n", args)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
EDIT: needs also support on adding the debug flag to the `podman machine ssh` command


in order to use the SSH variables for other uses, expose these args as a string, which can be used elsewhere

I wanted to build a container but I got the error:
```
Error: stat /var/tmp/libpod_builder758690613/build/["Dockerfile"]: no such file or directory
```

so I wanted to copy the docker file and the repo that came with it into the VM
which I was able to do

also I am now stuck on running 
```
podman images
localhost/IMAGE            latest      XXXX  12 minutes ago  XXXX

podman run --rm -it IMAGE bash
Error: Error initializing source docker://localhost/IMAGEr:latest: error pinging docker registry localhost: Get "https://localhost/v2/": dial tcp [::1]:443: connect: connection refused
```

I can create an issue if needed

(specs of my machine will be given upon request)
I am using macOS