### PR TITLE
Makefile: remove install.cni

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -613,7 +613,7 @@ podman-release.tar.gz: binaries docs  ## Build all binaries, docs., and installa
 	$(eval TMPDIR := $(shell mktemp -d podman_tmp_XXXX))
 	$(eval SUBDIR := podman-v$(RELEASE_NUMBER))
 	mkdir -p "$(TMPDIR)/$(SUBDIR)"
-	$(MAKE) install.bin install.man install.cni \
+	$(MAKE) install.bin install.man \
 		install.systemd "DESTDIR=$(TMPDIR)/$(SUBDIR)" "PREFIX=/usr"
 	tar -czvf $@ --xattrs -C "$(TMPDIR)" "./$(SUBDIR)"
 	-rm -rf "$(TMPDIR)"
@@ -666,7 +666,7 @@ package-install: package  ## Install rpm packages
 	/usr/bin/podman info  # will catch a broken conmon
 
 .PHONY: install
-install: .gopathok install.bin install.remote install.man install.cni install.systemd  ## Install binaries to system locations
+install: .gopathok install.bin install.remote install.man install.systemd  ## Install binaries to system locations
 
 .PHONY: install.catatonit
 install.catatonit:
@@ -718,11 +718,6 @@ install.completions:
 	install ${SELINUXOPT} -m 644 completions/fish/podman.fish ${DESTDIR}${FISHINSTALLDIR}
 	install ${SELINUXOPT} -m 644 completions/fish/podman-remote.fish ${DESTDIR}${FISHINSTALLDIR}
 	# There is no common location for powershell files so do not install them. Users have to source the file from their powershell profile.
-
-.PHONY: install.cni
-install.cni:
-	install ${SELINUXOPT} -d -m 755 ${DESTDIR}${ETCDIR}/cni/net.d/
-	install ${SELINUXOPT} -m 644 cni/87-podman-bridge.conflist ${DESTDIR}${ETCDIR}/cni/net.d/87-podman-bridge.conflist
 
 .PHONY: install.docker
 install.docker:

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -441,7 +441,6 @@ PODMAN_VERSION=%{version} %{__make} PREFIX=%{buildroot}%{_prefix} ETCDIR=%{build
 %if %{with doc}
         install.man-nobuild \
 %endif
-        install.cni \
         install.systemd \
         install.completions
 
@@ -526,7 +525,6 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/vendor:%{gopath}
 %{_datadir}/bash-completion/completions/*
 %{_datadir}/zsh/site-functions/*
 %{_datadir}/fish/vendor_completions.d/*
-%config(noreplace) %{_sysconfdir}/cni/net.d/87-%{name}-bridge.conflist
 %{_unitdir}/podman-auto-update.service
 %{_unitdir}/podman-auto-update.timer
 %{_unitdir}/podman.service


### PR DESCRIPTION
We no longer need to install /etc/cni/net.d/87-podman-bridge.conflist
so install.cni isn't needed either.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


@mheon @rhatdan @baude PTAL

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
