### PR TITLE
Implement --archive flag for podman cp

### DIFF
--- a/docs/source/markdown/podman-cp.1.md
+++ b/docs/source/markdown/podman-cp.1.md
@@ -4,9 +4,9 @@
 podman\-cp - Copy files/folders between a container and the local filesystem
 
 ## SYNOPSIS
-**podman cp** [*container*:]*src_path* [*container*:]*dest_path*
+**podman cp** [*options*] [*container*:]*src_path* [*container*:]*dest_path*
 
-**podman container cp** [*container*:]*src_path* [*container*:]*dest_path*
+**podman container cp** [*options*] [*container*:]*src_path* [*container*:]*dest_path*
 
 ## DESCRIPTION
 Copy the contents of **src_path** to the **dest_path**. You can copy from the container's filesystem to the local machine or the reverse, from the local filesystem to the container.
@@ -60,6 +60,13 @@ Using `-` as the *src_path* streams the contents of STDIN as a tar archive. The 
 Note that `podman cp` ignores permission errors when copying from a running rootless container.  The TTY devices inside a rootless container are owned by the host's root user and hence cannot be read inside the container's user namespace.
 
 ## OPTIONS
+
+#### **--archive**, **-a**
+
+Archive mode (copy all uid/gid information).
+When set to true, files copied to a container will have changed ownership to the primary uid/gid of the container.
+When set to false, maintain uid/gid from archive sources instead of changing them to the primary uid/gid of the destination container.
+The default is *true*.
 
 ## ALTERNATIVES
 

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -840,7 +840,7 @@ func (c *Container) ShouldRestart(ctx context.Context) bool {
 
 // CopyFromArchive copies the contents from the specified tarStream to path
 // *inside* the container.
-func (c *Container) CopyFromArchive(ctx context.Context, containerPath string, tarStream io.Reader) (func() error, error) {
+func (c *Container) CopyFromArchive(ctx context.Context, containerPath string, chown bool, tarStream io.Reader) (func() error, error) {
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()
@@ -850,7 +850,7 @@ func (c *Container) CopyFromArchive(ctx context.Context, containerPath string, t
 		}
 	}
 
-	return c.copyFromArchive(ctx, containerPath, tarStream)
+	return c.copyFromArchive(ctx, containerPath, chown, tarStream)
 }
 
 // CopyToArchive copies the contents from the specified path *inside* the

--- a/pkg/bindings/containers/archive.go
+++ b/pkg/bindings/containers/archive.go
@@ -50,11 +50,21 @@ func Stat(ctx context.Context, nameOrID string, path string) (*entities.Containe
 }
 
 func CopyFromArchive(ctx context.Context, nameOrID string, path string, reader io.Reader) (entities.ContainerCopyFunc, error) {
+	return CopyFromArchiveWithOptions(ctx, nameOrID, path, reader, nil)
+}
+
+// CopyFromArchiveWithOptions FIXME: remove this function and make CopyFromArchive accept the option as the last parameter in podman 4.0
+func CopyFromArchiveWithOptions(ctx context.Context, nameOrID string, path string, reader io.Reader, options *CopyOptions) (entities.ContainerCopyFunc, error) {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	params := url.Values{}
+
+	params, err := options.ToParams()
+	if err != nil {
+		return nil, err
+	}
+
 	params.Set("path", path)
 
 	return func() error {

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -251,3 +251,11 @@ type ExistsOptions struct {
 	// External checks for containers created outside of Podman
 	External *bool
 }
+
+//go:generate go run ../generator/generator.go CopyOptions
+// CopyOptions are options for copying to containers.
+type CopyOptions struct {
+	// If used with CopyFromArchive and set to true it will change ownership of files from the source tar archive
+	// to the primary uid/gid of the target container.
+	Chown *bool `schema:"copyUIDGID"`
+}

--- a/pkg/bindings/containers/types_copy_options.go
+++ b/pkg/bindings/containers/types_copy_options.go
@@ -1,0 +1,37 @@
+package containers
+
+import (
+	"net/url"
+
+	"github.com/containers/podman/v3/pkg/bindings/internal/util"
+)
+
+/*
+This file is generated automatically by go generate.  Do not edit.
+*/
+
+// Changed
+func (o *CopyOptions) Changed(fieldName string) bool {
+	return util.Changed(o, fieldName)
+}
+
+// ToParams
+func (o *CopyOptions) ToParams() (url.Values, error) {
+	return util.ToParams(o)
+}
+
+// WithChown
+func (o *CopyOptions) WithChown(value bool) *CopyOptions {
+	v := &value
+	o.Chown = v
+	return o
+}
+
+// GetChown
+func (o *CopyOptions) GetChown() bool {
+	var chown bool
+	if o.Chown == nil {
+		return chown
+	}
+	return *o.Chown
+}

--- a/pkg/bindings/internal/util/util.go
+++ b/pkg/bindings/internal/util/util.go
@@ -72,14 +72,18 @@ func ToParams(o interface{}) (url.Values, error) {
 		if reflect.Ptr == f.Kind() {
 			f = f.Elem()
 		}
+		paramName := fieldName
+		if pn, ok := sType.Field(i).Tag.Lookup("schema"); ok {
+			paramName = pn
+		}
 		switch {
 		case IsSimpleType(f):
-			params.Set(fieldName, SimpleTypeToParam(f))
+			params.Set(paramName, SimpleTypeToParam(f))
 		case f.Kind() == reflect.Slice:
 			for i := 0; i < f.Len(); i++ {
 				elem := f.Index(i)
 				if IsSimpleType(elem) {
-					params.Add(fieldName, SimpleTypeToParam(elem))
+					params.Add(paramName, SimpleTypeToParam(elem))
 				} else {
 					return nil, errors.New("slices must contain only simple types")
 				}
@@ -95,7 +99,7 @@ func ToParams(o interface{}) (url.Values, error) {
 				return nil, err
 			}
 
-			params.Set(fieldName, s)
+			params.Set(paramName, s)
 		}
 	}
 	return params, nil

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -160,6 +160,13 @@ type CommitOptions struct {
 	Writer         io.Writer
 }
 
+type CopyOptions struct {
+	// If used with ContainerCopyFromArchive and set to true
+	// it will change ownership of files from the source tar archive
+	// to the primary uid/gid of the destination container.
+	Chown bool
+}
+
 type CommitReport struct {
 	Id string //nolint
 }

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -20,7 +20,7 @@ type ContainerEngine interface {
 	ContainerCheckpoint(ctx context.Context, namesOrIds []string, options CheckpointOptions) ([]*CheckpointReport, error)
 	ContainerCleanup(ctx context.Context, namesOrIds []string, options ContainerCleanupOptions) ([]*ContainerCleanupReport, error)
 	ContainerCommit(ctx context.Context, nameOrID string, options CommitOptions) (*CommitReport, error)
-	ContainerCopyFromArchive(ctx context.Context, nameOrID string, path string, reader io.Reader) (ContainerCopyFunc, error)
+	ContainerCopyFromArchive(ctx context.Context, nameOrID, path string, reader io.Reader, options CopyOptions) (ContainerCopyFunc, error)
 	ContainerCopyToArchive(ctx context.Context, nameOrID string, path string, writer io.Writer) (ContainerCopyFunc, error)
 	ContainerCreate(ctx context.Context, s *specgen.SpecGenerator) (*ContainerCreateReport, error)
 	ContainerDiff(ctx context.Context, nameOrID string, options DiffOptions) (*DiffReport, error)

--- a/pkg/domain/infra/abi/archive.go
+++ b/pkg/domain/infra/abi/archive.go
@@ -7,12 +7,12 @@ import (
 	"github.com/containers/podman/v3/pkg/domain/entities"
 )
 
-func (ic *ContainerEngine) ContainerCopyFromArchive(ctx context.Context, nameOrID string, containerPath string, reader io.Reader) (entities.ContainerCopyFunc, error) {
+func (ic *ContainerEngine) ContainerCopyFromArchive(ctx context.Context, nameOrID, containerPath string, reader io.Reader, options entities.CopyOptions) (entities.ContainerCopyFunc, error) {
 	container, err := ic.Libpod.LookupContainer(nameOrID)
 	if err != nil {
 		return nil, err
 	}
-	return container.CopyFromArchive(ctx, containerPath, reader)
+	return container.CopyFromArchive(ctx, containerPath, options.Chown, reader)
 }
 
 func (ic *ContainerEngine) ContainerCopyToArchive(ctx context.Context, nameOrID string, containerPath string, writer io.Writer) (entities.ContainerCopyFunc, error) {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -833,8 +833,8 @@ func (ic *ContainerEngine) ContainerPort(ctx context.Context, nameOrID string, o
 	return reports, nil
 }
 
-func (ic *ContainerEngine) ContainerCopyFromArchive(ctx context.Context, nameOrID string, path string, reader io.Reader) (entities.ContainerCopyFunc, error) {
-	return containers.CopyFromArchive(ic.ClientCtx, nameOrID, path, reader)
+func (ic *ContainerEngine) ContainerCopyFromArchive(ctx context.Context, nameOrID, path string, reader io.Reader, options entities.CopyOptions) (entities.ContainerCopyFunc, error) {
+	return containers.CopyFromArchiveWithOptions(ic.ClientCtx, nameOrID, path, reader, new(containers.CopyOptions).WithChown(options.Chown))
 }
 
 func (ic *ContainerEngine) ContainerCopyToArchive(ctx context.Context, nameOrID string, path string, writer io.Writer) (entities.ContainerCopyFunc, error) {

--- a/test/apiv2/23-containersArchive.at
+++ b/test/apiv2/23-containersArchive.at
@@ -16,7 +16,7 @@ CTR="ArchiveTestingCtr"
 TMPD=$(mktemp -d podman-apiv2-test.archive.XXXXXXXX)
 HELLO_TAR="${TMPD}/hello.tar"
 echo "Hello" > $TMPD/hello.txt
-tar --format=posix -C $TMPD -cvf ${HELLO_TAR} hello.txt &> /dev/null
+tar --owner=1042 --group=1043 --format=posix -C $TMPD -cvf ${HELLO_TAR} hello.txt &> /dev/null
 
 podman run -d --name "${CTR}" "${IMAGE}" top
 
@@ -71,6 +71,20 @@ if [ "$(tar -xf "${TMPD}/body.tar" hello.txt  --to-stdout)" != "Hello" ]; then
   echo -e "${red}NOK: Content of file doesn't match.${nc}" 1>&2;
   ARCHIVE_TEST_ERROR="1"
 fi
+
+# test if uid/gid was set correctly in the server
+uidngid=$($PODMAN_BIN --root $WORKDIR/server_root exec "${CTR}" stat -c "%u:%g" "/tmp/hello.txt")
+if [[ "${uidngid}" != "1042:1043" ]]; then
+  echo -e "${red}NOK: UID/GID of the file doesn't match.${nc}" 1>&2;
+  ARCHIVE_TEST_ERROR="1"
+fi
+
+# TODO: uid/gid should be also preserved on way back (GET request)
+# right now it ends up as root:root instead of 1042:1043
+#if [[ "$(tar -tvf "${TMPD}/body.tar")" != *"1042/1043"* ]]; then
+#  echo -e "${red}NOK: UID/GID of the file doesn't match.${nc}" 1>&2;
+#  ARCHIVE_TEST_ERROR="1"
+#fi
 
 cleanUpArchiveTest
 if [[ "${ARCHIVE_TEST_ERROR}" ]] ; then


### PR DESCRIPTION
Implement --archive flag for `podman cp`

This PR implements for direction when a container is a destination, not a source.

resolves #10801

Signed-off-by: Matej Vasek <mvasek@redhat.com>