### PR TITLE
Handle advanced --network options in podman play kube

### DIFF
--- a/cmd/podman/common/netflags.go
+++ b/cmd/podman/common/netflags.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"net"
-	"strings"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v3/cmd/podman/parse"
@@ -204,17 +203,13 @@ func NetFlagsToNetOptions(cmd *cobra.Command, netnsFromConfig bool) (*entities.N
 			return nil, err
 		}
 
-		parts := strings.SplitN(network, ":", 2)
-
-		ns, cniNets, err := specgen.ParseNetworkNamespace(network, containerConfig.Containers.RootlessNetworking == "cni")
+		ns, cniNets, options, err := specgen.ParseNetworkString(network)
 		if err != nil {
 			return nil, err
 		}
 
-		if len(parts) > 1 {
-			opts.NetworkOptions = make(map[string][]string)
-			opts.NetworkOptions[parts[0]] = strings.Split(parts[1], ",")
-			cniNets = nil
+		if len(options) > 0 {
+			opts.NetworkOptions = options
 		}
 		opts.Network = ns
 		opts.CNINetworks = cniNets

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -68,6 +68,11 @@ func (n *Namespace) IsHost() bool {
 	return n.NSMode == Host
 }
 
+// IsBridge returns a bool if the namespace is a Bridge
+func (n *Namespace) IsBridge() bool {
+	return n.NSMode == Bridge
+}
+
 // IsPath indicates via bool if the namespace is based on a path
 func (n *Namespace) IsPath() bool {
 	return n.NSMode == Path
@@ -300,4 +305,21 @@ func ParseNetworkNamespace(ns string, rootlessDefaultCNI bool) (Namespace, []str
 	}
 
 	return toReturn, cniNetworks, nil
+}
+
+func ParseNetworkString(network string) (Namespace, []string, map[string][]string, error) {
+	var networkOptions map[string][]string
+	parts := strings.SplitN(network, ":", 2)
+
+	ns, cniNets, err := ParseNetworkNamespace(network, containerConfig.Containers.RootlessNetworking == "cni")
+	if err != nil {
+		return Namespace{}, nil, nil, err
+	}
+
+	if len(parts) > 1 {
+		networkOptions = make(map[string][]string)
+		networkOptions[parts[0]] = strings.Split(parts[1], ",")
+		cniNets = nil
+	}
+	return ns, cniNets, networkOptions, nil
 }

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -89,6 +89,18 @@ RELABEL="system_u:object_r:container_file_t:s0"
     run_podman pod rm -f test_pod
 }
 
+@test "podman play --network" {
+    TESTDIR=$PODMAN_TMPDIR/testdir
+    mkdir -p $TESTDIR
+    echo "$testYaml" | sed "s|TESTDIR|${TESTDIR}|g" > $PODMAN_TMPDIR/test.yaml
+    run_podman 125 play kube --network bridge $PODMAN_TMPDIR/test.yaml
+    is "$output" ".*invalid value passed to --network: bridge or host networking must be configured in YAML" "podman plan-network should fail wth --network host"
+    run_podman 125 play kube --network host $PODMAN_TMPDIR/test.yaml
+    is "$output" ".*invalid value passed to --network: bridge or host networking must be configured in YAML" "podman plan-network should fail wth --network host"
+    run_podman play kube --network slirp4netns:port_handler=slirp4netns $PODMAN_TMPDIR/test.yaml
+    run_podman pod rm -f test_pod
+}
+
 @test "podman play with user from image" {
     TESTDIR=$PODMAN_TMPDIR/testdir
     mkdir -p $TESTDIR


### PR DESCRIPTION
Since Podman create/run can support this, so should play.

Fixes: https://github.com/containers/podman/issues/10807

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
