### PR TITLE
[NO TESTS NEEDED] Make system connection ls deterministic

### DIFF
--- a/cmd/podman/system/connection/list.go
+++ b/cmd/podman/system/connection/list.go
@@ -3,6 +3,7 @@ package connection
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/config"
@@ -76,6 +77,10 @@ func list(cmd *cobra.Command, _ []string) error {
 		}
 		rows = append(rows, r)
 	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].Name < rows[j].Name
+	})
 
 	format := "{{.Name}}\t{{.Identity}}\t{{.URI}}\n"
 	switch {


### PR DESCRIPTION
Sort system connection ls by name, making the output deterministic. Previously, we were just iterating through a map, which caused CI flakes.

Signed-off-by: Ashley Cui <acui@redhat.com>

[NO TESTS NEEDED] I think, since its just about deterministic listing. 

Closes: #10813

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
