### PR TITLE
Add prune until filter test for podman volume cli

### DIFF
--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -23,12 +23,8 @@ Do not prompt for confirmation.
 
 Filter volumes to be pruned. Volumes can be filtered by the following attributes:
 
-- dangling
-- driver
 - label
-- name
-- opt
-- scope
+- until
 
 #### **--help**
 

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -63,6 +63,37 @@ var _ = Describe("Podman volume prune", func() {
 		podmanTest.Cleanup()
 	})
 
+	It("podman prune volume --filter until", func() {
+		session := podmanTest.Podman([]string{"volume", "create", "--label", "label1=value1", "myvol1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(2))
+
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "until=50"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(2))
+
+		session = podmanTest.Podman([]string{"volume", "prune", "--force", "--filter", "until=5000000000"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(0))
+
+		podmanTest.Cleanup()
+	})
+
 	It("podman prune volume --filter", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--label", "label1=value1", "myvol1"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
This commit follows work started in #10756. Changes made in #11015
enabled cli support for volume prune --filter until. Adding e2e test
 closes #10579.

Fixes #10579
