### PR TITLE
Make rootless-cni setup more robust

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -173,7 +173,7 @@ function _run_swagger() {
     trap "rm -f $envvarsfile" EXIT  # contains secrets
     # Warning: These values must _not_ be quoted, podman will not remove them.
     #shellcheck disable=SC2154
-    cat <<eof>>$envvarsfile
+    cat <<eof >>$envvarsfile
 GCPJSON=$GCPJSON
 GCPNAME=$GCPNAME
 GCPPROJECT=$GCPPROJECT
@@ -336,6 +336,11 @@ msg "************************************************************"
 
 # shellcheck disable=SC2154
 if [[ "$PRIV_NAME" == "rootless" ]] && [[ "$UID" -eq 0 ]]; then
+    # Remove /var/lib/cni, it is not required for rootless cni.
+    # We have to test that it works without this directory.
+    # https://github.com/containers/podman/issues/10857
+    rm -rf /var/lib/cni
+
     req_env_vars ROOTLESS_USER
     msg "Re-executing runner through ssh as user '$ROOTLESS_USER'"
     msg "************************************************************"


### PR DESCRIPTION
The rootless cni namespace needs a valid /etc/resolv.conf file. On some
distros is a symlink to somewhere under /run. Because the kernel will
follow the symlink before mounting, it is not possible to mount a file
at exactly /etc/resolv.conf. We have to ensure that the link target will
be available in the rootless cni mount ns.

Fixes #10855

Also fixed a bug in the /var/lib/cni directory lookup logic. It used
`filepath.Base` instead of `filepath.Dir` and thus looping infinitely.

Fixes #10857

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
