### PR TITLE
Implemented Until Query Parameter for Containers/logs

### DIFF
--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -56,7 +56,7 @@ func (c *Container) readFromLogFile(ctx context.Context, options *logs.LogOption
 		for _, nll := range tailLog {
 			nll.CID = c.ID()
 			nll.CName = c.Name()
-			if nll.Since(options.Since) {
+			if nll.Since(options.Since) && nll.Until(options.Until) {
 				logChannel <- nll
 			}
 		}
@@ -88,7 +88,7 @@ func (c *Container) readFromLogFile(ctx context.Context, options *logs.LogOption
 			}
 			nll.CID = c.ID()
 			nll.CName = c.Name()
-			if nll.Since(options.Since) {
+			if nll.Since(options.Since) && nll.Until(options.Until) {
 				logChannel <- nll
 			}
 		}

--- a/libpod/container_log_linux.go
+++ b/libpod/container_log_linux.go
@@ -97,6 +97,7 @@ func (c *Container) readFromJournal(ctx context.Context, options *logs.LogOption
 			}
 		}()
 
+		beforeTimeStamp := true
 		afterTimeStamp := false        // needed for options.Since
 		tailQueue := []*logs.LogLine{} // needed for options.Tail
 		doTail := options.Tail > 0
@@ -155,6 +156,13 @@ func (c *Container) readFromJournal(ctx context.Context, options *logs.LogOption
 					continue
 				}
 				afterTimeStamp = true
+			}
+			if beforeTimeStamp {
+				entryTime := time.Unix(0, int64(entry.RealtimeTimestamp)*int64(time.Microsecond))
+				if entryTime.Before(options.Until) || !options.Until.IsZero() {
+					continue
+				}
+				beforeTimeStamp = false
 			}
 
 			// If we're reading an event and the container exited/died,

--- a/libpod/logs/log.go
+++ b/libpod/logs/log.go
@@ -34,6 +34,7 @@ type LogOptions struct {
 	Details    bool
 	Follow     bool
 	Since      time.Time
+	Until      time.Time
 	Tail       int64
 	Timestamps bool
 	Multi      bool
@@ -184,7 +185,12 @@ func (l *LogLine) String(options *LogOptions) string {
 
 // Since returns a bool as to whether a log line occurred after a given time
 func (l *LogLine) Since(since time.Time) bool {
-	return l.Time.After(since)
+	return l.Time.After(since) || since.IsZero()
+}
+
+// Until returns a bool as to whether a log line occurred before a given time
+func (l *LogLine) Until(until time.Time) bool {
+	return l.Time.Before(until) || until.IsZero()
 }
 
 // NewLogLine creates a logLine struct from a container log string


### PR DESCRIPTION
compat containers/logs was missing actual usage of until query param.

fixes #10859

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
