### PR TITLE
auto-update: make output more user friendly

### DIFF
--- a/cmd/podman/auto-update.go
+++ b/cmd/podman/auto-update.go
@@ -50,7 +50,9 @@ func autoUpdate(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("`%s` takes no arguments", cmd.CommandPath())
 	}
 	report, failures := registry.ContainerEngine().AutoUpdate(registry.GetContext(), autoUpdateOptions)
-	if report != nil {
+	if report != nil && len(report.Units) > 0 {
+		// Make it more obvious to users what the output means.
+		fmt.Println("\nRestarted the following systemd units:")
 		for _, unit := range report.Units {
 			fmt.Println(unit)
 		}

--- a/docs/source/markdown/podman-auto-update.1.md
+++ b/docs/source/markdown/podman-auto-update.1.md
@@ -41,6 +41,22 @@ If the authorization state is not found there, `$HOME/.docker/config.json` is ch
 
 Note: There is also the option to override the default path of the authentication file by setting the `REGISTRY_AUTH_FILE` environment variable. This can be done with **export REGISTRY_AUTH_FILE=_path_**.
 
+#### **--format**=*format*
+
+Change the default output format.  This can be of a supported type like 'json' or a Go template.
+Valid placeholders for the Go template are listed below:
+
+| **Placeholder** | **Description**                        |
+| --------------- | -------------------------------------- |
+| .Unit           | Name of the systemd unit               |
+| .ContainerName  | Name of the container                  |
+| .ContainerID    | ID of the container                    |
+| .Container      | ID and name of the container           |
+| .Image          | Name of the image                      |
+| .Policy         | Auto-update policy of the container    |
+| .Updated        | Update status: true,false,failed       |
+
+
 ## EXAMPLES
 Autoupdate with registry policy
 
@@ -53,7 +69,7 @@ bc219740a210455fa27deacc96d50a9e20516492f1417507c13ce1533dbdcd9d
 
 ### Generate a systemd unit for this container
 $ podman generate systemd --new --files bc219740a210455fa27deacc96d50a9e20516492f1417507c13ce1533dbdcd9d
-/home/user/containers/libpod/container-bc219740a210455fa27deacc96d50a9e20516492f1417507c13ce1533dbdcd9d.service
+/home/user/container-bc219740a210455fa27deacc96d50a9e20516492f1417507c13ce1533dbdcd9d.service
 
 ### Load the new systemd unit and start it
 $ mv ./container-bc219740a210455fa27deacc96d50a9e20516492f1417507c13ce1533dbdcd9d.service ~/.config/systemd/user
@@ -67,7 +83,7 @@ $ systemctl --user start container-bc219740a210455fa27deacc96d50a9e20516492f1417
 
 ### Auto-update the container
 $ podman auto-update
-container-bc219740a210455fa27deacc96d50a9e20516492f1417507c13ce1533dbdcd9d.service
+[...]
 ```
 
 Autoupdate with local policy
@@ -80,7 +96,7 @@ be0889fd06f252a2e5141b37072c6bada68563026cb2b2649f53394d87ccc338
 
 ### Generate a systemd unit for this container
 $ podman generate systemd --new --files be0889fd06f252a2e5141b37072c6bada68563026cb2b2649f53394d87ccc338
-/home/user/containers/libpod/container-be0889fd06f252a2e5141b37072c6bada68563026cb2b2649f53394d87ccc338.service
+/home/user/container-be0889fd06f252a2e5141b37072c6bada68563026cb2b2649f53394d87ccc338.service
 
 ### Load the new systemd unit and start it
 $ mv ./container-be0889fd06f252a2e5141b37072c6bada68563026cb2b2649f53394d87ccc338.service ~/.config/systemd/user
@@ -102,7 +118,7 @@ $ podman commit --change CMD=/bin/bash inspiring_galileo busybox:latest
 
 ### Auto-update the container
 $ podman auto-update
-container-be0889fd06f252a2e5141b37072c6bada68563026cb2b2649f53394d87ccc338.service
+[...]
 ```
 
 ## SEE ALSO

--- a/pkg/domain/entities/auto-update.go
+++ b/pkg/domain/entities/auto-update.go
@@ -8,6 +8,17 @@ type AutoUpdateOptions struct {
 
 // AutoUpdateReport contains the results from running auto-update.
 type AutoUpdateReport struct {
-	// Units - the restarted systemd units during auto-update.
-	Units []string
+	// ID of the container *before* an update.
+	ContainerID string
+	// Name of the container *before* an update.
+	ContainerName string
+	// Name of the image.
+	ImageName string
+	// The configured auto-update policy.
+	Policy string
+	// SystemdUnit running a container configured for auto updates.
+	SystemdUnit string
+	// Indicates whether the image was updated and the container (and
+	// systemd unit) restarted.
+	Updated string
 }

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -14,7 +14,7 @@ import (
 type ContainerCopyFunc func() error
 
 type ContainerEngine interface {
-	AutoUpdate(ctx context.Context, options AutoUpdateOptions) (*AutoUpdateReport, []error)
+	AutoUpdate(ctx context.Context, options AutoUpdateOptions) ([]*AutoUpdateReport, []error)
 	Config(ctx context.Context) (*config.Config, error)
 	ContainerAttach(ctx context.Context, nameOrID string, options AttachOptions) error
 	ContainerCheckpoint(ctx context.Context, namesOrIds []string, options CheckpointOptions) ([]*CheckpointReport, error)

--- a/pkg/domain/infra/abi/auto-update.go
+++ b/pkg/domain/infra/abi/auto-update.go
@@ -12,6 +12,6 @@ func (ic *ContainerEngine) AutoUpdate(ctx context.Context, options entities.Auto
 	// them in the entities package as low-level packages must not leak
 	// into the remote client.
 	autoOpts := autoupdate.Options{Authfile: options.Authfile}
-	units, failures := autoupdate.AutoUpdate(ic.Libpod, autoOpts)
+	units, failures := autoupdate.AutoUpdate(ctx, ic.Libpod, autoOpts)
 	return &entities.AutoUpdateReport{Units: units}, failures
 }

--- a/pkg/domain/infra/abi/auto-update.go
+++ b/pkg/domain/infra/abi/auto-update.go
@@ -12,6 +12,5 @@ func (ic *ContainerEngine) AutoUpdate(ctx context.Context, options entities.Auto
 	// them in the entities package as low-level packages must not leak
 	// into the remote client.
 	autoOpts := autoupdate.Options{Authfile: options.Authfile}
-	units, failures := autoupdate.AutoUpdate(ctx, ic.Libpod, autoOpts)
-	return &entities.AutoUpdateReport{Units: units}, failures
+	return autoupdate.AutoUpdate(ctx, ic.Libpod, autoOpts)
 }

--- a/pkg/domain/infra/abi/auto-update.go
+++ b/pkg/domain/infra/abi/auto-update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/containers/podman/v3/pkg/domain/entities"
 )
 
-func (ic *ContainerEngine) AutoUpdate(ctx context.Context, options entities.AutoUpdateOptions) (*entities.AutoUpdateReport, []error) {
+func (ic *ContainerEngine) AutoUpdate(ctx context.Context, options entities.AutoUpdateOptions) ([]*entities.AutoUpdateReport, []error) {
 	// Convert the entities options to the autoupdate ones.  We can't use
 	// them in the entities package as low-level packages must not leak
 	// into the remote client.

--- a/pkg/domain/infra/tunnel/auto-update.go
+++ b/pkg/domain/infra/tunnel/auto-update.go
@@ -7,6 +7,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (ic *ContainerEngine) AutoUpdate(ctx context.Context, options entities.AutoUpdateOptions) (*entities.AutoUpdateReport, []error) {
+func (ic *ContainerEngine) AutoUpdate(ctx context.Context, options entities.AutoUpdateOptions) ([]*entities.AutoUpdateReport, []error) {
 	return nil, []error{errors.New("not implemented")}
 }

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -119,7 +119,7 @@ function service_cleanup() {
     # Run auto-update and check that it restarted the container
     run_podman commit --change "CMD=/bin/bash" $cname $IMAGE
     run_podman auto-update
-    is $output $SERVICE_NAME "autoupdate local restarted container"
+    is "$output" ".*$SERVICE_NAME.*" "autoupdate local restarted container"
 
     # All good. Stop service, clean up.
     service_cleanup

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -123,6 +123,8 @@ function _confirm_update() {
     _wait_service_ready container-$cname.service
     run_podman auto-update
     is "$output" "Trying to pull.*" "Image is updated."
+    is "$output" ".*Restarted the following systemd units:
+container-$cname.service" "Systemd unit has been restarted"
     _confirm_update $cname $ori_image
 }
 

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -121,10 +121,10 @@ function _confirm_update() {
     generate_service alpine image
 
     _wait_service_ready container-$cname.service
-    run_podman auto-update
+    run_podman auto-update --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
     is "$output" "Trying to pull.*" "Image is updated."
-    is "$output" ".*Restarted the following systemd units:
-container-$cname.service" "Systemd unit has been restarted"
+    is "$output" ".*container-$cname.service,quay.io/libpod/alpine:latest,true,registry.*" "Image is updated."
+
     _confirm_update $cname $ori_image
 }
 
@@ -153,10 +153,15 @@ container-$cname.service" "Systemd unit has been restarted"
 
 @test "podman auto-update - label io.containers.autoupdate=local" {
     generate_service localtest local
-    podman commit --change CMD=/bin/bash $cname quay.io/libpod/localtest:latest
+    image=quay.io/libpod/localtest:latest
+    podman commit --change CMD=/bin/bash $cname $image
+    podman image inspect --format "{{.ID}}" $image
+    imageID="$output"
 
     _wait_service_ready container-$cname.service
-    run_podman auto-update
+    run_podman auto-update --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
+    is "$output" ".*container-$cname.service,quay.io/libpod/localtest:latest,true,local.*" "Image is updated."
+
     _confirm_update $cname $ori_image
 }
 


### PR DESCRIPTION
The rather raw and scarce output of `podman auto-update` has been a                         
thorn in my eyes for a longer while.  So far, Podman would only print                       
updated systemd units, one per line, without further formatting.                            
                                                                                            
Motivated by issue #9949 which is asking for some more useful                               
information in combination with a dry-run feature, I sat down and                           
reflected which information may come in handy.                                              
                                                                                            
Running `podman auto-update` will now look as follows:                                      
                                                                                            
```                                                                                         
$ podman auto-update                                                                        
Trying to pull [...]                                                                        
                                                                                            
UNIT                    CONTAINER            IMAGE                   POLICY      UPDATED    
container-test.service  08fd34e533fd (test)  localhost:5000/busybox  registry    false      
```                                                                                         
                                                                                            
Also refactor the spaghetti code in the backend a bit to make it easier                     
to digest and maintain.                                                                     
                                                                                            
For easier testing and for the sake of consistency with other commands                      
listing output, add a `--format` flag.                                                                                                    
                                                                                            
The man page will get an overhaul in a follow up commit.                                    
                                                                                            
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>                                      
