### PR TITLE
Remove GetStore function from Libpod

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -946,9 +946,12 @@ func (r *Runtime) StorageConfig() storage.StoreOptions {
 	return r.storageConfig
 }
 
-// GetStore returns the runtime stores
-func (r *Runtime) GetStore() storage.Store {
-	return r.store
+// RunRoot retrieves the current c/storage temporary directory in use by Libpod.
+func (r *Runtime) RunRoot() string {
+	if r.store == nil {
+		return ""
+	}
+	return r.store.RunRoot()
 }
 
 // GetName retrieves the name associated with a given full ID.

--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -160,16 +160,11 @@ func generateContainerInfo(ctr *libpod.Container, options entities.GenerateSyste
 
 	nameOrID, serviceName := containerServiceName(ctr, options)
 
-	store := ctr.Runtime().GetStore()
-	if store == nil {
-		return nil, errors.Errorf("could not determine storage store for container")
-	}
-
 	var runRoot string
 	if options.New {
 		runRoot = "%t/containers"
 	} else {
-		runRoot = store.RunRoot()
+		runRoot = ctr.Runtime().RunRoot()
 		if runRoot == "" {
 			return nil, errors.Errorf("could not lookup container's runroot: got empty string")
 		}


### PR DESCRIPTION
We should not be exposing the store outside of Libpod. We want to encapsulate it as an internal implementation detail - there's no reason functions outside of Libpod should directly be manipulating container storage. Convert the last use to invoke a method on Libpod instead, and remove the function.

[NO TESTS NEEDED] as this is just a refactor.
