### PR TITLE
[CI:DOCS] fix: logo not loading after barnch renaming

### DIFF
--- a/docs/source/includes.rst
+++ b/docs/source/includes.rst
@@ -16,4 +16,4 @@
 .. _podman run: http://docs.podman.io/en/latest/markdown/podman-run.1.html
 .. _podman build: http://docs.podman.io/en/latest/markdown/podman-build.1.html
 .. _podman push: http://docs.podman.io/en/latest/markdown/podman-push.1.html
-.. image:: https://github.com/containers/podman/blob/master/logo/podman-logo.png?raw=true
+.. image:: https://github.com/containers/podman/blob/main/logo/podman-logo.png?raw=true


### PR DESCRIPTION
You've renamed your branch from master to main and thus this URL here did not work anymore and caused a glitch in displaying the image in the docs.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

Also, maybe just direct-link to https://raw.githubusercontent.com/containers/podman/main/logo/podman-logo.png?
After all, this saves one redirect and GitHub also just redirects the current URL there…