### PR TITLE
Add container config to compat image inspect

### DIFF
--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -232,27 +232,32 @@ func ImageDataToImageInspect(ctx context.Context, l *libimage.Image) (*ImageInsp
 		Name: info.GraphDriver.Name,
 		Data: info.GraphDriver.Data,
 	}
+	// Add in basic ContainerConfig to satisfy docker-compose
+	cc := new(dockerContainer.Config)
+	cc.Hostname = info.ID[0:11] // short ID is the hostname
+	cc.Volumes = info.Config.Volumes
+
 	dockerImageInspect := docker.ImageInspect{
-		Architecture:  info.Architecture,
-		Author:        info.Author,
-		Comment:       info.Comment,
-		Config:        &config,
-		Created:       l.Created().Format(time.RFC3339Nano),
-		DockerVersion: info.Version,
-		GraphDriver:   graphDriver,
-		ID:            "sha256:" + l.ID(),
-		Metadata:      docker.ImageMetadata{},
-		Os:            info.Os,
-		OsVersion:     info.Version,
-		Parent:        info.Parent,
-		RepoDigests:   info.RepoDigests,
-		RepoTags:      info.RepoTags,
-		RootFS:        rootfs,
-		Size:          info.Size,
-		Variant:       "",
-		VirtualSize:   info.VirtualSize,
+		Architecture:    info.Architecture,
+		Author:          info.Author,
+		Comment:         info.Comment,
+		Config:          &config,
+		ContainerConfig: cc,
+		Created:         l.Created().Format(time.RFC3339Nano),
+		DockerVersion:   info.Version,
+		GraphDriver:     graphDriver,
+		ID:              "sha256:" + l.ID(),
+		Metadata:        docker.ImageMetadata{},
+		Os:              info.Os,
+		OsVersion:       info.Version,
+		Parent:          info.Parent,
+		RepoDigests:     info.RepoDigests,
+		RepoTags:        info.RepoTags,
+		RootFS:          rootfs,
+		Size:            info.Size,
+		Variant:         "",
+		VirtualSize:     info.VirtualSize,
 	}
-	// TODO: consider filling the container config.
 	return &ImageInspect{dockerImageInspect}, nil
 }
 

--- a/test/compose/uptwice/Dockerfile
+++ b/test/compose/uptwice/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine
+WORKDIR /app

--- a/test/compose/uptwice/docker-compose.yml
+++ b/test/compose/uptwice/docker-compose.yml
@@ -1,0 +1,5 @@
+version: '3'
+services:
+    app:
+        build: .
+        command: sleep 10002

--- a/test/compose/uptwice/tests.sh
+++ b/test/compose/uptwice/tests.sh
@@ -1,0 +1,4 @@
+# -*- bash -*-
+
+sed -i -e 's/10001/10002/' docker-compose.yml
+docker-compose up -d


### PR DESCRIPTION
With docker-compose, there is a use case where you can `docker-compose
up -d`, then change a file like docker-compose.yml and run up again.
This requires a ContainerConfig with at least Volumes be populated in
the inspect data.  This PR adds just that.

Fixes: #10795

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
