### PR TITLE
podman pod create --pid flag

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -293,6 +293,7 @@ func createPodIfNecessary(s *specgen.SpecGenerator, netOpts *entities.NetOptions
 		Hostname:      s.ContainerBasicConfig.Hostname,
 		Cpus:          cliVals.CPUS,
 		CpusetCpus:    cliVals.CPUSetCPUs,
+		Pid:           cliVals.PID,
 	}
 	// Unset config values we passed to the pod to prevent them being used twice for the container and pod.
 	s.ContainerBasicConfig.Hostname = ""

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -102,6 +102,10 @@ func init() {
 	flags.StringVarP(&createOptions.Hostname, hostnameFlagName, "", "", "Set a hostname to the pod")
 	_ = createCommand.RegisterFlagCompletionFunc(hostnameFlagName, completion.AutocompleteNone)
 
+	pidFlagName := "pid"
+	flags.StringVar(&createOptions.Pid, pidFlagName, "", "PID namespace to use")
+	_ = createCommand.RegisterFlagCompletionFunc(pidFlagName, common.AutocompleteNamespace)
+
 	podIDFileFlagName := "pod-id-file"
 	flags.StringVar(&podIDFile, podIDFileFlagName, "", "Write the pod ID to the file")
 	_ = createCommand.RegisterFlagCompletionFunc(podIDFileFlagName, completion.AutocompleteDefault)
@@ -178,6 +182,8 @@ func create(cmd *cobra.Command, args []string) error {
 		defer errorhandling.CloseQuiet(podIDFD)
 		defer errorhandling.SyncQuiet(podIDFD)
 	}
+
+	createOptions.Pid = cmd.Flag("pid").Value.String()
 
 	createOptions.Net, err = common.NetFlagsToNetOptions(cmd, createOptions.Infra)
 	if err != nil {

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -120,6 +120,14 @@ Add a DNS alias for the container. When the container is joined to a CNI network
 
 Disable creation of /etc/hosts for the pod.
 
+#### **--pid**=*pid*
+
+Set the PID mode for the pod. The default is to create a private PID namespace for the pod. Requires the PID namespace to be shared via --share.
+
+    host: use the host’s PID namespace for the pod
+    ns: join the specified PID namespace
+    private: create a new namespace for the pod (default)
+
 #### **--pod-id-file**=*path*
 
 Write the pod ID to the file.

--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -103,6 +103,8 @@ type InspectPodInfraConfig struct {
 	CPUQuota int64 `json:"cpu_quota,omitempty"`
 	// CPUSetCPUs contains linux specific CPU data for the container
 	CPUSetCPUs string `json:"cpuset_cpus,omitempty"`
+	// Pid is the PID namespace mode of the pod's infra container
+	PidNS string `json:"pid_ns,omitempty"`
 }
 
 // InspectPodContainerInfo contains information on a container in a pod.

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/libpod/lock"
+	"github.com/containers/podman/v3/pkg/specgen"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -97,6 +98,7 @@ type InfraContainerConfig struct {
 	HasInfraContainer  bool                  `json:"makeInfraContainer"`
 	NoNetwork          bool                  `json:"noNetwork,omitempty"`
 	HostNetwork        bool                  `json:"infraHostNetwork,omitempty"`
+	PidNS              specgen.Namespace     `json:"infraPid,omitempty"`
 	PortBindings       []ocicni.PortMapping  `json:"infraPortBindings"`
 	StaticIP           net.IP                `json:"staticIP,omitempty"`
 	StaticMAC          net.HardwareAddr      `json:"staticMAC,omitempty"`
@@ -168,6 +170,11 @@ func (p *Pod) CPUQuota() int64 {
 		return *resCopy.CPU.Quota
 	}
 	return 0
+}
+
+// PidMode returns the PID mode given by the user ex: pod, private...
+func (p *Pod) PidMode() string {
+	return string(p.config.InfraContainer.PidNS.NSMode)
 }
 
 // Labels returns the pod's labels

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -541,6 +541,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		infraConfig.CPUPeriod = p.CPUPeriod()
 		infraConfig.CPUQuota = p.CPUQuota()
 		infraConfig.CPUSetCPUs = p.ResourceLim().CPU.Cpus
+		infraConfig.PidNS = p.PidMode()
 
 		if len(p.config.InfraContainer.DNSServer) > 0 {
 			infraConfig.DNSServer = make([]string, 0, len(p.config.InfraContainer.DNSServer))

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -145,6 +145,18 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, rawIm
 		if len(p.config.InfraContainer.ExitCommand) > 0 {
 			options = append(options, WithExitCommand(p.config.InfraContainer.ExitCommand))
 		}
+
+		if p.config.UsePodPID && p.config.InfraContainer.PidNS.NSMode != "host" {
+			g.AddOrReplaceLinuxNamespace(string(spec.LinuxNamespaceType("pid")), p.config.InfraContainer.PidNS.Value)
+		} else if p.config.InfraContainer.PidNS.NSMode == "host" {
+			newNS := []spec.LinuxNamespace{}
+			for _, entry := range g.Config.Linux.Namespaces {
+				if entry.Type != spec.LinuxNamespaceType("pid") {
+					newNS = append(newNS, entry)
+				}
+			}
+			g.Config.Linux.Namespaces = newNS
+		}
 	}
 	g.SetRootReadonly(true)
 	g.SetProcessArgs(infraCtrCommand)

--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -116,6 +116,7 @@ func (r *Runtime) NewPod(ctx context.Context, options ...PodCreateOption) (_ *Po
 	if pod.config.UsePodCgroup {
 		logrus.Debugf("Got pod cgroup as %s", pod.state.CgroupPath)
 	}
+
 	if !pod.HasInfraContainer() && pod.SharesNamespaces() {
 		return nil, errors.Errorf("Pods must have an infra container to share namespaces")
 	}

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -102,6 +102,10 @@ func createPodOptions(p *specgen.PodSpecGenerator, rt *libpod.Runtime) ([]libpod
 		options = append(options, libpod.WithInfraCommand(p.InfraCommand))
 	}
 
+	if !p.Pid.IsDefault() {
+		options = append(options, libpod.WithPodPidNS(p.Pid))
+	}
+
 	switch p.NetNS.NSMode {
 	case specgen.Default, "":
 		if p.NoInfra {

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -57,6 +57,10 @@ type PodBasicConfig struct {
 	// (e.g. `podman generate systemd --new`).
 	// Optional.
 	PodCreateCommand []string `json:"pod_create_command,omitempty"`
+	// Pid sets the process id namespace of the pod
+	// Optional (defaults to private if unset). This sets the PID namespace of the infra container
+	// This configuration will then be shared with the entire pod if PID namespace sharing is enabled via --share
+	Pid Namespace `json:"pid,omitempty:"`
 }
 
 // PodNetworkConfig contains networking configuration for a pod.

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -559,4 +559,65 @@ ENTRYPOINT ["sleep","99999"]
 		podJSON := podInspect.InspectPodToJSON()
 		Expect(podJSON.CPUSetCPUs).To(Equal(in))
 	})
+
+	It("podman pod create --pid", func() {
+		podName := "pidPod"
+		ns := "ns:/proc/self/ns/"
+		podCreate := podmanTest.Podman([]string{"pod", "create", "--pid", ns, "--name", podName, "--share", "pid"})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate.ExitCode()).To(Equal(0))
+
+		podInspect := podmanTest.Podman([]string{"pod", "inspect", podName})
+		podInspect.WaitWithDefaultTimeout()
+		Expect(podInspect.ExitCode()).To(Equal(0))
+		podJSON := podInspect.InspectPodToJSON()
+		Expect(podJSON.InfraConfig.PidNS).To(Equal("path"))
+
+		podName = "pidPod2"
+		ns = "pod"
+
+		podCreate = podmanTest.Podman([]string{"pod", "create", "--pid", ns, "--name", podName, "--share", "pid"})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate.ExitCode()).To(Equal(0))
+
+		podInspect = podmanTest.Podman([]string{"pod", "inspect", podName})
+		podInspect.WaitWithDefaultTimeout()
+		Expect(podInspect.ExitCode()).To(Equal(0))
+		podJSON = podInspect.InspectPodToJSON()
+		Expect(podJSON.InfraConfig.PidNS).To(Equal("pod"))
+
+		podName = "pidPod3"
+		ns = "host"
+
+		podCreate = podmanTest.Podman([]string{"pod", "create", "--pid", ns, "--name", podName, "--share", "pid"})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate.ExitCode()).To(Equal(0))
+
+		podInspect = podmanTest.Podman([]string{"pod", "inspect", podName})
+		podInspect.WaitWithDefaultTimeout()
+		Expect(podInspect.ExitCode()).To(Equal(0))
+		podJSON = podInspect.InspectPodToJSON()
+		Expect(podJSON.InfraConfig.PidNS).To(Equal("host"))
+
+		podName = "pidPod4"
+		ns = "private"
+
+		podCreate = podmanTest.Podman([]string{"pod", "create", "--pid", ns, "--name", podName, "--share", "pid"})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate.ExitCode()).To(Equal(0))
+
+		podInspect = podmanTest.Podman([]string{"pod", "inspect", podName})
+		podInspect.WaitWithDefaultTimeout()
+		Expect(podInspect.ExitCode()).To(Equal(0))
+		podJSON = podInspect.InspectPodToJSON()
+		Expect(podJSON.InfraConfig.PidNS).To(Equal("private"))
+
+		podName = "pidPod5"
+		ns = "container:randomfakeid"
+
+		podCreate = podmanTest.Podman([]string{"pod", "create", "--pid", ns, "--name", podName, "--share", "pid"})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate).Should(ExitWithError())
+
+	})
 })


### PR DESCRIPTION
added support for --pid flag. User can specify ns:file, pod, private, or host pid namespace values. container returns an error since you cannot point the ns of the pods infra container
to a container outside of the pod.

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
