### PR TITLE
manifest create subcommand should accept more than 2 arguments

### DIFF
--- a/cmd/podman/manifest/create.go
+++ b/cmd/podman/manifest/create.go
@@ -20,8 +20,9 @@ var (
 		ValidArgsFunction: common.AutocompleteImages,
 		Example: `podman manifest create mylist:v1.11
   podman manifest create mylist:v1.11 arch-specific-image-to-add
+  podman manifest create mylist:v1.11 arch-specific-image-to-add another-arch-specific-image-to-add
   podman manifest create --all mylist:v1.11 transport:tagged-image-to-add`,
-		Args: cobra.RangeArgs(1, 2),
+		Args: cobra.MinimumNArgs(1),
 	}
 )
 

--- a/cmd/podman/manifest/create.go
+++ b/cmd/podman/manifest/create.go
@@ -13,7 +13,7 @@ import (
 var (
 	manifestCreateOpts = entities.ManifestCreateOptions{}
 	createCmd          = &cobra.Command{
-		Use:               "create [options] LIST [IMAGE]",
+		Use:               "create [options] LIST [IMAGE...]",
 		Short:             "Create manifest list or image index",
 		Long:              "Creates manifest lists or image indexes.",
 		RunE:              create,

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -50,6 +50,12 @@ var _ = Describe("Podman manifest", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman manifest create", func() {
+		session := podmanTest.Podman([]string{"manifest", "create", "foo", imageList})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman manifest inspect", func() {
 		session := podmanTest.Podman([]string{"manifest", "inspect", BB})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
The current implementation does not allow passing more than one image.

- Before
```shell
$ podman manifest create quay.io/rsevilla/perfapp:manifest-latest2 quay.io/rsevilla/perfapp:latest quay.io/rsevilla/perfapp:arm
Error: accepts between 1 and 2 arg(s), received 3  
```
- After:
```shell
$ ./bin/podman manifest create quay.io/rsevilla/perfapp:manifest-latest2 quay.io/rsevilla/perfapp:latest quay.io/rsevilla/perfapp:arm
9c55826980e16d0202147e5ea01a191fa95d58a3614173e8a4e3e38cc384a7ae
$ podman manifest inspect quay.io/rsevilla/perfapp:manifest-latest2
{
    "schemaVersion": 2,
    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
    "manifests": [
        {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "size": 591,
            "digest": "sha256:9d1a6c94edea56d47a8f08dbe957eae6ae6797847017e6e243d06b424735ddfc",
            "platform": {
                "architecture": "amd64",
                "os": "linux"
            }
        },
        {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "size": 591,
            "digest": "sha256:8aec9d12c9033fddcd1840c7bc17b5b5671637e68301334421ce9876a5f2a7d8",
            "platform": {
                "architecture": "arm64",
                "os": "linux"
            }
        }
    ]
}

```

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

