### PR TITLE
auto-update: add --dry-run

### DIFF
--- a/cmd/podman/auto-update.go
+++ b/cmd/podman/auto-update.go
@@ -53,6 +53,8 @@ func init() {
 	flags.StringVar(&autoUpdateOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path to the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = autoUpdateCommand.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
+	flags.BoolVar(&autoUpdateOptions.DryRun, "dry-run", false, "Check for pending updates")
+
 	flags.StringVar(&autoUpdateOptions.format, "format", "", "Change the output format to JSON or a Go template")
 	_ = autoUpdateCommand.RegisterFlagCompletionFunc("format", common.AutocompleteFormat(autoUpdateOutput{}))
 }

--- a/pkg/domain/entities/auto-update.go
+++ b/pkg/domain/entities/auto-update.go
@@ -4,6 +4,10 @@ package entities
 type AutoUpdateOptions struct {
 	// Authfile to use when contacting registries.
 	Authfile string
+	// Only check for but do not perform any update.  If an update is
+	// pending, it will be indicated in the Updated field of
+	// AutoUpdateReport.
+	DryRun bool
 }
 
 // AutoUpdateReport contains the results from running auto-update.
@@ -18,7 +22,7 @@ type AutoUpdateReport struct {
 	Policy string
 	// SystemdUnit running a container configured for auto updates.
 	SystemdUnit string
-	// Indicates whether the image was updated and the container (and
-	// systemd unit) restarted.
+	// Indicates the update status: true, false, failed, pending (see
+	// DryRun).
 	Updated string
 }

--- a/pkg/domain/infra/abi/auto-update.go
+++ b/pkg/domain/infra/abi/auto-update.go
@@ -8,9 +8,5 @@ import (
 )
 
 func (ic *ContainerEngine) AutoUpdate(ctx context.Context, options entities.AutoUpdateOptions) ([]*entities.AutoUpdateReport, []error) {
-	// Convert the entities options to the autoupdate ones.  We can't use
-	// them in the entities package as low-level packages must not leak
-	// into the remote client.
-	autoOpts := autoupdate.Options{Authfile: options.Authfile}
-	return autoupdate.AutoUpdate(ctx, ic.Libpod, autoOpts)
+	return autoupdate.AutoUpdate(ctx, ic.Libpod, options)
 }

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -121,6 +121,9 @@ function _confirm_update() {
     generate_service alpine image
 
     _wait_service_ready container-$cname.service
+    run_podman auto-update --dry-run --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
+    is "$output" ".*container-$cname.service,quay.io/libpod/alpine:latest,pending,registry.*" "Image update is pending."
+
     run_podman auto-update --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
     is "$output" "Trying to pull.*" "Image is updated."
     is "$output" ".*container-$cname.service,quay.io/libpod/alpine:latest,true,registry.*" "Image is updated."
@@ -159,6 +162,9 @@ function _confirm_update() {
     imageID="$output"
 
     _wait_service_ready container-$cname.service
+    run_podman auto-update --dry-run --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
+    is "$output" ".*container-$cname.service,quay.io/libpod/localtest:latest,pending,local.*" "Image update is pending."
+
     run_podman auto-update --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
     is "$output" ".*container-$cname.service,quay.io/libpod/localtest:latest,true,local.*" "Image is updated."
 


### PR DESCRIPTION
Add a --dry-run flag to `podman auto-update` which will look for new
images but won't perform any pull or restart any service or container.

The "UPDATED" column will now indicate the availability of a newer image
via "pending".

```
$ podman auto-update --dry-run
UNIT                    CONTAINER            IMAGE                   POLICY      UPDATED
container-test.service  08fd34e533fd (test)  localhost:5000/busybox  registry    pending
```

Fixes: #9949
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
