### PR TITLE
podman start: remove containers configured for auto removal

### DIFF
--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -65,7 +65,6 @@ var _ = Describe("Podman start", func() {
 	})
 
 	It("podman start --rm --attach removed on failure", func() {
-		Skip("FIXME: #10935, race condition removing container")
 		session := podmanTest.Podman([]string{"create", "--rm", ALPINE, "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))


### PR DESCRIPTION
Make sure that containers configured for auto removal
(e.g., via `podman create --rm`) are removed in `podman start`
if starting the container failed.

Fixes: #10935
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
