### PR TITLE
systemd: require network*-online*.target

### DIFF
--- a/contrib/systemd/auto-update/podman-auto-update.service
+++ b/contrib/systemd/auto-update/podman-auto-update.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Podman auto-update service
 Documentation=man:podman-auto-update(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 
 [Service]

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -73,7 +73,7 @@ $ podman generate systemd --restart-policy=always -t 1 nginx
 [Unit]
 Description=Podman container-de1e3223b1b888bc02d0962dd6cb5855eb00734061013ffdd3479d225abacdc6.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/container/storage
 
@@ -102,7 +102,7 @@ $ sudo podman generate systemd --new --files --name bb310a0780ae
 [Unit]
 Description=Podman container-busy_moser.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/container/storage
 
@@ -144,7 +144,7 @@ Description=Podman pod-systemd-pod.service
 Documentation=man:podman-generate-systemd(1)
 Requires=container-amazing_chandrasekhar.service container-jolly_shtern.service
 Before=container-amazing_chandrasekhar.service container-jolly_shtern.service
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/container/storage
 

--- a/pkg/systemd/generate/common.go
+++ b/pkg/systemd/generate/common.go
@@ -34,7 +34,7 @@ const headerTemplate = `# {{{{.ServiceName}}}}.service
 [Unit]
 Description=Podman {{{{.ServiceName}}}}.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor={{{{.RunRoot}}}}
 `

--- a/pkg/systemd/generate/containers_test.go
+++ b/pkg/systemd/generate/containers_test.go
@@ -46,7 +46,7 @@ func TestCreateContainerSystemdUnit(t *testing.T) {
 [Unit]
 Description=Podman container-639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -72,7 +72,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman container-foobar.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -96,7 +96,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman container-foobar.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 BindsTo=a.service b.service c.service pod.service
@@ -122,7 +122,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -144,7 +144,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -166,7 +166,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -188,7 +188,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -210,7 +210,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman container-639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -233,7 +233,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -259,7 +259,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -281,7 +281,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -303,7 +303,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -325,7 +325,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -347,7 +347,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -369,7 +369,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -391,7 +391,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 
@@ -413,7 +413,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman jadda-jadda.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 

--- a/pkg/systemd/generate/pods_test.go
+++ b/pkg/systemd/generate/pods_test.go
@@ -45,7 +45,7 @@ func TestCreatePodSystemdUnit(t *testing.T) {
 [Unit]
 Description=Podman pod-123abc.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 Requires=container-1.service container-2.service
@@ -73,7 +73,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman pod-123abc.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 Requires=container-1.service container-2.service
@@ -101,7 +101,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman pod-123abc.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 Requires=container-1.service container-2.service
@@ -129,7 +129,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman pod-123abc.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 Requires=container-1.service container-2.service
@@ -157,7 +157,7 @@ WantedBy=multi-user.target default.target
 [Unit]
 Description=Podman pod-123abc.service
 Documentation=man:podman-generate-systemd(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 RequiresMountsFor=/var/run/containers/storage
 Requires=container-1.service container-2.service

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -249,7 +249,7 @@ EOF
 [Unit]
 Description=Podman auto-update testing service
 Documentation=man:podman-auto-update(1)
-Wants=network.target
+Wants=network-online.target
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
Require the network to be online in all (generated) systemd units to
make sure that containers and Podman run only after the network has been
fully configured.

Fixes: #10655
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
