### PR TITLE
--authfile command line argument for image sign command.

### DIFF
--- a/cmd/podman/images/sign.go
+++ b/cmd/podman/images/sign.go
@@ -3,6 +3,7 @@ package images
 import (
 	"os"
 
+	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/registry"
@@ -48,6 +49,10 @@ func init() {
 	flags.StringVar(&signOptions.CertDir, certDirFlagName, "", "`Pathname` of a directory containing TLS certificates and keys")
 	_ = signCommand.RegisterFlagCompletionFunc(certDirFlagName, completion.AutocompleteDefault)
 	flags.BoolVarP(&signOptions.All, "all", "a", false, "Sign all the manifests of the multi-architecture image")
+
+	authFileFlagName := "authfile"
+	flags.StringVar(&signOptions.AuthFile, authFileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file.")
+	_ = signCommand.RegisterFlagCompletionFunc(authFileFlagName, completion.AutocompleteDefault)
 }
 
 func sign(cmd *cobra.Command, args []string) error {

--- a/docs/source/markdown/podman-image-sign.1.md
+++ b/docs/source/markdown/podman-image-sign.1.md
@@ -36,6 +36,14 @@ Store the signatures in the specified directory.  Default: /var/lib/containers/s
 
 Override the default identity of the signature.
 
+#### **--authfile**=*path*
+
+Path of the authentication file. If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using docker login.
+
+Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using podman login.
+
+IMPORTANT: The default path of the authentication file can be overwritten by setting the REGISTRY\_AUTH\_FILE environment variable. export REGISTRY_AUTH_FILE=path
+
 ## EXAMPLES
 Sign the busybox image with the identity of foo@bar.com with a user's keyring and save the signature in /tmp/signatures/.
 

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -369,6 +369,7 @@ type SignOptions struct {
 	Directory string
 	SignBy    string
 	CertDir   string
+	AuthFile  string
 	All       bool
 }
 

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -638,7 +638,10 @@ func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entitie
 	return nil, nil
 }
 
-func getSigFilename(sigStoreDirPath string) (string, error) {
+func getSigFilename(sigStoreDirPath string, options entities.SignOptions) (string, error) {
+	if options.AuthFile != "" {
+		return options.AuthFile, nil
+	}
 	sigFileSuffix := 1
 	sigFiles, err := ioutil.ReadDir(sigStoreDirPath)
 	if err != nil {
@@ -677,7 +680,7 @@ func putSignature(manifestBlob []byte, mech signature.SigningMechanism, sigStore
 			return err
 		}
 	}
-	sigFilename, err := getSigFilename(signatureDir)
+	sigFilename, err := getSigFilename(signatureDir, options)
 	if err != nil {
 		return err
 	}

--- a/test/system/011-image.bats
+++ b/test/system/011-image.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+    skip_if_remote "--sign-by does not work with podman-remote"
+
+    basic_setup
+
+    export _GNUPGHOME_TMP=$PODMAN_TMPDIR/.gnupg
+    mkdir --mode=0700 $_GNUPGHOME_TMP $PODMAN_TMPDIR/signatures
+
+    cat >$PODMAN_TMPDIR/keydetails <<EOF
+    %echo Generating a basic OpenPGP key
+    Key-Type: RSA
+    Key-Length: 2048
+    Subkey-Type: RSA
+    Subkey-Length: 2048
+    Name-Real: Foo
+    Name-Comment: Foo
+    Name-Email: foo@bar.com
+    Expire-Date: 0
+    %no-ask-passphrase
+    %no-protection
+    # Do a commit here, so that we can later print "done" :-)
+    %commit
+    %echo done
+EOF
+    GNUPGHOME=$_GNUPGHOME_TMP gpg --verbose --batch --gen-key $PODMAN_TMPDIR/keydetails
+}
+
+function check_signature() {
+    ls -laR $PODMAN_TMPDIR/signatures
+    run_podman inspect --format '{{.Digest}}' $PODMAN_TEST_IMAGE_FQN
+    local repodigest=${output/:/=}
+
+    local dir="$PODMAN_TMPDIR/signatures/libpod/${PODMAN_TEST_IMAGE_NAME}@${repodigest}"
+
+    test -d $dir || die "Missing signature directory $dir"
+    test -e "$dir/$1" || die "Missing signature file '$1'"
+
+    # Confirm good signature
+    GNUPGHOME=$_GNUPGHOME_TMP gpg --verify "$dir/$1"
+}
+
+
+@test "podman image - sign with no authfile" {
+    GNUPGHOME=$_GNUPGHOME_TMP run_podman image sign --sign-by foo@bar.com --directory $PODMAN_TMPDIR/signatures  "docker://$PODMAN_TEST_IMAGE_FQN"
+    check_signature "signature-1"
+}
+
+@test "podman image - sign with authfile" {
+    local signature_file="$(random_string 10 | tr A-Z a-z)"
+
+    GNUPGHOME=$_GNUPGHOME_TMP run_podman image sign --sign-by foo@bar.com --directory $PODMAN_TMPDIR/signatures  --authfile $signature_file "docker://$PODMAN_TEST_IMAGE_FQN"
+    check_signature "$signature_file"
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
Adds the --auth-file command line argument to allow users to define the signature file name.

Closes #10866 