### PR TITLE
compat: image create: handle platform correctly

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -45,6 +45,11 @@ t POST "images/create?fromImage=alpine" 200 .error~null .status~".*Download comp
 
 t POST "images/create?fromImage=alpine&tag=latest" 200
 
+# 10977 - handle platform parameter correctly
+t POST "images/create?fromImage=alpine&platform=linux/arm64" 200
+t GET  "images/alpine/json" 200 \
+  .Architecture=arm64
+
 # Make sure that new images are pulled
 old_iid=$(podman image inspect --format "{{.ID}}" docker.io/library/alpine:latest)
 podman rmi -f docker.io/library/alpine:latest


### PR DESCRIPTION
Handle the platform parameter correctly.  The parameter was only parsed
in presence of credentials and the code was a bit complex.  Also add a
regression test.

Fixes: #10977
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
