### PR TITLE
Flake Fix: Wait before connecting to container port

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -139,6 +139,8 @@ load helpers
                    $IMAGE nc -l -n -v -p $myport
         cid="$output"
 
+        wait_for_port 127.0.0.1 $myport
+
         # emit random string, and check it
         teststring=$(random_string 30)
         echo "$teststring" | nc 127.0.0.1 $myport

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -278,6 +278,24 @@ function wait_for_ready {
     wait_for_output 'READY' "$@"
 }
 
+###################
+#  wait_for_port  #  Returns once port is available on host
+###################
+function wait_for_port() {
+    local host=$1                      # Probably "localhost"
+    local port=$2                      # Numeric port
+    local _timeout=${3:-5}              # Optional; default to 5 seconds
+
+    # Wait
+    while [ $_timeout -gt 0 ]; do
+        { exec 3<> /dev/tcp/$host/$port; } &>/dev/null && return
+        sleep 1
+        _timeout=$(( $_timeout - 1 ))
+    done
+
+    die "Timed out waiting for $host:$port"
+}
+
 # END   podman helpers
 ###############################################################################
 # BEGIN miscellaneous tools


### PR DESCRIPTION
It was observed during periodic testing, this test can fail due to the
container process being not fully running and listening on the expected
port:

```
[+1069s] not ok 220 podman networking: port with --userns=keep-id
[+1069s] # (in test file test/system/500-networking.bats, line 144)
[+1069s] #   `echo "$teststring" | nc 127.0.0.1 $myport' failed
[+1069s] # # /var/tmp/go/src/github.com/containers/podman/bin/podman rm
--all --force
[+1069s] # # /var/tmp/go/src/github.com/containers/podman/bin/podman ps
--all --external --format {{.ID}} {{.Names}}
[+1069s] # # /var/tmp/go/src/github.com/containers/podman/bin/podman
images --all --format {{.Repository}}:{{.Tag}} {{.ID}}
[+1069s] # quay.io/libpod/testimage:20210610 9f9ec7f2fdef
[+1069s] # # /var/tmp/go/src/github.com/containers/podman/bin/podman run
-d --userns=keep-id -p 127.0.0.1:54322:54322
quay.io/libpod/testimage:20210610 nc -l -n -v -p 54322
[+1069s] #
252c562c9a3c96892d867d1d72fb52b2efdfe62855ebedbccd2d281c472c2988
[+1069s] # Ncat: No route to host.
```

Fix this by using a new `wait_for_port()` function (thanks @edsantiago)
before attempting to communicate with the service.