### PR TITLE
system test: auto-update: multiarch fixes, and cleanup

### DIFF
--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -36,7 +36,7 @@ function teardown() {
 
     rm -f $SNAME_FILE
     run_podman ? rmi quay.io/libpod/alpine:latest
-    run_podman ? rmi quay.io/libpod/alpine_nginx:latest
+    run_podman ? rmi quay.io/libpod/busybox:latest
     run_podman ? rmi quay.io/libpod/localtest:latest
     basic_teardown
 }
@@ -191,7 +191,7 @@ function _confirm_update() {
     do
         local img_base="alpine"
         if [[ $auto_update == "registry" ]]; then
-            img_base="alpine_nginx"
+            img_base="busybox"
         elif [[ $auto_update == "local" ]]; then
             img_base="localtest"
         fi


### PR DESCRIPTION
auto-update test is failing on non-x86_64 arch:

   https://gitlab.com/cki-project/kernel-tests/-/issues/614#note_630010734

Reason: test was relying on alpine_nginx image; this is
a custom libpod image that only has a x86_64 version.

Solution: use busybox instead. Busybox was copied from
docker.io using skopeo copy --all, so it has all arches.

Also: allow tests to run as rootless, they were being
skipped for no clear reason.

Also: use --files and --name option in generate-systemd. Before,
output went to stdout, resulting in completely unreadable logs
on test failure.

Signed-off-by: Ed Santiago <santiago@redhat.com>
