### PR TITLE
[CI:DOCS] refine the runlabel man page

### DIFF
--- a/docs/source/markdown/podman-container.1.md
+++ b/docs/source/markdown/podman-container.1.md
@@ -38,7 +38,7 @@ The container command allows you to manage containers
 | restore    | [podman-container-restore(1)](podman-container-restore.1.md)  | Restores one or more containers from a checkpoint.                 |
 | rm         | [podman-rm(1)](podman-rm.1.md)                      | Remove one or more containers.                                               |
 | run        | [podman-run(1)](podman-run.1.md)                    | Run a command in a container.                                                |
-| runlabel   | [podman-container-runlabel(1)](podman-container-runlabel.1.md)  | Executes a command as described by a container image label.      |
+| runlabel   | [podman-container-runlabel(1)](podman-container-runlabel.1.md)  | Executes a command as described by a container-image label.      |
 | start      | [podman-start(1)](podman-start.1.md)                | Starts one or more containers.                                               |
 | stats      | [podman-stats(1)](podman-stats.1.md)                | Display a live stream of one or more container's resource usage statistics.  |
 | stop       | [podman-stop(1)](podman-stop.1.md)                  | Stop one or more running containers.                                         |


### PR DESCRIPTION
* Write a description to outline the scope and mechanism of runlabel.
* Describe the variables/attributes that we want to be used.
* Do not describe the --optN or OPTN flags/variables since they are
  already hidden flags and date back to the Atomic days.
* Update references to other man pages.
* Remove unsupported variables (e.g., SUDO_*) which caused confusion.

Fixes: #10799
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
