### PR TITLE
system tests: cleaner, safer use of systemd

### DIFF
--- a/test/system/270-socket-activation.bats
+++ b/test/system/270-socket-activation.bats
@@ -4,21 +4,12 @@
 #
 
 load helpers
+load helpers.systemd
 
 SERVICE_NAME="podman_test_$(random_string)"
 
-SYSTEMCTL="systemctl"
-UNIT_DIR="/usr/lib/systemd/system"
 SERVICE_SOCK_ADDR="/run/podman/podman.sock"
-
 if is_rootless; then
-    UNIT_DIR="$HOME/.config/systemd/user"
-    mkdir -p $UNIT_DIR
-
-    SYSTEMCTL="$SYSTEMCTL --user"
-    if [ -z "$XDG_RUNTIME_DIR" ]; then
-        export XDG_RUNTIME_DIR=/run/user/$(id -u)
-    fi
     SERVICE_SOCK_ADDR="$XDG_RUNTIME_DIR/podman/podman.sock"
 fi
 
@@ -66,13 +57,13 @@ EOF
             rm -f $pause_pid
         fi
     fi
-    $SYSTEMCTL start "$SERVICE_NAME.socket"
+    systemctl start "$SERVICE_NAME.socket"
 }
 
 function teardown() {
-    $SYSTEMCTL stop "$SERVICE_NAME.socket"
+    systemctl stop "$SERVICE_NAME.socket"
     rm -f "$SERVICE_FILE" "$SOCKET_FILE"
-    $SYSTEMCTL daemon-reload
+    systemctl daemon-reload
     basic_teardown
 }
 

--- a/test/system/helpers.systemd.bash
+++ b/test/system/helpers.systemd.bash
@@ -1,0 +1,30 @@
+# -*- bash -*-
+#
+# BATS helpers for systemd-related functionality
+#
+
+# podman initializes this if unset, but systemctl doesn't
+if [ -z "$XDG_RUNTIME_DIR" ]; then
+    if is_rootless; then
+        export XDG_RUNTIME_DIR=/run/user/$(id -u)
+    fi
+fi
+
+# For tests which write systemd unit files
+UNIT_DIR="/run/systemd/system"
+_DASHUSER=
+if is_rootless; then
+    UNIT_DIR="${XDG_RUNTIME_DIR}/systemd/user"
+    # Why isn't systemd smart enough to figure this out on its own?
+    _DASHUSER="--user"
+fi
+
+mkdir -p $UNIT_DIR
+
+systemctl() {
+    command systemctl $_DASHUSER "$@"
+}
+
+journalctl() {
+    command journalctl $_DASHUSER "$@"
+}


### PR DESCRIPTION
First and foremost: use ephemeral (/run, $XDG) directories
for systemd unit files, so as not to vandalize a working system.

Second, refactor common systemd-related functionality into
a new helper file, loaded by the systemd-related tests.
Shared functionality includes:

  * setting $XDG_RUNTIME_DIR if unset and rootless
  * setting $UNIT_DIR for use by tests
  * new systemctl() and journalctl() functions, which
    include "--user" when rootless (why can't systemd
    figure this out on its own?)

Signed-off-by: Ed Santiago <santiago@redhat.com>
