### PR TITLE
Implemented --until flag for Libpod's Container Logs

### DIFF
--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -19,6 +19,8 @@ type logsOptionsWrapper struct {
 	entities.ContainerLogsOptions
 
 	SinceRaw string
+
+	UntilRaw string
 }
 
 var (
@@ -101,6 +103,10 @@ func logsFlags(cmd *cobra.Command) {
 	flags.StringVar(&logsOptions.SinceRaw, sinceFlagName, "", "Show logs since TIMESTAMP")
 	_ = cmd.RegisterFlagCompletionFunc(sinceFlagName, completion.AutocompleteNone)
 
+	untilFlagName := "until"
+	flags.StringVar(&logsOptions.UntilRaw, untilFlagName, "", "Show logs until TIMESTAMP")
+	_ = cmd.RegisterFlagCompletionFunc(untilFlagName, completion.AutocompleteNone)
+
 	tailFlagName := "tail"
 	flags.Int64Var(&logsOptions.Tail, tailFlagName, -1, "Output the specified number of LINES at the end of the logs.  Defaults to -1, which prints all lines")
 	_ = cmd.RegisterFlagCompletionFunc(tailFlagName, completion.AutocompleteNone)
@@ -119,6 +125,14 @@ func logs(_ *cobra.Command, args []string) error {
 			return errors.Wrapf(err, "error parsing --since %q", logsOptions.SinceRaw)
 		}
 		logsOptions.Since = since
+	}
+	if logsOptions.UntilRaw != "" {
+		// parse time, error out if something is wrong
+		until, err := util.ParseInputTime(logsOptions.UntilRaw)
+		if err != nil {
+			return errors.Wrapf(err, "error parsing --until %q", logsOptions.UntilRaw)
+		}
+		logsOptions.Until = until
 	}
 	logsOptions.StdoutWriter = os.Stdout
 	logsOptions.StderrWriter = os.Stderr

--- a/docs/source/markdown/podman-logs.1.md
+++ b/docs/source/markdown/podman-logs.1.md
@@ -39,6 +39,14 @@ strings (e.g. 10m, 1h30m) computed relative to the client machine's time. Suppor
 time stamps include RFC3339Nano, RFC3339, 2006-01-02T15:04:05, 2006-01-02T15:04:05.999999999, 2006-01-02Z07:00,
 and 2006-01-02.
 
+#### **--until**=*TIMESTAMP*
+
+Show logs until TIMESTAMP. The --until option can be Unix timestamps, date formatted timestamps, or Go duration
+strings (e.g. 10m, 1h30m) computed relative to the client machine's time. Supported formats for date formatted
+time stamps include RFC3339Nano, RFC3339, 2006-01-02T15:04:05, 2006-01-02T15:04:05.999999999, 2006-01-02Z07:00,
+and 2006-01-02.
+
+
 #### **--tail**=*LINES*
 
 Output the specified number of LINES at the end of the logs.  LINES must be an integer.  Defaults to -1,
@@ -74,6 +82,17 @@ podman logs --tail 2 b3f2436bdb97
 # Server initialized
 ```
 
+To view all containers logs:
+```
+podman logs -t --since 0 myserver
+
+1:M 07 Aug 14:10:09.055 # Server can't set maximum open files to 10032 because of OS error: Operation not permitted.
+1:M 07 Aug 14:10:09.055 # Current maximum open files is 4096. maxclients has been reduced to 4064 to compensate for low ulimit. If you need higher maxclients increase 'ulimit -n'.
+1:M 07 Aug 14:10:09.056 * Running mode=standalone, port=6379.
+1:M 07 Aug 14:10:09.056 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
+1:M 07 Aug 14:10:09.056 # Server initialized
+```
+
 To view a containers logs since a certain time:
 ```
 podman logs -t --since 2017-08-07T10:10:09.055837383-04:00 myserver
@@ -91,6 +110,16 @@ podman logs --since 10m myserver
 
 # Server can't set maximum open files to 10032 because of OS error: Operation not permitted.
 # Current maximum open files is 4096. maxclients has been reduced to 4064 to compensate for low ulimit. If you need higher maxclients increase 'ulimit -n'.
+```
+
+To view a container's logs until 30 minutes ago:
+```
+podman logs --until 30m myserver
+
+AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 10.0.2.100. Set the 'ServerName' directive globally to suppress this message
+AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 10.0.2.100. Set the 'ServerName' directive globally to suppress this message
+[Tue Jul 20 13:18:14.223727 2021] [mpm_event:notice] [pid 1:tid 140021067187328] AH00489: Apache/2.4.48 (Unix) configured -- resuming normal operations
+[Tue Jul 20 13:18:14.223819 2021] [core:notice] [pid 1:tid 140021067187328] AH00094: Command line: 'httpd -D FOREGROUND'
 ```
 
 ## SEE ALSO

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -242,6 +242,8 @@ type ContainerLogsOptions struct {
 	Names bool
 	// Show logs since this timestamp.
 	Since time.Time
+	// Show logs until this timestamp.
+	Until time.Time
 	// Number of lines to display at the end of the output.
 	Tail int64
 	// Show timestamps in the logs.

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -998,6 +998,7 @@ func (ic *ContainerEngine) ContainerLogs(ctx context.Context, containers []strin
 		Details:    options.Details,
 		Follow:     options.Follow,
 		Since:      options.Since,
+		Until:      options.Until,
 		Tail:       options.Tail,
 		Timestamps: options.Timestamps,
 		UseName:    options.Names,

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -369,10 +369,11 @@ func (ic *ContainerEngine) ContainerCreate(ctx context.Context, s *specgen.SpecG
 
 func (ic *ContainerEngine) ContainerLogs(_ context.Context, nameOrIDs []string, opts entities.ContainerLogsOptions) error {
 	since := opts.Since.Format(time.RFC3339)
+	until := opts.Until.Format(time.RFC3339)
 	tail := strconv.FormatInt(opts.Tail, 10)
 	stdout := opts.StdoutWriter != nil
 	stderr := opts.StderrWriter != nil
-	options := new(containers.LogOptions).WithFollow(opts.Follow).WithSince(since).WithStderr(stderr)
+	options := new(containers.LogOptions).WithFollow(opts.Follow).WithSince(since).WithUntil(until).WithStderr(stderr)
 	options.WithStdout(stdout).WithTail(tail)
 
 	var err error


### PR DESCRIPTION
Compat containers/logs was missing actual usage of until query param.
This led me to implement the until param for libpod's container logs as well. Added e2e tests and documentation.

Until is a parameter which shows logs up until a certain timestamp. The default, similar to `--since`, is zero which means all logs. Support added for all log formats that libpod supports.

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
