### PR TITLE
Drop support for the --storage-opt container flag

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -655,15 +655,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	)
 	_ = cmd.RegisterFlagCompletionFunc(stopTimeoutFlagName, completion.AutocompleteNone)
 
-	storageOptFlagName := "storage-opt"
-	createFlags.StringSliceVar(
-		&cf.StorageOpt,
-		storageOptFlagName, []string{},
-		"Storage driver options per container",
-	)
-	//FIXME: What should we suggest here? The flag is not in the man page.
-	_ = cmd.RegisterFlagCompletionFunc(storageOptFlagName, completion.AutocompleteNone)
-
 	subgidnameFlagName := "subgidname"
 	createFlags.StringVar(
 		&cf.SubUIDName,

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -146,6 +146,8 @@ func replaceContainer(name string) error {
 }
 
 func createInit(c *cobra.Command) error {
+	cliVals.StorageOpt = registry.PodmanConfig().StorageOpts
+
 	if c.Flag("shm-size").Changed {
 		cliVals.ShmSize = c.Flag("shm-size").Value.String()
 	}

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -342,10 +342,6 @@ func rootFlags(cmd *cobra.Command, opts *entities.PodmanConfig) {
 		pFlags.StringVar(&opts.StorageDriver, storageDriverFlagName, "", "Select which storage driver is used to manage storage of images and containers (default is overlay)")
 		_ = cmd.RegisterFlagCompletionFunc(storageDriverFlagName, completion.AutocompleteNone) //TODO: what can we recommend here?
 
-		storageOptFlagName := "storage-opt"
-		pFlags.StringArrayVar(&opts.StorageOpts, storageOptFlagName, []string{}, "Used to pass an option to the storage driver")
-		_ = cmd.RegisterFlagCompletionFunc(storageOptFlagName, completion.AutocompleteNone)
-
 		tmpdirFlagName := "tmpdir"
 		pFlags.StringVar(&opts.Engine.TmpDir, tmpdirFlagName, "", "Path to the tmp directory for libpod state content.\n\nNote: use the environment variable 'TMPDIR' to change the temporary storage location for container images, '/var/tmp'.\n")
 		_ = cmd.RegisterFlagCompletionFunc(tmpdirFlagName, completion.AutocompleteDefault)
@@ -365,6 +361,10 @@ func rootFlags(cmd *cobra.Command, opts *entities.PodmanConfig) {
 			}
 		}
 	}
+	storageOptFlagName := "storage-opt"
+	pFlags.StringArrayVar(&opts.StorageOpts, storageOptFlagName, []string{}, "Used to pass an option to the storage driver")
+	_ = cmd.RegisterFlagCompletionFunc(storageOptFlagName, completion.AutocompleteNone)
+
 	// Override default --help information of `--help` global flag
 	var dummyHelp bool
 	pFlags.BoolVar(&dummyHelp, "help", false, "Help for podman")

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -420,7 +420,6 @@ func (c *Container) setupStorage(ctx context.Context) error {
 	if c.config.Rootfs == "" && (c.config.RootfsImageID == "" || c.config.RootfsImageName == "") {
 		return errors.Wrapf(define.ErrInvalidArg, "must provide image ID and image name to use an image")
 	}
-
 	options := storage.ContainerOptions{
 		IDMappingOptions: storage.IDMappingOptions{
 			HostUIDMapping: true,

--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -22,6 +22,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
+
 	warn, err := generate.CompleteSpec(r.Context(), runtime, &sg)
 	if err != nil {
 		utils.InternalServerError(w, err)


### PR DESCRIPTION
The global flag will work in either location, and this flag just breaks
users expectations, and is basically a noop.

[NO TESTS NEEDED] Since it would be difficult to test in ci/cd.

Fixes: https://github.com/containers/podman/issues/10264

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
