### PR TITLE
stats: add a interval parameter to cli and api stats streaming

### DIFF
--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/podman/v3/utils"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -140,7 +139,7 @@ func stats(cmd *cobra.Command, args []string) error {
 			return report.Error
 		}
 		if err := outputStats(report.Stats); err != nil {
-			logrus.Error(err)
+			return err
 		}
 	}
 	return nil

--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	tm "github.com/buger/goterm"
+	"github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/report"
 	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/registry"
@@ -55,6 +56,7 @@ type statsOptionsCLI struct {
 	Latest   bool
 	NoReset  bool
 	NoStream bool
+	Interval int
 }
 
 var (
@@ -72,6 +74,9 @@ func statFlags(cmd *cobra.Command) {
 
 	flags.BoolVar(&statsOptions.NoReset, "no-reset", false, "Disable resetting the screen between intervals")
 	flags.BoolVar(&statsOptions.NoStream, "no-stream", false, "Disable streaming stats and only pull the first result, default setting is false")
+	intervalFlagName := "interval"
+	flags.IntVarP(&statsOptions.Interval, intervalFlagName, "i", 5, "Time in seconds between stats reports")
+	_ = cmd.RegisterFlagCompletionFunc(intervalFlagName, completion.AutocompleteNone)
 }
 
 func init() {
@@ -122,8 +127,9 @@ func stats(cmd *cobra.Command, args []string) error {
 	// Convert to the entities options.  We should not leak CLI-only
 	// options into the backend and separate concerns.
 	opts := entities.ContainerStatsOptions{
-		Latest: statsOptions.Latest,
-		Stream: !statsOptions.NoStream,
+		Latest:   statsOptions.Latest,
+		Stream:   !statsOptions.NoStream,
+		Interval: statsOptions.Interval,
 	}
 	statsChan, err := registry.ContainerEngine().ContainerStats(registry.Context(), args, opts)
 	if err != nil {

--- a/docs/source/markdown/podman-stats.1.md
+++ b/docs/source/markdown/podman-stats.1.md
@@ -37,6 +37,10 @@ Do not clear the terminal/screen in between reporting intervals
 
 Disable streaming stats and only pull the first result, default setting is false
 
+#### **--interval**=*seconds*, **-i**=*seconds*
+
+Time in seconds between stats reports, defaults to 5 seconds.
+
 #### **--format**=*template*
 
 Pretty-print container statistics to JSON or using a Go template

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -1106,6 +1106,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    type: boolean
 	//    default: true
 	//    description: Stream the output
+	//  - in: query
+	//    name: interval
+	//    type: integer
+	//    default: 5
+	//    description: Time in seconds between stats reports
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -223,6 +223,9 @@ func Stats(ctx context.Context, containers []string, options *StatsOptions) (cha
 	if err != nil {
 		return nil, err
 	}
+	if !response.IsSuccess() {
+		return nil, response.Process(nil)
+	}
 
 	statsChan := make(chan entities.ContainerStatsReport)
 

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -165,7 +165,8 @@ type StartOptions struct {
 //go:generate go run ../generator/generator.go StatsOptions
 // StatsOptions are optional options for getting stats on containers
 type StatsOptions struct {
-	Stream *bool
+	Stream   *bool
+	Interval *int
 }
 
 //go:generate go run ../generator/generator.go TopOptions

--- a/pkg/bindings/containers/types_stats_options.go
+++ b/pkg/bindings/containers/types_stats_options.go
@@ -35,3 +35,19 @@ func (o *StatsOptions) GetStream() bool {
 	}
 	return *o.Stream
 }
+
+// WithInterval
+func (o *StatsOptions) WithInterval(value int) *StatsOptions {
+	v := &value
+	o.Interval = v
+	return o
+}
+
+// GetInterval
+func (o *StatsOptions) GetInterval() int {
+	var interval int
+	if o.Interval == nil {
+		return interval
+	}
+	return *o.Interval
+}

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -435,6 +435,8 @@ type ContainerStatsOptions struct {
 	Latest bool
 	// Stream stats.
 	Stream bool
+	// Interval in seconds
+	Interval int
 }
 
 // ContainerStatsReport is used for streaming container stats.

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1281,6 +1281,9 @@ func (ic *ContainerEngine) Shutdown(_ context.Context) {
 }
 
 func (ic *ContainerEngine) ContainerStats(ctx context.Context, namesOrIds []string, options entities.ContainerStatsOptions) (statsChan chan entities.ContainerStatsReport, err error) {
+	if options.Interval < 1 {
+		return nil, errors.New("Invalid interval, must be a positive number greater zero")
+	}
 	statsChan = make(chan entities.ContainerStatsReport, 1)
 
 	containerFunc := ic.Libpod.GetRunningContainers
@@ -1361,7 +1364,7 @@ func (ic *ContainerEngine) ContainerStats(ctx context.Context, namesOrIds []stri
 			return
 		}
 
-		time.Sleep(time.Second)
+		time.Sleep(time.Second * time.Duration(options.Interval))
 		goto stream
 	}()
 

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -871,7 +871,7 @@ func (ic *ContainerEngine) ContainerStats(ctx context.Context, namesOrIds []stri
 	if options.Latest {
 		return nil, errors.New("latest is not supported for the remote client")
 	}
-	return containers.Stats(ic.ClientCtx, namesOrIds, new(containers.StatsOptions).WithStream(options.Stream))
+	return containers.Stats(ic.ClientCtx, namesOrIds, new(containers.StatsOptions).WithStream(options.Stream).WithInterval(options.Interval))
 }
 
 // ShouldRestart reports back whether the container will restart

--- a/test/e2e/pod_stats_test.go
+++ b/test/e2e/pod_stats_test.go
@@ -37,19 +37,19 @@ var _ = Describe("Podman pod stats", func() {
 		processTestResult(f)
 
 	})
-	It("podman stats should run with no pods", func() {
+	It("podman pod stats should run with no pods", func() {
 		session := podmanTest.Podman([]string{"pod", "stats", "--no-stream"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})
 
-	It("podman stats with a bogus pod", func() {
+	It("podman pod stats with a bogus pod", func() {
 		session := podmanTest.Podman([]string{"pod", "stats", "foobar"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(125))
 	})
 
-	It("podman stats on a specific running pod", func() {
+	It("podman pod stats on a specific running pod", func() {
 		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
@@ -66,7 +66,7 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(stats).Should(Exit(0))
 	})
 
-	It("podman stats on a specific running pod with shortID", func() {
+	It("podman pod stats on a specific running pod with shortID", func() {
 		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
@@ -83,7 +83,7 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(stats).Should(Exit(0))
 	})
 
-	It("podman stats on a specific running pod with name", func() {
+	It("podman pod stats on a specific running pod with name", func() {
 		_, ec, podid := podmanTest.CreatePod(map[string][]string{"--name": {"test"}})
 		Expect(ec).To(Equal(0))
 
@@ -100,7 +100,7 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(stats).Should(Exit(0))
 	})
 
-	It("podman stats on running pods", func() {
+	It("podman pod stats on running pods", func() {
 		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
@@ -117,7 +117,7 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(stats).Should(Exit(0))
 	})
 
-	It("podman stats on all pods", func() {
+	It("podman pod stats on all pods", func() {
 		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
@@ -134,7 +134,7 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(stats).Should(Exit(0))
 	})
 
-	It("podman stats with json output", func() {
+	It("podman pod stats with json output", func() {
 		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
@@ -151,7 +151,7 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(stats).Should(Exit(0))
 		Expect(stats.IsJSONOutputValid()).To(BeTrue())
 	})
-	It("podman stats with GO template", func() {
+	It("podman pod stats with GO template", func() {
 		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
@@ -163,7 +163,7 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(stats).To(Exit(0))
 	})
 
-	It("podman stats with invalid GO template", func() {
+	It("podman pod stats with invalid GO template", func() {
 		_, ec, podid := podmanTest.CreatePod(nil)
 		Expect(ec).To(Equal(0))
 
@@ -175,7 +175,7 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(stats).To(ExitWithError())
 	})
 
-	It("podman stats on net=host post", func() {
+	It("podman pod stats on net=host post", func() {
 		SkipIfRootless("--net=host not supported for rootless pods at present")
 		podName := "testPod"
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--net=host", "--name", podName})


### PR DESCRIPTION
podman stats cli and api polls reports by default in a 1 sec period.

This can put some load on a machine if you run many containers.

A simple test is to run e.g. a range of pause containers like so:

``` seq 35 |xargs -rn1 podman run -d --rm gcr.io/google_containers/pause```

Next, run "podman stats" (or the API request), and monitor e.g. "Top" to see the load. 
I found that the compat api endpoint polls by default in a 5 sec period which is not so aggressive.

Making it configurable seemed to be a good solution, hence this PR. You can now easily align the poll period and e.g. your metrics collector interval. 
There was also a unused 5 sec const in the libpod endpoint, i removed it.

You can now change this interval with a optional --interval cli flag.
The api request got a interval query parameter for the same purpose.
Default behavior is not changed.

I could not find a unit or e2e test for the stats streaming mode, so i was unsure how to provide/enhance a test.
CLI Manual and REST API doc should be covered in the PR.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
