### PR TITLE
[v3.2.3-rhel] Remove a test that is nonfunctional on RHEL8

### DIFF
--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -81,6 +81,7 @@ function _events_disjunctive_filters() {
 
 @test "events with disjunctive filters - journald" {
     skip_if_remote "remote does not support --events-backend"
+    skip_if_journald_unavailable "system does not support journald events"
     _events_disjunctive_filters --events-backend=journald
 }
 


### PR DESCRIPTION
We don't support the journald events backend on 8, so remove a test that forces its use.

Partial fix for RHBZ1955166