### PR TITLE
Ensure journald events tests only run where supported

### DIFF
--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -81,6 +81,7 @@ function _events_disjunctive_filters() {
 
 @test "events with disjunctive filters - journald" {
     skip_if_remote "remote does not support --events-backend"
+    skip_if_journald_unavailable "system does not support journald events"
     _events_disjunctive_filters --events-backend=journald
 }
 


### PR DESCRIPTION
Forward-port #11006 to main branch, so this doesn't bite us in the future.