### PR TITLE
[CI:DOCS] Fix GitHub URL to Podman logo

### DIFF
--- a/docs/source/includes.rst
+++ b/docs/source/includes.rst
@@ -16,4 +16,4 @@
 .. _podman run: http://docs.podman.io/en/latest/markdown/podman-run.1.html
 .. _podman build: http://docs.podman.io/en/latest/markdown/podman-build.1.html
 .. _podman push: http://docs.podman.io/en/latest/markdown/podman-push.1.html
-.. image:: https://github.com/containers/podman/blob/main/logo/podman-logo.png?raw=true
+.. image:: https://raw.githubusercontent.com/containers/podman/main/logo/podman-logo.png

--- a/pkg/api/server/docs.go
+++ b/pkg/api/server/docs.go
@@ -42,7 +42,7 @@
 //
 //     InfoExtensions:
 //     x-logo:
-//       - url: https://raw.githubusercontent.com/containers/libpod/master/logo/podman-logo.png
+//       - url: https://raw.githubusercontent.com/containers/libpod/main/logo/podman-logo.png
 //       - altText: "Podman logo"
 //
 //     Produces:


### PR DESCRIPTION
The Podman logo is not rendered on [docs.podman.io](https://docs.podman.io) with the current URL.

Signed-off-by: David Ward <david.ward@ll.mit.edu>