### PR TITLE
[CI:DOCS] Add notes to flags not supported on cgroups V2

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -181,6 +181,8 @@ Limit the CPU real-time period in microseconds
 
 Limit the container's Real Time CPU usage. This flag tell the kernel to restrict the container's Real Time CPU usage to the period you specify.
 
+This flag is not supported on cgroups V2 systems.
+
 #### **--cpu-rt-runtime**=*microseconds*
 
 Limit the CPU real-time runtime in microseconds
@@ -189,6 +191,8 @@ Limit the containers Real Time CPU usage. This flag tells the kernel to limit th
 Period of 1,000,000us and Runtime of 950,000us means that this container could consume 95% of available CPU and leave the remaining 5% to normal priority tasks.
 
 The sum of all runtimes across containers cannot exceed the amount allotted to the parent cgroup.
+
+This flag is not supported on cgroups V2 systems.
 
 #### **--cpu-shares**=*shares*
 
@@ -479,6 +483,8 @@ is not limited. If you specify a limit, it may be rounded up to a multiple
 of the operating system's page size and the value can be very large,
 millions of trillions.
 
+This flag is not supported on cgroups V2 systems.
+
 #### **--label**, **-l**=*label*
 
 Add metadata to a container (e.g., --label com.example.key=value)
@@ -560,6 +566,8 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 #### **--memory-swappiness**=*number*
 
 Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
+
+This flag is not supported on cgroups V2 systems.
 
 #### **--mount**=*type=TYPE,TYPE-SPECIFIC-OPTION[,...]*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -199,6 +199,8 @@ Limit the CPU real-time period in microseconds.
 
 Limit the container's Real Time CPU usage. This flag tell the kernel to restrict the container's Real Time CPU usage to the period you specify.
 
+This flag is not supported on cgroups V2 systems.
+
 #### **--cpu-rt-runtime**=*microseconds*
 
 Limit the CPU real-time runtime in microseconds.
@@ -207,6 +209,8 @@ Limit the containers Real Time CPU usage. This flag tells the kernel to limit th
 Period of 1,000,000us and Runtime of 950,000us means that this container could consume 95% of available CPU and leave the remaining 5% to normal priority tasks.
 
 The sum of all runtimes across containers cannot exceed the amount allotted to the parent cgroup.
+
+This flag is not supported on cgroups V2 systems.
 
 #### **--cpu-shares**=*shares*
 
@@ -518,6 +522,8 @@ is not limited. If you specify a limit, it may be rounded up to a multiple
 of the operating system's page size and the value can be very large,
 millions of trillions.
 
+This flag is not supported on cgroups V2 systems.
+
 #### **--label**, **-l**=*key*=*value*
 
 Add metadata to a container.
@@ -594,6 +600,8 @@ Set _number_ to **-1** to enable unlimited swap.
 #### **--memory-swappiness**=*number*
 
 Tune a container's memory swappiness behavior. Accepts an integer between *0* and *100*.
+
+This flag is not supported on cgroups V2 systems.
 
 #### **--mount**=*type=TYPE,TYPE-SPECIFIC-OPTION[,...]*
 


### PR DESCRIPTION
Clarify what flags are not supported on cgroups V2 in documentation.
The following flags of `create` and `run` commands are not supported:
- --cpu-rt-period
- --cpu-rt-runtime
- --kernel-memory
- --memory-swappiness

Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
