### PR TITLE
Add until filter to volume ls filters list

### DIFF
--- a/docs/source/markdown/podman-volume-ls.1.md
+++ b/docs/source/markdown/podman-volume-ls.1.md
@@ -24,6 +24,7 @@ Volumes can be filtered by the following attributes:
 - name
 - opt
 - scope
+- until
 
 #### **--format**=*format*
 

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -68,6 +68,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//        - label=<key> or label=<key>:<value> Matches volumes based on the presence of a label alone or a label and a value.
 	//        - name=<volume-name> Matches all of volume name.
 	//        - opt=<driver-option> Matches a storage driver options
+	//        - `until=<timestamp>` List volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
 	// responses:
 	//   '200':
 	//     "$ref": "#/responses/VolumeList"
@@ -166,6 +167,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//        - driver=<volume-driver-name> Matches volumes based on their driver.
 	//        - label=<key> or label=<key>:<value> Matches volumes based on the presence of a label alone or a label and a value.
 	//        - name=<volume-name> Matches all of volume name.
+	//        - `until=<timestamp>` List volumes created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
 	//
 	//      Note:
 	//        The boolean `dangling` filter is not yet implemented for this endpoint.

--- a/test/apiv2/30-volumes.at
+++ b/test/apiv2/30-volumes.at
@@ -174,6 +174,8 @@ t POST libpod/volumes/create \
 # with date way back in the past, volume should not be deleted (compat api)
 t POST volumes/prune?filters='{"until":["500000"]}' 200
 t GET libpod/volumes/json?filters='{"label":["testuntilcompat"]}' 200 length=1
+t GET libpod/volumes/json?filters='{"until":["500000"]}' 200 length=0
+t GET libpod/volumes/json?filters='{"until":["5000000000"]}' 200 length=1
 
 # with date far in the future, volume should be deleted (compat api)
 t POST volumes/prune?filters='{"until":["5000000000"]}' 200

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -101,6 +101,22 @@ var _ = Describe("Podman volume ls", func() {
 		Expect(len(session.OutputToStringArray())).To(Equal(0))
 	})
 
+	It("podman ls volume with --filter until flag", func() {
+		session := podmanTest.Podman([]string{"volume", "create"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "until=5000000000"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(2))
+
+		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "until=50000"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(0))
+	})
+
 	It("podman volume ls with --filter dangling", func() {
 		volName1 := "volume1"
 		session := podmanTest.Podman([]string{"volume", "create", volName1})


### PR DESCRIPTION
As a conclusion of a discussion in #10861, until filter is added
by this commit to volume ls filters.

Signed-off-by: Jakub Guzik <jakubmguzik@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
