### PR TITLE
import: write stdin to tmp file

### DIFF
--- a/cmd/podman/images/import.go
+++ b/cmd/podman/images/import.go
@@ -3,6 +3,9 @@ package images
 import (
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
@@ -97,6 +100,22 @@ func importCon(cmd *cobra.Command, args []string) error {
 	default:
 		return errors.Errorf("too many arguments. Usage TARBALL [REFERENCE]")
 	}
+
+	if source == "-" {
+		outFile, err := ioutil.TempFile("", "podman")
+		if err != nil {
+			return errors.Errorf("error creating file %v", err)
+		}
+		defer os.Remove(outFile.Name())
+		defer outFile.Close()
+
+		_, err = io.Copy(outFile, os.Stdin)
+		if err != nil {
+			return errors.Errorf("error copying file %v", err)
+		}
+		source = outFile.Name()
+	}
+
 	errFileName := parse.ValidateFileName(source)
 	errURL := parse.ValidURL(source)
 	if errURL == nil {

--- a/cmd/podman/parse/net.go
+++ b/cmd/podman/parse/net.go
@@ -180,9 +180,12 @@ func ValidateFileName(filename string) error {
 
 // ValidURL checks a string urlStr is a url or not
 func ValidURL(urlStr string) error {
-	_, err := url.ParseRequestURI(urlStr)
+	url, err := url.ParseRequestURI(urlStr)
 	if err != nil {
-		return errors.Wrapf(err, "invalid url path: %q", urlStr)
+		return errors.Wrapf(err, "invalid url %q", urlStr)
+	}
+	if url.Scheme == "" {
+		return errors.Errorf("invalid url %q: missing scheme", urlStr)
 	}
 	return nil
 }

--- a/test/system/125-import.bats
+++ b/test/system/125-import.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# tests for podman import
+#
+
+load helpers
+
+@test "podman import" {
+    local archive=$PODMAN_TMPDIR/archive.tar
+    local random_content=$(random_string 12)
+    # Generate a random name and tag (must be lower-case)
+    local random_name=x0$(random_string 12 | tr A-Z a-z)
+    local random_tag=t0$(random_string 7 | tr A-Z a-z)
+    local fqin=localhost/$random_name:$random_tag
+
+    run_podman run --name import $IMAGE sh -c "echo ${random_content} > /random.txt"
+    run_podman export import -o $archive
+    run_podman rm -f import
+
+    # Simple import
+    run_podman import -q $archive
+    iid="$output"
+    run_podman run -t --rm $iid cat /random.txt
+    is "$output" "$random_content" "simple import"
+    run_podman rmi -f $iid
+
+    # Simple import via stdin
+    run_podman import -q - < <(cat $archive)
+    iid="$output"
+    run_podman run -t --rm $iid cat /random.txt
+    is "$output" "$random_content" "simple import via stdin"
+    run_podman rmi -f $iid
+
+    # Tagged import
+    run_podman import -q $archive $fqin
+    run_podman run -t --rm $fqin cat /random.txt
+    is "$output" "$random_content" "tagged import"
+    run_podman rmi -f $fqin
+
+    # Tagged import via stdin
+    run_podman import -q - $fqin < <(cat $archive)
+    run_podman run -t --rm $fqin cat /random.txt
+    is "$output" "$random_content" "tagged import via stdin"
+    run_podman rmi -f $fqin
+}


### PR DESCRIPTION
If importing an archive via stdin write it to a temporary file such that
the temporary file can be opened multiple times later on.  Otherwise, we
may end up with an empty image.

Add system tests for `podman import` exercising the basics.

Fixes: #10994
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
