### PR TITLE
Add IPVLAN network support to podman network.

### DIFF
--- a/libpod/network/config.go
+++ b/libpod/network/config.go
@@ -22,9 +22,9 @@ const (
 	// LockFileName is used for obtaining a lock and is appended
 	// to libpod's tmpdir in practice
 	LockFileName = "cni.lock"
-	// PluginTypeMacVLAN
+	// PluginTypeMacVLAN is to create macvlan networks.
 	PluginTypeMacVLAN = "macvlan"
-	// PluginTypeIPVLAN
+	// PluginTypeIPVLAN is used to create ipvlan networks
 	PluginTypeIPVLAN = "ipvlan"
 )
 
@@ -105,7 +105,8 @@ func (p PortMapConfig) Bytes() ([]byte, error) {
 	return json.MarshalIndent(p, "", "\t")
 }
 
-// MacVLANConfig describes the macvlan config
+// MacVLANConfig describes either a macvlan or an ipvlan network config.
+// PluginType specifies which network type it is.
 type MacVLANConfig struct {
 	PluginType string     `json:"type"`
 	Master     string     `json:"master"`

--- a/libpod/network/config.go
+++ b/libpod/network/config.go
@@ -22,6 +22,10 @@ const (
 	// LockFileName is used for obtaining a lock and is appended
 	// to libpod's tmpdir in practice
 	LockFileName = "cni.lock"
+	// PluginTypeMacVLAN
+	PluginTypeMacVLAN = "macvlan"
+	// PluginTypeIPVLAN
+	PluginTypeIPVLAN = "ipvlan"
 )
 
 // CNILock is for preventing name collision and
@@ -112,19 +116,6 @@ type MacVLANConfig struct {
 // Bytes outputs the configuration as []byte
 func (p MacVLANConfig) Bytes() ([]byte, error) {
 	return json.MarshalIndent(p, "", "\t")
-}
-
-// IPVLANConfig describes the ipvlan config
-type IPVLANConfig struct {
-	PluginType string     `json:"type"`
-	Master     string     `json:"master"`
-	IPAM       IPAMConfig `json:"ipam"`
-	MTU        int        `json:"mtu,omitempty"`
-}
-
-// Bytes outputs the configuration as []byte
-func (i IPVLANConfig) Bytes() ([]byte, error) {
-	return json.MarshalIndent(i, "", "\t")
 }
 
 // FirewallConfig describes the firewall plugin

--- a/libpod/network/config.go
+++ b/libpod/network/config.go
@@ -114,6 +114,19 @@ func (p MacVLANConfig) Bytes() ([]byte, error) {
 	return json.MarshalIndent(p, "", "\t")
 }
 
+// IPVLANConfig describes the ipvlan config
+type IPVLANConfig struct {
+	PluginType string     `json:"type"`
+	Master     string     `json:"master"`
+	IPAM       IPAMConfig `json:"ipam"`
+	MTU        int        `json:"mtu,omitempty"`
+}
+
+// Bytes outputs the configuration as []byte
+func (i IPVLANConfig) Bytes() ([]byte, error) {
+	return json.MarshalIndent(i, "", "\t")
+}
+
 // FirewallConfig describes the firewall plugin
 type FirewallConfig struct {
 	PluginType string `json:"type"`

--- a/libpod/network/create.go
+++ b/libpod/network/create.go
@@ -257,7 +257,15 @@ func createBridge(name string, options entities.NetworkCreateOptions, runtimeCon
 	return cniPathName, err
 }
 
+func validateMacVLANOptions(options entities.NetworkCreateOptions) error {
+	return nil
+}
+
 func createMacVLAN(name string, options entities.NetworkCreateOptions, runtimeConfig *config.Config) (string, error) {
+	if err := validateMacVLANOptions(options); err != nil {
+		return "", err
+	}
+
 	var (
 		mtu     int
 		plugins []CNIPlugins
@@ -318,7 +326,15 @@ func createMacVLAN(name string, options entities.NetworkCreateOptions, runtimeCo
 	return cniPathName, err
 }
 
+func validateIPVLANOptions(options entities.NetworkCreateOptions) error {
+	return nil
+}
+
 func createIPVLAN(name string, options entities.NetworkCreateOptions, runtimeConfig *config.Config) (string, error) {
+	if err := validateIPVLANOptions(options); err != nil {
+		return "", err
+	}
+
 	var (
 		mtu     int
 		plugins []CNIPlugins

--- a/libpod/network/create.go
+++ b/libpod/network/create.go
@@ -303,7 +303,7 @@ func createMacVLAN(name string, options entities.NetworkCreateOptions, runtimeCo
 			mtu = intVal
 		}
 	}
-	macvlan, err := NewMacVLANPlugin(parentNetworkDevice, options.Gateway, &options.Range, &options.Subnet, mtu)
+	macvlan, err := NewMacVLANPlugin(PluginTypeMacVLAN, parentNetworkDevice, options.Gateway, &options.Range, &options.Subnet, mtu)
 	if err != nil {
 		return "", err
 	}
@@ -358,7 +358,7 @@ func createIPVLAN(name string, options entities.NetworkCreateOptions, runtimeCon
 			mtu = intVal
 		}
 	}
-	ipvlan, err := NewIPVLANPlugin(parentNetworkDevice, options.Gateway, &options.Range, &options.Subnet, mtu)
+	ipvlan, err := NewMacVLANPlugin(PluginTypeIPVLAN, parentNetworkDevice, options.Gateway, &options.Range, &options.Subnet, mtu)
 	if err != nil {
 		return "", err
 	}

--- a/libpod/network/create.go
+++ b/libpod/network/create.go
@@ -257,12 +257,12 @@ func createBridge(name string, options entities.NetworkCreateOptions, runtimeCon
 	return cniPathName, err
 }
 
-func validateMacVLANOptions(options entities.NetworkCreateOptions) error {
+func validateMacVLANOptions(pluginType string, options entities.NetworkCreateOptions) error {
 	return nil
 }
 
 func createMacVLAN(pluginType string, name string, options entities.NetworkCreateOptions, runtimeConfig *config.Config) (string, error) {
-	if err := validateMacVLANOptions(options); err != nil {
+	if err := validateMacVLANOptions(pluginType, options); err != nil {
 		return "", err
 	}
 

--- a/libpod/network/netconflist.go
+++ b/libpod/network/netconflist.go
@@ -176,7 +176,7 @@ func HasDNSNamePlugin(paths []string) bool {
 }
 
 // NewMacVLANPlugin creates a macvlanconfig with a given device name
-func NewMacVLANPlugin(device string, gateway net.IP, ipRange *net.IPNet, subnet *net.IPNet, mtu int) (MacVLANConfig, error) {
+func NewMacVLANPlugin(pluginType string, device string, gateway net.IP, ipRange *net.IPNet, subnet *net.IPNet, mtu int) (MacVLANConfig, error) {
 	i := IPAMConfig{PluginType: "dhcp"}
 	if gateway != nil ||
 		(ipRange != nil && ipRange.IP != nil && ipRange.Mask != nil) ||
@@ -197,7 +197,7 @@ func NewMacVLANPlugin(device string, gateway net.IP, ipRange *net.IPNet, subnet 
 	}
 
 	m := MacVLANConfig{
-		PluginType: "macvlan",
+		PluginType: pluginType,
 		IPAM:       i,
 	}
 	if mtu > 0 {
@@ -209,42 +209,6 @@ func NewMacVLANPlugin(device string, gateway net.IP, ipRange *net.IPNet, subnet 
 		m.Master = device
 	}
 	return m, nil
-}
-
-// NewIPVLANPlugin creates an ipvlanconfig with a given device name
-func NewIPVLANPlugin(device string, gateway net.IP, ipRange *net.IPNet, subnet *net.IPNet, mtu int) (IPVLANConfig, error) {
-	i := IPAMConfig{PluginType: "dhcp"}
-	if gateway != nil ||
-		(ipRange != nil && ipRange.IP != nil && ipRange.Mask != nil) ||
-		(subnet != nil && subnet.IP != nil && subnet.Mask != nil) {
-		ipam, err := NewIPAMLocalHostRange(subnet, ipRange, gateway)
-		if err != nil {
-			return IPVLANConfig{}, err
-		}
-		ranges := make([][]IPAMLocalHostRangeConf, 0)
-		ranges = append(ranges, ipam)
-		i.Ranges = ranges
-		route, err := NewIPAMDefaultRoute(IsIPv6(subnet.IP))
-		if err != nil {
-			return IPVLANConfig{}, err
-		}
-		i.Routes = []IPAMRoute{route}
-		i.PluginType = "host-local"
-	}
-
-	cfg := IPVLANConfig{
-		PluginType: "macvlan",
-		IPAM:       i,
-	}
-	if mtu > 0 {
-		cfg.MTU = mtu
-	}
-	// CNI is supposed to use the default route if a
-	// parent device is not provided
-	if len(device) > 0 {
-		cfg.Master = device
-	}
-	return cfg, nil
 }
 
 // IfPassesFilter filters NetworkListReport and returns true if the filter match the given config

--- a/libpod/network/netconflist.go
+++ b/libpod/network/netconflist.go
@@ -176,7 +176,7 @@ func HasDNSNamePlugin(paths []string) bool {
 }
 
 // NewMacVLANPlugin creates a MacVLANConfig with specified plugin type and device.
-// Plugin type can be one of macvlan or ipvlan.
+// Plugin type must be one of macvlan or ipvlan.
 func NewMacVLANPlugin(pluginType string, device string, gateway net.IP, ipRange *net.IPNet, subnet *net.IPNet, mtu int) (MacVLANConfig, error) {
 	if pluginType != PluginTypeMacVLAN && pluginType != PluginTypeIPVLAN {
 		return MacVLANConfig{}, errors.Errorf("invalid plugin type: %s", pluginType)

--- a/libpod/network/netconflist.go
+++ b/libpod/network/netconflist.go
@@ -175,8 +175,13 @@ func HasDNSNamePlugin(paths []string) bool {
 	return false
 }
 
-// NewMacVLANPlugin creates a macvlanconfig with a given device name
+// NewMacVLANPlugin creates a MacVLANConfig with specified plugin type and device.
+// Plugin type can be one of macvlan or ipvlan.
 func NewMacVLANPlugin(pluginType string, device string, gateway net.IP, ipRange *net.IPNet, subnet *net.IPNet, mtu int) (MacVLANConfig, error) {
+	if pluginType != PluginTypeMacVLAN && pluginType != PluginTypeIPVLAN {
+		return MacVLANConfig{}, errors.Errorf("invalid plugin type: %s", pluginType)
+	}
+
 	i := IPAMConfig{PluginType: "dhcp"}
 	if gateway != nil ||
 		(ipRange != nil && ipRange.IP != nil && ipRange.Mask != nil) ||

--- a/libpod/network/network.go
+++ b/libpod/network/network.go
@@ -24,10 +24,12 @@ var (
 	DefaultNetworkDriver = BridgeNetworkDriver
 	// MacVLANNetworkDriver defines the macvlan cni driver
 	MacVLANNetworkDriver = "macvlan"
+	// IPVLANNetworkDriver defines the ipvlan cni driver
+	IPVLANNetworkDriver = "ipvlan"
 )
 
 // SupportedNetworkDrivers describes the list of supported drivers
-var SupportedNetworkDrivers = []string{BridgeNetworkDriver, MacVLANNetworkDriver}
+var SupportedNetworkDrivers = []string{BridgeNetworkDriver, MacVLANNetworkDriver, IPVLANNetworkDriver}
 
 // isSupportedDriver checks if the user provided driver is supported
 func isSupportedDriver(driver string) error {


### PR DESCRIPTION
podman network learns the modified `--driver=ipvlan` option which will create an ipvlan network using the relevant CNI plugin.\
Additionally, both macvlan and ipvlan drivers gain the ability to set network mode via the `macvlan_mode` and `ipvlan_mode` driver options.
