### PR TITLE
[CI:DOCS] Fix handling of shadow-utils

### DIFF
--- a/contrib/podmanimage/stable/Dockerfile
+++ b/contrib/podmanimage/stable/Dockerfile
@@ -11,7 +11,7 @@ FROM registry.fedoraproject.org/fedora:latest
 # Don't include container-selinux and remove
 # directories used by yum that are just taking
 # up space.
-RUN dnf -y update; rpm --restore --quiet shadow-utils; \
+RUN dnf -y update; rpm --restore shadow-utils 2>/dev/null; \
 yum -y install podman fuse-overlayfs --exclude container-selinux; \
 rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 

--- a/contrib/podmanimage/testing/Dockerfile
+++ b/contrib/podmanimage/testing/Dockerfile
@@ -13,7 +13,7 @@ FROM registry.fedoraproject.org/fedora:latest
 # Don't include container-selinux and remove
 # directories used by yum that are just taking
 # up space.
-RUN yum -y update; rpm --restore --quiet shadow-utils; yum -y install podman fuse-overlayfs --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+RUN yum -y update; rpm --restore shadow-utils 2>/dev/null; yum -y install podman fuse-overlayfs --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 RUN useradd podman; \
 echo podman:10000:5000 > /etc/subuid; \

--- a/contrib/podmanimage/upstream/Dockerfile
+++ b/contrib/podmanimage/upstream/Dockerfile
@@ -17,7 +17,7 @@ ENV GOPATH=/root/podman
 # to the container.
 # Finally remove the podman directory and a few other packages
 # that are needed for building but not running Podman
-RUN yum -y update; rpm --restore --quiet shadow-utils; yum -y install --exclude container-selinux \
+RUN yum -y update; rpm --restore shadow-utils 2>/dev/null;  yum -y install --exclude container-selinux \
      --enablerepo=updates-testing \
      btrfs-progs-devel \
      containernetworking-cni \


### PR DESCRIPTION
There seems to be a bug in rpm, where it fails silently if you specify
rpm --restore --quiet shadow-utils.

rpm --restore shadow-utils 2> /dev/null

Does the right thing.

[NO TESTS NEEDED] Might add tests from buildah, once we have them
working correctly.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>