### PR TITLE
wait_for_port: use filehandle 5, not 3

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -288,7 +288,7 @@ function wait_for_port() {
 
     # Wait
     while [ $_timeout -gt 0 ]; do
-        { exec 3<> /dev/tcp/$host/$port; } &>/dev/null && return
+        { exec 5<> /dev/tcp/$host/$port; } &>/dev/null && return
         sleep 1
         _timeout=$(( $_timeout - 1 ))
     done


### PR DESCRIPTION
...because 3 is reserved by BATS. Using 3 causes a very
unpleasant failure mode.

Signed-off-by: Ed Santiago <santiago@redhat.com>
