### PR TITLE
Networking test: fix silent breakage

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -139,7 +139,7 @@ load helpers
                    $IMAGE nc -l -n -v -p $myport
         cid="$output"
 
-        wait_for_port 127.0.0.1 $myport
+        wait_for_output "listening on .*:$myport .*" $cid
 
         # emit random string, and check it
         teststring=$(random_string 30)

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -288,7 +288,7 @@ function wait_for_port() {
 
     # Wait
     while [ $_timeout -gt 0 ]; do
-        { exec 3<> /dev/tcp/$host/$port; } &>/dev/null && return
+        { exec 5<> /dev/tcp/$host/$port; } &>/dev/null && return
         sleep 1
         _timeout=$(( $_timeout - 1 ))
     done


### PR DESCRIPTION
Wow did I screw up. #10982 introduced (at my suggestion) a
new wait_for_port() helper, with the goal of eliminating a
race condition. It didn't work.

First: wait_for_port() tests by connecting to the port, which
is a Bad Idea when you have a one-shot server that exits upon
the first connection closing. We should've caught that, but:

Second: I wrote wait_for_port() for a non-BATS test framework,
and used the conventional file descriptor 3. BATS uses fd3
for internal control. Overriding that made the test silently
just disappear, no "not ok" message, no warnings, nothing
except vanishing into the ether.

Third: this was caught by my log-colorizer script, which
loudly yelled "WARNING: expected 234" (tests) at the
bottom of the log. Unfortunately, since this wasn't
my PR, I didn't actually look at the test logs.

Solution: we can't use wait_for_port() in the network port
test. Use wait_for_output() instead, triggering on the
'listening' message emitted by netcat in the container.

Also: fix wait_for_port() to use fd5 instead of 3. Although
no code currently uses wait_for_port() as of this PR, it's
a useful helper that we may want to keep.

Signed-off-by: Ed Santiago <santiago@redhat.com>