### PR TITLE
[3.2] seccomp: propagate defaultErrnoRet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
 	github.com/containers/buildah v1.21.3
-	github.com/containers/common v0.38.16
+	github.com/containers/common v0.38.18
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.12.0
 	github.com/containers/ocicrypt v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRD
 github.com/containers/buildah v1.21.3 h1:YY9WKcJ4Z/y7o+LAq57+HUbGftqp+uNltjn0KWiivT8=
 github.com/containers/buildah v1.21.3/go.mod h1:ncw3+bwxJq3b/5ALL3XAchIJh7EGXoR5ZXo/c6yZQ9U=
 github.com/containers/common v0.38.12/go.mod h1:egfpX/Y3+19Dz4Wa1eRZDdgzoEOeneieF9CQppKzLBg=
-github.com/containers/common v0.38.16 h1:m8wF48XUmh47Z1kiYCdfGu4Rok0zqCL2v53P3jSKSCQ=
-github.com/containers/common v0.38.16/go.mod h1:egfpX/Y3+19Dz4Wa1eRZDdgzoEOeneieF9CQppKzLBg=
+github.com/containers/common v0.38.18 h1:gazCipPCS/3V/MmBhhFRlPzPVJlOBkYErZjvbopEb2A=
+github.com/containers/common v0.38.18/go.mod h1:egfpX/Y3+19Dz4Wa1eRZDdgzoEOeneieF9CQppKzLBg=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.12.0 h1:1hNS2QkzFQ4lH3GYQLyAXB0acRMhS1Ubm6oV++8vw4w=

--- a/vendor/github.com/containers/common/pkg/seccomp/conversion.go
+++ b/vendor/github.com/containers/common/pkg/seccomp/conversion.go
@@ -118,6 +118,7 @@ func specToSeccomp(spec *specs.LinuxSeccomp) (*Seccomp, error) {
 		return nil, errors.Wrap(err, "convert default action")
 	}
 	res.DefaultAction = newDefaultAction
+	res.DefaultErrnoRet = spec.DefaultErrnoRet
 
 	// Loop through all syscall blocks and convert them to the internal format
 	for _, call := range spec.Syscalls {

--- a/vendor/github.com/containers/common/pkg/seccomp/filter.go
+++ b/vendor/github.com/containers/common/pkg/seccomp/filter.go
@@ -41,7 +41,7 @@ func BuildFilter(spec *specs.LinuxSeccomp) (*libseccomp.ScmpFilter, error) {
 		return nil, errors.Wrap(err, "convert spec to seccomp profile")
 	}
 
-	defaultAction, err := toAction(profile.DefaultAction, nil)
+	defaultAction, err := toAction(profile.DefaultAction, profile.DefaultErrnoRet)
 	if err != nil {
 		return nil, errors.Wrapf(err, "convert default action %s", profile.DefaultAction)
 	}

--- a/vendor/github.com/containers/common/pkg/seccomp/seccomp_linux.go
+++ b/vendor/github.com/containers/common/pkg/seccomp/seccomp_linux.go
@@ -111,6 +111,7 @@ func setupSeccomp(config *Seccomp, rs *specs.Spec) (*specs.LinuxSeccomp, error) 
 	}
 
 	newConfig.DefaultAction = specs.LinuxSeccompAction(config.DefaultAction)
+	newConfig.DefaultErrnoRet = config.DefaultErrnoRet
 
 Loop:
 	// Loop through all syscall blocks and convert them to libcontainer format after filtering them

--- a/vendor/github.com/containers/common/pkg/seccomp/types.go
+++ b/vendor/github.com/containers/common/pkg/seccomp/types.go
@@ -6,7 +6,8 @@ package seccomp
 
 // Seccomp represents the config for a seccomp profile for syscall restriction.
 type Seccomp struct {
-	DefaultAction Action `json:"defaultAction"`
+	DefaultAction   Action `json:"defaultAction"`
+	DefaultErrnoRet *uint  `json:"defaultErrnoRet,omitempty"`
 	// Architectures is kept to maintain backward compatibility with the old
 	// seccomp profile.
 	Architectures []Arch         `json:"architectures,omitempty"`

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.38.16"
+const Version = "0.38.18"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -91,7 +91,7 @@ github.com/containers/buildah/pkg/overlay
 github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/util
-# github.com/containers/common v0.38.16
+# github.com/containers/common v0.38.18
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
 github.com/containers/common/pkg/apparmor


### PR DESCRIPTION
This fixes the issue of not propagating `defaultErrnoRet` from
system's seccomp.json to container's config.json, which can
result in redundant seccomp rules and inability to start a container
when using some runtimes (notably runc up to and including 1.0.1).

The fix is to vendor in containers/common with the fixed pkg/seccomp
which no longer ignores defaultErrnoRet.

Fixes: https://github.com/containers/podman/issues/11031

### Proposed changelog entry
```markdown
Bugfixes:
 * Fixed a bug of ignoring the `defaultErrnoRet` field in system's seccomp.json,
   which may cause an "error adding seccomp filter rule for syscall" error
   and a failure to start a container when using `--runtime=runc` (#11031).
 ```
