### PR TITLE
play kube: support capitalized pull policy

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -277,7 +277,10 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		// registry on localhost.
 		pullPolicy := config.PullPolicyNewer
 		if len(container.ImagePullPolicy) > 0 {
-			pullPolicy, err = config.ParsePullPolicy(string(container.ImagePullPolicy))
+			// Make sure to lower the strings since K8s pull policy
+			// may be capitalized (see bugzilla.redhat.com/show_bug.cgi?id=1985905).
+			rawPolicy := string(container.ImagePullPolicy)
+			pullPolicy, err = config.ParsePullPolicy(strings.ToLower(rawPolicy))
 			if err != nil {
 				return nil, err
 			}

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1729,7 +1729,7 @@ var _ = Describe("Podman play kube", func() {
 	})
 
 	It("podman play kube with pull policy of missing", func() {
-		ctr := getCtr(withPullPolicy("missing"), withImage(BB))
+		ctr := getCtr(withPullPolicy("Missing"), withImage(BB))
 		err := generateKubeYaml("pod", getPod(withCtr(ctr)), kubeYaml)
 		Expect(err).To(BeNil())
 


### PR DESCRIPTION
Pull policies in K8s yaml may be capitalized, so lower them before
parsing.

Fixes: bugzilla.redhat.com/show_bug.cgi?id=1985905
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
