### PR TITLE
dual-stack network: fix duplicated subnet assignment

### DIFF
--- a/libpod/network/network.go
+++ b/libpod/network/network.go
@@ -111,8 +111,10 @@ func allocatorToIPNets(networks []*allocator.Net) []*net.IPNet {
 		if len(network.IPAM.Ranges) > 0 {
 			// this is the new IPAM range style
 			// append each subnet from ipam the rangeset
-			for _, r := range network.IPAM.Ranges[0] {
-				nets = append(nets, newIPNetFromSubnet(r.Subnet))
+			for _, allocatorRange := range network.IPAM.Ranges {
+				for _, r := range allocatorRange {
+					nets = append(nets, newIPNetFromSubnet(r.Subnet))
+				}
 			}
 		} else {
 			//	 looks like the old, deprecated style


### PR DESCRIPTION
Make sure podman network create reads all subnets from existing cni configs
and not only the first one.

Fixes #11032

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
