### PR TITLE
Fixed Healthcheck formatting, string to []string

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -521,7 +521,9 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 		for _, str := range cc.Config.Healthcheck.Test {
 			finCmd = finCmd + str + " "
 		}
-		finCmd = finCmd[:len(finCmd)-1]
+		if len(finCmd) > 1 {
+			finCmd = finCmd[:len(finCmd)-1]
+		}
 		cliOpts.HealthCmd = finCmd
 		cliOpts.HealthInterval = cc.Config.Healthcheck.Interval.String()
 		cliOpts.HealthRetries = uint(cc.Config.Healthcheck.Retries)

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -517,7 +517,12 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 		cliOpts.OOMKillDisable = *cc.HostConfig.OomKillDisable
 	}
 	if cc.Config.Healthcheck != nil {
-		cliOpts.HealthCmd = strings.Join(cc.Config.Healthcheck.Test, " ")
+		finCmd := ""
+		for _, str := range cc.Config.Healthcheck.Test {
+			finCmd = finCmd + str + " "
+		}
+		finCmd = finCmd[:len(finCmd)-1]
+		cliOpts.HealthCmd = finCmd
 		cliOpts.HealthInterval = cc.Config.Healthcheck.Interval.String()
 		cliOpts.HealthRetries = uint(cc.Config.Healthcheck.Retries)
 		cliOpts.HealthStartPeriod = cc.Config.Healthcheck.StartPeriod.String()

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -173,6 +173,16 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(inspect[0].State.Healthcheck.Status).To(Equal("healthy"))
 	})
 
+	It("podman healthcheck unhealthy but valid arguments check", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-retries", "2", "--health-cmd", "[\"ls\", \"/foo\"]", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(1))
+	})
+
 	It("podman healthcheck single healthy result changes failed to healthy", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-retries", "2", "--health-cmd", "ls /foo || exit 1", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1205,21 +1205,21 @@ USER mail`, BB)
 	})
 
 	It("podman run with bad healthcheck retries", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "[\"foo\"]", "--health-retries", "0", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "foo", "--health-retries", "0", ALPINE, "top"})
 		session.Wait()
 		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("healthcheck-retries must be greater than 0"))
 	})
 
 	It("podman run with bad healthcheck timeout", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "[\"foo\"]", "--health-timeout", "0s", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "foo", "--health-timeout", "0s", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("healthcheck-timeout must be at least 1 second"))
 	})
 
 	It("podman run with bad healthcheck start-period", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "[\"foo\"]", "--health-start-period", "-1s", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "foo", "--health-start-period", "-1s", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("healthcheck-start-period must be 0 seconds or greater"))

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1205,7 +1205,7 @@ USER mail`, BB)
 	})
 
 	It("podman run with bad healthcheck retries", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "foo", "--health-retries", "0", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "[\"foo\"]", "--health-retries", "0", ALPINE, "top"})
 		session.Wait()
 		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("healthcheck-retries must be greater than 0"))


### PR DESCRIPTION
Compat healthcheck tests are of the format []string but podman's were of
the format string. Converted podman's to []string at the specgen level since it has the same effect
and removed the incorrect parsing of compat healthchecks.

fixes #10617

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
