### PR TITLE
support container to container copy

### DIFF
--- a/docs/source/markdown/podman-cp.1.md
+++ b/docs/source/markdown/podman-cp.1.md
@@ -9,10 +9,10 @@ podman\-cp - Copy files/folders between a container and the local filesystem
 **podman container cp** [*options*] [*container*:]*src_path* [*container*:]*dest_path*
 
 ## DESCRIPTION
-Copy the contents of **src_path** to the **dest_path**. You can copy from the container's filesystem to the local machine or the reverse, from the local filesystem to the container.
+Copy the contents of **src_path** to the **dest_path**. You can copy from the container's filesystem to the local machine or the reverse, from the local filesystem to the container or between two containers.
 If `-` is specified for either the SRC_PATH or DEST_PATH, you can also stream a tar archive from STDIN or to STDOUT.
 
-The CONTAINER can be a running or stopped container. The **src_path** or **dest_path** can be a file or directory.
+The containers can be a running or stopped. The **src_path** or **dest_path** can be a file or directory.
 
 The **podman cp** command assumes container paths are relative to the container's root directory (i.e., `/`).
 
@@ -70,10 +70,9 @@ The default is *true*.
 
 ## ALTERNATIVES
 
-Podman has much stronger capabilities than just `podman cp` to achieve copy files between host and container.
+Podman has much stronger capabilities than just `podman cp` to achieve copying files between the host and containers.
 
-Using standard podman-mount and podman-umount takes advantage of the entire linux tool chain, rather
-then just cp.
+Using standard podman-mount and podman-umount takes advantage of the entire linux tool chain, rather than just cp.
 
 If a user wants to copy contents out of a container or into a container, they can execute a few simple commands.
 
@@ -112,6 +111,8 @@ podman cp /home/myuser/myfiles.tar containerID:/tmp
 podman cp containerID:/myapp/ /myapp/
 
 podman cp containerID:/home/myuser/. /home/myuser/
+
+podman cp containerA:/myapp containerB:/yourapp
 
 podman cp - containerID:/myfiles.tar.gz < myfiles.tar.gz
 

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -840,7 +840,7 @@ func (c *Container) ShouldRestart(ctx context.Context) bool {
 
 // CopyFromArchive copies the contents from the specified tarStream to path
 // *inside* the container.
-func (c *Container) CopyFromArchive(ctx context.Context, containerPath string, chown bool, tarStream io.Reader) (func() error, error) {
+func (c *Container) CopyFromArchive(ctx context.Context, containerPath string, chown bool, rename map[string]string, tarStream io.Reader) (func() error, error) {
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()
@@ -850,7 +850,7 @@ func (c *Container) CopyFromArchive(ctx context.Context, containerPath string, c
 		}
 	}
 
-	return c.copyFromArchive(ctx, containerPath, chown, tarStream)
+	return c.copyFromArchive(ctx, containerPath, chown, rename, tarStream)
 }
 
 // CopyToArchive copies the contents from the specified path *inside* the

--- a/libpod/container_copy_linux.go
+++ b/libpod/container_copy_linux.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func (c *Container) copyFromArchive(ctx context.Context, path string, chown bool, reader io.Reader) (func() error, error) {
+func (c *Container) copyFromArchive(ctx context.Context, path string, chown bool, rename map[string]string, reader io.Reader) (func() error, error) {
 	var (
 		mountPoint   string
 		resolvedRoot string
@@ -89,6 +89,7 @@ func (c *Container) copyFromArchive(ctx context.Context, path string, chown bool
 			GIDMap:     c.config.IDMappings.GIDMap,
 			ChownDirs:  idPair,
 			ChownFiles: idPair,
+			Rename:     rename,
 		}
 
 		return c.joinMountAndExec(ctx,

--- a/pkg/api/handlers/compat/containers_archive.go
+++ b/pkg/api/handlers/compat/containers_archive.go
@@ -1,6 +1,7 @@
 package compat
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -93,8 +94,9 @@ func handleHeadAndGet(w http.ResponseWriter, r *http.Request, decoder *schema.De
 
 func handlePut(w http.ResponseWriter, r *http.Request, decoder *schema.Decoder, runtime *libpod.Runtime) {
 	query := struct {
-		Path  string `schema:"path"`
-		Chown bool   `schema:"copyUIDGID"`
+		Path   string `schema:"path"`
+		Chown  bool   `schema:"copyUIDGID"`
+		Rename string `schema:"rename"`
 		// TODO handle params below
 		NoOverwriteDirNonDir bool `schema:"noOverwriteDirNonDir"`
 	}{
@@ -107,10 +109,19 @@ func handlePut(w http.ResponseWriter, r *http.Request, decoder *schema.Decoder, 
 		return
 	}
 
+	var rename map[string]string
+	if query.Rename != "" {
+		if err := json.Unmarshal([]byte(query.Rename), &rename); err != nil {
+			utils.Error(w, "Bad Request.", http.StatusBadRequest, errors.Wrap(err, "couldn't decode the query"))
+			return
+		}
+	}
+
 	containerName := utils.GetName(r)
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 
-	copyFunc, err := containerEngine.ContainerCopyFromArchive(r.Context(), containerName, query.Path, r.Body, entities.CopyOptions{Chown: query.Chown})
+	copyOptions := entities.CopyOptions{Chown: query.Chown, Rename: rename}
+	copyFunc, err := containerEngine.ContainerCopyFromArchive(r.Context(), containerName, query.Path, r.Body, copyOptions)
 	if errors.Cause(err) == define.ErrNoSuchCtr || os.IsNotExist(err) {
 		// 404 is returned for an absent container and path.  The
 		// clients must deal with it accordingly.

--- a/pkg/api/server/register_archive.go
+++ b/pkg/api/server/register_archive.go
@@ -151,6 +151,10 @@ func (s *APIServer) registerArchiveHandlers(r *mux.Router) error {
 	//     type: string
 	//     description: Path to a directory in the container to extract
 	//     required: true
+	//   - in: query
+	//     name: rename
+	//     type: string
+	//     description: JSON encoded map[string]string to translate paths
 	//  responses:
 	//    200:
 	//      description: no error

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -263,4 +263,6 @@ type CopyOptions struct {
 	// If used with CopyFromArchive and set to true it will change ownership of files from the source tar archive
 	// to the primary uid/gid of the target container.
 	Chown *bool `schema:"copyUIDGID"`
+	// Map to translate path names.
+	Rename map[string]string
 }

--- a/pkg/bindings/containers/types_copy_options.go
+++ b/pkg/bindings/containers/types_copy_options.go
@@ -35,3 +35,19 @@ func (o *CopyOptions) GetChown() bool {
 	}
 	return *o.Chown
 }
+
+// WithRename
+func (o *CopyOptions) WithRename(value map[string]string) *CopyOptions {
+	v := value
+	o.Rename = v
+	return o
+}
+
+// GetRename
+func (o *CopyOptions) GetRename() map[string]string {
+	var rename map[string]string
+	if o.Rename == nil {
+		return rename
+	}
+	return o.Rename
+}

--- a/pkg/copy/parse.go
+++ b/pkg/copy/parse.go
@@ -18,18 +18,6 @@ func ParseSourceAndDestination(source, destination string) (string, string, stri
 	sourceContainer, sourcePath := parseUserInput(source)
 	destContainer, destPath := parseUserInput(destination)
 
-	numContainers := 0
-	if len(sourceContainer) > 0 {
-		numContainers++
-	}
-	if len(destContainer) > 0 {
-		numContainers++
-	}
-
-	if numContainers != 1 {
-		return "", "", "", "", errors.Errorf("invalid arguments %q, %q: exactly 1 container expected but %d specified", source, destination, numContainers)
-	}
-
 	if len(sourcePath) == 0 || len(destPath) == 0 {
 		return "", "", "", "", errors.Errorf("invalid arguments %q, %q: you must specify paths", source, destination)
 	}

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -165,6 +165,8 @@ type CopyOptions struct {
 	// it will change ownership of files from the source tar archive
 	// to the primary uid/gid of the destination container.
 	Chown bool
+	// Map to translate path names.
+	Rename map[string]string
 }
 
 type CommitReport struct {

--- a/pkg/domain/infra/abi/archive.go
+++ b/pkg/domain/infra/abi/archive.go
@@ -12,7 +12,7 @@ func (ic *ContainerEngine) ContainerCopyFromArchive(ctx context.Context, nameOrI
 	if err != nil {
 		return nil, err
 	}
-	return container.CopyFromArchive(ctx, containerPath, options.Chown, reader)
+	return container.CopyFromArchive(ctx, containerPath, options.Chown, options.Rename, reader)
 }
 
 func (ic *ContainerEngine) ContainerCopyToArchive(ctx context.Context, nameOrID string, containerPath string, writer io.Writer) (entities.ContainerCopyFunc, error) {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -853,7 +853,8 @@ func (ic *ContainerEngine) ContainerPort(ctx context.Context, nameOrID string, o
 }
 
 func (ic *ContainerEngine) ContainerCopyFromArchive(ctx context.Context, nameOrID, path string, reader io.Reader, options entities.CopyOptions) (entities.ContainerCopyFunc, error) {
-	return containers.CopyFromArchiveWithOptions(ic.ClientCtx, nameOrID, path, reader, new(containers.CopyOptions).WithChown(options.Chown))
+	copyOptions := new(containers.CopyOptions).WithChown(options.Chown).WithRename(options.Rename)
+	return containers.CopyFromArchiveWithOptions(ic.ClientCtx, nameOrID, path, reader, copyOptions)
 }
 
 func (ic *ContainerEngine) ContainerCopyToArchive(ctx context.Context, nameOrID string, path string, writer io.Writer) (entities.ContainerCopyFunc, error) {

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -22,8 +22,7 @@ load helpers
     mkdir -p $srcdir/subdir
     echo "${randomcontent[2]}" > $srcdir/subdir/dotfile.
 
-    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sleep infinity
-    run_podman exec cpcontainer mkdir /srv/subdir
+    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sh -c "mkdir /srv/subdir; sleep infinity"
 
     # Commit the image for testing non-running containers
     run_podman commit -q cpcontainer
@@ -41,7 +40,6 @@ load helpers
 0 | /tmp                 | /tmp/hostfile0        | copy to /tmp
 1 | /tmp/                | /tmp/hostfile1        | copy to /tmp/
 2 | /tmp/.               | /tmp/hostfile2        | copy to /tmp/.
-0 | /tmp/hostfile2       | /tmp/hostfile2        | overwrite previous copy
 0 | /tmp/anotherbase.txt | /tmp/anotherbase.txt  | copy to /tmp, new name
 0 | .                    | /srv/hostfile0        | copy to workdir (rel path), new name
 1 | ./                   | /srv/hostfile1        | copy to workdir (rel path), new name
@@ -175,11 +173,12 @@ load helpers
         random-1-$(random_string 15)
         random-2-$(random_string 20)
     )
-    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sleep infinity
-    run_podman exec cpcontainer sh -c "echo ${randomcontent[0]} > /tmp/containerfile"
-    run_podman exec cpcontainer sh -c "echo ${randomcontent[0]} > /tmp/dotfile."
-    run_podman exec cpcontainer sh -c "echo ${randomcontent[1]} > /srv/containerfile1"
-    run_podman exec cpcontainer sh -c "mkdir /srv/subdir; echo ${randomcontent[2]} > /srv/subdir/containerfile2"
+    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sh -c "mkdir /srv/subdir;
+         echo ${randomcontent[0]} > /tmp/containerfile;
+         echo ${randomcontent[0]} > /tmp/dotfile.;
+         echo ${randomcontent[1]} > /srv/containerfile1;
+         echo ${randomcontent[2]} > /srv/subdir/containerfile2;
+         sleep infinity"
 
     # Commit the image for testing non-running containers
     run_podman commit -q cpcontainer
@@ -233,11 +232,13 @@ load helpers
         random-1-$(random_string 15)
         random-2-$(random_string 20)
     )
-    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sleep infinity
-    run_podman exec cpcontainer sh -c "echo ${randomcontent[0]} > /tmp/containerfile"
-    run_podman exec cpcontainer sh -c "echo ${randomcontent[0]} > /tmp/dotfile."
-    run_podman exec cpcontainer sh -c "echo ${randomcontent[1]} > /srv/containerfile1"
-    run_podman exec cpcontainer sh -c "mkdir /srv/subdir; echo ${randomcontent[2]} > /srv/subdir/containerfile2"
+
+    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sh -c "mkdir /srv/subdir;
+         echo ${randomcontent[0]} > /tmp/containerfile;
+         echo ${randomcontent[0]} > /tmp/dotfile.;
+         echo ${randomcontent[1]} > /srv/containerfile1;
+         echo ${randomcontent[2]} > /srv/subdir/containerfile2;
+         sleep infinity"
 
     # Commit the image for testing non-running containers
     run_podman commit -q cpcontainer
@@ -331,8 +332,7 @@ load helpers
     mkdir -p $srcdir/dir.
     cp -r $srcdir/dir/* $srcdir/dir.
 
-    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sleep infinity
-    run_podman exec cpcontainer mkdir /srv/subdir
+    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sh -c "mkdir /srv/subdir; sleep infinity"
 
     # Commit the image for testing non-running containers
     run_podman commit -q cpcontainer
@@ -399,12 +399,12 @@ load helpers
         random-0-$(random_string 10)
         random-1-$(random_string 15)
     )
-    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sleep infinity
-    run_podman exec cpcontainer sh -c "mkdir /srv/subdir; echo ${randomcontent[0]} > /srv/subdir/containerfile0"
-    run_podman exec cpcontainer sh -c "echo ${randomcontent[1]} > /srv/subdir/containerfile1"
-    # "." and "dir/." will copy the contents, so make sure that a dir ending
-    # with dot is treated correctly.
-    run_podman exec cpcontainer sh -c 'mkdir /tmp/subdir.; cp /srv/subdir/* /tmp/subdir./'
+
+    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sh -c "mkdir /srv/subdir;
+         echo ${randomcontent[0]} > /srv/subdir/containerfile0; \
+         echo ${randomcontent[1]} > /srv/subdir/containerfile1; \
+         mkdir /tmp/subdir.; cp /srv/subdir/* /tmp/subdir./; \
+         sleep infinity"
 
     # Commit the image for testing non-running containers
     run_podman commit -q cpcontainer
@@ -473,12 +473,12 @@ load helpers
         random-0-$(random_string 10)
         random-1-$(random_string 15)
     )
-    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sleep infinity
-    run_podman exec cpcontainer sh -c "mkdir /srv/subdir; echo ${randomcontent[0]} > /srv/subdir/containerfile0"
-    run_podman exec cpcontainer sh -c "echo ${randomcontent[1]} > /srv/subdir/containerfile1"
-    # "." and "dir/." will copy the contents, so make sure that a dir ending
-    # with dot is treated correctly.
-    run_podman exec cpcontainer sh -c 'mkdir /tmp/subdir.; cp /srv/subdir/* /tmp/subdir./'
+
+    run_podman run -d --name cpcontainer --workdir=/srv $IMAGE sh -c "mkdir /srv/subdir;
+         echo ${randomcontent[0]} > /srv/subdir/containerfile0; \
+         echo ${randomcontent[1]} > /srv/subdir/containerfile1; \
+         mkdir /tmp/subdir.; cp /srv/subdir/* /tmp/subdir./; \
+         sleep infinity"
 
     # Commit the image for testing non-running containers
     run_podman commit -q cpcontainer
@@ -581,10 +581,10 @@ ${randomcontent[1]}" "$description"
         random-1-$(random_string 15)
     )
 
-    run_podman run -d --name cpcontainer $IMAGE sleep infinity
-    run_podman exec cpcontainer sh -c "echo ${randomcontent[0]} > /tmp/containerfile0"
-    run_podman exec cpcontainer sh -c "echo ${randomcontent[1]} > /tmp/containerfile1"
-    run_podman exec cpcontainer sh -c "mkdir /tmp/sub && cd /tmp/sub && ln -s .. weirdlink"
+    run_podman run -d --name cpcontainer $IMAGE sh -c "echo ${randomcontent[0]} > /tmp/containerfile0; \
+         echo ${randomcontent[1]} > /tmp/containerfile1; \
+         mkdir /tmp/sub && cd /tmp/sub && ln -s .. weirdlink; \
+         sleep infinity"
 
     # Commit the image for testing non-running containers
     run_podman commit -q cpcontainer


### PR DESCRIPTION
Implement container to container copy.  Previously data could only be
copied from/to the host.

Fixes: #7370
Co-authored-by: Mehul Arora <aroram18@mcmaster.ca>
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
