### PR TITLE
exec: fix cleanup

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -618,7 +618,7 @@ func makeExecConfig(options entities.ExecOptions, rt *libpod.Runtime) (*libpod.E
 		return nil, errors.Wrapf(err, "error retrieving Libpod configuration to build exec exit command")
 	}
 	// TODO: Add some ability to toggle syslog
-	exitCommandArgs, err := generate.CreateExitCommandArgs(storageConfig, runtimeConfig, false, true, true)
+	exitCommandArgs, err := generate.CreateExitCommandArgs(storageConfig, runtimeConfig, false, false, true)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error constructing exit command for exec session")
 	}


### PR DESCRIPTION
Commit 341e6a1 made sure that all exec sessions are getting cleaned up.
But it also came with a peformance penalty.  Fix that penalty by
spawning the cleanup process to really only cleanup the exec session
without attempting to remove the container.

[NO TESTS NEEDED] since we have no means to test such performance
issues in CI.

Fixes: #10701
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@edsantiago PTAL
