### PR TITLE
command: migrate doesn't move process to cgroup

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -46,7 +46,9 @@ func setupContainerEngine(cmd *cobra.Command) (entities.ContainerEngine, error) 
 		return nil, err
 	}
 	if !registry.IsRemote() && rootless.IsRootless() {
-		err := containerEngine.SetupRootless(registry.Context(), cmd)
+		_, noMoveProcess := cmd.Annotations[registry.NoMoveProcess]
+
+		err := containerEngine.SetupRootless(registry.Context(), noMoveProcess)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -15,6 +15,9 @@ import (
 )
 
 const (
+	// NoMoveProcess used as cobra.Annotation when command doesn't need Podman to be moved to a separate cgroup
+	NoMoveProcess = "NoMoveProcess"
+
 	// ParentNSRequired used as cobra.Annotation when command requires root access
 	ParentNSRequired = "ParentNSRequired"
 

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -208,7 +208,8 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 	// 3) command doesn't require Parent Namespace
 	_, found := cmd.Annotations[registry.ParentNSRequired]
 	if !registry.IsRemote() && rootless.IsRootless() && !found {
-		err := registry.ContainerEngine().SetupRootless(registry.Context(), cmd)
+		_, noMoveProcess := cmd.Annotations[registry.NoMoveProcess]
+		err := registry.ContainerEngine().SetupRootless(registry.Context(), noMoveProcess)
 		if err != nil {
 			return err
 		}

--- a/cmd/podman/system/migrate.go
+++ b/cmd/podman/system/migrate.go
@@ -22,7 +22,10 @@ var (
 `
 
 	migrateCommand = &cobra.Command{
-		Annotations:       map[string]string{registry.EngineMode: registry.ABIMode},
+		Annotations: map[string]string{
+			registry.EngineMode:    registry.ABIMode,
+			registry.NoMoveProcess: registry.NoMoveProcess,
+		},
 		Use:               "migrate [options]",
 		Args:              validate.NoArgs,
 		Short:             "Migrate containers",

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/domain/entities/reports"
 	"github.com/containers/podman/v3/pkg/specgen"
-	"github.com/spf13/cobra"
 )
 
 type ContainerCopyFunc func() error
@@ -82,7 +81,7 @@ type ContainerEngine interface {
 	PodStop(ctx context.Context, namesOrIds []string, options PodStopOptions) ([]*PodStopReport, error)
 	PodTop(ctx context.Context, options PodTopOptions) (*StringSliceReport, error)
 	PodUnpause(ctx context.Context, namesOrIds []string, options PodunpauseOptions) ([]*PodUnpauseReport, error)
-	SetupRootless(ctx context.Context, cmd *cobra.Command) error
+	SetupRootless(ctx context.Context, noMoveProcess bool) error
 	SecretCreate(ctx context.Context, name string, reader io.Reader, options SecretCreateOptions) (*SecretCreateReport, error)
 	SecretInspect(ctx context.Context, nameOrIDs []string) ([]*SecretInfoReport, []error, error)
 	SecretList(ctx context.Context) ([]*SecretInfoReport, error)

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -24,7 +24,6 @@ import (
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -57,7 +56,7 @@ func (ic *ContainerEngine) Info(ctx context.Context) (*define.Info, error) {
 	return info, err
 }
 
-func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command) error {
+func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool) error {
 	// do it only after podman has already re-execed and running with uid==0.
 	hasCapSysAdmin, err := unshare.HasCapSysAdmin()
 	if err != nil {
@@ -104,6 +103,9 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command) 
 	if became {
 		os.Exit(ret)
 	}
+	if noMoveProcess {
+		return nil
+	}
 
 	// if there is no pid file, try to join existing containers, and create a pause process.
 	ctrs, err := ic.Libpod.GetRunningContainers()
@@ -118,6 +120,7 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command) 
 	}
 
 	became, ret, err = rootless.TryJoinFromFilePaths(pausePidPath, true, paths)
+
 	if err := movePauseProcessToScope(ic.Libpod); err != nil {
 		conf, err2 := ic.Config(context.Background())
 		if err2 != nil {
@@ -148,7 +151,6 @@ func movePauseProcessToScope(r *libpod.Runtime) error {
 	if err != nil {
 		return errors.Wrapf(err, "could not get pause process pid file path")
 	}
-
 	data, err := ioutil.ReadFile(pausePidPath)
 	if err != nil {
 		return errors.Wrapf(err, "cannot read pause pid file")

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -119,8 +119,8 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command) 
 
 	became, ret, err = rootless.TryJoinFromFilePaths(pausePidPath, true, paths)
 	if err := movePauseProcessToScope(ic.Libpod); err != nil {
-		conf, err := ic.Config(context.Background())
-		if err != nil {
+		conf, err2 := ic.Config(context.Background())
+		if err2 != nil {
 			return err
 		}
 		if conf.Engine.CgroupManager == config.SystemdCgroupsManager {

--- a/pkg/domain/infra/tunnel/system.go
+++ b/pkg/domain/infra/tunnel/system.go
@@ -7,14 +7,13 @@ import (
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/bindings/system"
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/spf13/cobra"
 )
 
 func (ic *ContainerEngine) Info(ctx context.Context) (*define.Info, error) {
 	return system.Info(ic.ClientCtx, nil)
 }
 
-func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command) error {
+func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool) error {
 	panic(errors.New("rootless engine mode is not supported when tunneling"))
 }
 


### PR DESCRIPTION
add a new annotation for the "system migrate" command to not move the pause process to a separate cgroup.
    
The operation is not needed since "system migrate" destroys the pause process, so there won't be any process left to move to a cgroup.

[NO TESTS NEEDED]

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
