### PR TITLE
ps: support the `container...` notation for `ps --filter network=...`

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -618,38 +618,7 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 	hostConfig.Tmpfs = tmpfs
 
 	// Network mode parsing.
-	networkMode := ""
-	switch {
-	case c.config.CreateNetNS:
-		// We actually store the network
-		// mode for Slirp and Bridge, so
-		// we can just use that
-		networkMode = string(c.config.NetMode)
-	case c.config.NetNsCtr != "":
-		networkMode = fmt.Sprintf("container:%s", c.config.NetNsCtr)
-	default:
-		// Find the spec's network namespace.
-		// If there is none, it's host networking.
-		// If there is one and it has a path, it's "ns:".
-		foundNetNS := false
-		for _, ns := range ctrSpec.Linux.Namespaces {
-			if ns.Type == spec.NetworkNamespace {
-				foundNetNS = true
-				if ns.Path != "" {
-					networkMode = fmt.Sprintf("ns:%s", ns.Path)
-				} else {
-					// We're making a network ns,  but not
-					// configuring with Slirp or CNI. That
-					// means it's --net=none
-					networkMode = "none"
-				}
-				break
-			}
-		}
-		if !foundNetNS {
-			networkMode = "host"
-		}
-	}
+	networkMode := c.NetworkMode()
 	hostConfig.NetworkMode = networkMode
 
 	// Port bindings.

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -894,6 +894,18 @@ func (r *Runtime) LookupContainer(idOrName string) (*Container, error) {
 	return r.state.LookupContainer(idOrName)
 }
 
+// LookupContainerId looks up a container id by its name or a partial ID
+// If a partial ID is not unique, an error will be returned
+func (r *Runtime) LookupContainerID(idOrName string) (string, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	if !r.valid {
+		return "", define.ErrRuntimeStopped
+	}
+	return r.state.LookupContainerID(idOrName)
+}
+
 // GetContainers retrieves all containers from the state
 // Filters can be provided which will determine what containers are included in
 // the output. Multiple filters are handled by ANDing their output, so only


### PR DESCRIPTION
Hi team,

Following PR extends `ps --filter` to support docker like:
 `podman container ps --filter network=container:<CtrIdorCtrName>`.

Closes: https://github.com/containers/podman/issues/10361
