### PR TITLE
`ci-fix`: healthcheck tests should use `.Should()` instead of `.To()`.

### DIFF
--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -177,11 +177,11 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck unhealthy but valid arguments check", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-retries", "2", "--health-cmd", "[\"ls\", \"/foo\"]", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
 		hc.WaitWithDefaultTimeout()
-		Expect(hc.ExitCode()).To(Equal(1))
+		Expect(hc).Should(Exit(1))
 	})
 
 	It("podman healthcheck single healthy result changes failed to healthy", func() {


### PR DESCRIPTION
Hi Team,

Another PR (https://github.com/containers/podman/pull/11075) is blocked because of this. Created a separate PR so this can be merged quickly and no new PR gets stuck because of this. I am not really sure please feel free to close this PR if its not needed.

CI error
```bash
# Check if the files can be loaded by the shell
. completions/bash/podman
if [ -x /bin/zsh ]; then /bin/zsh completions/zsh/_podman; fi
if [ -x /bin/fish ]; then /bin/fish completions/fish/podman.fish; fi
CGO_ENABLED=1 \
	go build \
	-mod=vendor  \
	-gcflags 'all=-trimpath=/var/tmp/go/src/github.com/containers/podman' \
	-asmflags 'all=-trimpath=/var/tmp/go/src/github.com/containers/podman' \
	-ldflags '-X github.com/containers/podman/v3/libpod/define.gitCommit=6af6f197c3da59899bff1a7d1047e081ee7a382c -X github.com/containers/podman/v3/libpod/define.buildInfo=1627568292 -X github.com/containers/podman/v3/libpod/config._installPrefix=/usr/local -X github.com/containers/podman/v3/libpod/config._etcDir=/usr/local/etc ' \
	-tags "   selinux systemd exclude_graphdriver_devicemapper seccomp" \
	-o bin/podman ./cmd/podman
hack/man-page-checker
hack/xref-helpmsgs-manpages
hack/swagger-check
contrib/cirrus/pr-should-include-tests
test/e2e/healthcheck_run_test.go:		Expect(session.ExitCode()).To(Equal(0))
test/e2e/healthcheck_run_test.go:		Expect(hc.ExitCode()).To(Equal(1))
^^^ Unhelpful use of Expect(ExitCode())
   Please use '.Should(Exit(...))' pattern instead.
   If that's not possible, please add an annotation (description) to your assertion:
        Expect(...).To(..., "Friendly explanation of this check")
make: *** [Makefile:610: tests-expect-exit] Error 1

Exit status: 2
```

Thanks

