### PR TITLE
Fix auto-update system test for older systemd

### DIFF
--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -261,7 +261,8 @@ EOF
     systemctl enable --now podman-auto-update-$cname.timer
     systemctl list-timers --all
 
-    local expect='Finished Podman auto-update testing service'
+    # While systemd v245 and later uses 'Finished', older versions uses 'Started' for oneshot services
+    local expect='(Finished|Started) Podman auto-update testing service'
     local failed_start=failed
     local count=0
     while [ $count -lt 120 ]; do


### PR DESCRIPTION
If the systemd version is older than this [PR](https://github.com/systemd/systemd/pull/14851), the systemd uses
'Started' when a oneshot service finishes.

Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
