### PR TITLE
fix rootless port forwarding with network dis-/connect

### DIFF
--- a/docs/source/markdown/podman-network-connect.1.md
+++ b/docs/source/markdown/podman-network-connect.1.md
@@ -10,8 +10,6 @@ podman\-network\-connect - Connect a container to a network
 Connects a container to a network. A container can be connected to a network by name or by ID.
 Once connected, the container can communicate with other containers in the same network.
 
-This command is not available for rootless users.
-
 ## OPTIONS
 #### **--alias**
 Add network-scoped alias for the container.  If the network is using the `dnsname` CNI plugin, these aliases

--- a/docs/source/markdown/podman-network-disconnect.1.md
+++ b/docs/source/markdown/podman-network-disconnect.1.md
@@ -7,9 +7,10 @@ podman\-network\-disconnect - Disconnect a container from a network
 **podman network disconnect** [*options*] network container
 
 ## DESCRIPTION
-Disconnects a container from a network.
+Disconnects a container from a network. A container can be disconnected from a network by name or by ID.
+If all networks are disconnected from the container, it will behave like a container created with `--network=none`
+and it will longer have network connectivity until a network is connected again.
 
-This command is not available for rootless users.
 
 ## OPTIONS
 #### **--force**, **-f**

--- a/docs/source/markdown/podman-network-reload.1.md
+++ b/docs/source/markdown/podman-network-reload.1.md
@@ -13,8 +13,6 @@ Rootfull Podman relies on iptables rules in order to provide network connectivit
 this happens for example with `firewall-cmd --reload`, the container loses network connectivity. This command restores
 the network connectivity.
 
-This command is not available for rootless users since rootless containers are not affected by such connectivity problems.
-
 ## OPTIONS
 #### **--all**, **-a**
 

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/opencontainers/selinux v1.8.2
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
-	github.com/rootless-containers/rootlesskit v0.14.2
+	github.com/rootless-containers/rootlesskit v0.14.3
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -403,7 +403,7 @@ github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
 github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -555,7 +555,6 @@ github.com/insomniacslk/dhcp v0.0.0-20210120172423-cc9239ac6294/go.mod h1:TKl4jN
 github.com/ishidawataru/sctp v0.0.0-20210226210310-f2269e66cdee h1:PAXLXk1heNZ5yokbMBpVLZQxo43wCZxRwl00mX+dd44=
 github.com/ishidawataru/sctp v0.0.0-20210226210310-f2269e66cdee/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-github.com/jamescun/tuntap v0.0.0-20190712092105-cb1fb277045c/go.mod h1:zzwpsgcYhzzIP5WyF8g9ivCv38cY9uAV9Gu0m3lThhE=
 github.com/jinzhu/copier v0.3.2 h1:QdBOCbaouLDYaIPFfi1bKv5F5tPpeTwXe4sD0jqtz5w=
 github.com/jinzhu/copier v0.3.2/go.mod h1:24xnZezI2Yqac9J61UC6/dG/k76ttpq0DdJI3QmUvro=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -812,8 +811,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rootless-containers/rootlesskit v0.14.2 h1:jmsSyNyRG0QdWc3usppt5jEy5qOheeUsIINcymPrOFg=
-github.com/rootless-containers/rootlesskit v0.14.2/go.mod h1:nV3TpRISvwhZQSwo0nmQQnxjCxXr3mvrMi0oASLvzcg=
+github.com/rootless-containers/rootlesskit v0.14.3 h1:mS6lkZgT1McqUoZ9wjUIbYq7bWfd9aZGUgZgg8B55Sk=
+github.com/rootless-containers/rootlesskit v0.14.3/go.mod h1:Ai3detLzryb/4EkzXmNfh8aByUcBXp/qqkQusJs1SO8=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -839,6 +838,7 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8/go.mod h1:P5HUIBuIWKbyjl083/loAegFkfbFNx5i2qEP4CNbm7E=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=

--- a/pkg/rootlessport/rootlessport_linux.go
+++ b/pkg/rootlessport/rootlessport_linux.go
@@ -17,9 +17,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containers/storage/pkg/reexec"
@@ -43,12 +45,14 @@ const (
 // Config needs to be provided to the process via stdin as a JSON string.
 // stdin needs to be closed after the message has been written.
 type Config struct {
-	Mappings  []ocicni.PortMapping
-	NetNSPath string
-	ExitFD    int
-	ReadyFD   int
-	TmpDir    string
-	ChildIP   string
+	Mappings    []ocicni.PortMapping
+	NetNSPath   string
+	ExitFD      int
+	ReadyFD     int
+	TmpDir      string
+	ChildIP     string
+	ContainerID string
+	RootlessCNI bool
 }
 
 func init() {
@@ -125,6 +129,12 @@ func parent() error {
 		case <-exitC:
 		}
 	}()
+
+	socketDir := filepath.Join(cfg.TmpDir, "rp")
+	err = os.MkdirAll(socketDir, 0700)
+	if err != nil {
+		return err
+	}
 
 	// create the parent driver
 	stateDir, err := ioutil.TempDir(cfg.TmpDir, "rootlessport")
@@ -231,6 +241,16 @@ outer:
 		return err
 	}
 
+	// we only need to have a socket to reload ports when we run under rootless cni
+	if cfg.RootlessCNI {
+		socket, err := net.Listen("unix", filepath.Join(socketDir, cfg.ContainerID))
+		if err != nil {
+			return err
+		}
+		defer socket.Close()
+		go serve(socket, driver)
+	}
+
 	// write and close ReadyFD (convention is same as slirp4netns --ready-fd)
 	logrus.Info("ready")
 	if _, err := readyW.Write([]byte("1")); err != nil {
@@ -244,6 +264,53 @@ outer:
 	logrus.Info("waiting for exitfd to be closed")
 	if _, err := ioutil.ReadAll(exitR); err != nil {
 		return err
+	}
+	return nil
+}
+
+func serve(listener net.Listener, pm rkport.Manager) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			// we cannot log this error, stderr is already closed
+			continue
+		}
+		ctx := context.TODO()
+		err = handler(ctx, conn, pm)
+		if err != nil {
+			conn.Write([]byte(err.Error()))
+		} else {
+			conn.Write([]byte("OK"))
+		}
+		conn.Close()
+	}
+}
+
+func handler(ctx context.Context, conn io.Reader, pm rkport.Manager) error {
+	var childIP string
+	dec := json.NewDecoder(conn)
+	err := dec.Decode(&childIP)
+	if err != nil {
+		return errors.Wrap(err, "rootless port failed to decode ports")
+	}
+	portStatus, err := pm.ListPorts(ctx)
+	if err != nil {
+		return errors.Wrap(err, "rootless port failed to list ports")
+	}
+	for _, status := range portStatus {
+		err = pm.RemovePort(ctx, status.ID)
+		if err != nil {
+			return errors.Wrap(err, "rootless port failed to remove port")
+		}
+	}
+	// add the ports with the new child IP
+	for _, status := range portStatus {
+		// set the new child IP
+		status.Spec.ChildIP = childIP
+		_, err = pm.AddPort(ctx, status.Spec)
+		if err != nil {
+			return errors.Wrap(err, "rootless port failed to add port")
+		}
 	}
 	return nil
 }

--- a/vendor/github.com/rootless-containers/rootlesskit/pkg/port/builtin/parent/parent.go
+++ b/vendor/github.com/rootless-containers/rootlesskit/pkg/port/builtin/parent/parent.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -140,8 +141,13 @@ func (d *driver) AddPort(ctx context.Context, spec port.Spec) (*port.Status, err
 	}
 	routineStopCh := make(chan struct{})
 	routineStop := func() error {
-		close(routineStopCh)
-		return nil // FIXME
+		routineStopCh <- struct{}{}
+		select {
+		case <-routineStopCh:
+		case <-time.After(5 * time.Second):
+			return errors.New("stop timeout after 5 seconds")
+		}
+		return nil
 	}
 	switch spec.Proto {
 	case "tcp", "tcp4", "tcp6":

--- a/vendor/github.com/rootless-containers/rootlesskit/pkg/port/builtin/parent/tcp/tcp.go
+++ b/vendor/github.com/rootless-containers/rootlesskit/pkg/port/builtin/parent/tcp/tcp.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rootless-containers/rootlesskit/pkg/port/builtin/msg"
 )
 
-func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
+func Run(socketPath string, spec port.Spec, stopCh chan struct{}, logWriter io.Writer) error {
 	ln, err := net.Listen(spec.Proto, net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		fmt.Fprintf(logWriter, "listen: %v\n", err)
@@ -31,7 +31,10 @@ func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io
 		}
 	}()
 	go func() {
-		defer ln.Close()
+		defer func() {
+			ln.Close()
+			close(stopCh)
+		}()
 		for {
 			select {
 			case c, ok := <-newConns:

--- a/vendor/github.com/rootless-containers/rootlesskit/pkg/port/builtin/parent/udp/udp.go
+++ b/vendor/github.com/rootless-containers/rootlesskit/pkg/port/builtin/parent/udp/udp.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rootless-containers/rootlesskit/pkg/port/builtin/parent/udp/udpproxy"
 )
 
-func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io.Writer) error {
+func Run(socketPath string, spec port.Spec, stopCh chan struct{}, logWriter io.Writer) error {
 	addr, err := net.ResolveUDPAddr(spec.Proto, net.JoinHostPort(spec.ParentIP, strconv.Itoa(spec.ParentPort)))
 	if err != nil {
 		return err
@@ -51,6 +51,7 @@ func Run(socketPath string, spec port.Spec, stopCh <-chan struct{}, logWriter io
 			case <-stopCh:
 				// udpp.Close closes ln as well
 				udpp.Close()
+				close(stopCh)
 				return
 			}
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -558,7 +558,7 @@ github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/rivo/uniseg v0.2.0
 github.com/rivo/uniseg
-# github.com/rootless-containers/rootlesskit v0.14.2
+# github.com/rootless-containers/rootlesskit v0.14.3
 github.com/rootless-containers/rootlesskit/pkg/api
 github.com/rootless-containers/rootlesskit/pkg/msgutil
 github.com/rootless-containers/rootlesskit/pkg/port


### PR DESCRIPTION
The rootlessport forwarder requires a child IP to be set. This must be a
valid ip in the container network namespace. The problem is that after a
network disconnect and connect the eth0 ip changed. Therefore the
packages are dropped since the source ip does no longer exists in the
netns.
One solution is to set the child IP to 127.0.0.1, however this is a
security problem. [1]

To fix this we have to recreate the ports after network connect and
disconnect. To make this work the rootlessport process exposes a socket
where podman network connect/disconnect connect to and send to new child
IP to rootlessport. The rootlessport process will remove all ports and
recreate them with the new correct child IP.

Fixes #10052

[1] https://nvd.nist.gov/vuln/detail/CVE-2021-20199


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
