### PR TITLE
Bump to v4.0.0-dev

### DIFF
--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -18,7 +18,7 @@ t HEAD libpod/_ping 200
 for i in /version version; do
     t GET  $i      200                               \
       .Components[0].Name="Podman Engine"            \
-      .Components[0].Details.APIVersion~3[0-9.-]\\+  \
+      .Components[0].Details.APIVersion~4[0-9.-]\\+  \
       .Components[0].Details.MinAPIVersion=3.1.0     \
       .Components[0].Details.Os=linux                \
       .ApiVersion=1.40                               \

--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ const (
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-var Version = semver.MustParse("3.3.0-dev")
+var Version = semver.MustParse("4.0.0-dev")
 
 // See https://docs.docker.com/engine/api/v1.40/
 // libpod compat handlers are expected to honor docker API versions


### PR DESCRIPTION
Bump the main branch's `-dev` version to differentiate between it and the v3.3 branch.