### PR TITLE
Use static path for gvproxy

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -603,9 +603,9 @@ func CheckActiveVM() (bool, string, error) {
 // startHostNetworking runs a binary on the host system that allows users
 // to setup port forwarding to the podman virtual machine
 func (v *MachineVM) startHostNetworking() error {
-	binary, err := exec.LookPath(machine.ForwarderBinaryName)
-	if err != nil {
-		return err
+	binary := filepath.Join("/usr/lib/podman/", machine.ForwarderBinaryName)
+	if _, err := os.Stat(binary); os.IsNotExist(err) {
+		return errors.Errorf("unable to find %s", binary)
 	}
 	// Listen on all at port 7777 for setting up and tearing
 	// down forwarding


### PR DESCRIPTION
Given that we do not want to support gvproxy for anything other than
podman machine, we have decided to use a static path of
/usr/libexec/podman/gvproxy instead of a lookpath.

[NO TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
