### PR TITLE
Fix handling of user specified container labels

### DIFF
--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -50,6 +50,18 @@ function check_label() {
     check_label "--systemd=always" "container_init_t"
 }
 
+@test "podman selinux: init container with --security-opt type" {
+    check_label "--systemd=always --security-opt=label=type:spc_t" "spc_t"
+}
+
+@test "podman selinux: init container with --security-opt level&type" {
+    check_label "--systemd=always --security-opt=label=level:s0:c1,c2 --security-opt=label=type:spc_t" "spc_t" "s0:c1,c2"
+}
+
+@test "podman selinux: init container with --security-opt level" {
+    check_label "--systemd=always --security-opt=label=level:s0:c1,c2" "container_init_t"  "s0:c1,c2"
+}
+
 @test "podman selinux: pid=host" {
     # FIXME this test fails when run rootless with runc:
     #   Error: container_linux.go:367: starting container process caused: process_linux.go:495: container init caused: readonly path /proc/asound: operation not permitted: OCI permission denied


### PR DESCRIPTION
Currently we override the SELinux labels specified by the user
if the container is runing a kata container or systemd container.

This PR fixes to use the label specified by the user.

Fixes: https://github.com/containers/podman/issues/11100

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
