### PR TITLE
Bump Buildah to v1.22.0 [NO TESTS NEEDED]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/container-orchestrated-devices/container-device-interface v0.0.0-20210325223243-f99e8b6c10b9
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
-	github.com/containers/buildah v1.21.1-0.20210721171232-54cafea4c933
-	github.com/containers/common v0.41.1-0.20210730122913-cd6c45fd20e3
+	github.com/containers/buildah v1.22.0
+	github.com/containers/common v0.42.1
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.15.0
 	github.com/containers/ocicrypt v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -73,7 +73,6 @@ github.com/Microsoft/hcsshim v0.8.9/go.mod h1:5692vkUqntj1idxauYlpoINNKeqCiG6Sg3
 github.com/Microsoft/hcsshim v0.8.14/go.mod h1:NtVKoYxQuTLx6gEq0L96c9Ju4JbRJ4nY2ow3VK6a9Lg=
 github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn69iY6URG00=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
-github.com/Microsoft/hcsshim v0.8.17/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim v0.8.20 h1:ZTwcx3NS8n07kPf/JZ1qwU6vnjhVPMUWlXBF8r9UxrE=
 github.com/Microsoft/hcsshim v0.8.20/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
@@ -144,7 +143,6 @@ github.com/cilium/ebpf v0.0.0-20200507155900-a9f01edf17e3/go.mod h1:XT+cAw5wfvso
 github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLIdUjrmSXlK9pkrsDlLHbO8jiB8X8JnOc=
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
-github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.1/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -239,14 +237,12 @@ github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHV
 github.com/containernetworking/plugins v0.8.7/go.mod h1:R7lXeZaBzpfqapcAbHRW8/CYwm0dHzbz0XEjofx0uB0=
 github.com/containernetworking/plugins v0.9.1 h1:FD1tADPls2EEi3flPc2OegIY1M9pUa9r2Quag7HMLV8=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
-github.com/containers/buildah v1.21.1-0.20210721171232-54cafea4c933 h1:jqO3hDypBoKM5be+fVcqGHOpX2fOiQy2DFEeb/VKpsk=
-github.com/containers/buildah v1.21.1-0.20210721171232-54cafea4c933/go.mod h1:9gspFNeUJxIK72n1IMIKIHmtcePEZQsv0tjo+1LqkCo=
-github.com/containers/common v0.41.1-0.20210721112610-c95d2f794edf/go.mod h1:Ba5YVNCnyX6xDtg1JqEHa2EMVMW5UbHmIyEqsEwpeGE=
-github.com/containers/common v0.41.1-0.20210730122913-cd6c45fd20e3 h1:lHOZ+G5B7aP2YPsbDo4DtALFAuFG5PWH3Pv5zL2bC08=
-github.com/containers/common v0.41.1-0.20210730122913-cd6c45fd20e3/go.mod h1:UzAAjDsxwd4qkN1mgsk6aspduBY5bspxvKgwQElaBwk=
+github.com/containers/buildah v1.22.0 h1:VwDrweEEUkfIB0t+hVhwE6FdoV0PZjCTz9sVkaZyv2g=
+github.com/containers/buildah v1.22.0/go.mod h1:a6JsF0iNlJJ5GsiVy16e2fgiUV4S3gWZymrpyqzhar0=
+github.com/containers/common v0.42.1 h1:ADOZrVAS8ZY5hBAvr/GoRoPv5Z7TBkxWgxQEXQjlqac=
+github.com/containers/common v0.42.1/go.mod h1:AaF3ipZfgezsctDuhzLkq4Vl+LkEy7J74ikh2HSXDsg=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
-github.com/containers/image/v5 v5.13.2/go.mod h1:GkWursKDlDcUIT7L7vZf70tADvZCk/Ga0wgS0MuF0ag=
 github.com/containers/image/v5 v5.14.0/go.mod h1:SxiBKOcKuT+4yTjD0AskjO+UwFvNcVOJ9qlAw1HNSPU=
 github.com/containers/image/v5 v5.15.0 h1:NduhN20ptHNlf0uRny5iTJa2OodB9SLMEB4hKKbzBBs=
 github.com/containers/image/v5 v5.15.0/go.mod h1:gzdBcooi6AFdiqfzirUqv90hUyHyI0MMdaqKzACKr2s=
@@ -260,7 +256,6 @@ github.com/containers/ocicrypt v1.1.2/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B
 github.com/containers/psgo v1.5.2 h1:3aoozst/GIwsrr/5jnFy3FrJay98uujPCu9lTuSZ/Cw=
 github.com/containers/psgo v1.5.2/go.mod h1:2ubh0SsreMZjSXW1Hif58JrEcFudQyIy9EzPUWfawVU=
 github.com/containers/storage v1.23.5/go.mod h1:ha26Q6ngehFNhf3AWoXldvAvwI4jFe3ETQAf/CeZPyM=
-github.com/containers/storage v1.32.2/go.mod h1:YIBxxjfXZTi04Ah49sh1uSGfmT1V89+I5i3deRobzQo=
 github.com/containers/storage v1.32.6/go.mod h1:mdB+b89p+jU8zpzLTVXA0gWMmIo0WrkfGMh1R8O2IQw=
 github.com/containers/storage v1.33.0/go.mod h1:FUZPF4nJijX8ixdhByZJXf02cvbyLi6dyDwXdIe8QVY=
 github.com/containers/storage v1.33.1 h1:RHUPZ7vQxwoeOoMoKUDsVun4f9Wi8BTXmr/wQiruBYU=
@@ -280,7 +275,6 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
-github.com/coreos/go-systemd/v22 v22.3.1/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
@@ -583,7 +577,6 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.13.0/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.1 h1:wXr2uRxZTJXHLly6qhJabee5JqIhTRoLBhDOA74hDEQ=
 github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
@@ -732,7 +725,6 @@ github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc91/go.mod h1:3Sm6Dt7OT8z88EbdQqqcRN2oCT54jbi72tT/HqgflT8=
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
-github.com/opencontainers/runc v1.0.0-rc95/go.mod h1:z+bZxa/+Tz/FmYVWkhUajJdzFeOqjc5vrqskhVyHGUM=
 github.com/opencontainers/runc v1.0.0/go.mod h1:MU2S3KEB2ZExnhnAQYbwjdYV6HwKtDlNbA2Z2OeNDeA=
 github.com/opencontainers/runc v1.0.1 h1:G18PGckGdAm3yVQRWDVQ1rLSLntiniKJ0cNRT2Tm5gs=
 github.com/opencontainers/runc v1.0.1/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
@@ -902,7 +894,6 @@ github.com/vbatts/tar-split v0.11.1 h1:0Odu65rhcZ3JZaPHxl7tCI3V/C/Q9Zf82UFravl02
 github.com/vbatts/tar-split v0.11.1/go.mod h1:LEuURwDEiWjRjwu46yU3KVGuUdVv/dcnpcEPSzR8z6g=
 github.com/vbauerster/mpb/v6 v6.0.4 h1:h6J5zM/2wimP5Hj00unQuV8qbo5EPcj6wbkCqgj7KcY=
 github.com/vbauerster/mpb/v6 v6.0.4/go.mod h1:a/+JT57gqh6Du0Ay5jSR+uBMfXGdlR7VQlGP52fJxLM=
-github.com/vbauerster/mpb/v7 v7.0.2/go.mod h1:Mnq3gESXJ9eQhccbGZDggJ1faTCrmaA4iN57fUloRGE=
 github.com/vbauerster/mpb/v7 v7.0.3 h1:NfX0pHWhlDTev15M/C3qmSTM1EiIjcS+/d6qS6H4FnI=
 github.com/vbauerster/mpb/v7 v7.0.3/go.mod h1:NXGsfPGx6G2JssqvEcULtDqUrxuuYs4llpv8W6ZUpzk=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
@@ -1185,7 +1176,6 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201113234701-d7a72108b828/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=

--- a/vendor/github.com/containers/buildah/.cirrus.yml
+++ b/vendor/github.com/containers/buildah/.cirrus.yml
@@ -98,7 +98,7 @@ smoke_task:
     # the git-validate tool which are difficult to debug and fix.
     skip: $CIRRUS_PR == ''
 
-    timeout_in: 10m
+    timeout_in: 30m
 
     setup_script: '${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
     build_script: '${SCRIPT_BASE}/build.sh |& ${_TIMESTAMP}'

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -221,6 +221,316 @@
   * Reset upstream branch to dev version
   * If destination does not exists, do not throw error
 
+## v1.22.0 (2021-08-02)
+    c/image, c/storage, c/common vendor before Podman 3.3 release
+    WIP: tests: new assert()
+    Proposed patch for 3399 (shadowutils)
+    Fix handling of --restore shadow-utils
+    build(deps): bump github.com/containers/image/v5 from 5.13.2 to 5.14.0
+    runtime-flag (debug) test: handle old & new runc
+    build(deps): bump github.com/containers/storage from 1.32.6 to 1.33.0
+    Allow dst and destination for target in secret mounts
+    Multi-arch: Always push updated version-tagged img
+    Add a few tests on cgroups V2
+    imagebuildah.stageExecutor.prepare(): remove pseudonym check
+    refine dangling filter
+    Chown with environment variables not set should fail
+    Just restore protections of shadow-utils
+    build(deps): bump github.com/opencontainers/runc from 1.0.0 to 1.0.1
+    Remove specific kernel version number requirement from install.md
+    Multi-arch image workflow: Make steps generic
+    chroot: fix environment value leakage to intermediate processes
+    Update nix pin with `make nixpkgs`
+    buildah source - create and manage source images
+    Update cirrus-cron notification GH workflow
+    Reuse code from containers/common/pkg/parse
+    Cirrus: Freshen VM images
+    build(deps): bump github.com/containers/storage from 1.32.5 to 1.32.6
+    Fix excludes exception begining with / or ./
+    Fix syntax for --manifest example
+    build(deps): bump github.com/onsi/gomega from 1.13.0 to 1.14.0
+    vendor containers/common@main
+    Cirrus: Drop dependence on fedora-minimal
+    Adjust conformance-test error-message regex
+    Workaround appearance of differing debug messages
+    Cirrus: Install docker from package cache
+    build(deps): bump github.com/containers/ocicrypt from 1.1.1 to 1.1.2
+    Switch rusagelogfile to use options.Out
+    build(deps): bump github.com/containers/storage from 1.32.4 to 1.32.5
+    Turn stdio back to blocking when command finishes
+    Add support for default network creation
+    Cirrus: Updates for master->main rename
+    Change references from master to main
+    Add `--env` and `--workingdir` flags to run command
+    build(deps): bump github.com/opencontainers/runc
+    [CI:DOCS] buildah bud: spelling --ignore-file requires parameter
+    [CI:DOCS] push/pull: clarify supported transports
+    Remove unused function arguments
+    Create mountOptions for mount command flags
+    Extract version command implementation to function
+    Add --json flags to `mount` and `version` commands
+    build(deps): bump github.com/containers/storage from 1.32.2 to 1.32.3
+    build(deps): bump github.com/containers/common from 0.40.0 to 0.40.1
+    copier.Put(): set xattrs after ownership
+    buildah add/copy: spelling
+    build(deps): bump github.com/containers/common from 0.39.0 to 0.40.0
+    buildah copy and buildah add should support .containerignore
+    Remove unused util.StartsWithValidTransport
+    Fix documentation of the --format option of buildah push
+    Don't use alltransports.ParseImageName with known transports
+    build(deps): bump github.com/containers/image/v5 from 5.13.0 to 5.13.1
+    man pages: clarify `rmi` removes dangling parents
+    tests: make it easer to override the location of the copy helper
+    build(deps): bump github.com/containers/image/v5 from 5.12.0 to 5.13.0
+    [CI:DOCS] Fix links to c/image master branch
+    imagebuildah: use the specified logger for logging preprocessing warnings
+    Fix copy into workdir for a single file
+    Fix docs links due to branch rename
+    Update nix pin with `make nixpkgs`
+    build(deps): bump github.com/fsouza/go-dockerclient from 1.7.2 to 1.7.3
+    build(deps): bump github.com/opencontainers/selinux from 1.8.1 to 1.8.2
+    build(deps): bump go.etcd.io/bbolt from 1.3.5 to 1.3.6
+    build(deps): bump github.com/containers/storage from 1.32.1 to 1.32.2
+    build(deps): bump github.com/mattn/go-shellwords from 1.0.11 to 1.0.12
+    build(deps): bump github.com/onsi/ginkgo from 1.16.3 to 1.16.4
+    fix(docs): typo
+    Move to v1.22.0-dev
+    Fix handling of auth.json file while in a user namespace
+    Add rusage-logfile flag to optionally send rusage to a file
+    imagebuildah: redo step logging
+    build(deps): bump github.com/onsi/ginkgo from 1.16.2 to 1.16.3
+    build(deps): bump github.com/containers/storage from 1.32.0 to 1.32.1
+    Add volumes to make running buildah within a container easier
+    build(deps): bump github.com/onsi/gomega from 1.12.0 to 1.13.0
+    Add and use a "copy" helper instead of podman load/save
+    Bump github.com/containers/common from 0.38.4 to 0.39.0
+    containerImageRef/containerImageSource: don't buffer uncompressed layers
+    containerImageRef(): squashed images have no parent images
+    Sync. workflow across skopeo, buildah, and podman
+    Bump github.com/containers/storage from 1.31.1 to 1.31.2
+    Bump github.com/opencontainers/runc from 1.0.0-rc94 to 1.0.0-rc95
+    Bump to v1.21.1-dev [NO TESTS NEEDED]
+
+## v1.21.0 (2021-05-19)
+    Don't blow up if cpp detects errors
+    Vendor in containers/common v0.38.4
+    Remove 'buildah run --security-opt' from completion
+    update c/common
+    Fix handling of --default-mounts-file
+    update vendor of containers/storage v1.31.1
+    Bump github.com/containers/storage from 1.30.3 to 1.31.0
+    Send logrus messages back to caller when building
+    github: Fix bad repo. ref in workflow config
+    Check earlier for bad image tags name
+    buildah bud: fix containers/podman/issues/10307
+    Bump github.com/containers/storage from 1.30.1 to 1.30.3
+    Cirrus: Support [CI:DOCS] test skipping
+    Notification email for cirrus-cron build failures
+    Bump github.com/opencontainers/runc from 1.0.0-rc93 to 1.0.0-rc94
+    Fix race condition
+    Fix copy race while walking paths
+    Preserve ownership of lower directory when doing an overlay mount
+    Bump github.com/onsi/gomega from 1.11.0 to 1.12.0
+    Update nix pin with `make nixpkgs`
+    codespell cleanup
+    Multi-arch github-action workflow unification
+    Bump github.com/containers/image/v5 from 5.11.1 to 5.12.0
+    Bump github.com/onsi/ginkgo from 1.16.1 to 1.16.2
+    imagebuildah: ignore signatures when tagging images
+    update to latest libimage
+    Bump github.com/containers/common from 0.37.0 to 0.37.1
+    Bump github.com/containers/storage from 1.30.0 to 1.30.1
+    Upgrade to GitHub-native Dependabot
+    Document location of auth.json file if XDG_RUNTIME_DIR is not set
+    run.bats: fix flake in run-user test
+    Cirrus: Update F34beta -> F34
+    pr-should-include-tests: try to make work in buildah
+    runUsingRuntime: when relaying error from the runtime, mention that
+    Run(): avoid Mkdir() into the rootfs
+    imagebuildah: replace archive with chrootarchive
+    imagebuildah.StageExecutor.volumeCacheSaveVFS(): set up bind mounts
+    conformance: use :Z with transient mounts when SELinux is enabled
+    bud.bats: fix a bats warning
+    imagebuildah: create volume directories when using overlays
+    imagebuildah: drop resolveSymlink()
+    namespaces test - refactoring and cleanup
+    Refactor 'idmapping' system test
+    Cirrus: Update Ubuntu images to 21.04
+    Tiny fixes in bud system tests
+    Add compabitility wrappers for removed packages
+    Fix expected message at pulling image
+    Fix system tests of 'bud' subcommand
+    [CI:DOCS] Update steps for CentOS runc users
+    Add support for secret mounts
+    Add buildah manifest rm command
+    restore push/pull and util API
+    [CI:DOCS] Remove older distro docs
+    Rename rhel secrets to subscriptions
+    vendor in openshift/imagebuilder
+    Remove buildah bud --loglevel ...
+    use new containers/common/libimage package
+    Fix copier when using globs
+    Test namespace flags of 'bud' subcommand
+    Add system test of 'bud' subcommand
+    Output names of multiple tags in buildah bud
+    push to docker test: don't get fooled by podman
+    copier: add Remove()
+    build(deps): bump github.com/containers/image/v5 from 5.10.5 to 5.11.1
+    Restore log timestamps
+    Add system test of 'buildah help' with a tiny fix
+    tests: copy.bats: fix infinite hang
+    Do not force hard code to crun in rootless mode
+    build(deps): bump github.com/openshift/imagebuilder from 1.2.0 to 1.2.1
+    build(deps): bump github.com/containers/ocicrypt from 1.1.0 to 1.1.1
+    build(deps): bump github.com/containers/common from 0.35.4 to 0.36.0
+    Fix arg missing warning in bud
+    Check without flag in 'from --cgroup-parent' test
+    Minor fixes to Buildah as a library tutorial documentation
+    Add system test of 'buildah version' for packaged buildah
+    Add a few system tests of 'buildah from'
+    Log the final error with %+v at logging level "trace"
+    copier: add GetOptions.NoCrossDevice
+    Update nix pin with `make nixpkgs`
+    Bump to v1.20.2-dev
+
+## v1.20.1 (2021-04-13)
+    Run container with isolation type set at 'from'
+    bats helpers.bash - minor refactoring
+    Bump containers/storage vendor to v1.29.0
+    build(deps): bump github.com/onsi/ginkgo from 1.16.0 to 1.16.1
+    Cirrus: Update VMs w/ F34beta
+    CLI add/copy: add a --from option
+    build(deps): bump github.com/onsi/ginkgo from 1.15.2 to 1.16.0
+    Add authentication system tests for 'commit' and 'bud'
+    fix local image lookup for custom platform
+    Double-check existence of OCI runtimes
+    Cirrus: Make use of shared get_ci_vm container
+    Add system tests of "buildah run"
+    Update nix pin with `make nixpkgs`
+    Remove some stuttering on returns errors
+    Setup alias for --tty to --terminal
+    Add conformance tests for COPY /...
+    Put a few more minutes on the clock for the CI conformance test
+    Add a conformance test for COPY --from $symlink
+    Add conformance tests for COPY ""
+    Check for symlink in builtin volume
+    Sort all mounts by destination directory
+    System-test cleanup
+    Export parse.Platform string to be used by podman-remote
+    blobcache: fix sequencing error
+    build(deps): bump github.com/containers/common from 0.35.3 to 0.35.4
+    Fix URL in demos/buildah_multi_stage.sh
+    Add a few system tests
+    [NO TESTS NEEDED] Use --recurse-modules when building git context
+    Bump to v1.20.1-dev
+
+## v1.20.0 (2021-03-25)
+  * vendor in containers/storage v1.28.1
+  * build(deps): bump github.com/containers/common from 0.35.2 to 0.35.3
+  * tests: prefetch: use buildah, not podman, for pulls
+  * Use faster way to check image tag existence during multi-arch build
+  * Add information about multi-arch images to the Readme
+  * COPY --chown: expand the conformance test
+  * pkg/chrootuser: use a bufio.Scanner
+  * [CI:DOCS] Fix rootful typo in docs
+  * build(deps): bump github.com/onsi/ginkgo from 1.15.1 to 1.15.2
+  * Add documentation and testing for .containerignore
+  * build(deps): bump github.com/sirupsen/logrus from 1.8.0 to 1.8.1
+  * build(deps): bump github.com/hashicorp/go-multierror from 1.1.0 to 1.1.1
+  * Lookup Containerfile if user specifies a directory
+  * Add Tag format placeholder to docs
+  * copier: ignore sockets
+  * image: propagate errors from extractRootfs
+  * Remove system test of 'buildah containers -a'
+  * Clarify userns options are usable only as root in man pages
+  * Fix system test of 'containers -a'
+  * Remove duplicated code in addcopy
+  * build(deps): bump github.com/onsi/ginkgo from 1.15.0 to 1.15.1
+  * build(deps): bump github.com/onsi/gomega from 1.10.5 to 1.11.0
+  * build(deps): bump github.com/fsouza/go-dockerclient from 1.7.1 to 1.7.2
+  * Update multi-arch buildah build setup with new logic
+  * Update nix pin with `make nixpkgs`
+  * overlay.bats: fix the "overlay source permissions" test
+  * imagebuildah: use overlay for volumes when using overlay
+  * Make PolicyMap and PullPolicy names align
+  * copier: add GetOptions.IgnoreUnreadable
+  * Check local image to match system context
+  * fix: Containerfiles - smaller set of userns u/gids
+  * Set upperdir permissions based on source
+  * Shrink the vendoring size of pkc/cli
+  * Clarify image name match failure message
+  * ADD/COPY: create the destination directory first, chroot to it
+  * copier.GetOptions: add NoDerefSymLinks
+  * copier: add an Eval function
+  * Update system test for 'from --cap-add/drop'
+  * copier: fix a renaming bug
+  * copier: return child process stderr if we can't JSON decode the response
+  * Add some system tests
+  * build(deps): bump github.com/containers/storage from 1.26.0 to 1.27.0
+  * complement add/copy --chmod documentation
+  * buildah login and logout, do not need to enter user namespace
+  * Add multi-arch image build
+  * chmod/chown added/fixed in bash completions
+  * OWNERS: add @lsm5
+  * buildah add/copy --chmod dockerfile implementation
+  * bump github.com/openshift/imagebuilder from 1.1.8 to 1.2.0
+  * buildah add/copy --chmod cli implementation for files and urls
+  * Make sure we set the buildah version label
+  * Isolation strings, should match user input
+  * [CI:DOCS] buildah-from.md: remove dup arch,os
+  * build(deps): bump github.com/containers/image/v5 from 5.10.2 to 5.10.3
+  * Cirrus: Temp. disable prior-fedora (F32) testing
+  * pr-should-include-tests: recognized "renamed" tests
+  * build(deps): bump github.com/sirupsen/logrus from 1.7.0 to 1.8.0
+  * build(deps): bump github.com/fsouza/go-dockerclient from 1.7.0 to 1.7.1
+  * build(deps): bump github.com/containers/common from 0.34.2 to 0.35.0
+  * Fix reaping of stages with no instructions
+  * add stale bot
+  * Add base image name to comment
+  * build(deps): bump github.com/spf13/cobra from 1.1.1 to 1.1.3
+  * Don't fail copy to emptydir
+  * buildah: use volatile containers
+  * vendor: update containers/storage
+  * Eliminate the use of containers/building import in pkg subdirs
+  * Add more support for removing config
+  * Improve messages about --cache-from not being supported
+  * Revert patch to allow COPY/ADD of empty dirs.
+  * Don't fail copy to emptydir
+  * Fix tutorial for rootless mode
+  * Fix caching layers with build args
+  * Vendor in containers/image v5.10.2
+  * build(deps): bump github.com/containers/common from 0.34.0 to 0.34.2
+  * build(deps): bump github.com/onsi/ginkgo from 1.14.2 to 1.15.0
+  * 'make validate': require PRs to include tests
+  * build(deps): bump github.com/onsi/gomega from 1.10.4 to 1.10.5
+  * build(deps): bump github.com/containers/storage from 1.24.5 to 1.25.0
+  * Use chown function for U volume flag from containers/common repository
+  * --iidfile: print hash prefix
+  * bump containernetworking/cni to v0.8.1 - fix for CVE-2021-20206
+  * run: fix check for host pid namespace
+  * Finish plumbing for buildah bud --manifest
+  * buildah manifest add localimage should work
+  * Stop testing directory permissions with latest docker
+  * Fix build arg check
+  * build(deps): bump github.com/containers/ocicrypt from 1.0.3 to 1.1.0
+  * [ci:docs] Fix man page for buildah push
+  * Update nix pin with `make nixpkgs`
+  * Bump to containers/image v5.10.1
+  * Rebuild layer if a change in ARG is detected
+  * Bump golang.org/x/crypto to the latest
+  * Add Ashley and Urvashi to Approvers
+  * local image lookup by digest
+  * Use build-arg ENV val from local environment if set
+  * Pick default OCI Runtime from containers.conf
+  * Added required devel packages
+  * Cirrus: Native OSX Build
+  * Cirrus: Two minor cleanup items
+  * Workaround for RHEL gating test failure
+  * build(deps): bump github.com/stretchr/testify from 1.6.1 to 1.7.0
+  * build(deps): bump github.com/mattn/go-shellwords from 1.0.10 to 1.0.11
+  * Reset upstream branch to dev version
+  * If destination does not exists, do not throw error
+
 ## v1.19.0 (2021-01-08)
     Update vendor of containers/storage and containers/common
     Buildah inspect should be able to inspect manifests

--- a/vendor/github.com/containers/buildah/Makefile
+++ b/vendor/github.com/containers/buildah/Makefile
@@ -107,6 +107,7 @@ validate: install.tools
 	./tests/validate/git-validation.sh
 	./hack/xref-helpmsgs-manpages
 	./tests/validate/pr-should-include-tests
+	./tests/validate/buildahimages-are-sane
 
 .PHONY: install.tools
 install.tools:

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,93 @@
+- Changelog for v1.22.0 (2021-08-02)
+  * c/image, c/storage, c/common vendor before Podman 3.3 release
+  * WIP: tests: new assert()
+  * Proposed patch for 3399 (shadowutils)
+  * Fix handling of --restore shadow-utils
+  * build(deps): bump github.com/containers/image/v5 from 5.13.2 to 5.14.0
+  * runtime-flag (debug) test: handle old & new runc
+  * build(deps): bump github.com/containers/storage from 1.32.6 to 1.33.0
+  * Allow dst and destination for target in secret mounts
+  * Multi-arch: Always push updated version-tagged img
+  * Add a few tests on cgroups V2
+  * imagebuildah.stageExecutor.prepare(): remove pseudonym check
+  * refine dangling filter
+  * Chown with environment variables not set should fail
+  * Just restore protections of shadow-utils
+  * build(deps): bump github.com/opencontainers/runc from 1.0.0 to 1.0.1
+  * Remove specific kernel version number requirement from install.md
+  * Multi-arch image workflow: Make steps generic
+  * chroot: fix environment value leakage to intermediate processes
+  * Update nix pin with `make nixpkgs`
+  * buildah source - create and manage source images
+  * Update cirrus-cron notification GH workflow
+  * Reuse code from containers/common/pkg/parse
+  * Cirrus: Freshen VM images
+  * build(deps): bump github.com/containers/storage from 1.32.5 to 1.32.6
+  * Fix excludes exception begining with / or ./
+  * Fix syntax for --manifest example
+  * build(deps): bump github.com/onsi/gomega from 1.13.0 to 1.14.0
+  * vendor containers/common@main
+  * Cirrus: Drop dependence on fedora-minimal
+  * Adjust conformance-test error-message regex
+  * Workaround appearance of differing debug messages
+  * Cirrus: Install docker from package cache
+  * build(deps): bump github.com/containers/ocicrypt from 1.1.1 to 1.1.2
+  * Switch rusagelogfile to use options.Out
+  * build(deps): bump github.com/containers/storage from 1.32.4 to 1.32.5
+  * Turn stdio back to blocking when command finishes
+  * Add support for default network creation
+  * Cirrus: Updates for master->main rename
+  * Change references from master to main
+  * Add `--env` and `--workingdir` flags to run command
+  * build(deps): bump github.com/opencontainers/runc
+  * [CI:DOCS] buildah bud: spelling --ignore-file requires parameter
+  * [CI:DOCS] push/pull: clarify supported transports
+  * Remove unused function arguments
+  * Create mountOptions for mount command flags
+  * Extract version command implementation to function
+  * Add --json flags to `mount` and `version` commands
+  * build(deps): bump github.com/containers/storage from 1.32.2 to 1.32.3
+  * build(deps): bump github.com/containers/common from 0.40.0 to 0.40.1
+  * copier.Put(): set xattrs after ownership
+  * buildah add/copy: spelling
+  * build(deps): bump github.com/containers/common from 0.39.0 to 0.40.0
+  * buildah copy and buildah add should support .containerignore
+  * Remove unused util.StartsWithValidTransport
+  * Fix documentation of the --format option of buildah push
+  * Don't use alltransports.ParseImageName with known transports
+  * build(deps): bump github.com/containers/image/v5 from 5.13.0 to 5.13.1
+  * man pages: clarify `rmi` removes dangling parents
+  * tests: make it easer to override the location of the copy helper
+  * build(deps): bump github.com/containers/image/v5 from 5.12.0 to 5.13.0
+  * [CI:DOCS] Fix links to c/image master branch
+  * imagebuildah: use the specified logger for logging preprocessing warnings
+  * Fix copy into workdir for a single file
+  * Fix docs links due to branch rename
+  * Update nix pin with `make nixpkgs`
+  * build(deps): bump github.com/fsouza/go-dockerclient from 1.7.2 to 1.7.3
+  * build(deps): bump github.com/opencontainers/selinux from 1.8.1 to 1.8.2
+  * build(deps): bump go.etcd.io/bbolt from 1.3.5 to 1.3.6
+  * build(deps): bump github.com/containers/storage from 1.32.1 to 1.32.2
+  * build(deps): bump github.com/mattn/go-shellwords from 1.0.11 to 1.0.12
+  * build(deps): bump github.com/onsi/ginkgo from 1.16.3 to 1.16.4
+  * fix(docs): typo
+  * Move to v1.22.0-dev
+  * Fix handling of auth.json file while in a user namespace
+  * Add rusage-logfile flag to optionally send rusage to a file
+  * imagebuildah: redo step logging
+  * build(deps): bump github.com/onsi/ginkgo from 1.16.2 to 1.16.3
+  * build(deps): bump github.com/containers/storage from 1.32.0 to 1.32.1
+  * Add volumes to make running buildah within a container easier
+  * build(deps): bump github.com/onsi/gomega from 1.12.0 to 1.13.0
+  * Add and use a "copy" helper instead of podman load/save
+  * Bump github.com/containers/common from 0.38.4 to 0.39.0
+  * containerImageRef/containerImageSource: don't buffer uncompressed layers
+  * containerImageRef(): squashed images have no parent images
+  * Sync. workflow across skopeo, buildah, and podman
+  * Bump github.com/containers/storage from 1.31.1 to 1.31.2
+  * Bump github.com/opencontainers/runc from 1.0.0-rc94 to 1.0.0-rc95
+  * Bump to v1.21.1-dev [NO TESTS NEEDED]
+
 - Changelog for v1.21.0 (2021-05-19)
   * Don't blow up if cpp detects errors
   * Vendor in containers/common v0.38.4

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -28,7 +28,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.22.0-dev"
+	Version = "1.22.0"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/vendor/github.com/containers/buildah/go.mod
+++ b/vendor/github.com/containers/buildah/go.mod
@@ -4,10 +4,10 @@ go 1.12
 
 require (
 	github.com/containernetworking/cni v0.8.1
-	github.com/containers/common v0.41.1-0.20210721112610-c95d2f794edf
-	github.com/containers/image/v5 v5.13.2
+	github.com/containers/common v0.42.1
+	github.com/containers/image/v5 v5.15.0
 	github.com/containers/ocicrypt v1.1.2
-	github.com/containers/storage v1.32.6
+	github.com/containers/storage v1.33.1
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/go-units v0.4.0
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20190625141545-5a177b73e316
@@ -36,7 +36,7 @@ require (
 	go.etcd.io/bbolt v1.3.6
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210603125802-9665404d3644
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	k8s.io/klog v1.0.0 // indirect
 )
 

--- a/vendor/github.com/containers/buildah/go.sum
+++ b/vendor/github.com/containers/buildah/go.sum
@@ -73,7 +73,6 @@ github.com/Microsoft/hcsshim v0.8.9/go.mod h1:5692vkUqntj1idxauYlpoINNKeqCiG6Sg3
 github.com/Microsoft/hcsshim v0.8.14/go.mod h1:NtVKoYxQuTLx6gEq0L96c9Ju4JbRJ4nY2ow3VK6a9Lg=
 github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn69iY6URG00=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
-github.com/Microsoft/hcsshim v0.8.17/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim v0.8.20 h1:ZTwcx3NS8n07kPf/JZ1qwU6vnjhVPMUWlXBF8r9UxrE=
 github.com/Microsoft/hcsshim v0.8.20/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwTOcER2fw4I4=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
@@ -135,7 +134,6 @@ github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmE
 github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLIdUjrmSXlK9pkrsDlLHbO8jiB8X8JnOc=
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
-github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.1/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -225,10 +223,11 @@ github.com/containernetworking/cni v0.8.1 h1:7zpDnQ3T3s4ucOuJ/ZCLrYBxzkg0AELFfII
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
-github.com/containers/common v0.41.1-0.20210721112610-c95d2f794edf h1:z0ciG0ByyJG3WCBpLYd2XLThCC7UBaH7GeSfXY4sAqc=
-github.com/containers/common v0.41.1-0.20210721112610-c95d2f794edf/go.mod h1:Ba5YVNCnyX6xDtg1JqEHa2EMVMW5UbHmIyEqsEwpeGE=
-github.com/containers/image/v5 v5.13.2 h1:AgYunV/9d2fRkrmo23wH2MkqeHolFd6oQCkK+1PpuFA=
-github.com/containers/image/v5 v5.13.2/go.mod h1:GkWursKDlDcUIT7L7vZf70tADvZCk/Ga0wgS0MuF0ag=
+github.com/containers/common v0.42.1 h1:ADOZrVAS8ZY5hBAvr/GoRoPv5Z7TBkxWgxQEXQjlqac=
+github.com/containers/common v0.42.1/go.mod h1:AaF3ipZfgezsctDuhzLkq4Vl+LkEy7J74ikh2HSXDsg=
+github.com/containers/image/v5 v5.14.0/go.mod h1:SxiBKOcKuT+4yTjD0AskjO+UwFvNcVOJ9qlAw1HNSPU=
+github.com/containers/image/v5 v5.15.0 h1:NduhN20ptHNlf0uRny5iTJa2OodB9SLMEB4hKKbzBBs=
+github.com/containers/image/v5 v5.15.0/go.mod h1:gzdBcooi6AFdiqfzirUqv90hUyHyI0MMdaqKzACKr2s=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=
@@ -236,9 +235,10 @@ github.com/containers/ocicrypt v1.1.0/go.mod h1:b8AOe0YR67uU8OqfVNcznfFpAzu3rdgU
 github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/containers/ocicrypt v1.1.2 h1:Ez+GAMP/4GLix5Ywo/fL7O0nY771gsBIigiqUm1aXz0=
 github.com/containers/ocicrypt v1.1.2/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
-github.com/containers/storage v1.32.2/go.mod h1:YIBxxjfXZTi04Ah49sh1uSGfmT1V89+I5i3deRobzQo=
-github.com/containers/storage v1.32.6 h1:NqdFRewXO/PYPjgCAScoigZc5QUA21yapSEj6kqD8cw=
 github.com/containers/storage v1.32.6/go.mod h1:mdB+b89p+jU8zpzLTVXA0gWMmIo0WrkfGMh1R8O2IQw=
+github.com/containers/storage v1.33.0/go.mod h1:FUZPF4nJijX8ixdhByZJXf02cvbyLi6dyDwXdIe8QVY=
+github.com/containers/storage v1.33.1 h1:RHUPZ7vQxwoeOoMoKUDsVun4f9Wi8BTXmr/wQiruBYU=
+github.com/containers/storage v1.33.1/go.mod h1:FUZPF4nJijX8ixdhByZJXf02cvbyLi6dyDwXdIe8QVY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
@@ -251,7 +251,6 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
-github.com/coreos/go-systemd/v22 v22.3.1/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
@@ -515,7 +514,6 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.13.0/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.1 h1:wXr2uRxZTJXHLly6qhJabee5JqIhTRoLBhDOA74hDEQ=
 github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
@@ -636,7 +634,6 @@ github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59P
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
-github.com/opencontainers/runc v1.0.0-rc95/go.mod h1:z+bZxa/+Tz/FmYVWkhUajJdzFeOqjc5vrqskhVyHGUM=
 github.com/opencontainers/runc v1.0.0/go.mod h1:MU2S3KEB2ZExnhnAQYbwjdYV6HwKtDlNbA2Z2OeNDeA=
 github.com/opencontainers/runc v1.0.1 h1:G18PGckGdAm3yVQRWDVQ1rLSLntiniKJ0cNRT2Tm5gs=
 github.com/opencontainers/runc v1.0.1/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
@@ -780,8 +777,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vbatts/tar-split v0.11.1 h1:0Odu65rhcZ3JZaPHxl7tCI3V/C/Q9Zf82UFravl02dE=
 github.com/vbatts/tar-split v0.11.1/go.mod h1:LEuURwDEiWjRjwu46yU3KVGuUdVv/dcnpcEPSzR8z6g=
-github.com/vbauerster/mpb/v7 v7.0.2 h1:eN6AD/ytv1nqCO7Dm8MO0/pGMKmMyH/WMnTJhAUuc/w=
-github.com/vbauerster/mpb/v7 v7.0.2/go.mod h1:Mnq3gESXJ9eQhccbGZDggJ1faTCrmaA4iN57fUloRGE=
+github.com/vbauerster/mpb/v7 v7.0.3 h1:NfX0pHWhlDTev15M/C3qmSTM1EiIjcS+/d6qS6H4FnI=
+github.com/vbauerster/mpb/v7 v7.0.3/go.mod h1:NXGsfPGx6G2JssqvEcULtDqUrxuuYs4llpv8W6ZUpzk=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852 h1:cPXZWzzG0NllBLdjWoD1nDfaqu98YMv+OneaKc8sPOA=
@@ -1044,8 +1041,8 @@ golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210603125802-9665404d3644 h1:CA1DEQ4NdKphKeL70tvsWNdT5oFh1lOjihRcEDROi0I=
-golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201113234701-d7a72108b828/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/vendor/github.com/containers/buildah/run_linux.go
+++ b/vendor/github.com/containers/buildah/run_linux.go
@@ -2334,7 +2334,7 @@ func getSecretMount(tokens []string, secrets map[string]string, mountlabel strin
 		switch kv[0] {
 		case "id":
 			id = kv[1]
-		case "target":
+		case "target", "dst", "destination":
 			target = kv[1]
 		case "required":
 			required, err = strconv.ParseBool(kv[1])

--- a/vendor/github.com/containers/common/libimage/pull.go
+++ b/vendor/github.com/containers/common/libimage/pull.go
@@ -61,7 +61,10 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 		// Check whether `name` points to a transport.  If so, we
 		// return the error.  Otherwise we assume that `name` refers to
 		// an image on a registry (e.g., "fedora").
-		if alltransports.TransportFromImageName(name) != nil {
+		//
+		// NOTE: the `docker` transport is an exception to support a
+		// `pull docker:latest` which would otherwise return an error.
+		if t := alltransports.TransportFromImageName(name); t != nil && t.Name() != registryTransport.Transport.Name() {
 			return nil, err
 		}
 

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -20,18 +20,18 @@
 # "key = value"
 # If it is empty or commented out, no annotations will be added
 #
-# annotations = []
+#annotations = []
 
 # Used to change the name of the default AppArmor profile of container engine.
 #
-# apparmor_profile = "container-default"
+#apparmor_profile = "container-default"
 
 # Default way to to create a cgroup namespace for the container
 # Options are:
 # `private` Create private Cgroup Namespace for the container.
 # `host`    Share host Cgroup Namespace with the container.
 #
-# cgroupns = "private"
+#cgroupns = "private"
 
 # Control container cgroup configuration
 # Determines  whether  the  container will create CGroups.
@@ -40,23 +40,23 @@
 # `disabled`  Disable cgroup support, will inherit cgroups from parent
 # `no-conmon` Do not create a cgroup dedicated to conmon.
 #
-# cgroups = "enabled"
+#cgroups = "enabled"
 
 # List of default capabilities for containers. If it is empty or commented out,
 # the default capabilities defined in the container engine will be added.
 #
 default_capabilities = [
-    "CHOWN",
-    "DAC_OVERRIDE",
-    "FOWNER",
-    "FSETID",
-    "KILL",
-    "NET_BIND_SERVICE",
-    "SETFCAP",
-    "SETGID",
-    "SETPCAP",
-    "SETUID",
-    "SYS_CHROOT"
+  "CHOWN",
+  "DAC_OVERRIDE",
+  "FOWNER",
+  "FSETID",
+  "KILL",
+  "NET_BIND_SERVICE",
+  "SETFCAP",
+  "SETGID",
+  "SETPCAP",
+  "SETUID",
+  "SYS_CHROOT"
 ]
 
 # A list of sysctls to be set in containers by default,
@@ -64,7 +64,7 @@ default_capabilities = [
 # for example:"net.ipv4.ping_group_range = 0 0".
 #
 default_sysctls = [
- "net.ipv4.ping_group_range=0 0",
+  "net.ipv4.ping_group_range=0 0",
 ]
 
 # A list of ulimits to be set in containers by default, specified as
@@ -75,24 +75,24 @@ default_sysctls = [
 # container engine.
 # Ulimits has limits for non privileged container engines.
 #
-# default_ulimits = [
+#default_ulimits = [
 #  "nofile=1280:2560",
-# ]
+#]
 
 # List of devices. Specified as
 # "<device-on-host>:<device-on-container>:<permissions>", for example:
 # "/dev/sdc:/dev/xvdc:rwm".
 # If it is empty or commented out, only the default devices will be used
 #
-# devices = []
+#devices = []
 
 # List of default DNS options to be added to /etc/resolv.conf inside of the container.
 #
-# dns_options = []
+#dns_options = []
 
 # List of default DNS search domains to be added to /etc/resolv.conf inside of the container.
 #
-# dns_searches = []
+#dns_searches = []
 
 # Set default DNS servers.
 # This option can be used to override the DNS configuration passed to the
@@ -100,19 +100,19 @@ default_sysctls = [
 # /etc/resolv.conf in the container.
 # The /etc/resolv.conf file in the image will be used without changes.
 #
-# dns_servers = []
+#dns_servers = []
 
 # Environment variable list for the conmon process; used for passing necessary
 # environment variables to conmon or the runtime.
 #
-# env = [
-#    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-#    "TERM=xterm",
-# ]
+#env = [
+#  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+#  "TERM=xterm",
+#]
 
 # Pass all host environment variables into the container.
 #
-# env_host = false
+#env_host = false
 
 # Default proxy environment variables passed into the container.
 # The environment variables passed in include:
@@ -121,49 +121,50 @@ default_sysctls = [
 # should not use proxy. Proxy environment variables specified for the container
 # in any other way will override the values passed from the host.
 #
-# http_proxy = true
+#http_proxy = true
 
 # Run an init inside the container that forwards signals and reaps processes.
 #
-# init = false
+#init = false
 
-#  Container init binary, if init=true, this is the init binary to be used for containers.
+# Container init binary, if init=true, this is the init binary to be used for containers.
 #
-# init_path = "/usr/libexec/podman/catatonit"
+#init_path = "/usr/libexec/podman/catatonit"
 
 # Default way to to create an IPC namespace (POSIX SysV IPC) for the container
 # Options are:
 # `private` Create private IPC Namespace for the container.
 # `host`    Share host IPC Namespace with the container.
 #
-# ipcns = "private"
+#ipcns = "private"
 
 # keyring tells the container engine whether to create
 # a kernel keyring for use within the container.
-# keyring = true
+#
+#keyring = true
 
 # label tells the container engine whether to use container separation using
 # MAC(SELinux) labeling or not.
 # The label flag is ignored on label disabled systems.
 #
-# label = true
+#label = true
 
 # Logging driver for the container. Available options: k8s-file and journald.
 #
-# log_driver = "k8s-file"
+#log_driver = "k8s-file"
 
 # Maximum size allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If positive, it must be >= 8192 to match or
 # exceed conmon's read buffer. The file is truncated and re-opened so the
 # limit is never exceeded.
 #
-# log_size_max = -1
+#log_size_max = -1
 
 # Specifies default format tag for container log messages.
 # This is useful for creating a specific tag for container log messages.
 # Containers logs default to truncated container ID as a tag.
 #
-# log_tag = ""
+#log_tag = ""
 
 # Default way to to create a Network namespace for the container
 # Options are:
@@ -171,143 +172,147 @@ default_sysctls = [
 # `host`    Share host Network Namespace with the container.
 # `none`    Containers do not use the network
 #
-# netns = "private"
+#netns = "private"
 
 # Create /etc/hosts for the container.  By default, container engine manage
 # /etc/hosts, automatically adding  the container's  own  IP  address.
 #
-# no_hosts = false
+#no_hosts = false
 
 # Default way to to create a PID namespace for the container
 # Options are:
 # `private` Create private PID Namespace for the container.
 # `host`    Share host PID Namespace with the container.
 #
-# pidns = "private"
+#pidns = "private"
 
 # Maximum number of processes allowed in a container.
 #
-# pids_limit = 2048
+#pids_limit = 2048
 
 # Copy the content from the underlying image into the newly created volume
 # when the container is created instead of when it is started. If false,
 # the container engine will not copy the content until the container is started.
 # Setting it to true may have negative performance implications.
 #
-# prepare_volume_on_create = false
+#prepare_volume_on_create = false
 
 # Indicates the networking to be used for rootless containers
-# rootless_networking = "slirp4netns"
+#
+#rootless_networking = "slirp4netns"
 
 # Path to the seccomp.json profile which is used as the default seccomp profile
 # for the runtime.
 #
-# seccomp_profile = "/usr/share/containers/seccomp.json"
+#seccomp_profile = "/usr/share/containers/seccomp.json"
 
 # Size of /dev/shm. Specified as <number><unit>.
 # Unit is optional, values:
 # b (bytes), k (kilobytes), m (megabytes), or g (gigabytes).
 # If the unit is omitted, the system uses bytes.
 #
-# shm_size = "65536k"
+#shm_size = "65536k"
 
 # Set timezone in container. Takes IANA timezones as well as "local",
 # which sets the timezone in the container to match the host machine.
 #
-# tz = ""
+#tz = ""
 
 # Set umask inside the container
 #
-# umask = "0022"
+#umask = "0022"
 
 # Default way to to create a User namespace for the container
 # Options are:
 # `auto`        Create unique User Namespace for the container.
 # `host`    Share host User Namespace with the container.
 #
-# userns = "host"
+#userns = "host"
 
 # Number of UIDs to allocate for the automatic container creation.
 # UIDs are allocated from the "container" UIDs listed in
 # /etc/subuid & /etc/subgid
 #
-# userns_size = 65536
+#userns_size = 65536
 
 # Default way to to create a UTS namespace for the container
 # Options are:
 # `private`        Create private UTS Namespace for the container.
 # `host`    Share host UTS Namespace with the container.
 #
-# utsns = "private"
+#utsns = "private"
 
 # List of volumes. Specified as
 # "<directory-on-host>:<directory-in-container>:<options>", for example:
 # "/db:/var/lib/db:ro".
 # If it is empty or commented out, no volumes will be added
 #
-# volumes = []
+#volumes = []
 
 # The network table contains settings pertaining to the management of
 # CNI plugins.
 
 [secrets]
-# driver = "file"
+#driver = "file"
 
 [secrets.opts]
-# root = "/example/directory"
+#root = "/example/directory"
 
 [network]
 
 # Path to directory where CNI plugin binaries are located.
 #
-# cni_plugin_dirs = ["/usr/libexec/cni"]
+#cni_plugin_dirs = ["/usr/libexec/cni"]
 
 # The network name of the default CNI network to attach pods to.
-# default_network = "podman"
+#
+#default_network = "podman"
 
 # The default subnet for the default CNI network given in default_network.
 # If a network with that name does not exist, a new network using that name and
 # this subnet will be created.
 # Must be a valid IPv4 CIDR prefix.
+#
 #default_subnet = "10.88.0.0/16"
 
 # Path to the directory where CNI configuration files are located.
 #
-# network_config_dir = "/etc/cni/net.d/"
+#network_config_dir = "/etc/cni/net.d/"
 
 [engine]
 # Index to the active service
-# active_service = production
+#
+#active_service = production
 
 # Cgroup management implementation used for the runtime.
 # Valid options "systemd" or "cgroupfs"
 #
-# cgroup_manager = "systemd"
+#cgroup_manager = "systemd"
 
 # Environment variables to pass into conmon
 #
-# conmon_env_vars = [
-#        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-# ]
+#conmon_env_vars = [
+#  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+#]
 
 # Paths to look for the conmon container manager binary
 #
-# conmon_path = [
-#        "/usr/libexec/podman/conmon",
-#        "/usr/local/libexec/podman/conmon",
-#        "/usr/local/lib/podman/conmon",
-#        "/usr/bin/conmon",
-#        "/usr/sbin/conmon",
-#        "/usr/local/bin/conmon",
-#        "/usr/local/sbin/conmon"
-# ]
+#conmon_path = [
+#  "/usr/libexec/podman/conmon",
+#  "/usr/local/libexec/podman/conmon",
+#  "/usr/local/lib/podman/conmon",
+#  "/usr/bin/conmon",
+#  "/usr/sbin/conmon",
+#  "/usr/local/bin/conmon",
+#  "/usr/local/sbin/conmon"
+#]
 
 # Specify the keys sequence used to detach a container.
 # Format is a single character [a-Z] or a comma separated sequence of
 # `ctrl-<value>`, where `<value>` is one of:
 # `a-z`, `@`, `^`, `[`, `\`, `]`, `^` or `_`
 #
-# detach_keys = "ctrl-p,ctrl-q"
+#detach_keys = "ctrl-p,ctrl-q"
 
 # Determines whether engine will reserve ports on the host when they are
 # forwarded to containers. When enabled, when ports are forwarded to containers,
@@ -316,48 +321,51 @@ default_sysctls = [
 # significant memory usage if a container has many ports forwarded to it.
 # Disabling this can save memory.
 #
-# enable_port_reservation = true
+#enable_port_reservation = true
 
 # Environment variables to be used when running the container engine (e.g., Podman, Buildah).
 # For example "http_proxy=internal.proxy.company.com".
 # Note these environment variables will not be used within the container.
 # Set the env section under [containers] table, if you want to set environment variables for the container.
-# env = []
+#
+#env = []
 
 # Selects which logging mechanism to use for container engine events.
 # Valid values are `journald`, `file` and `none`.
 #
-# events_logger = "journald"
+#events_logger = "journald"
 
 # Path to OCI hooks directories for automatically executed hooks.
 #
-# hooks_dir = [
-#     "/usr/share/containers/oci/hooks.d",
-# ]
+#hooks_dir = [
+#  "/usr/share/containers/oci/hooks.d",
+#]
 
 # Manifest Type (oci, v2s2, or v2s1) to use when pulling, pushing, building
 # container images. By default image pulled and pushed match the format of the
 # source image. Building/committing defaults to OCI.
-# image_default_format = ""
+#
+#image_default_format = ""
 
 # Default transport method for pulling and pushing for images
 #
-# image_default_transport = "docker://"
+#image_default_transport = "docker://"
 
 # Maximum number of image layers to be copied (pulled/pushed) simultaneously.
 # Not setting this field, or setting it to zero, will fall back to containers/image defaults.
-# image_parallel_copies = 0
+#
+#image_parallel_copies = 0
 
 # Default command to run the infra container
 #
-# infra_command = "/pause"
+#infra_command = "/pause"
 
 # Infra (pause) container image name for pod infra containers.  When running a
 # pod, we start a `pause` process in a container to hold open the namespaces
 # associated with the  pod.  This container does nothing other then sleep,
 # reserving the pods resources for the lifetime of the pod.
 #
-# infra_image = "k8s.gcr.io/pause:3.4.1"
+#infra_image = "k8s.gcr.io/pause:3.4.1"
 
 # Specify the locking mechanism to use; valid values are "shm" and "file".
 # Change the default only if you are sure of what you are doing, in general
@@ -365,18 +373,19 @@ default_sysctls = [
 # faster "shm" lock type.  You may need to run "podman system renumber" after
 # you change the lock type.
 #
-# lock_type** = "shm"
+#lock_type** = "shm"
 
 # Indicates if Podman is running inside a VM via Podman Machine.
 # Podman uses this value to do extra setup around networking from the
 # container inside the VM to to host.
-# machine_enabled = false
+#
+#machine_enabled = false
 
 # MultiImageArchive - if true, the container engine allows for storing archives
 # (e.g., of the docker-archive transport) with multiple images.  By default,
 # Podman creates single-image archives.
 #
-# multi_image_archive = "false"
+#multi_image_archive = "false"
 
 # Default engine namespace
 # If engine is joined to a namespace, it will see only containers and pods
@@ -385,131 +394,136 @@ default_sysctls = [
 # The default namespace is "", which corresponds to no namespace. When no
 # namespace is set, all containers and pods are visible.
 #
-# namespace = ""
+#namespace = ""
 
 # Path to the slirp4netns binary
 #
-# network_cmd_path = ""
+#network_cmd_path = ""
 
 # Default options to pass to the slirp4netns binary.
 # For example "allow_host_loopback=true"
 #
-# network_cmd_options = []
+#network_cmd_options = []
 
 # Whether to use chroot instead of pivot_root in the runtime
 #
-# no_pivot_root = false
+#no_pivot_root = false
 
 # Number of locks available for containers and pods.
 # If this is changed, a lock renumber must be performed (e.g. with the
 # 'podman system renumber' command).
 #
-# num_locks = 2048
+#num_locks = 2048
 
 # Whether to pull new image before running a container
-# pull_policy = "missing"
+#
+#pull_policy = "missing"
 
 # Indicates whether the application should be running in remote mode. This flag modifies the
 # --remote option on container engines. Setting the flag to true will default
 # `podman --remote=true` for access to the remote Podman service.
-# remote = false
+#
+#remote = false
 
 # Default OCI runtime
 #
-# runtime = "crun"
+#runtime = "crun"
 
 # List of the OCI runtimes that support --format=json.  When json is supported
 # engine will use it for reporting nicer errors.
 #
-# runtime_supports_json = ["crun", "runc", "kata", "runsc"]
+#runtime_supports_json = ["crun", "runc", "kata", "runsc"]
 
 # List of the OCI runtimes that supports running containers with KVM Separation.
 #
-# runtime_supports_kvm = ["kata"]
+#runtime_supports_kvm = ["kata"]
 
 # List of the OCI runtimes that supports running containers without cgroups.
 #
-# runtime_supports_nocgroups = ["crun"]
+#runtime_supports_nocgroups = ["crun"]
 
 # Directory for persistent engine files (database, etc)
 # By default, this will be configured relative to where the containers/storage
 # stores containers
 # Uncomment to change location from this default
 #
-# static_dir = "/var/lib/containers/storage/libpod"
+#static_dir = "/var/lib/containers/storage/libpod"
 
 # Number of seconds to wait for container to exit before sending kill signal.
-# stop_timeout = 10
+#
+#stop_timeout = 10
 
 # map of service destinations
-# [service_destinations]
-#   [service_destinations.production]
+#
+#[service_destinations]
+#  [service_destinations.production]
 #     URI to access the Podman service
 #     Examples:
 #       rootless "unix://run/user/$UID/podman/podman.sock" (Default)
 #       rootfull "unix://run/podman/podman.sock (Default)
 #       remote rootless ssh://engineering.lab.company.com/run/user/1000/podman/podman.sock
 #       remote rootfull ssh://root@10.10.1.136:22/run/podman/podman.sock
-#     uri = "ssh://user@production.example.com/run/user/1001/podman/podman.sock"
-#     Path to file containing ssh identity key
-#     identity = "~/.ssh/id_rsa"
+#
+#    uri = "ssh://user@production.example.com/run/user/1001/podman/podman.sock"
+#    Path to file containing ssh identity key
+#    identity = "~/.ssh/id_rsa"
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
 #
-# tmp_dir = "/run/libpod"
+#tmp_dir = "/run/libpod"
 
 # Directory for libpod named volumes.
 # By default, this will be configured relative to where containers/storage
 # stores containers.
 # Uncomment to change location from this default.
 #
-# volume_path = "/var/lib/containers/storage/volumes"
+#volume_path = "/var/lib/containers/storage/volumes"
 
 # Paths to look for a valid OCI runtime (crun, runc, kata, runsc, etc)
 [engine.runtimes]
-# crun = [
-#            "/usr/bin/crun",
-#            "/usr/sbin/crun",
-#            "/usr/local/bin/crun",
-#            "/usr/local/sbin/crun",
-#            "/sbin/crun",
-#            "/bin/crun",
-#            "/run/current-system/sw/bin/crun",
-# ]
+#crun = [
+#  "/usr/bin/crun",
+#  "/usr/sbin/crun",
+#  "/usr/local/bin/crun",
+#  "/usr/local/sbin/crun",
+#  "/sbin/crun",
+#  "/bin/crun",
+#  "/run/current-system/sw/bin/crun",
+#]
 
-# kata = [
-#            "/usr/bin/kata-runtime",
-#            "/usr/sbin/kata-runtime",
-#            "/usr/local/bin/kata-runtime",
-#            "/usr/local/sbin/kata-runtime",
-#            "/sbin/kata-runtime",
-#            "/bin/kata-runtime",
-#            "/usr/bin/kata-qemu",
-#            "/usr/bin/kata-fc",
-# ]
+#kata = [
+#  "/usr/bin/kata-runtime",
+#  "/usr/sbin/kata-runtime",
+#  "/usr/local/bin/kata-runtime",
+#  "/usr/local/sbin/kata-runtime",
+#  "/sbin/kata-runtime",
+#  "/bin/kata-runtime",
+#  "/usr/bin/kata-qemu",
+#  "/usr/bin/kata-fc",
+#]
 
-# runc = [
-#        "/usr/bin/runc",
-#        "/usr/sbin/runc",
-#        "/usr/local/bin/runc",
-#        "/usr/local/sbin/runc",
-#        "/sbin/runc",
-#        "/bin/runc",
-#        "/usr/lib/cri-o-runc/sbin/runc",
-# ]
+#runc = [
+#  "/usr/bin/runc",
+#  "/usr/sbin/runc",
+#  "/usr/local/bin/runc",
+#  "/usr/local/sbin/runc",
+#  "/sbin/runc",
+#  "/bin/runc",
+#  "/usr/lib/cri-o-runc/sbin/runc",
+#]
 
-# runsc = [
-#            "/usr/bin/runsc",
-#            "/usr/sbin/runsc",
-#            "/usr/local/bin/runsc",
-#            "/usr/local/sbin/runsc",
-#            "/bin/runsc",
-#            "/sbin/runsc",
-#            "/run/current-system/sw/bin/runsc",
-# ]
+#runsc = [
+#  "/usr/bin/runsc",
+#  "/usr/sbin/runsc",
+#  "/usr/local/bin/runsc",
+#  "/usr/local/sbin/runsc",
+#  "/bin/runsc",
+#  "/sbin/runsc",
+#  "/run/current-system/sw/bin/runsc",
+#]
 
 [engine.volume_plugins]
-# testplugin = "/run/podman/plugins/test.sock"
+#testplugin = "/run/podman/plugins/test.sock"
 
 # The [engine.volume_plugins] table MUST be the last entry in this file.
 # (Unless another table is added)

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.41.1-dev"
+const Version = "0.42.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -77,7 +77,7 @@ github.com/containernetworking/plugins/pkg/utils/hwaddr
 github.com/containernetworking/plugins/pkg/utils/sysctl
 github.com/containernetworking/plugins/plugins/ipam/host-local/backend
 github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator
-# github.com/containers/buildah v1.21.1-0.20210721171232-54cafea4c933
+# github.com/containers/buildah v1.22.0
 github.com/containers/buildah
 github.com/containers/buildah/bind
 github.com/containers/buildah/chroot
@@ -93,7 +93,7 @@ github.com/containers/buildah/pkg/overlay
 github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/util
-# github.com/containers/common v0.41.1-0.20210730122913-cd6c45fd20e3
+# github.com/containers/common v0.42.1
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
 github.com/containers/common/pkg/apparmor


### PR DESCRIPTION
Bump Buildah to v1.22.0 in preparation for RHEL 8.5 and
RHEL 9.0beta.  Also bump c/common to v0.42.1
[NO TESTS NEEDED]

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
