### PR TITLE
Fix podman unpause to work like podman stop

### DIFF
--- a/cmd/podman/utils/error.go
+++ b/cmd/podman/utils/error.go
@@ -1,6 +1,9 @@
 package utils
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 type OutputErrors []error
 
@@ -10,7 +13,7 @@ func (o OutputErrors) PrintErrors() (lastError error) {
 	}
 	lastError = o[len(o)-1]
 	for e := 0; e < len(o)-1; e++ {
-		fmt.Println(o[e])
+		fmt.Fprintf(os.Stderr, "Error: %s\n", o[e])
 	}
 	return
 }


### PR DESCRIPTION
Currently if you execute podman unpause --all, it
shows attempts to unpause containers that are not paused and prints
an error.  This PR catches this error and only prints errors if
a paused container was not able to be unpaused.

Also change printing of multiple errors to go to stderr and to prefix
"Error: " in front to match the output of the last error.

Fixes: https://github.com/containers/podman/issues/11098

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
