### PR TITLE
image scp: fix typo in output

### DIFF
--- a/cmd/podman/images/scp.go
+++ b/cmd/podman/images/scp.go
@@ -111,7 +111,7 @@ func scp(cmd *cobra.Command, args []string) (finalErr error) {
 		if err != nil {
 			return err
 		}
-		fmt.Println("Loaded images(s): " + strings.Join(report.Names, ","))
+		fmt.Println("Loaded image(s): " + strings.Join(report.Names, ","))
 	case scpOpts.ToRemote: // remote host load
 		scpOpts.Save.Format = "oci-archive"
 		abiErr := abiEng.Save(context.Background(), scpOpts.SourceImageName, []string{}, scpOpts.Save) // save the image locally before loading it on remote, local, or ssh
@@ -137,7 +137,7 @@ func scp(cmd *cobra.Command, args []string) (finalErr error) {
 		if err != nil {
 			return err
 		}
-		fmt.Println("Loaded images(s): " + strings.Join(rep.Names, ","))
+		fmt.Println("Loaded image(s): " + strings.Join(rep.Names, ","))
 	}
 	return nil
 }

--- a/docs/source/markdown/podman-image-scp.1.md
+++ b/docs/source/markdown/podman-image-scp.1.md
@@ -59,7 +59,7 @@ Copying blob 9450ef9feb15 [--------------------------------------] 0.0b / 0.0b
 Copying config 1f97f0559c done
 Writing manifest to image destination
 Storing signatures
-Loaded images(s): docker.io/library/alpine:latest
+Loaded image(s): docker.io/library/alpine:latest
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
s/Loaded images(s)/Loaded image(s)/

[NO TESTS NEEDED] (I think we should test the output at some point)

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@cdoern PTAL
