### PR TITLE
Do not add an entry to /etc/hosts with `--net=host`

### DIFF
--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -685,13 +685,6 @@ var _ = Describe("Podman run networking", func() {
 		Expect(podrm).Should(Exit(0))
 	})
 
-	It("podman run net=host adds entry to /etc/hosts", func() {
-		run := podmanTest.Podman([]string{"run", "--net=host", ALPINE, "cat", "/etc/hosts"})
-		run.WaitWithDefaultTimeout()
-		Expect(run).Should(Exit(0))
-		Expect(strings.Contains(run.OutputToString(), "127.0.1.1")).To(BeTrue())
-	})
-
 	It("podman run with --net=host and --hostname sets correct hostname", func() {
 		hostname := "testctr"
 		run := podmanTest.Podman([]string{"run", "--net=host", "--hostname", hostname, ALPINE, "hostname"})
@@ -729,10 +722,6 @@ var _ = Describe("Podman run networking", func() {
 
 	It("podman attempt to ping container name and hostname --net=none", func() {
 		ping_test("--net=none")
-	})
-
-	It("podman attempt to ping container name and hostname --net=host", func() {
-		ping_test("--net=host")
 	})
 
 	It("podman attempt to ping container name and hostname --net=private", func() {


### PR DESCRIPTION
To match Docker's behavior, in the `--net=host` case, we need to use the host's `/etc/hosts` file, unmodified (without adding an entry for the container). We will still respect hosts from `--add-host` but will not make any automatic changes.

Fortuntely, this is strictly a matter of removal and refactoring as we already base our `/etc/hosts` on the host's version - just need to remove the code that added entries when net=host was set.

Fixes #10319
