### PR TITLE
[v3.3] Disable aarch64 support

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -20,6 +20,7 @@ var (
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine init myvm`,
 		ValidArgsFunction: completion.AutocompleteNone,
+		PreRunE:           noAarch64,
 	}
 )
 

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -30,6 +30,7 @@ var (
 		ValidArgsFunction: completion.AutocompleteNone,
 		Example: `podman machine list,
   podman machine ls`,
+		PreRunE: noAarch64,
 	}
 	listFlag = listFlagType{}
 )

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -3,6 +3,8 @@
 package machine
 
 import (
+	"errors"
+	"runtime"
 	"strings"
 
 	"github.com/containers/podman/v3/cmd/podman/registry"
@@ -16,6 +18,18 @@ var (
 	noOp = func(cmd *cobra.Command, args []string) error {
 		return nil
 	}
+	// noAarch64 temporarily disables arm64 support on
+	// Apple Silicon
+	noAarch64 = func(cmd *cobra.Command, args []string) error {
+		if runtime.GOARCH == "arm64" {
+			if runtime.GOOS == "darwin" {
+				return errors.New("due to missing upstream patches, Apple Silicon is not capable of running Podman machine yet")
+			}
+			return errors.New("no aarch64 images are available at this time")
+		}
+		return nil
+	}
+
 	// Command: podman _machine_
 	machineCmd = &cobra.Command{
 		Use:                "machine",

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -23,6 +23,7 @@ var (
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine rm myvm`,
 		ValidArgsFunction: autocompleteMachine,
+		PreRunE:           noAarch64,
 	}
 )
 

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -19,6 +19,7 @@ var (
 		Example: `podman machine ssh myvm
   podman machine ssh myvm echo hello`,
 		ValidArgsFunction: autocompleteMachineSSH,
+		PreRunE:           noAarch64,
 	}
 )
 

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -19,6 +19,7 @@ var (
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine start myvm`,
 		ValidArgsFunction: autocompleteMachine,
+		PreRunE:           noAarch64,
 	}
 )
 

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -18,6 +18,7 @@ var (
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine stop myvm`,
 		ValidArgsFunction: autocompleteMachine,
+		PreRunE:           noAarch64,
 	}
 )
 


### PR DESCRIPTION
until we have a fedora coreos images officially on aarch64, we cannot run podman machine on aarch64 linux.  Moreover, on Apple Silicon, we need upstream patches for qemu to be merged and release.

[NO TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
