### PR TITLE
podman info: try qfile before equery

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -33,12 +33,16 @@ cgroupVersion: v[12]
     expr_nvr="[a-z0-9-]\\\+-[a-z0-9.]\\\+-[a-z0-9]\\\+\."
     expr_path="/[a-z0-9\\\/.-]\\\+\\\$"
 
+    # FIXME: if we're ever able to get package versions on Debian,
+    #        add '-[0-9]' to all '*.package' queries below.
     tests="
 host.buildahVersion       | [0-9.]
 host.conmon.path          | $expr_path
+host.conmon.package       | .*conmon.*
 host.cgroupManager        | \\\(systemd\\\|cgroupfs\\\)
 host.cgroupVersion        | v[12]
 host.ociRuntime.path      | $expr_path
+host.ociRuntime.package   | .*\\\(crun\\\|runc\\\).*
 store.configFile          | $expr_path
 store.graphDriverName     | [a-z0-9]\\\+\\\$
 store.graphRoot           | $expr_path


### PR DESCRIPTION
podman info takes >20s on Gentoo, because equery is s..l..o..w.
qfile is much faster and, I suspect, present in most Gentoo
installations, so let's try it first.

And, because packageVersion() was scarily unmaintainable,
refactor it. Define a simple (string) list of packaging tools
to query (rpm, dpkg, ...) and iterate until we find one that
works.

IMPORTANT NOTE: the Debian (and, presumably, Ubuntu) query does not
include version number! There is no standard way on Debian to get
a package version from a file path, you can only do it via pipes
of chained commands, and I have no desire to implement that.

Signed-off-by: Ed Santiago <santiago@redhat.com>
