### PR TITLE
Fix TS parsing for fractional values

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -530,9 +531,10 @@ func ParseInputTime(inputTime string) (time.Time, error) {
 		}
 	}
 
-	unixTimestamp, err := strconv.ParseInt(inputTime, 10, 64)
+	unixTimestamp, err := strconv.ParseFloat(inputTime, 64)
 	if err == nil {
-		return time.Unix(unixTimestamp, 0), nil
+		iPart, fPart := math.Modf(unixTimestamp)
+		return time.Unix(int64(iPart), int64(fPart*1_000_000_000)).UTC(), nil
 	}
 
 	// input might be a duration

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -276,4 +277,18 @@ func TestPeriodAndQuotaToCores(t *testing.T) {
 	)
 
 	assert.Equal(t, PeriodAndQuotaToCores(period, quota), expectedCores)
+}
+
+func TestParseInputTime(t *testing.T) {
+	tm, err := ParseInputTime("1.5")
+	if err != nil {
+		t.Errorf("expected error to be nil but was: %v", err)
+	}
+
+	expected, err := time.ParseInLocation(time.RFC3339Nano, "1970-01-01T00:00:01.500000000Z", time.UTC)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, expected, tm)
 }


### PR DESCRIPTION
resolves #11131

Parse Unix timestamps that contains fractional part.

Signed-off-by: Matej Vasek <mvasek@redhat.com>