### PR TITLE
[CI:DOCS] tests-expect-exit: include source line numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -607,7 +607,7 @@ tests-included:
 
 .PHONY: tests-expect-exit
 tests-expect-exit:
-	@if egrep 'Expect.*ExitCode' test/e2e/*.go | egrep -v ', ".*"\)'; then \
+	@if egrep --line-number 'Expect.*ExitCode' test/e2e/*.go | egrep -v ', ".*"\)'; then \
 		echo "^^^ Unhelpful use of Expect(ExitCode())"; \
 		echo "   Please use '.Should(Exit(...))' pattern instead."; \
 		echo "   If that's not possible, please add an annotation (description) to your assertion:"; \


### PR DESCRIPTION
In the new check for preventing 'Expect(ExitCode...)',
include source line numbers.

Response to #11034, which I totally didn't even understand
because it was referencing a different test. Sorry, Brent.

Signed-off-by: Ed Santiago <santiago@redhat.com>
