### PR TITLE
personality: Add support for setting execution domain.

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -498,6 +498,14 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	)
 	_ = cmd.RegisterFlagCompletionFunc(variantFlagName, completion.AutocompleteNone)
 
+	personalityFlagName := "personality"
+	createFlags.StringVar(
+		&cf.Personality,
+		personalityFlagName, "",
+		"Configure execution domain using personality (e.g., LINUX/LINUX32)",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(personalityFlagName, AutocompleteNamespace)
+
 	pidFlagName := "pid"
 	createFlags.String(
 		pidFlagName, "",

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -81,6 +81,7 @@ type ContainerCLIOpts struct {
 	Arch              string
 	OS                string
 	Variant           string
+	Personality       string
 	PID               string
 	PIDsLimit         *int64
 	Platform          string

--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -651,6 +651,12 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	if err != nil {
 		return err
 	}
+
+	if c.Personality != "" {
+		s.Personality = &specs.LinuxPersonality{}
+		s.Personality.Domain = specs.LinuxPersonalityDomain(c.Personality)
+	}
+
 	s.Remove = c.Rm
 	s.StopTimeout = &c.StopTimeout
 	s.Timeout = c.Timeout

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -706,6 +706,10 @@ Tune the host's OOM preferences for containers (accepts -1000 to 1000)
 #### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
 
+#### **--personality**=*persona*
+
+Personality sets the execution domain via Linux personality(2).
+
 #### **--pid**=*pid*
 
 Set the PID mode for the container
@@ -1429,6 +1433,12 @@ $ podman start --attach container3
 $ podman create -v /var/lib/design:/var/lib/design --group-add keep-groups ubi8
 ```
 
+### Configure execution domain for containers using personality flag
+
+```
+$ podman create --name container1 --personaity=LINUX32 fedora bash
+```
+
 ### Rootless Containers
 
 Podman runs as a non root user on most systems. This feature requires that a new enough version of shadow-utils
@@ -1491,7 +1501,7 @@ NOTE: Use the environment variable `TMPDIR` to change the temporary storage loca
 
 ## SEE ALSO
 **podman**(1), **podman-secret**(1), **podman-save**(1), **podman-ps**(1), **podman-attach**(1), **podman-pod-create**(1), **podman-port**(1), **podman-start*(1), **podman-kill**(1), **podman-stop**(1),
-**podman-generate-systemd**(1) **podman-rm**(1), **subgid**(5), **subuid**(5), **containers.conf**(5), **systemd.unit**(5), **setsebool**(8), **slirp4netns**(1), **fuse-overlayfs**(1), **proc**(5), **conmon**(8).
+**podman-generate-systemd**(1) **podman-rm**(1), **subgid**(5), **subuid**(5), **containers.conf**(5), **systemd.unit**(5), **setsebool**(8), **slirp4netns**(1), **fuse-overlayfs**(1), **proc**(5), **conmon**(8), **personality**(2).
 
 ## HISTORY
 October 2017, converted from Docker documentation to Podman by Dan Walsh for Podman `<dwalsh@redhat.com>`

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -726,6 +726,10 @@ Tune the host's OOM preferences for containers (accepts values from **-1000** to
 #### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
 
+#### **--personality**=*persona*
+
+Personality sets the execution domain via Linux personality(2).
+
 #### **--pid**=*mode*
 
 Set the PID namespace mode for the container.
@@ -1776,6 +1780,12 @@ $ podman run --name container3 --requires container1,container2 -t -i fedora bas
 $ podman run -v /var/lib/design:/var/lib/design --group-add keep-groups ubi8
 ```
 
+### Configure execution domain for containers using personality flag
+
+```
+$ podman run --name container1 --personaity=LINUX32 fedora bash
+```
+
 ### Rootless Containers
 
 Podman runs as a non root user on most systems. This feature requires that a new enough version of **shadow-utils**
@@ -1836,7 +1846,7 @@ NOTE: Use the environment variable `TMPDIR` to change the temporary storage loca
 
 ## SEE ALSO
 **podman**(1), **podman-save**(1), **podman-ps**(1), **podman-attach**(1), **podman-pod-create**(1), **podman-port**(1), **podman-start**(1), **podman-kill**(1), **podman-stop**(1),
-**podman-generate-systemd**(1) **podman-rm**(1), **subgid**(5), **subuid**(5), **containers.conf**(5), **systemd.unit**(5), **setsebool**(8), **slirp4netns**(1), **fuse-overlayfs**(1), **proc**(5), **conmon**(8).
+**podman-generate-systemd**(1) **podman-rm**(1), **subgid**(5), **subuid**(5), **containers.conf**(5), **systemd.unit**(5), **setsebool**(8), **slirp4netns**(1), **fuse-overlayfs**(1), **proc**(5), **conmon**(8), **personality**(2).
 
 ## HISTORY
 September 2018, updated by Kunal Kushwaha `<kushwaha_kunal_v7@lab.ntt.co.jp>`

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -285,6 +285,9 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		}
 		g.AddMount(cgroupMnt)
 	}
+
+	g.Config.Linux.Personality = s.Personality
+
 	g.SetProcessCwd(s.WorkDir)
 
 	g.SetProcessArgs(finalCmd)

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -186,6 +186,11 @@ type ContainerBasicConfig struct {
 	// InitContainerType describes if this container is an init container
 	// and if so, what type: always or oneshot
 	InitContainerType string `json:"init_container_type"`
+	// Personality allows users to configure different execution domains.
+	// Execution domains tell Linux how to map signal numbers into signal actions.
+	// The execution domain system allows Linux to provide limited support
+	// for binaries compiled under other UNIX-like operating systems.
+	Personality *spec.LinuxPersonality `json:"personality,omitempty"`
 }
 
 // ContainerStorageConfig contains information on the storage configuration of a

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1790,4 +1790,15 @@ WORKDIR /madethis`, BB)
 		_, err = strconv.Atoi(containerPID) // Make sure it's a proper integer
 		Expect(err).To(BeNil())
 	})
+
+	It("podman run check personality support", func() {
+		// TODO: Remove this as soon as this is merged and made available in our CI https://github.com/opencontainers/runc/pull/3126.
+		if !strings.Contains(podmanTest.OCIRuntime, "crun") {
+			Skip("Test only works on crun")
+		}
+		session := podmanTest.Podman([]string{"run", "--personality=LINUX32", "--name=testpersonality", ALPINE, "uname", "-a"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("i686"))
+	})
 })


### PR DESCRIPTION
Hi Team,

Following PR allows users to set execution domain via Linux personality. Please find a detailed discussion of 
**use-case:** https://github.com/opencontainers/runc/pull/3126#issuecomment-892161740
**upstream-PR:** https://github.com/opencontainers/runc/pull/3126 

References:
https://man7.org/linux/man-pages/man2/personality.2.html
