### PR TITLE
Added autocompletion for images and system connections for podman image SCP

### DIFF
--- a/cmd/podman/images/scp.go
+++ b/cmd/podman/images/scp.go
@@ -33,7 +33,7 @@ var (
 		Short:             "securely copy images",
 		RunE:              scp,
 		Args:              cobra.RangeArgs(1, 2),
-		ValidArgsFunction: common.AutocompleteImages,
+		ValidArgsFunction: common.AutocompleteScp,
 		Example:           `podman image scp myimage:latest otherhost::`,
 	}
 )


### PR DESCRIPTION
image scp should autocomplete images and system connections since the args can
be either. Made a new function, `common.AutocompleteScp`

This function looks at the current arg length and either gives the user a connection name, an image, or nothing depending on what has already been typed.

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
