### PR TITLE
Libpod images pull changes

### DIFF
--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -33,6 +33,7 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 		TLSVerify  bool   `schema:"tlsVerify"`
 		AllTags    bool   `schema:"allTags"`
 		PullPolicy string `schema:"policy"`
+		Quiet      bool   `schema:"quiet"`
 	}{
 		TLSVerify:  true,
 		PullPolicy: "always",
@@ -116,8 +117,10 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 		select {
 		case s := <-writer.Chan():
 			report.Stream = string(s)
-			if err := enc.Encode(report); err != nil {
-				logrus.Warnf("Failed to encode json: %v", err)
+			if !query.Quiet {
+				if err := enc.Encode(report); err != nil {
+					logrus.Warnf("Failed to encode json: %v", err)
+				}
 			}
 			flush()
 		case <-runCtx.Done():

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -962,6 +962,15 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     description: "Mandatory reference to the image (e.g., quay.io/image/name:tag)"
 	//     type: string
 	//   - in: query
+	//     name: quiet
+	//     description: "silences extra stream data on pull"
+	//     type: boolean
+	//     default: false
+	//   - in: query
+	//     name: credentials
+	//     description: "username:password for the registry"
+	//     type: string
+	//   - in: query
 	//     name: Arch
 	//     description: Pull image for the specified architecture.
 	//     type: string

--- a/test/apiv2/python/rest_api/test_v2_0_0_image.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_image.py
@@ -87,6 +87,27 @@ class ImageTestCase(APITestCase):
         self.assertTrue(keys["images"], "Expected to find images stanza")
         self.assertTrue(keys["stream"], "Expected to find stream progress stanza's")
 
+        r = requests.post(self.uri("/images/pull?reference=alpine&quiet=true"), timeout=15)
+        self.assertEqual(r.status_code, 200, r.status_code)
+        text = r.text
+        keys = {
+            "error": False,
+            "id": False,
+            "images": False,
+            "stream": False,
+        }
+        # Read and record stanza's from pull
+        for line in str.splitlines(text):
+            obj = json.loads(line)
+            key_list = list(obj.keys())
+            for k in key_list:
+                keys[k] = True
+
+        self.assertFalse(keys["error"], "Expected no errors")
+        self.assertTrue(keys["id"], "Expected to find id stanza")
+        self.assertTrue(keys["images"], "Expected to find images stanza")
+        self.assertFalse(keys["stream"], "Expected to find stream progress stanza's")
+
     def test_create(self):
         r = requests.post(
             self.podman_url + "/v1.40/images/create?fromImage=alpine&platform=linux/amd64/v8",


### PR DESCRIPTION
Added quiet param to docs to limit stream output. Formatted JSON.

This is a breaking change for podman 4.0 as it changes the output of the libpod API, but I believe this makes it function more similarly to native podman pull.

fixes #10612

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
