### PR TITLE
Reproducible Builds: trim embedded cgo paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,7 @@ else
 	ISODATE ?= $(shell date --iso-8601)
 endif
 LIBPOD := ${PROJECT}/v3/libpod
-GCFLAGS ?= all=-trimpath=$(CURDIR)
-ASMFLAGS ?= all=-trimpath=$(CURDIR)
+GOFLAGS ?= -trimpath
 LDFLAGS_PODMAN ?= \
 	-X $(LIBPOD)/define.gitCommit=$(GIT_COMMIT) \
 	-X $(LIBPOD)/define.buildInfo=$(BUILD_INFO) \
@@ -295,8 +294,6 @@ endif
 	CGO_ENABLED=$(CGO_ENABLED) \
 		$(GO) build \
 		$(BUILDFLAGS) \
-		-gcflags '$(GCFLAGS)' \
-		-asmflags '$(ASMFLAGS)' \
 		-ldflags '$(LDFLAGS_PODMAN)' \
 		-tags "$(BUILDTAGS)" \
 		-o $@ ./cmd/podman
@@ -310,8 +307,6 @@ $(SRCBINDIR)/podman$(BINSFX): $(SRCBINDIR) .gopathok $(SOURCES) go.mod go.sum
 		GOOS=$(GOOS) \
 		$(GO) build \
 		$(BUILDFLAGS) \
-		-gcflags '$(GCFLAGS)' \
-		-asmflags '$(ASMFLAGS)' \
 		-ldflags '$(LDFLAGS_PODMAN)' \
 		-tags "${REMOTETAGS}" \
 		-o $@ ./cmd/podman
@@ -321,8 +316,6 @@ $(SRCBINDIR)/podman-remote-static: $(SRCBINDIR) .gopathok $(SOURCES) go.mod go.s
 		GOOS=$(GOOS) \
 		$(GO) build \
 		$(BUILDFLAGS) \
-		-gcflags '$(GCFLAGS)' \
-		-asmflags '$(ASMFLAGS)' \
 		-ldflags '$(LDFLAGS_PODMAN_STATIC)' \
 		-tags "${REMOTETAGS}" \
 		-o $@ ./cmd/podman
@@ -376,8 +369,6 @@ bin/podman.cross.%: .gopathok
 	CGO_ENABLED=0 \
 		$(GO) build \
 		$(BUILDFLAGS) \
-		-gcflags '$(GCFLAGS)' \
-		-asmflags '$(ASMFLAGS)' \
 		-ldflags '$(LDFLAGS_PODMAN)' \
 		-tags '$(BUILDTAGS_CROSS)' \
 		-o "$@" ./cmd/podman


### PR DESCRIPTION
The Arch Linux reproducible builds setup currently fails to reproduce podman ([diff](https://reproducible.archlinux.org/api/v0/builds/147183/diffoscope)). The relevant part in the diff is:

```
│ │ ├── strings --all --bytes=8 {}
│ │ │ @@ -1,9 +1,9 @@
│ │ │  /lib64/ld-linux-x86-64.so.2
│ │ │ -fDMoJcLZqojBJnlXadN9/no_IKXu28dGv-5kgjWUm/HSPy4nrzjaE7jAmxaDUT/06FhXFIFJ4FwF81sy8x_
│ │ │ +CIrZsC53vVGulPBnzvSY/P_VErASmHt8np5NCPDQ8/LcpPc2AxUJaJ-MAKOAvh/xHYbWCnqxFpRwLK2eL7s
│ │ │  -*m4ibT|
│ │ │  _ITM_deregisterTMCloneTable
│ │ │  _ITM_registerTMCloneTable
│ │ │  pthread_mutexattr_setrobust
│ │ │  pthread_mutex_consistent
│ │ │  pthread_mutex_init
│ │ │  pthread_cond_wait
│ │ │ @@ -78810,15 +78810,15 @@
│ │ │  go/src/net/sockopt_posix.go
│ │ │  go/src/net/splice_linux.go
│ │ │  go/src/net/tcpsock_posix.go
│ │ │  go/src/net/tcpsockopt_posix.go
│ │ │  go/src/net/tcpsockopt_unix.go
│ │ │  go/src/net/udpsock_posix.go
│ │ │  go/src/net/unixsock_posix.go
│ │ │ -/tmp/go-build3474806368/b051/_cgo_gotypes.go
│ │ │ +/tmp/go-build3959924547/b051/_cgo_gotypes.go
│ │ │  go/src/net/cgo_resnew.go
│ │ │  go/src/net/cgo_unix.go
│ │ │  go/src/net/cgo_socknew.go
│ │ │  go/src/net/hook.go
│ │ │  go/src/net/hook_unix.go
│ │ │  go/src/net/url/url.go
│ │ │  go/src/crypto/dsa/dsa.go
│ │ │ @@ -78961,15 +78961,15 @@
│ │ │  go/src/strconv/atob.go
│ │ │  vendor/github.com/BurntSushi/toml/parse.go
│ │ │  vendor/github.com/BurntSushi/toml/type_check.go
│ │ │  vendor/github.com/BurntSushi/toml/type_fields.go
│ │ │  vendor/github.com/containers/image/v5/internal/rootless/rootless.go
│ │ │  go/src/os/user/lookup.go
│ │ │  go/src/os/user/user.go
│ │ │ -/tmp/go-build3474806368/b159/_cgo_gotypes.go
│ │ │ +/tmp/go-build3959924547/b159/_cgo_gotypes.go
│ │ │  go/src/os/user/cgo_lookup_unix.go
│ │ │  vendor/github.com/syndtr/gocapability/capability/capability.go
│ │ │  vendor/github.com/syndtr/gocapability/capability/capability_linux.go
│ │ │  vendor/github.com/syndtr/gocapability/capability/enum.go
│ │ │  vendor/github.com/syndtr/gocapability/capability/enum_gen.go
│ │ │  vendor/github.com/syndtr/gocapability/capability/syscall_linux.go
│ │ │  vendor/github.com/docker/go-units/duration.go
[...]
```

To fix the cgo paths, `-trimpath` needs to be passed in $GOFLAGS instead of `-gcflags` and `-asmflags`. This automatically resolves the other issues shown in the diff too. For more info on -trimpath with cgo see https://github.com/golang/go/issues/47256.

Thanks!

cc: @Foxboron 

[NO TESTS NEEDED]