### PR TITLE
podman info show correct slirp4netns path

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -47,6 +47,7 @@ store.configFile          | $expr_path
 store.graphDriverName     | [a-z0-9]\\\+\\\$
 store.graphRoot           | $expr_path
 store.imageStore.number   | 1
+host.slirp4netns.executable | $expr_path
 "
 
     parse_table "$tests" | while read field expect; do


### PR DESCRIPTION
The slirp4netns path can be set in the config file or with
--network-cmd-path. Podman info should read the version information
correctly and not use PATH in this case. Also show the slirp4netns
version information to root users.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
