### PR TITLE
Enable docker-py compat. testing w/ ignored result

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -378,8 +378,7 @@ osx_alt_build_task:
     always: *binary_artifacts
 
 
-# This task is a stub: In the future it will be used to verify
-# podman is compatible with the docker python-module.
+# Verify podman is compatible with the docker python-module.
 docker-py_test_task:
     name: Docker-py Compat.
     alias: docker-py_test

--- a/Makefile
+++ b/Makefile
@@ -502,10 +502,12 @@ validate.completions:
 	if [ -x /bin/zsh ]; then /bin/zsh completions/zsh/_podman; fi
 	if [ -x /bin/fish ]; then /bin/fish completions/fish/podman.fish; fi
 
+# Note: Assumes test/python/requirements.txt is installed & available
 .PHONY: run-docker-py-tests
 run-docker-py-tests:
-	$(eval testLogs=$(shell mktemp podman_tmp_XXXX))
-	./bin/podman run --rm --security-opt label=disable --privileged -v $(testLogs):/testLogs --net=host -e DOCKER_HOST=tcp://localhost:8080 $(DOCKERPY_IMAGE) sh -c "pytest $(DOCKERPY_TEST) "
+	touch test/__init__.py
+	pytest test/python/docker/
+	-rm test/__init__.py
 
 .PHONY: localunit
 localunit: test/goecho/goecho
@@ -850,11 +852,13 @@ clean: ## Clean all make artifacts
 		build \
 		test/checkseccomp/checkseccomp \
 		test/goecho/goecho \
+		test/__init__.py \
 		test/testdata/redis-image \
 		libpod/container_ffjson.go \
 		libpod/pod_ffjson.go \
 		libpod/container_easyjson.go \
 		libpod/pod_easyjson.go \
 		.install.goimports \
-		docs/build
+		docs/build \
+		venv
 	make -C docs clean

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -88,7 +88,8 @@ function _run_bindings() {
 }
 
 function _run_docker-py() {
-    msg "This is docker-py stub, it is only a stub"
+    source venv/bin/activate
+    make run-docker-py-tests
 }
 
 function _run_endpoint() {

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -191,7 +191,19 @@ case "$TEST_FLAVOR" in
             bigto dnf install -y glibc-minimal-langpack rpm-build
         fi
         ;&
-    docker-py) ;&
+    docker-py)
+        remove_packaged_podman_files
+        make install PREFIX=/usr ETCDIR=/etc
+
+        # TODO: Don't install stuff at test runtime!  Do this from
+        # cache_images/fedora_packaging.sh in containers/automation_images
+        # and STRONGLY prefer installing RPMs vs pip packages in venv
+        dnf install -y python3-virtualenv python3-pytest4
+        virtualenv venv
+        source venv/bin/activate
+        pip install --upgrade pip
+        pip install --requirement $GOSRC/test/python/requirements.txt
+        ;;
     build) make clean ;;
     unit) ;;
     apiv2) ;&  # use next item

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,5 +1,5 @@
 docker~=4.4.3
-
+requests-mock~=1.9.3
 requests~=2.20.0
 setuptools~=50.3.2
 python-dateutil~=2.8.1


### PR DESCRIPTION
Partially address #9229 

Significant bitrot results in almost immediate test failure.  This
commit adds only the very basic, bare-minimum needed to get them
started directly on the host.

***TESTING RESULTS ARE IGNORED***