### PR TITLE
[CI:DOCS] Add link to running ctrimage on enablesysadm

### DIFF
--- a/contrib/podmanimage/README.md
+++ b/contrib/podmanimage/README.md
@@ -66,3 +66,7 @@ exit
 the fuse kernel module has not been loaded on your host system.  Use the command `modprobe fuse` to load the
 module and then run the container image.  To enable this automatically at boot time, you can add a configuration
 file to `/etc/modules.load.d`.  See `man modules-load.d` for more details.
+
+### Blog Post with Details
+
+Dan Walsh wrote a blog post on the [Enable Sysadmin](https://www.redhat.com/sysadmin/) site titled [How to use Podman inside of a container](https://www.redhat.com/sysadmin/podman-inside-container).  In it, he details how to use these images as a rootful and as a rootless user.  Please refer to this blog for more detailed information.


### PR DESCRIPTION
Add a link to the podman images readme.md to Dan's recent post
on Enable Sysadm about running containers inside of Podman

Fixes: #3119

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
