### PR TITLE
skip flaking auto-update test

### DIFF
--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -221,6 +221,7 @@ function _confirm_update() {
 }
 
 @test "podman auto-update - label io.containers.autoupdate=local with rollback" {
+    skip "This test flakes way too often, see #11175"
     # sdnotify fails with runc 1.0.0-3-dev2 on Ubuntu. Let's just
     # assume that we work only with crun, nothing else.
     # [copied from 260-sdnotify.bats]


### PR DESCRIPTION
This test flakes on almost every PR, so skip it for now until
someone can fix it, see #11175.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
