### PR TITLE
[NO TESTS NEEDED] Change connection error to be helpful for machine users

### DIFF
--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -117,7 +117,7 @@ func NewConnectionWithIdentity(ctx context.Context, uri string, identity string)
 
 	ctx = context.WithValue(ctx, clientKey, &connection)
 	if err := pingNewConnection(ctx); err != nil {
-		return nil, errors.Wrap(err, "cannot connect to the Podman socket, please verify that Podman REST API service is running")
+		return nil, errors.Wrap(err, "cannot connect to the Podman socket, please verify the connection to the Linux system, or use `podman machine` to create/start a Linux VM.")
 	}
 	return ctx, nil
 }


### PR DESCRIPTION
If a podman-remote connection fails, remind the user to check their linux system and podman machine vm

[NO TESTS NEEDED] 

Signed-off-by: Ashley Cui <acui@redhat.com>


Fixes: #10944

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
