### PR TITLE
rootful: unset XDG_RUNTIME_DIR

### DIFF
--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -89,7 +89,12 @@ func newPodmanConfig() {
 // use for the containers.conf configuration file.
 func setXdgDirs() error {
 	if !rootless.IsRootless() {
-		return nil
+		// unset XDG_RUNTIME_DIR for root
+		// Sometimes XDG_RUNTIME_DIR is set to /run/user/0 sometimes it is unset,
+		// the inconsistency is causing issues for the dnsname plugin.
+		// It is already set to an empty string for conmon so lets do the same
+		// for podman. see #10806 and #10745
+		return os.Unsetenv("XDG_RUNTIME_DIR")
 	}
 
 	// Setup XDG_RUNTIME_DIR


### PR DESCRIPTION
Depending how the user logs in to the root account, XDG_RUNTIME_DIR is
set to /run/user/0 or it is unset. For conmon we already set it always
to an empty string. The inconsistency is causing issues for the dnsname
plugin. To fix it also set XDG_RUNTIME_DIR to an empty string for the
podman process.

Fixes #10806
Fixes #10745

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
