### PR TITLE
Support for --tls-verify flag in podman-run & podman-create

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -544,6 +544,15 @@ func DefineCreateFlags(cmd *cobra.Command, cf *ContainerCLIOpts) {
 	)
 	_ = cmd.RegisterFlagCompletionFunc(podIDFileFlagName, completion.AutocompleteDefault)
 
+	// Flag for TLS verification, so that `run` and `create` commands can make use of it.
+	// Make sure to use `=` while using this flag i.e `--tls-verify=false/true`
+	tlsVerifyFlagName := "tls-verify"
+	createFlags.BoolVar(
+		&cf.TLSVerify,
+		tlsVerifyFlagName, true,
+		"Require HTTPS and verify certificates when contacting registries for pulling images",
+	)
+
 	createFlags.BoolVar(
 		&cf.Privileged,
 		"privileged", false,

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -112,6 +112,7 @@ type ContainerCLIOpts struct {
 	Sysctl            []string
 	Systemd           string
 	Timeout           uint
+	TLSVerify         bool
 	TmpFS             []string
 	TTY               bool
 	Timezone          string

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/transports/alltransports"
+	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/cmd/podman/utils"
@@ -260,7 +261,7 @@ func createInit(c *cobra.Command) error {
 }
 
 func pullImage(imageName string) (string, error) {
-	pullPolicy, err := config.ValidatePullPolicy(cliVals.Pull)
+	pullPolicy, err := config.ParsePullPolicy(cliVals.Pull)
 	if err != nil {
 		return "", err
 	}
@@ -286,6 +287,7 @@ func pullImage(imageName string) (string, error) {
 		Variant:         cliVals.Variant,
 		SignaturePolicy: cliVals.SignaturePolicy,
 		PullPolicy:      pullPolicy,
+		SkipTLSVerify:   types.NewOptionalBool(!cliVals.TLSVerify), // If Flag changed for TLS Verification
 	})
 	if pullErr != nil {
 		return "", pullErr

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -992,6 +992,10 @@ Maximum time a container is allowed to run before conmon sends it the kill
 signal.  By default containers will run until they exit or are stopped by
 `podman stop`.
 
+#### **--tls-verify**=**true**|**false**
+
+Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true, then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified, TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
+
 #### **--tmpfs**=*fs*
 
 Create a tmpfs mount

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1048,6 +1048,10 @@ Maximum time a container is allowed to run before conmon sends it the kill
 signal.  By default containers will run until they exit or are stopped by
 `podman stop`.
 
+#### **--tls-verify**=**true**|**false**
+
+Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true, then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified, TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
+
 #### **--tmpfs**=*fs*
 
 Create a tmpfs mount.


### PR DESCRIPTION
podman-run & podman-create doesn't support `--tls-verify` parameter, this is problematic when Developers/Ops want to run a container with images that are not locally present, in these types of scenarios below issue may appear[*] wherein the localhost:8000 is an insecure registry. We can add insecure registry in use to the `/etc/containers/registries.conf` under `[registries.insecure]` however this is not so convenient in large clusters. 

With this PR, I have added `--tls-verify` support for `podman-run` and `podman-create` command. 

Signed-off-by: Shivkumar Ople sople@redhat.com

Fixes #11129

> [*] 
> 
> > [root@localhost ~]# podman run localhost:8000/httpd:v1
> > Trying to pull localhost:8000/httpd:v1...
> >   Get "https://localhost:8000/v2/": http: server gave HTTP response to HTTPS client
> > Error: Error initializing source docker://localhost:8000/httpd:v1: error pinging docker registry localhost:8000: Get "https://localhost:8000/v2/": http: server gave HTTP response to HTTPS client
> 