### PR TITLE
Set gvproxy path to /usr/libexec/podman/gvproxy

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -605,10 +605,12 @@ func CheckActiveVM() (bool, string, error) {
 // startHostNetworking runs a binary on the host system that allows users
 // to setup port forwarding to the podman virtual machine
 func (v *MachineVM) startHostNetworking() error {
-	binary, err := exec.LookPath(machine.ForwarderBinaryName)
-	if err != nil {
+	// TODO we may wish to configure the directory in containers common
+	binary := filepath.Join("/usr/libexec/podman/", machine.ForwarderBinaryName)
+	if _, err := os.Stat(binary); err != nil {
 		return err
 	}
+
 	// Listen on all at port 7777 for setting up and tearing
 	// down forwarding
 	listenSocket := "tcp://0.0.0.0:7777"


### PR DESCRIPTION
We have reverted the previous patches to look for the gvproxy binary in
/usr/lib/podman and have again decided to use /usr/libexec/podman

[NO TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>
