### PR TITLE
rename oneshot initcontainers to once

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/cmd/podman/utils"
+	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/containers/podman/v3/pkg/specgen"
 	"github.com/containers/podman/v3/pkg/util"
@@ -105,8 +106,8 @@ func create(cmd *cobra.Command, args []string) error {
 		if !cmd.Flags().Changed("pod") {
 			return errors.New("must specify pod value with init-ctr")
 		}
-		if !util.StringInSlice(initctr, []string{"always", "oneshot"}) {
-			return errors.New("init-ctr value must be 'always' or 'oneshot'")
+		if !util.StringInSlice(initctr, []string{define.AlwaysInitContainer, define.OneShotInitContainer}) {
+			return errors.Errorf("init-ctr value must be '%s' or '%s'", define.AlwaysInitContainer, define.OneShotInitContainer)
 		}
 		cliVals.InitContainerType = initctr
 	}

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -453,8 +453,8 @@ When using pods, create an init style container, which is run after the infra co
 but before regular pod containers are started.  Init containers are useful for running
 setup operations for the pod's applications.
 
-Valid values for `init-ctr` type are *always* or *oneshot*.  The *always* value
-means the container will run with each and every `pod start`, whereas the *oneshot*
+Valid values for `init-ctr` type are *always* or *once*.  The *always* value
+means the container will run with each and every `pod start`, whereas the *once*
 value means the container will only run once when the pod is started and then the container is removed.
 
 Init containers are only run on pod `start`.  Restarting a pod will not execute any init

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -376,6 +376,6 @@ type ContainerMiscConfig struct {
 	// EnvSecrets are secrets that are set as environment variables
 	EnvSecrets map[string]*secrets.Secret `json:"secret_env,omitempty"`
 	// InitContainerType specifies if the container is an initcontainer
-	// and if so, what type: always or oneshot are possible non-nil entries
+	// and if so, what type: always or once are possible non-nil entries
 	InitContainerType string `json:"init_container_type,omitempty"`
 }

--- a/libpod/define/container.go
+++ b/libpod/define/container.go
@@ -34,5 +34,5 @@ const (
 	AlwaysInitContainer = "always"
 	// OneShotInitContainer is a container that only runs as init once
 	// and is then deleted.
-	OneShotInitContainer = "oneshot"
+	OneShotInitContainer = "once"
 )

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -32,14 +32,14 @@ func (p *Pod) startInitContainers(ctx context.Context) error {
 		if rc != 0 {
 			return errors.Errorf("init container %s exited with code %d", initCon.ID(), rc)
 		}
-		// If the container is an oneshot init container, we need to remove it
+		// If the container is a once init container, we need to remove it
 		// after it runs
 		if initCon.Config().InitContainerType == define.OneShotInitContainer {
 			icLock := initCon.lock
 			icLock.Lock()
 			if err := p.runtime.removeContainer(ctx, initCon, false, false, true); err != nil {
 				icLock.Unlock()
-				return errors.Wrapf(err, "failed to remove oneshot init container %s", initCon.ID())
+				return errors.Wrapf(err, "failed to remove once init container %s", initCon.ID())
 			}
 			// Removing a container this way requires an explicit call to clean up the db
 			if err := p.runtime.state.RemoveContainerFromPod(p, initCon); err != nil {

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -184,7 +184,7 @@ type ContainerBasicConfig struct {
 	// Optional.
 	EnvSecrets map[string]string `json:"secret_env,omitempty"`
 	// InitContainerType describes if this container is an init container
-	// and if so, what type: always or oneshot
+	// and if so, what type: always or once
 	InitContainerType string `json:"init_container_type"`
 	// Personality allows users to configure different execution domains.
 	// Execution domains tell Linux how to map signal numbers into signal actions.

--- a/test/e2e/pod_initcontainers_test.go
+++ b/test/e2e/pod_initcontainers_test.go
@@ -98,10 +98,10 @@ var _ = Describe("Podman init containers", func() {
 		Expect(checkLog.OutputToString()).To(Equal(content))
 	})
 
-	It("podman make sure oneshot container is removed", func() {
+	It("podman make sure once container is removed", func() {
 		filename := filepath.Join("/dev/shm", RandomString(12))
 		content := RandomString(16)
-		session := podmanTest.Podman([]string{"create", "--init-ctr", "oneshot", "--pod", "new:foobar", ALPINE, "bin/sh", "-c", fmt.Sprintf("echo %s > %s", content, filename)})
+		session := podmanTest.Podman([]string{"create", "--init-ctr", "once", "--pod", "new:foobar", ALPINE, "bin/sh", "-c", fmt.Sprintf("echo %s > %s", content, filename)})
 		session.WaitWithDefaultTimeout()
 		initContainerID := session.OutputToString()
 		Expect(session).Should(Exit(0))


### PR DESCRIPTION
after the init containers pr merged, it was suggested to use `once`
instead of `oneshot` containers as it is more aligned with other
terminology used similarly.

[NO TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>
