### PR TITLE
Add space trimming check in ValidateSysctls

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -618,6 +618,12 @@ func ValidateSysctls(strSlice []string) (map[string]string, error) {
 		if len(arr) < 2 {
 			return nil, errors.Errorf("%s is invalid, sysctl values must be in the form of KEY=VALUE", val)
 		}
+
+		trimmed := fmt.Sprintf("%s=%s", strings.TrimSpace(arr[0]), strings.TrimSpace(arr[1]))
+		if trimmed != val {
+			return nil, errors.Errorf("'%s' is invalid, extra spaces found", val)
+		}
+
 		if validSysctlMap[arr[0]] {
 			sysctl[arr[0]] = arr[1]
 			continue

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -257,6 +258,28 @@ func TestValidateSysctlBadSysctl(t *testing.T) {
 	strSlice := []string{"BLAU=BLUE", "GELB^YELLOW"}
 	_, err := ValidateSysctls(strSlice)
 	assert.Error(t, err)
+}
+
+func TestValidateSysctlBadSysctlWithExtraSpaces(t *testing.T) {
+	expectedError := "'%s' is invalid, extra spaces found"
+
+	// should fail fast on first sysctl
+	strSlice1 := []string{
+		"net.ipv4.ping_group_range = 0 0",
+		"net.ipv4.ping_group_range=0 0 ",
+	}
+	_, err := ValidateSysctls(strSlice1)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), fmt.Sprintf(expectedError, strSlice1[0]))
+
+	// should fail on second sysctl
+	strSlice2 := []string{
+		"net.ipv4.ping_group_range=0 0",
+		"net.ipv4.ping_group_range=0 0 ",
+	}
+	_, err = ValidateSysctls(strSlice2)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), fmt.Sprintf(expectedError, strSlice2[1]))
 }
 
 func TestCoresToPeriodAndQuota(t *testing.T) {


### PR DESCRIPTION
This is to catch invalid sysctl configs with extra spacing.

See
https://github.com/containers/common/issues/723#issuecomment-897395506

Signed-off-by: xatier <xatierlike@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
