### PR TITLE
Fix rootless cni dns without systemd stub resolver

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -210,6 +210,9 @@ load helpers
 	       $IMAGE nc -l -n -v -p $myport
     cid="$output"
 
+    # check that dns is working inside the container
+    run_podman exec $cid nslookup google.com
+
     # emit random string, and check it
     teststring=$(random_string 30)
     echo "$teststring" | nc 127.0.0.1 $myport


### PR DESCRIPTION
When a host uses systemd-resolved but not the resolved stub resolver the
following symlinks are created: `/etc/resolv.conf` ->
`/run/systemd/resolve/stub-resolv.conf` -> `/run/systemd/resolve/resolv.conf`.
Because the code uses filepath.EvalSymlinks we put the new resolv.conf
to `/run/systemd/resolve/resolv.conf` but the `/run/systemd/resolve/stub-resolv.conf`
link does not exists in the mount ns.
To fix this we will walk the symlinks manually until we reach the first
one under `/run` and use this for the resolv.conf file destination.

This fixes a regression which was introduced in e73d4829900c.

Fixes #11222

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
