### PR TITLE
fix gvproxy path search for macos

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -605,10 +605,15 @@ func CheckActiveVM() (bool, string, error) {
 // startHostNetworking runs a binary on the host system that allows users
 // to setup port forwarding to the podman virtual machine
 func (v *MachineVM) startHostNetworking() error {
-	// TODO we may wish to configure the directory in containers common
-	binary := filepath.Join("/usr/libexec/podman/", machine.ForwarderBinaryName)
-	if _, err := os.Stat(binary); err != nil {
-		return err
+	// MacOS does not have /usr/libexec so we look in the executable
+	// paths.
+	binary, err := exec.LookPath(machine.ForwarderBinaryName)
+	if errors.Cause(err) == exec.ErrNotFound {
+		// Nothing was found, so now check /usr/libexec, else error out
+		binary = filepath.Join("/usr/libexec/podman/", machine.ForwarderBinaryName)
+		if _, err := os.Stat(binary); err != nil {
+			return err
+		}
 	}
 
 	// Listen on all at port 7777 for setting up and tearing


### PR DESCRIPTION
macos does not have /usr/libexec/ so we look in the executable paths
first.

Fixes: #11226

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
