### PR TITLE
make sure that signal buffers are sufficiently big

### DIFF
--- a/libpod/shutdown/handler.go
+++ b/libpod/shutdown/handler.go
@@ -35,7 +35,7 @@ func Start() error {
 		return nil
 	}
 
-	sigChan = make(chan os.Signal, 1)
+	sigChan = make(chan os.Signal, 2)
 	cancelChan = make(chan bool, 1)
 	stopped = false
 

--- a/pkg/domain/infra/abi/terminal/sigproxy_linux.go
+++ b/pkg/domain/infra/abi/terminal/sigproxy_linux.go
@@ -12,13 +12,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Make sure the signal buffer is sufficiently big.
+// runc is using the same value.
+const signalBufferSize = 2048
+
 // ProxySignals ...
 func ProxySignals(ctr *libpod.Container) {
 	// Stop catching the shutdown signals (SIGINT, SIGTERM) - they're going
 	// to the container now.
 	shutdown.Stop()
 
-	sigBuffer := make(chan os.Signal, 128)
+	sigBuffer := make(chan os.Signal, signalBufferSize)
 	signal.CatchAll(sigBuffer)
 
 	logrus.Debugf("Enabling signal proxying")

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -397,8 +397,6 @@ func becomeRootInUserNS(pausePid, fileToRead string, fileOutput *os.File) (_ boo
 		return false, -1, errors.Wrapf(err, "error setting up the process")
 	}
 
-	c := make(chan os.Signal, 1)
-
 	signals := []os.Signal{}
 	for sig := 0; sig < numSig; sig++ {
 		if sig == int(unix.SIGTSTP) {
@@ -407,6 +405,7 @@ func becomeRootInUserNS(pausePid, fileToRead string, fileOutput *os.File) (_ boo
 		signals = append(signals, unix.Signal(sig))
 	}
 
+	c := make(chan os.Signal, len(signals))
 	gosignal.Notify(c, signals...)
 	defer gosignal.Reset()
 	go func() {


### PR DESCRIPTION
Dealing with os.Signal channels seems more like an art than science
since signals may get lost.  os.Notify doesn't block on an unbuffered
channel, so users are expected to know what they're doing or hope for
the best.

In the recent past, I've seen a number of flakes and BZs on non-amd64
architectures where I was under the impression that signals may got
lost, for instance, during stop and exec.

[NO TESTS NEEDED] since this is art.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@containers/podman-maintainers PTAL :art: 
