### PR TITLE
Implement SD-NOTIFY proxy in conmon

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -126,6 +126,10 @@ type Container struct {
 	// This is true if a container is restored from a checkpoint.
 	restoreFromCheckpoint bool
 
+	// Used to query the NOTIFY_SOCKET once along with setting up
+	// mounts etc.
+	notifySocket string
+
 	slirp4netnsSubnet *net.IPNet
 }
 

--- a/libpod/diff.go
+++ b/libpod/diff.go
@@ -14,6 +14,7 @@ var initInodes = map[string]bool{
 	"/etc/resolv.conf":   true,
 	"/proc":              true,
 	"/run":               true,
+	"/run/notify":        true,
 	"/run/.containerenv": true,
 	"/run/secrets":       true,
 	"/sys":               true,

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -462,7 +462,7 @@ func (r *ConmonOCIRuntime) startExec(c *Container, sessionID string, options *Ex
 		Setpgid: true,
 	}
 
-	err = startCommandGivenSelinux(execCmd)
+	err = startCommandGivenSelinux(execCmd, c)
 
 	// We don't need children pipes  on the parent side
 	errorhandling.CloseQuiet(childSyncPipe)

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -221,7 +221,6 @@ function _confirm_update() {
 }
 
 @test "podman auto-update - label io.containers.autoupdate=local with rollback" {
-    skip "This test flakes way too often, see #11175"
     # sdnotify fails with runc 1.0.0-3-dev2 on Ubuntu. Let's just
     # assume that we work only with crun, nothing else.
     # [copied from 260-sdnotify.bats]

--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -130,6 +130,8 @@ function _assert_mainpid_is_conmon() {
     _stop_socat
 }
 
+# These tests can fail in dev. environment because of SELinux.
+# quick fix: chcon -t container_runtime_exec_t ./bin/podman
 @test "sdnotify : container" {
     # Sigh... we need to pull a humongous image because it has systemd-notify.
     # (IMPORTANT: fedora:32 and above silently removed systemd-notify; this
@@ -150,7 +152,7 @@ function _assert_mainpid_is_conmon() {
     wait_for_ready $cid
 
     run_podman logs $cid
-    is "${lines[0]}" "/.*/container\.sock/notify" "NOTIFY_SOCKET is passed to container"
+    is "${lines[0]}" "/run/notify/notify.sock" "NOTIFY_SOCKET is passed to container"
 
     # With container, READY=1 isn't necessarily the last message received;
     # just look for it anywhere in received messages


### PR DESCRIPTION
This leverages conmon's ability to proxy the SD-NOTIFY socket.        
This prevents locking caused by OCI runtime blocking, waiting for     
SD-NOTIFY messages, and instead passes the messages directly up       
to the host.                                                          
                                                                      
NOTE: Also re-enable the auto-update tests which has been disabled due
to flakiness.  With this change, Podman properly integrates into      
systemd.                                                              
                                                                      
Fixes: #7316                                                          
Signed-off-by: Joseph Gooch <mrwizard@dok.org>                        
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>                     
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>                