### PR TITLE
Cirrus: Resolve two upgrade-test FIXMEs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -632,17 +632,11 @@ rootless_system_test_task:
     main_script: *main
     always: *logs_artifacts
 
-# FIXME: we may want to consider running this from nightly cron instead of CI.
-# The tests are actually pretty quick (less than a minute) but they do rely
-# on pulling images from quay.io, which means we're subject to network flakes.
-#
-# FIXME: how does this env matrix work, anyway? Does it spin up multiple VMs?
-# We might just want to encode the version matrix in runner.sh instead
 upgrade_test_task:
     name: "Upgrade test: from $PODMAN_UPGRADE_FROM"
     alias: upgrade_test
     skip: *tags
-    only_if: *not_docs
+    only_if: $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' || $CIRRUS_CRON != ''
     depends_on:
       - local_system_test
     matrix:


### PR DESCRIPTION
I attempted to [run the tests in a loop](https://github.com/containers/podman/pull/11251) (one VM) but it fails with:

```
not ok 8 exec
 (from function `is' in file test/upgrade/../system/helpers.bash, line
474,
   in test file test/upgrade/test-upgrade.bats, line 222)
    `is "$output" "$RANDOM_STRING_1" "exec into myrunningcontainer"'
failed
   /var/tmp/go/src/github.com/containers/podman/bin/podman exec
myrunningcontainer cat /var/www/index.txt
  time="2021-08-17T13:34:21-05:00" level=warning msg="Failed to add
conmon to systemd sandbox cgroup: Invalid unit name '/libpod_parent'"
  uagHtpYnA47bkz3
   /vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
   |     FAIL: exec into myrunningcontainer
   | expected: 'uagHtpYnA47bkz3'
   |   actual: 'time="2021-08-17T13:34:21-05:00" level=warning
msg="Failed to add conmon to systemd sandbox cgroup: Invalid unit name
'/libpod_parent'"'
   |         > 'uagHtpYnA47bkz3'
   \^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Since the current implementation doesn't reproduce this error, the
change isn't worth the cost of debugging/fixing.  OTOH, making the job
only run from the daily cirrus-cron builds is a simple change.

Signed-off-by: Chris Evich <cevich@redhat.com>