### PR TITLE
libpod/Container.readFromJournal(): don't skip the first entry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
 	github.com/containers/buildah v1.22.3
-	github.com/containers/common v0.42.1
+	github.com/containers/common v0.43.0
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.15.2
 	github.com/containers/ocicrypt v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
 	github.com/containers/buildah v1.22.3
-	github.com/containers/common v0.43.0
+	github.com/containers/common v0.43.2
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.15.2
 	github.com/containers/ocicrypt v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -240,11 +240,13 @@ github.com/containernetworking/plugins v0.9.1 h1:FD1tADPls2EEi3flPc2OegIY1M9pUa9
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containers/buildah v1.22.3 h1:RomxwUa24jMcqzXQetpw4wGMfNlNZLhc9qwyoWHblwc=
 github.com/containers/buildah v1.22.3/go.mod h1:JVXRyx5Rkp5w5jwvaXe45kuHtyoxpERMjXrR45+3Wfg=
-github.com/containers/common v0.42.1 h1:ADOZrVAS8ZY5hBAvr/GoRoPv5Z7TBkxWgxQEXQjlqac=
 github.com/containers/common v0.42.1/go.mod h1:AaF3ipZfgezsctDuhzLkq4Vl+LkEy7J74ikh2HSXDsg=
+github.com/containers/common v0.43.0 h1:CeDdfhLyPfsG6TAKJneT/4RWOhHfWF2Yv+Wz6SuMusU=
+github.com/containers/common v0.43.0/go.mod h1:BAoVyRYlxKZKAYpHcFMdrXlIZyzbJp9NwKTgadTd/Dg=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.14.0/go.mod h1:SxiBKOcKuT+4yTjD0AskjO+UwFvNcVOJ9qlAw1HNSPU=
+github.com/containers/image/v5 v5.15.0/go.mod h1:gzdBcooi6AFdiqfzirUqv90hUyHyI0MMdaqKzACKr2s=
 github.com/containers/image/v5 v5.15.2 h1:DKicmVr0h1HGkzs9muoErX+fVbV9sV9W5TyMy5perLE=
 github.com/containers/image/v5 v5.15.2/go.mod h1:8jejVSzTDfyPwr/HXp9rri34n/vbdavYk6IzTiB3TBw=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=
@@ -258,7 +260,9 @@ github.com/containers/psgo v1.5.2 h1:3aoozst/GIwsrr/5jnFy3FrJay98uujPCu9lTuSZ/Cw
 github.com/containers/psgo v1.5.2/go.mod h1:2ubh0SsreMZjSXW1Hif58JrEcFudQyIy9EzPUWfawVU=
 github.com/containers/storage v1.23.5/go.mod h1:ha26Q6ngehFNhf3AWoXldvAvwI4jFe3ETQAf/CeZPyM=
 github.com/containers/storage v1.32.6/go.mod h1:mdB+b89p+jU8zpzLTVXA0gWMmIo0WrkfGMh1R8O2IQw=
+github.com/containers/storage v1.33.0/go.mod h1:FUZPF4nJijX8ixdhByZJXf02cvbyLi6dyDwXdIe8QVY=
 github.com/containers/storage v1.33.1/go.mod h1:FUZPF4nJijX8ixdhByZJXf02cvbyLi6dyDwXdIe8QVY=
+github.com/containers/storage v1.34.0/go.mod h1:t6I+hTgPU0/tVxQ75vw406wDi/TXwYBqZp4QZV9N7b8=
 github.com/containers/storage v1.34.1 h1:PsBGMH7hwuQ3MOr7qTgPznFrE8ebfIbwQbg2gKvg0lE=
 github.com/containers/storage v1.34.1/go.mod h1:FY2TcbfgCLMU4lYoKnlZeZXeH353TOTbpDEA+sAcqAY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -582,6 +586,7 @@ github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/klauspost/compress v1.13.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.13.4 h1:0zhec2I8zGnjWcKyLl6i3gPqKANCCn5e9xmviEEeX6s=
 github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
@@ -713,6 +718,7 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
+github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -751,6 +757,7 @@ github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwy
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
+github.com/opencontainers/selinux v1.8.3/go.mod h1:HTvjPFoGMbpQsG886e3lQwnsRWtE4TC1OF3OUvG9FAo=
 github.com/opencontainers/selinux v1.8.4 h1:krlgQ6/j9CkCXT5oW0yVXdQFOME3NjKuuAZXuR6O7P4=
 github.com/opencontainers/selinux v1.8.4/go.mod h1:HTvjPFoGMbpQsG886e3lQwnsRWtE4TC1OF3OUvG9FAo=
 github.com/openshift/imagebuilder v1.2.2-0.20210415181909-87f3e48c2656 h1:WaxyNFpmIDu4i6so9r6LVFIbSaXqsj8oitMitt86ae4=

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRD
 github.com/containers/buildah v1.22.3 h1:RomxwUa24jMcqzXQetpw4wGMfNlNZLhc9qwyoWHblwc=
 github.com/containers/buildah v1.22.3/go.mod h1:JVXRyx5Rkp5w5jwvaXe45kuHtyoxpERMjXrR45+3Wfg=
 github.com/containers/common v0.42.1/go.mod h1:AaF3ipZfgezsctDuhzLkq4Vl+LkEy7J74ikh2HSXDsg=
-github.com/containers/common v0.43.0 h1:CeDdfhLyPfsG6TAKJneT/4RWOhHfWF2Yv+Wz6SuMusU=
-github.com/containers/common v0.43.0/go.mod h1:BAoVyRYlxKZKAYpHcFMdrXlIZyzbJp9NwKTgadTd/Dg=
+github.com/containers/common v0.43.2 h1:oSP5d5sDrq7OkoqLPVrLpi1LZOAwpTwOZXgPDHfmD0E=
+github.com/containers/common v0.43.2/go.mod h1:BAoVyRYlxKZKAYpHcFMdrXlIZyzbJp9NwKTgadTd/Dg=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.14.0/go.mod h1:SxiBKOcKuT+4yTjD0AskjO+UwFvNcVOJ9qlAw1HNSPU=

--- a/libpod/container_log_unsupported.go
+++ b/libpod/container_log_unsupported.go
@@ -13,3 +13,7 @@ import (
 func (c *Container) readFromJournal(_ context.Context, _ *logs.LogOptions, _ chan *logs.LogLine) error {
 	return errors.Wrapf(define.ErrOSNotSupported, "Journald logging only enabled with systemd on linux")
 }
+
+func (c *Container) initializeJournal(ctx context.Context) error {
+	return errors.Wrapf(define.ErrOSNotSupported, "Journald logging only enabled with systemd on linux")
+}

--- a/libpod/logs/log.go
+++ b/libpod/logs/log.go
@@ -251,11 +251,19 @@ func (l *LogLine) Write(stdout io.Writer, stderr io.Writer, logOpts *LogOptions)
 	switch l.Device {
 	case "stdout":
 		if stdout != nil {
-			fmt.Fprintln(stdout, l.String(logOpts))
+			if l.Partial() {
+				fmt.Fprint(stdout, l.String(logOpts))
+			} else {
+				fmt.Fprintln(stdout, l.String(logOpts))
+			}
 		}
 	case "stderr":
 		if stderr != nil {
-			fmt.Fprintln(stderr, l.String(logOpts))
+			if l.Partial() {
+				fmt.Fprint(stderr, l.String(logOpts))
+			} else {
+				fmt.Fprintln(stderr, l.String(logOpts))
+			}
 		}
 	default:
 		// Warn the user if the device type does not match. Most likely the file is corrupted.

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -625,9 +625,11 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 				if err != nil {
 					break
 				}
-				_, err = httpBuf.Write([]byte("\n"))
-				if err != nil {
-					break
+				if !logLine.Partial() {
+					_, err = httpBuf.Write([]byte("\n"))
+					if err != nil {
+						break
+					}
 				}
 				err = httpBuf.Flush()
 				if err != nil {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -462,8 +462,15 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		ctrNamedVolumes = append(ctrNamedVolumes, newVol)
 	}
 
-	if ctr.config.LogPath == "" && ctr.config.LogDriver != define.JournaldLogging && ctr.config.LogDriver != define.NoLogging {
-		ctr.config.LogPath = filepath.Join(ctr.config.StaticDir, "ctr.log")
+	switch ctr.config.LogDriver {
+	case define.NoLogging:
+		break
+	case define.JournaldLogging:
+		ctr.initializeJournal(ctx)
+	default:
+		if ctr.config.LogPath == "" {
+			ctr.config.LogPath = filepath.Join(ctr.config.StaticDir, "ctr.log")
+		}
 	}
 
 	if !MountExists(ctr.config.Spec.Mounts, "/dev/shm") && ctr.config.ShmDir == "" {

--- a/pkg/api/handlers/compat/containers_logs.go
+++ b/pkg/api/handlers/compat/containers_logs.go
@@ -152,9 +152,7 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 		}
 
 		frame.WriteString(line.Msg)
-		// Log lines in the compat layer require adding EOL
-		// https://github.com/containers/podman/issues/8058
-		if !utils.IsLibpodRequest(r) {
+		if !line.Partial() {
 			frame.WriteString("\n")
 		}
 

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -404,11 +404,11 @@ func (ic *ContainerEngine) ContainerLogs(_ context.Context, nameOrIDs []string, 
 			return err
 		case line := <-stdoutCh:
 			if opts.StdoutWriter != nil {
-				_, _ = io.WriteString(opts.StdoutWriter, line+"\n")
+				_, _ = io.WriteString(opts.StdoutWriter, line)
 			}
 		case line := <-stderrCh:
 			if opts.StderrWriter != nil {
-				_, _ = io.WriteString(opts.StderrWriter, line+"\n")
+				_, _ = io.WriteString(opts.StderrWriter, line)
 			}
 		}
 	}

--- a/test/system/130-kill.bats
+++ b/test/system/130-kill.bats
@@ -33,7 +33,7 @@ load helpers
     exec 5<$fifo
 
     # First container emits READY when ready; wait for it.
-    read -t 10 -u 5 ready
+    read -t 60 -u 5 ready
     is "$ready" "READY" "first log message from container"
 
     # Helper function: send the given signal, verify that it's received.
@@ -42,7 +42,7 @@ load helpers
         local signum=${2:-$1}       # e.g. if signal=HUP, we expect to see '1'
 
         run_podman kill -s $signal $cid
-        read -t 10 -u 5 actual || die "Timed out: no ACK for kill -s $signal"
+        read -t 60 -u 5 actual || die "Timed out: no ACK for kill -s $signal"
         is "$actual" "got: $signum" "Signal $signal handled by container"
     }
 

--- a/vendor/github.com/containers/common/libimage/image.go
+++ b/vendor/github.com/containers/common/libimage/image.go
@@ -499,9 +499,15 @@ func (i *Image) Untag(name string) error {
 		return errors.Wrapf(err, "error normalizing name %q", name)
 	}
 
-	if _, isDigested := ref.(reference.Digested); isDigested {
-		return errors.Wrap(errUntagDigest, name)
-	}
+	// FIXME: this is breaking Podman CI but must be re-enabled once
+	// c/storage supports alterting the digests of an image.  Then,
+	// Podman will do the right thing.
+	//
+	// !!! Also make sure to re-enable the tests !!!
+	//
+	//	if _, isDigested := ref.(reference.Digested); isDigested {
+	//		return errors.Wrap(errUntagDigest, name)
+	//	}
 
 	name = ref.String()
 

--- a/vendor/github.com/containers/common/pkg/auth/auth.go
+++ b/vendor/github.com/containers/common/pkg/auth/auth.go
@@ -104,7 +104,6 @@ func Login(ctx context.Context, systemContext *types.SystemContext, opts *LoginO
 			return errors.Wrap(err, "get credentials for repository")
 		}
 	} else {
-		// nolint: staticcheck
 		authConfig, err = config.GetCredentials(systemContext, registry)
 		if err != nil {
 			return errors.Wrap(err, "get credentials")
@@ -321,7 +320,6 @@ func Logout(systemContext *types.SystemContext, opts *LogoutOptions, args []stri
 				return errors.Wrap(err, "get credentials for repository")
 			}
 		} else {
-			// nolint: staticcheck
 			authConfig, err = config.GetCredentials(systemContext, registry)
 			if err != nil {
 				return errors.Wrap(err, "get credentials")

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -274,6 +274,9 @@ type EngineConfig struct {
 	// MachineEnabled indicates if Podman is running in a podman-machine VM
 	MachineEnabled bool `toml:"machine_enabled,omitempty"`
 
+	// MachineImage is the image used when creating a podman-machine VM
+	MachineImage string `toml:"machine_image,omitempty"`
+
 	// MultiImageArchive - if true, the container engine allows for storing
 	// archives (e.g., of the docker-archive transport) with multiple
 	// images.  By default, Podman creates single-image archives.
@@ -691,8 +694,8 @@ func (c *Config) Validate() error {
 }
 
 func (c *EngineConfig) findRuntime() string {
-	// Search for crun first followed by runc and kata
-	for _, name := range []string{"crun", "runc", "kata"} {
+	// Search for crun first followed by runc, kata, runsc
+	for _, name := range []string{"crun", "runc", "kata", "runsc"} {
 		for _, v := range c.OCIRuntimes[name] {
 			if _, err := os.Stat(v); err == nil {
 				return name

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -60,23 +60,23 @@ default_capabilities = [
 ]
 
 # A list of sysctls to be set in containers by default,
-# specified as "name=value",
+# specified as "name = value",
 # for example:"net.ipv4.ping_group_range = 0 0".
 #
 default_sysctls = [
-  "net.ipv4.ping_group_range=0 0",
+  "net.ipv4.ping_group_range = 0 0",
 ]
 
 # A list of ulimits to be set in containers by default, specified as
-# "<ulimit name>=<soft limit>:<hard limit>", for example:
-# "nofile=1024:2048"
+# "<ulimit name> = <soft limit>:<hard limit>", for example:
+# "nofile = 1024:2048"
 # See setrlimit(2) for a list of resource names.
 # Any limit not specified here will be inherited from the process launching the
 # container engine.
 # Ulimits has limits for non privileged container engines.
 #
 #default_ulimits = [
-#  "nofile=1280:2560",
+#  "nofile = 1280:2560",
 #]
 
 # List of devices. Specified as
@@ -380,6 +380,9 @@ default_sysctls = [
 # container inside the VM to to host.
 #
 #machine_enabled = false
+
+# The image used when creating a podman-machine VM.
+# machine_image = "testing"
 
 # MultiImageArchive - if true, the container engine allows for storing archives
 # (e.g., of the docker-archive transport) with multiple images.  By default,

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -60,23 +60,23 @@ default_capabilities = [
 ]
 
 # A list of sysctls to be set in containers by default,
-# specified as "name = value",
-# for example:"net.ipv4.ping_group_range = 0 0".
+# specified as "name=value",
+# for example:"net.ipv4.ping_group_range=0 0".
 #
 default_sysctls = [
-  "net.ipv4.ping_group_range = 0 0",
+  "net.ipv4.ping_group_range=0 0",
 ]
 
 # A list of ulimits to be set in containers by default, specified as
-# "<ulimit name> = <soft limit>:<hard limit>", for example:
-# "nofile = 1024:2048"
+# "<ulimit name>=<soft limit>:<hard limit>", for example:
+# "nofile=1024:2048"
 # See setrlimit(2) for a list of resource names.
 # Any limit not specified here will be inherited from the process launching the
 # container engine.
 # Ulimits has limits for non privileged container engines.
 #
 #default_ulimits = [
-#  "nofile = 1280:2560",
+#  "nofile=1280:2560",
 #]
 
 # List of devices. Specified as
@@ -382,7 +382,8 @@ default_sysctls = [
 #machine_enabled = false
 
 # The image used when creating a podman-machine VM.
-# machine_image = "testing"
+#
+#machine_image = "testing"
 
 # MultiImageArchive - if true, the container engine allows for storing archives
 # (e.g., of the docker-archive transport) with multiple images.  By default,

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -105,8 +105,6 @@ const (
 	DefaultApparmorProfile = apparmor.Profile
 	// SystemdCgroupsManager represents systemd native cgroup manager
 	SystemdCgroupsManager = "systemd"
-	// DefaultLogDriver is the default type of log files
-	DefaultLogDriver = "k8s-file"
 	// DefaultLogSizeMax is the default value for the maximum log size
 	// allowed for a container. Negative values mean that no limit is imposed.
 	DefaultLogSizeMax = -1
@@ -339,6 +337,7 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	// constants.
 	c.LockType = "shm"
 	c.MachineEnabled = false
+	c.MachineImage = "testing"
 
 	c.ChownCopiedFiles = true
 
@@ -549,6 +548,7 @@ func (c *Config) LogDriver() string {
 	return c.Containers.LogDriver
 }
 
+// MachineEnabled returns if podman is running inside a VM or not
 func (c *Config) MachineEnabled() bool {
 	return c.Engine.MachineEnabled
 }
@@ -557,4 +557,10 @@ func (c *Config) MachineEnabled() bool {
 // rootless containers should use
 func (c *Config) RootlessNetworking() string {
 	return c.Containers.RootlessNetworking
+}
+
+// MachineImage returns the image to be
+// used when creating a podman-machine VM
+func (c *Config) MachineImage() string {
+	return c.Engine.MachineImage
 }

--- a/vendor/github.com/containers/common/pkg/config/nosystemd.go
+++ b/vendor/github.com/containers/common/pkg/config/nosystemd.go
@@ -1,6 +1,11 @@
-// +build !systemd
+// +build !systemd !cgo
 
 package config
+
+const (
+	// DefaultLogDriver is the default type of log files
+	DefaultLogDriver = "k8s-file"
+)
 
 func defaultCgroupManager() string {
 	return CgroupfsCgroupsManager

--- a/vendor/github.com/containers/common/pkg/parse/parse.go
+++ b/vendor/github.com/containers/common/pkg/parse/parse.go
@@ -5,6 +5,7 @@ package parse
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -155,7 +156,7 @@ func ValidateVolumeCtrDir(ctrDir string) error {
 	if ctrDir == "" {
 		return errors.New("container directory cannot be empty")
 	}
-	if !filepath.IsAbs(ctrDir) {
+	if !path.IsAbs(ctrDir) {
 		return errors.Errorf("invalid container path %q, must be an absolute path", ctrDir)
 	}
 	return nil

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.42.1"
+const Version = "0.43.0"

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.43.0"
+const Version = "0.43.2"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -94,7 +94,7 @@ github.com/containers/buildah/pkg/overlay
 github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/util
-# github.com/containers/common v0.42.1
+# github.com/containers/common v0.43.0
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
 github.com/containers/common/pkg/apparmor

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -94,7 +94,7 @@ github.com/containers/buildah/pkg/overlay
 github.com/containers/buildah/pkg/parse
 github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/util
-# github.com/containers/common v0.43.0
+# github.com/containers/common v0.43.2
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
 github.com/containers/common/pkg/apparmor


### PR DESCRIPTION
When reading log entries from the journal, don't skip past the first matching entry after we've positioned the cursor at it.

Fixes #11253.