### PR TITLE
Clean up swagger

### DIFF
--- a/pkg/api/handlers/compat/swagger.go
+++ b/pkg/api/handlers/compat/swagger.go
@@ -2,7 +2,6 @@ package compat
 
 import (
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/containers/storage/pkg/archive"
 	"github.com/docker/docker/api/types"
 )
 
@@ -25,15 +24,6 @@ type swagCtrWaitResponse struct {
 		Error      struct {
 			Message string
 		}
-	}
-}
-
-// Object Changes
-// swagger:response Changes
-type swagChangesResponse struct {
-	// in:body
-	Body struct {
-		Changes []archive.Change
 	}
 }
 

--- a/pkg/api/handlers/swagger/swagger.go
+++ b/pkg/api/handlers/swagger/swagger.go
@@ -152,13 +152,6 @@ type swagPodTopResponse struct {
 	}
 }
 
-// List processes in pod
-// swagger:response DocsPodStatsResponse
-type swagPodStatsResponse struct {
-	// in:body
-	Body []*entities.PodStatsReport
-}
-
 // Inspect container
 // swagger:response LibpodInspectContainerResponse
 type swagLibpodInspectContainerResponse struct {
@@ -181,14 +174,5 @@ type swagInspectPodResponse struct {
 	// in:body
 	Body struct {
 		define.InspectPodData
-	}
-}
-
-// Inspect volume
-// swagger:response InspectVolumeResponse
-type swagInspectVolumeResponse struct {
-	// in:body
-	Body struct {
-		define.InspectVolumeData
 	}
 }

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -104,6 +104,7 @@ type ContainerWaitOKBody struct {
 }
 
 // CreateContainerConfig used when compatible endpoint creates a container
+// swagger:model CreateContainerConfig
 type CreateContainerConfig struct {
 	Name                   string                         // container name
 	dockerContainer.Config                                // desired container configuration

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -21,6 +21,12 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//      name: name
 	//      type: string
 	//      description: container name
+	//    - in: body
+	//      name: body
+	//      description: Container to create
+	//      schema:
+	//        $ref: "#/definitions/CreateContainerConfig"
+	//      required: true
 	//   responses:
 	//     201:
 	//       $ref: "#/responses/ContainerCreateResponse"

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -25,6 +25,10 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// produces:
 	// - application/json
 	// parameters:
+	//  - in: header
+	//    name: X-Registry-Auth
+	//    type: string
+	//    description: A base64-encoded auth configuration.
 	//  - in: query
 	//    name: fromImage
 	//    type: string
@@ -49,13 +53,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    name: platform
 	//    type: string
 	//    description: Platform in the format os[/arch[/variant]]
-	//    default: ""
-	//  - in: header
-	//    name: X-Registry-Auth
-	//    type: string
-	//    description: A base64-encoded auth configuration.
 	//  - in: body
-	//    name: request
+	//    name: inputImage
 	//    schema:
 	//      type: string
 	//      format: binary
@@ -472,6 +471,14 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// summary: Create image
 	// description: Build an image from the given Dockerfile(s)
 	// parameters:
+	//  - in: header
+	//    name: Content-Type
+	//    type: string
+	//    default: application/x-tar
+	//    enum: ["application/x-tar"]
+	//  - in: header
+	//    name: X-Registry-Config
+	//    type: string
 	//  - in: query
 	//    name: dockerfile
 	//    type: string
@@ -653,6 +660,14 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    description: |
 	//      output configuration TBD
 	//      (As of version 1.xx)
+	//  - in: body
+	//    name: inputStream
+	//    description: |
+	//      A tar archive compressed with one of the following algorithms:
+	//      identity (no compression), gzip, bzip2, xz.
+	//    schema:
+	//      type: string
+	//      format: binary
 	// produces:
 	// - application/json
 	// responses:
@@ -852,6 +867,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// summary: Import image
 	// description: Import a previously exported tarball as an image.
 	// parameters:
+	//   - in: header
+	//     name: Content-Type
+	//     type: string
+	//     default: application/x-tar
+	//     enum: ["application/x-tar"]
 	//   - in: query
 	//     name: changes
 	//     description: "Apply the following possible instructions to the created image: CMD | ENTRYPOINT | ENV | EXPOSE | LABEL | STOPSIGNAL | USER | VOLUME | WORKDIR.  JSON encoded string"
@@ -875,7 +895,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     required: true
 	//     description: tarball for imported image
 	//     schema:
-	//       type: "string"
+	//       type: string
+	//       format: binary
 	// produces:
 	// - application/json
 	// consumes:

--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -51,7 +51,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	// responses:
 	//   201:
 	//     schema:
-	//       $ref: "#/definitions/IdResponse"
+	//       $ref: "#/definitions/IDResponse"
 	//   400:
 	//     $ref: "#/responses/BadParamError"
 	//   409:

--- a/pkg/api/server/swagger.go
+++ b/pkg/api/server/swagger.go
@@ -141,13 +141,6 @@ type swagImageSummary struct {
 	Body []entities.ImageSummary
 }
 
-// Registries summary
-// swagger:response DocsRegistriesList
-type swagRegistriesList struct {
-	// in:body
-	Body entities.ListRegistriesReport
-}
-
 // List Containers
 // swagger:response DocsListContainer
 type swagListContainers struct {


### PR DESCRIPTION
* Removed defined by unused responses
* Added missing body definitions
* Updated header input definitions

Outstanding issues:
* Supporting body ContainerConfig for /commit endpoint

Fixes #8577

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
