### PR TITLE
Fix network aliases with network id

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -246,6 +246,20 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		ctr.config.Networks = netNames
 	}
 
+	// https://github.com/containers/podman/issues/11285
+	// normalize the networks aliases to use network names and never ids
+	if len(ctr.config.NetworkAliases) > 0 {
+		netAliases := make(map[string][]string, len(ctr.config.NetworkAliases))
+		for nameOrID, aliases := range ctr.config.NetworkAliases {
+			netName, err := network.NormalizeName(r.config, nameOrID)
+			if err != nil {
+				return nil, err
+			}
+			netAliases[netName] = aliases
+		}
+		ctr.config.NetworkAliases = netAliases
+	}
+
 	// Inhibit shutdown until creation succeeds
 	shutdown.Inhibit()
 	defer shutdown.Uninhibit()

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -236,8 +236,6 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network connect and run with network ID", func() {
-		SkipIfRemote("remote flakes to much I will fix this in another PR")
-		SkipIfRootless("network connect and disconnect are only rootful")
 		netName := "ID" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
@@ -249,7 +247,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(session).Should(Exit(0))
 		netID := session.OutputToString()
 
-		ctr := podmanTest.Podman([]string{"run", "-dt", "--name", "test", "--network", netID, ALPINE, "top"})
+		ctr := podmanTest.Podman([]string{"run", "-dt", "--name", "test", "--network", netID, "--network-alias", "somealias", ALPINE, "top"})
 		ctr.WaitWithDefaultTimeout()
 		Expect(ctr).Should(Exit(0))
 
@@ -269,7 +267,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(session).Should(Exit(0))
 		newNetID := session.OutputToString()
 
-		connect := podmanTest.Podman([]string{"network", "connect", newNetID, "test"})
+		connect := podmanTest.Podman([]string{"network", "connect", "--alias", "secondalias", newNetID, "test"})
 		connect.WaitWithDefaultTimeout()
 		Expect(connect).Should(Exit(0))
 
@@ -324,8 +322,6 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network disconnect and run with network ID", func() {
-		SkipIfRemote("remote flakes to much I will fix this in another PR")
-		SkipIfRootless("network connect and disconnect are only rootful")
 		netName := "aliasTest" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -764,7 +764,6 @@ var _ = Describe("Podman run networking", func() {
 	})
 
 	It("podman run check dnsname adds dns search domain", func() {
-		Skip("needs dnsname#57")
 		net := "dnsname" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
When a network id is used to create a container we translate it to use the
name internally for the db. The network aliases are also stored with the
network name as key so we have to also translate them for the db.

Also removed some outdated skips from the e2e tests.

Fixes #11285

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
