### PR TITLE
add flag to record memory profiles

### DIFF
--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -39,6 +39,7 @@ type PodmanConfig struct {
 	EngineMode     EngineMode // ABI or Tunneling mode
 	Identity       string     // ssh identity for connecting to server
 	MaxWorks       int        // maximum number of parallel threads
+	MemoryProfile  string     // Hidden: Should memory profile be taken
 	RegistriesConf string     // allows for specifying a custom registries.conf
 	Remote         bool       // Connection to Podman API Service will use RESTful API
 	RuntimePath    string     // --runtime flag will set Engine.RuntimePath


### PR DESCRIPTION
Add a new flag `--memory-profile=$path` which creates a memory profile.
The generated profile can later be analyzed via `go tool pprof`.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@baude, PTAL