### PR TITLE
Use pod netns with --pod-id-file

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -96,7 +96,7 @@ func create(cmd *cobra.Command, args []string) error {
 	var (
 		err error
 	)
-	cliVals.Net, err = common.NetFlagsToNetOptions(cmd, cliVals.Pod == "")
+	cliVals.Net, err = common.NetFlagsToNetOptions(cmd, cliVals.Pod == "" && cliVals.PodIDFile == "")
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -106,7 +106,7 @@ func init() {
 
 func run(cmd *cobra.Command, args []string) error {
 	var err error
-	cliVals.Net, err = common.NetFlagsToNetOptions(cmd, cliVals.Pod == "")
+	cliVals.Net, err = common.NetFlagsToNetOptions(cmd, cliVals.Pod == "" && cliVals.PodIDFile == "")
 	if err != nil {
 		return err
 	}

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -121,6 +121,21 @@ var _ = Describe("Podman pod create", func() {
 		Expect(check).Should(Exit(0))
 	})
 
+	It("podman create pod with id file with network portbindings", func() {
+		file := filepath.Join(podmanTest.TempDir, "pod.id")
+		name := "test"
+		session := podmanTest.Podman([]string{"pod", "create", "--name", name, "--pod-id-file", file, "-p", "8080:80"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		webserver := podmanTest.Podman([]string{"run", "--pod-id-file", file, "-dt", nginx})
+		webserver.WaitWithDefaultTimeout()
+		Expect(webserver).Should(Exit(0))
+
+		check := SystemExec("nc", []string{"-z", "localhost", "8080"})
+		Expect(check).Should(Exit(0))
+	})
+
 	It("podman create pod with no infra but portbindings should fail", func() {
 		name := "test"
 		session := podmanTest.Podman([]string{"pod", "create", "--infra=false", "--name", name, "-p", "80:80"})


### PR DESCRIPTION
When `--pod-id-file` is used do not parse the default network namespace
and let specgen handle it instead.
This regression was introduced in commit 7ef3981abe24.

Fixes #11303

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
