### PR TITLE
utils.RunUnderSystemdScope(): always close Conn

### DIFF
--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -36,6 +36,7 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 			return err
 		}
 	}
+	defer conn.Close()
 	properties = append(properties, systemdDbus.PropSlice(slice))
 	properties = append(properties, newProp("PIDs", []uint32{uint32(pid)}))
 	properties = append(properties, newProp("Delegate", true))
@@ -54,7 +55,6 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 		}
 		return err
 	}
-	defer conn.Close()
 
 	// Block until job is started
 	<-ch


### PR DESCRIPTION
Make sure we close our private connection to the bus, even if we're not successful in in using it to ask systemd to move a unit's processes to a specific control group.