### PR TITLE
podman inspect show exposed ports

### DIFF
--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -99,6 +99,11 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 	for _, p := range c.config.PortMappings {
 		importBuilder.SetPort(fmt.Sprintf("%d/%s", p.ContainerPort, p.Protocol))
 	}
+	for port, protocols := range c.config.ExposedPorts {
+		for _, protocol := range protocols {
+			importBuilder.SetPort(fmt.Sprintf("%d/%s", port, protocol))
+		}
+	}
 	// Labels
 	for k, v := range c.Labels() {
 		importBuilder.SetLabel(k, v)

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -229,6 +229,12 @@ type ContainerNetworkConfig struct {
 	// namespace
 	// These are not used unless CreateNetNS is true
 	PortMappings []ocicni.PortMapping `json:"portMappings,omitempty"`
+	// ExposedPorts are the ports which are exposed but not forwarded
+	// into the container.
+	// The map key is the port and the string slice contains the protocols,
+	// e.g. tcp and udp
+	// These are only set when exposed ports are given but not published.
+	ExposedPorts map[uint16][]string `json:"exposedPorts,omitempty"`
 	// UseImageResolvConf indicates that resolv.conf should not be
 	// bind-mounted inside the container.
 	// Conflicts with DNSServer, DNSSearch, DNSOption.

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -624,7 +624,7 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 	// Port bindings.
 	// Only populate if we're using CNI to configure the network.
 	if c.config.CreateNetNS {
-		hostConfig.PortBindings = makeInspectPortBindings(c.config.PortMappings)
+		hostConfig.PortBindings = makeInspectPortBindings(c.config.PortMappings, c.config.ExposedPorts)
 	} else {
 		hostConfig.PortBindings = make(map[string][]define.InspectHostPort)
 	}

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1015,7 +1015,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 	}
 
 	settings := new(define.InspectNetworkSettings)
-	settings.Ports = makeInspectPortBindings(c.config.PortMappings)
+	settings.Ports = makeInspectPortBindings(c.config.PortMappings, c.config.ExposedPorts)
 
 	networks, isDefault, err := c.networks()
 	if err != nil {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1041,7 +1041,7 @@ func WithDependencyCtrs(ctrs []*Container) CtrCreateOption {
 // namespace with a minimal configuration.
 // An optional array of port mappings can be provided.
 // Conflicts with WithNetNSFrom().
-func WithNetNS(portMappings []ocicni.PortMapping, postConfigureNetNS bool, netmode string, networks []string) CtrCreateOption {
+func WithNetNS(portMappings []ocicni.PortMapping, exposedPorts map[uint16][]string, postConfigureNetNS bool, netmode string, networks []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
 			return define.ErrCtrFinalized
@@ -1051,6 +1051,7 @@ func WithNetNS(portMappings []ocicni.PortMapping, postConfigureNetNS bool, netmo
 		ctr.config.NetMode = namespaces.NetworkMode(netmode)
 		ctr.config.CreateNetNS = true
 		ctr.config.PortMappings = portMappings
+		ctr.config.ExposedPorts = exposedPorts
 
 		ctr.config.Networks = networks
 

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -616,7 +616,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 			infraConfig.Networks = append(infraConfig.Networks, p.config.InfraContainer.Networks...)
 		}
 		infraConfig.NetworkOptions = p.config.InfraContainer.NetworkOptions
-		infraConfig.PortBindings = makeInspectPortBindings(p.config.InfraContainer.PortBindings)
+		infraConfig.PortBindings = makeInspectPortBindings(p.config.InfraContainer.PortBindings, nil)
 	}
 
 	inspectData := define.InspectPodData{

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -112,7 +112,8 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, rawIm
 					options = append(options, WithNetworkOptions(p.config.InfraContainer.NetworkOptions))
 				}
 			}
-			options = append(options, WithNetNS(p.config.InfraContainer.PortBindings, !p.config.InfraContainer.Userns.IsHost(), netmode, p.config.InfraContainer.Networks))
+			// FIXME allow pods to have exposed ports
+			options = append(options, WithNetNS(p.config.InfraContainer.PortBindings, nil, !p.config.InfraContainer.Userns.IsHost(), netmode, p.config.InfraContainer.Networks))
 		}
 
 		// For each option in InfraContainerConfig - if set, pass into

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -242,7 +242,7 @@ func namespaceOptions(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.
 		}
 		toReturn = append(toReturn, libpod.WithNetNSFrom(netCtr))
 	case specgen.Slirp:
-		portMappings, err := createPortMappings(ctx, s, imageData)
+		portMappings, expose, err := createPortMappings(ctx, s, imageData)
 		if err != nil {
 			return nil, err
 		}
@@ -250,15 +250,15 @@ func namespaceOptions(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.
 		if s.NetNS.Value != "" {
 			val = fmt.Sprintf("slirp4netns:%s", s.NetNS.Value)
 		}
-		toReturn = append(toReturn, libpod.WithNetNS(portMappings, postConfigureNetNS, val, nil))
+		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, postConfigureNetNS, val, nil))
 	case specgen.Private:
 		fallthrough
 	case specgen.Bridge:
-		portMappings, err := createPortMappings(ctx, s, imageData)
+		portMappings, expose, err := createPortMappings(ctx, s, imageData)
 		if err != nil {
 			return nil, err
 		}
-		toReturn = append(toReturn, libpod.WithNetNS(portMappings, postConfigureNetNS, "bridge", s.CNINetworks))
+		toReturn = append(toReturn, libpod.WithNetNS(portMappings, expose, postConfigureNetNS, "bridge", s.CNINetworks))
 	}
 
 	if s.UseImageHosts {

--- a/pkg/specgen/generate/ports.go
+++ b/pkg/specgen/generate/ports.go
@@ -253,17 +253,15 @@ func ParsePortMapping(portMappings []specgen.PortMapping) ([]ocicni.PortMapping,
 }
 
 // Make final port mappings for the container
-func createPortMappings(ctx context.Context, s *specgen.SpecGenerator, imageData *libimage.ImageData) ([]ocicni.PortMapping, error) {
+func createPortMappings(ctx context.Context, s *specgen.SpecGenerator, imageData *libimage.ImageData) ([]ocicni.PortMapping, map[uint16][]string, error) {
 	finalMappings, containerPortValidate, hostPortValidate, err := ParsePortMapping(s.PortMappings)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// If not publishing exposed ports, or if we are publishing and there is
-	// nothing to publish - then just return the port mappings we've made so
-	// far.
-	if !s.PublishExposedPorts || (len(s.Expose) == 0 && imageData == nil) {
-		return finalMappings, nil
+	// No exposed ports so return the port mappings we've made so far.
+	if len(s.Expose) == 0 && imageData == nil {
+		return finalMappings, nil, nil
 	}
 
 	logrus.Debugf("Adding exposed ports")
@@ -272,7 +270,7 @@ func createPortMappings(ctx context.Context, s *specgen.SpecGenerator, imageData
 	if imageData != nil {
 		expose, err = GenExposedPorts(imageData.Config.ExposedPorts)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -288,11 +286,11 @@ func createPortMappings(ctx context.Context, s *specgen.SpecGenerator, imageData
 		// Validate protocol first
 		protocols, err := checkProtocol(proto, false)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error validating protocols for exposed port %d", port)
+			return nil, nil, errors.Wrapf(err, "error validating protocols for exposed port %d", port)
 		}
 
 		if port == 0 {
-			return nil, errors.Errorf("cannot expose 0 as it is not a valid port number")
+			return nil, nil, errors.Errorf("cannot expose 0 as it is not a valid port number")
 		}
 
 		// Check to see if the port is already present in existing
@@ -316,6 +314,11 @@ func createPortMappings(ctx context.Context, s *specgen.SpecGenerator, imageData
 		}
 	}
 
+	// If not publishing exposed ports return mappings and exposed ports.
+	if !s.PublishExposedPorts {
+		return finalMappings, toExpose, nil
+	}
+
 	// We now have a final list of ports that we want exposed.
 	// Let's find empty, unallocated host ports for them.
 	for port, protocols := range toExpose {
@@ -331,7 +334,7 @@ func createPortMappings(ctx context.Context, s *specgen.SpecGenerator, imageData
 				// unfortunate for the UDP case.
 				candidate, err := utils.GetRandomPort()
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 
 				// Check if the host port is already bound
@@ -362,12 +365,12 @@ func createPortMappings(ctx context.Context, s *specgen.SpecGenerator, imageData
 			}
 			if tries == 0 && hostPort == 0 {
 				// We failed to find an open port.
-				return nil, errors.Errorf("failed to find an open port to expose container port %d on the host", port)
+				return nil, nil, errors.Errorf("failed to find an open port to expose container port %d on the host", port)
 			}
 		}
 	}
 
-	return finalMappings, nil
+	return finalMappings, nil, nil
 }
 
 // Check a string to ensure it is a comma-separated set of valid protocols

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"os"
 
+	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/annotations"
 	. "github.com/containers/podman/v3/test/utils"
 	. "github.com/onsi/ginkgo"
@@ -42,5 +43,29 @@ var _ = Describe("Podman container inspect", func() {
 		data := podmanTest.InspectContainer(testContainer)
 		Expect(data[0].Config.Annotations[annotations.ContainerManager]).
 			To(Equal(annotations.ContainerManagerLibpod))
+	})
+
+	It("podman inspect shows exposed ports", func() {
+		name := "testcon"
+		session := podmanTest.Podman([]string{"run", "-d", "--stop-timeout", "0", "--expose", "8080/udp", "--name", name, ALPINE, "sleep", "inf"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		data := podmanTest.InspectContainer(name)
+
+		Expect(data).To(HaveLen(1))
+		Expect(data[0].NetworkSettings.Ports).
+			To(Equal(map[string][]define.InspectHostPort{"8080/udp": nil}))
+	})
+
+	It("podman inspect shows exposed ports on image", func() {
+		name := "testcon"
+		session := podmanTest.Podman([]string{"run", "-d", "--expose", "8080", "--name", name, nginx})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		data := podmanTest.InspectContainer(name)
+		Expect(data).To(HaveLen(1))
+		Expect(data[0].NetworkSettings.Ports).
+			To(Equal(map[string][]define.InspectHostPort{"80/tcp": nil, "8080/tcp": nil}))
 	})
 })


### PR DESCRIPTION
Podman inspect has to show exposed ports to match docker. This requires
storing the exposed ports in the container config.
A exposed port is shown as `"80/tcp": null` while a forwarded port is
shown as `"80/tcp": [{"HostIp": "", "HostPort": "8080" }]`.

Fixes #10777

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
