### PR TITLE
Add init containers to generate and play kube

### DIFF
--- a/docs/source/markdown/podman-generate-kube.1.md
+++ b/docs/source/markdown/podman-generate-kube.1.md
@@ -16,6 +16,9 @@ Volumes appear in the generated YAML according to two different volume types. Bi
 
 Potential name conflicts between volumes are avoided by using a standard naming scheme for each volume type. The *hostPath* volume types are named according to the path on the host machine, replacing forward slashes with hyphens less any leading and trailing forward slashes. The special case of the filesystem root, `/`, translates to the name `root`. Additionally, the name is suffixed with `-host` to avoid naming conflicts with *persistentVolumeClaim* volumes. Each *persistentVolumeClaim* volume type uses the name of its associated named volume suffixed with `-pvc`.
 
+Note that if an init container is created with type `once` and the pod has been started, the init container will not show up in the generated kube YAML as `once` type init containers are deleted after they are run. If the pod has only been created and not started, it will be in the generated kube YAML.
+Init containers created with type `always` will always be generated in the kube YAML as they are never deleted, even after running to completion.
+
 Note that the generated Kubernetes YAML file can be used to re-run the deployment via podman-play-kube(1).
 
 ## OPTIONS

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -20,6 +20,8 @@ Currently, the supported Kubernetes kinds are:
 
 Only two volume types are supported by play kube, the *hostPath* and *persistentVolumeClaim* volume types. For the *hostPath* volume type, only the  *default (empty)*, *DirectoryOrCreate*, *Directory*, *FileOrCreate*, *File*, and *Socket* subtypes are supported. The *CharDevice* and *BlockDevice* subtypes are not supported. Podman interprets the value of *hostPath* *path* as a file path when it contains at least one forward slash, otherwise Podman treats the value as the name of a named volume. When using a *persistentVolumeClaim*, the value for *claimName* is the name for the Podman named volume.
 
+Note: When playing a kube YAML with init containers, the init container will be created with init type value `always`.
+
 Note: *hostPath* volume types created by play kube will be given an SELinux private label (Z)
 
 Note: If the `:latest` tag is used, Podman will attempt to pull the image from a registry. If the image was built locally with Podman or Buildah, it will have `localhost` as the domain, in that case, Podman will use the image from the local store even if it has the `:latest` tag.

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1062,6 +1062,11 @@ func (c *Container) IsInfra() bool {
 	return c.config.IsInfra
 }
 
+// IsInitCtr returns whether the container is an init container
+func (c *Container) IsInitCtr() bool {
+	return len(c.config.InitContainerType) > 0
+}
+
 // IsReadOnly returns whether the container is running in read only mode
 func (c *Container) IsReadOnly() bool {
 	return c.config.Spec.Root.Readonly

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -51,6 +51,8 @@ type PlayKubePod struct {
 	ID string
 	// Containers - the IDs of the containers running in the created pod.
 	Containers []string
+	// InitContainers - the IDs of the init containers to be run in the created pod.
+	InitContainers []string
 	// Logs - non-fatal errors and log messages while processing.
 	Logs []string
 	// ContainerErrors - any errors that occurred while starting containers

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -114,6 +114,9 @@ type CtrSpecGenOptions struct {
 	Labels map[string]string
 	//
 	IsInfra bool
+	// InitContainerType sets what type the init container is
+	// Note: When playing a kube yaml, the inti container type will be set to "always" only
+	InitContainerType string
 }
 
 func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGenerator, error) {
@@ -134,6 +137,8 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	s.LogConfiguration = &specgen.LogConfig{
 		Driver: opts.LogDriver,
 	}
+
+	s.InitContainerType = opts.InitContainerType
 
 	setupSecurityContext(s, opts.Container)
 	err := setupLivenessProbe(s, opts.Container, opts.RestartPolicy)


### PR DESCRIPTION
Kubernetes has a concept of init containers that run and exit before
the regular containers in a pod are started. We added init containers
to podman pods as well. This patch adds support for generating init
containers in the kube yaml when a pod we are converting had init
containers. When playing a kube yaml, it detects an init container
and creates such a container in podman accordingly.
Note, only init containers created with the init type set to "always"
will be generated as the "once" option deletes the init container after
it has run and exited. Play kube will always creates init containers
with the "always" init container type.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
