### PR TITLE
Add support for mount options to API

### DIFF
--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -620,9 +620,9 @@ func getTmpfsMounts(tmpfsFlag []string) (map[string]spec.Mount, error) {
 
 		mount := spec.Mount{
 			Destination: filepath.Clean(destPath),
-			Type:        string(define.TypeTmpfs),
+			Type:        define.TypeTmpfs,
 			Options:     options,
-			Source:      string(define.TypeTmpfs),
+			Source:      define.TypeTmpfs,
 		}
 		m[destPath] = mount
 	}

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -366,4 +366,12 @@ t GET containers/$cid/json 200 \
   .Config.Healthcheck.Timeout=30000000000 \
   .Config.Healthcheck.Retries=3
 
+# compat api: Test for mount options support
+payload='{"Mounts":[{"Type":"tmpfs","Target":"/mnt/scratch","TmpfsOptions":{"SizeBytes":1024,"Mode":755}}]}'
+t POST containers/create Image=$IMAGE HostConfig="$payload" 201 .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 \
+    .HostConfig.Tmpfs['"/mnt/scratch"']~.*size=1024.* \
+    .HostConfig.Tmpfs['"/mnt/scratch"']~.*mode=755.*
+
 t DELETE containers/$cid?v=true 204

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -327,7 +327,8 @@ function start_service() {
         die "Cannot start service on non-localhost ($HOST)"
     fi
 
-    $PODMAN_BIN --root $WORKDIR/server_root system service \
+    $PODMAN_BIN --root $WORKDIR/server_root --syslog=true \
+                system service \
                 --time 15 \
                 tcp:127.0.0.1:$PORT \
         &> $WORKDIR/server.log &


### PR DESCRIPTION
When creating containers the specialized mount options where not
populated via the API.

Fixes: #10831
Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
