### PR TITLE
Shell completion for --format with anonymous fields

### DIFF
--- a/cmd/podman/common/completion_test.go
+++ b/cmd/podman/common/completion_test.go
@@ -17,6 +17,10 @@ type Car struct {
 	Extras map[string]string
 }
 
+type Anonymous struct {
+	Hello string
+}
+
 func (c Car) Type() string {
 	return ""
 }
@@ -30,7 +34,10 @@ func TestAutocompleteFormat(t *testing.T) {
 		Name string
 		Age  int
 		Car  *Car
-	}{}
+		*Anonymous
+	}{
+		Anonymous: &Anonymous{},
+	}
 
 	testStruct.Car = &Car{}
 	testStruct.Car.Extras = map[string]string{"test": "1"}
@@ -73,12 +80,12 @@ func TestAutocompleteFormat(t *testing.T) {
 		{
 			"fist level struct field name",
 			"{{.",
-			[]string{"{{.Name}}", "{{.Age}}", "{{.Car."},
+			[]string{"{{.Name}}", "{{.Age}}", "{{.Car.", "{{.Anonymous.", "{{.Hello}}"},
 		},
 		{
 			"fist level struct field name",
 			"{{ .",
-			[]string{"{{ .Name}}", "{{ .Age}}", "{{ .Car."},
+			[]string{"{{ .Name}}", "{{ .Age}}", "{{ .Car.", "{{ .Anonymous.", "{{ .Hello}}"},
 		},
 		{
 			"fist level struct field name",

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -57,7 +57,7 @@ func init() {
 
 	formatFlagName := "format"
 	flags.StringVar(&psInput.Format, formatFlagName, "", "Pretty-print pods to JSON or using a Go template")
-	_ = psCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(ListPodReporter{}))
+	_ = psCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(ListPodReporter{ListPodsReport: &entities.ListPodsReport{}}))
 
 	flags.Bool("noheading", false, "Do not print headers")
 	flags.BoolVar(&psInput.Namespace, "namespace", false, "Display namespace information of the pod")


### PR DESCRIPTION
In commit d81021ed265e I introduced shell completion for the `--format`
flag. This is a very nice way to complete go template field names.
However it did not work correct for anonymous fields. In this case the
child fields can be accessed directly from the parent.

For example:
```
type Anonymous struct {
   Field1 string
   Field2 string
   ...
}

type MyType struct {
    Anonymous
}

var s = MyType{}
```

Now if you want to access a field from the Anonymous struct you can just
do `s.Field1`. The same is allowed for go templates, using `{{.Field1}}`
should work. This commit adds this functionality, if the field is anonymous
read the child field names recursively and add them to the suggestions.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
