### PR TITLE
Add support for libsubid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ BUILDTAGS ?= \
 	$(shell hack/btrfs_tag.sh) \
 	$(shell hack/selinux_tag.sh) \
 	$(shell hack/systemd_tag.sh) \
+	$(shell hack/libsubid_tag.sh) \
 	exclude_graphdriver_devicemapper \
 	seccomp
 PYTHON ?= $(shell command -v python3 python|head -n1)

--- a/hack/libsubid_tag.sh
+++ b/hack/libsubid_tag.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+if test $(${GO:-go} env GOOS) != "linux" ; then
+	exit 0
+fi
+tmpdir="$PWD/tmp.$RANDOM"
+mkdir -p "$tmpdir"
+trap 'rm -fr "$tmpdir"' EXIT
+cc -o "$tmpdir"/libsubid_tag -l subid -x c - > /dev/null 2> /dev/null << EOF
+#include <shadow/subid.h>
+int main() {
+	struct subid_range *ranges = NULL;
+	get_subuid_ranges("root", &ranges);
+	free(ranges);
+	return 0;
+}
+EOF
+if test $? -eq 0 ; then
+	echo libsubid
+fi


### PR DESCRIPTION
This will enable remote access to /etc/subuid and /etc/subgid
information from ldap services, if shadow-utils ships with a libsubid.

[NO TESTS NEEDED] Since we have no way to test this.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
