### PR TITLE
change error comparison for exec.ErrNotFound

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -608,7 +608,7 @@ func (v *MachineVM) startHostNetworking() error {
 	// MacOS does not have /usr/libexec so we look in the executable
 	// paths.
 	binary, err := exec.LookPath(machine.ForwarderBinaryName)
-	if errors.Cause(err) == exec.ErrNotFound {
+	if errors.Is(err, exec.ErrNotFound) {
 		// Nothing was found, so now check /usr/libexec, else error out
 		binary = filepath.Join("/usr/libexec/podman/", machine.ForwarderBinaryName)
 		if _, err := os.Stat(binary); err != nil {


### PR DESCRIPTION
it seeems exec.ErrNotFound does not work with simple equality checks and
needs errors.Is() to work correctly.

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
