### PR TITLE
container: resolve workdir during initialization after all the mounts are completed.

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1072,6 +1072,11 @@ func (c *Container) init(ctx context.Context, retainRetries bool) error {
 		return err
 	}
 
+	// Make sure the workdir exists while initializing container
+	if err := c.resolveWorkDir(); err != nil {
+		return err
+	}
+
 	// Save the OCI newSpec to disk
 	if err := c.saveSpec(newSpec); err != nil {
 		return err

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -176,11 +176,6 @@ func (c *Container) prepare() error {
 		return err
 	}
 
-	// Make sure the workdir exists
-	if err := c.resolveWorkDir(); err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
There are use-cases where users would want to use overlay-mounts as
workdir for containers. For such use-cases workdir should be resolved after all the mounts
are completed during the container init process.

Closes: https://github.com/containers/podman/issues/11352