### PR TITLE
Add parsing to image manifest if result is not manifest list

### DIFF
--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -90,6 +90,20 @@ func ManifestInspect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(schema2List.Manifests) == 0 {
+		var schema2 manifest.Schema2
+		if err := json.Unmarshal(rawManifest, &schema2); err != nil {
+			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+			return
+		}
+		if len(schema2.LayersDescriptors) == 0 {
+			utils.WriteResponse(w, http.StatusNoContent, nil)
+			return
+		}
+		utils.WriteResponse(w, http.StatusOK, schema2)
+		return
+	}
+
 	utils.WriteResponse(w, http.StatusOK, schema2List)
 }
 

--- a/test/apiv2/python/rest_api/test_v2_0_0_manifest.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_manifest.py
@@ -9,6 +9,25 @@ class ManifestTestCase(APITestCase):
         r = requests.post(self.uri("/manifests/create"), params={"name": "ThisIsAnInvalidImage"})
         self.assertEqual(r.status_code, 400, r.text)
 
+    def test_manifest_inspect_multi_image(self):
+        r = requests.get(self.uri("/manifests/quay.io/libpod/busybox:latest/json"))
+        j = r.json()
+        self.assertEqual(len(j.get("manifests", [])), 9)
+
+    def test_manifest_inspect_single_image(self):
+        r = requests.get(self.uri("/manifests/quay.io/libpod/busybox@sha256:c9249fdf56138f0d929e2080ae98ee9cb2946f71498fc1484288e6a935b5e5bc/json"))
+        j = r.json()
+        self.assertEqual(j.get("config", {}).get("mediaType", ""), "application/vnd.docker.container.image.v1+json")
+
+    def test_manifest_inspect_non_existant_image(self):
+        r = requests.get(self.uri("/manifests/quay.io/libpod/foobar:1234/json"))
+        j = r.json()
+        self.assertEqual(j.get("response", 200), 404)
+
+    def test_manifest_inspect_non_existant_repository(self):
+        r = requests.get(self.uri("/manifests/foo.bar/libpod/busybox:latest/json"))
+        j = r.json()
+        self.assertEqual(j.get("response", 200), 404)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This modification aims to even the behavior between the cli and the REST
API.

When retrieving a manifest of an single image via
```
podman manifest inspect custom.registry.com/container:v0.1
```

we obtain the following warning: `The manifest type
application/vnd.docker.distribution.manifest.v2+json is not a manifest
list but a single image.` and the content of the manifest. 

ex: 
```
$ podman manifest inspect docker.io/williamyeh/dummy:latest
WARN[0001] Warning! The manifest type application/vnd.docker.distribution.manifest.v2+json is not a manifest list but a single image.
{
    "schemaVersion": 2,
    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    "config": {
        "mediaType": "application/vnd.docker.container.image.v1+json",
        "size": 1629,
        "digest": "sha256:f5891d1355691307d37711001b329fd1a8b193f41fd9011ce6b914cf6d2818b0"
    },
    "layers": [
        {
            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "size": 723172,
            "digest": "sha256:f70adabe43c0cccffbae8785406d490e26855b8748fc982d14bc2b20c778b929"
        }
    ]
}
```

When using the REST API with the socket, we receive an empty manifest
response like the following:
```
$ curl --unix-socket ${XDG_RUNTIME_DIR}/podman/podman.sock http://localhost/v2/libpod/manifests/docker.io/williamyeh/dummy:latest/json
{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","manifests":null}
```

The goal of this patch is to have the following response from the REST API:
```
$ curl --unix-socket ${XDG_RUNTIME_DIR}/podman/podman.sock http://localhost/v2/libpod/manifests/docker.io/williamyeh/dummy:latest/json
{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"mediaType":"application/vnd.docker.container.image.v1+json","size":1629,"digest":"sha256:f5891d1355691307d37711001b329fd1a8b193f41fd9011ce6b914cf6d2818b0"},"layers":[{"mediaType":"application/vnd.docker.image.rootfs.diff.tar.gzip","size":723172,"digest":"sha256:f70adabe43c0cccffbae8785406d490e26855b8748fc982d14bc2b20c778b929"}]}
```

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
