### PR TITLE
auto-update: fix authfile label

### DIFF
--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -224,7 +224,7 @@ func autoUpdateRegistry(ctx context.Context, image *libimage.Image, ctr *libpod.
 		return report, nil
 	}
 
-	if _, err := updateImage(ctx, runtime, rawImageName, options); err != nil {
+	if _, err := updateImage(ctx, runtime, rawImageName, authfile); err != nil {
 		return report, errors.Wrapf(err, "registry auto-updating container %q: image update for %q failed", cid, rawImageName)
 	}
 	updatedRawImages[rawImageName] = true
@@ -417,9 +417,9 @@ func newerLocalImageAvailable(runtime *libpod.Runtime, img *libimage.Image, rawI
 }
 
 // updateImage pulls the specified image.
-func updateImage(ctx context.Context, runtime *libpod.Runtime, name string, options *entities.AutoUpdateOptions) (*libimage.Image, error) {
+func updateImage(ctx context.Context, runtime *libpod.Runtime, name, authfile string) (*libimage.Image, error) {
 	pullOptions := &libimage.PullOptions{}
-	pullOptions.AuthFilePath = options.Authfile
+	pullOptions.AuthFilePath = authfile
 	pullOptions.Writer = os.Stderr
 
 	pulledImages, err := runtime.LibimageRuntime().Pull(ctx, name, config.PullPolicyAlways, pullOptions)

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -149,6 +149,9 @@ function _confirm_update() {
 }
 
 @test "podman auto-update - label io.containers.autoupdate=image with rollback" {
+    # FIXME: this test should exercise the authfile label to have a regression
+    # test for #11171.
+
     # Note: the autoupdatebroken image is empty on purpose so it cannot be
     # executed and force a rollback.  The rollback test for the local policy
     # is exercising the case where the container doesn't send a ready message.


### PR DESCRIPTION
Make sure that the container's authfile label is used when pulling down
a new image.

[NO TESTS NEEDED] since it would require some larger rewrite of the
auto-update system tests that I currently have no time for.  I added a
reminder to have some breadcrumbs when there is more time.

Fixes: #11171
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
