### PR TITLE
rootless cni: resolve absolute symlinks correctly

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -185,7 +185,13 @@ func (r *RootlessCNI) Do(toRun func() error) error {
 				// if there is no symlink exit
 				break
 			}
-			resolvePath = filepath.Join(filepath.Dir(resolvePath), link)
+			if filepath.IsAbs(link) {
+				// link is as an absolute path
+				resolvePath = link
+			} else {
+				// link is as a relative, join it with the previous path
+				resolvePath = filepath.Join(filepath.Dir(resolvePath), link)
+			}
 			if strings.HasPrefix(resolvePath, "/run/") {
 				break
 			}


### PR DESCRIPTION
When `/etc/resolv.conf` is a symlink to an absolute path use it and not
join it the the previous path.

[NO TESTS NEEDED] This depends on the host layout.

Fixes #11358

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
