### PR TITLE
Cirrus: Reduce APIv2 task timeout

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -423,6 +423,9 @@ apiv2_test_task:
     depends_on:
         - validate
     gce_instance: *standardvm
+    # Test is normally pretty quick, about 10-minutes.  If it hangs,
+    # don't make developers wait the full 1-hour timeout.
+    timeout_in: 20m
     env:
         <<: *stdenvars
         TEST_FLAVOR: apiv2


### PR DESCRIPTION
At the time of this commit, a significant problem has been identified
(introduced in f5ce02b227f4).  The effect is, `podman pull` has a chance
of hanging, especially when re-pulling an existing image.  While a fix
is in the works, there's no reason to make developers wait the full
(default) 1-hour timeout for the APIv2 task.  Reduce it to 2x nominal
test runtime, so if the hang/flake is hit, the task can be re-run more
quickly.

Signed-off-by: Chris Evich <cevich@redhat.com>