### PR TITLE
[CI:DOCS] podman cp: highlight globbing and multi-file copy

### DIFF
--- a/docs/source/markdown/podman-cp.1.md
+++ b/docs/source/markdown/podman-cp.1.md
@@ -52,6 +52,8 @@ Using `-` as the **src_path** streams the contents of `STDIN` as a tar archive. 
 
 Note that `podman cp` ignores permission errors when copying from a running rootless container.  The TTY devices inside a rootless container are owned by the host's root user and hence cannot be read inside the container's user namespace.
 
+Further note that `podman cp` does not support globbing (e.g., `cp dir/*.txt`).  If you want to copy multiple files from the host to the container you may use xargs(1) or find(1) (or similar tools for chaining commands) in conjunction with `podman cp`.  If you want to copy multiple files from the container to the host, you may use `podman mount CONTAINER` and operate on the returned mount point instead (see ALTERNATIVES below).
+
 ## OPTIONS
 
 #### **--archive**, **-a**=**true** | *false*


### PR DESCRIPTION
`podman cp` does not allow for globbing or filtering copied data in any
form.  `docker cp` does not either, so Podman remains compatible.  Due
to a number of requests, highlight how users can effectively achieve
that by means of chaining with tools such as xargs(1) or find(1), or by
making use of `podman mount`.

Closes: #11346
Closes: #11194
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
