### PR TITLE
Make secret env var available to exec session

### DIFF
--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -685,6 +685,19 @@ func prepareProcessExec(c *Container, options *ExecOptions, env []string, sessio
 		pspec.Env = append(pspec.Env, env...)
 	}
 
+	// Add secret envs if they exist
+	manager, err := c.runtime.SecretsManager()
+	if err != nil {
+		return nil, err
+	}
+	for name, secr := range c.config.EnvSecrets {
+		_, data, err := manager.LookupSecretData(secr.Name)
+		if err != nil {
+			return nil, err
+		}
+		pspec.Env = append(pspec.Env, fmt.Sprintf("%s=%s", name, string(data)))
+	}
+
 	if options.Cwd != "" {
 		pspec.Cwd = options.Cwd
 	}


### PR DESCRIPTION
Secret environment variables were only available to a podman run/start.
This commit makes sure that exec sessions can see them as well.

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
