### PR TITLE
logging: new mode -l passthrough

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -771,10 +771,13 @@ func AutocompleteImageVolume(cmd *cobra.Command, args []string, toComplete strin
 }
 
 // AutocompleteLogDriver - Autocomplete log-driver options.
-// -> "journald", "none", "k8s-file"
+// -> "journald", "none", "k8s-file", "passthrough"
 func AutocompleteLogDriver(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// don't show json-file
 	logDrivers := []string{define.JournaldLogging, define.NoLogging, define.KubernetesLogging}
+	if !registry.IsRemote() {
+		logDrivers = append(logDrivers, define.PassthroughLogging)
+	}
 	return logDrivers, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -513,7 +513,11 @@ Not implemented
 
 #### **--log-driver**="*k8s-file*"
 
-Logging driver for the container. Currently available options are *k8s-file*, *journald*, and *none*, with *json-file* aliased to *k8s-file* for scripting compatibility.
+Logging driver for the container. Currently available options are *k8s-file*, *journald*, *none* and *passthrough*, with *json-file* aliased to *k8s-file* for scripting compatibility.
+
+The *passthrough* driver passes down the standard streams (stdin, stdout, stderr) to the
+container.  It is not allowed with the remote Podman client and on a tty, since it is
+vulnerable to attacks via TIOCSTI.
 
 #### **--log-opt**=*name*=*value*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -538,7 +538,12 @@ Not implemented.
 
 #### **--log-driver**="*driver*"
 
-Logging driver for the container. Currently available options are **k8s-file**, **journald**, and **none**, with **json-file** aliased to **k8s-file** for scripting compatibility.
+Logging driver for the container. Currently available options are **k8s-file**, **journald**, **none** and **passthrough**, with **json-file** aliased to **k8s-file** for scripting compatibility.
+
+The **passthrough** driver passes down the standard streams (stdin, stdout, stderr) to the
+container.  It is not allowed with the remote Podman client and on a tty, since it is
+vulnerable to attacks via TIOCSTI.
+
 
 #### **--log-opt**=*name*=*value*
 

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/hpcloud/tail v1.0.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
 	github.com/mrunalp/fileutils v0.5.0
 	github.com/onsi/ginkgo v1.16.4

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -229,6 +229,10 @@ func (c *Container) Kill(signal uint) error {
 // This function returns when the attach finishes. It does not hold the lock for
 // the duration of its runtime, only using it at the beginning to verify state.
 func (c *Container) Attach(streams *define.AttachStreams, keys string, resize <-chan define.TerminalSize) error {
+	switch c.LogDriver() {
+	case define.PassthroughLogging:
+		return errors.Wrapf(define.ErrNoLogs, "this container is using the 'passthrough' log driver, cannot attach")
+	}
 	if !c.batched {
 		c.lock.Lock()
 		if err := c.syncContainer(); err != nil {

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -18,7 +18,7 @@ import (
 var logDrivers []string
 
 func init() {
-	logDrivers = append(logDrivers, define.KubernetesLogging, define.NoLogging)
+	logDrivers = append(logDrivers, define.KubernetesLogging, define.NoLogging, define.PassthroughLogging)
 }
 
 // Log is a runtime function that can read one or more container logs.
@@ -34,6 +34,8 @@ func (r *Runtime) Log(ctx context.Context, containers []*Container, options *log
 // ReadLog reads a containers log based on the input options and returns log lines over a channel.
 func (c *Container) ReadLog(ctx context.Context, options *logs.LogOptions, logChannel chan *logs.LogLine) error {
 	switch c.LogDriver() {
+	case define.PassthroughLogging:
+		return errors.Wrapf(define.ErrNoLogs, "this container is using the 'passthrough' log driver, cannot read logs")
 	case define.NoLogging:
 		return errors.Wrapf(define.ErrNoLogs, "this container is using the 'none' log driver, cannot read logs")
 	case define.JournaldLogging:

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -78,6 +78,9 @@ const JSONLogging = "json-file"
 // NoLogging is the string conmon expects when specifying to use no log driver whatsoever
 const NoLogging = "none"
 
+// PassthroughLogging is the string conmon expects when specifying to use the passthrough driver
+const PassthroughLogging = "passthrough"
+
 // Strings used for --sdnotify option to podman
 const (
 	SdNotifyModeContainer = "container"

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1288,6 +1288,8 @@ func (r *ConmonOCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, p
 		logDriverArg = define.JournaldLogging
 	case define.NoLogging:
 		logDriverArg = define.NoLogging
+	case define.PassthroughLogging:
+		logDriverArg = define.PassthroughLogging
 	case define.JSONLogging:
 		fallthrough
 	//lint:ignore ST1015 the default case has to be here

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1114,7 +1114,7 @@ func WithLogDriver(driver string) CtrCreateOption {
 		switch driver {
 		case "":
 			return errors.Wrapf(define.ErrInvalidArg, "log driver must be set")
-		case define.JournaldLogging, define.KubernetesLogging, define.JSONLogging, define.NoLogging:
+		case define.JournaldLogging, define.KubernetesLogging, define.JSONLogging, define.NoLogging, define.PassthroughLogging:
 			break
 		default:
 			return errors.Wrapf(define.ErrInvalidArg, "invalid log driver")

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -473,7 +473,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 	}
 
 	switch ctr.config.LogDriver {
-	case define.NoLogging:
+	case define.NoLogging, define.PassthroughLogging:
 		break
 	case define.JournaldLogging:
 		ctr.initializeJournal(ctx)


### PR DESCRIPTION
it allows to pass the current std streams down to the container.

conmon support: https://github.com/containers/conmon/pull/289

[NO TESTS NEEDED] it needs a new conmon.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
