### PR TITLE
rootlessport: allow socket paths with more than 108 chars

### DIFF
--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -632,16 +632,7 @@ func (c *Container) reloadRootlessRLKPortMapping() error {
 	childIP := getRootlessPortChildIP(c)
 	logrus.Debugf("reloading rootless ports for container %s, childIP is %s", c.config.ID, childIP)
 
-	var conn net.Conn
-	var err error
-	// try three times to connect to the socket, maybe it is not ready yet
-	for i := 0; i < 3; i++ {
-		conn, err = net.Dial("unix", filepath.Join(c.runtime.config.Engine.TmpDir, "rp", c.config.ID))
-		if err == nil {
-			break
-		}
-		time.Sleep(250 * time.Millisecond)
-	}
+	conn, err := openUnixSocket(filepath.Join(c.runtime.config.Engine.TmpDir, "rp", c.config.ID))
 	if err != nil {
 		// This is not a hard error for backwards compatibility. A container started
 		// with an old version did not created the rootlessport socket.


### PR DESCRIPTION
Creating the rootlessport socket can fail with `bind: invalid argument`
when the socket path is longer than 108 chars. This is the case for
users with a long runtime directory.
Since the kernel does not allow to use socket paths with more then 108
chars use a workaround to open the socket path.

[NO TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
