### PR TITLE
System tests: add cleanup & debugging output

### DIFF
--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -157,6 +157,10 @@ function _assert_mainpid_is_conmon() {
     # With container, READY=1 isn't necessarily the last message received;
     # just look for it anywhere in received messages
     run cat $_SOCAT_LOG
+    # The 'echo's help us debug failed runs
+    echo "socat log:"
+    echo "$output"
+
     is "$output" ".*READY=1" "received READY=1 through notify socket"
 
     _assert_mainpid_is_conmon "${lines[0]}"

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -140,4 +140,5 @@ _EOF
     run_podman inspect --format "{{ .Config.User }}" test_pod-test
     is "$output" bin "expect container within pod to run as the bin user"
     run_podman pod rm -f test_pod
+    run_podman rmi -f userimage:latest
 }


### PR DESCRIPTION
Cleanup: the final 'play' test wasn't cleaning up after itself,
leading to angry warning messages when rerunning tests (in
my environment; never in CI)

Debug: I'm seeing a lot of "Could not parse READY=1 as MAINPID=nnn"
flakes in the sdnotify:container test (nine in the past month). Add
debug traces to help diagnose in future flakes.

Signed-off-by: Ed Santiago <santiago@redhat.com>
