### PR TITLE
network create: add warning for deprecated macvlan flag

### DIFF
--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -56,7 +57,8 @@ func networkCreateFlags(cmd *cobra.Command) {
 
 	macvlanFlagName := "macvlan"
 	flags.StringVar(&networkCreateOptions.MacVLAN, macvlanFlagName, "", "create a Macvlan connection based on this device")
-	_ = cmd.RegisterFlagCompletionFunc(macvlanFlagName, completion.AutocompleteNone)
+	// This option is deprecated
+	flags.MarkHidden(macvlanFlagName)
 
 	labelFlagName := "label"
 	flags.StringArrayVar(&labels, labelFlagName, nil, "set metadata on a network")
@@ -100,6 +102,11 @@ func networkCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrapf(err, "unable to process options")
 	}
+
+	if networkCreateOptions.MacVLAN != "" {
+		logrus.Warn("The --macvlan option is deprecated, use `--driver macvlan --opt parent=<device>` instead")
+	}
+
 	response, err := registry.ContainerEngine().NetworkCreate(registry.Context(), name, networkCreateOptions)
 	if err != nil {
 		return err

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -25,7 +25,8 @@ resolution.
 
 #### **--driver**, **-d**
 
-Driver to manage the network (default "bridge").  Currently only `bridge` is supported.
+Driver to manage the network. Currently `bridge` and `macvlan` is supported. Defaults to `bridge`.
+As rootless the `macvlan` driver has no access to the host network interfaces because rootless networking requires a separate network namespace.
 
 #### **--opt**=*option*, **-o**
 
@@ -53,13 +54,6 @@ must be used with a *subnet* option.
 #### **--label**
 
 Set metadata for a network (e.g., --label mykey=value).
-
-#### **--macvlan**
-
-*This option is being deprecated*
-
-Create a *Macvlan* based connection rather than a classic bridge.  You must pass an interface name from the host for the
-Macvlan connection.
 
 #### **--subnet**
 


### PR DESCRIPTION
The macvlan driver is not deprecated, only the --macvlan flag is.
Remove the flag from the man page since it is deprecated and add a
warning to podman network create if it is used.

Fixes #11400

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
