### PR TITLE
Drop dependency on iproute

### DIFF
--- a/libpod/network/devices.go
+++ b/libpod/network/devices.go
@@ -2,12 +2,11 @@ package network
 
 import (
 	"fmt"
-	"os/exec"
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v3/pkg/util"
-	"github.com/containers/podman/v3/utils"
 	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
 )
 
 // GetFreeDeviceName returns a device name that is unused; used when no network
@@ -52,12 +51,9 @@ func GetFreeDeviceName(config *config.Config) (string, error) {
 
 // RemoveInterface removes an interface by the given name
 func RemoveInterface(interfaceName string) error {
-	// Make sure we have the ip command on the system
-	ipPath, err := exec.LookPath("ip")
+	link, err := netlink.LinkByName(interfaceName)
 	if err != nil {
 		return err
 	}
-	// Delete the network interface
-	_, err = utils.ExecCmd(ipPath, []string{"link", "del", interfaceName}...)
-	return err
+	return netlink.LinkDel(link)
 }

--- a/libpod/network/network.go
+++ b/libpod/network/network.go
@@ -194,8 +194,9 @@ func removeNetwork(config *config.Config, name string) error {
 				return errors.Wrapf(err, "failed to get live network names")
 			}
 			if util.StringInSlice(interfaceName, liveNetworkNames) {
-				if err := RemoveInterface(interfaceName); err != nil {
-					return errors.Wrapf(err, "failed to delete the network interface %q", interfaceName)
+				if err = RemoveInterface(interfaceName); err != nil {
+					// only log the error, it is not fatal
+					logrus.Infof("failed to remove network interface %s: %v", interfaceName, err)
 				}
 			}
 		}


### PR DESCRIPTION
We only use the `ip` util to remove a network interface. We can do
this directly via the netlink lib, no need to call a external binary.

Fixes #11403

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
