### PR TITLE
machine: always check error of net.Dial, even after last try

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -278,6 +278,9 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		time.Sleep(wait)
 		wait++
 	}
+	if err != nil {
+		return err
+	}
 
 	fd, err := qemuSocketConn.(*net.UnixConn).File()
 	if err != nil {


### PR DESCRIPTION
When net.Dial always fail in the above loop, the code following the loop
is executed. This error check prevents this.

Related to https://github.com/containers/podman/issues/11424