### PR TITLE
Normalize auth key before calling `SetAuthentication`

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -259,7 +259,9 @@ func authConfigsToAuthFile(authConfigs map[string]types.DockerAuthConfig) (strin
 	// tested, and we make sure to use the same code as the image backend.
 	sys := types.SystemContext{AuthFilePath: authFilePath}
 	for server, config := range authConfigs {
-		// Note that we do not validate the credentials here. Wassume
+		server = normalize(server)
+
+		// Note that we do not validate the credentials here. We assume
 		// that all credentials are valid. They'll be used on demand
 		// later.
 		if err := imageAuth.SetAuthentication(&sys, server, config.Username, config.Password); err != nil {
@@ -268,6 +270,22 @@ func authConfigsToAuthFile(authConfigs map[string]types.DockerAuthConfig) (strin
 	}
 
 	return authFilePath, nil
+}
+
+// normalize takes a server and removes the leading "http[s]://" prefix as well
+// as removes path suffixes from docker registries.
+func normalize(server string) string {
+	stripped := strings.TrimPrefix(server, "http://")
+	stripped = strings.TrimPrefix(stripped, "https://")
+
+	/// Normalize docker registries
+	if strings.HasPrefix(stripped, "index.docker.io/") ||
+		strings.HasPrefix(stripped, "registry-1.docker.io/") ||
+		strings.HasPrefix(stripped, "docker.io/") {
+		stripped = strings.SplitN(stripped, "/", 2)[0]
+	}
+
+	return stripped
 }
 
 // dockerAuthToImageAuth converts a docker auth config to one we're using

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,66 @@
+package auth
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/containers/image/v5/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthConfigsToAuthFile(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		server           string
+		shouldErr        bool
+		expectedContains string
+	}{
+		{
+			name:             "empty auth configs",
+			server:           "",
+			shouldErr:        false,
+			expectedContains: "{}",
+		},
+		{
+			name:             "registry with prefix",
+			server:           "my-registry.local/username",
+			shouldErr:        false,
+			expectedContains: `"my-registry.local/username":`,
+		},
+		{
+			name:             "normalize https:// prefix",
+			server:           "http://my-registry.local/username",
+			shouldErr:        false,
+			expectedContains: `"my-registry.local/username":`,
+		},
+		{
+			name:             "normalize docker registry with https prefix",
+			server:           "http://index.docker.io/v1/",
+			shouldErr:        false,
+			expectedContains: `"index.docker.io":`,
+		},
+		{
+			name:             "normalize docker registry without https prefix",
+			server:           "docker.io/v2/",
+			shouldErr:        false,
+			expectedContains: `"docker.io":`,
+		},
+	} {
+		configs := map[string]types.DockerAuthConfig{}
+		if tc.server != "" {
+			configs[tc.server] = types.DockerAuthConfig{}
+		}
+
+		filePath, err := authConfigsToAuthFile(configs)
+
+		if tc.shouldErr {
+			assert.NotNil(t, err)
+			assert.Empty(t, filePath)
+		} else {
+			assert.Nil(t, err)
+			content, err := ioutil.ReadFile(filePath)
+			assert.Nil(t, err)
+			assert.Contains(t, string(content), tc.expectedContains)
+		}
+	}
+}


### PR DESCRIPTION
Recent changes in c/image caused the `SetAuthentication` API to be more
restrictive in terms of validating the `key` (`server`) input. To ensure
that manually modified or entries in `~/.docker/config.json` still work,
we now strip the leading `http[s]://` prefix.

Fixes https://github.com/containers/podman/issues/11235

