### PR TITLE
[NO TESTS NEEDED] Fix #11418 - Default TMPDIR to /tmp on OS X

### DIFF
--- a/pkg/machine/qemu/options_darwin.go
+++ b/pkg/machine/qemu/options_darwin.go
@@ -2,14 +2,12 @@ package qemu
 
 import (
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 func getRuntimeDir() (string, error) {
 	tmpDir, ok := os.LookupEnv("TMPDIR")
 	if !ok {
-		return "", errors.New("unable to resolve TMPDIR")
+		tmpDir = "/tmp"
 	}
 	return tmpDir, nil
 }


### PR DESCRIPTION
This PR fixes bug #11418 - on OS X there was a bug where podman would fail when the `TMPDIR` environment variable was empty. 

This commit fixes that issue by defaulting to `/tmp` when that environment variable is empty. 