### PR TITLE
Use default username for podman machine ssh

### DIFF
--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -61,7 +61,8 @@ type ListResponse struct {
 }
 
 type SSHOptions struct {
-	Args []string
+	Username string
+	Args     []string
 }
 type StartOptions struct{}
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -485,7 +485,12 @@ func (v *MachineVM) SSH(name string, opts machine.SSHOptions) error {
 		return errors.Errorf("vm %q is not running.", v.Name)
 	}
 
-	sshDestination := v.RemoteUsername + "@localhost"
+	username := opts.Username
+	if username == "" {
+		username = v.RemoteUsername
+	}
+
+	sshDestination := username + "@localhost"
 	port := strconv.Itoa(v.Port)
 
 	args := []string{"-i", v.IdentityPath, "-p", port, sshDestination, "-o", "UserKnownHostsFile /dev/null", "-o", "StrictHostKeyChecking no"}


### PR DESCRIPTION
When using the defaut conection for podman machine ssh, use the default
username too.

Signed-off-by: Ashley Cui <acui@redhat.com>

[NO TESTS NEEDED] 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
