### PR TITLE
Qemu TCG Accel fallback for Apple Silicon. Iss #10577

### DIFF
--- a/pkg/machine/qemu/options_darwin_arm64.go
+++ b/pkg/machine/qemu/options_darwin_arm64.go
@@ -13,6 +13,7 @@ func (v *MachineVM) addArchOptions() []string {
 	ovmfDir := getOvmfDir(v.ImagePath, v.Name)
 	opts := []string{
 		"-accel", "hvf",
+		"-accel", "tcg",
 		"-cpu", "cortex-a57",
 		"-M", "virt,highmem=off",
 		"-drive", "file=/usr/local/share/qemu/edk2-aarch64-code.fd,if=pflash,format=raw,readonly=on",


### PR DESCRIPTION
Cause qemu to fall back to using TCG acceleration when HVF acceleration
is not available on Darwin Aarch64.  Qemu prints a warning which it is
desirable to leave to embarrass the upstream Qemu into approving the HVF
patches.

Address Issue #10577 

Signed-off-by: Jonathan Springer <jspringer@us.ibm.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
