### PR TITLE
QEMU Apple Silicon: Find BIOS FD wherever

### DIFF
--- a/pkg/machine/qemu/options_darwin_arm64.go
+++ b/pkg/machine/qemu/options_darwin_arm64.go
@@ -1,6 +1,7 @@
 package qemu
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 )
@@ -16,7 +17,7 @@ func (v *MachineVM) addArchOptions() []string {
 		"-accel", "tcg",
 		"-cpu", "cortex-a57",
 		"-M", "virt,highmem=off",
-		"-drive", "file=/usr/local/share/qemu/edk2-aarch64-code.fd,if=pflash,format=raw,readonly=on",
+		"-drive", "file=" + getEdk2CodeFd("edk2-aarch64-code.fd") + ",if=pflash,format=raw,readonly=on",
 		"-drive", "file=" + ovmfDir + ",if=pflash,format=raw"}
 	return opts
 }
@@ -34,4 +35,24 @@ func (v *MachineVM) archRemovalFiles() []string {
 
 func getOvmfDir(imagePath, vmName string) string {
 	return filepath.Join(filepath.Dir(imagePath), vmName+"_ovmf_vars.fd")
+}
+
+/*
+ *  QEmu can be installed in multiple locations on MacOS, especially on
+ *  Apple Silicon systems.  A build from source will likely install it in
+ *  /usr/local/bin, whereas Homebrew package management standard is to
+ *  install in /opt/homebrew
+ */
+func getEdk2CodeFd(name string) string {
+	dirs := []string{
+		"/usr/local/share/qemu",
+		"/opt/homebrew/share/qemu",
+	}
+	for _, dir := range dirs {
+		fullpath := filepath.Join(dir, name)
+		if _, err := os.Stat(fullpath); err == nil {
+			return fullpath
+		}
+	}
+	return name
 }


### PR DESCRIPTION
QEmu normally install BIOS images under `/usr/local` prefix, but
Homebrew installs them under `/opt/homebrew`.  This change searches both
locations and then puts back to an unpathed name if it doesn't find the
BIOS.  (I imitated other architectures' implemenations in that failback
behavior.)

[NO TESTS NEEDED]

Signed-off-by: Jonathan Springer <jonpspri@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
