### PR TITLE
Implement virtfs volumes for podman machine

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -92,6 +92,10 @@ func init() {
 	flags.StringArrayVarP(&initOpts.Volumes, VolumeFlagName, "v", []string{}, "Volumes to mount, source:target")
 	_ = initCmd.RegisterFlagCompletionFunc(VolumeFlagName, completion.AutocompleteDefault)
 
+	VolumeDriverFlagName := "volume-driver"
+	flags.StringVar(&initOpts.VolumeDriver, VolumeDriverFlagName, "", "Optional volume driver")
+	_ = initCmd.RegisterFlagCompletionFunc(VolumeDriverFlagName, completion.AutocompleteDefault)
+
 	IgnitionPathFlagName := "ignition-path"
 	flags.StringVar(&initOpts.IgnitionPath, IgnitionPathFlagName, "", "Path to ignition file")
 	_ = initCmd.RegisterFlagCompletionFunc(IgnitionPathFlagName, completion.AutocompleteDefault)

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -88,6 +88,10 @@ func init() {
 	flags.StringVar(&initOpts.ImagePath, ImagePathFlagName, cfg.Machine.Image, "Path to qcow image")
 	_ = initCmd.RegisterFlagCompletionFunc(ImagePathFlagName, completion.AutocompleteDefault)
 
+	VolumeFlagName := "volume"
+	flags.StringArrayVarP(&initOpts.Volumes, VolumeFlagName, "v", []string{}, "Volumes to mount, source:target")
+	_ = initCmd.RegisterFlagCompletionFunc(VolumeFlagName, completion.AutocompleteDefault)
+
 	IgnitionPathFlagName := "ignition-path"
 	flags.StringVar(&initOpts.IgnitionPath, IgnitionPathFlagName, "", "Path to ignition file")
 	_ = initCmd.RegisterFlagCompletionFunc(IgnitionPathFlagName, completion.AutocompleteDefault)

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -61,6 +61,16 @@ Set the timezone for the machine and containers.  Valid values are `local` or
 a `timezone` such as `America/Chicago`.  A value of `local`, which is the default,
 means to use the timezone of the machine host.
 
+#### **--volume**, **-v**=*source:target*
+
+Mounts a volume from source to target.
+
+Create a mount. If /host-dir:/machine-dir is specified as the `*source:target*`,
+Podman mounts _host-dir_ in the host to _machine-dir_ in the Podman machine.
+
+The root filesystem is mounted read-only in the default operating system,
+so mounts must be created under the /mnt directory.
+
 #### **--help**
 
 Print usage statement.
@@ -72,6 +82,7 @@ $ podman machine init
 $ podman machine init myvm
 $ podman machine init --disk-size 50
 $ podman machine init --memory=1024 myvm
+$ podman machine init -v /Users:/mnt/Users
 ```
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -71,6 +71,10 @@ Podman mounts _host-dir_ in the host to _machine-dir_ in the Podman machine.
 The root filesystem is mounted read-only in the default operating system,
 so mounts must be created under the /mnt directory.
 
+#### **--volume-driver**
+
+Driver to use for mounting volumes from the host, such as `virtfs`.
+
 #### **--help**
 
 Print usage statement.

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -18,6 +18,7 @@ type InitOptions struct {
 	DiskSize     uint64
 	IgnitionPath string
 	ImagePath    string
+	Volumes      []string
 	IsDefault    bool
 	Memory       uint64
 	Name         string

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -19,6 +19,7 @@ type InitOptions struct {
 	IgnitionPath string
 	ImagePath    string
 	Volumes      []string
+	VolumeDriver string
 	IsDefault    bool
 	Memory       uint64
 	Name         string

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -11,6 +11,8 @@ type MachineVM struct {
 	CPUs uint64
 	// The command line representation of the qemu command
 	CmdLine []string
+	// Mounts is the list of remote filesystems to mount
+	Mounts []Mount
 	// IdentityPath is the fq path to the ssh priv key
 	IdentityPath string
 	// IgnitionFilePath is the fq path to the .ign file
@@ -31,6 +33,13 @@ type MachineVM struct {
 	QMPMonitor Monitor
 	// RemoteUsername of the vm user
 	RemoteUsername string
+}
+
+type Mount struct {
+	Type   string
+	Tag    string
+	Source string
+	Target string
 }
 
 type Monitor struct {

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -36,10 +36,11 @@ type MachineVM struct {
 }
 
 type Mount struct {
-	Type   string
-	Tag    string
-	Source string
-	Target string
+	Type     string
+	Tag      string
+	Source   string
+	Target   string
+	ReadOnly bool
 }
 
 type Monitor struct {

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -36,6 +36,11 @@ func GetQemuProvider() machine.Provider {
 	return qemuProvider
 }
 
+const (
+	VolumeTypeVirtfs = "virtfs"
+	MountType9p      = "9p"
+)
+
 // NewMachine initializes an instance of a virtual machine based on the qemu
 // virtualization.
 func (p *Provider) NewMachine(opts machine.InitOptions) (machine.VM, error) {
@@ -167,18 +172,42 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	// Add arch specific options including image location
 	v.CmdLine = append(v.CmdLine, v.addArchOptions()...)
 
+	// TODO: add to opts
+	volumeType := VolumeTypeVirtfs
+
 	mounts := []Mount{}
 	for i, volume := range opts.Volumes {
 		tag := fmt.Sprintf("vol%d", i)
-		paths := strings.SplitN(volume, ":", 2)
+		paths := strings.SplitN(volume, ":", 3)
 		source := paths[0]
 		target := source
+		readonly := false
 		if len(paths) > 1 {
 			target = paths[1]
 		}
-		addVirtfsOptions := []string{"-virtfs", fmt.Sprintf("local,path=%s,mount_tag=%s,security_model=mapped-xattr", source, tag)}
-		v.CmdLine = append(v.CmdLine, addVirtfsOptions...)
-		mounts = append(mounts, Mount{Type: "9p", Tag: tag, Source: source, Target: target})
+		if len(paths) > 2 {
+			options := paths[2]
+			volopts := strings.Split(options, ",")
+			for _, o := range volopts {
+				switch o {
+				case "rw":
+					readonly = false
+				case "ro":
+					readonly = true
+				default:
+					fmt.Printf("Unknown option: %s\n", o)
+				}
+			}
+		}
+		switch volumeType {
+		case VolumeTypeVirtfs:
+			virtfsOptions := fmt.Sprintf("local,path=%s,mount_tag=%s,security_model=mapped-xattr", source, tag)
+			if readonly {
+				virtfsOptions += ",readonly"
+			}
+			v.CmdLine = append(v.CmdLine, []string{"-virtfs", virtfsOptions}...)
+			mounts = append(mounts, Mount{Type: MountType9p, Tag: tag, Source: source, Target: target, ReadOnly: readonly})
+		}
 	}
 	v.Mounts = mounts
 
@@ -360,9 +389,20 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		if err != nil {
 			return err
 		}
-		err = v.SSH(name, machine.SSHOptions{Args: []string{"-q", "--", "sudo", "mount", "-t", mount.Type, "-o", "trans=virtio", mount.Tag, mount.Target, "-o", "version=9p2000.L,msize=131072"}})
-		if err != nil {
-			return err
+		switch mount.Type {
+		case MountType9p:
+			mountOptions := []string{"-t", "9p"}
+			mountOptions = append(mountOptions, []string{"-o", "trans=virtio", mount.Tag, mount.Target}...)
+			mountOptions = append(mountOptions, []string{"-o", "version=9p2000.L,msize=131072"}...)
+			if mount.ReadOnly {
+				mountOptions = append(mountOptions, []string{"-o", "ro"}...)
+			}
+			err = v.SSH(name, machine.SSHOptions{Args: append([]string{"-q", "--", "sudo", "mount"}, mountOptions...)})
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown mount type: %s", mount.Type)
 		}
 	}
 	return nil

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -167,6 +167,21 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	// Add arch specific options including image location
 	v.CmdLine = append(v.CmdLine, v.addArchOptions()...)
 
+	mounts := []Mount{}
+	for i, volume := range opts.Volumes {
+		tag := fmt.Sprintf("vol%d", i)
+		paths := strings.SplitN(volume, ":", 2)
+		source := paths[0]
+		target := source
+		if len(paths) > 1 {
+			target = paths[1]
+		}
+		addVirtfsOptions := []string{"-virtfs", fmt.Sprintf("local,path=%s,mount_tag=%s,security_model=mapped-xattr", source, tag)}
+		v.CmdLine = append(v.CmdLine, addVirtfsOptions...)
+		mounts = append(mounts, Mount{Type: "9p", Tag: tag, Source: source, Target: target})
+	}
+	v.Mounts = mounts
+
 	// Add location of bootable image
 	v.CmdLine = append(v.CmdLine, "-drive", "if=virtio,file="+v.ImagePath)
 	// This kind of stinks but no other way around this r/n
@@ -329,7 +344,28 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		return err
 	}
 	_, err = bufio.NewReader(conn).ReadString('\n')
-	return err
+	if err != nil {
+		return err
+	}
+
+	if len(v.Mounts) > 0 {
+		for !v.isRunning() || !v.isListening() {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	for _, mount := range v.Mounts {
+		fmt.Printf("Mounting volume... %s:%s\n", mount.Source, mount.Target)
+		// create mountpoint directory if it doesn't exist
+		err = v.SSH(name, machine.SSHOptions{Args: []string{"-q", "--", "sudo", "mkdir", "-p", mount.Target}})
+		if err != nil {
+			return err
+		}
+		err = v.SSH(name, machine.SSHOptions{Args: []string{"-q", "--", "sudo", "mount", "-t", mount.Type, "-o", "trans=virtio", mount.Tag, mount.Target, "-o", "version=9p2000.L,msize=131072"}})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Stop uses the qmp monitor to call a system_powerdown
@@ -503,6 +539,16 @@ func (v *MachineVM) isRunning() bool {
 	if _, err := qmp.NewSocketMonitor(v.QMPMonitor.Network, v.QMPMonitor.Address, v.QMPMonitor.Timeout); err != nil {
 		return false
 	}
+	return true
+}
+
+func (v *MachineVM) isListening() bool {
+	// Check if we can dial it
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", "localhost", v.Port), 10*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	conn.Close()
 	return true
 }
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -172,8 +172,16 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	// Add arch specific options including image location
 	v.CmdLine = append(v.CmdLine, v.addArchOptions()...)
 
-	// TODO: add to opts
-	volumeType := VolumeTypeVirtfs
+	var volumeType string
+	switch opts.VolumeDriver {
+	case "virtfs":
+		volumeType = VolumeTypeVirtfs
+	case "": // default driver
+		volumeType = VolumeTypeVirtfs
+	default:
+		err := fmt.Errorf("unknown volume driver: %s", opts.VolumeDriver)
+		return false, err
+	}
 
 	mounts := []Mount{}
 	for i, volume := range opts.Volumes {


### PR DESCRIPTION
Allow using the built-in 9pfs feature of qemu,
mounting host directories into vm mountpoints.

https://wiki.qemu.org/Documentation/9psetup

Wait for the machine to be "running", otherwise
the SSH function might throw an error instead.

For #8016

Example usage:

```console
$ ./bin/podman machine init -v /tmp/one:/mnt/one -v /tmp/two:/mnt/two
Extracting compressed file
$ mkdir -p /tmp/one /tmp/two
$ ./bin/podman machine start
INFO[0000] waiting for clients...                       
INFO[0000] listening tcp://0.0.0.0:7777                 
INFO[0000] new connection from @ to /run/user/1000/podman/qemu_podman-machine-default.sock 
Waiting for VM ...
Mounting volume... /tmp/one:/mnt/one
Mounting volume... /tmp/two:/mnt/two
$ touch /tmp/one/foo
$ ./bin/podman-remote run -v /mnt/one:/mnt busybox ls /mnt/
Resolved "busybox" as an alias (/etc/containers/registries.conf.d/000-shortnames.conf)
Trying to pull docker.io/library/busybox:latest...
Getting image source signatures
Copying blob sha256:8ec32b265e94aafb0d43ab71f1d8f786122c19afb37d25532aea169f414f8881
Copying blob sha256:8ec32b265e94aafb0d43ab71f1d8f786122c19afb37d25532aea169f414f8881
Copying config sha256:42b97d3c2ae95232263a04324aaf656dc80e7792dee6629a9eff276cdfb806c0
Writing manifest to image destination
Storing signatures
foo
$ touch /tmp/two/bar
$ ./bin/podman-remote run -v /mnt/two:/mnt busybox ls /mnt/
bar
```

Note: tested on Linux (Ubuntu 20.04)

Edit: tested OK on macOS 11.5 as well (works with some problems, see below for details)

----

Some directories (most) are read-only on CoreOS, you can work around this by mounting in another location:

`podman machine init -v /Users:/mnt/Users`

And then remember to add this extra prefix, when bind-mounting from the remote filesystem into the container:

`podman --remote run -v /mnt/Users:/Users`

----

This is a nice document on VirtFS : https://www.kernel.org/doc/ols/2010/ols2010-pages-109-120.pdf

> By the virtue of its design **VirtFS is expected to yield better performance** compared to its alternatives like NFS/CIFS.

Note: CIFS is a dialect of SMB

https://en.wikipedia.org/wiki/9P_(protocol)