### PR TITLE
generate systemd: handle --restart

### DIFF
--- a/pkg/api/handlers/libpod/generate.go
+++ b/pkg/api/handlers/libpod/generate.go
@@ -16,16 +16,15 @@ func GenerateSystemd(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
-		Name            bool   `schema:"useName"`
-		New             bool   `schema:"new"`
-		NoHeader        bool   `schema:"noHeader"`
-		RestartPolicy   string `schema:"restartPolicy"`
-		StopTimeout     uint   `schema:"stopTimeout"`
-		ContainerPrefix string `schema:"containerPrefix"`
-		PodPrefix       string `schema:"podPrefix"`
-		Separator       string `schema:"separator"`
+		Name            bool    `schema:"useName"`
+		New             bool    `schema:"new"`
+		NoHeader        bool    `schema:"noHeader"`
+		RestartPolicy   *string `schema:"restartPolicy"`
+		StopTimeout     uint    `schema:"stopTimeout"`
+		ContainerPrefix string  `schema:"containerPrefix"`
+		PodPrefix       string  `schema:"podPrefix"`
+		Separator       string  `schema:"separator"`
 	}{
-		RestartPolicy:   "on-failure",
 		StopTimeout:     util.DefaultContainerConfig().Engine.StopTimeout,
 		ContainerPrefix: "container",
 		PodPrefix:       "pod",
@@ -49,6 +48,7 @@ func GenerateSystemd(w http.ResponseWriter, r *http.Request) {
 		PodPrefix:       query.PodPrefix,
 		Separator:       query.Separator,
 	}
+
 	report, err := containerEngine.GenerateSystemd(r.Context(), utils.GetName(r), options)
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error generating systemd units"))

--- a/pkg/domain/entities/generate.go
+++ b/pkg/domain/entities/generate.go
@@ -9,7 +9,7 @@ type GenerateSystemdOptions struct {
 	// New - create a new container instead of starting a new one.
 	New bool
 	// RestartPolicy - systemd restart policy.
-	RestartPolicy string
+	RestartPolicy *string
 	// StopTimeout - time when stopping the container.
 	StopTimeout *uint
 	// ContainerPrefix - systemd unit name prefix for containers

--- a/pkg/domain/infra/tunnel/generate.go
+++ b/pkg/domain/infra/tunnel/generate.go
@@ -9,7 +9,10 @@ import (
 
 func (ic *ContainerEngine) GenerateSystemd(ctx context.Context, nameOrID string, opts entities.GenerateSystemdOptions) (*entities.GenerateSystemdReport, error) {
 	options := new(generate.SystemdOptions).WithUseName(opts.Name).WithContainerPrefix(opts.ContainerPrefix).WithNew(opts.New).WithNoHeader(opts.NoHeader)
-	options.WithPodPrefix(opts.PodPrefix).WithRestartPolicy(opts.RestartPolicy).WithSeparator(opts.Separator)
+	options.WithPodPrefix(opts.PodPrefix).WithSeparator(opts.Separator)
+	if opts.RestartPolicy != nil {
+		options.WithRestartPolicy(*opts.RestartPolicy)
+	}
 	if to := opts.StopTimeout; to != nil {
 		options.WithStopTimeout(*opts.StopTimeout)
 	}

--- a/pkg/systemd/define/const.go
+++ b/pkg/systemd/define/const.go
@@ -1,8 +1,13 @@
 package define
 
-// EnvVariable "PODMAN_SYSTEMD_UNIT" is set in all generated systemd units and
-// is set to the unit's (unique) name.
-const EnvVariable = "PODMAN_SYSTEMD_UNIT"
+const (
+	// Default restart policy for generated unit files.
+	DefaultRestartPolicy = "on-failure"
+
+	// EnvVariable "PODMAN_SYSTEMD_UNIT" is set in all generated systemd units and
+	// is set to the unit's (unique) name.
+	EnvVariable = "PODMAN_SYSTEMD_UNIT"
+)
 
 // RestartPolicies includes all valid restart policies to be used in a unit
 // file.

--- a/pkg/systemd/generate/common.go
+++ b/pkg/systemd/generate/common.go
@@ -71,12 +71,13 @@ func filterCommonContainerFlags(command []string, argCount int) []string {
 		case s == "--rm":
 			// Boolean flags support --flag and --flag={true,false}.
 			continue
-		case s == "--sdnotify", s == "--cgroups", s == "--cidfile":
+		case s == "--sdnotify", s == "--cgroups", s == "--cidfile", s == "--restart":
 			i++
 			continue
 		case strings.HasPrefix(s, "--rm="),
 			strings.HasPrefix(s, "--cgroups="),
-			strings.HasPrefix(s, "--cidfile="):
+			strings.HasPrefix(s, "--cidfile="),
+			strings.HasPrefix(s, "--restart="):
 			continue
 		}
 		processed = append(processed, s)

--- a/pkg/systemd/generate/common_test.go
+++ b/pkg/systemd/generate/common_test.go
@@ -117,12 +117,12 @@ func TestFilterCommonContainerFlags(t *testing.T) {
 			1,
 		},
 		{
-			[]string{"podman", "run", "--cgroups=foo", "alpine"},
+			[]string{"podman", "run", "--cgroups=foo", "--restart=foo", "alpine"},
 			[]string{"podman", "run", "alpine"},
 			1,
 		},
 		{
-			[]string{"podman", "run", "--cgroups=foo", "--rm", "alpine"},
+			[]string{"podman", "run", "--cgroups=foo", "--rm", "--restart", "foo", "alpine"},
 			[]string{"podman", "run", "alpine"},
 			1,
 		},

--- a/pkg/systemd/generate/containers_test.go
+++ b/pkg/systemd/generate/containers_test.go
@@ -52,7 +52,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=82
 ExecStart=/usr/bin/podman start 639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401
 ExecStop=/usr/bin/podman stop -t 22 639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401
@@ -78,7 +78,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStart=/usr/bin/podman start foobar
 ExecStop=/usr/bin/podman stop -t 10 foobar
@@ -104,7 +104,7 @@ After=a.service b.service c.service pod.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStart=/usr/bin/podman start foobar
 ExecStop=/usr/bin/podman stop -t 10 foobar
@@ -128,7 +128,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman container run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d --replace --name jadda-jadda --hostname hello-world awesome-image:latest command arg1 ... argN "foo=arg \"with \" space"
@@ -153,7 +153,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman container run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm -d --replace --sdnotify=container --name jadda-jadda --hostname hello-world awesome-image:latest command arg1 ... argN "foo=arg \"with \" space"
@@ -178,7 +178,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon --replace -d --name jadda-jadda --hostname hello-world awesome-image:latest command arg1 ... argN
@@ -203,7 +203,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --pod-id-file %t/pod-foobar.pod-id-file --sdnotify=conmon --replace -d --name jadda-jadda --hostname hello-world awesome-image:latest command arg1 ... argN
@@ -228,7 +228,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon --replace --detach --name jadda-jadda --hostname hello-world awesome-image:latest command arg1 ... argN
@@ -253,7 +253,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d awesome-image:latest
@@ -279,7 +279,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=102
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon ` +
@@ -308,7 +308,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=102
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d --replace --name test -p 80:80 awesome-image:latest somecmd --detach=false
@@ -333,7 +333,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=102
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman --events-backend none --runroot /root run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d awesome-image:latest
@@ -358,7 +358,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman container run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d awesome-image:latest
@@ -383,7 +383,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d --replace --name test --log-driver=journald --log-opt=tag={{.Name}} awesome-image:latest
@@ -408,7 +408,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d --replace --name test awesome-image:latest sh -c "kill $$$$ && echo %%\\"
@@ -433,7 +433,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d --conmon-pidfile=foo awesome-image:latest podman run --cgroups=foo --conmon-pidfile=foo --cidfile=foo alpine
@@ -458,7 +458,7 @@ RequiresMountsFor=/var/run/containers/storage
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --pod-id-file %t/pod-foobar.pod-id-file --sdnotify=conmon -d --conmon-pidfile=foo awesome-image:latest podman run --cgroups=foo --conmon-pidfile=foo --cidfile=foo --pod-id-file /tmp/pod-foobar.pod-id-file alpine
@@ -484,10 +484,36 @@ RequiresMountsFor=/var/run/containers/storage
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Environment=FOO=abc "BAR=my test" USER=%%a
-Restart=always
+Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d --env FOO --env=BAR --env=MYENV=2 -e USER awesome-image:latest
+ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+Type=notify
+NotifyAccess=all
+
+[Install]
+WantedBy=multi-user.target default.target
+`
+
+	goodNewWithRestartPolicy := `# jadda-jadda.service
+# autogenerated by Podman CI
+
+[Unit]
+Description=Podman jadda-jadda.service
+Documentation=man:podman-generate-systemd(1)
+Wants=network-online.target
+After=network-online.target
+RequiresMountsFor=/var/run/containers/storage
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+Restart=on-failure
+StartLimitBurst=42
+TimeoutStopSec=70
+ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --sdnotify=conmon -d awesome-image:latest
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify
@@ -510,7 +536,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "container-639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401",
 				ContainerNameOrID: "639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401",
-				RestartPolicy:     "always",
 				PIDFile:           "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       22,
 				PodmanVersion:     "CI",
@@ -528,7 +553,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "container-639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401",
 				ContainerNameOrID: "639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401",
-				RestartPolicy:     "always",
 				PIDFile:           "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       22,
 				PodmanVersion:     "CI",
@@ -546,7 +570,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "container-foobar",
 				ContainerNameOrID: "foobar",
-				RestartPolicy:     "always",
 				PIDFile:           "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -564,7 +587,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "container-foobar",
 				ContainerNameOrID: "foobar",
-				RestartPolicy:     "always",
 				PIDFile:           "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -578,29 +600,11 @@ WantedBy=multi-user.target default.target
 			false,
 			false,
 		},
-		{"bad restart policy",
-			containerInfo{
-				Executable:    "/usr/bin/podman",
-				ServiceName:   "639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401",
-				RestartPolicy: "never",
-				PIDFile:       "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
-				StopTimeout:   10,
-				PodmanVersion: "CI",
-				EnvVariable:   define.EnvVariable,
-				GraphRoot:     "/var/lib/containers/storage",
-				RunRoot:       "/var/run/containers/storage",
-			},
-			"",
-			false,
-			false,
-			true,
-		},
 		{"good with name and generic",
 			containerInfo{
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -619,7 +623,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -638,7 +641,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -657,7 +659,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -679,7 +680,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -698,7 +698,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "container-639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401",
 				ContainerNameOrID: "639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401",
-				RestartPolicy:     "always",
 				PIDFile:           "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -717,7 +716,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       42,
 				PodmanVersion:     "CI",
@@ -736,7 +734,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       42,
 				PodmanVersion:     "CI",
@@ -755,7 +752,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       42,
 				PodmanVersion:     "CI",
@@ -774,7 +770,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       42,
 				PodmanVersion:     "CI",
@@ -793,7 +788,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       42,
 				PodmanVersion:     "CI",
@@ -812,26 +806,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
-				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
-				StopTimeout:       42,
-				PodmanVersion:     "CI",
-				CreateCommand:     []string{"I'll get stripped", "run", "-tid", "awesome-image:latest"},
-				EnvVariable:       define.EnvVariable,
-				GraphRoot:         "/var/lib/containers/storage",
-				RunRoot:           "/var/run/containers/storage",
-			},
-			genGoodNewDetach("-tid"),
-			true,
-			false,
-			false,
-		},
-		{"good with root flags",
-			containerInfo{
-				Executable:        "/usr/bin/podman",
-				ServiceName:       "jadda-jadda",
-				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       42,
 				PodmanVersion:     "CI",
@@ -850,7 +824,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -869,7 +842,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -888,7 +860,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -907,7 +878,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -926,7 +896,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -948,7 +917,6 @@ WantedBy=multi-user.target default.target
 				Executable:        "/usr/bin/podman",
 				ServiceName:       "jadda-jadda",
 				ContainerNameOrID: "jadda-jadda",
-				RestartPolicy:     "always",
 				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:       10,
 				PodmanVersion:     "CI",
@@ -963,6 +931,24 @@ WantedBy=multi-user.target default.target
 			false,
 			false,
 		},
+		{"good with restart policy",
+			containerInfo{
+				Executable:        "/usr/bin/podman",
+				ServiceName:       "jadda-jadda",
+				ContainerNameOrID: "jadda-jadda",
+				PIDFile:           "/var/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
+				StopTimeout:       10,
+				PodmanVersion:     "CI",
+				GraphRoot:         "/var/lib/containers/storage",
+				RunRoot:           "/var/run/containers/storage",
+				CreateCommand:     []string{"I'll get stripped", "create", "--restart", "on-failure:42", "awesome-image:latest"},
+				EnvVariable:       define.EnvVariable,
+			},
+			goodNewWithRestartPolicy,
+			true,
+			false,
+			false,
+		},
 	}
 	for _, tt := range tests {
 		test := tt
@@ -971,6 +957,7 @@ WantedBy=multi-user.target default.target
 				New:      test.new,
 				NoHeader: test.noHeader,
 			}
+			test.info.RestartPolicy = define.DefaultRestartPolicy
 			got, err := executeContainerTemplate(&test.info, opts)
 			if (err != nil) != test.wantErr {
 				t.Errorf("CreateContainerSystemdUnit() %s error = \n%v, wantErr \n%v", test.name, err, test.wantErr)

--- a/pkg/systemd/generate/pods.go
+++ b/pkg/systemd/generate/pods.go
@@ -217,7 +217,6 @@ func generatePodInfo(pod *libpod.Pod, options entities.GenerateSystemdOptions) (
 	info := podInfo{
 		ServiceName:       serviceName,
 		InfraNameOrID:     ctrNameOrID,
-		RestartPolicy:     options.RestartPolicy,
 		PIDFile:           conmonPidFile,
 		StopTimeout:       timeout,
 		GenerateTimestamp: true,
@@ -230,8 +229,12 @@ func generatePodInfo(pod *libpod.Pod, options entities.GenerateSystemdOptions) (
 // that the podInfo is also post processed and completed, which allows for an
 // easier unit testing.
 func executePodTemplate(info *podInfo, options entities.GenerateSystemdOptions) (string, error) {
-	if err := validateRestartPolicy(info.RestartPolicy); err != nil {
-		return "", err
+	info.RestartPolicy = define.DefaultRestartPolicy
+	if options.RestartPolicy != nil {
+		if err := validateRestartPolicy(*options.RestartPolicy); err != nil {
+			return "", err
+		}
+		info.RestartPolicy = *options.RestartPolicy
 	}
 
 	// Make sure the executable is set.

--- a/pkg/systemd/generate/pods_test.go
+++ b/pkg/systemd/generate/pods_test.go
@@ -53,7 +53,7 @@ Before=container-1.service container-2.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=always
+Restart=on-failure
 TimeoutStopSec=102
 ExecStart=/usr/bin/podman start jadda-jadda-infra
 ExecStop=/usr/bin/podman stop -t 42 jadda-jadda-infra
@@ -192,7 +192,6 @@ WantedBy=multi-user.target default.target
 				Executable:       "/usr/bin/podman",
 				ServiceName:      "pod-123abc",
 				InfraNameOrID:    "jadda-jadda-infra",
-				RestartPolicy:    "always",
 				PIDFile:          "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:      42,
 				PodmanVersion:    "CI",
@@ -211,7 +210,6 @@ WantedBy=multi-user.target default.target
 				Executable:       "/usr/bin/podman",
 				ServiceName:      "pod-123abc",
 				InfraNameOrID:    "jadda-jadda-infra",
-				RestartPolicy:    "always",
 				PIDFile:          "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:      42,
 				PodmanVersion:    "CI",
@@ -230,7 +228,6 @@ WantedBy=multi-user.target default.target
 				Executable:       "/usr/bin/podman",
 				ServiceName:      "pod-123abc",
 				InfraNameOrID:    "jadda-jadda-infra",
-				RestartPolicy:    "always",
 				PIDFile:          "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:      42,
 				PodmanVersion:    "CI",
@@ -249,7 +246,6 @@ WantedBy=multi-user.target default.target
 				Executable:       "/usr/bin/podman",
 				ServiceName:      "pod-123abc",
 				InfraNameOrID:    "jadda-jadda-infra",
-				RestartPolicy:    "on-failure",
 				PIDFile:          "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:      10,
 				PodmanVersion:    "CI",
@@ -268,7 +264,6 @@ WantedBy=multi-user.target default.target
 				Executable:       "/usr/bin/podman",
 				ServiceName:      "pod-123abc",
 				InfraNameOrID:    "jadda-jadda-infra",
-				RestartPolicy:    "on-failure",
 				PIDFile:          "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:      10,
 				PodmanVersion:    "CI",
@@ -287,7 +282,6 @@ WantedBy=multi-user.target default.target
 				Executable:       "/usr/bin/podman",
 				ServiceName:      "pod-123abc",
 				InfraNameOrID:    "jadda-jadda-infra",
-				RestartPolicy:    "on-failure",
 				PIDFile:          "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:      10,
 				PodmanVersion:    "CI",
@@ -306,7 +300,6 @@ WantedBy=multi-user.target default.target
 				Executable:       "/usr/bin/podman",
 				ServiceName:      "pod-123abc",
 				InfraNameOrID:    "jadda-jadda-infra",
-				RestartPolicy:    "on-failure",
 				PIDFile:          "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:      10,
 				PodmanVersion:    "CI",
@@ -325,7 +318,6 @@ WantedBy=multi-user.target default.target
 				Executable:       "/usr/bin/podman",
 				ServiceName:      "pod-123abc",
 				InfraNameOrID:    "jadda-jadda-infra",
-				RestartPolicy:    "on-failure",
 				PIDFile:          "/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid",
 				StopTimeout:      10,
 				PodmanVersion:    "CI",


### PR DESCRIPTION
Handle custom restart policies of containers when generating the unit
files; those should be set on the unit level and removed from ExecStart
flags.

Fixes: #11438
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
