### PR TITLE
cgroup-info: check if user.slice is valid before accessing value

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -231,7 +231,10 @@ func getCgroupPathForCurrentProcess() (string, error) {
 	for s.Scan() {
 		text := s.Text()
 		procEntries := strings.SplitN(text, "::", 2)
-		cgroupPath = procEntries[1]
+		// set process cgroupPath only if entry is valid
+		if len(procEntries) > 1 {
+			cgroupPath = procEntries[1]
+		}
 	}
 	if err := s.Err(); err != nil {
 		return cgroupPath, err


### PR DESCRIPTION
Prevent hitting `panic: runtime error: index out of range [1] with length 1`
while performing`podman info` and we get unexpected values for `user.slice`.
