### PR TITLE
logs -f: file: fix dead lock

### DIFF
--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -174,4 +174,31 @@ $s_after"
     _log_test_until journald
 }
 
+function _log_test_follow() {
+    local driver=$1
+    cname=$(random_string)
+    contentA=$(random_string)
+    contentB=$(random_string)
+    contentC=$(random_string)
+
+    # Note: it seems we need at least three log lines to hit #11461.
+    run_podman run --log-driver=$driver --name $cname $IMAGE sh -c "echo $contentA; echo $contentB; echo $contentC"
+    run_podman logs -f $cname
+    is "$output" "$contentA
+$contentB
+$contentC" "logs -f on exitted container works"
+
+    run_podman rm -f $cname
+}
+
+@test "podman logs - --follow k8s-file" {
+    _log_test_follow k8s-file
+}
+
+@test "podman logs - --follow journald" {
+    # We can't use journald on RHEL as rootless: rhbz#1895105
+    skip_if_journald_unavailable
+
+    _log_test_follow journald
+}
 # vim: filetype=sh


### PR DESCRIPTION
Fix a dead lock in the file log driver where one goroutine would wait on
the tail to hit EOF but reading is blocked for the function to return.

Fixes: 11461
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
