### PR TITLE
[CI:DOCS] Document default timeout for libpod API Container Restart

### DIFF
--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -1028,7 +1028,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: t
 	//    type: integer
-	//    description: timeout before sending kill signal to container
+	//    default: 10
+	//    description: number of seconds to wait before killing container
 	// produces:
 	// - application/json
 	// responses:


### PR DESCRIPTION
Signed-off-by: Jelle van der Waa <jvanderwaa@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
