### PR TITLE
fix play kube --network options

### DIFF
--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -113,9 +113,28 @@ Set logging driver for all created containers.
 
 Assign a static mac address to the pod. This option can be specified several times when play kube creates more than one pod.
 
-#### **--network**=*networks*, **--net**
+#### **--network**=*mode*, **--net**
 
-A comma-separated list of the names of CNI networks the pod should join.
+Change the network mode of the pod. The host and bridge network mode should be configured in the yaml file.
+Valid _mode_ values are:
+
+- **none**: Create a network namespace for the container but do not configure network interfaces for it, thus the container has no network connectivity.
+- **container:**_id_: Reuse another container's network stack.
+- **network**: Connect to a user-defined network, multiple networks should be comma-separated.
+- **ns:**_path_: Path to a network namespace to join.
+- **private**: Create a new namespace for the container. This will use the **bridge** mode for rootfull containers and **slirp4netns** for rootless ones.
+- **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options:
+  - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`, which is added to `/etc/hosts` as `host.containers.internal` for your convenience). Default is false.
+  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
+  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
+  - **enable_ipv6=true|false**: Enable IPv6. Default is false. (Required for `outbound_addr6`).
+  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp should bind to (ipv4 traffic only).
+  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp should bind to.
+  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp should bind to (ipv6 traffic only).
+  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp should bind to.
+  - **port_handler=rootlesskit**: Use rootlesskit for port forwarding. Default.
+  Note: Rootlesskit changes the source IP address of incoming packets to a IP address in the container network namespace, usually `10.0.2.100`. If your application requires the real source IP address, e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for rootless containers when connected to user-defined networks.
+  - **port_handler=slirp4netns**: Use the slirp4netns port forwarding, it is slower than rootlesskit but preserves the correct source IP address. This port handler cannot be used for user-defined networks.
 
 #### **--quiet**, **-q**
 

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -196,9 +196,11 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		if (ns.IsBridge() && len(cniNets) == 0) || ns.IsHost() {
 			return nil, errors.Errorf("invalid value passed to --network: bridge or host networking must be configured in YAML")
 		}
-		logrus.Debugf("Pod %q joining CNI networks: %v", podName, cniNets)
-		podOpt.Net.Network.NSMode = specgen.Bridge
-		podOpt.Net.CNINetworks = append(podOpt.Net.CNINetworks, cniNets...)
+
+		podOpt.Net.Network = ns
+		if len(cniNets) > 0 {
+			podOpt.Net.CNINetworks = append(podOpt.Net.CNINetworks, cniNets...)
+		}
 		if len(netOpts) > 0 {
 			podOpt.Net.NetworkOptions = netOpts
 		}

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -98,6 +98,16 @@ RELABEL="system_u:object_r:container_file_t:s0"
     run_podman 125 play kube --network host $PODMAN_TMPDIR/test.yaml
     is "$output" ".*invalid value passed to --network: bridge or host networking must be configured in YAML" "podman plan-network should fail with --network host"
     run_podman play kube --network slirp4netns:port_handler=slirp4netns $PODMAN_TMPDIR/test.yaml
+    run_podman pod inspect --format {{.InfraContainerID}} "${lines[1]}"
+    infraID="$output"
+    run_podman container inspect --format "{{.HostConfig.NetworkMode}}" $infraID
+    is "$output" "slirp4netns" "network mode slirp4netns is set for the container"
+    run_podman pod rm -f test_pod
+    run_podman play kube --network none $PODMAN_TMPDIR/test.yaml
+    run_podman pod inspect --format {{.InfraContainerID}} "${lines[1]}"
+    infraID="$output"
+    run_podman container inspect --format "{{.HostConfig.NetworkMode}}" $infraID
+    is "$output" "none" "network mode none is set for the container"
     run_podman pod rm -f test_pod
 }
 


### PR DESCRIPTION
Commit 092902b45555 introduced advanced network options for podman play
kube. However this never worked because it unconditionally set the
network mode to bridge after it parsed the network option.

Added a test to ensure the correct mode is set.

Truly fixes #10807


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
