### PR TITLE
pkg/bindings/images.nTar(): set ownership of build context to 0:0

### DIFF
--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -501,6 +501,7 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 					if err != nil {
 						return err
 					}
+					hdr.Uid, hdr.Gid = 0, 0
 					orig, ok := seen[di]
 					if ok {
 						hdr.Typeflag = tar.TypeLink
@@ -532,6 +533,7 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 						return lerr
 					}
 					hdr.Name = name
+					hdr.Uid, hdr.Gid = 0, 0
 					if lerr := tw.WriteHeader(hdr); lerr != nil {
 						return lerr
 					}
@@ -545,6 +547,7 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 						return lerr
 					}
 					hdr.Name = name
+					hdr.Uid, hdr.Gid = 0, 0
 					if lerr := tw.WriteHeader(hdr); lerr != nil {
 						return lerr
 					}

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -929,6 +929,33 @@ EOF
     is "$output" ".*test1" "test1 should exists in the final image"
 }
 
+@test "podman build build context ownership" {
+    tmpdir=$PODMAN_TMPDIR/build-test
+    subdir=$tmpdir/subdir
+    mkdir -p $subdir
+
+    touch $tmpdir/empty-file.txt
+    if is_remote && ! is_rootless ; then
+	# TODO: set this file's owner to a UID:GID that will not be mapped
+	# in the context where the remote server is running, which generally
+	# requires us to be root (or running with more mapped IDs) on the
+	# client, but not root (or running with fewer mapped IDs) on the
+	# remote server
+	# 4294967292:4294967292 (0xfffffffc:0xfffffffc) isn't that, but
+	# it will catch errors where a remote server doesn't apply the right
+	# default as it copies content into the container
+        chown 4294967292:4294967292 $tmpdir/empty-file.txt
+    fi
+    cat >$tmpdir/Dockerfile <<EOF
+FROM $IMAGE
+COPY empty-file.txt .
+RUN echo 0:0 | tee expected.txt
+RUN stat -c "%u:%g" empty-file.txt | tee actual.txt
+RUN cmp expected.txt actual.txt
+EOF
+    run_podman build -t build_test $tmpdir
+}
+
 function teardown() {
     # A timeout or other error in 'build' can leave behind stale images
     # that podman can't even see and which will cascade into subsequent


### PR DESCRIPTION
When attempting to run remote builds, users with UID/GID values that were high enough that they wouldn't be mapped into their default user namespace configurations would see their builds fail when the server attempted to extract the build contexts that they supplied, and failed to set ownership of the build context content to the UID/GID that were originally assigned to them.

When archiving the build context at the client, set ownership of everything to 0:0, which we know is always mapped.  Both ADD and COPY require that we set the ownership of newly-added content to 0:0 (unless the --chown flag is used), so throwing away the original ownership information doesn't hurt, anyway.  As usual, tarballs that we extract as part of ADD aren't going to be affected.

Fixes #11474.