### PR TITLE
container inspect: improve error handling

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -371,7 +371,7 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 	if options.Latest {
 		ctr, err := ic.Libpod.GetLatestContainer()
 		if err != nil {
-			if errors.Cause(err) == define.ErrNoSuchCtr {
+			if errors.Is(err, define.ErrNoSuchCtr) {
 				return nil, []error{errors.Wrapf(err, "no containers to inspect")}, nil
 			}
 			return nil, nil, err
@@ -397,7 +397,7 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 		if err != nil {
 			// ErrNoSuchCtr is non-fatal, other errors will be
 			// treated as fatal.
-			if errors.Cause(err) == define.ErrNoSuchCtr {
+			if errors.Is(err, define.ErrNoSuchCtr) {
 				errs = append(errs, errors.Errorf("no such container %s", name))
 				continue
 			}
@@ -406,6 +406,12 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 
 		inspect, err := ctr.Inspect(options.Size)
 		if err != nil {
+			// ErrNoSuchCtr is non-fatal, other errors will be
+			// treated as fatal.
+			if errors.Is(err, define.ErrNoSuchCtr) {
+				errs = append(errs, errors.Errorf("no such container %s", name))
+				continue
+			}
 			return nil, nil, err
 		}
 


### PR DESCRIPTION
Improve the error handling of `container inspect` to properly handle
when the container has been removed _between_ the lookup and the
inspect.  That will yield the correct "no such object" error message in
`inspect`.

[NO TESTS NEEDED] since I do not know a reliable and cheap
reproducer.  It's fixing a CI flake, so there's already an indicator.

Fixes: #11392
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
