### PR TITLE
Use Make GVPROXY_PATH to locate gvproxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ ETCDIR ?= ${PREFIX}/etc
 TMPFILESDIR ?= ${PREFIX}/lib/tmpfiles.d
 SYSTEMDDIR ?= ${PREFIX}/lib/systemd/system
 USERSYSTEMDDIR ?= ${PREFIX}/lib/systemd/user
+GVPROXY_PATH ?= /usr/libexec/gvproxy
 REMOTETAGS ?= remote exclude_graphdriver_btrfs btrfs_noversion exclude_graphdriver_devicemapper containers_image_openpgp
 BUILDTAGS ?= \
 	$(shell hack/apparmor_tag.sh) \
@@ -90,11 +91,13 @@ else
 	BUILD_INFO ?= $(shell date "+$(DATE_FMT)")
 	ISODATE ?= $(shell date --iso-8601)
 endif
-LIBPOD := ${PROJECT}/v3/libpod
+MODULE ?= $(shell grep -m1 ^module go.mod | cut -d\  -f2)
+LIBPOD := ${MODULE}/libpod
 GOFLAGS ?= -trimpath
 LDFLAGS_PODMAN ?= \
 	-X $(LIBPOD)/define.gitCommit=$(GIT_COMMIT) \
 	-X $(LIBPOD)/define.buildInfo=$(BUILD_INFO) \
+	-X $(MODULE)/pkg/machine.ForwarderBinaryPath=$(GVPROXY_PATH) \
 	-X $(LIBPOD)/config._installPrefix=$(PREFIX) \
 	-X $(LIBPOD)/config._etcDir=$(ETCDIR) \
 	$(EXTRA_LDFLAGS)

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -34,7 +34,7 @@ var (
 	ErrVMAlreadyExists                           = errors.New("VM already exists")
 	ErrVMAlreadyRunning                          = errors.New("VM already running")
 	ErrMultipleActiveVM                          = errors.New("only one VM can be active at a time")
-	ForwarderBinaryName                          = "gvproxy"
+	ForwarderBinaryPath  string // Populated by Makefile
 )
 
 type Download struct {

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -622,9 +622,10 @@ func CheckActiveVM() (bool, string, error) {
 // startHostNetworking runs a binary on the host system that allows users
 // to setup port forwarding to the podman virtual machine
 func (v *MachineVM) startHostNetworking() error {
-	// TODO we may wish to configure the directory in containers common
-	binary := filepath.Join("/usr/libexec/podman/", machine.ForwarderBinaryName)
+
+	binary := machine.ForwarderBinaryPath
 	if _, err := os.Stat(binary); err != nil {
+		fmt.Println("Failed to find " + binary + ".  Perhaps build using `make GVPROXY+PATH=...`")
 		return err
 	}
 


### PR DESCRIPTION
Presented as an alternative to PR #11449

Rather than do backflips in the code to locate `gvproxy`, use a
build-time variable to set the location.  That variable can default to
`/usr/libexec` but other build packages (_e.g._ Homebrew) can set it to
something of their liking.

I'll take no offense if the consensus is that we do not want to pollute
the build, but we should likely add a runtime configuration parameter as an
alternative in that case.

Fixes: #11226

Signed-off-by: Jonathan Springer <jonpspri@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
