### PR TITLE
Add 'Machine %q started' message when podman machine start successful

### DIFF
--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -3,6 +3,8 @@
 package machine
 
 import (
+	"fmt"
+
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/pkg/machine"
 	"github.com/containers/podman/v3/pkg/machine/qemu"
@@ -58,5 +60,9 @@ func start(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return vm.Start(vmName, machine.StartOptions{})
+	if err := vm.Start(vmName, machine.StartOptions{}); err != nil {
+		return err
+	}
+	fmt.Printf("Machine %q started successfully\n", vmName)
+	return nil
 }


### PR DESCRIPTION
Currently users are confused if podman machine prints warnings about
whether or not podman machine was successful.  Printing this message
clears up the confusion.


[NO TESTS NEEDED] Since we don't have a way to test podman machine in ci/cd system


Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
