### PR TITLE
inspect: printTmpl must Flush writer

### DIFF
--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -254,7 +254,9 @@ func printTmpl(typ, row string, data []interface{}) error {
 	if err != nil {
 		return err
 	}
-	return t.Execute(w, data)
+	err = t.Execute(w, data)
+	w.Flush()
+	return err
 }
 
 func (i *inspector) inspectAll(ctx context.Context, namesOrIDs []string) ([]interface{}, []error, error) {

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -80,5 +80,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return t.Execute(w, *responses)
+	err = t.Execute(w, *responses)
+	w.Flush()
+	return err
 }

--- a/test/e2e/build/envwithtab/Dockerfile
+++ b/test/e2e/build/envwithtab/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+
+ENV TEST="	t"

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -50,6 +50,24 @@ var _ = Describe("Podman inspect", func() {
 		Expect(session).To(ExitWithError())
 	})
 
+	It("podman inspect filter should work if result contains tab", func() {
+		session := podmanTest.Podman([]string{"build", "--tag", "envwithtab", "build/envwithtab"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		// Verify that OS and Arch are being set
+		inspect := podmanTest.Podman([]string{"inspect", "-f", "{{ .Config.Env }}", "envwithtab"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		// output should not be empty
+		// test validates fix for https://github.com/containers/podman/issues/8785
+		Expect(strings.Contains(inspect.OutputToString(), "TEST"))
+
+		session = podmanTest.Podman([]string{"rmi", "envwithtab"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+	})
+
 	It("podman inspect with GO format", func() {
 		session := podmanTest.Podman([]string{"inspect", "--format", "{{.ID}}", ALPINE})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Flush should be called after the last formatting call to ensure that any data buffered in the Writer is written to output.
Any incomplete escape sequence at the end is considered complete for formatting purposes.

Fixes: https://github.com/containers/podman/issues/8785