### PR TITLE
Fix conmon attach socket buffer size

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -46,7 +46,9 @@ import (
 const (
 	// This is Conmon's STDIO_BUF_SIZE. I don't believe we have access to it
 	// directly from the Go code, so const it here
-	bufferSize = conmonConfig.BufSize
+	// Important: The conmon attach socket uses an extra byte at the beginning of each
+	// message to specify the STREAM so we have to increase the buffer size by one
+	bufferSize = conmonConfig.BufSize + 1
 )
 
 // ConmonOCIRuntime is an OCI runtime managed by Conmon.


### PR DESCRIPTION
The conmon buffer size is 8192, however the attach socket needs two extra
bytes. The first byte of each message will be the STREAM type. The last
byte is a null byte. So when we want to read 8192 message bytes we need
to read 8193 bytes since the first one is special.
check https://github.com/containers/conmon/blob/1ef246896b4f6566964ed861b98cd32d0e7bf7a2/src/ctr_stdio.c#L101-L107

This problem can be seen in podman-remote run/exec when it prints output
with 8192 or more bytes. The output will miss the 8192 byte.

Fixes #11496

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
