### PR TITLE
Cirrus: Run unit-tests rootless

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -144,24 +144,24 @@ build_task:
         image_name: "${VM_IMAGE_NAME}"  # from stdenvars
     matrix: &platform_axis
         # Ref: https://cirrus-ci.org/guide/writing-tasks/#matrix-modification
-        - env:  &stdenvars
+        - env: &stdenvars
               DISTRO_NV: ${FEDORA_NAME}
               # Not used here, is used in other tasks
               VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
               # ID for re-use of build output
               _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-        - env:
+        - env: &priorfedora_envvars
               DISTRO_NV: ${PRIOR_FEDORA_NAME}
               VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
               CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
               _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-        - env:
+        - env: &ubuntu_envvars
               DISTRO_NV: ${UBUNTU_NAME}
               VM_IMAGE_NAME: ${UBUNTU_CACHE_IMAGE_NAME}
               CTR_FQIN: ${UBUNTU_CONTAINER_FQIN}
               _BUILD_CACHE_HANDLE: ${UBUNTU_NAME}-build-${CIRRUS_BUILD_ID}
-        - env:
+        - env: &priorubuntu_envvars
               DISTRO_NV: ${PRIOR_UBUNTU_NAME}
               VM_IMAGE_NAME: ${PRIOR_UBUNTU_CACHE_IMAGE_NAME}
               CTR_FQIN: ${PRIOR_UBUNTU_CONTAINER_FQIN}
@@ -404,7 +404,16 @@ unit_test_task:
     only_if: *not_docs
     depends_on:
         - validate
-    matrix: *platform_axis
+    matrix:
+        - env: *stdenvars
+        - env: *priorfedora_envvars
+        - env: *ubuntu_envvars
+        - env: *priorubuntu_envvars
+        # Special-case: Rootless on latest Fedora (standard) VM
+        - name: "Rootless unit on $DISTRO_NV"
+          env:
+              <<: *stdenvars
+              PRIV_NAME: rootless
     gce_instance: *standardvm
     env:
         TEST_FLAVOR: unit

--- a/Makefile
+++ b/Makefile
@@ -492,7 +492,6 @@ run-docker-py-tests:
 
 .PHONY: localunit
 localunit: test/goecho/goecho
-	hack/check_root.sh make localunit
 	rm -rf ${COVERAGE_PATH} && mkdir -p ${COVERAGE_PATH}
 	$(GOBIN)/ginkgo \
 		-r \


### PR DESCRIPTION
Previously (for various reasons) the unittests were limited by the
Makefile to root-only.  However, experimentation via PR #11490
shows they will actually execute and pass when run as a regular user.
Enable this for only the latest Fedora VMs, so as to only add one new
task to the (already large) set.