### PR TITLE
stats: detect container restart and allow paused containers

### DIFF
--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -54,6 +54,12 @@ func (c *Container) GetContainerStats(previousStats *define.ContainerStats) (*de
 		return nil, err
 	}
 
+	// If the current total usage in the cgroup is less than what was previously
+	// recorded then it means the container was restarted and runs in a new cgroup
+	if previousStats.Duration > cgroupStats.CPU.Usage.Total {
+		previousStats = &define.ContainerStats{}
+	}
+
 	previousCPU := previousStats.CPUNano
 	now := uint64(time.Now().UnixNano())
 	stats.Duration = cgroupStats.CPU.Usage.Total

--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -30,7 +30,7 @@ func (c *Container) GetContainerStats(previousStats *define.ContainerStats) (*de
 		}
 	}
 
-	if c.state.State != define.ContainerStateRunning {
+	if c.state.State != define.ContainerStateRunning && c.state.State != define.ContainerStatePaused {
 		return stats, define.ErrCtrStateInvalid
 	}
 
@@ -65,7 +65,7 @@ func (c *Container) GetContainerStats(previousStats *define.ContainerStats) (*de
 	stats.MemLimit = getMemLimit(cgroupStats.Memory.Usage.Limit)
 	stats.MemPerc = (float64(stats.MemUsage) / float64(stats.MemLimit)) * 100
 	stats.PIDs = 0
-	if conState == define.ContainerStateRunning {
+	if conState == define.ContainerStateRunning || conState == define.ContainerStatePaused {
 		stats.PIDs = cgroupStats.Pids.Current
 	}
 	stats.BlockInput, stats.BlockOutput = calculateBlockIO(cgroupStats)

--- a/pkg/api/handlers/compat/containers_stats.go
+++ b/pkg/api/handlers/compat/containers_stats.go
@@ -97,7 +97,7 @@ streamLabel: // A label to flatten the scope
 
 	default:
 		// Container stats
-		stats, err := ctnr.GetContainerStats(stats)
+		stats, err = ctnr.GetContainerStats(stats)
 		if err != nil {
 			logrus.Errorf("Unable to get container stats: %v", err)
 			return

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -79,6 +79,11 @@ var _ = Describe("Podman pause", func() {
 		Expect(result).To(ExitWithError())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(strings.ToLower(podmanTest.GetContainerStatus())).To(ContainSubstring(createdState))
+
+		// check we can read stats for a paused container
+		result = podmanTest.Podman([]string{"stats", "--no-stream", cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result).To(ExitWithError())
 	})
 
 	It("podman pause a running container by id", func() {


### PR DESCRIPTION
if the current cpu usage time is lower than what previously recorded, then it means the container was restarted and now it runs in a new cgroup.  When this happens, reset the prevStats.

Also allow to read stats from paused containers.
    
Closes: https://github.com/containers/podman/issues/11469
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
