### PR TITLE
Include arch in release zip/tarball filename

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -371,7 +371,7 @@ osx_alt_build_task:
     script:
         - brew install go
         - brew install go-md2man
-        - make podman-remote-release-darwin.zip
+        - make podman-remote-release-darwin_amd64.zip
     always: *binary_artifacts
 
 

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,8 @@ else
 BINSFX := -remote
 SRCBINDIR := bin
 endif
+# Default to the native architecture type
+GOARCH ?= $(shell $(GO) env GOARCH)
 # Necessary for nested-$(MAKE) calls and docs/remote-docs.sh
 export GOOS CGO_ENABLED BINSFX SRCBINDIR
 
@@ -602,7 +604,7 @@ tests-expect-exit:
 ### Release/Packaging targets
 ###
 
-podman-release.tar.gz: binaries docs  ## Build all binaries, docs., and installation tree, into a tarball.
+podman-release_$(GOARCH).tar.gz: binaries docs  ## Build all binaries, docs., and installation tree, into a tarball.
 	$(eval TMPDIR := $(shell mktemp -d podman_tmp_XXXX))
 	$(eval SUBDIR := podman-v$(RELEASE_NUMBER))
 	mkdir -p "$(TMPDIR)/$(SUBDIR)"
@@ -611,12 +613,13 @@ podman-release.tar.gz: binaries docs  ## Build all binaries, docs., and installa
 	tar -czvf $@ --xattrs -C "$(TMPDIR)" "./$(SUBDIR)"
 	-rm -rf "$(TMPDIR)"
 
-podman-remote-release-%.zip: podman-remote-% install-podman-remote-%-docs  ## Build podman-remote for GOOS=%, docs., and installation zip.
+podman-remote-release-%_$(GOARCH).zip: podman-remote-% install-podman-remote-%-docs  ## Build podman-remote for GOOS=%, docs., and installation zip.
 	$(eval TMPDIR := $(shell mktemp -d podman_tmp_XXXX))
 	$(eval SUBDIR := podman-$(RELEASE_NUMBER))
 	mkdir -p "$(TMPDIR)/$(SUBDIR)"
 	$(MAKE) \
 		GOOS=$* \
+		GOARCH=$(GOARCH) \
 		DESTDIR=$(TMPDIR)/ \
 		BINDIR=$(SUBDIR) \
 		SELINUXOPT="" \

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -205,7 +205,7 @@ function _run_build() {
     # Ensure always start from clean-slate with all vendor modules downloaded
     make clean
     make vendor
-    make podman-release.tar.gz  # includes podman, podman-remote, and docs
+    make podman-release_amd64.tar.gz  # includes podman, podman-remote, and docs
 }
 
 function _run_altbuild() {
@@ -221,7 +221,7 @@ function _run_altbuild() {
             make build-all-new-commits GIT_BASE_BRANCH=origin/$DEST_BRANCH
             ;;
         *Windows*)
-            make podman-remote-release-windows.zip
+            make podman-remote-release-windows_amd64.zip
             make podman.msi
             ;;
         *Without*)


### PR DESCRIPTION
Fixes #11417

Namely: Includes the go-architecture name in the release filename.  This
is needed esp. for 'darwin' where there are now multiple architectures.