### PR TITLE
[v3.3.1-rhel] auto-update: fix authfile label

### DIFF
--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -224,7 +224,7 @@ func autoUpdateRegistry(ctx context.Context, image *libimage.Image, ctr *libpod.
 		return report, nil
 	}
 
-	if _, err := updateImage(ctx, runtime, rawImageName, options); err != nil {
+	if _, err := updateImage(ctx, runtime, rawImageName, authfile); err != nil {
 		return report, errors.Wrapf(err, "error registry auto-updating container %q: image update for %q failed", cid, rawImageName)
 	}
 	updatedRawImages[rawImageName] = true
@@ -379,9 +379,9 @@ func newerLocalImageAvailable(runtime *libpod.Runtime, img *libimage.Image, rawI
 }
 
 // updateImage pulls the specified image.
-func updateImage(ctx context.Context, runtime *libpod.Runtime, name string, options *entities.AutoUpdateOptions) (*libimage.Image, error) {
+func updateImage(ctx context.Context, runtime *libpod.Runtime, name, authfile string) (*libimage.Image, error) {
 	pullOptions := &libimage.PullOptions{}
-	pullOptions.AuthFilePath = options.Authfile
+	pullOptions.AuthFilePath = authfile
 	pullOptions.Writer = os.Stderr
 
 	pulledImages, err := runtime.LibimageRuntime().Pull(ctx, name, config.PullPolicyAlways, pullOptions)

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -148,7 +148,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		search := podmanTest.Podman([]string{"search", "docker.io/alpine"})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
-		Expect(len(search.OutputToStringArray())).To(Equal(26))
+		Expect(len(search.OutputToStringArray())).To(BeNumerically(">", 10))
 
 		search = podmanTest.Podman([]string{"search", "--limit", "3", "docker.io/alpine"})
 		search.WaitWithDefaultTimeout()
@@ -462,7 +462,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		search = podmanTest.Podman([]string{"search", "--list-tags", "docker.io/library/alpine"})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
-		Expect(len(search.OutputToStringArray()) > 2).To(BeTrue())
+		Expect(len(search.OutputToStringArray())).To(BeNumerically(">", 2))
 
 		search = podmanTest.Podman([]string{"search", "--filter=is-official", "--list-tags", "docker.io/library/alpine"})
 		search.WaitWithDefaultTimeout()
@@ -477,6 +477,6 @@ registries = ['{{.Host}}:{{.Port}}']`
 		search := podmanTest.Podman([]string{"search", "--limit", "130", "registry.redhat.io/rhel"})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
-		Expect(len(search.OutputToStringArray())).To(Equal(131))
+		Expect(len(search.OutputToStringArray())).To(BeNumerically("<=", 131))
 	})
 })


### PR DESCRIPTION
Make sure that the container's authfile label is used when pulling down
a new image.

[NO TESTS NEEDED] since we need to add authfile tests to the main
branch.

Fixes: #11171
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

BZ:
* https://bugzilla.redhat.com/show_bug.cgi?id=2002670
* https://bugzilla.redhat.com/show_bug.cgi?id=2000943

@TomSweeneyRedHat please take a look
