### PR TITLE
Stop outputting 'healthy' on healthcheck

### DIFF
--- a/cmd/podman/healthcheck/run.go
+++ b/cmd/podman/healthcheck/run.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/registry"
+	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/spf13/cobra"
 )
@@ -34,9 +35,9 @@ func run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if response.Status == "unhealthy" {
+	if response.Status == define.HealthCheckUnhealthy {
 		registry.SetExitCode(1)
+		fmt.Println(response.Status)
 	}
-	fmt.Println(response.Status)
 	return err
 }

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -326,11 +326,11 @@ var _ = Describe("Podman containers ", func() {
 		// TODO for the life of me, i cannot get this to work. maybe another set
 		// of eyes will
 		// successful healthcheck
-		//status := "healthy"
+		//status := define.HealthCheckHealthy
 		//for i:=0; i < 10; i++ {
 		//	result, err := containers.RunHealthCheck(connText, "hc")
 		//	Expect(err).To(BeNil())
-		//	if result.Status != "healthy" {
+		//	if result.Status != define.HealthCheckHealthy {
 		//		fmt.Println("Healthcheck container still starting, retrying in 1 second")
 		//		time.Sleep(1 * time.Second)
 		//		continue
@@ -338,7 +338,7 @@ var _ = Describe("Podman containers ", func() {
 		//	status = result.Status
 		//	break
 		//}
-		//Expect(status).To(Equal("healthy"))
+		//Expect(status).To(Equal(define.HealthCheckHealthy))
 
 		// TODO enable this when wait is working
 		// healthcheck on a stopped container should be a 409

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	define "github.com/containers/podman/v3/libpod/define"
 	. "github.com/containers/podman/v3/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -157,7 +158,7 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(hc).Should(Exit(1))
 
 		inspect = podmanTest.InspectContainer("hc")
-		Expect(inspect[0].State.Healthcheck.Status).To(Equal("unhealthy"))
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal(define.HealthCheckUnhealthy))
 
 	})
 
@@ -171,7 +172,7 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(hc).Should(Exit(0))
 
 		inspect := podmanTest.InspectContainer("hc")
-		Expect(inspect[0].State.Healthcheck.Status).To(Equal("healthy"))
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal(define.HealthCheckHealthy))
 	})
 
 	It("podman healthcheck unhealthy but valid arguments check", func() {
@@ -201,7 +202,7 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(hc).Should(Exit(1))
 
 		inspect = podmanTest.InspectContainer("hc")
-		Expect(inspect[0].State.Healthcheck.Status).To(Equal("unhealthy"))
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal(define.HealthCheckUnhealthy))
 
 		foo := podmanTest.Podman([]string{"exec", "hc", "touch", "/foo"})
 		foo.WaitWithDefaultTimeout()
@@ -212,6 +213,6 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(hc).Should(Exit(0))
 
 		inspect = podmanTest.InspectContainer("hc")
-		Expect(inspect[0].State.Healthcheck.Status).To(Equal("healthy"))
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal(define.HealthCheckHealthy))
 	})
 })

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/containers/common/pkg/config"
+	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/util"
 	. "github.com/containers/podman/v3/test/utils"
 	"github.com/containers/storage/pkg/stringid"
@@ -1209,7 +1210,7 @@ var _ = Describe("Podman play kube", func() {
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "liveness-unhealthy-probe-pod-0-alpine"})
 		hc.WaitWithDefaultTimeout()
 		hcoutput := hc.OutputToString()
-		Expect(hcoutput).To(ContainSubstring("unhealthy"))
+		Expect(hcoutput).To(ContainSubstring(define.HealthCheckUnhealthy))
 	})
 
 	It("podman play kube fail with nonexistent authfile", func() {

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -74,7 +74,7 @@ EOF
     #
     # So, just force a healthcheck run, then confirm that it's running.
     run_podman healthcheck run healthcheck_c
-    is "$output" "healthy" "output from 'podman healthcheck run'"
+    is "$output" "" "output from 'podman healthcheck run'"
 
     _check_health "All healthy" "
 Status           | healthy


### PR DESCRIPTION
We should only print unhealthy if the check fails.  Currently this is
filling logs when users are running lots of healthchecks.

Improves: https://github.com/containers/podman/issues/11157

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
