### PR TITLE
Add deprecated event fields for 1.22+ clients that still expect them

### DIFF
--- a/pkg/domain/entities/events.go
+++ b/pkg/domain/entities/events.go
@@ -60,6 +60,10 @@ func ConvertToEntitiesEvent(e libpodEvents.Event) *Event {
 	attributes["name"] = e.Name
 	attributes["containerExitCode"] = strconv.Itoa(e.ContainerExitCode)
 	return &Event{dockerEvents.Message{
+		// Compatibility with clients that still look for deprecated API elements
+		Status: e.Status.String(),
+		ID:     e.ID,
+		From:   e.Image,
 		Type:   e.Type.String(),
 		Action: e.Status.String(),
 		Actor: dockerEvents.Actor{

--- a/test/apiv2/python/rest_api/test_v2_0_0_system.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_system.py
@@ -28,6 +28,14 @@ class SystemTestCase(APITestCase):
             obj = json.loads(line)
             # Actor.ID is uppercase for compatibility
             self.assertIn("ID", obj["Actor"])
+            # Verify 1.22+ deprecated variants are present if current originals are
+            if (obj["Actor"]["ID"]):
+               self.assertEqual(obj["Actor"]["ID"], obj["id"])
+            if (obj["Action"]):
+               self.assertEqual(obj["Action"], obj["status"])
+            if (obj["Actor"].get("Attributes") and obj["Actor"]["Attributes"].get("image")):
+               self.assertEqual(obj["Actor"]["Attributes"]["image"], obj["from"])
+
 
     def test_ping(self):
         required_headers = (


### PR DESCRIPTION
In 1.22 of the Docker REST API, 3 fields in event payload were renamed and or relocated in the structure. However, the original fields were preserved in the API entity definition for compatibility. Unfortunately, some existing docker clients, such as docker-compose, refer to the old names since they are still sent by dockerd.
This PR improves compatibility by including the additional deprecated entries in the compatible payload. 

Signed-off-by: Jason Greene <jason.greene@redhat.com>

