### PR TITLE
[CI:DOCS] Remove short 'a' option from all-tags

### DIFF
--- a/docs/source/markdown/podman-pull.1.md
+++ b/docs/source/markdown/podman-pull.1.md
@@ -43,7 +43,7 @@ $ podman pull oci-archive:/tmp/myimage
 ```
 
 ## OPTIONS
-#### **--all-tags**, **a**
+#### **--all-tags**
 
 All tagged images in the repository will be pulled.
 


### PR DESCRIPTION
The short option 'a' for the --all-tags option in the pull
page is not valid, remove it.

Addresses: #11536

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
