### PR TITLE
Fix HTTP credentials passing

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -270,9 +270,9 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authConf, authfile, key, err := auth.GetCredentials(r)
+	authConf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -453,10 +453,10 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	creds, authfile, key, err := auth.GetCredentials(r)
+	creds, authfile, err := auth.GetCredentials(r)
 	if err != nil {
 		// Credential value(s) not returned as their value is not human readable
-		utils.BadRequest(w, key.String(), "n/a", err)
+		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)

--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -85,9 +85,9 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authconf, authfile, key, err := auth.GetCredentials(r)
+	authconf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)

--- a/pkg/api/handlers/compat/images_search.go
+++ b/pkg/api/handlers/compat/images_search.go
@@ -34,9 +34,9 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, authfile, key, err := auth.GetCredentials(r)
+	_, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -497,9 +497,9 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authconf, authfile, key, err := auth.GetCredentials(r)
+	authconf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)

--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -68,9 +68,9 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Do the auth dance.
-	authConf, authfile, key, err := auth.GetCredentials(r)
+	authConf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -176,9 +176,9 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 	}
 
 	source := utils.GetName(r)
-	authconf, authfile, key, err := auth.GetCredentials(r)
+	authconf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)

--- a/pkg/api/handlers/libpod/play.go
+++ b/pkg/api/handlers/libpod/play.go
@@ -86,9 +86,9 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error closing temporary file"))
 		return
 	}
-	authConf, authfile, key, err := auth.GetCredentials(r)
+	authConf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, errors.Wrapf(err, "failed to parse %q header for %s", key, r.URL.String()))
+		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -34,8 +34,8 @@ const XRegistryConfigHeader HeaderAuthName = "X-Registry-Config"
 // the necessary authentication information for libpod operations
 func GetCredentials(r *http.Request) (*types.DockerAuthConfig, string, error) {
 	has := func(key HeaderAuthName) bool {
-		hdr, found := r.Header[key.String()]
-		return found && len(hdr) > 0
+		hdr := r.Header.Values(key.String())
+		return len(hdr) > 0
 	}
 	switch {
 	case has(XRegistryConfigHeader):

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -115,7 +115,7 @@ func getAuthCredentials(r *http.Request) (*types.DockerAuthConfig, string, error
 	}
 
 	// Fallback to looking for a single-auth header (i.e., one config).
-	authConfigs, err = singleAuthHeader(r)
+	authConfigs, err = parseSingleAuthHeader(r)
 	if err != nil {
 		return nil, "", err
 	}
@@ -309,9 +309,9 @@ func imageAuthToDockerAuth(authConfig types.DockerAuthConfig) dockerAPITypes.Aut
 	}
 }
 
-// singleAuthHeader extracts a DockerAuthConfig from the request's header.
+// parseSingleAuthHeader extracts a DockerAuthConfig from the request's header.
 // The header content is a single DockerAuthConfig.
-func singleAuthHeader(r *http.Request) (map[string]types.DockerAuthConfig, error) {
+func parseSingleAuthHeader(r *http.Request) (map[string]types.DockerAuthConfig, error) {
 	authHeader := r.Header.Get(string(XRegistryAuthHeader))
 	authConfig := dockerAPITypes.AuthConfig{}
 	// Accept "null" and handle it as empty value for compatibility reason with Docker.

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -317,14 +317,16 @@ func imageAuthToDockerAuth(authConfig types.DockerAuthConfig) dockerAPITypes.Aut
 // The header content is a single DockerAuthConfig.
 func parseSingleAuthHeader(r *http.Request) (types.DockerAuthConfig, error) {
 	authHeader := r.Header.Get(string(XRegistryAuthHeader))
-	authConfig := dockerAPITypes.AuthConfig{}
 	// Accept "null" and handle it as empty value for compatibility reason with Docker.
 	// Some java docker clients pass this value, e.g. this one used in Eclipse.
-	if len(authHeader) > 0 && authHeader != "null" {
-		authJSON := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authHeader))
-		if err := json.NewDecoder(authJSON).Decode(&authConfig); err != nil {
-			return types.DockerAuthConfig{}, err
-		}
+	if len(authHeader) == 0 || authHeader == "null" {
+		return types.DockerAuthConfig{}, nil
+	}
+
+	authConfig := dockerAPITypes.AuthConfig{}
+	authJSON := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authHeader))
+	if err := json.NewDecoder(authJSON).Decode(&authConfig); err != nil {
+		return types.DockerAuthConfig{}, err
 	}
 	return dockerAuthToImageAuth(authConfig), nil
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -33,7 +33,10 @@ const XRegistryConfigHeader HeaderAuthName = "X-Registry-Config"
 // GetCredentials queries the http.Request for X-Registry-.* headers and extracts
 // the necessary authentication information for libpod operations
 func GetCredentials(r *http.Request) (*types.DockerAuthConfig, string, error) {
-	has := func(key HeaderAuthName) bool { hdr, found := r.Header[string(key)]; return found && len(hdr) > 0 }
+	has := func(key HeaderAuthName) bool {
+		hdr, found := r.Header[key.String()]
+		return found && len(hdr) > 0
+	}
 	switch {
 	case has(XRegistryConfigHeader):
 		c, f, err := getConfigCredentials(r)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -21,7 +21,7 @@ type HeaderAuthName string
 func (h HeaderAuthName) String() string { return string(h) }
 
 // XRegistryAuthHeader is the key to the encoded registry authentication configuration in an http-request header.
-// This header supports one registry per header occurrence. To support N registries provided N headers, one per registry.
+// This header supports one registry per header occurrence. To support N registries provide N headers, one per registry.
 // As of Docker API 1.40 and Libpod API 1.0.0, this header is supported by all endpoints.
 const XRegistryAuthHeader HeaderAuthName = "X-Registry-Auth"
 
@@ -108,7 +108,7 @@ func getConfigCredentials(r *http.Request) (*types.DockerAuthConfig, string, err
 // should be removed after usage.
 func getAuthCredentials(r *http.Request) (*types.DockerAuthConfig, string, error) {
 	// First look for a multi-auth header (i.e., a map).
-	authConfigs, err := multiAuthHeader(r)
+	authConfigs, err := parseMultiAuthHeader(r)
 	if err == nil {
 		authfile, err := authConfigsToAuthFile(authConfigs)
 		return nil, authfile, err
@@ -327,9 +327,9 @@ func singleAuthHeader(r *http.Request) (map[string]types.DockerAuthConfig, error
 	return authConfigs, nil
 }
 
-// multiAuthHeader extracts a DockerAuthConfig from the request's header.
+// parseMultiAuthHeader extracts a DockerAuthConfig from the request's header.
 // The header content is a map[string]DockerAuthConfigs.
-func multiAuthHeader(r *http.Request) (map[string]types.DockerAuthConfig, error) {
+func parseMultiAuthHeader(r *http.Request) (map[string]types.DockerAuthConfig, error) {
 	authHeader := r.Header.Get(string(XRegistryAuthHeader))
 	// Accept "null" and handle it as empty value for compatibility reason with Docker.
 	// Some java docker clients pass this value, e.g. this one used in Eclipse.

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -258,24 +258,24 @@ func authConfigsToAuthFile(authConfigs map[string]types.DockerAuthConfig) (strin
 	// Now use the c/image packages to store the credentials. It's battle
 	// tested, and we make sure to use the same code as the image backend.
 	sys := types.SystemContext{AuthFilePath: authFilePath}
-	for server, config := range authConfigs {
-		server = normalize(server)
+	for authFileKey, config := range authConfigs {
+		key := normalizeAuthFileKey(authFileKey)
 
 		// Note that we do not validate the credentials here. We assume
 		// that all credentials are valid. They'll be used on demand
 		// later.
-		if err := imageAuth.SetAuthentication(&sys, server, config.Username, config.Password); err != nil {
-			return "", errors.Wrapf(err, "error storing credentials in temporary auth file (server: %q, user: %q)", server, config.Username)
+		if err := imageAuth.SetAuthentication(&sys, key, config.Username, config.Password); err != nil {
+			return "", errors.Wrapf(err, "error storing credentials in temporary auth file (key: %q / %q, user: %q)", authFileKey, key, config.Username)
 		}
 	}
 
 	return authFilePath, nil
 }
 
-// normalize takes a server and removes the leading "http[s]://" prefix as well
+// normalizeAuthFileKey takes an auth file key and removes the leading "http[s]://" prefix as well
 // as removes path suffixes from docker registries.
-func normalize(server string) string {
-	stripped := strings.TrimPrefix(server, "http://")
+func normalizeAuthFileKey(authFileKey string) string {
+	stripped := strings.TrimPrefix(authFileKey, "http://")
 	stripped = strings.TrimPrefix(stripped, "https://")
 
 	/// Normalize docker registries

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -141,18 +140,6 @@ func getAuthCredentials(headers []string) (*types.DockerAuthConfig, map[string]t
 		return nil, nil, err
 	}
 	return &authConfig, nil, nil
-}
-
-// Header builds the requested Authentication Header
-func Header(sys *types.SystemContext, headerName HeaderAuthName, authfile, username, password string) (map[string]string, error) {
-	switch headerName {
-	case XRegistryAuthHeader:
-		return MakeXRegistryAuthHeader(sys, authfile, username, password)
-	case XRegistryConfigHeader:
-		return MakeXRegistryConfigHeader(sys, authfile, username, password)
-	default:
-		return nil, fmt.Errorf("unsupported authentication header: %q", headerName)
-	}
 }
 
 // MakeXRegistryConfigHeader returns a map with the XRegistryConfigHeader set which can

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -144,12 +144,9 @@ func getAuthCredentials(headers []string) (*types.DockerAuthConfig, map[string]t
 
 // MakeXRegistryConfigHeader returns a map with the XRegistryConfigHeader set which can
 // conveniently be used in the http stack.
-func MakeXRegistryConfigHeader(sys *types.SystemContext, authfile, username, password string) (map[string]string, error) {
+func MakeXRegistryConfigHeader(sys *types.SystemContext, username, password string) (map[string]string, error) {
 	if sys == nil {
 		sys = &types.SystemContext{}
-	}
-	if authfile != "" {
-		sys.AuthFilePath = authfile
 	}
 	authConfigs, err := imageAuth.GetAllCredentials(sys)
 	if err != nil {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -172,7 +172,7 @@ func MakeXRegistryConfigHeader(sys *types.SystemContext, username, password stri
 
 // MakeXRegistryAuthHeader returns a map with the XRegistryAuthHeader set which can
 // conveniently be used in the http stack.
-func MakeXRegistryAuthHeader(sys *types.SystemContext, authfile, username, password string) (map[string]string, error) {
+func MakeXRegistryAuthHeader(sys *types.SystemContext, username, password string) (map[string]string, error) {
 	if username != "" {
 		content, err := encodeSingleAuthConfig(types.DockerAuthConfig{Username: username, Password: password})
 		if err != nil {
@@ -183,9 +183,6 @@ func MakeXRegistryAuthHeader(sys *types.SystemContext, authfile, username, passw
 
 	if sys == nil {
 		sys = &types.SystemContext{}
-	}
-	if authfile != "" {
-		sys.AuthFilePath = authfile
 	}
 	authConfigs, err := imageAuth.GetAllCredentials(sys)
 	if err != nil {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -320,10 +320,7 @@ func TestParseSingleAuthHeader(t *testing.T) {
 			expected: types.DockerAuthConfig{Username: "u1", Password: "p1"},
 		},
 	} {
-		req, err := http.NewRequest(http.MethodPost, "/", nil)
-		require.NoError(t, err, tc.input)
-		req.Header.Set(XRegistryAuthHeader.String(), tc.input)
-		res, err := parseSingleAuthHeader(req)
+		res, err := parseSingleAuthHeader(tc.input)
 		if tc.shouldErr {
 			assert.Error(t, err, tc.input)
 		} else {
@@ -356,10 +353,7 @@ func TestParseMultiAuthHeader(t *testing.T) {
 			},
 		},
 	} {
-		req, err := http.NewRequest(http.MethodPost, "/", nil)
-		require.NoError(t, err, tc.input)
-		req.Header.Set(XRegistryAuthHeader.String(), tc.input)
-		res, err := parseMultiAuthHeader(req)
+		res, err := parseMultiAuthHeader(tc.input)
 		if tc.shouldErr {
 			assert.Error(t, err, tc.input)
 		} else {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -79,30 +79,29 @@ func TestMakeXRegistryConfigHeaderGetCredentialsRoundtrip(t *testing.T) {
 			expectedFileValues: largeAuthFileValues,
 		},
 	} {
-		name := tc.name
 		inputAuthFile, cleanup := tempAuthFilePath(t, tc.fileContents)
 		defer cleanup()
 		headers, err := MakeXRegistryConfigHeader(nil, inputAuthFile, tc.username, tc.password)
 		require.NoError(t, err)
 		req, err := http.NewRequest(http.MethodPost, "/", nil)
-		require.NoError(t, err, name)
+		require.NoError(t, err, tc.name)
 		for k, v := range headers {
 			req.Header.Set(k, v)
 		}
 
 		override, resPath, err := GetCredentials(req)
-		require.NoError(t, err, name)
+		require.NoError(t, err, tc.name)
 		defer RemoveAuthfile(resPath)
 		if tc.expectedOverride == nil {
-			assert.Nil(t, override, name)
+			assert.Nil(t, override, tc.name)
 		} else {
-			require.NotNil(t, override, name)
-			assert.Equal(t, *tc.expectedOverride, *override, name)
+			require.NotNil(t, override, tc.name)
+			assert.Equal(t, *tc.expectedOverride, *override, tc.name)
 		}
 		for key, expectedAuth := range tc.expectedFileValues {
 			auth, err := config.GetCredentials(&types.SystemContext{AuthFilePath: resPath}, key)
-			require.NoError(t, err, name)
-			assert.Equal(t, expectedAuth, auth, "%s, key %s", name, key)
+			require.NoError(t, err, tc.name)
+			assert.Equal(t, expectedAuth, auth, "%s, key %s", tc.name, key)
 		}
 	}
 }
@@ -132,30 +131,29 @@ func TestMakeXRegistryAuthHeaderGetCredentialsRoundtrip(t *testing.T) {
 			expectedFileValues: largeAuthFileValues,
 		},
 	} {
-		name := tc.name
 		inputAuthFile, cleanup := tempAuthFilePath(t, tc.fileContents)
 		defer cleanup()
 		headers, err := MakeXRegistryAuthHeader(nil, inputAuthFile, tc.username, tc.password)
 		require.NoError(t, err)
 		req, err := http.NewRequest(http.MethodPost, "/", nil)
-		require.NoError(t, err, name)
+		require.NoError(t, err, tc.name)
 		for k, v := range headers {
 			req.Header.Set(k, v)
 		}
 
 		override, resPath, err := GetCredentials(req)
-		require.NoError(t, err, name)
+		require.NoError(t, err, tc.name)
 		defer RemoveAuthfile(resPath)
 		if tc.expectedOverride == nil {
-			assert.Nil(t, override, name)
+			assert.Nil(t, override, tc.name)
 		} else {
-			require.NotNil(t, override, name)
-			assert.Equal(t, *tc.expectedOverride, *override, name)
+			require.NotNil(t, override, tc.name)
+			assert.Equal(t, *tc.expectedOverride, *override, tc.name)
 		}
 		for key, expectedAuth := range tc.expectedFileValues {
 			auth, err := config.GetCredentials(&types.SystemContext{AuthFilePath: resPath}, key)
-			require.NoError(t, err, name)
-			assert.Equal(t, expectedAuth, auth, "%s, key %s", name, key)
+			require.NoError(t, err, tc.name)
+			assert.Equal(t, expectedAuth, auth, "%s, key %s", tc.name, key)
 		}
 	}
 }
@@ -208,30 +206,29 @@ func TestMakeXRegistryConfigHeader(t *testing.T) {
 				}`,
 		},
 	} {
-		name := tc.name
 		authFile, cleanup := tempAuthFilePath(t, tc.fileContents)
 		defer cleanup()
 		res, err := MakeXRegistryConfigHeader(nil, authFile, tc.username, tc.password)
 		if tc.shouldErr {
-			assert.Error(t, err, name)
+			assert.Error(t, err, tc.name)
 		} else {
-			require.NoError(t, err, name)
+			require.NoError(t, err, tc.name)
 			if tc.expectedContents == "" {
-				assert.Empty(t, res, name)
+				assert.Empty(t, res, tc.name)
 			} else {
-				require.Len(t, res, 1, name)
+				require.Len(t, res, 1, tc.name)
 				header, ok := res[XRegistryConfigHeader.String()]
-				require.True(t, ok, name)
+				require.True(t, ok, tc.name)
 				decodedHeader, err := base64.URLEncoding.DecodeString(header)
-				require.NoError(t, err, name)
+				require.NoError(t, err, tc.name)
 				// Don't test for a specific JSON representation, just for the expected contents.
 				expected := map[string]interface{}{}
 				actual := map[string]interface{}{}
 				err = json.Unmarshal([]byte(tc.expectedContents), &expected)
-				require.NoError(t, err, name)
+				require.NoError(t, err, tc.name)
 				err = json.Unmarshal(decodedHeader, &actual)
-				require.NoError(t, err, name)
-				assert.Equal(t, expected, actual, name)
+				require.NoError(t, err, tc.name)
+				assert.Equal(t, expected, actual, tc.name)
 			}
 		}
 	}
@@ -272,30 +269,29 @@ func TestMakeXRegistryAuthHeader(t *testing.T) {
 			}`,
 		},
 	} {
-		name := tc.name
 		authFile, cleanup := tempAuthFilePath(t, tc.fileContents)
 		defer cleanup()
 		res, err := MakeXRegistryAuthHeader(nil, authFile, tc.username, tc.password)
 		if tc.shouldErr {
-			assert.Error(t, err, name)
+			assert.Error(t, err, tc.name)
 		} else {
-			require.NoError(t, err, name)
+			require.NoError(t, err, tc.name)
 			if tc.expectedContents == "" {
-				assert.Empty(t, res, name)
+				assert.Empty(t, res, tc.name)
 			} else {
-				require.Len(t, res, 1, name)
+				require.Len(t, res, 1, tc.name)
 				header, ok := res[XRegistryAuthHeader.String()]
-				require.True(t, ok, name)
+				require.True(t, ok, tc.name)
 				decodedHeader, err := base64.URLEncoding.DecodeString(header)
-				require.NoError(t, err, name)
+				require.NoError(t, err, tc.name)
 				// Don't test for a specific JSON representation, just for the expected contents.
 				expected := map[string]interface{}{}
 				actual := map[string]interface{}{}
 				err = json.Unmarshal([]byte(tc.expectedContents), &expected)
-				require.NoError(t, err, name)
+				require.NoError(t, err, tc.name)
 				err = json.Unmarshal(decodedHeader, &actual)
-				require.NoError(t, err, name)
-				assert.Equal(t, expected, actual, name)
+				require.NoError(t, err, tc.name)
+				assert.Equal(t, expected, actual, tc.name)
 			}
 		}
 	}

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -81,7 +81,7 @@ func TestMakeXRegistryConfigHeaderGetCredentialsRoundtrip(t *testing.T) {
 	} {
 		inputAuthFile, cleanup := tempAuthFilePath(t, tc.fileContents)
 		defer cleanup()
-		headers, err := MakeXRegistryConfigHeader(nil, inputAuthFile, tc.username, tc.password)
+		headers, err := MakeXRegistryConfigHeader(&types.SystemContext{AuthFilePath: inputAuthFile}, tc.username, tc.password)
 		require.NoError(t, err)
 		req, err := http.NewRequest(http.MethodPost, "/", nil)
 		require.NoError(t, err, tc.name)
@@ -208,7 +208,7 @@ func TestMakeXRegistryConfigHeader(t *testing.T) {
 	} {
 		authFile, cleanup := tempAuthFilePath(t, tc.fileContents)
 		defer cleanup()
-		res, err := MakeXRegistryConfigHeader(nil, authFile, tc.username, tc.password)
+		res, err := MakeXRegistryConfigHeader(&types.SystemContext{AuthFilePath: authFile}, tc.username, tc.password)
 		if tc.shouldErr {
 			assert.Error(t, err, tc.name)
 		} else {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/containers/image/v5/types"
@@ -57,13 +58,14 @@ func TestAuthConfigsToAuthFile(t *testing.T) {
 		filePath, err := authConfigsToAuthFile(configs)
 
 		if tc.shouldErr {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 			assert.Empty(t, filePath)
 		} else {
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			content, err := ioutil.ReadFile(filePath)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Contains(t, string(content), tc.expectedContains)
+			os.Remove(filePath)
 		}
 	}
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -104,7 +104,7 @@ func TestHeaderGetCredentialsRoundtrip(t *testing.T) {
 			req.Header.Set(k, v)
 		}
 
-		override, resPath, parsedHeader, err := GetCredentials(req)
+		override, resPath, err := GetCredentials(req)
 		require.NoError(t, err, name)
 		defer RemoveAuthfile(resPath)
 		if tc.expectedOverride == nil {
@@ -117,12 +117,6 @@ func TestHeaderGetCredentialsRoundtrip(t *testing.T) {
 			auth, err := config.GetCredentials(&types.SystemContext{AuthFilePath: resPath}, key)
 			require.NoError(t, err, name)
 			assert.Equal(t, expectedAuth, auth, "%s, key %s", name, key)
-		}
-		if len(headers) != 0 {
-			assert.Len(t, headers, 1)
-			assert.Equal(t, tc.headerName, parsedHeader)
-		} else {
-			assert.Equal(t, HeaderAuthName(""), parsedHeader)
 		}
 	}
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -217,7 +217,7 @@ func TestMakeXRegistryConfigHeader(t *testing.T) {
 				assert.Empty(t, res, tc.name)
 			} else {
 				require.Len(t, res, 1, tc.name)
-				header, ok := res[XRegistryConfigHeader.String()]
+				header, ok := res[xRegistryConfigHeader]
 				require.True(t, ok, tc.name)
 				decodedHeader, err := base64.URLEncoding.DecodeString(header)
 				require.NoError(t, err, tc.name)
@@ -280,7 +280,7 @@ func TestMakeXRegistryAuthHeader(t *testing.T) {
 				assert.Empty(t, res, tc.name)
 			} else {
 				require.Len(t, res, 1, tc.name)
-				header, ok := res[XRegistryAuthHeader.String()]
+				header, ok := res[xRegistryAuthHeader]
 				require.True(t, ok, tc.name)
 				decodedHeader, err := base64.URLEncoding.DecodeString(header)
 				require.NoError(t, err, tc.name)

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -302,24 +302,22 @@ func TestParseSingleAuthHeader(t *testing.T) {
 	for _, tc := range []struct {
 		input     string
 		shouldErr bool
-		expected  map[string]types.DockerAuthConfig
+		expected  types.DockerAuthConfig
 	}{
 		{
 			input:    "", // An empty (or missing) header
-			expected: map[string]types.DockerAuthConfig{"0": {}},
+			expected: types.DockerAuthConfig{},
 		},
 		{
 			input:    "null",
-			expected: map[string]types.DockerAuthConfig{"0": {}},
+			expected: types.DockerAuthConfig{},
 		},
 		// Invalid JSON
 		{input: "@", shouldErr: true},
 		// Success
 		{
-			input: base64.URLEncoding.EncodeToString([]byte(`{"username":"u1","password":"p1"}`)),
-			expected: map[string]types.DockerAuthConfig{
-				"0": {Username: "u1", Password: "p1"},
-			},
+			input:    base64.URLEncoding.EncodeToString([]byte(`{"username":"u1","password":"p1"}`)),
+			expected: types.DockerAuthConfig{Username: "u1", Password: "p1"},
 		},
 	} {
 		req, err := http.NewRequest(http.MethodPost, "/", nil)

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -24,10 +24,10 @@ const largeAuthFile = `{"auths":{
 
 // Semantics of largeAuthFile
 var largeAuthFileValues = map[string]types.DockerAuthConfig{
-	// "docker.io/vendor": {Username: "docker", Password: "vendor"},
-	// "docker.io":        {Username: "docker", Password: "top"},
-	"quay.io/libpod": {Username: "quay", Password: "libpod"},
-	"quay.io":        {Username: "quay", Password: "top"},
+	"docker.io/vendor": {Username: "docker", Password: "vendor"},
+	"docker.io":        {Username: "docker", Password: "top"},
+	"quay.io/libpod":   {Username: "quay", Password: "libpod"},
+	"quay.io":          {Username: "quay", Password: "top"},
 }
 
 // Test that GetCredentials() correctly parses what Header() produces
@@ -260,28 +260,28 @@ func TestAuthConfigsToAuthFile(t *testing.T) {
 			expectedContains: "{}",
 		},
 		{
-			name:             "registry with prefix",
+			name:             "registry with a namespace prefix",
 			server:           "my-registry.local/username",
 			shouldErr:        false,
 			expectedContains: `"my-registry.local/username":`,
 		},
 		{
-			name:             "normalize https:// prefix",
+			name:             "URLs are interpreted as full registries",
 			server:           "http://my-registry.local/username",
 			shouldErr:        false,
-			expectedContains: `"my-registry.local/username":`,
+			expectedContains: `"my-registry.local":`,
 		},
 		{
-			name:             "normalize docker registry with https prefix",
+			name:             "the old-style docker registry URL is normalized",
 			server:           "http://index.docker.io/v1/",
 			shouldErr:        false,
-			expectedContains: `"index.docker.io":`,
+			expectedContains: `"docker.io":`,
 		},
 		{
-			name:             "normalize docker registry without https prefix",
-			server:           "docker.io/v2/",
+			name:             "docker.io vendor namespace",
+			server:           "docker.io/vendor",
 			shouldErr:        false,
-			expectedContains: `"docker.io":`,
+			expectedContains: `"docker.io/vendor":`,
 		},
 	} {
 		configs := map[string]types.DockerAuthConfig{}

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -294,12 +294,12 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		err     error
 	)
 	if options.SystemContext == nil {
-		headers, err = auth.Header(options.SystemContext, auth.XRegistryConfigHeader, "", "", "")
+		headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, "", "", "")
 	} else {
 		if options.SystemContext.DockerAuthConfig != nil {
 			headers, err = auth.Header(options.SystemContext, auth.XRegistryAuthHeader, options.SystemContext.AuthFilePath, options.SystemContext.DockerAuthConfig.Username, options.SystemContext.DockerAuthConfig.Password)
 		} else {
-			headers, err = auth.Header(options.SystemContext, auth.XRegistryConfigHeader, options.SystemContext.AuthFilePath, "", "")
+			headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, options.SystemContext.AuthFilePath, "", "")
 		}
 	}
 	if err != nil {

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -294,7 +294,7 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		err     error
 	)
 	if options.SystemContext != nil && options.SystemContext.DockerAuthConfig != nil {
-		headers, err = auth.MakeXRegistryAuthHeader(options.SystemContext, options.SystemContext.AuthFilePath, options.SystemContext.DockerAuthConfig.Username, options.SystemContext.DockerAuthConfig.Password)
+		headers, err = auth.MakeXRegistryAuthHeader(options.SystemContext, options.SystemContext.DockerAuthConfig.Username, options.SystemContext.DockerAuthConfig.Password)
 	} else {
 		headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, "", "")
 	}

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -293,14 +293,10 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		headers map[string]string
 		err     error
 	)
-	if options.SystemContext == nil {
-		headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, "", "")
+	if options.SystemContext != nil && options.SystemContext.DockerAuthConfig != nil {
+		headers, err = auth.MakeXRegistryAuthHeader(options.SystemContext, options.SystemContext.AuthFilePath, options.SystemContext.DockerAuthConfig.Username, options.SystemContext.DockerAuthConfig.Password)
 	} else {
-		if options.SystemContext.DockerAuthConfig != nil {
-			headers, err = auth.MakeXRegistryAuthHeader(options.SystemContext, options.SystemContext.AuthFilePath, options.SystemContext.DockerAuthConfig.Username, options.SystemContext.DockerAuthConfig.Password)
-		} else {
-			headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, "", "")
-		}
+		headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, "", "")
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -294,12 +294,12 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		err     error
 	)
 	if options.SystemContext == nil {
-		headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, "", "", "")
+		headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, "", "")
 	} else {
 		if options.SystemContext.DockerAuthConfig != nil {
 			headers, err = auth.MakeXRegistryAuthHeader(options.SystemContext, options.SystemContext.AuthFilePath, options.SystemContext.DockerAuthConfig.Username, options.SystemContext.DockerAuthConfig.Password)
 		} else {
-			headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, options.SystemContext.AuthFilePath, "", "")
+			headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, "", "")
 		}
 	}
 	if err != nil {

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -297,7 +297,7 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, "", "", "")
 	} else {
 		if options.SystemContext.DockerAuthConfig != nil {
-			headers, err = auth.Header(options.SystemContext, auth.XRegistryAuthHeader, options.SystemContext.AuthFilePath, options.SystemContext.DockerAuthConfig.Username, options.SystemContext.DockerAuthConfig.Password)
+			headers, err = auth.MakeXRegistryAuthHeader(options.SystemContext, options.SystemContext.AuthFilePath, options.SystemContext.DockerAuthConfig.Username, options.SystemContext.DockerAuthConfig.Password)
 		} else {
 			headers, err = auth.MakeXRegistryConfigHeader(options.SystemContext, options.SystemContext.AuthFilePath, "", "")
 		}

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 
+	imageTypes "github.com/containers/image/v5/types"
 	"github.com/containers/podman/v3/pkg/api/handlers/types"
 	"github.com/containers/podman/v3/pkg/auth"
 	"github.com/containers/podman/v3/pkg/bindings"
@@ -280,7 +281,7 @@ func Push(ctx context.Context, source string, destination string, options *PushO
 		return err
 	}
 	// TODO: have a global system context we can pass around (1st argument)
-	header, err := auth.MakeXRegistryAuthHeader(nil, options.GetAuthfile(), options.GetUsername(), options.GetPassword())
+	header, err := auth.MakeXRegistryAuthHeader(&imageTypes.SystemContext{AuthFilePath: options.GetAuthfile()}, options.GetUsername(), options.GetPassword())
 	if err != nil {
 		return err
 	}
@@ -329,7 +330,7 @@ func Search(ctx context.Context, term string, options *SearchOptions) ([]entitie
 	}
 
 	// TODO: have a global system context we can pass around (1st argument)
-	header, err := auth.MakeXRegistryAuthHeader(nil, options.GetAuthfile(), "", "")
+	header, err := auth.MakeXRegistryAuthHeader(&imageTypes.SystemContext{AuthFilePath: options.GetAuthfile()}, "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -280,7 +280,7 @@ func Push(ctx context.Context, source string, destination string, options *PushO
 		return err
 	}
 	// TODO: have a global system context we can pass around (1st argument)
-	header, err := auth.Header(nil, auth.XRegistryAuthHeader, options.GetAuthfile(), options.GetUsername(), options.GetPassword())
+	header, err := auth.MakeXRegistryAuthHeader(nil, options.GetAuthfile(), options.GetUsername(), options.GetPassword())
 	if err != nil {
 		return err
 	}
@@ -329,7 +329,7 @@ func Search(ctx context.Context, term string, options *SearchOptions) ([]entitie
 	}
 
 	// TODO: have a global system context we can pass around (1st argument)
-	header, err := auth.Header(nil, auth.XRegistryAuthHeader, options.GetAuthfile(), "", "")
+	header, err := auth.MakeXRegistryAuthHeader(nil, options.GetAuthfile(), "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/images/pull.go
+++ b/pkg/bindings/images/pull.go
@@ -42,7 +42,7 @@ func Pull(ctx context.Context, rawImage string, options *PullOptions) ([]string,
 	}
 
 	// TODO: have a global system context we can pass around (1st argument)
-	header, err := auth.Header(nil, auth.XRegistryAuthHeader, options.GetAuthfile(), options.GetUsername(), options.GetPassword())
+	header, err := auth.MakeXRegistryAuthHeader(nil, options.GetAuthfile(), options.GetUsername(), options.GetPassword())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/images/pull.go
+++ b/pkg/bindings/images/pull.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v3/pkg/auth"
 	"github.com/containers/podman/v3/pkg/bindings"
 	"github.com/containers/podman/v3/pkg/domain/entities"
@@ -42,7 +43,7 @@ func Pull(ctx context.Context, rawImage string, options *PullOptions) ([]string,
 	}
 
 	// TODO: have a global system context we can pass around (1st argument)
-	header, err := auth.MakeXRegistryAuthHeader(nil, options.GetAuthfile(), options.GetUsername(), options.GetPassword())
+	header, err := auth.MakeXRegistryAuthHeader(&types.SystemContext{AuthFilePath: options.GetAuthfile()}, options.GetUsername(), options.GetPassword())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/play/play.go
+++ b/pkg/bindings/play/play.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v3/pkg/auth"
 	"github.com/containers/podman/v3/pkg/bindings"
 	"github.com/containers/podman/v3/pkg/domain/entities"
@@ -40,7 +41,7 @@ func Kube(ctx context.Context, path string, options *KubeOptions) (*entities.Pla
 	}
 
 	// TODO: have a global system context we can pass around (1st argument)
-	header, err := auth.MakeXRegistryAuthHeader(nil, options.GetAuthfile(), options.GetUsername(), options.GetPassword())
+	header, err := auth.MakeXRegistryAuthHeader(&types.SystemContext{AuthFilePath: options.GetAuthfile()}, options.GetUsername(), options.GetPassword())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/play/play.go
+++ b/pkg/bindings/play/play.go
@@ -40,7 +40,7 @@ func Kube(ctx context.Context, path string, options *KubeOptions) (*entities.Pla
 	}
 
 	// TODO: have a global system context we can pass around (1st argument)
-	header, err := auth.Header(nil, auth.XRegistryAuthHeader, options.GetAuthfile(), options.GetUsername(), options.GetPassword())
+	header, err := auth.MakeXRegistryAuthHeader(nil, options.GetAuthfile(), options.GetUsername(), options.GetPassword())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This primarily fixes the incorrect normalization added in #11430 .

<s>That requires UNMERGED https://github.com/containers/image/pull/1373 </s>

<s>Separately I abuse this PR for testing UNMERGED and mostly unrelated https://github.com/containers/common/pull/763 .</s>

Also, this adds a lot of unit tests to the HTTP credential passing code, and proposes a fairly significant WIP refactoring. <s>Still outstanding:
- Remove unnecessary/redundant parameters to `auth.Make…Header` (at the very least don’t modify caller’s `SystemContext`)
- Split `auth.MakeXRegistryAuthHeader` yet further into two, to emphasize the exclusive sets of parameters instead of pretending to handle both.
</s>

See individual commit messages for details.