### PR TITLE
Fix #11444: remote breaks with stdout redirection

### DIFF
--- a/pkg/terminal/console_windows.go
+++ b/pkg/terminal/console_windows.go
@@ -25,7 +25,7 @@ func setConsoleMode(handle windows.Handle, flags uint32) error {
 	var mode uint32
 	err := windows.GetConsoleMode(handle, &mode)
 	if err != nil {
-		return err
+		return nil // not a terminal
 	}
 	if err := windows.SetConsoleMode(handle, mode|flags); err != nil {
 		// In similar code, it is not considered an error if we cannot set the


### PR DESCRIPTION
Fixes #11444.

`setConsoleMode` should do nothing if the handle is not a terminal. The proposed change is [exactly what `golang.org/x/term/IsTerminal()` does on Windows](https://cs.opensource.google/go/x/term/+/6886f2df:term_windows.go).