### PR TITLE
Show variant and codename of the distribution

### DIFF
--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -42,6 +42,7 @@ host:
   cpus: 8
   distribution:
     distribution: fedora
+    variant: workstation
     version: "34"
   eventLogger: journald
   hostname: localhost.localdomain

--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -78,7 +78,9 @@ type IDMappings struct {
 // for libpod
 type DistributionInfo struct {
 	Distribution string `json:"distribution"`
+	Variant      string `json:"variant,omitempty"`
 	Version      string `json:"version"`
+	Codename     string `json:"codename,omitempty"`
 }
 
 // ConmonInfo describes the conmon executable being used

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -370,8 +370,14 @@ func (r *Runtime) GetHostDistributionInfo() define.DistributionInfo {
 		if strings.HasPrefix(l.Text(), "ID=") {
 			dist.Distribution = strings.TrimPrefix(l.Text(), "ID=")
 		}
+		if strings.HasPrefix(l.Text(), "VARIANT_ID=") {
+			dist.Variant = strings.Trim(strings.TrimPrefix(l.Text(), "VARIANT_ID="), "\"")
+		}
 		if strings.HasPrefix(l.Text(), "VERSION_ID=") {
 			dist.Version = strings.Trim(strings.TrimPrefix(l.Text(), "VERSION_ID="), "\"")
+		}
+		if strings.HasPrefix(l.Text(), "VERSION_CODENAME=") {
+			dist.Codename = strings.Trim(strings.TrimPrefix(l.Text(), "VERSION_CODENAME="), "\"")
 		}
 	}
 	return dist


### PR DESCRIPTION
Along with the name (id) and the version(_id)

But only show the information if is available

Examples: Fedora CoreOS, Ubuntu Focal

```yaml
  distribution:
    distribution: fedora
    variant: coreos
    version: "34"
```

```yaml
  distribution:
    codename: focal
    distribution: ubuntu
    version: "20.04"
```

See: https://github.com/containers/podman/issues/11554#issuecomment-918513560