### PR TITLE
[v3.4] Revert "logs: adjust handling around partial log messages"

### DIFF
--- a/libpod/logs/log.go
+++ b/libpod/logs/log.go
@@ -251,19 +251,11 @@ func (l *LogLine) Write(stdout io.Writer, stderr io.Writer, logOpts *LogOptions)
 	switch l.Device {
 	case "stdout":
 		if stdout != nil {
-			if l.Partial() {
-				fmt.Fprint(stdout, l.String(logOpts))
-			} else {
-				fmt.Fprintln(stdout, l.String(logOpts))
-			}
+			fmt.Fprintln(stdout, l.String(logOpts))
 		}
 	case "stderr":
 		if stderr != nil {
-			if l.Partial() {
-				fmt.Fprint(stderr, l.String(logOpts))
-			} else {
-				fmt.Fprintln(stderr, l.String(logOpts))
-			}
+			fmt.Fprintln(stderr, l.String(logOpts))
 		}
 	default:
 		// Warn the user if the device type does not match. Most likely the file is corrupted.

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -624,11 +624,9 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 				if err != nil {
 					break
 				}
-				if !logLine.Partial() {
-					_, err = httpBuf.Write([]byte("\n"))
-					if err != nil {
-						break
-					}
+				_, err = httpBuf.Write([]byte("\n"))
+				if err != nil {
+					break
 				}
 				err = httpBuf.Flush()
 				if err != nil {

--- a/pkg/api/handlers/compat/containers_logs.go
+++ b/pkg/api/handlers/compat/containers_logs.go
@@ -153,7 +153,9 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 		}
 
 		frame.WriteString(line.Msg)
-		if !line.Partial() {
+		// Log lines in the compat layer require adding EOL
+		// https://github.com/containers/podman/issues/8058
+		if !utils.IsLibpodRequest(r) {
 			frame.WriteString("\n")
 		}
 

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -404,11 +404,11 @@ func (ic *ContainerEngine) ContainerLogs(_ context.Context, nameOrIDs []string, 
 			return err
 		case line := <-stdoutCh:
 			if opts.StdoutWriter != nil {
-				_, _ = io.WriteString(opts.StdoutWriter, line)
+				_, _ = io.WriteString(opts.StdoutWriter, line+"\n")
 			}
 		case line := <-stderrCh:
 			if opts.StderrWriter != nil {
-				_, _ = io.WriteString(opts.StderrWriter, line)
+				_, _ = io.WriteString(opts.StderrWriter, line+"\n")
 			}
 		}
 	}


### PR DESCRIPTION
This reverts commit 21f396de6f5024abbf6edd2ca63edcb1525eefcc.

Changing the log endpoint is a breaking change we should not do in 3.4.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
