### PR TITLE
libpod: honor --cgroups=split also with pods

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2495,9 +2495,6 @@ func (c *Container) getOCICgroupPath() (string, error) {
 		}
 		return c.config.CgroupParent, nil
 	case c.config.CgroupsMode == cgroupSplit:
-		if c.config.CgroupParent != "" {
-			return c.config.CgroupParent, nil
-		}
 		selfCgroup, err := utils.GetOwnCgroup()
 		if err != nil {
 			return "", err

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1295,31 +1295,42 @@ USER mail`, BB)
 		SkipIfRootlessCgroupsV1("Disable cgroups not supported on cgroupv1 for rootless users")
 		SkipIfRemote("--cgroups=split cannot be used in remote mode")
 
+		checkLines := func(lines []string) {
+			cgroup := ""
+			for _, line := range lines {
+				parts := strings.SplitN(line, ":", 3)
+				if len(parts) < 2 {
+					continue
+				}
+				if !CGROUPSV2 {
+					// ignore unified on cgroup v1.
+					// both runc and crun do not set it.
+					// crun does not set named hierarchies.
+					if parts[1] == "" || strings.Contains(parts[1], "name=") {
+						continue
+					}
+				}
+				if parts[2] == "/" {
+					continue
+				}
+				if cgroup == "" {
+					cgroup = parts[2]
+					continue
+				}
+				Expect(cgroup).To(Equal(parts[2]))
+			}
+		}
+
 		container := podmanTest.Podman([]string{"run", "--rm", "--cgroups=split", ALPINE, "cat", "/proc/self/cgroup"})
 		container.WaitWithDefaultTimeout()
 		Expect(container).Should(Exit(0))
-		lines := container.OutputToStringArray()
+		checkLines(container.OutputToStringArray())
 
-		cgroup := ""
-		for _, line := range lines {
-			parts := strings.SplitN(line, ":", 3)
-			if !CGROUPSV2 {
-				// ignore unified on cgroup v1.
-				// both runc and crun do not set it.
-				// crun does not set named hierarchies.
-				if parts[1] == "" || strings.Contains(parts[1], "name=") {
-					continue
-				}
-			}
-			if parts[2] == "/" {
-				continue
-			}
-			if cgroup == "" {
-				cgroup = parts[2]
-				continue
-			}
-			Expect(cgroup).To(Equal(parts[2]))
-		}
+		// check that --cgroups=split is honored also when a container runs in a pod
+		container = podmanTest.Podman([]string{"run", "--rm", "--pod", "new:split-test-pod", "--cgroups=split", ALPINE, "cat", "/proc/self/cgroup"})
+		container.WaitWithDefaultTimeout()
+		Expect(container).Should(Exit(0))
+		checkLines(container.OutputToStringArray())
 	})
 
 	It("podman run with cgroups=disabled runs without cgroups", func() {


### PR DESCRIPTION
Honor --cgroups=split also when the container is running in a pod.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
