### PR TITLE
build: take advantage of --platform lists

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -476,7 +476,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		runtimeFlags = append(runtimeFlags, "--systemd-cgroup")
 	}
 
-	imageOS, arch, err := parse.PlatformFromOptions(c)
+	platforms, err := parse.PlatformsFromOptions(c)
 	if err != nil {
 		return nil, err
 	}
@@ -490,7 +490,6 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		AddCapabilities:         flags.CapAdd,
 		AdditionalTags:          tags,
 		Annotations:             flags.Annotation,
-		Architecture:            arch,
 		Args:                    args,
 		BlobDirectory:           flags.BlobCache,
 		CNIConfigDir:            flags.CNIConfigDir,
@@ -516,11 +515,11 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 		MaxPullPushRetries:      3,
 		NamespaceOptions:        nsValues,
 		NoCache:                 flags.NoCache,
-		OS:                      imageOS,
 		OciDecryptConfig:        decConfig,
 		Out:                     stdout,
 		Output:                  output,
 		OutputFormat:            format,
+		Platforms:               platforms,
 		PullPolicy:              pullPolicy,
 		PullPushRetryDelay:      2 * time.Second,
 		Quiet:                   flags.Quiet,

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -220,6 +220,16 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 	if len(platform) > 0 {
 		params.Set("platform", platform)
 	}
+	if len(options.Platforms) > 0 {
+		params.Del("platform")
+		for _, platformSpec := range options.Platforms {
+			platform = platformSpec.OS + "/" + platformSpec.Arch
+			if platformSpec.Variant != "" {
+				platform += "/" + platformSpec.Variant
+			}
+			params.Add("platform", platform)
+		}
+	}
 
 	params.Set("pullpolicy", options.PullPolicy.String())
 


### PR DESCRIPTION
The builder can take a list of platforms in the Platforms field of its BuildOptions argument, and we should definitely take advantage of that.

The `bud-multiple-platform-values` test from buildah exercises support for this, so
[NO NEW TESTS NEEDED]