### PR TITLE
[CI:DOCS] Document `all` query parameter for /libpod/images/prune

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -1038,6 +1038,12 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// description: Remove images that are not being used by a container
 	// parameters:
 	//  - in: query
+	//    name: all
+	//    default: false
+	//    type: boolean
+	//    description: |
+	//      Remove all images not in use by containers, not just dangling ones
+	//  - in: query
 	//    name: filters
 	//    type: string
 	//    description: |


### PR DESCRIPTION
Signed-off-by: Jelle van der Waa <jvanderwaa@redhat.com>