### PR TITLE
api: handle nil pointer dereference in api endpoints

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -104,8 +104,12 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filterMap, err := util.PrepareFilters(r)
+	if err != nil {
+		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to decode filter parameters for %s", r.URL.String()))
+		return
+	}
 
-	if dErr := decoder.Decode(&query, r.URL.Query()); dErr != nil || err != nil {
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -73,8 +73,13 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filterMap, err := util.PrepareFilters(r)
+	if err != nil {
+		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+			errors.Wrapf(err, "failed to decode filter parameters for %s", r.URL.String()))
+		return
+	}
 
-	if dErr := decoder.Decode(&query, r.URL.Query()); dErr != nil || err != nil {
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -156,8 +156,14 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filterMap, err := util.PrepareFilters(r)
+	if err != nil {
+		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+			errors.
+				Wrapf(err, "failed to decode filter parameters for %s", r.URL.String()))
+		return
+	}
 
-	if dErr := decoder.Decode(&query, r.URL.Query()); dErr != nil || err != nil {
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
 			errors.
 				Wrapf(err, "failed to parse parameters for %s", r.URL.String()))

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -94,6 +94,10 @@ t GET libpod/images/json?filters='garb1age}' 500 \
 t GET libpod/images/json?filters='{"label":["testl' 500 \
     .cause="unexpected end of JSON input"
 
+# Prune images - bad all input
+t POST libpod/images/prune?all='garb1age' 500 \
+    .cause="schema: error converting value for \"all\""
+
 # Prune images - bad filter input
 t POST images/prune?filters='garb1age}' 500 \
     .cause="invalid character 'g' looking for beginning of value"

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -22,6 +22,10 @@ podman run $IMAGE true
 
 t GET libpod/containers/json 200 length=0
 
+# bad all input
+t GET libpod/containers/json?all='garb1age' 500 \
+    .cause="schema: error converting value for \"all\""
+
 t GET libpod/containers/json?all=true 200 \
   length=1 \
   .[0].Id~[0-9a-f]\\{64\\} \

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -327,6 +327,7 @@ function start_service() {
         die "Cannot start service on non-localhost ($HOST)"
     fi
 
+    echo $WORKDIR
     $PODMAN_BIN --root $WORKDIR/server_root --syslog=true \
                 system service \
                 --time 15 \


### PR DESCRIPTION
When `?all=garbage` is passed to /libpod/images/prune the schema
validation fails and err is nil, but is used in Wrapf causing a nil
pointer dereference.

Signed-off-by: Jelle van der Waa <jvanderwaa@redhat.com>