### PR TITLE
container runlabel remove image tag from name

### DIFF
--- a/pkg/domain/infra/abi/containers_runlabel.go
+++ b/pkg/domain/infra/abi/containers_runlabel.go
@@ -133,6 +133,9 @@ func generateRunlabelCommand(runlabel string, img *libimage.Image, inputName str
 		}
 		splitImageName := strings.Split(normalize, "/")
 		name = splitImageName[len(splitImageName)-1]
+		// make sure to remove the tag from the image name, otherwise the name cannot
+		// be used as container name because a colon is an illegal character
+		name = strings.SplitN(name, ":", 2)[0]
 	}
 
 	// Append the user-specified arguments to the runlabel (command).


### PR DESCRIPTION
When no name is given for podman container runlabel it will default to
the image base name. However this can contain a tag. Since podman does
not accept container names with a colon the run command will fail if it
contains something like `podman run --name NAME ...`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2004263

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
