### PR TITLE
Fix /auth compat endpoint

### DIFF
--- a/pkg/api/handlers/compat/auth.go
+++ b/pkg/api/handlers/compat/auth.go
@@ -50,9 +50,19 @@ func Auth(w http.ResponseWriter, r *http.Request) {
 			Status:        "Login Succeeded",
 		})
 	} else {
-		utils.WriteResponse(w, http.StatusBadRequest, entities.AuthReport{
-			IdentityToken: "",
-			Status:        "login attempt to " + authConfig.ServerAddress + " failed with status: " + err.Error(),
+		var msg string
+
+		var unauthErr DockerClient.ErrUnauthorizedForCredentials
+		if errors.As(err, &unauthErr) {
+			msg = "401 Unauthorized"
+		} else {
+			msg = err.Error()
+		}
+
+		utils.WriteResponse(w, http.StatusInternalServerError, struct {
+			Message string `json:"message"`
+		}{
+			Message: "login attempt to " + authConfig.ServerAddress + " failed with status: " + msg,
 		})
 	}
 }

--- a/test/apiv2/60-auth.at
+++ b/test/apiv2/60-auth.at
@@ -5,10 +5,15 @@
 
 start_registry
 
+# Test unreachable
+t POST /v1.40/auth username=$REGISTRY_USERNAME password=WrOnGPassWord serveraddress=does.not.exist.io:1234/ \
+  500 \
+  .message~'.*no such host.*'
+
 # Test with wrong password. Confirm bad status and appropriate error message
 t POST /v1.40/auth username=$REGISTRY_USERNAME password=WrOnGPassWord serveraddress=localhost:$REGISTRY_PORT/ \
-  400 \
-  .Status~'.* invalid username/password'
+  500 \
+  .message~'.* 401 Unauthorized'
 
 # Test with the right password. Confirm status message
 t POST /v1.40/auth username=$REGISTRY_USERNAME password=$REGISTRY_PASSWORD serveraddress=localhost:$REGISTRY_PORT/ \


### PR DESCRIPTION
Fix `/auth` Docker APIv2 endpoint to match `moby` behavior.
