### PR TITLE
Do not allow network modes to be used as network names

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -224,7 +224,8 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 		// FIXME can we use the IPAM driver and options?
 	}
 
-	network, err := runtime.Network().NetworkCreate(network)
+	ic := abi.ContainerEngine{Libpod: runtime}
+	newNetwork, err := ic.NetworkCreate(r.Context(), network)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
@@ -234,7 +235,7 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 		ID      string `json:"Id"`
 		Warning []string
 	}{
-		ID: network.ID,
+		ID: newNetwork.ID,
 	}
 	utils.WriteResponse(w, http.StatusCreated, body)
 }

--- a/pkg/api/handlers/libpod/networks.go
+++ b/pkg/api/handlers/libpod/networks.go
@@ -25,7 +25,7 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ic := abi.ContainerEngine{Libpod: runtime}
-	report, err := ic.Libpod.Network().NetworkCreate(network)
+	report, err := ic.NetworkCreate(r.Context(), network)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -59,7 +59,7 @@ type ContainerEngine interface {
 	HealthCheckRun(ctx context.Context, nameOrID string, options HealthCheckOptions) (*define.HealthCheckResults, error)
 	Info(ctx context.Context) (*define.Info, error)
 	NetworkConnect(ctx context.Context, networkname string, options NetworkConnectOptions) error
-	NetworkCreate(ctx context.Context, network types.Network) (*NetworkCreateReport, error)
+	NetworkCreate(ctx context.Context, network types.Network) (*types.Network, error)
 	NetworkDisconnect(ctx context.Context, networkname string, options NetworkDisconnectOptions) error
 	NetworkExists(ctx context.Context, networkname string) (*BoolReport, error)
 	NetworkInspect(ctx context.Context, namesOrIds []string, options InspectOptions) ([]types.Network, []error, error)

--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -107,12 +107,15 @@ func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, o
 	return reports, nil
 }
 
-func (ic *ContainerEngine) NetworkCreate(ctx context.Context, network types.Network) (*entities.NetworkCreateReport, error) {
+func (ic *ContainerEngine) NetworkCreate(ctx context.Context, network types.Network) (*types.Network, error) {
+	if util.StringInSlice(network.Name, []string{"none", "host", "bridge", "private", "slirp4netns", "container", "ns"}) {
+		return nil, errors.Errorf("cannot create network with name %q because it conflicts with a valid network mode", network.Name)
+	}
 	network, err := ic.Libpod.Network().NetworkCreate(network)
 	if err != nil {
 		return nil, err
 	}
-	return &entities.NetworkCreateReport{Name: network.Name}, nil
+	return &network, nil
 }
 
 // NetworkDisconnect removes a container from a given network

--- a/pkg/domain/infra/tunnel/network.go
+++ b/pkg/domain/infra/tunnel/network.go
@@ -62,12 +62,12 @@ func (ic *ContainerEngine) NetworkRm(ctx context.Context, namesOrIds []string, o
 	return reports, nil
 }
 
-func (ic *ContainerEngine) NetworkCreate(ctx context.Context, net types.Network) (*entities.NetworkCreateReport, error) {
+func (ic *ContainerEngine) NetworkCreate(ctx context.Context, net types.Network) (*types.Network, error) {
 	net, err := network.Create(ic.ClientCtx, &net)
 	if err != nil {
 		return nil, err
 	}
-	return &entities.NetworkCreateReport{Name: net.Name}, nil
+	return &net, nil
 }
 
 // NetworkDisconnect removes a container from a given network

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -343,4 +343,13 @@ var _ = Describe("Podman network create", func() {
 		Expect(nc.OutputToString()).ToNot(ContainSubstring("dnsname"))
 	})
 
+	It("podman network create with invalid name", func() {
+		for _, name := range []string{"none", "host", "bridge", "private", "slirp4netns", "container", "ns"} {
+			nc := podmanTest.Podman([]string{"network", "create", name})
+			nc.WaitWithDefaultTimeout()
+			Expect(nc).To(Exit(125))
+			Expect(nc.ErrorToString()).To(ContainSubstring("cannot create network with name %q because it conflicts with a valid network mode", name))
+		}
+	})
+
 })


### PR DESCRIPTION
`podman network create` should not allow users to create networks with a
name which is already used for a network mode in `podman run --network`.

Fixes #11448

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
