### PR TITLE
Add no-trunc support to podman-events

### DIFF
--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -62,7 +62,8 @@ func mountFlags(cmd *cobra.Command) {
 	flags.StringVar(&mountOpts.Format, formatFlagName, "", "Print the mounted containers in specified format (json)")
 	_ = cmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(nil))
 
-	flags.BoolVar(&mountOpts.NoTruncate, "notruncate", false, "Do not truncate output")
+	flags.BoolVar(&mountOpts.NoTruncate, "no-trunc", false, "Do not truncate output")
+	flags.SetNormalizeFunc(utils.AliasFlags)
 }
 
 func init() {

--- a/cmd/podman/images/history.go
+++ b/cmd/podman/images/history.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/common/pkg/report"
 	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/registry"
+	"github.com/containers/podman/v3/cmd/podman/utils"
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
@@ -73,8 +74,8 @@ func historyFlags(cmd *cobra.Command) {
 
 	flags.BoolVarP(&opts.human, "human", "H", true, "Display sizes and dates in human readable format")
 	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Do not truncate the output")
-	flags.BoolVar(&opts.noTrunc, "notruncate", false, "Do not truncate the output")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Display the numeric IDs only")
+	flags.SetNormalizeFunc(utils.AliasFlags)
 }
 
 func history(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -36,6 +36,7 @@ var (
 var (
 	eventOptions entities.EventsOptions
 	eventFormat  string
+	noTrunc      bool
 )
 
 func init() {
@@ -57,6 +58,8 @@ func init() {
 	sinceFlagName := "since"
 	flags.StringVar(&eventOptions.Since, sinceFlagName, "", "show all events created since timestamp")
 	_ = eventsCommand.RegisterFlagCompletionFunc(sinceFlagName, completion.AutocompleteNone)
+
+	flags.BoolVar(&noTrunc, "no-trunc", true, "do not truncate the output")
 
 	untilFlagName := "until"
 	flags.StringVar(&eventOptions.Until, untilFlagName, "", "show all events until timestamp")
@@ -110,7 +113,7 @@ func eventsCmd(cmd *cobra.Command, _ []string) error {
 			}
 			fmt.Println("")
 		default:
-			fmt.Println(event.ToHumanReadable())
+			fmt.Println(event.ToHumanReadable(!noTrunc))
 		}
 	}
 

--- a/cmd/podman/utils/alias.go
+++ b/cmd/podman/utils/alias.go
@@ -23,6 +23,8 @@ func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "external"
 	case "purge":
 		name = "rm"
+	case "notruncate":
+		name = "no-trunc"
 	case "override-arch":
 		name = "arch"
 	case "override-os":

--- a/docs/source/markdown/podman-auto-update.1.md
+++ b/docs/source/markdown/podman-auto-update.1.md
@@ -41,7 +41,7 @@ If the authorization state is not found there, `$HOME/.docker/config.json` is ch
 
 Note: There is also the option to override the default path of the authentication file by setting the `REGISTRY_AUTH_FILE` environment variable. This can be done with **export REGISTRY_AUTH_FILE=_path_**.
 
-#### **--dry-run**=*true|false*
+#### **--dry-run**
 
 Check for the availability of new images but do not perform any pull operation or restart any service or container.
 The `UPDATED` field indicates the availability of a new image with "pending".
@@ -51,7 +51,7 @@ The `UPDATED` field indicates the availability of a new image with "pending".
 Change the default output format.  This can be of a supported type like 'json' or a Go template.
 Valid placeholders for the Go template are listed below:
 
-#### **--rollback**=*true|false*
+#### **--rollback**
 
 If restarting a systemd unit after updating the image has failed, rollback to using the previous image and restart the unit another time.  Default is true.
 

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -292,7 +292,7 @@ context.
 
 If you specify `-f -`, the Containerfile contents will be read from stdin.
 
-#### **--force-rm**=*true|false*
+#### **--force-rm**
 
 Always remove intermediate containers after a build, even if the build fails
 (default true).
@@ -474,7 +474,7 @@ Suppress output messages which indicate which instruction is being processed,
 and of progress when pulling images from a registry, and when writing the
 output image.
 
-#### **--rm**=*true|false*
+#### **--rm**
 
 Remove intermediate containers after a successful build (default true).
 
@@ -579,7 +579,7 @@ specified and therefore not changed, allowing the image's sha256 hash to remain 
 same. All files committed to the layers of the image will be created with the
 timestamp.
 
-#### **--tls-verify**=*true|false*
+#### **--tls-verify**
 
 Require HTTPS and verify certificates when talking to container registries
 (defaults to true). (This option is not available with the remote Podman client)

--- a/docs/source/markdown/podman-cp.1.md
+++ b/docs/source/markdown/podman-cp.1.md
@@ -56,7 +56,7 @@ Further note that `podman cp` does not support globbing (e.g., `cp dir/*.txt`). 
 
 ## OPTIONS
 
-#### **--archive**, **-a**=**true** | *false*
+#### **--archive**, **-a**
 
 Archive mode (copy all uid/gid information).
 When set to true, files copied to a container will have changed ownership to the primary UID/GID of the container.

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -346,7 +346,7 @@ This option allows arbitrary environment variables that are available for the pr
 
 See [**Environment**](#environment) note below for precedence and examples.
 
-#### **--env-host**=*true|false*
+#### **--env-host**
 
 Use host environment inside of the container. See **Environment** note below for precedence. (This option is not available with the remote Podman client)
 
@@ -414,7 +414,7 @@ Sets the container host name that is available inside the container. Can only be
 
 Print usage statement
 
-#### **--http-proxy**=*true|false*
+#### **--http-proxy**
 
 By default proxy environment variables are passed into the container if set
 for the Podman process. This can be disabled by setting the `--http-proxy`
@@ -465,7 +465,7 @@ pod when that pod is not running.
 
 Path to the container-init binary.
 
-#### **--interactive**, **-i**=*true|false*
+#### **--interactive**, **-i**
 
 Keep STDIN open even if not attached. The default is *false*.
 
@@ -684,18 +684,18 @@ Valid _mode_ values are:
 
 Add network-scoped alias for the container
 
-#### **--no-healthcheck**=*true|false*
+#### **--no-healthcheck**
 
 Disable any defined healthchecks for container.
 
-#### **--no-hosts**=*true|false*
+#### **--no-hosts**
 
 Do not create /etc/hosts for the container.
 By default, Podman will manage /etc/hosts, adding the container's own IP address and any hosts from **--add-host**.
 #### **--no-hosts** disables this, and the image's **/etc/host** will be preserved unmodified.
 This option conflicts with **--add-host**.
 
-#### **--oom-kill-disable**=*true|false*
+#### **--oom-kill-disable**
 
 Whether to disable OOM Killer for the container or not.
 
@@ -737,7 +737,7 @@ To make a pod with more granular options, use the `podman pod create` command be
 
 Run container in an existing pod and read the pod's ID from the specified file. If a container is run within a pod, and the pod has an infra-container, the infra-container will be started before the container is.
 
-#### **--privileged**=*true|false*
+#### **--privileged**
 
 Give extended privileges to this container. The default is *false*.
 
@@ -776,7 +776,7 @@ associated ports. If one container binds to a port, no other container can use t
 within the pod while it is in use. Containers in the pod can also communicate over localhost
 by having one container bind to localhost in the pod, and another connect to that port.
 
-#### **--publish-all**, **-P**=*true|false*
+#### **--publish-all**, **-P**
 
 Publish all exposed ports to random ports on the host interfaces. The default is *false*.
 
@@ -801,7 +801,7 @@ Defaults to *missing*.
 
 Suppress output information when pulling images
 
-#### **--read-only**=*true|false*
+#### **--read-only**
 
 Mount the container's root filesystem as read only.
 
@@ -809,11 +809,11 @@ By default a container will have its root filesystem writable allowing processes
 to write files anywhere. By specifying the `--read-only` flag the container will have
 its root filesystem mounted as read only prohibiting any writes.
 
-#### **--read-only-tmpfs**=*true|false*
+#### **--read-only-tmpfs**
 
 If container is running in --read-only mode, then mount a read-write tmpfs on /run, /tmp, and /var/tmp. The default is *true*
 
-#### **--replace**=**true**|**false**
+#### **--replace**
 
 If another container with the same name already exists, replace and remove it. The default is **false**.
 
@@ -839,7 +839,7 @@ Please note that restart will not restart containers after a system reboot.
 If this functionality is required in your environment, you can invoke Podman from a systemd unit file, or create an init script for whichever init system is in use.
 To generate systemd unit files, please see *podman generate systemd*
 
-#### **--rm**=*true|false*
+#### **--rm**
 
 Automatically remove the container when it exits. The default is *false*.
 
@@ -1001,7 +1001,7 @@ Maximum time a container is allowed to run before conmon sends it the kill
 signal.  By default containers will run until they exit or are stopped by
 `podman stop`.
 
-#### **--tls-verify**=**true**|**false**
+#### **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true, then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified, TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
@@ -1018,7 +1018,7 @@ options are the same as the Linux default `mount` flags. If you do not specify
 any options, the systems uses the following options:
 `rw,noexec,nosuid,nodev`.
 
-#### **--tty**, **-t**=*true|false*
+#### **--tty**, **-t**
 
 Allocate a pseudo-TTY. The default is *false*.
 

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -93,6 +93,10 @@ filters are supported:
 
 In the case where an ID is used, the ID may be in its full or shortened form.
 
+#### **--no-trunc**
+
+Do not truncate the output (default *true*).
+
 #### **--since**=*timestamp*
 
 Show all events created since the given timestamp

--- a/docs/source/markdown/podman-exec.1.md
+++ b/docs/source/markdown/podman-exec.1.md
@@ -30,7 +30,7 @@ command to be executed.
 
 Read in a line delimited file of environment variables.
 
-#### **--interactive**, **-i**=*true|false*
+#### **--interactive**, **-i**
 
 When set to true, keep stdin open even if not attached. The default is *false*.
 

--- a/docs/source/markdown/podman-history.1.md
+++ b/docs/source/markdown/podman-history.1.md
@@ -29,19 +29,15 @@ Valid placeholders for the Go template are listed below:
 
 ## OPTIONS
 
-#### **--human**, **-H**=*true|false*
+#### **--human**, **-H**
 
 Display sizes and dates in human readable format (default *true*).
 
-#### **--no-trunc**=*true|false*
+#### **--no-trunc**
 
 Do not truncate the output (default *false*).
 
-#### **--notruncate**
-
-Do not truncate the output
-
-#### **--quiet**, **-q**=*true|false*
+#### **--quiet**, **-q**
 
 Print the numeric IDs only (default *false*).
 #### **--format**=*format*

--- a/docs/source/markdown/podman-images.1.md
+++ b/docs/source/markdown/podman-images.1.md
@@ -35,13 +35,13 @@ Filter output based on conditions provided
   **before=IMAGE**
     Filter on images created before the given IMAGE (name or tag).
 
-  **dangling=true|false**
+  **dangling
     Show dangling images. Dangling images are a file system layer that was used in a previous build of an image and is no longer referenced by any image. They are denoted with the `<none>` tag, consume disk space and serve no active purpose.
 
   **label**
     Filter by images labels key and/or value.
 
-  **readonly=true|false**
+  **readonly
      Show only read only images or Read/Write images. The default is to show both.  Read/Only images can be configured by modifying the  "additionalimagestores" in the /etc/containers/storage.conf file.
 
   **reference=**
@@ -74,13 +74,13 @@ Omit the table headings from the listing of images.
 
 #### **--no-trunc**
 
-Do not truncate output.
+Do not truncate the output (default *false*).
 
 #### **--quiet**, **-q**
 
 Lists only the image IDs.
 
-#### **--sort**=*sort*
+#### **--sort**=*sort*=*created*
 
 Sort by created, id, repository, size or tag (default: created)
 

--- a/docs/source/markdown/podman-login.1.md
+++ b/docs/source/markdown/podman-login.1.md
@@ -56,7 +56,7 @@ Password for registry
 
 Take the password from stdin
 
-#### **--tls-verify**=*true|false*
+#### **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,

--- a/docs/source/markdown/podman-mount.1.md
+++ b/docs/source/markdown/podman-mount.1.md
@@ -40,9 +40,9 @@ Instead of providing the container name or ID, use the last created container.
 If you use methods other than Podman to run containers such as CRI-O, the last
 started container could be from either of those methods. (This option is not available with the remote Podman client)
 
-#### **--notruncate**
+#### **--no-trunc**
 
-Do not truncate IDs in output.
+Do not truncate the output (default *false*).
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -146,11 +146,11 @@ Suppress output information when pulling images
 
 Directory path for seccomp profiles (default: "/var/lib/kubelet/seccomp"). (This option is not available with the remote Podman client)
 
-#### **--start**=*true|false*
+#### **--start**
 
 Start the pod after creating it, set to false to only create it.
 
-#### **--tls-verify**=*true|false*
+#### **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -78,7 +78,7 @@ Print usage statement.
 
 Set a hostname to the pod
 
-#### **--infra**=**true**|**false**
+#### **--infra**
 
 Create an infra container and associate it with the pod. An infra container is a lightweight container used to coordinate the shared kernel namespace of a pod. Default: true.
 
@@ -143,7 +143,7 @@ Set network mode for the pod. Supported values are:
 
 Add a DNS alias for the container. When the container is joined to a CNI network with support for the dnsname plugin, the container will be accessible through this name from other containers in the network.
 
-#### **--no-hosts**=**true**|**false**
+#### **--no-hosts**
 
 Disable creation of /etc/hosts for the pod.
 
@@ -170,7 +170,7 @@ Use `podman port` to see the actual mapping: `podman port CONTAINER $CONTAINERPO
 
 NOTE: This cannot be modified once the pod is created.
 
-#### **--replace**=**true**|**false**
+#### **--replace**
 
 If another pod with the same name already exists, replace and remove it.  The default is **false**.
 

--- a/docs/source/markdown/podman-pod-ps.1.md
+++ b/docs/source/markdown/podman-pod-ps.1.md
@@ -50,7 +50,7 @@ Omit the table headings from the listing of pods.
 
 #### **--no-trunc**
 
-Display the extended information
+Do not truncate the output (default *false*).
 
 #### **--ns**
 

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -106,7 +106,7 @@ Omit the table headings from the listing of containers.
 
 #### **--no-trunc**
 
-Display the extended information
+Do not truncate the output (default *false*).
 
 #### **--pod**, **-p**
 
@@ -116,11 +116,10 @@ Display the pods the containers are associated with
 
 Print the numeric IDs of the containers only
 
-#### **--sort**
+#### **--sort**=*created*
 
 Sort by command, created, id, image, names, runningfor, size, or status",
 Note: Choosing size will sort by size of rootFs, not alphabetically like the rest of the options
-Default: created
 
 #### **--size**, **-s**
 

--- a/docs/source/markdown/podman-pull.1.md
+++ b/docs/source/markdown/podman-pull.1.md
@@ -95,7 +95,7 @@ Specify the platform for selecting the image. The `--platform` option can be use
 
 Suppress output information when pulling images
 
-#### **--tls-verify**=*true|false*
+#### **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,

--- a/docs/source/markdown/podman-push.1.md
+++ b/docs/source/markdown/podman-push.1.md
@@ -97,7 +97,7 @@ Discard any pre-existing signatures in the image. (This option is not available 
 
 Add a signature at the destination using the specified key. (This option is not available with the remote Podman client)
 
-#### **--tls-verify**=*true|false*
+#### **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -270,7 +270,7 @@ Memory nodes (MEMs) in which to allow execution. Only effective on NUMA systems.
 For example, if you have four memory nodes (0-3) on your system, use **--cpuset-mems=0,1**
 to only use memory from the first two memory nodes.
 
-#### **--detach**, **-d**=**true**|**false**
+#### **--detach**, **-d**
 
 Detached mode: run the container in the background and print the new container ID. The default is *false*.
 
@@ -381,7 +381,7 @@ This option allows arbitrary environment variables that are available for the pr
 
 See [**Environment**](#environment) note below for precedence and examples.
 
-#### **--env-host**=**true**|**false**
+#### **--env-host**
 
 Use host environment inside of the container. See **Environment** note below for precedence. (This option is not available with the remote Podman client)
 
@@ -456,7 +456,7 @@ Container host name
 
 Sets the container host name that is available inside the container. Can only be used with a private UTS namespace `--uts=private` (default). If `--pod` is specified and the pod shares the UTS namespace (default) the pod's hostname will be used.
 
-#### **--http-proxy**=**true**|**false**
+#### **--http-proxy**
 
 By default proxy environment variables are passed into the container if set
 for the Podman process. This can be disabled by setting the value to **false**.
@@ -488,7 +488,7 @@ Run an init inside the container that forwards signals and reaps processes.
 
 Path to the container-init binary.
 
-#### **--interactive**, **-i**=**true**|**false**
+#### **--interactive**, **-i**
 
 When set to **true**, keep stdin open even if not attached. The default is **false**.
 
@@ -704,11 +704,11 @@ Valid _mode_ values are:
 
 Add network-scoped alias for the container
 
-#### **--no-healthcheck**=*true|false*
+#### **--no-healthcheck**
 
 Disable any defined healthchecks for container.
 
-#### **--no-hosts**=**true**|**false**
+#### **--no-hosts**
 
 Do not create _/etc/hosts_ for the container.
 
@@ -716,7 +716,7 @@ By default, Podman will manage _/etc/hosts_, adding the container's own IP addre
 #### **--no-hosts** disables this, and the image's _/etc/hosts_ will be preserved unmodified.
 This option conflicts with **--add-host**.
 
-#### **--oom-kill-disable**=**true**|**false**
+#### **--oom-kill-disable**
 
 Whether to disable OOM Killer for the container or not.
 
@@ -766,7 +766,7 @@ If a container is run within a pod, and the pod has an infra-container, the infr
 Pass down to the process N additional file descriptors (in addition to 0, 1, 2).
 The total FDs will be 3+N. (This option is not available with the remote Podman client)
 
-#### **--privileged**=**true**|**false**
+#### **--privileged**
 
 Give extended privileges to this container. The default is **false**.
 
@@ -804,7 +804,7 @@ associated ports. If one container binds to a port, no other container can use t
 within the pod while it is in use. Containers in the pod can also communicate over localhost
 by having one container bind to localhost in the pod, and another connect to that port.
 
-#### **--publish-all**, **-P**=**true**|**false**
+#### **--publish-all**, **-P**
 
 Publish all exposed ports to random ports on the host interfaces. The default is **false**.
 
@@ -829,7 +829,7 @@ Pull image before running. The default is **missing**.
 
 Suppress output information when pulling images
 
-#### **--read-only**=**true**|**false**
+#### **--read-only**
 
 Mount the container's root filesystem as read only.
 
@@ -837,11 +837,11 @@ By default a container will have its root filesystem writable allowing processes
 to write files anywhere. By specifying the **--read-only** flag, the container will have
 its root filesystem mounted as read only prohibiting any writes.
 
-#### **--read-only-tmpfs**=**true**|**false**
+#### **--read-only-tmpfs**
 
 If container is running in **--read-only** mode, then mount a read-write tmpfs on _/run_, _/tmp_, and _/var/tmp_. The default is **true**.
 
-#### **--replace**=**true**|**false**
+#### **--replace**
 
 If another container with the same name already exists, replace and remove it. The default is **false**.
 
@@ -867,11 +867,11 @@ Please note that restart will not restart containers after a system reboot.
 If this functionality is required in your environment, you can invoke Podman from a **systemd.unit**(5) file, or create an init script for whichever init system is in use.
 To generate systemd unit files, please see **podman generate systemd**.
 
-#### **--rm**=**true**|**false**
+#### **--rm**
 
 Automatically remove the container when it exits. The default is **false**.
 
-#### **--rmi**=*true|false*
+#### **--rmi**
 
 After exit of the container, remove the image unless another
 container is using it. The default is *false*.
@@ -974,7 +974,7 @@ Size of _/dev/shm_. A _unit_ can be **b** (bytes), **k** (kilobytes), **m** (meg
 If you omit the unit, the system uses bytes. If you omit the size entirely, the default is **64m**.
 When _size_ is **0**, there is no limit on the amount of memory used for IPC by the container.
 
-#### **--sig-proxy**=**true**|**false**
+#### **--sig-proxy**
 
 Sets whether the signals sent to the **podman run** command are proxied to the container process. SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is **true**.
 
@@ -1058,7 +1058,7 @@ Maximum time a container is allowed to run before conmon sends it the kill
 signal.  By default containers will run until they exit or are stopped by
 `podman stop`.
 
-#### **--tls-verify**=**true**|**false**
+#### **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true, then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified, TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
@@ -1077,7 +1077,7 @@ options are the same as the Linux default mount flags. If you do not specify
 any options, the systems uses the following options:
 **rw,noexec,nosuid,nodev**.
 
-#### **--tty**, **-t**=**true**|**false**
+#### **--tty**, **-t**
 
 Allocate a pseudo-TTY. The default is **false**.
 

--- a/docs/source/markdown/podman-search.1.md
+++ b/docs/source/markdown/podman-search.1.md
@@ -81,9 +81,9 @@ The result contains the Image name and its tag, one line for every tag associate
 
 #### **--no-trunc**
 
-Do not truncate the output
+Do not truncate the output (default *false*).
 
-#### **--tls-verify**=*true|false*
+#### **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used if needed. If not specified,

--- a/docs/source/markdown/podman-start.1.md
+++ b/docs/source/markdown/podman-start.1.md
@@ -34,7 +34,7 @@ Attach container's STDIN. The default is false.
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client)
 
-#### **--sig-proxy**=*true|false*
+#### **--sig-proxy**
 
 Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true* when attaching, *false* otherwise.
 

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -152,7 +152,7 @@ specify additional options via the `--storage-opt` flag.
 
 Storage driver option, Default storage driver options are configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode). The `STORAGE_OPTS` environment variable overrides the default. The --storage-opt specified options overrides all. If you specify --storage-opt="", no storage options will be used.
 
-#### **--syslog**=*true|false*
+#### **--syslog**
 
 Output logging information to syslog as well as the console (default *false*).
 

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/containers/storage/pkg/stringid"
 	"github.com/hpcloud/tail"
 	"github.com/pkg/errors"
 )
@@ -65,11 +66,15 @@ func (e *Event) ToJSONString() (string, error) {
 }
 
 // ToHumanReadable returns human readable event as a formatted string
-func (e *Event) ToHumanReadable() string {
+func (e *Event) ToHumanReadable(truncate bool) string {
 	var humanFormat string
+	id := e.ID
+	if truncate {
+		id = stringid.TruncateID(id)
+	}
 	switch e.Type {
 	case Container, Pod:
-		humanFormat = fmt.Sprintf("%s %s %s %s (image=%s, name=%s", e.Time, e.Type, e.Status, e.ID, e.Image, e.Name)
+		humanFormat = fmt.Sprintf("%s %s %s %s (image=%s, name=%s", e.Time, e.Type, e.Status, id, e.Image, e.Name)
 		// check if the container has labels and add it to the output
 		if len(e.Attributes) > 0 {
 			for k, v := range e.Attributes {
@@ -78,9 +83,9 @@ func (e *Event) ToHumanReadable() string {
 		}
 		humanFormat += ")"
 	case Network:
-		humanFormat = fmt.Sprintf("%s %s %s %s (container=%s, name=%s)", e.Time, e.Type, e.Status, e.ID, e.ID, e.Network)
+		humanFormat = fmt.Sprintf("%s %s %s %s (container=%s, name=%s)", e.Time, e.Type, e.Status, id, id, e.Network)
 	case Image:
-		humanFormat = fmt.Sprintf("%s %s %s %s %s", e.Time, e.Type, e.Status, e.ID, e.Name)
+		humanFormat = fmt.Sprintf("%s %s %s %s %s", e.Time, e.Type, e.Status, id, e.Name)
 	case System:
 		humanFormat = fmt.Sprintf("%s %s %s", e.Time, e.Type, e.Status)
 	case Volume:

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -63,7 +63,7 @@ func (e EventJournalD) Write(ee Event) error {
 	case Volume:
 		m["PODMAN_NAME"] = ee.Name
 	}
-	return journal.Send(string(ee.ToHumanReadable()), journal.PriInfo, m)
+	return journal.Send(string(ee.ToHumanReadable(false)), journal.PriInfo, m)
 }
 
 // Read reads events from the journal and sends qualified events to the event channel

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Podman mount", func() {
 		Expect(setup).Should(Exit(0))
 		cid := setup.OutputToString()
 
-		lmount := podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount := podmanTest.Podman([]string{"mount", "--no-trunc"})
 		lmount.WaitWithDefaultTimeout()
 		Expect(lmount).Should(Exit(0))
 		Expect(lmount.OutputToString()).To(Equal(""))
@@ -178,7 +178,7 @@ var _ = Describe("Podman mount", func() {
 		mount.WaitWithDefaultTimeout()
 		Expect(mount).Should(Exit(0))
 
-		lmount = podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount = podmanTest.Podman([]string{"mount", "--no-trunc"})
 		lmount.WaitWithDefaultTimeout()
 		Expect(lmount).Should(Exit(0))
 		Expect(lmount.OutputToString()).To(ContainSubstring(cid))
@@ -195,7 +195,7 @@ var _ = Describe("Podman mount", func() {
 		Expect(setup).Should(Exit(0))
 		cid := setup.OutputToString()
 
-		lmount := podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount := podmanTest.Podman([]string{"mount", "--no-trunc"})
 		lmount.WaitWithDefaultTimeout()
 		Expect(lmount).Should(Exit(0))
 		Expect(lmount.OutputToString()).To(ContainSubstring(cid))
@@ -204,7 +204,7 @@ var _ = Describe("Podman mount", func() {
 		stop.WaitWithDefaultTimeout()
 		Expect(stop).Should(Exit(0))
 
-		lmount = podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount = podmanTest.Podman([]string{"mount", "--no-trunc"})
 		lmount.WaitWithDefaultTimeout()
 		Expect(lmount).Should(Exit(0))
 		Expect(lmount.OutputToString()).To(Equal(""))
@@ -227,7 +227,7 @@ var _ = Describe("Podman mount", func() {
 		Expect(setup).Should(Exit(0))
 		cid3 := setup.OutputToString()
 
-		lmount := podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount := podmanTest.Podman([]string{"mount", "--no-trunc"})
 		lmount.WaitWithDefaultTimeout()
 		Expect(lmount).Should(Exit(0))
 		Expect(lmount.OutputToString()).To(Equal(""))
@@ -236,7 +236,7 @@ var _ = Describe("Podman mount", func() {
 		mount.WaitWithDefaultTimeout()
 		Expect(mount).Should(Exit(0))
 
-		lmount = podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount = podmanTest.Podman([]string{"mount", "--no-trunc"})
 		lmount.WaitWithDefaultTimeout()
 		Expect(lmount).Should(Exit(0))
 		Expect(lmount.OutputToString()).To(ContainSubstring(cid1))
@@ -247,7 +247,7 @@ var _ = Describe("Podman mount", func() {
 		umount.WaitWithDefaultTimeout()
 		Expect(umount).Should(Exit(0))
 
-		lmount = podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount = podmanTest.Podman([]string{"mount", "--no-trunc"})
 		lmount.WaitWithDefaultTimeout()
 		Expect(lmount).Should(Exit(0))
 		Expect(lmount.OutputToString()).To(Equal(""))
@@ -261,7 +261,7 @@ var _ = Describe("Podman mount", func() {
 		Expect(setup).Should(Exit(0))
 		cid := setup.OutputToString()
 
-		lmount := podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount := podmanTest.Podman([]string{"mount", "--no-trunc"})
 		lmount.WaitWithDefaultTimeout()
 		Expect(lmount).Should(Exit(0))
 		Expect(lmount.OutputToString()).To(Equal(""))
@@ -270,6 +270,7 @@ var _ = Describe("Podman mount", func() {
 		mount.WaitWithDefaultTimeout()
 		Expect(mount).Should(Exit(0))
 
+		// test --notruncate alias
 		lmount = podmanTest.Podman([]string{"mount", "--notruncate"})
 		lmount.WaitWithDefaultTimeout()
 		Expect(lmount).Should(Exit(0))

--- a/test/e2e/run_cleanup_test.go
+++ b/test/e2e/run_cleanup_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Podman run exit", func() {
 		Expect(mount).Should(Exit(0))
 		Expect(mount.OutputToString()).To(ContainSubstring(cid))
 
-		pmount := podmanTest.Podman([]string{"mount", "--notruncate"})
+		pmount := podmanTest.Podman([]string{"mount", "--no-trunc"})
 		pmount.WaitWithDefaultTimeout()
 		Expect(pmount).Should(Exit(0))
 		Expect(pmount.OutputToString()).To(ContainSubstring(cid))
@@ -64,7 +64,7 @@ var _ = Describe("Podman run exit", func() {
 		Expect(mount).Should(Exit(0))
 		Expect(mount.OutputToString()).NotTo(ContainSubstring(cid))
 
-		pmount = podmanTest.Podman([]string{"mount", "--notruncate"})
+		pmount = podmanTest.Podman([]string{"mount", "--no-trunc"})
 		pmount.WaitWithDefaultTimeout()
 		Expect(pmount).Should(Exit(0))
 		Expect(pmount.OutputToString()).NotTo(ContainSubstring(cid))

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -25,6 +25,23 @@ load helpers
     is "$output" "$expect" "filtering just by label"
 }
 
+@test "truncate events" {
+    cname=test-$(random_string 30 | tr A-Z a-z)
+    labelname=$(random_string 10)
+    labelvalue=$(random_string 15)
+
+    run_podman run -d --name=$cname --rm $IMAGE echo hi
+    id="$output"
+
+    expect="$id"
+    run_podman events --filter container=$cname --filter event=start --stream=false
+    is "$output" ".* $id " "filtering by container name full id"
+
+    truncID=$(expr substr "$id" 1 12)
+    run_podman events --filter container=$cname --filter event=start --stream=false --no-trunc=false
+    is "$output" ".* $truncID " "filtering by container name trunc id"
+}
+
 @test "image events" {
     skip_if_remote "remote does not support --events-backend"
     pushedDir=$PODMAN_TMPDIR/dir


### PR DESCRIPTION
Standardize on no-trunc through the code.
Alias notruncate where necessary.

Standardize on the man page display of no-trunc.

Fixes: https://github.com/containers/podman/issues/8941

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
