### PR TITLE
Only add 127.0.0.1 entry to /etc/hosts with --net=none

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2033,15 +2033,16 @@ func (c *Container) getHosts() string {
 
 		// Do we have a network namespace?
 		netNone := false
-		for _, ns := range c.config.Spec.Linux.Namespaces {
-			if ns.Type == spec.NetworkNamespace {
-				if ns.Path == "" && !c.config.CreateNetNS {
-					netNone = true
+		if c.config.NetNsCtr == "" && !c.config.CreateNetNS {
+			for _, ns := range c.config.Spec.Linux.Namespaces {
+				if ns.Type == spec.NetworkNamespace {
+					if ns.Path == "" {
+						netNone = true
+					}
+					break
 				}
-				break
 			}
 		}
-
 		// If we are net=none (have a network namespace, but not connected to
 		// anything) add the container's name and hostname to localhost.
 		if netNone {

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -709,6 +709,18 @@ var _ = Describe("Podman run networking", func() {
 		Expect(strings.Contains(run.OutputToString(), hostname)).To(BeTrue())
 	})
 
+	It("podman run with pod does not add extra 127 entry to /etc/hosts", func() {
+		pod := "testpod"
+		hostname := "test-hostname"
+		run := podmanTest.Podman([]string{"pod", "create", "--hostname", hostname, "--name", pod})
+		run.WaitWithDefaultTimeout()
+		Expect(run).Should(Exit(0))
+		run = podmanTest.Podman([]string{"run", "--pod", pod, ALPINE, "cat", "/etc/hosts"})
+		run.WaitWithDefaultTimeout()
+		Expect(run).Should(Exit(0))
+		Expect(run.OutputToString()).ToNot(ContainSubstring("127.0.0.1 %s", hostname))
+	})
+
 	ping_test := func(netns string) {
 		hostname := "testctr"
 		run := podmanTest.Podman([]string{"run", netns, "--hostname", hostname, ALPINE, "ping", "-c", "1", hostname})


### PR DESCRIPTION
The check for net=none was wrong. It just assumed when we do not create
the netns but have one set that we use the none mode. This however also
applies to a container which joins the pod netns.
To correctly check for the none mode use `config.NetMode.IsNone()`.

Fixes #11596


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
