### PR TITLE
runtime: move pause process to scope

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -35,6 +35,7 @@ import (
 	"github.com/containers/podman/v3/pkg/rootless"
 	"github.com/containers/podman/v3/pkg/systemd"
 	"github.com/containers/podman/v3/pkg/util"
+	"github.com/containers/podman/v3/utils"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/docker/docker/pkg/namesgenerator"
@@ -543,6 +544,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 				return err
 			}
 			if became {
+				utils.MovePauseProcessToScope(pausePid)
 				os.Exit(ret)
 			}
 		}

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -3,12 +3,10 @@ package abi
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v3/libpod/define"
@@ -114,14 +112,7 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool) 
 	}
 
 	became, ret, err = rootless.TryJoinFromFilePaths(pausePidPath, true, paths)
-
-	if err := movePauseProcessToScope(pausePidPath); err != nil {
-		if utils.RunsOnSystemd() {
-			logrus.Warnf("Failed to add pause process to systemd sandbox cgroup: %v", err)
-		} else {
-			logrus.Debugf("Failed to add pause process to systemd sandbox cgroup: %v", err)
-		}
-	}
+	utils.MovePauseProcessToScope(pausePidPath)
 	if err != nil {
 		logrus.Error(errors.Wrapf(err, "invalid internal status, try resetting the pause process with %q", os.Args[0]+" system migrate"))
 		os.Exit(1)
@@ -130,19 +121,6 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool) 
 		os.Exit(ret)
 	}
 	return nil
-}
-
-func movePauseProcessToScope(pausePidPath string) error {
-	data, err := ioutil.ReadFile(pausePidPath)
-	if err != nil {
-		return errors.Wrapf(err, "cannot read pause pid file")
-	}
-	pid, err := strconv.ParseUint(string(data), 10, 0)
-	if err != nil {
-		return errors.Wrapf(err, "cannot parse pid file %s", pausePidPath)
-	}
-
-	return utils.RunUnderSystemdScope(int(pid), "user.slice", "podman-pause.scope")
 }
 
 // SystemPrune removes unused data from the system. Pruning pods, containers, volumes and images.

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/containers/common/pkg/config"
-	"github.com/containers/podman/v3/libpod"
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/cgroups"
 	"github.com/containers/podman/v3/pkg/domain/entities"
@@ -121,7 +120,7 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool) 
 
 	became, ret, err = rootless.TryJoinFromFilePaths(pausePidPath, true, paths)
 
-	if err := movePauseProcessToScope(ic.Libpod); err != nil {
+	if err := movePauseProcessToScope(pausePidPath); err != nil {
 		conf, err2 := ic.Config(context.Background())
 		if err2 != nil {
 			return err
@@ -142,15 +141,7 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, noMoveProcess bool) 
 	return nil
 }
 
-func movePauseProcessToScope(r *libpod.Runtime) error {
-	tmpDir, err := r.TmpDir()
-	if err != nil {
-		return err
-	}
-	pausePidPath, err := util.GetRootlessPauseProcessPidPathGivenDir(tmpDir)
-	if err != nil {
-		return errors.Wrapf(err, "could not get pause process pid file path")
-	}
+func movePauseProcessToScope(pausePidPath string) error {
 	data, err := ioutil.ReadFile(pausePidPath)
 	if err != nil {
 		return errors.Wrapf(err, "cannot read pause pid file")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/storage/pkg/archive"
@@ -154,4 +156,19 @@ func RemoveScientificNotationFromFloat(x float64) (float64, error) {
 		return x, errors.Wrapf(err, "unable to remove scientific number from calculations")
 	}
 	return result, nil
+}
+
+var (
+	runsOnSystemdOnce sync.Once
+	runsOnSystemd     bool
+)
+
+// RunsOnSystemd returns whether the system is using systemd
+func RunsOnSystemd() bool {
+	runsOnSystemdOnce.Do(func() {
+		initCommand, err := ioutil.ReadFile("/proc/1/comm")
+		// On errors, default to systemd
+		runsOnSystemd = err != nil || strings.TrimRight(string(initCommand), "\n") == "systemd"
+	})
+	return runsOnSystemd
 }


### PR DESCRIPTION
make sure the pause process is moved to its own scope as well as what we do when we join an existing user+mount namespace.

Closes: https://github.com/containers/podman/issues/11560

[NO TESTS NEEDED]

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
