### PR TITLE
[CI:DOCS] html docs: fix broken links

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,3 +21,4 @@ clean:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	find $(BUILDDIR) -name 'podman*.html' | xargs sed -ie 's/\(href="podman[^"]\+\)\.md"/\1.html"/'


### PR DESCRIPTION
sphinx generates broken links pointing to foo.md. Change all
of those to foo.html.

Signed-off-by: Ed Santiago <santiago@redhat.com>
