### PR TITLE
[CI:DOCS] Implement PR template to assist review & release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,41 @@
 <!--
 Thanks for sending a pull request!
 
-Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).
+Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).
 
 In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
+
+Finally, be sure to sign commits with your real name.  Since by opening
+a PR you already have commits, you can add signatures if needed with
+something like `git commit -s --amend`.
 -->
+
+#### What this PR does / why we need it:
+
+<!---
+Please put your overall PR description here
+-->
+
+#### How to verify it
+
+<!---
+Please specify the precise conditions and/or the specific test(s) which must pass.
+-->
+
+#### Which issue(s) this PR fixes:
+
+<!--
+Please uncomment this block and include only one of the following on a
+line by itself:
+
+None
+
+-OR-
+
+Fixes #<issue number>
+
+*** Please also put 'Fixes #' in the commit and PR description***
+
+-->
+
+#### Special notes for your reviewer:


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This duplicates the template used for buildah.  The intention
is to make it immediately clear to reviewers:

* The intended/basic purpose of the PR (also machine readable)
* Why are changes being proposed
* If there are any specific items need additional checking or scrutiny
* What should go into the release-notes (if anything).

#### How to verify it

You can't, it will only take effect on all new PRs after this one is merged.

#### Which issue(s) this PR fixes:

This was talked about and requested ages ago during a team meeting.  Recently I smelled it's ripened enough to be plucked off my TODO list :grin: 

#### Special notes for your reviewer:

You can see the rendered markdown, by click the **view file** link in the github WebUI under the **files changed** tab

#### Does this PR introduce a user-facing change?

None