### PR TITLE
[NO TESTS NEEDED] Add username flag for machine ssh

### DIFF
--- a/docs/source/markdown/podman-machine-ssh.1.md
+++ b/docs/source/markdown/podman-machine-ssh.1.md
@@ -4,7 +4,7 @@
 podman\-machine\-ssh - SSH into a virtual machine
 
 ## SYNOPSIS
-**podman machine ssh** [*name*] [*command* [*arg* ...]]
+**podman machine ssh** [*options*] [*name*] [*command* [*arg* ...]]
 
 ## DESCRIPTION
 
@@ -20,6 +20,10 @@ with the virtual machine is established.
 #### **--help**
 
 Print usage statement.
+
+#### **--username**=*name*
+
+Username to use when SSH-ing into the VM.
 
 ## EXAMPLES
 


### PR DESCRIPTION
allow users to specify what username to use when ssh-ing into the vm

[NO TESTS NEEDED] 

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
