### PR TITLE
[CI:DOCS] markdown cleanup

### DIFF
--- a/docs/source/markdown/podman-inspect.1.md
+++ b/docs/source/markdown/podman-inspect.1.md
@@ -13,14 +13,10 @@ all results in a JSON array. If the inspect type is all, the order of inspection
  So, if a container has the same name as an image, then the container JSON will be returned, and so on.
  If a format is specified, the given template will be executed for each result.
 
-For more inspection options, see:
-
-      podman container inspect
-      podman image inspect
-      podman network inspect
-      podman pod inspect
-      podman volume inspect
-
+For more inspection options, see also
+[podman-network-inspect(1)](podman-network-inspect.1.md),
+[podman-pod-inspect(1)](podman-pod-inspect.1.md), and
+[podman-volume-inspect(1)](podman-volume-inspect.1.md).
 
 ## OPTIONS
 

--- a/docs/source/markdown/podman-pull.1.md
+++ b/docs/source/markdown/podman-pull.1.md
@@ -234,7 +234,7 @@ Storing signatures
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-push(1)](podman-push.1.md)**, **[podman-login(1)](podman-login.1.md)**, **[containers-certs.d(5](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**, **[containers-registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.d.5.md)**, **[containers-transports(5)](https://github.com/containers/image/blob/main/docs/containers-transports.5.md)**
+**[podman(1)](podman.1.md)**, **[podman-push(1)](podman-push.1.md)**, **[podman-login(1)](podman-login.1.md)**, **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**, **[containers-registries.conf(5)](https://github.com/containers/image/blob/main/docs/containers-registries.d.5.md)**, **[containers-transports(5)](https://github.com/containers/image/blob/main/docs/containers-transports.5.md)**
 
 ## HISTORY
 July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/source/markdown/podman-search.1.md
+++ b/docs/source/markdown/podman-search.1.md
@@ -169,7 +169,7 @@ Note: This works only with registries that implement the v2 API. If tried with a
 
 **registries.conf** (`/etc/containers/registries.conf`)
 
-	registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
+registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
 podman(1), containers-registries.conf(5)

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -276,7 +276,7 @@ the exit codes follow the `chroot` standard, see below:
 
 **containers.conf** (`/usr/share/containers/containers.conf`, `/etc/containers/containers.conf`, `$HOME/.config/containers/containers.conf`)
 
-    Podman has builtin defaults for command line options. These defaults can be overridden using the containers.conf configuration files.
+Podman has builtin defaults for command line options. These defaults can be overridden using the containers.conf configuration files.
 
 Distributions ship the `/usr/share/containers/containers.conf` file with their default settings. Administrators can override fields in this file by creating the `/etc/containers/containers.conf` file.  Users can further modify defaults by creating the `$HOME/.config/containers/containers.conf` file. Podman merges its builtin defaults with the specified fields from these files, if they exist. Fields specified in the users file override the administrator's file, which overrides the distribution's file, which override the built-in defaults.
 
@@ -286,31 +286,31 @@ If the **CONTAINERS_CONF** environment variable is set, then its value is used f
 
 **mounts.conf** (`/usr/share/containers/mounts.conf`)
 
-    The mounts.conf file specifies volume mount directories that are automatically mounted inside containers when executing the `podman run` or `podman start` commands. Administrators can override the defaults file by creating `/etc/containers/mounts.conf`.
+The mounts.conf file specifies volume mount directories that are automatically mounted inside containers when executing the `podman run` or `podman start` commands. Administrators can override the defaults file by creating `/etc/containers/mounts.conf`.
 
 When Podman runs in rootless mode, the file `$HOME/.config/containers/mounts.conf` will override the default if it exists. Please refer to containers-mounts.conf(5) for further details.
 
 **policy.json** (`/etc/containers/policy.json`)
 
-    Signature verification policy files are used to specify policy, e.g. trusted keys, applicable when deciding whether to accept an image, or individual signatures of that image, as valid.
+Signature verification policy files are used to specify policy, e.g. trusted keys, applicable when deciding whether to accept an image, or individual signatures of that image, as valid.
 
 **registries.conf** (`/etc/containers/registries.conf`, `$HOME/.config/containers/registries.conf`)
 
-    registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
+registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
-    Non root users of Podman can create the `$HOME/.config/containers/registries.conf` file to be used instead of the system defaults.
+Non root users of Podman can create the `$HOME/.config/containers/registries.conf` file to be used instead of the system defaults.
 
-    If the **CONTAINERS_REGISTRIES_CONF** environment variable is set, then its value is used for the registries.conf file rather than the default.
+If the **CONTAINERS_REGISTRIES_CONF** environment variable is set, then its value is used for the registries.conf file rather than the default.
 
 **storage.conf** (`/etc/containers/storage.conf`, `$HOME/.config/containers/storage.conf`)
 
-    storage.conf is the storage configuration file for all tools using containers/storage
+storage.conf is the storage configuration file for all tools using containers/storage
 
-    The storage configuration file specifies all of the available container storage options for tools using shared container storage.
+The storage configuration file specifies all of the available container storage options for tools using shared container storage.
 
-    When Podman runs in rootless mode, the file `$HOME/.config/containers/storage.conf` is used instead of the system defaults.
+When Podman runs in rootless mode, the file `$HOME/.config/containers/storage.conf` is used instead of the system defaults.
 
-    If the **CONTAINERS_STORAGE_CONF** environment variable is set, the its value is used for the storage.conf file rather than the default.
+If the **CONTAINERS_STORAGE_CONF** environment variable is set, the its value is used for the storage.conf file rather than the default.
 
 ## Rootless mode
 Podman can also be used as non-root user. When podman runs in rootless mode, a user namespace is automatically created for the user, defined in /etc/subuid and /etc/subgid.


### PR DESCRIPTION
* podman-inspect: make references be live links, not a static
  list. Also, remove container- and image-inspect, because
  those are NOPs.

* podman-pull: add a missing right-paren

* podman-search, podman: remove unwanted indentation from
  some file descriptions. Markdown indentation renders as
  one very very long line, requiring the user to use a
  horizontal scroll bar to read the text. I searched
  using grep '^    ' and eyeball-looking for text that
  doesn't look like one-line code examples, and see
  no more, but eyeball checks are fragile.

One bug remains: MyST renders mailto: links uglily. I can find
no way to fix this other than patching the source code.

Signed-off-by: Ed Santiago <santiago@redhat.com>
