### PR TITLE
[NO TESTS NEEDED] Remind user to check connection or use podman machine

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -92,6 +92,11 @@ func Execute() {
 		if registry.GetExitCode() == 0 {
 			registry.SetExitCode(define.ExecErrorCodeGeneric)
 		}
+		if registry.IsRemote() {
+			if strings.Contains(err.Error(), "unable to connect to Podman") {
+				fmt.Fprintln(os.Stderr, "Cannot connect to Podman. Please verify your connection to the Linux system using `podman system connection list`, or try `podman machine init` and `podman machine start` to manage a new Linux VM")
+			}
+		}
 		fmt.Fprintln(os.Stderr, formatError(err))
 	}
 	os.Exit(registry.GetExitCode())

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -112,12 +112,12 @@ func NewConnectionWithIdentity(ctx context.Context, uri string, identity string)
 		return nil, errors.Errorf("unable to create connection. %q is not a supported schema", _url.Scheme)
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create %sClient", _url.Scheme)
+		return nil, errors.Wrapf(err, "unable to connect to Podman. failed to create %sClient", _url.Scheme)
 	}
 
 	ctx = context.WithValue(ctx, clientKey, &connection)
 	if err := pingNewConnection(ctx); err != nil {
-		return nil, errors.Wrap(err, "cannot connect to the Podman socket, please verify the connection to the Linux system, or use `podman machine` to create/start a Linux VM.")
+		return nil, errors.Wrap(err, "unable to connect to Podman socket")
 	}
 	return ctx, nil
 }


### PR DESCRIPTION
~~Change error message to be more helpful when trying to run a remote
command by reminding the user to start their podman machine vm.~~

Remind user to check their remote linux connection or use podman
machine. Move the warning from bindings to cmd/podman.


Fixes #11419

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
