### PR TITLE
[WIP] Introduce unix socket proxying for Docker API clients

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -29,6 +29,7 @@ var (
 	initOpts           = machine.InitOptions{}
 	defaultMachineName = "podman-machine-default"
 	now                bool
+	nocompat           bool
 )
 
 func init() {
@@ -70,6 +71,18 @@ func init() {
 		"Start machine now",
 	)
 
+	flags.BoolVar(
+		&nocompat,
+		"nocompat", false,
+		"Disable compatibility socket proxies when starting",
+	)
+
+	flags.BoolVar(
+		&initOpts.NoLink,
+		"nolink", false,
+		"Do not link /var/run/docker.sock",
+	)
+
 	ImagePathFlagName := "image-path"
 	flags.StringVar(&initOpts.ImagePath, ImagePathFlagName, cfg.Engine.MachineImage, "Path to qcow image")
 	_ = initCmd.RegisterFlagCompletionFunc(ImagePathFlagName, completion.AutocompleteDefault)
@@ -105,7 +118,7 @@ func initMachine(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if now {
-		err = vm.Start(initOpts.Name, machine.StartOptions{})
+		err = vm.Start(initOpts.Name, machine.StartOptions{NoCompat: nocompat, NoLink: initOpts.NoLink})
 		if err == nil {
 			fmt.Printf("Machine %q started successfully\n", initOpts.Name)
 		}

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -3,8 +3,6 @@
 package machine
 
 import (
-	"fmt"
-
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/pkg/machine"
 	"github.com/containers/podman/v3/pkg/machine/qemu"
@@ -14,7 +12,7 @@ import (
 
 var (
 	startCmd = &cobra.Command{
-		Use:               "start [MACHINE]",
+		Use:               "start [options] [MACHINE]",
 		Short:             "Start an existing machine",
 		Long:              "Start a managed virtual machine ",
 		RunE:              start,
@@ -22,6 +20,8 @@ var (
 		Example:           `podman machine start myvm`,
 		ValidArgsFunction: autocompleteMachine,
 	}
+
+	startOptions machine.StartOptions
 )
 
 func init() {
@@ -29,6 +29,9 @@ func init() {
 		Command: startCmd,
 		Parent:  machineCmd,
 	})
+	flags := startCmd.Flags()
+	flags.BoolVar(&startOptions.NoCompat, "nocompat", false, "Disable Docker API compatibility socket proxies")
+	flags.BoolVar(&startOptions.NoLink, "nolink", false, "Do not link /var/run/docker.sock",)
 }
 
 func start(cmd *cobra.Command, args []string) error {
@@ -60,9 +63,8 @@ func start(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := vm.Start(vmName, machine.StartOptions{}); err != nil {
+	if err := vm.Start(vmName, startOptions); err != nil {
 		return err
 	}
-	fmt.Printf("Machine %q started successfully\n", vmName)
 	return nil
 }

--- a/cmd/podman/system/umask_noop.go
+++ b/cmd/podman/system/umask_noop.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package system
+
+func umask(mask int) int {
+	return 0
+}

--- a/cmd/podman/system/umask_unix.go
+++ b/cmd/podman/system/umask_unix.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package system
+
+import "syscall"
+
+func umask(mask int) int {
+	return syscall.Umask(mask)
+}

--- a/cmd/podman/system/unixproxy.go
+++ b/cmd/podman/system/unixproxy.go
@@ -1,0 +1,249 @@
+package system
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/containers/common/pkg/completion"
+	"github.com/containers/podman/v3/cmd/podman/common"
+	"github.com/containers/podman/v3/cmd/podman/registry"
+	"github.com/containers/podman/v3/pkg/bindings"
+	"github.com/containers/podman/v3/pkg/rootless"
+	"github.com/containers/podman/v3/pkg/util"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh"
+)
+
+var (
+	unixProxyDescription = `Proxy a remote podman service
+
+	Proxies a remote podman service over a local unix domain socket.
+`
+
+	upCmd = &cobra.Command{
+		Use:               "unix-proxy [options] [URI]",
+		Args:              cobra.MaximumNArgs(1),
+		Short:             "Proxies a remote podman service over a local unix domain socket",
+		Long:              unixProxyDescription,
+		RunE:              proxy,
+		ValidArgsFunction: common.AutocompleteDefaultOneArg,
+		Example:           `podman system unix-proxy unix:///tmp/podman.sock`,
+	}
+
+	upArgs = struct {
+		PidFile string
+		Quiet   bool
+	}{}
+)
+
+type CloseWriteStream interface {
+	io.Reader
+	io.WriteCloser
+	CloseWrite() error
+}
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: upCmd,
+		Parent:  systemCmd,
+	})
+
+	flags := upCmd.Flags()
+
+	flags.StringVarP(&upArgs.PidFile, "pid-file", "", "", "File to save PID")
+	_ = upCmd.RegisterFlagCompletionFunc("pid-file", completion.AutocompleteNone)
+	flags.BoolVarP(&upArgs.Quiet, "quiet", "q", false, "Suppress printed output")
+	_ = upCmd.RegisterFlagCompletionFunc("quiet", completion.AutocompleteNone)
+}
+
+func proxy(cmd *cobra.Command, args []string) error {
+	apiURI, err := resolveUnixURI(args)
+	if err != nil {
+		return err
+	}
+	logrus.Infof("using API endpoint: '%s'", apiURI)
+	// Clean up any old existing unix domain socket
+	var uri *url.URL
+	if len(apiURI) > 0 {
+		var err error
+		uri, err = url.Parse(apiURI)
+		if err != nil {
+			return err
+		}
+
+		// socket activation uses a unix:// socket in the shipped unit files but apiURI is coded as "" at this layer.
+		if uri.Scheme == "unix" {
+			if err := os.Remove(uri.Path); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		} else {
+			return errors.Errorf("Only unix domain sockets are supported as a proxy address: %s", uri)
+		}
+	}
+
+	if len(upArgs.PidFile) > 0 {
+		f, err := os.Create(upArgs.PidFile)
+		if err != nil {
+			errors.Wrap(err, "Error creating pid")
+		}
+		defer os.Remove(upArgs.PidFile)
+		pid := os.Getpid()
+		if _, err := f.WriteString(strconv.Itoa(pid)); err != nil {
+			errors.Wrap(err, "Error creating pid")
+		}
+	}
+
+	return setupProxy(uri)
+}
+
+func connectForward(bastion *bindings.Bastion) (CloseWriteStream, error) {
+	for retries := 1; ; retries++ {
+		forward, err := bastion.Client.Dial("unix", bastion.URI.Path)
+		if err == nil {
+			return forward.(ssh.Channel), nil
+		}
+		// Check if ssh connection is still alive
+		_, _, err2 := bastion.Client.Conn.SendRequest("alive@podman", true, nil)
+		if err2 != nil || retries > 2 {
+			// couldn't reconnect ssh tunnel, or the destination is unreachable
+			return nil, errors.Wrapf(err, "Couldn't reestablish ssh connection: %s", bastion.URI)
+		}
+
+		bastion.Reconnect()
+	}
+}
+
+func listenUnix(socketURI *url.URL) (net.Listener, error) {
+	oldmask := umask(0177)
+	defer umask(oldmask)
+	listener, err := net.Listen("unix", socketURI.Path)
+	if err != nil {
+		return listener, errors.Wrapf(err, "Error listening on socket: %s", socketURI.Path)
+	}
+
+	return listener, nil
+}
+
+func setupProxy(socketURI *url.URL) error {
+	cfg := registry.PodmanConfig()
+
+	uri, err := url.Parse(cfg.URI)
+	if err != nil {
+		return errors.Wrapf(err, "Not a valid url: %s", uri)
+	}
+
+	if uri.Scheme != "ssh" {
+		return errors.Errorf("Only ssh is supported, specify another connection: %s", uri)
+	}
+
+	bastion, err := bindings.CreateBastion(uri, "", cfg.Identity)
+	defer bastion.Client.Close()
+	if err != nil {
+		return err
+	}
+
+	printfOrQuiet("SSH Bastion connected: %s\n", uri)
+
+	listener, err := listenUnix(socketURI)
+	if err != nil {
+		return errors.Wrapf(err, "Error listening on socket: %s", socketURI.Path)
+	}
+	defer listener.Close()
+
+	printfOrQuiet("Listening on: %s\n", socketURI)
+
+	for {
+		acceptConnection(listener, &bastion, socketURI)
+	}
+}
+
+func printfOrQuiet(format string, a ...interface{}) (n int, err error) {
+	if !upArgs.Quiet {
+		return fmt.Printf(format, a...)
+	}
+
+	return 0, nil
+}
+
+func acceptConnection(listener net.Listener, bastion *bindings.Bastion, socketURI *url.URL) error {
+	con, err := accept(listener)
+	if err != nil {
+		return errors.Wrapf(err, "Error accepting on socket: %s", socketURI.Path)
+	}
+
+	src, ok := con.(CloseWriteStream)
+	if !ok {
+		con.Close()
+		return errors.Wrapf(err, "Underlying socket does not support half-close %s", socketURI.Path)
+	}
+
+	dest, err := connectForward(bastion)
+	if err != nil {
+		con.Close()
+		logrus.Error(err)
+		return nil // eat
+	}
+
+	go forward(src, dest)
+	go forward(dest, src)
+
+	return nil
+}
+
+func backOff(delay time.Duration) time.Duration {
+	if delay == 0 {
+		delay = 5 * time.Millisecond
+	} else {
+		delay *= 2
+	}
+	if delay > time.Second {
+		delay = time.Second
+	}
+	return delay
+}
+
+func accept(listener net.Listener) (net.Conn, error) {
+	con, err := listener.Accept()
+	delay := time.Duration(0)
+	if ne, ok := err.(net.Error); ok && ne.Temporary() {
+		delay = backOff(delay)
+		time.Sleep(delay)
+	}
+	return con, err
+}
+
+func forward(src io.Reader, dest CloseWriteStream) {
+	defer dest.CloseWrite()
+	io.Copy(dest, src)
+}
+
+func resolveUnixURI(_url []string) (string, error) {
+	socketName := "podman-remote.sock"
+
+	if len(_url) > 0 && _url[0] != "" {
+		return _url[0], nil
+	}
+
+	xdg, err := util.GetRuntimeDir()
+	if rootless.IsRootless() {
+		xdg = os.TempDir()
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	socketPath := filepath.Join(xdg, "podman", socketName)
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0700); err != nil {
+		return "", err
+	}
+	return "unix:" + socketPath, nil
+}

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -1,3 +1,4 @@
+//go:build (amd64 && !windows) || (arm64 && !windows)
 // +build amd64,!windows arm64,!windows
 
 package machine
@@ -21,6 +22,7 @@ type InitOptions struct {
 	IsDefault    bool
 	Memory       uint64
 	Name         string
+	NoLink       bool
 	URI          url.URL
 	Username     string
 }
@@ -64,7 +66,10 @@ type SSHOptions struct {
 	Username string
 	Args     []string
 }
-type StartOptions struct{}
+type StartOptions struct {
+	NoCompat bool
+	NoLink   bool
+}
 
 type StopOptions struct{}
 


### PR DESCRIPTION
Consider this PR a proposal to generate discussion. Should everyone decide this is the direction to go I can clean it up and add tests.

### Overview

The main goal of this proposal is to add support for clients (such as testcontainers) that do not support ssh (or if they do (e.g. docker compose), they do not support podman's style of ssh which rightly appends the unix socket path to the URI: docker ~~doesn't support unix domain sockets over ssh, only~~ only supports the usage of the host defined default sock or tcp/tls connections nested under ssh)

To achieve this, this PR introduces a new command `podman system unix-proxy`, which operates similarly to podman system service, but instead creates a unix domain socket that points to the specified connection entry (e.g. via -c or the default), provided that connection entry is an ssh destination.

Additionally, it modifies docker machine start to automatically launch two child processes (one for rootless, one for rootful), unless `--nocompat is specified`. It then prints the DOCKER_HOST settings to the screen, so that the user can cut and paste (assumes bash atm). 

Additionally, `init` and `start` will create a symlink to the root socket. This acquires root privileges via sudo on the first usage (reusing thereafter until moby or some other provider reclaims it). This can be disabled by passing --nolink.

Since the proxy is long-running, there is some logic in this patch to auto-reconnect and retry.

### Challenges / Thoughts

- gvproxy is currently noisy, so in the process of waiting for connection availability, which requires polling the connection, it can generate scary looking logs. The machine start code in this patch adds a 1 second sleep to try to hide some of these, but it's marginally effective at suppressing the noise. 
- I am interested in discussions around the security impact of this. My thinking is that it is no less secure than what is achievable via podman connection entries, since the files are created with a umask of 1777, as is the case with the podman system service handler 
- There seems to be a short delay on the first SSH connections (~1 second), this might be related to /dev/random entropy and key negotiation, but I did not dive into that. 
- **Windows Support** - A future PR will add windows support specifics, and possibly named pipe support since unfortunately moby has not yet added support for Windows AF_UNIX


### Example Output (Using compatibility mode)
 ./bin/darwin/podman machine start
INFO[0000] waiting for clients...                       
INFO[0000] listening tcp://0.0.0.0:7777                 
INFO[0000] new connection from  to /var/folders/5p/1gyddrwn4cj6w3ccfy8bj4kr0000gs/T/podman/qemu_podman-machine-default.sock 
Waiting for VM ...
Waiting on SSH to come up..
Waiting on initial proxy connections..
Machine "podman-machine-default" started successfully!

Podman Clients
--------------
Podman clients can now access this machine using standard podman commands.
For example, to run a date command on a *rootless* container:

    podman run ubi8/ubi-micro date

To bind port 80 using a *root* container:

    podman -c podman-machine-default-root run -dt -p 80:80/tcp docker.io/library/httpd

Docker API Clients
------------------
Compatibility socket link is present. Docker API clients require no special environment for *root* containers.

Docker API clients can also access *rootless* podman with the following environment:

    export DOCKER_HOST=unix:///var/folders/5p/1gyddrwn4cj6w3ccfy8bj4kr0000gs/T/podman/podman-machine-default-api.sock