### PR TITLE
Add podman machine init --now option

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -3,6 +3,8 @@
 package machine
 
 import (
+	"fmt"
+
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/pkg/machine"
@@ -26,6 +28,7 @@ var (
 var (
 	initOpts           = machine.InitOptions{}
 	defaultMachineName = "podman-machine-default"
+	now                bool
 )
 
 func init() {
@@ -61,6 +64,12 @@ func init() {
 	)
 	_ = initCmd.RegisterFlagCompletionFunc(memoryFlagName, completion.AutocompleteNone)
 
+	flags.BoolVar(
+		&now,
+		"now", false,
+		"Start machine now",
+	)
+
 	ImagePathFlagName := "image-path"
 	flags.StringVar(&initOpts.ImagePath, ImagePathFlagName, cfg.Engine.MachineImage, "Path to qcow image")
 	_ = initCmd.RegisterFlagCompletionFunc(ImagePathFlagName, completion.AutocompleteDefault)
@@ -91,5 +100,15 @@ func initMachine(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return vm.Init(initOpts)
+	err = vm.Init(initOpts)
+	if err != nil {
+		return err
+	}
+	if now {
+		err = vm.Start(initOpts.Name, machine.StartOptions{})
+		if err == nil {
+			fmt.Printf("Machine %q started successfully\n", initOpts.Name)
+		}
+	}
+	return err
 }

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -47,6 +47,10 @@ Defaults to `testing`.
 
 Memory (in MB).
 
+#### **--now**
+
+Start the virtual machine immediately after it has been initialized.
+
 #### **--help**
 
 Print usage statement.


### PR DESCRIPTION
Once we have this option, the new documentation from users becomes
a little simpler.

brew install podman
podman machine init --now
podman run ...

--now option is based off of `systemctl enable XYZ.service --now`

[NO TESTS NEEDED] The infrastructure has not been setup yet to test
podman machine init.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
