### PR TITLE
Add support for :U flag with --mount option

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -595,6 +595,8 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
        type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
 
+       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
+
        type=volume,source=vol1,destination=/path/in/container,ro=true
 
        type=tmpfs,tmpfs-size=512M,destination=/path/in/container
@@ -613,6 +615,8 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      · ro, readonly: true or false (default).
 
+        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
        Options specific to image:
 
 	      · rw, readwrite: true or false (default).
@@ -627,6 +631,8 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      . relabel: shared, private.
 
+        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
        Options specific to tmpfs:
 
 	      · ro, readonly: true or false (default).
@@ -639,6 +645,7 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      · notmpcopyup: Disable copying files from the image to the tmpfs.
 
+        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
 
 #### **--name**=*name*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -615,6 +615,8 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
        type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
 
+       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
+
        type=volume,source=vol1,destination=/path/in/container,ro=true
 
        type=tmpfs,tmpfs-size=512M,destination=/path/in/container
@@ -633,6 +635,8 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      · ro, readonly: true or false (default).
 
+        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
        Options specific to image:
 
 	      · rw, readwrite: true or false (default).
@@ -647,6 +651,8 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      . relabel: shared, private.
 
+        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
        Options specific to tmpfs:
 
 	      · ro, readonly: true or false (default).
@@ -658,6 +664,8 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 	      · tmpcopyup: Enable copyup from the image directory at the same location to the tmpfs. Used by default.
 
 	      · notmpcopyup: Disable copying files from the image to the tmpfs.
+
+        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
 
 #### **--name**=*name*
 


### PR DESCRIPTION
The :U flag can be used to change the ownership of source volumes based on
the UID, GID of the container. This is only supported by the --volume option,
this will allow to use --mount option as well.

Fix #11491 

Signed-off-by: Eduardo Vega <edvegavalerio@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
