### PR TITLE
utils: raise warning only on cgroupv2

### DIFF
--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -47,10 +47,10 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 		// On errors check if the cgroup already exists, if it does move the process there
 		if props, err := conn.GetUnitTypeProperties(unitName, "Scope"); err == nil {
 			if cgroup, ok := props["ControlGroup"].(string); ok && cgroup != "" {
-				if err := moveUnderCgroup(cgroup, "", []uint32{uint32(pid)}); err != nil {
-					return err
+				if err := moveUnderCgroup(cgroup, "", []uint32{uint32(pid)}); err == nil {
+					return nil
 				}
-				return nil
+				// On errors return the original error message we got from StartTransientUnit.
 			}
 		}
 		return err


### PR DESCRIPTION
if it is not running on cgroup v2, print only a debug message since rootless users cannot create the cgroup.

commit 9c1e27fdd536f6026efe3da4360755a3e9135ca8 introduced the regression.
  
[NO TESTS NEEDED]

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

