### PR TITLE
remote untag: support digests

### DIFF
--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -165,6 +165,9 @@ func (ir *ImageEngine) Untag(ctx context.Context, nameOrID string, tags []string
 		if t, ok := ref.(reference.Tagged); ok {
 			tag = t.Tag()
 		}
+		if t, ok := ref.(reference.Digested); ok {
+			tag += "@" + t.Digest().String()
+		}
 		if r, ok := ref.(reference.Named); ok {
 			repo = r.Name()
 		}

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -57,6 +57,9 @@ function setup() {
 
     # Now untag the digest reference again.
     run_podman untag $IMAGE $IMAGE@$digest
+
+    # Make sure the original image is still present (#11557).
+    run_podman image exists $IMAGE
 }
 
 # PR #7212: allow --remote anywhere before subcommand, not just as 1st flag


### PR DESCRIPTION
Fix a bug when remotely untagging an image via tag@digest.
The digest has been lost in the remote client and hence led
to a wrong behaviour on the server.

Fixes: #11557
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@edsantiago PTAL
