### PR TITLE
[3.4] vendor c/common@v0.44.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
 	github.com/containers/buildah v1.23.0
-	github.com/containers/common v0.44.0
+	github.com/containers/common v0.44.1
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.16.0
 	github.com/containers/ocicrypt v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,9 @@ github.com/containernetworking/plugins v0.9.1 h1:FD1tADPls2EEi3flPc2OegIY1M9pUa9
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containers/buildah v1.23.0 h1:qGIeSNOczUHzvnaaOS29HSMiYAjw6JgIXYksAyvqnLs=
 github.com/containers/buildah v1.23.0/go.mod h1:K0iMKgy/MffkkgELBXhSXwTy2HTT6hM0X8qruDR1FwU=
-github.com/containers/common v0.44.0 h1:YpjfOxmWrnVyxugYgiWV1Vo/Xg8JUfe32QZz3SAMfUk=
 github.com/containers/common v0.44.0/go.mod h1:7sdP4vmI5Bm6FPFxb3lvAh1Iktb6tiO1MzjUzhxdoGo=
+github.com/containers/common v0.44.1 h1:B4cSH5ZJS69Kkum0hFwvX3TL9XSmEXj5b+f5okFzAVg=
+github.com/containers/common v0.44.1/go.mod h1:7sdP4vmI5Bm6FPFxb3lvAh1Iktb6tiO1MzjUzhxdoGo=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.16.0 h1:WQcNSzb7+ngS2cfynx0vUwhk+scpgiKlldVcsF8GPbI=

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -404,7 +404,8 @@ func newerRemoteImageAvailable(ctx context.Context, runtime *libpod.Runtime, img
 	if err != nil {
 		return false, err
 	}
-	return img.HasDifferentDigest(ctx, remoteRef)
+	options := &libimage.HasDifferentDigestOptions{AuthFilePath: authfile}
+	return img.HasDifferentDigest(ctx, remoteRef, options)
 }
 
 // newerLocalImageAvailable returns true if the container and local image have different digests

--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -18,7 +18,7 @@ t HEAD libpod/_ping 200
 for i in /version version; do
     t GET  $i      200                               \
       .Components[0].Name="Podman Engine"            \
-      .Components[0].Details.APIVersion~4[0-9.-]\\+  \
+      .Components[0].Details.APIVersion~3[0-9.-]\\+  \
       .Components[0].Details.MinAPIVersion=3.1.0     \
       .Components[0].Details.Os=linux                \
       .ApiVersion=1.40                               \

--- a/vendor/github.com/containers/common/libimage/pull.go
+++ b/vendor/github.com/containers/common/libimage/pull.go
@@ -561,7 +561,7 @@ func (r *Runtime) copySingleImageFromRegistry(ctx context.Context, imageName str
 		}
 
 		if pullPolicy == config.PullPolicyNewer && localImage != nil {
-			isNewer, err := localImage.HasDifferentDigest(ctx, srcRef)
+			isNewer, err := localImage.hasDifferentDigestWithSystemContext(ctx, srcRef, c.systemContext)
 			if err != nil {
 				pullErrors = append(pullErrors, err)
 				continue

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.44.0"
+const Version = "0.44.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -99,7 +99,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.44.0
+# github.com/containers/common v0.44.1
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
 github.com/containers/common/pkg/apparmor


### PR DESCRIPTION
Finalizes the linked BZ to fix passing down custom authfiles during auto
updates.  Also fixes the if-newer pull policy.

[NO TESTS NEEDED] for now validated manually.  A new system test will be
added to the main branch shortly.

BZ: bugzilla.redhat.com/show_bug.cgi?id=2000943
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @TomSweeneyRedHat 