### PR TITLE
compat API: /images/json prefix image id with sha256

### DIFF
--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -183,7 +183,8 @@ func ImageToImageSummary(l *libimage.Image) (*entities.ImageSummary, error) {
 	}
 
 	is := entities.ImageSummary{
-		ID:           l.ID(),
+		// docker adds sha256: in front of the ID
+		ID:           "sha256:" + l.ID(),
 		ParentId:     imageData.Parent,
 		RepoTags:     imageData.RepoTags,
 		RepoDigests:  imageData.RepoDigests,

--- a/test/apiv2/python/rest_api/test_v2_0_0_image.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_image.py
@@ -32,6 +32,9 @@ class ImageTestCase(APITestCase):
             for k in required_keys:
                 self.assertIn(k, item)
 
+            # Id should be prefixed with sha256: (#11645)
+            self.assertIn("sha256:",item['Id'])
+
     def test_inspect(self):
         r = requests.get(self.podman_url + "/v1.40/images/alpine/json")
         self.assertEqual(r.status_code, 200, r.text)
@@ -59,6 +62,8 @@ class ImageTestCase(APITestCase):
         for item in required_keys:
             self.assertIn(item, image)
         _ = parse(image["Created"])
+        # Id should be prefixed with sha256: (#11645)
+        self.assertIn("sha256:",image['Id'])
 
     def test_delete(self):
         r = requests.delete(self.podman_url + "/v1.40/images/alpine?force=true")


### PR DESCRIPTION
Docker adds the `sha256:` prefix to the image ID, so our compat endpoint
has to do this as well.

Fixes #11623

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
