### PR TITLE
[CI:DOCS] Add link to skopeo delete in podman rmi

### DIFF
--- a/docs/source/markdown/podman-rmi.1.md
+++ b/docs/source/markdown/podman-rmi.1.md
@@ -12,6 +12,8 @@ podman\-rmi - Removes one or more locally stored images
 Removes one or more locally stored images.
 Passing an argument _image_ deletes it, along with any of its dangling parent images.  A dangling image is an image without a tag and without being referenced by another image.
 
+Note: To delete an image from a remote registry, use the [**skopeo delete**](https://github.com/containers/skopeo/blob/main/docs/skopeo-delete.1.md) command. Some registries do not allow users to delete an image via a CLI remotely.
+
 ## OPTIONS
 
 #### **--all**, **-a**
@@ -51,7 +53,7 @@ $ podman rmi -a -f
   **125** The command fails for any other reason
 
 ## SEE ALSO
-podman(1)
+podman(1), skopeo-delete(1)
 
 ## HISTORY
 March 2017, Originally compiled by Dan Walsh <dwalsh@redhat.com>


### PR DESCRIPTION
Add a note pointing to skopeo delete for when
users want to delete an image in a remote registry.

Fixes https://github.com/containers/podman/issues/9866

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
