### PR TITLE
Remove references to kube being development

### DIFF
--- a/docs/source/markdown/podman-generate-kube.1.md
+++ b/docs/source/markdown/podman-generate-kube.1.md
@@ -37,8 +37,6 @@ random port is assigned by Podman in the specification.
 Create Kubernetes Pod YAML for a container called `some-mariadb`.
 ```
 $ sudo podman generate kube some-mariadb
-# Generation of Kubernetes YAML is still under development!
-#
 # Save the output of this file and use kubectl create -f to import
 # it into Kubernetes.
 #
@@ -93,8 +91,6 @@ status: {}
 Create Kubernetes Pod YAML for a container with the directory `/home/user/my-data` on the host bind-mounted in the container to `/volume`.
 ```
 $ podman generate kube my-container-with-bind-mounted-data
-# Generation of Kubernetes YAML is still under development!
-#
 # Save the output of this file and use kubectl create -f to import
 # it into Kubernetes.
 #
@@ -147,8 +143,6 @@ status: {}
 Create Kubernetes Pod YAML for a container with the named volume `priceless-data` mounted in the container at `/volume`.
 ```
 $ podman generate kube my-container-using-priceless-data
-# Generation of Kubernetes YAML is still under development!
-#
 # Save the output of this file and use kubectl create -f to import
 # it into Kubernetes.
 #
@@ -200,8 +194,6 @@ status: {}
 Create Kubernetes Pod YAML for a pod called `demoweb` and include a service.
 ```
 $ sudo podman generate kube -s demoweb
-# Generation of Kubernetes YAML is still under development!
-#
 # Save the output of this file and use kubectl create -f to import
 # it into Kubernetes.
 #

--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -210,9 +210,7 @@ func generateKubeYAML(kubeKind interface{}) ([]byte, error) {
 func generateKubeOutput(content [][]byte) ([]byte, error) {
 	output := make([]byte, 0)
 
-	header := `# Generation of Kubernetes YAML is still under development!
-#
-# Save the output of this file and use kubectl create -f to import
+	header := `# Save the output of this file and use kubectl create -f to import
 # it into Kubernetes.
 #
 # Created with podman-%s


### PR DESCRIPTION
At this point and even though we are always improving the play and
generate kube functions, I would say it no longers needs to be denoted
as under development.

[NO TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
