### PR TITLE
Fix an issue with podman save trying to store signatures

### DIFF
--- a/cmd/podman/images/save.go
+++ b/cmd/podman/images/save.go
@@ -70,6 +70,10 @@ func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: saveCommand,
 	})
+
+	// Saving signatures is not supported
+	saveOpts.RemoveSignatures = true
+
 	saveFlags(saveCommand)
 
 	registry.Commands = append(registry.Commands, registry.CliCommand{


### PR DESCRIPTION
**Issue**
Running the following command:
```
podman save registry.redhat.io/openshift-logging/cluster-logging-operator-bundle@sha256:70d57b8062d855c6e1f38d99c796fdf06ddbc8070447770453f7ac37db5e93f8 -o ./tmp/cluster-logging.5.0.7-27/cluster-logging.5.0.7-27.tar
```

I get:
```
Getting image source signatures
Checking if image destination supports signatures
Error: Can not copy signatures to docker-archive:./tmp/cluster-logging.5.0.7-27/cluster-logging.5.0.7-27.tar: Storing signatures for docker tar files is not supported
```

This is similar to what was raised in [this issue](https://github.com/containers/podman/issues/7659) and should have been fixed with this [PR](https://github.com/containers/podman/pull/7956)

Applying this one line code change fixed the issue for me however I am not knowledgeable enough about podman code base to be confident that it is *the right way* of doing it.