### PR TITLE
Generate kube should'd add podman default environment vars

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/libpod/network/types"
+	"github.com/containers/podman/v3/pkg/env"
 	"github.com/containers/podman/v3/pkg/lookup"
 	"github.com/containers/podman/v3/pkg/namespaces"
 	"github.com/containers/podman/v3/pkg/specgen"
@@ -570,11 +571,15 @@ func ocicniPortMappingToContainerPort(portMappings []types.OCICNIPortMapping) ([
 
 // libpodEnvVarsToKubeEnvVars converts a key=value string slice to []v1.EnvVar
 func libpodEnvVarsToKubeEnvVars(envs []string) ([]v1.EnvVar, error) {
+	defaultEnv := env.DefaultEnvVariables()
 	envVars := make([]v1.EnvVar, 0, len(envs))
 	for _, e := range envs {
 		split := strings.SplitN(e, "=", 2)
 		if len(split) != 2 {
 			return envVars, errors.Errorf("environment variable %s is malformed; should be key=value", e)
+		}
+		if defaultEnv[split[0]] == split[1] {
+			continue
 		}
 		ev := v1.EnvVar{
 			Name:  split[0],

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -17,8 +17,9 @@ const whiteSpaces = " \t"
 // DefaultEnvVariables returns a default environment, with $PATH and $TERM set.
 func DefaultEnvVariables() map[string]string {
 	return map[string]string{
-		"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-		"TERM": "xterm",
+		"PATH":      "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"TERM":      "xterm",
+		"container": "podman",
 	}
 }
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -63,12 +63,6 @@ spec:
     - -d
     - "1.5"
     env:
-    - name: PATH
-      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - name: TERM
-      value: xterm
-    - name: container
-      value: podman
     - name: HOSTNAME
       value: label-pod
     image: quay.io/libpod/alpine:latest
@@ -171,12 +165,6 @@ spec:
     - -d
     - "1.5"
     env:
-    - name: PATH
-      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - name: TERM
-      value: xterm
-    - name: container
-      value: podman
     - name: HOSTNAME
       value: label-pod
     image: quay.io/libpod/alpine:latest
@@ -287,13 +275,7 @@ spec:
     - {{.}}
     {{ end }}
     env:
-    - name: PATH
-      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - name: TERM
-      value: xterm
     - name: HOSTNAME
-    - name: container
-      value: podman
     {{ range .Env }}
     - name: {{ .Name }}
     {{ if (eq .ValueFrom "configmap") }}
@@ -453,13 +435,7 @@ spec:
         - {{.}}
         {{ end }}
         env:
-        - name: PATH
-          value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-        - name: TERM
-          value: xterm
         - name: HOSTNAME
-        - name: container
-          value: podman
         image: {{ .Image }}
         name: {{ .Name }}
         imagePullPolicy: {{ .PullPolicy }}


### PR DESCRIPTION
Currently we add the default PATH, TERM and container from Podman
to every kubernetes.yaml file. These values should not be recorded
in the yaml files.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
