### PR TITLE
Pod Device-Read-BPS support

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -164,14 +164,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(deviceCgroupRuleFlagName, completion.AutocompleteNone)
 
-		deviceReadBpsFlagName := "device-read-bps"
-		createFlags.StringSliceVar(
-			&cf.DeviceReadBPs,
-			deviceReadBpsFlagName, []string{},
-			"Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(deviceReadBpsFlagName, completion.AutocompleteDefault)
-
 		deviceReadIopsFlagName := "device-read-iops"
 		createFlags.StringSliceVar(
 			&cf.DeviceReadIOPs,
@@ -869,6 +861,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		volumeDesciption,
 	)
 	_ = cmd.RegisterFlagCompletionFunc(volumeFlagName, AutocompleteVolumeFlag)
+
 	deviceFlagName := "device"
 	createFlags.StringSliceVar(
 		&cf.Devices,
@@ -876,4 +869,12 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		"Add a host device to the container",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(deviceFlagName, completion.AutocompleteDefault)
+
+	deviceReadBpsFlagName := "device-read-bps"
+	createFlags.StringSliceVar(
+		&cf.DeviceReadBPs,
+		deviceReadBpsFlagName, []string{},
+		"Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(deviceReadBpsFlagName, completion.AutocompleteDefault)
 }

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -41,7 +41,7 @@ Examples of the List Format:
 #### **--device**=_host-device_[**:**_container-device_][**:**_permissions_]
 
 Add a host device to the pod. Optional *permissions* parameter
-can be used to specify device permissions It is a combination of
+can be used to specify device permissions. It is a combination of
 **r** for read, **w** for write, and **m** for **mknod**(2).
 
 Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
@@ -54,6 +54,10 @@ Note: the pod implements devices by storing the initial configuration passed by 
 Podman may load kernel modules required for using the specified
 device. The devices that Podman will load modules for when necessary are:
 /dev/fuse.
+
+#### **--device-read-bps**=*path*
+
+Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)
 
 #### **--dns**=*ipaddr*
 

--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -61,6 +61,8 @@ type InspectPodData struct {
 	Mounts []InspectMount `json:"mounts,omitempty"`
 	// Devices contains the specified host devices
 	Devices []InspectDevice `json:"devices,omitempty"`
+	// BlkioDeviceReadBps contains the Read/Access limit for the pod's devices
+	BlkioDeviceReadBps []InspectBlkioThrottleDevice `json:"device_read_bps,omitempty"`
 }
 
 // InspectPodInfraConfig contains the configuration of the pod's infra

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -584,6 +584,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 	var infraConfig *define.InspectPodInfraConfig
 	var inspectMounts []define.InspectMount
 	var devices []define.InspectDevice
+	var deviceLimits []define.InspectBlkioThrottleDevice
 	if p.state.InfraContainerID != "" {
 		infra, err := p.runtime.GetContainer(p.state.InfraContainerID)
 		if err != nil {
@@ -599,16 +600,22 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		infraConfig.CPUSetCPUs = p.ResourceLim().CPU.Cpus
 		infraConfig.PidNS = p.PidMode()
 		infraConfig.UserNS = p.UserNSMode()
-		namedVolumes, mounts := infra.sortUserVolumes(infra.Config().Spec)
+		namedVolumes, mounts := infra.sortUserVolumes(infra.config.Spec)
 		inspectMounts, err = infra.GetInspectMounts(namedVolumes, infra.config.ImageVolumes, mounts)
 		if err != nil {
 			return nil, err
 		}
-
 		var nodes map[string]string
 		devices, err = infra.GetDevices(false, *infra.config.Spec, nodes)
 		if err != nil {
 			return nil, err
+		}
+		spec := infra.config.Spec
+		if spec.Linux != nil && spec.Linux.Resources != nil && spec.Linux.Resources.BlockIO != nil {
+			deviceLimits, err = blkioDeviceThrottle(nodes, spec.Linux.Resources.BlockIO.ThrottleReadBpsDevice)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if len(infra.Config().ContainerNetworkConfig.DNSServer) > 0 {
@@ -638,28 +645,29 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 	}
 
 	inspectData := define.InspectPodData{
-		ID:               p.ID(),
-		Name:             p.Name(),
-		Namespace:        p.Namespace(),
-		Created:          p.CreatedTime(),
-		CreateCommand:    p.config.CreateCommand,
-		State:            podState,
-		Hostname:         p.config.Hostname,
-		Labels:           p.Labels(),
-		CreateCgroup:     p.config.UsePodCgroup,
-		CgroupParent:     p.CgroupParent(),
-		CgroupPath:       p.state.CgroupPath,
-		CreateInfra:      infraConfig != nil,
-		InfraContainerID: p.state.InfraContainerID,
-		InfraConfig:      infraConfig,
-		SharedNamespaces: sharesNS,
-		NumContainers:    uint(len(containers)),
-		Containers:       ctrs,
-		CPUSetCPUs:       p.ResourceLim().CPU.Cpus,
-		CPUPeriod:        p.CPUPeriod(),
-		CPUQuota:         p.CPUQuota(),
-		Mounts:           inspectMounts,
-		Devices:          devices,
+		ID:                 p.ID(),
+		Name:               p.Name(),
+		Namespace:          p.Namespace(),
+		Created:            p.CreatedTime(),
+		CreateCommand:      p.config.CreateCommand,
+		State:              podState,
+		Hostname:           p.config.Hostname,
+		Labels:             p.Labels(),
+		CreateCgroup:       p.config.UsePodCgroup,
+		CgroupParent:       p.CgroupParent(),
+		CgroupPath:         p.state.CgroupPath,
+		CreateInfra:        infraConfig != nil,
+		InfraContainerID:   p.state.InfraContainerID,
+		InfraConfig:        infraConfig,
+		SharedNamespaces:   sharesNS,
+		NumContainers:      uint(len(containers)),
+		Containers:         ctrs,
+		CPUSetCPUs:         p.ResourceLim().CPU.Cpus,
+		CPUPeriod:          p.CPUPeriod(),
+		CPUQuota:           p.CPUQuota(),
+		Mounts:             inspectMounts,
+		Devices:            devices,
+		BlkioDeviceReadBps: deviceLimits,
 	}
 
 	return &inspectData, nil

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -119,6 +119,7 @@ type PodCreateOptions struct {
 	CGroupParent       string            `json:"cgroup_parent,omitempty"`
 	CreateCommand      []string          `json:"create_command,omitempty"`
 	Devices            []string          `json:"devices,omitempty"`
+	DeviceReadBPs      []string          `json:"device_read_bps,omitempty"`
 	Hostname           string            `json:"hostname,omitempty"`
 	Infra              bool              `json:"infra,omitempty"`
 	InfraImage         string            `json:"infra_image,omitempty"`
@@ -167,7 +168,7 @@ type ContainerCreateOptions struct {
 	CPUSetMems        string
 	Devices           []string `json:"devices,omitempty"`
 	DeviceCGroupRule  []string
-	DeviceReadBPs     []string
+	DeviceReadBPs     []string `json:"device_read_bps,omitempty"`
 	DeviceReadIOPs    []string
 	DeviceWriteBPs    []string
 	DeviceWriteIOPs   []string
@@ -200,7 +201,7 @@ type ContainerCreateOptions struct {
 	MemoryReservation string
 	MemorySwap        string
 	MemorySwappiness  int64
-	Name              string `json:"container_name,omitempty"`
+	Name              string `json:"container_name"`
 	NoHealthCheck     bool
 	OOMKillDisable    bool
 	OOMScoreAdj       int

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -201,6 +201,8 @@ type PodResourceConfig struct {
 	CPUPeriod uint64 `json:"cpu_period,omitempty"`
 	// CPU quota of the cpuset, determined by --cpus
 	CPUQuota int64 `json:"cpu_quota,omitempty"`
+	// ThrottleReadBpsDevice contains the rate at which the devices in the pod can be read from/accessed
+	ThrottleReadBpsDevice map[string]spec.LinuxThrottleDevice `json:"throttleReadBpsDevice,omitempty"`
 }
 
 // NewPodSpecGenerator creates a new pod spec

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -903,4 +903,25 @@ ENTRYPOINT ["sleep","99999"]
 
 	})
 
+	It("podman pod create --device-read-bps", func() {
+		SkipIfRootless("Cannot create devices in /dev in rootless mode")
+		SkipIfRootlessCgroupsV1("Setting device-read-bps not supported on cgroupv1 for rootless users")
+
+		podName := "testPod"
+		session := podmanTest.Podman([]string{"pod", "create", "--device-read-bps", "/dev/zero:1mb", "--name", podName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		if CGROUPSV2 {
+			session = podmanTest.Podman([]string{"run", "--rm", "--pod", podName, ALPINE, "sh", "-c", "cat /sys/fs/cgroup/$(sed -e 's|0::||' < /proc/self/cgroup)/io.max"})
+		} else {
+			session = podmanTest.Podman([]string{"run", "--rm", "--pod", podName, ALPINE, "cat", "/sys/fs/cgroup/blkio/blkio.throttle.read_bps_device"})
+		}
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		if !CGROUPSV2 {
+			Expect(session.OutputToString()).To(ContainSubstring("1048576"))
+		}
+	})
+
 })


### PR DESCRIPTION
added the option for the user to specify a rate, in bytes, at which they would like to be able to read from the device being added to the pod. This is the first in a line of pod device options.

WARNING: changed pod name json tag to pod_name to avoid confusion when marshaling with the containerspec's name cc/ @jwhonce 

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
