### PR TITLE
sync container state before reading the healthcheck

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -151,7 +151,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 
 	if c.config.HealthCheckConfig != nil {
 		// This container has a healthcheck defined in it; we need to add it's state
-		healthCheckState, err := c.GetHealthCheckLog()
+		healthCheckState, err := c.getHealthCheckLog()
 		if err != nil {
 			// An error here is not considered fatal; no health state will be displayed
 			logrus.Error(err)

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -214,5 +214,12 @@ var _ = Describe("Podman healthcheck run", func() {
 
 		inspect = podmanTest.InspectContainer("hc")
 		Expect(inspect[0].State.Healthcheck.Status).To(Equal(define.HealthCheckHealthy))
+
+		// Test podman ps --filter heath is working (#11687)
+		ps := podmanTest.Podman([]string{"ps", "--filter", "health=healthy"})
+		ps.WaitWithDefaultTimeout()
+		Expect(ps).Should(Exit(0))
+		Expect(len(ps.OutputToStringArray())).To(Equal(2))
+		Expect(ps.OutputToString()).To(ContainSubstring("hc"))
 	})
 })


### PR DESCRIPTION
The health check result is stored in the container state. Since the
state can change or might not even be set we have to retrive the current
state before we try to read the health check result.

Fixes #11687

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
