### PR TITLE
Eighty-six eighty-eighty

### DIFF
--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -332,7 +332,7 @@ var _ = Describe("Podman commit", func() {
 
 	It("podman commit adds exposed ports", func() {
 		name := "testcon"
-		s := podmanTest.Podman([]string{"run", "--name", name, "-p", "8080:80", ALPINE, "true"})
+		s := podmanTest.Podman([]string{"run", "--name", name, "-p", "8585:80", ALPINE, "true"})
 		s.WaitWithDefaultTimeout()
 		Expect(s).Should(Exit(0))
 

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -47,25 +47,25 @@ var _ = Describe("Podman container inspect", func() {
 
 	It("podman inspect shows exposed ports", func() {
 		name := "testcon"
-		session := podmanTest.Podman([]string{"run", "-d", "--stop-timeout", "0", "--expose", "8080/udp", "--name", name, ALPINE, "sleep", "inf"})
+		session := podmanTest.Podman([]string{"run", "-d", "--stop-timeout", "0", "--expose", "8787/udp", "--name", name, ALPINE, "sleep", "inf"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		data := podmanTest.InspectContainer(name)
 
 		Expect(data).To(HaveLen(1))
 		Expect(data[0].NetworkSettings.Ports).
-			To(Equal(map[string][]define.InspectHostPort{"8080/udp": nil}))
+			To(Equal(map[string][]define.InspectHostPort{"8787/udp": nil}))
 	})
 
 	It("podman inspect shows exposed ports on image", func() {
 		name := "testcon"
-		session := podmanTest.Podman([]string{"run", "-d", "--expose", "8080", "--name", name, nginx})
+		session := podmanTest.Podman([]string{"run", "-d", "--expose", "8989", "--name", name, nginx})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
 		data := podmanTest.InspectContainer(name)
 		Expect(data).To(HaveLen(1))
 		Expect(data[0].NetworkSettings.Ports).
-			To(Equal(map[string][]define.InspectHostPort{"80/tcp": nil, "8080/tcp": nil}))
+			To(Equal(map[string][]define.InspectHostPort{"80/tcp": nil, "8989/tcp": nil}))
 	})
 })

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -618,7 +618,7 @@ var _ = Describe("Podman create", func() {
 		pod.WaitWithDefaultTimeout()
 		Expect(pod).Should(Exit(0))
 
-		session := podmanTest.Podman([]string{"create", "--pod", name, "-p", "8080:80", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"create", "--pod", name, "-p", "8086:80", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitWithError())
 	})

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -451,14 +451,14 @@ var _ = Describe("Podman inspect", func() {
 	It("podman inspect --format json .NetworkSettings.Ports", func() {
 		ctnrName := "Ctnr_" + RandomString(25)
 
-		create := podmanTest.Podman([]string{"create", "--name", ctnrName, "-p", "8080:80", ALPINE})
+		create := podmanTest.Podman([]string{"create", "--name", ctnrName, "-p", "8084:80", ALPINE})
 		create.WaitWithDefaultTimeout()
 		Expect(create).Should(Exit(0))
 
 		inspect := podmanTest.Podman([]string{"inspect", `--format="{{json .NetworkSettings.Ports}}"`, ctnrName})
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(Exit(0))
-		Expect(inspect.OutputToString()).To(Equal(`"{"80/tcp":[{"HostIp":"","HostPort":"8080"}]}"`))
+		Expect(inspect.OutputToString()).To(Equal(`"{"80/tcp":[{"HostIp":"","HostPort":"8084"}]}"`))
 	})
 
 	It("Verify container inspect has default network", func() {

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Podman pod create", func() {
 
 	It("podman create pod with network portbindings", func() {
 		name := "test"
-		session := podmanTest.Podman([]string{"pod", "create", "--name", name, "-p", "8080:80"})
+		session := podmanTest.Podman([]string{"pod", "create", "--name", name, "-p", "8081:80"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		pod := session.OutputToString()
@@ -117,14 +117,14 @@ var _ = Describe("Podman pod create", func() {
 		webserver.WaitWithDefaultTimeout()
 		Expect(webserver).Should(Exit(0))
 
-		check := SystemExec("nc", []string{"-z", "localhost", "8080"})
+		check := SystemExec("nc", []string{"-z", "localhost", "8081"})
 		Expect(check).Should(Exit(0))
 	})
 
 	It("podman create pod with id file with network portbindings", func() {
 		file := filepath.Join(podmanTest.TempDir, "pod.id")
 		name := "test"
-		session := podmanTest.Podman([]string{"pod", "create", "--name", name, "--pod-id-file", file, "-p", "8080:80"})
+		session := podmanTest.Podman([]string{"pod", "create", "--name", name, "--pod-id-file", file, "-p", "8082:80"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -132,7 +132,7 @@ var _ = Describe("Podman pod create", func() {
 		webserver.WaitWithDefaultTimeout()
 		Expect(webserver).Should(Exit(0))
 
-		check := SystemExec("nc", []string{"-z", "localhost", "8080"})
+		check := SystemExec("nc", []string{"-z", "localhost", "8082"})
 		Expect(check).Should(Exit(0))
 	})
 

--- a/test/e2e/pod_inspect_test.go
+++ b/test/e2e/pod_inspect_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Podman pod inspect", func() {
 
 	It("podman pod inspect outputs port bindings", func() {
 		podName := "testPod"
-		create := podmanTest.Podman([]string{"pod", "create", "--name", podName, "-p", "8080:80"})
+		create := podmanTest.Podman([]string{"pod", "create", "--name", podName, "-p", "8383:80"})
 		create.WaitWithDefaultTimeout()
 		Expect(create).Should(Exit(0))
 
@@ -98,7 +98,7 @@ var _ = Describe("Podman pod inspect", func() {
 		Expect(err).To(BeNil())
 		Expect(inspectJSON.InfraConfig).To(Not(BeNil()))
 		Expect(len(inspectJSON.InfraConfig.PortBindings["80/tcp"])).To(Equal(1))
-		Expect(inspectJSON.InfraConfig.PortBindings["80/tcp"][0].HostPort).To(Equal("8080"))
+		Expect(inspectJSON.InfraConfig.PortBindings["80/tcp"][0].HostPort).To(Equal("8383"))
 	})
 
 	It("podman pod inspect outputs show correct MAC", func() {

--- a/test/e2e/pod_start_test.go
+++ b/test/e2e/pod_start_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Podman pod start", func() {
 		pod, _, podid1 := podmanTest.CreatePod(map[string][]string{
 			"--infra":   {"true"},
 			"--name":    {podName[0]},
-			"--publish": {"127.0.0.1:8080:80"},
+			"--publish": {"127.0.0.1:8083:80"},
 		})
 		Expect(pod).To(Exit(0))
 
@@ -103,7 +103,7 @@ var _ = Describe("Podman pod start", func() {
 		pod, _, podid2 := podmanTest.CreatePod(map[string][]string{
 			"--infra":   {"true"},
 			"--name":    {podName[1]},
-			"--publish": {"127.0.0.1:8080:80"},
+			"--publish": {"127.0.0.1:8083:80"},
 		})
 		Expect(pod).To(Exit(0))
 

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -609,7 +609,7 @@ var _ = Describe("Podman ps", func() {
 
 	It("podman ps test with port shared with pod", func() {
 		podName := "testPod"
-		pod := podmanTest.Podman([]string{"pod", "create", "-p", "8080:80", "--name", podName})
+		pod := podmanTest.Podman([]string{"pod", "create", "-p", "8085:80", "--name", podName})
 		pod.WaitWithDefaultTimeout()
 		Expect(pod).Should(Exit(0))
 
@@ -621,7 +621,7 @@ var _ = Describe("Podman ps", func() {
 		ps := podmanTest.Podman([]string{"ps", "--filter", fmt.Sprintf("name=%s", ctrName), "--format", "{{.Ports}}"})
 		ps.WaitWithDefaultTimeout()
 		Expect(ps).Should(Exit(0))
-		Expect(ps.OutputToString()).To(ContainSubstring("0.0.0.0:8080->80/tcp"))
+		Expect(ps.OutputToString()).To(ContainSubstring("0.0.0.0:8085->80/tcp"))
 	})
 
 	It("podman ps truncate long create command", func() {

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -98,9 +98,9 @@ var _ = Describe("Podman run networking", func() {
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal(""))
 	})
 
-	It("podman run -p 80-82 -p 8080:8080", func() {
+	It("podman run -p 80-82 -p 8090:8090", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "80-82", "-p", "8080:8080", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "80-82", "-p", "8090:8090", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
@@ -114,14 +114,14 @@ var _ = Describe("Podman run networking", func() {
 		Expect(len(inspectOut[0].NetworkSettings.Ports["82/tcp"])).To(Equal(1))
 		Expect(inspectOut[0].NetworkSettings.Ports["82/tcp"][0].HostPort).To(Not(Equal("82")))
 		Expect(inspectOut[0].NetworkSettings.Ports["82/tcp"][0].HostIP).To(Equal(""))
-		Expect(len(inspectOut[0].NetworkSettings.Ports["8080/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["8080/tcp"][0].HostPort).To(Equal("8080"))
-		Expect(inspectOut[0].NetworkSettings.Ports["8080/tcp"][0].HostIP).To(Equal(""))
+		Expect(len(inspectOut[0].NetworkSettings.Ports["8090/tcp"])).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports["8090/tcp"][0].HostPort).To(Equal("8090"))
+		Expect(inspectOut[0].NetworkSettings.Ports["8090/tcp"][0].HostIP).To(Equal(""))
 	})
 
-	It("podman run -p 80-81 -p 8080-8081", func() {
+	It("podman run -p 80-81 -p 8180-8181", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "80-81", "-p", "8080-8081", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "80-81", "-p", "8180-8181", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
@@ -132,17 +132,17 @@ var _ = Describe("Podman run networking", func() {
 		Expect(len(inspectOut[0].NetworkSettings.Ports["81/tcp"])).To(Equal(1))
 		Expect(inspectOut[0].NetworkSettings.Ports["81/tcp"][0].HostPort).To(Not(Equal("81")))
 		Expect(inspectOut[0].NetworkSettings.Ports["81/tcp"][0].HostIP).To(Equal(""))
-		Expect(len(inspectOut[0].NetworkSettings.Ports["8080/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["8080/tcp"][0].HostPort).To(Not(Equal("8080")))
-		Expect(inspectOut[0].NetworkSettings.Ports["8080/tcp"][0].HostIP).To(Equal(""))
-		Expect(len(inspectOut[0].NetworkSettings.Ports["8081/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["8081/tcp"][0].HostPort).To(Not(Equal("8081")))
-		Expect(inspectOut[0].NetworkSettings.Ports["8081/tcp"][0].HostIP).To(Equal(""))
+		Expect(len(inspectOut[0].NetworkSettings.Ports["8180/tcp"])).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports["8180/tcp"][0].HostPort).To(Not(Equal("8180")))
+		Expect(inspectOut[0].NetworkSettings.Ports["8180/tcp"][0].HostIP).To(Equal(""))
+		Expect(len(inspectOut[0].NetworkSettings.Ports["8181/tcp"])).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports["8181/tcp"][0].HostPort).To(Not(Equal("8181")))
+		Expect(inspectOut[0].NetworkSettings.Ports["8181/tcp"][0].HostIP).To(Equal(""))
 	})
 
-	It("podman run -p 80 -p 8080-8082:8080-8082", func() {
+	It("podman run -p 80 -p 8280-8282:8280-8282", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "80", "-p", "8080-8082:8080-8082", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "80", "-p", "8280-8282:8280-8282", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
@@ -150,40 +150,40 @@ var _ = Describe("Podman run networking", func() {
 		Expect(len(inspectOut[0].NetworkSettings.Ports["80/tcp"])).To(Equal(1))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Not(Equal("80")))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal(""))
-		Expect(len(inspectOut[0].NetworkSettings.Ports["8080/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["8080/tcp"][0].HostPort).To(Equal("8080"))
-		Expect(inspectOut[0].NetworkSettings.Ports["8080/tcp"][0].HostIP).To(Equal(""))
-		Expect(len(inspectOut[0].NetworkSettings.Ports["8081/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["8081/tcp"][0].HostPort).To(Equal("8081"))
-		Expect(inspectOut[0].NetworkSettings.Ports["8081/tcp"][0].HostIP).To(Equal(""))
-		Expect(len(inspectOut[0].NetworkSettings.Ports["8082/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["8082/tcp"][0].HostPort).To(Equal("8082"))
-		Expect(inspectOut[0].NetworkSettings.Ports["8082/tcp"][0].HostIP).To(Equal(""))
+		Expect(len(inspectOut[0].NetworkSettings.Ports["8280/tcp"])).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports["8280/tcp"][0].HostPort).To(Equal("8280"))
+		Expect(inspectOut[0].NetworkSettings.Ports["8280/tcp"][0].HostIP).To(Equal(""))
+		Expect(len(inspectOut[0].NetworkSettings.Ports["8281/tcp"])).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports["8281/tcp"][0].HostPort).To(Equal("8281"))
+		Expect(inspectOut[0].NetworkSettings.Ports["8281/tcp"][0].HostIP).To(Equal(""))
+		Expect(len(inspectOut[0].NetworkSettings.Ports["8282/tcp"])).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports["8282/tcp"][0].HostPort).To(Equal("8282"))
+		Expect(inspectOut[0].NetworkSettings.Ports["8282/tcp"][0].HostIP).To(Equal(""))
 	})
 
-	It("podman run -p 8080:80", func() {
+	It("podman run -p 8380:80", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "8080:80", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "8380:80", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports["80/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("8080"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("8380"))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal(""))
 	})
 
-	It("podman run -p 8080:80/TCP", func() {
+	It("podman run -p 8480:80/TCP", func() {
 		name := "testctr"
 		// "TCP" in upper characters
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "8080:80/TCP", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "8480:80/TCP", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
 		// "tcp" in lower characters
 		Expect(len(inspectOut[0].NetworkSettings.Ports["80/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("8080"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("8480"))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal(""))
 	})
 
@@ -199,51 +199,51 @@ var _ = Describe("Podman run networking", func() {
 		Expect(inspectOut[0].NetworkSettings.Ports["80/udp"][0].HostIP).To(Equal(""))
 	})
 
-	It("podman run -p 127.0.0.1:8080:80", func() {
+	It("podman run -p 127.0.0.1:8580:80", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "127.0.0.1:8080:80", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "127.0.0.1:8580:80", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports["80/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("8080"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("8580"))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal("127.0.0.1"))
 	})
 
-	It("podman run -p 127.0.0.1:8080:80/udp", func() {
+	It("podman run -p 127.0.0.1:8680:80/udp", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "127.0.0.1:8080:80/udp", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "127.0.0.1:8680:80/udp", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports["80/udp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["80/udp"][0].HostPort).To(Equal("8080"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/udp"][0].HostPort).To(Equal("8680"))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/udp"][0].HostIP).To(Equal("127.0.0.1"))
 	})
 
-	It("podman run -p [::1]:8080:80/udp", func() {
+	It("podman run -p [::1]:8780:80/udp", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "[::1]:8080:80/udp", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "[::1]:8780:80/udp", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports["80/udp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["80/udp"][0].HostPort).To(Equal("8080"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/udp"][0].HostPort).To(Equal("8780"))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/udp"][0].HostIP).To(Equal("::1"))
 	})
 
-	It("podman run -p [::1]:8080:80/tcp", func() {
+	It("podman run -p [::1]:8880:80/tcp", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "[::1]:8080:80/tcp", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "[::1]:8880:80/tcp", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports["80/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("8080"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("8880"))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal("::1"))
 	})
 
@@ -283,33 +283,33 @@ var _ = Describe("Podman run networking", func() {
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal(""))
 	})
 
-	It("podman run -p 127.0.0.1::8080/udp", func() {
+	It("podman run -p 127.0.0.1::8980/udp", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "127.0.0.1::8080/udp", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "127.0.0.1::8980/udp", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
-		Expect(len(inspectOut[0].NetworkSettings.Ports["8080/udp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["8080/udp"][0].HostPort).To(Not(Equal("8080")))
-		Expect(inspectOut[0].NetworkSettings.Ports["8080/udp"][0].HostIP).To(Equal("127.0.0.1"))
+		Expect(len(inspectOut[0].NetworkSettings.Ports["8980/udp"])).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports["8980/udp"][0].HostPort).To(Not(Equal("8980")))
+		Expect(inspectOut[0].NetworkSettings.Ports["8980/udp"][0].HostIP).To(Equal("127.0.0.1"))
 	})
 
-	It("podman run -p :8080", func() {
+	It("podman run -p :8181", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", ":8080", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", ":8181", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
-		Expect(len(inspectOut[0].NetworkSettings.Ports["8080/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["8080/tcp"][0].HostPort).To(Not(Equal("8080")))
-		Expect(inspectOut[0].NetworkSettings.Ports["8080/tcp"][0].HostIP).To(Equal(""))
+		Expect(len(inspectOut[0].NetworkSettings.Ports["8181/tcp"])).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports["8181/tcp"][0].HostPort).To(Not(Equal("8181")))
+		Expect(inspectOut[0].NetworkSettings.Ports["8181/tcp"][0].HostIP).To(Equal(""))
 	})
 
-	It("podman run -p 8080:8080 -p 8081:8080", func() {
+	It("podman run -p xxx:8080 -p yyy:8080", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "4000:8080", "-p", "8000:8080", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "4444:8080", "-p", "5555:8080", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
@@ -320,18 +320,18 @@ var _ = Describe("Podman run networking", func() {
 		hp2 := inspectOut[0].NetworkSettings.Ports["8080/tcp"][1].HostPort
 
 		// We can't guarantee order
-		Expect((hp1 == "4000" && hp2 == "8000") || (hp1 == "8000" && hp2 == "4000")).To(BeTrue())
+		Expect((hp1 == "4444" && hp2 == "5555") || (hp1 == "5555" && hp2 == "4444")).To(BeTrue())
 	})
 
-	It("podman run -p 0.0.0.0:8080:80", func() {
+	It("podman run -p 0.0.0.0:9280:80", func() {
 		name := "testctr"
-		session := podmanTest.Podman([]string{"create", "-t", "-p", "0.0.0.0:8080:80", "--name", name, ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "0.0.0.0:9280:80", "--name", name, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		inspectOut := podmanTest.InspectContainer(name)
 		Expect(len(inspectOut)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
 		Expect(len(inspectOut[0].NetworkSettings.Ports["80/tcp"])).To(Equal(1))
-		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("8080"))
+		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostPort).To(Equal("9280"))
 		Expect(inspectOut[0].NetworkSettings.Ports["80/tcp"][0].HostIP).To(Equal(""))
 	})
 
@@ -348,20 +348,20 @@ var _ = Describe("Podman run networking", func() {
 		Expect(ncBusy).To(ExitWithError())
 	})
 
-	It("podman run network expose host port 8081 to container port 8000 using rootlesskit port handler", func() {
-		session := podmanTest.Podman([]string{"run", "--network", "slirp4netns:port_handler=rootlesskit", "-dt", "-p", "8081:8000", ALPINE, "/bin/sh"})
+	It("podman run network expose host port 18081 to container port 8000 using rootlesskit port handler", func() {
+		session := podmanTest.Podman([]string{"run", "--network", "slirp4netns:port_handler=rootlesskit", "-dt", "-p", "18081:8000", ALPINE, "/bin/sh"})
 		session.Wait(30)
 		Expect(session).Should(Exit(0))
 
-		ncBusy := SystemExec("nc", []string{"-l", "-p", "8081"})
+		ncBusy := SystemExec("nc", []string{"-l", "-p", "18081"})
 		Expect(ncBusy).To(ExitWithError())
 	})
 
-	It("podman run network expose host port 8082 to container port 8000 using slirp4netns port handler", func() {
-		session := podmanTest.Podman([]string{"run", "--network", "slirp4netns:port_handler=slirp4netns", "-dt", "-p", "8082:8000", ALPINE, "/bin/sh"})
+	It("podman run network expose host port 18082 to container port 8000 using slirp4netns port handler", func() {
+		session := podmanTest.Podman([]string{"run", "--network", "slirp4netns:port_handler=slirp4netns", "-dt", "-p", "18082:8000", ALPINE, "/bin/sh"})
 		session.Wait(30)
 		Expect(session).Should(Exit(0))
-		ncBusy := SystemExec("nc", []string{"-l", "-p", "8082"})
+		ncBusy := SystemExec("nc", []string{"-l", "-p", "18082"})
 		Expect(ncBusy).To(ExitWithError())
 	})
 
@@ -650,13 +650,13 @@ var _ = Describe("Podman run networking", func() {
 		defer podmanTest.removeCNINetwork(netName)
 
 		name := "nc-server"
-		run := podmanTest.Podman([]string{"run", "--log-driver", "k8s-file", "-d", "--name", name, "--net", netName, ALPINE, "nc", "-l", "-p", "8080"})
+		run := podmanTest.Podman([]string{"run", "--log-driver", "k8s-file", "-d", "--name", name, "--net", netName, ALPINE, "nc", "-l", "-p", "9480"})
 		run.WaitWithDefaultTimeout()
 		Expect(run).Should(Exit(0))
 
 		// NOTE: we force the k8s-file log driver to make sure the
 		// tests are passing inside a container.
-		run = podmanTest.Podman([]string{"run", "--log-driver", "k8s-file", "--rm", "--net", netName, "--uidmap", "0:1:4096", ALPINE, "sh", "-c", fmt.Sprintf("echo podman | nc -w 1 %s.dns.podman 8080", name)})
+		run = podmanTest.Podman([]string{"run", "--log-driver", "k8s-file", "--rm", "--net", netName, "--uidmap", "0:1:4096", ALPINE, "sh", "-c", fmt.Sprintf("echo podman | nc -w 1 %s.dns.podman 9480", name)})
 		run.WaitWithDefaultTimeout()
 		Expect(run).Should(Exit(0))
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1148,11 +1148,11 @@ USER mail`, BB)
 	})
 
 	It("podman run --pod automatically", func() {
-		session := podmanTest.Podman([]string{"run", "-d", "--pod", "new:foobar", ALPINE, "nc", "-l", "-p", "8080"})
+		session := podmanTest.Podman([]string{"run", "-d", "--pod", "new:foobar", ALPINE, "nc", "-l", "-p", "8686"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"run", "--pod", "foobar", ALPINE, "/bin/sh", "-c", "echo test | nc -w 1 127.0.0.1 8080"})
+		session = podmanTest.Podman([]string{"run", "--pod", "foobar", ALPINE, "/bin/sh", "-c", "echo test | nc -w 1 127.0.0.1 8686"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -138,7 +138,7 @@ var _ = Describe("podman system connection", func() {
 	It("add tcp", func() {
 		cmd := []string{"system", "connection", "add",
 			"QA-TCP",
-			"tcp://localhost:8080",
+			"tcp://localhost:8888",
 		}
 		session := podmanTest.Podman(cmd)
 		session.WaitWithDefaultTimeout()
@@ -150,7 +150,7 @@ var _ = Describe("podman system connection", func() {
 		Expect(cfg.Engine.ActiveService).To(Equal("QA-TCP"))
 		Expect(cfg.Engine.ServiceDestinations["QA-TCP"]).To(Equal(
 			config.Destination{
-				URI:      "tcp://localhost:8080",
+				URI:      "tcp://localhost:8888",
 				Identity: "",
 			},
 		))


### PR DESCRIPTION
(Sorry, couldn't resist).

CI flakes have been coming down - thank you to everyone who has
been making them a priority.

This leaves a noisy subset that I've just been ignoring for months:

    Running: podman ... -p 8080:something
    ...cannot listen on the TCP port: listen tcp4 :8080: bind: address already in use

Sometimes these are one-time errors resolved on 2nd try; sometimes
they fail three times, forcing CI user to hit Rerun. In all cases
they make noise in my flake logs, which costs me time.

My assumption is that this has to do with ginkgo running random
tests in parallel. Since many e2e tests simplemindedly use 8080,
collisions are inevitable.

Solution: simplemindedly replace 8080 with other (also arbitrarily
picked) numbers. This is imperfect -- it requires human developers
to pick a number NNNN and 'grep NNNN test/e2e/*' before adding
new tests, which I am 100% confident ain't gonna happen -- but
it's better than what we have now.

Side note: I considered writing and using a RandomAvailablePort()
helper, but that would still be racy. Plus, it would be a pain
to interpolate strings into so many places. Finally, with this
hand-tooled approach, if/when we _do_ get conflicts on port NNNN,
it should be very easy to grep for NNNN, find the offending tests
that reuse that port, and fix one of them.

Signed-off-by: Ed Santiago <santiago@redhat.com>
