### PR TITLE
Fix machine image

### DIFF
--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -40,7 +40,7 @@ do these things manually or handle otherwise.
 #### **--image-path**
 
 Fully qualified path or URL to the VM image.
-Can also be set to `testing` or `stable` to pull down default image.
+Can also be set to `testing`, `next`, or `stable` to pull down default image.
 Defaults to `testing`.
 
 #### **--memory**, **-m**=*number*

--- a/pkg/machine/fcos.go
+++ b/pkg/machine/fcos.go
@@ -139,6 +139,8 @@ func getFCOSDownload(imageStream string) (*fcosDownloadInfo, error) {
 	)
 	switch imageStream {
 	case "testing", "":
+		streamType = fedoracoreos.StreamTesting
+	case "next":
 		streamType = fedoracoreos.StreamNext
 	case "stable":
 		streamType = fedoracoreos.StreamStable

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -140,7 +140,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) error {
 	v.IdentityPath = filepath.Join(sshDir, v.Name)
 
 	switch opts.ImagePath {
-	case "testing", "stable", "":
+	case "testing", "next", "stable", "":
 		// Get image as usual
 		dd, err := machine.NewFcosDownloader(vmtype, v.Name, opts.ImagePath)
 		if err != nil {


### PR DESCRIPTION
Make sure setting machine image to `testing` pulls down the testing
stream, and not the next stream

[NO TESTS NEEDED]

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
