### PR TITLE
Cirrus: Add gitlab podman runner test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -637,6 +637,33 @@ rootless_system_test_task:
     main_script: *main
     always: *logs_artifacts
 
+rootless_gitlab_test_task:
+    name: *std_name_fmt
+    alias: rootless_gitlab_test
+    skip: *tags
+    only_if: *not_docs
+    # Community-maintained downstream test may fail unexpectedly.
+    # Ref. repository: https://gitlab.com/gitlab-org/gitlab-runner
+    # If necessary, uncomment the next line and file issue(s) with details.
+    # allow_failures: $CI == $CI
+    depends_on:
+      - rootless_integration_test
+    gce_instance: *standardvm
+    env:
+        <<: *ubuntu_envvars
+        TEST_FLAVOR: 'gitlab'
+        PRIV_NAME: rootless
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always:
+        <<: *logs_artifacts
+        junit_artifacts:
+            path: gitlab-runner-podman.xml
+            type: text/xml
+            format: junit
+
 upgrade_test_task:
     name: "Upgrade test: from $PODMAN_UPGRADE_FROM"
     alias: upgrade_test
@@ -720,6 +747,7 @@ success_task:
         - local_system_test
         - remote_system_test
         - rootless_system_test
+        - rootless_gitlab_test
         - upgrade_test
         - buildah_bud_test
         - meta


### PR DESCRIPTION
Add execution of the downstream gitlab-runner tests using
rootless podman through the magic of socket-level
docker compatibility.  Include a comment suggesting how
to temporarily disable the test in case it fails beyond
podman code scope.