### PR TITLE
[NO TESTS NEEDED] Disable docker and alias to podman in FCOS ignition

### DIFF
--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 )
 
 /*
@@ -80,6 +81,7 @@ func NewIgnitionFile(ign DynamicIgnition) error {
 	// so a listening host knows it can being interacting with it
 	ready := `[Unit]
 Requires=dev-virtio\\x2dports-%s.device
+After=remove-moby.service
 OnFailure=emergency.target
 OnFailureJobMode=isolate
 [Service]
@@ -89,6 +91,23 @@ ExecStart=/bin/sh -c '/usr/bin/echo Ready >/dev/%s'
 [Install]
 RequiredBy=multi-user.target
 `
+	deMoby := `[Unit]
+Description=Remove moby-engine
+# Run once for the machine
+After=systemd-machine-id-commit.service
+Before=zincati.service
+ConditionPathExists=!/var/lib/%N.stamp
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/rpm-ostree override remove moby-engine
+ExecStart=/usr/bin/rpm-ostree ex apply-live --allow-replacement
+ExecStartPost=/bin/touch /var/lib/%N.stamp
+
+[Install]
+WantedBy=multi-user.target
+ `
 	_ = ready
 	ignSystemd := Systemd{
 		Units: []Unit{
@@ -100,6 +119,21 @@ RequiredBy=multi-user.target
 				Enabled:  boolToPtr(true),
 				Name:     "ready.service",
 				Contents: strToPtr(fmt.Sprintf(ready, "vport1p1", "vport1p1")),
+			},
+			{
+				Enabled: boolToPtr(false),
+				Name:    "docker.service",
+				Mask:    boolToPtr(true),
+			},
+			{
+				Enabled: boolToPtr(false),
+				Name:    "docker.socket",
+				Mask:    boolToPtr(true),
+			},
+			{
+				Enabled:  boolToPtr(true),
+				Name:     "remove-moby.service",
+				Contents: &deMoby,
 			},
 		}}
 	ignConfig := Config{
@@ -161,6 +195,22 @@ func getFiles(usrName string) []File {
 	var (
 		files []File
 	)
+
+	lingerExample := `[Unit]
+Description=A systemd user unit demo
+After=network-online.target
+Wants=network-online.target podman.socket
+[Service]
+ExecStart=/usr/bin/sleep infinity
+`
+	containers := `[containers]
+netns="bridge"
+rootless_networking="cni"
+`
+	rootContainers := `[engine]
+machine_enabled=true
+`
+
 	// Add a fake systemd service to get the user socket rolling
 	files = append(files, File{
 		Node: Node{
@@ -171,7 +221,7 @@ func getFiles(usrName string) []File {
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
-				Source: strToPtr("data:,%5BUnit%5D%0ADescription%3DA%20systemd%20user%20unit%20demo%0AAfter%3Dnetwork-online.target%0AWants%3Dnetwork-online.target%20podman.socket%0A%5BService%5D%0AExecStart%3D%2Fusr%2Fbin%2Fsleep%20infinity%0A"),
+				Source: encodeDataURLPtr(lingerExample),
 			},
 			Mode: intToPtr(0744),
 		},
@@ -188,7 +238,7 @@ func getFiles(usrName string) []File {
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
-				Source: strToPtr("data:,%5Bcontainers%5D%0D%0Anetns%3D%22bridge%22%0D%0Arootless_networking%3D%22cni%22"),
+				Source: encodeDataURLPtr(containers),
 			},
 			Mode: intToPtr(0744),
 		},
@@ -213,7 +263,7 @@ func getFiles(usrName string) []File {
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
-				Source: strToPtr("data:,%5Bengine%5D%0Amachine_enabled%3Dtrue%0A"),
+				Source: encodeDataURLPtr(rootContainers),
 			},
 			Mode: intToPtr(0644),
 		},
@@ -233,7 +283,22 @@ func getFiles(usrName string) []File {
 		FileEmbedded1: FileEmbedded1{
 			Append: nil,
 			Contents: Resource{
-				Source: strToPtr("data:,unqualified-search-registries%3D%5B%22docker.io%22%5D"),
+				Source: encodeDataURLPtr("unqualified-search-registries=[\"docker.io\"]\n"),
+			},
+			Mode: intToPtr(0644),
+		},
+	})
+
+	files = append(files, File{
+		Node: Node{
+			Path: "/etc/tmpfiles.d/podman-docker.conf",
+		},
+		FileEmbedded1: FileEmbedded1{
+			Append: nil,
+			// Create a symlink from the docker socket to the podman socket.
+			// Taken from https://github.com/containers/podman/blob/main/contrib/systemd/system/podman-docker.conf
+			Contents: Resource{
+				Source: encodeDataURLPtr("L+  /run/docker.sock   -    -    -     -   /run/podman/podman.sock\n"),
 			},
 			Mode: intToPtr(0644),
 		},
@@ -253,5 +318,20 @@ func getLinks(usrName string) []Link {
 			Hard:   boolToPtr(false),
 			Target: "/home/" + usrName + "/.config/systemd/user/linger-example.service",
 		},
+	}, {
+		Node: Node{
+			Group:     getNodeGrp("root"),
+			Path:      "/usr/local/bin/docker",
+			Overwrite: boolToPtr(true),
+			User:      getNodeUsr("root"),
+		},
+		LinkEmbedded1: LinkEmbedded1{
+			Hard:   boolToPtr(false),
+			Target: "/usr/bin/podman",
+		},
 	}}
+}
+
+func encodeDataURLPtr(contents string) *string {
+	return strToPtr(fmt.Sprintf("data:,%s", url.PathEscape(contents)))
 }


### PR DESCRIPTION
This PR disables the docker.sock systemd unit and sets up an overlay to replace /usr/bin/docker with a symlink to podman as discussed in [1].  A future PR will add support for dial-stdio, which would result in docker compatibility for those using docker cli ssh connections (not the local proxy/forwarding approach which is handled differently).

[1] https://github.com/containers/podman/pull/11643#issuecomment-922252033 

[NO TESTS NEEDED] since this is specific to podman machine(no testing infra yet)

Signed-off-by: Jason Greene <jason.greene@redhat.com>