### PR TITLE
Add podman play kube --no-hosts options

### DIFF
--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -78,6 +78,7 @@ func init() {
 	flags.StringVar(&kubeOptions.LogDriver, logDriverFlagName, "", "Logging driver for the container")
 	_ = kubeCmd.RegisterFlagCompletionFunc(logDriverFlagName, common.AutocompleteLogDriver)
 
+	flags.BoolVar(&kubeOptions.NoHosts, "no-hosts", false, "Do not create /etc/hosts within the pod's containers, instead use the version from the image")
 	flags.BoolVarP(&kubeOptions.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
 	flags.BoolVar(&kubeOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 	flags.BoolVar(&kubeOptions.StartCLI, "start", true, "Start the pod after creating it")

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -138,6 +138,10 @@ Valid _mode_ values are:
   Note: Rootlesskit changes the source IP address of incoming packets to a IP address in the container network namespace, usually `10.0.2.100`. If your application requires the real source IP address, e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for rootless containers when connected to user-defined networks.
   - **port_handler=slirp4netns**: Use the slirp4netns port forwarding, it is slower than rootlesskit but preserves the correct source IP address. This port handler cannot be used for user-defined networks.
 
+#### **--no-hosts**
+
+Do not create /etc/hosts within the pod's containers, instead use the version from the image
+
 #### **--quiet**, **-q**
 
 Suppress output information when pulling images

--- a/pkg/api/handlers/libpod/play.go
+++ b/pkg/api/handlers/libpod/play.go
@@ -29,6 +29,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 		Start      bool     `schema:"start"`
 		StaticIPs  []string `schema:"staticIPs"`
 		StaticMACs []string `schema:"staticMACs"`
+		NoHosts    bool     `schema:"noHosts"`
 	}{
 		TLSVerify: true,
 		Start:     true,
@@ -102,6 +103,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 		Username:   username,
 		Password:   password,
 		Network:    query.Network,
+		NoHosts:    query.NoHosts,
 		Quiet:      true,
 		LogDriver:  query.LogDriver,
 		StaticIPs:  staticIPs,

--- a/pkg/bindings/play/play.go
+++ b/pkg/bindings/play/play.go
@@ -6,11 +6,10 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/containers/podman/v3/pkg/auth"
 	"github.com/containers/podman/v3/pkg/bindings"
 	"github.com/containers/podman/v3/pkg/domain/entities"
+	"github.com/sirupsen/logrus"
 )
 
 func Kube(ctx context.Context, path string, options *KubeOptions) (*entities.PlayKubeReport, error) {

--- a/pkg/bindings/play/types.go
+++ b/pkg/bindings/play/types.go
@@ -17,6 +17,8 @@ type KubeOptions struct {
 	Password *string
 	// Network - name of the CNI network to connect to.
 	Network *string
+	// NoHosts - do not generate /etc/hosts file in pod's containers
+	NoHosts *bool
 	// Quiet - suppress output when pulling images.
 	Quiet *bool
 	// SignaturePolicy - path to a signature-policy file.

--- a/pkg/bindings/play/types_kube_options.go
+++ b/pkg/bindings/play/types_kube_options.go
@@ -93,6 +93,21 @@ func (o *KubeOptions) GetNetwork() string {
 	return *o.Network
 }
 
+// WithNoHosts set field NoHosts to given value
+func (o *KubeOptions) WithNoHosts(value bool) *KubeOptions {
+	o.NoHosts = &value
+	return o
+}
+
+// GetNoHosts returns value of field NoHosts
+func (o *KubeOptions) GetNoHosts() bool {
+	if o.NoHosts == nil {
+		var z bool
+		return z
+	}
+	return *o.NoHosts
+}
+
 // WithQuiet set field Quiet to given value
 func (o *KubeOptions) WithQuiet(value bool) *KubeOptions {
 	o.Quiet = &value

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -17,6 +17,9 @@ type PlayKubeOptions struct {
 	// Down indicates whether to bring contents of a yaml file "down"
 	// as in stop
 	Down bool
+	// Do not create /etc/hosts within the pod's containers,
+	// instead use the version from the image
+	NoHosts bool
 	// Username for authenticating against the registry.
 	Username string
 	// Password for authenticating against the registry.

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -181,7 +181,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		}
 	}
 
-	podOpt := entities.PodCreateOptions{Infra: true, Net: &entities.NetOptions{StaticIP: &net.IP{}, StaticMAC: &net.HardwareAddr{}}}
+	podOpt := entities.PodCreateOptions{Infra: true, Net: &entities.NetOptions{StaticIP: &net.IP{}, StaticMAC: &net.HardwareAddr{}, NoHosts: options.NoHosts}}
 	podOpt, err = kube.ToPodOpt(ctx, podName, podOpt, podYAML)
 	if err != nil {
 		return nil, err

--- a/pkg/domain/infra/tunnel/play.go
+++ b/pkg/domain/infra/tunnel/play.go
@@ -13,7 +13,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, path string, opts entit
 	options.WithCertDir(opts.CertDir).WithQuiet(opts.Quiet).WithSignaturePolicy(opts.SignaturePolicy).WithConfigMaps(opts.ConfigMaps)
 	options.WithLogDriver(opts.LogDriver).WithNetwork(opts.Network).WithSeccompProfileRoot(opts.SeccompProfileRoot)
 	options.WithStaticIPs(opts.StaticIPs).WithStaticMACs(opts.StaticMACs)
-
+	options.WithNoHosts(opts.NoHosts)
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		options.WithSkipTLSVerify(s == types.OptionalBoolTrue)
 	}


### PR DESCRIPTION
This option will setup the containers to not modify their /etc/hosts
file and just use the one from the image.

Fixes: https://github.com/containers/podman/issues/9500

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
