### PR TITLE
podman save: enforce signature removal

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -359,7 +359,6 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 		MultiImageArchive:           len(query.References) > 1,
 		OciAcceptUncompressedLayers: query.OciAcceptUncompressedLayers,
 		Output:                      output,
-		RemoveSignatures:            true,
 	}
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -305,8 +305,6 @@ type ImageSaveOptions struct {
 	OciAcceptUncompressedLayers bool
 	// Output - write image to the specified path.
 	Output string
-	// Do not save the signature from the source image
-	RemoveSignatures bool
 	// Quiet - suppress output when copying images
 	Quiet bool
 }

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -368,7 +368,10 @@ func (ir *ImageEngine) Save(ctx context.Context, nameOrID string, tags []string,
 	saveOptions := &libimage.SaveOptions{}
 	saveOptions.DirForceCompress = options.Compress
 	saveOptions.OciAcceptUncompressedLayers = options.OciAcceptUncompressedLayers
-	saveOptions.RemoveSignatures = options.RemoveSignatures
+
+	// Force signature removal to preserve backwards compat.
+	// See https://github.com/containers/podman/pull/11669#issuecomment-925250264
+	saveOptions.RemoveSignatures = true
 
 	if !options.Quiet {
 		saveOptions.Writer = os.Stderr


### PR DESCRIPTION
Enforce the removal of signatures in `podman save` to restore behavior
prior to the migration to libimage.  We may consider improving on that
in the future.  For details, please refer to the excellent summary by
@mtrmac [1].

[1] https://github.com/containers/podman/pull/11669#issuecomment-925250264

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
