### PR TITLE
shell completion: do not show images without tag

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -194,20 +194,13 @@ func getImages(cmd *cobra.Command, toComplete string) ([]string, cobra.ShellComp
 			} else {
 				// suggested "registry.fedoraproject.org/f29/httpd:latest" as
 				// - "registry.fedoraproject.org/f29/httpd:latest"
-				// - "registry.fedoraproject.org/f29/httpd"
 				// - "f29/httpd:latest"
-				// - "f29/httpd"
 				// - "httpd:latest"
-				// - "httpd"
 				paths := strings.Split(repo, "/")
 				for i := range paths {
 					suggestionWithTag := strings.Join(paths[i:], "/")
 					if strings.HasPrefix(suggestionWithTag, toComplete) {
 						suggestions = append(suggestions, suggestionWithTag)
-					}
-					suggestionWithoutTag := strings.SplitN(strings.SplitN(suggestionWithTag, ":", 2)[0], "@", 2)[0]
-					if strings.HasPrefix(suggestionWithoutTag, toComplete) {
-						suggestions = append(suggestions, suggestionWithoutTag)
 					}
 				}
 			}

--- a/test/system/600-completion.bats
+++ b/test/system/600-completion.bats
@@ -110,12 +110,10 @@ function check_shell_completion() {
                     is "$output" ".*localhost/$random_image_name:$random_image_tag${nl}" \
                        "$* $cmd: actual image listed in suggestions"
 
-                    # check that we complete the image with and without tag after at least one char is typed
+                    # check that we complete the image with tag after at least one char is typed
                     run_completion "$@" $cmd "${extra_args[@]}" "${random_image_name:0:1}"
                     is "$output" ".*$random_image_name:$random_image_tag${nl}" \
                        "$* $cmd: image name:tag included in suggestions"
-                    is "$output" ".*$random_image_name${nl}" \
-                       "$* $cmd: image name(w/o tag) included in suggestions"
 
                     # check that we complete the image id after at least two chars are typed
                     run_completion "$@" $cmd "${extra_args[@]}" "${random_image_id:0:2}"


### PR DESCRIPTION
The shell completion should only suggest arguments that work. Using a
image without tag does not work in many cases. Having both the version
with and without tag also forces users to press one key more because
tab completion will always stop at the colon.

Fixes #11673

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
