### PR TITLE
[3.4] podman save: enforce signature removal

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -357,7 +357,6 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 		Format:            query.Format,
 		MultiImageArchive: len(query.References) > 1,
 		Output:            output,
-		RemoveSignatures:  true,
 	}
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -303,8 +303,6 @@ type ImageSaveOptions struct {
 	MultiImageArchive bool
 	// Output - write image to the specified path.
 	Output string
-	// Do not save the signature from the source image
-	RemoveSignatures bool
 	// Quiet - suppress output when copying images
 	Quiet bool
 }

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -367,7 +367,10 @@ func (ir *ImageEngine) Load(ctx context.Context, options entities.ImageLoadOptio
 func (ir *ImageEngine) Save(ctx context.Context, nameOrID string, tags []string, options entities.ImageSaveOptions) error {
 	saveOptions := &libimage.SaveOptions{}
 	saveOptions.DirForceCompress = options.Compress
-	saveOptions.RemoveSignatures = options.RemoveSignatures
+
+	// Force signature removal to preserve backwards compat.
+	// See https://github.com/containers/podman/pull/11669#issuecomment-925250264
+	saveOptions.RemoveSignatures = true
 
 	if !options.Quiet {
 		saveOptions.Writer = os.Stderr


### PR DESCRIPTION
Enforce the removal of signatures in `podman save` to restore behavior
prior to the migration to libimage.  We may consider improving on that
in the future.  For details, please refer to the excellent summary by
@mtrmac [1].

[NO TESTS NEEDED] - manually verified but exisiting tests need some
further investigation (see [1]).

[1] https://github.com/containers/podman/pull/11669#issuecomment-925250264

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@mheon @rhatdan PTAL
