### PR TITLE
Set context dir for play kube build

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -435,6 +435,7 @@ func (ic *ContainerEngine) getImageAndLabelInfo(ctx context.Context, cwd string,
 		buildOpts.Isolation = buildahDefine.IsolationChroot
 		buildOpts.CommonBuildOpts = commonOpts
 		buildOpts.Output = container.Image
+		buildOpts.ContextDirectory = filepath.Dir(buildFile)
 		if _, _, err := ic.Libpod.Build(ctx, *buildOpts, []string{buildFile}...); err != nil {
 			return nil, nil, err
 		}

--- a/test/e2e/play_build_test.go
+++ b/test/e2e/play_build_test.go
@@ -80,12 +80,17 @@ status: {}
 FROM quay.io/libpod/alpine_nginx:latest
 RUN apk update && apk add strace
 LABEL homer=dad
+COPY copyfile /copyfile
 `
 	var prebuiltImage = `
 FROM quay.io/libpod/alpine_nginx:latest
 RUN apk update && apk add strace
 LABEL marge=mom
 `
+
+	var copyFile = `just a text file
+`
+
 	It("Check that image is built using Dockerfile", func() {
 		// Setup
 		yamlDir := filepath.Join(tempdir, RandomString(12))
@@ -97,7 +102,9 @@ LABEL marge=mom
 		Expect(err).To(BeNil())
 		err = writeYaml(playBuildFile, filepath.Join(app1Dir, "Dockerfile"))
 		Expect(err).To(BeNil())
-
+		// Write a file to be copied
+		err = writeYaml(copyFile, filepath.Join(app1Dir, "copyfile"))
+		Expect(err).To(BeNil())
 		// Switch to temp dir and restore it afterwards
 		cwd, err := os.Getwd()
 		Expect(err).To(BeNil())
@@ -131,7 +138,9 @@ LABEL marge=mom
 		Expect(err).To(BeNil())
 		err = writeYaml(playBuildFile, filepath.Join(app1Dir, "Containerfile"))
 		Expect(err).To(BeNil())
-
+		// Write a file to be copied
+		err = writeYaml(copyFile, filepath.Join(app1Dir, "copyfile"))
+		Expect(err).To(BeNil())
 		// Switch to temp dir and restore it afterwards
 		cwd, err := os.Getwd()
 		Expect(err).To(BeNil())
@@ -171,6 +180,9 @@ LABEL marge=mom
 		err = os.Mkdir(app1Dir, 0755)
 		Expect(err).To(BeNil())
 		err = writeYaml(playBuildFile, filepath.Join(app1Dir, "Containerfile"))
+		Expect(err).To(BeNil())
+		// Write a file to be copied
+		err = writeYaml(copyFile, filepath.Join(app1Dir, "copyfile"))
 		Expect(err).To(BeNil())
 
 		// Switch to temp dir and restore it afterwards
@@ -214,6 +226,9 @@ LABEL marge=mom
 		err = os.Mkdir(app1Dir, 0755)
 		Expect(err).To(BeNil())
 		err = writeYaml(playBuildFile, filepath.Join(app1Dir, "Containerfile"))
+		Expect(err).To(BeNil())
+		// Write a file to be copied
+		err = writeYaml(copyFile, filepath.Join(app1Dir, "copyfile"))
 		Expect(err).To(BeNil())
 
 		// Switch to temp dir and restore it afterwards


### PR DESCRIPTION
When performing an image build with play kube, we need to set the
context directory so things like file copies have the correct input
path.

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
