### PR TITLE
rootful: do not set XDG_RUNTIME_DIR for cni plugins

### DIFF
--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -89,12 +89,7 @@ func newPodmanConfig() {
 // use for the containers.conf configuration file.
 func setXdgDirs() error {
 	if !rootless.IsRootless() {
-		// unset XDG_RUNTIME_DIR for root
-		// Sometimes XDG_RUNTIME_DIR is set to /run/user/0 sometimes it is unset,
-		// the inconsistency is causing issues for the dnsname plugin.
-		// It is already set to an empty string for conmon so lets do the same
-		// for podman. see #10806 and #10745
-		return os.Unsetenv("XDG_RUNTIME_DIR")
+		return nil
 	}
 
 	// Setup XDG_RUNTIME_DIR


### PR DESCRIPTION
#### Revert "rootful: unset XDG_RUNTIME_DIR"

This reverts commit 91e21be.

XDG_RUNTIME_DIR is required for the authfile path. We cannot unset it.

Fixes #11725


#### rootful: do not set XDG_RUNTIME_DIR for cni plugins

The dnsname plugin tries to use XDG_RUNTIME_DIR to store files.
podman run will have XDG_RUNTIME_DIR set and thus the cni plugin can use
it. The problems is that XDG_RUNTIME_DIR is unset for the conmon process
for rootful users. This causes issues since the cleanup process is spawned
by conmon and thus not have XDG_RUNTIME_DIR set to same value as podman run.

Because of it dnsname will not find the config files and cannot correctly cleanup.
To fix this we should also unset XDG_RUNTIME_DIR for the cni plugins as rootful.
