### PR TITLE
image prune: support removing external containers

### DIFF
--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -41,6 +41,7 @@ func init() {
 
 	flags := pruneCmd.Flags()
 	flags.BoolVarP(&pruneOpts.All, "all", "a", false, "Remove all images not in use by containers, not just dangling ones")
+	flags.BoolVarP(&pruneOpts.External, "external", "", false, "Remove images even when they are used by external containers (e.g., by build containers)")
 	flags.BoolVarP(&force, "force", "f", false, "Do not prompt for confirmation")
 
 	filterFlagName := "filter"

--- a/docs/source/markdown/podman-image-prune.1.md
+++ b/docs/source/markdown/podman-image-prune.1.md
@@ -17,6 +17,10 @@ The image prune command does not prune cache images that only use layers that ar
 
 Remove dangling images and images that have no associated containers.
 
+#### **--external**
+
+Remove images even when they are used by external containers (e.g., build containers).
+
 #### **--filter**=*filters*
 
 Provide filter values.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.0.1
 	github.com/containernetworking/plugins v1.0.1
 	github.com/containers/buildah v1.23.0
-	github.com/containers/common v0.46.0
+	github.com/containers/common v0.46.1-0.20210928081721-32e20295f1c6
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.16.0
 	github.com/containers/ocicrypt v1.1.2
@@ -61,7 +61,6 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/vbauerster/mpb/v6 v6.0.4
-	github.com/vbauerster/mpb/v7 v7.1.4 // indirect
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 	go.etcd.io/bbolt v1.3.6
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/containernetworking/plugins v1.0.1/go.mod h1:QHCfGpaTwYTbbH+nZXKVTxNB
 github.com/containers/buildah v1.23.0 h1:qGIeSNOczUHzvnaaOS29HSMiYAjw6JgIXYksAyvqnLs=
 github.com/containers/buildah v1.23.0/go.mod h1:K0iMKgy/MffkkgELBXhSXwTy2HTT6hM0X8qruDR1FwU=
 github.com/containers/common v0.44.0/go.mod h1:7sdP4vmI5Bm6FPFxb3lvAh1Iktb6tiO1MzjUzhxdoGo=
-github.com/containers/common v0.46.0 h1:95zB7kYBQJW+aK5xxZnaobCwoPyYOf85Y0yUx0E5aRg=
-github.com/containers/common v0.46.0/go.mod h1:zxv7KjdYddSGoWuLUVp6eSb++Ow1zmSMB2jwxuNB4cU=
+github.com/containers/common v0.46.1-0.20210928081721-32e20295f1c6 h1:DojkCc4a9f3WB25Fk0GDap1/OkKU9UmDLvPJyqw3TBc=
+github.com/containers/common v0.46.1-0.20210928081721-32e20295f1c6/go.mod h1:L4+sJlqi+R7frlbiWBW0baPra/cH8u5ZYwbxkukw3Lk=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.16.0 h1:WQcNSzb7+ngS2cfynx0vUwhk+scpgiKlldVcsF8GPbI=

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -150,7 +150,8 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := struct {
-		All bool `schema:"all"`
+		All      bool `schema:"all"`
+		External bool `schema:"external"`
 	}{
 		// override any golang type defaults
 	}
@@ -190,8 +191,9 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 
 	pruneOptions := entities.ImagePruneOptions{
-		All:    query.All,
-		Filter: libpodFilters,
+		All:      query.All,
+		External: query.External,
+		Filter:   libpodFilters,
 	}
 	imagePruneReports, err := imageEngine.Prune(r.Context(), pruneOptions)
 	if err != nil {

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -1050,6 +1050,12 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    description: |
 	//      Remove all images not in use by containers, not just dangling ones
 	//  - in: query
+	//    name: external
+	//    default: false
+	//    type: boolean
+	//    description: |
+	//      Remove images even when they are used by external containers (e.g, by build containers)
+	//  - in: query
 	//    name: filters
 	//    type: string
 	//    description: |

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -74,6 +74,8 @@ type ExportOptions struct {
 type PruneOptions struct {
 	// Prune all images
 	All *bool
+	// Prune images even when they're used by external containers
+	External *bool
 	// Filters to apply when pruning images
 	Filters map[string][]string
 }

--- a/pkg/bindings/images/types_prune_options.go
+++ b/pkg/bindings/images/types_prune_options.go
@@ -32,6 +32,21 @@ func (o *PruneOptions) GetAll() bool {
 	return *o.All
 }
 
+// WithExternal set field External to given value
+func (o *PruneOptions) WithExternal(value bool) *PruneOptions {
+	o.External = &value
+	return o
+}
+
+// GetExternal returns value of field External
+func (o *PruneOptions) GetExternal() bool {
+	if o.External == nil {
+		var z bool
+		return z
+	}
+	return *o.External
+}
+
 // WithFilters set field Filters to given value
 func (o *PruneOptions) WithFilters(value map[string][]string) *PruneOptions {
 	o.Filters = value

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -251,8 +251,9 @@ type ImageListOptions struct {
 }
 
 type ImagePruneOptions struct {
-	All    bool     `json:"all" schema:"all"`
-	Filter []string `json:"filter" schema:"filter"`
+	All      bool     `json:"all" schema:"all"`
+	External bool     `json:"external" schema:"external"`
+	Filter   []string `json:"filter" schema:"filter"`
 }
 
 type ImageTagOptions struct{}

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -95,7 +95,7 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 		f := strings.Split(filter, "=")
 		filters[f[0]] = f[1:]
 	}
-	options := new(images.PruneOptions).WithAll(opts.All).WithFilters(filters)
+	options := new(images.PruneOptions).WithAll(opts.All).WithFilters(filters).WithExternal(opts.External)
 	reports, err := images.Prune(ir.ClientCtx, options)
 	if err != nil {
 		return nil, err

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -92,24 +92,38 @@ load helpers
     # Force a buildah timeout; this leaves a buildah container behind
     PODMAN_TIMEOUT=5 run_podman 124 build -t thiswillneverexist - <<EOF
 FROM $IMAGE
+RUN touch /intermediate.image.to.be.pruned
 RUN sleep 30
 EOF
 
     run_podman ps -a
-    is "${#lines[@]}" "1" "podman ps -a does not see buildah container"
+    is "${#lines[@]}" "1" "podman ps -a does not see buildah containers"
 
     run_podman ps --external -a
-    is "${#lines[@]}" "2" "podman ps -a --external sees buildah container"
+    is "${#lines[@]}" "3" "podman ps -a --external sees buildah containers"
     is "${lines[1]}" \
        "[0-9a-f]\{12\} \+$IMAGE *buildah .* seconds ago .* storage .* ${PODMAN_TEST_IMAGE_NAME}-working-container" \
        "podman ps --external"
 
-    cid="${lines[1]:0:12}"
-
     # 'rm -a' should be a NOP
     run_podman rm -a
     run_podman ps --external -a
-    is "${#lines[@]}" "2" "podman ps -a --external sees buildah container"
+    is "${#lines[@]}" "3" "podman ps -a --external sees buildah containers"
+
+    # Cannot prune intermediate image as it's being used by a buildah
+    # container.
+    run_podman image prune -f
+    is "$output" "" "No image is pruned"
+
+    # --external for removing buildah containers.
+    run_podman image prune -f --external
+    is "${#lines[@]}" "1" "Image used by build container is pruned"
+
+    # One buildah container has been removed.
+    run_podman ps --external -a
+    is "${#lines[@]}" "2" "podman ps -a --external sees buildah containers"
+
+    cid="${lines[1]:0:12}"
 
     # We can't rm it without -f, but podman should issue a helpful message
     run_podman 2 rm "$cid"

--- a/test/system/330-corrupt-images.bats
+++ b/test/system/330-corrupt-images.bats
@@ -78,7 +78,7 @@ function _corrupt_image_test() {
 
         # Run the requested command. Confirm it succeeds, with suitable warnings
         run_podman $*
-        is "$output" ".*error determining parent of image.*ignoring the error" \
+        is "$output" ".*Failed to determine parent of image.*ignoring the error" \
            "$* with missing $what_to_rm"
 
         run_podman images -a --noheading

--- a/vendor/github.com/containers/common/libimage/copier.go
+++ b/vendor/github.com/containers/common/libimage/copier.go
@@ -304,7 +304,7 @@ func (r *Runtime) newCopier(options *CopyOptions) (*copier, error) {
 
 	defaultContainerConfig, err := config.Default()
 	if err != nil {
-		logrus.Warnf("failed to get container config for copy options: %v", err)
+		logrus.Warnf("Failed to get container config for copy options: %v", err)
 	} else {
 		c.imageCopyOptions.MaxParallelDownloads = defaultContainerConfig.Engine.ImageParallelCopies
 	}

--- a/vendor/github.com/containers/common/libimage/manifests/manifests.go
+++ b/vendor/github.com/containers/common/libimage/manifests/manifests.go
@@ -125,19 +125,19 @@ func (l *list) SaveToImage(store storage.Store, imageID string, names []string, 
 		if err != nil {
 			if created {
 				if _, err2 := store.DeleteImage(img.ID, true); err2 != nil {
-					logrus.Errorf("error deleting image %q after failing to save manifest for it", img.ID)
+					logrus.Errorf("Deleting image %q after failing to save manifest for it", img.ID)
 				}
 			}
-			return "", errors.Wrapf(err, "error saving manifest list to image %q", imageID)
+			return "", errors.Wrapf(err, "saving manifest list to image %q", imageID)
 		}
 		err = store.SetImageBigData(imageID, instancesData, instancesBytes, nil)
 		if err != nil {
 			if created {
 				if _, err2 := store.DeleteImage(img.ID, true); err2 != nil {
-					logrus.Errorf("error deleting image %q after failing to save instance locations for it", img.ID)
+					logrus.Errorf("Deleting image %q after failing to save instance locations for it", img.ID)
 				}
 			}
-			return "", errors.Wrapf(err, "error saving instance list to image %q", imageID)
+			return "", errors.Wrapf(err, "saving instance list to image %q", imageID)
 		}
 		return imageID, nil
 	}
@@ -200,7 +200,7 @@ func (l *list) Push(ctx context.Context, dest types.ImageReference, options Push
 	}
 	defer func() {
 		if err2 := policyContext.Destroy(); err2 != nil {
-			logrus.Errorf("error destroying signature policy context: %v", err2)
+			logrus.Errorf("Destroying signature policy context: %v", err2)
 		}
 	}()
 

--- a/vendor/github.com/containers/common/pkg/apparmor/apparmor_linux.go
+++ b/vendor/github.com/containers/common/pkg/apparmor/apparmor_linux.go
@@ -97,22 +97,22 @@ func InstallDefault(name string) error {
 	}
 	if err := cmd.Start(); err != nil {
 		if pipeErr := pipe.Close(); pipeErr != nil {
-			logrus.Errorf("unable to close AppArmor pipe: %q", pipeErr)
+			logrus.Errorf("Unable to close AppArmor pipe: %q", pipeErr)
 		}
 		return errors.Wrapf(err, "start %s command", apparmorParserPath)
 	}
 	if err := p.generateDefault(apparmorParserPath, pipe); err != nil {
 		if pipeErr := pipe.Close(); pipeErr != nil {
-			logrus.Errorf("unable to close AppArmor pipe: %q", pipeErr)
+			logrus.Errorf("Unable to close AppArmor pipe: %q", pipeErr)
 		}
 		if cmdErr := cmd.Wait(); cmdErr != nil {
-			logrus.Errorf("unable to wait for AppArmor command: %q", cmdErr)
+			logrus.Errorf("Unable to wait for AppArmor command: %q", cmdErr)
 		}
 		return errors.Wrap(err, "generate default profile into pipe")
 	}
 
 	if pipeErr := pipe.Close(); pipeErr != nil {
-		logrus.Errorf("unable to close AppArmor pipe: %q", pipeErr)
+		logrus.Errorf("Unable to close AppArmor pipe: %q", pipeErr)
 	}
 
 	return errors.Wrap(cmd.Wait(), "wait for AppArmor command")
@@ -252,7 +252,7 @@ func CheckProfileAndLoadDefault(name string) (string, error) {
 		if name != "" {
 			return "", errors.Wrapf(ErrApparmorRootless, "cannot load AppArmor profile %q", name)
 		} else {
-			logrus.Debug("skipping loading default AppArmor profile (rootless mode)")
+			logrus.Debug("Skipping loading default AppArmor profile (rootless mode)")
 			return "", nil
 		}
 	}
@@ -292,7 +292,7 @@ func CheckProfileAndLoadDefault(name string) (string, error) {
 		if err != nil {
 			return "", errors.Wrapf(err, "install profile %s", name)
 		}
-		logrus.Infof("successfully loaded AppAmor profile %q", name)
+		logrus.Infof("Successfully loaded AppAmor profile %q", name)
 	} else {
 		logrus.Infof("AppAmor profile %q is already loaded", name)
 	}

--- a/vendor/github.com/containers/common/pkg/retry/retry.go
+++ b/vendor/github.com/containers/common/pkg/retry/retry.go
@@ -30,7 +30,7 @@ func RetryIfNecessary(ctx context.Context, operation func() error, retryOptions 
 		if retryOptions.Delay != 0 {
 			delay = retryOptions.Delay
 		}
-		logrus.Warnf("failed, retrying in %s ... (%d/%d). Error: %v", delay, attempt+1, retryOptions.MaxRetry, err)
+		logrus.Warnf("Failed, retrying in %s ... (%d/%d). Error: %v", delay, attempt+1, retryOptions.MaxRetry, err)
 		select {
 		case <-time.After(delay):
 			break

--- a/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go
+++ b/vendor/github.com/containers/common/pkg/subscriptions/subscriptions.go
@@ -114,13 +114,13 @@ func getMounts(filePath string) []string {
 	file, err := os.Open(filePath)
 	if err != nil {
 		// This is expected on most systems
-		logrus.Debugf("file %q not found, skipping...", filePath)
+		logrus.Debugf("File %q not found, skipping...", filePath)
 		return nil
 	}
 	defer file.Close()
 	scanner := bufio.NewScanner(file)
 	if err = scanner.Err(); err != nil {
-		logrus.Errorf("error reading file %q, %v skipping...", filePath, err)
+		logrus.Errorf("Reading file %q, %v skipping...", filePath, err)
 		return nil
 	}
 	var mounts []string
@@ -128,7 +128,7 @@ func getMounts(filePath string) []string {
 		if strings.HasPrefix(strings.TrimSpace(scanner.Text()), "/") {
 			mounts = append(mounts, scanner.Text())
 		} else {
-			logrus.Debugf("skipping unrecognized mount in %v: %q",
+			logrus.Debugf("Skipping unrecognized mount in %v: %q",
 				filePath, scanner.Text())
 		}
 	}
@@ -176,7 +176,7 @@ func MountsWithUIDGID(mountLabel, containerWorkingDir, mountFile, mountPoint str
 		if _, err := os.Stat(file); err == nil {
 			mounts, err := addSubscriptionsFromMountsFile(file, mountLabel, containerWorkingDir, uid, gid)
 			if err != nil {
-				logrus.Warnf("error mounting subscriptions, skipping entry in %s: %v", file, err)
+				logrus.Warnf("Failed to mount subscriptions, skipping entry in %s: %v", file, err)
 			}
 			subscriptionMounts = mounts
 			break
@@ -192,7 +192,7 @@ func MountsWithUIDGID(mountLabel, containerWorkingDir, mountFile, mountPoint str
 	switch {
 	case err == nil:
 		if err := addFIPSModeSubscription(&subscriptionMounts, containerWorkingDir, mountPoint, mountLabel, uid, gid); err != nil {
-			logrus.Errorf("error adding FIPS mode subscription to container: %v", err)
+			logrus.Errorf("Adding FIPS mode subscription to container: %v", err)
 		}
 	case os.IsNotExist(err):
 		logrus.Debug("/etc/system-fips does not exist on host, not mounting FIPS mode subscription")

--- a/vendor/github.com/containers/common/pkg/supplemented/supplemented.go
+++ b/vendor/github.com/containers/common/pkg/supplemented/supplemented.go
@@ -83,12 +83,12 @@ func (s *supplementedImageReference) NewImageSource(ctx context.Context, sys *ty
 			if iss != nil {
 				// The composite source has been created.  Use its Close method.
 				if err2 := iss.Close(); err2 != nil {
-					logrus.Errorf("error opening image: %v", err2)
+					logrus.Errorf("Opening image: %v", err2)
 				}
 			} else if top != nil {
 				// The composite source has not been created, but the top was already opened.  Close it.
 				if err2 := top.Close(); err2 != nil {
-					logrus.Errorf("error opening image: %v", err2)
+					logrus.Errorf("Closing image: %v", err2)
 				}
 			}
 		}

--- a/vendor/github.com/containers/common/pkg/sysinfo/sysinfo_linux.go
+++ b/vendor/github.com/containers/common/pkg/sysinfo/sysinfo_linux.go
@@ -237,7 +237,7 @@ func checkCgroupPids(cgMounts map[string]string, quiet bool) cgroupPids {
 		_, ok := cgMounts["pids"]
 		if !ok {
 			if !quiet {
-				logrus.Warn("unable to find pids cgroup in mounts")
+				logrus.Warn("Unable to find pids cgroup in mounts")
 			}
 			return cgroupPids{}
 		}

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.46.0"
+const Version = "0.46.1-dev"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -97,7 +97,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.46.0
+# github.com/containers/common v0.46.1-0.20210928081721-32e20295f1c6
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
 github.com/containers/common/pkg/apparmor


### PR DESCRIPTION
Support removing external containers (e.g., build containers) during
image prune.

Fixes: #11472
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>