### PR TITLE
Allow machine options to be set from containers.conf

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -42,7 +42,7 @@ func init() {
 	cpusFlagName := "cpus"
 	flags.Uint64Var(
 		&initOpts.CPUS,
-		cpusFlagName, 1,
+		cpusFlagName, cfg.Machine.CPUs,
 		"Number of CPUs",
 	)
 	_ = initCmd.RegisterFlagCompletionFunc(cpusFlagName, completion.AutocompleteNone)
@@ -50,7 +50,7 @@ func init() {
 	diskSizeFlagName := "disk-size"
 	flags.Uint64Var(
 		&initOpts.DiskSize,
-		diskSizeFlagName, 10,
+		diskSizeFlagName, cfg.Machine.DiskSize,
 		"Disk size in GB",
 	)
 
@@ -59,7 +59,7 @@ func init() {
 	memoryFlagName := "memory"
 	flags.Uint64VarP(
 		&initOpts.Memory,
-		memoryFlagName, "m", 2048,
+		memoryFlagName, "m", cfg.Machine.Memory,
 		"Memory in MB",
 	)
 	_ = initCmd.RegisterFlagCompletionFunc(memoryFlagName, completion.AutocompleteNone)
@@ -71,7 +71,7 @@ func init() {
 	)
 
 	ImagePathFlagName := "image-path"
-	flags.StringVar(&initOpts.ImagePath, ImagePathFlagName, cfg.Engine.MachineImage, "Path to qcow image")
+	flags.StringVar(&initOpts.ImagePath, ImagePathFlagName, cfg.Machine.Image, "Path to qcow image")
 	_ = initCmd.RegisterFlagCompletionFunc(ImagePathFlagName, completion.AutocompleteDefault)
 
 	IgnitionPathFlagName := "ignition-path"

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.0.1
 	github.com/containernetworking/plugins v1.0.1
 	github.com/containers/buildah v1.23.0
-	github.com/containers/common v0.44.1-0.20210921143342-f2f10e650c73
+	github.com/containers/common v0.46.0
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.16.0
 	github.com/containers/ocicrypt v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/containernetworking/plugins v1.0.1/go.mod h1:QHCfGpaTwYTbbH+nZXKVTxNB
 github.com/containers/buildah v1.23.0 h1:qGIeSNOczUHzvnaaOS29HSMiYAjw6JgIXYksAyvqnLs=
 github.com/containers/buildah v1.23.0/go.mod h1:K0iMKgy/MffkkgELBXhSXwTy2HTT6hM0X8qruDR1FwU=
 github.com/containers/common v0.44.0/go.mod h1:7sdP4vmI5Bm6FPFxb3lvAh1Iktb6tiO1MzjUzhxdoGo=
-github.com/containers/common v0.44.1-0.20210921143342-f2f10e650c73 h1:+qKOyTHbuFo3GPsrUksphfHxYMIJQmPgwpDdQnARGAI=
-github.com/containers/common v0.44.1-0.20210921143342-f2f10e650c73/go.mod h1:zxv7KjdYddSGoWuLUVp6eSb++Ow1zmSMB2jwxuNB4cU=
+github.com/containers/common v0.46.0 h1:95zB7kYBQJW+aK5xxZnaobCwoPyYOf85Y0yUx0E5aRg=
+github.com/containers/common v0.46.0/go.mod h1:zxv7KjdYddSGoWuLUVp6eSb++Ow1zmSMB2jwxuNB4cU=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.16.0 h1:WQcNSzb7+ngS2cfynx0vUwhk+scpgiKlldVcsF8GPbI=

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -54,6 +54,8 @@ type Config struct {
 	Containers ContainersConfig `toml:"containers"`
 	// Engine specifies how the container engine based on Engine will run
 	Engine EngineConfig `toml:"engine"`
+	// Machine specifies configurations of podman machine VMs
+	Machine MachineConfig `toml:"machine"`
 	// Network section defines the configuration of CNI Plugins
 	Network NetworkConfig `toml:"network"`
 	// Secret section defines configurations for the secret management
@@ -281,9 +283,6 @@ type EngineConfig struct {
 	// MachineEnabled indicates if Podman is running in a podman-machine VM
 	MachineEnabled bool `toml:"machine_enabled,omitempty"`
 
-	// MachineImage is the image used when creating a podman-machine VM
-	MachineImage string `toml:"machine_image,omitempty"`
-
 	// MultiImageArchive - if true, the container engine allows for storing
 	// archives (e.g., of the docker-archive transport) with multiple
 	// images.  By default, Podman creates single-image archives.
@@ -488,6 +487,18 @@ type SecretConfig struct {
 	Driver string `toml:"driver,omitempty"`
 	// Opts contains driver specific options
 	Opts map[string]string `toml:"opts,omitempty"`
+}
+
+// MachineConfig represents the "machine" TOML config table
+type MachineConfig struct {
+	// Number of CPU's a machine is created with.
+	CPUs uint64 `toml:"cpus,omitempty"`
+	// DiskSize is the size of the disk in GB created when init-ing a podman-machine VM
+	DiskSize uint64 `toml:"disk_size,omitempty"`
+	// MachineImage is the image used when init-ing a podman-machine VM
+	Image string `toml:"image,omitempty"`
+	// Memory in MB a machine is created with.
+	Memory uint64 `toml:"memory,omitempty"`
 }
 
 // Destination represents destination for remote service

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -396,10 +396,6 @@ default_sysctls = [
 #
 #machine_enabled = false
 
-# The image used when creating a podman-machine VM.
-#
-#machine_image = "testing"
-
 # MultiImageArchive - if true, the container engine allows for storing archives
 # (e.g., of the docker-archive transport) with multiple images.  By default,
 # Podman creates single-image archives.
@@ -559,8 +555,25 @@ default_sysctls = [
 [engine.volume_plugins]
 #testplugin = "/run/podman/plugins/test.sock"
 
-# The [engine.volume_plugins] table MUST be the last entry in this file.
+[machine]
+# Number of CPU's a machine is created with.
+#
+#cpus=1
+
+# The size of the disk in GB created when init-ing a podman-machine VM.
+#
+#disk_size=10
+
+# The image used when creating a podman-machine VM.
+#
+#image = "testing"
+
+# Memory in MB a machine is created with.
+#
+#memory=2048
+
+# The [machine] table MUST be the last entry in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being
-# defined, so every key hereafter will be part of [volume_plugins] and not the
+# defined, so every key hereafter will be part of [machine] and not the
 # main config.

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -208,6 +208,7 @@ func DefaultConfig() (*Config, error) {
 		},
 		Engine:  *defaultEngineConfig,
 		Secrets: defaultSecretConfig(),
+		Machine: defaultMachineConfig(),
 	}, nil
 }
 
@@ -216,6 +217,16 @@ func DefaultConfig() (*Config, error) {
 func defaultSecretConfig() SecretConfig {
 	return SecretConfig{
 		Driver: "file",
+	}
+}
+
+// defaultMachineConfig returns the default machine configuration.
+func defaultMachineConfig() MachineConfig {
+	return MachineConfig{
+		CPUs:     1,
+		DiskSize: 10,
+		Image:    "testing",
+		Memory:   2048,
 	}
 }
 
@@ -345,8 +356,6 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	// constants.
 	c.LockType = "shm"
 	c.MachineEnabled = false
-	c.MachineImage = "testing"
-
 	c.ChownCopiedFiles = true
 
 	return c, nil
@@ -565,10 +574,4 @@ func (c *Config) MachineEnabled() bool {
 // rootless containers should use
 func (c *Config) RootlessNetworking() string {
 	return c.Containers.RootlessNetworking
-}
-
-// MachineImage returns the image to be
-// used when creating a podman-machine VM
-func (c *Config) MachineImage() string {
-	return c.Engine.MachineImage
 }

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.44.1-dev"
+const Version = "0.46.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -97,7 +97,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.44.1-0.20210921143342-f2f10e650c73
+# github.com/containers/common v0.46.0
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
 github.com/containers/common/pkg/apparmor


### PR DESCRIPTION
Allow machine options to be set from containers.conf
CPUS, memory, disk size, and image path defaults can be set from [machine] table in containers.conf
Bump containers/common to v0.46.0

[NO TESTS NEEDED]