### PR TITLE
[WIP] Add support for podman build prune.

### DIFF
--- a/cmd/podman/images/build_prune.go
+++ b/cmd/podman/images/build_prune.go
@@ -1,0 +1,90 @@
+package images
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/containers/common/pkg/completion"
+	"github.com/containers/podman/v3/cmd/podman/common"
+	"github.com/containers/podman/v3/cmd/podman/registry"
+	"github.com/containers/podman/v3/cmd/podman/utils"
+	"github.com/containers/podman/v3/cmd/podman/validate"
+	"github.com/containers/podman/v3/pkg/domain/entities"
+	"github.com/containers/podman/v3/pkg/specgenutil"
+	"github.com/spf13/cobra"
+)
+
+var (
+	buildPruneDescription = `Remove build cache.`
+	buildPruneCmd         = &cobra.Command{
+		Use:               "prune [options]",
+		Args:              validate.NoArgs,
+		Short:             "Remove unused builder images",
+		Long:              pruneDescription,
+		RunE:              buildPrune,
+		ValidArgsFunction: completion.AutocompleteNone,
+		Example:           `podman image prune`,
+	}
+	buildPruneOpts = entities.ImagePruneOptions{}
+	buildForce     bool
+	buildFilter    = []string{}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: buildPruneCmd,
+		Parent:  buildxCmd,
+	})
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: buildPruneCmd,
+		Parent:  buildCmd,
+	})
+
+	flags := buildPruneCmd.Flags()
+	flags.BoolVarP(&pruneOpts.All, "all", "a", false, "Remove all unused build cache, not just dangling ones")
+	flags.BoolVarP(&force, "force", "f", false, "Do not prompt for confirmation")
+
+	filterFlagName := "filter"
+	flags.StringArrayVar(&filter, filterFlagName, []string{}, "Provide filter values (e.g. 'label=<key>=<value>')")
+	_ = buildPruneCmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePruneFilters)
+}
+
+func buildPrune(cmd *cobra.Command, args []string) error {
+	if !force {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Printf("%s", buildCreatePruneWarningMessage(buildPruneOpts))
+		answer, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if strings.ToLower(answer)[0] != 'y' {
+			return nil
+		}
+	}
+	filterMap, err := specgenutil.ParseFilters(filter)
+	if err != nil {
+		return err
+	}
+	for k, v := range filterMap {
+		for _, val := range v {
+			pruneOpts.Filter = append(pruneOpts.Filter, fmt.Sprintf("%s=%s", k, val))
+		}
+	}
+	results, err := registry.ImageEngine().Prune(registry.GetContext(), pruneOpts)
+	if err != nil {
+		return err
+	}
+
+	return utils.PrintImagePruneResults(results, false)
+}
+
+func buildCreatePruneWarningMessage(pruneOpts entities.ImagePruneOptions) string {
+	question := "Are you sure you want to continue? [y/N] "
+	warning := "WARNING! This will remove all dangling build cache.\n"
+	if pruneOpts.All {
+		warning = "WARNING! This will remove all build cache.\n"
+	}
+	return warning + question
+}

--- a/cmd/podman/images/buildx.go
+++ b/cmd/podman/images/buildx.go
@@ -14,11 +14,12 @@ var (
 	// If we are adding new buildx features, we will add them by default
 	// to podman build.
 	buildxCmd = &cobra.Command{
-		Use:    "buildx",
-		Short:  "Build images",
-		Long:   "Build images",
-		RunE:   validate.SubCommandExists,
-		Hidden: true,
+		Use:     "buildx",
+		Aliases: []string{"builder"},
+		Short:   "Build images",
+		Long:    "Build images",
+		RunE:    validate.SubCommandExists,
+		Hidden:  true,
 	}
 )
 

--- a/docs/source/markdown/podman-build-prune.1.md
+++ b/docs/source/markdown/podman-build-prune.1.md
@@ -1,0 +1,86 @@
+% podman-build-prune(1)
+
+## NAME
+podman-build-prune - Remove build cache
+
+## SYNOPSIS
+**podman build prune** [*options*]
+
+## DESCRIPTION
+**podman build prune** removes all dangling build cache from local storage. With the `all` option,
+you can delete all build cache.
+
+## OPTIONS
+#### **--all**, **-a**
+
+Remove all build cache.
+
+#### **--filter**=*filters*
+
+Provide filter values.
+
+The --filter flag format is of “key=value”. If there is more than one filter, then pass multiple flags (e.g., --filter "foo=bar" --filter "bif=baz")
+
+Supported filters:
+
+- `until` (_timestamp_) - only remove build cache created before given timestamp
+
+The until filter can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. 10m, 1h30m) computed relative to the machine’s time.
+
+#### **--force**, **-f**
+
+Do not provide an interactive prompt for container removal.
+
+#### **--help**, **-h**
+
+Print usage statement
+
+#### **--keep-storage**
+
+Ammount of space to keep for cache. (Ignored)
+
+## EXAMPLES
+
+Remove all dangling build cache from local storage
+```
+$ sudo podman build prune
+
+WARNING! This will remove all dangling build cache.
+Are you sure you want to continue? [y/N] y
+f3e20dc537fb04cb51672a5cb6fdf2292e61d411315549391a0d1f64e4e3097e
+324a7a3b2e0135f4226ffdd473e4099fd9e477a74230cdc35de69e84c0f9d907
+```
+
+Remove all build cache from local storage without confirming
+```
+$ sudo podman build prune -a -f
+f3e20dc537fb04cb51672a5cb6fdf2292e61d411315549391a0d1f64e4e3097e
+324a7a3b2e0135f4226ffdd473e4099fd9e477a74230cdc35de69e84c0f9d907
+6125002719feb1ddf3030acab1df6156da7ce0e78e571e9b6e9c250424d6220c
+91e732da5657264c6f4641b8d0c4001c218ae6c1adb9dcef33ad00cafd37d8b6
+e4e5109420323221f170627c138817770fb64832da7d8fe2babd863148287fca
+77a57fa8285e9656dbb7b23d9efa837a106957409ddd702f995605af27a45ebe
+
+```
+
+Remove all build cache from local storage since given time/hours.
+```
+$ sudo podman image prune -a --filter until=2019-11-14T06:15:42.937792374Z
+
+WARNING! This will remove all build cache.
+Are you sure you want to continue? [y/N] y
+e813d2135f17fadeffeea8159a34cfdd4c30b98d8111364b913a91fd930643e9
+5e6572320437022e2746467ddf5b3561bf06e099e8e6361df27e0b2a7ed0b17b
+58fda2abf5042b35dfe04e5f8ee458a3cc26375bf309efb42c078b551a2055c7
+6d2bd30fe924d3414b64bd3920760617e6ced872364bc3bc6959a623252da002
+33d1c829be64a1e1d379caf4feec1f05a892c3ef7aa82c0be53d3c08a96c59c5
+f9f0a8a58c9e02a2b3250b88cc5c95b1e10245ca2c4161d19376580aaa90f55c
+1ef14d5ede80db78978b25ad677fd3e897a578c3af614e1fda608d40c8809707
+45e1482040e441a521953a6da2eca9bafc769e15667a07c23720d6e0cafc3ab2
+```
+
+## SEE ALSO
+podman(1), podman-build(1)
+
+## HISTORY
+December 2021, Originally compiled by Dan Walsh (dwalsh at redhat dot com)

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -45,6 +45,12 @@ command to see these containers. External containers can be removed with the
 
 `podman buildx build` command is an alias of `podman build`.  Not all `buildx build` features are available in Podman. The `buildx build` option is provided for scripting compatibility.
 
+## COMMANDS
+
+| Command  | Man Page                                            | Description             |
+| -------- | --------------------------------------------------- | ----------------------- |
+| prune    | [podman-build-prune(1)](podman-build-prune.1.md)    | Remove build cache.     |
+
 ## OPTIONS
 
 #### **--add-host**=*host*

--- a/docs/source/markdown/podman-image-prune.1.md
+++ b/docs/source/markdown/podman-image-prune.1.md
@@ -99,7 +99,7 @@ f9f0a8a58c9e02a2b3250b88cc5c95b1e10245ca2c4161d19376580aaa90f55c
 ```
 
 ## SEE ALSO
-podman(1), podman-images
+podman(1), podman-images(1)
 
 ## HISTORY
 December 2018, Originally compiled by Brent Baude (bbaude at redhat dot com)


### PR DESCRIPTION
Docker has support for `docker builder prune` and
`docker builder build`

This patch will add a hidden command to support scripts using this
syntax. We don't want to encourage this deviation.

Add `podman build prune` to implement `docker builder prune`
functionality.

Fixes: #11744

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>