### PR TITLE
always add short container id as net alias

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1310,7 +1310,7 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 	if err == nil && options.Name == "" && (!options.IgnoreStaticIP || !options.IgnoreStaticMAC) {
 		// The file with the network.status does exist. Let's restore the
 		// container with the same networks settings as during checkpointing.
-		aliases, err := c.runtime.state.GetAllNetworkAliases(c)
+		aliases, err := c.GetAllNetworkAliases()
 		if err != nil {
 			return err
 		}

--- a/libpod/network/cni/run.go
+++ b/libpod/network/cni/run.go
@@ -186,9 +186,6 @@ outer:
 		}
 		return errors.Errorf("requested static ip %s not in any subnet on network %s", ip.String(), network.libpodNet.Name)
 	}
-	if len(netOpts.Aliases) > 0 && !network.libpodNet.DNSEnabled {
-		return errors.New("cannot set aliases on a network without dns enabled")
-	}
 	return nil
 }
 

--- a/libpod/network/cni/run_test.go
+++ b/libpod/network/cni/run_test.go
@@ -966,6 +966,26 @@ var _ = Describe("run CNI", func() {
 			})
 		})
 
+		It("setup with aliases but dns disabled should work", func() {
+			runTest(func() {
+				defNet := types.DefaultNetworkName
+				intName := "eth0"
+				setupOpts := types.SetupOptions{
+					NetworkOptions: types.NetworkOptions{
+						ContainerID: stringid.GenerateNonCryptoID(),
+						Networks: map[string]types.PerNetworkOptions{
+							defNet: {
+								InterfaceName: intName,
+								Aliases:       []string{"somealias"},
+							},
+						},
+					},
+				}
+				_, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
 	})
 
 	Context("invalid network setup test", func() {
@@ -1049,27 +1069,6 @@ var _ = Describe("run CNI", func() {
 				_, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("ContainerID is empty"))
-			})
-		})
-
-		It("setup with aliases but dns disabled", func() {
-			runTest(func() {
-				defNet := types.DefaultNetworkName
-				intName := "eth0"
-				setupOpts := types.SetupOptions{
-					NetworkOptions: types.NetworkOptions{
-						ContainerID: stringid.GenerateNonCryptoID(),
-						Networks: map[string]types.PerNetworkOptions{
-							defNet: {
-								InterfaceName: intName,
-								Aliases:       []string{"somealias"},
-							},
-						},
-					},
-				}
-				_, err := libpodNet.Setup(netNSContainer.Path(), setupOpts)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("cannot set aliases on a network without dns enabled"))
 			})
 		})
 

--- a/libpod/network/types/network.go
+++ b/libpod/network/types/network.go
@@ -151,7 +151,9 @@ type PerNetworkOptions struct {
 	// StaticIPv4 for this container. Optional.
 	StaticIPs []net.IP `json:"static_ips,omitempty"`
 	// Aliases contains a list of names which the dns server should resolve
-	// to this container. Can only be set when DNSEnabled is true on the Network.
+	// to this container. Should only be set when DNSEnabled is true on the Network.
+	// If aliases are set but there is no dns support for this network the
+	// network interface implementation should ignore this and NOT error.
 	// Optional.
 	Aliases []string `json:"aliases,omitempty"`
 	// StaticMac for this container. Optional.

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1262,6 +1262,14 @@ func (c *Container) NetworkConnect(nameOrID, netName string, aliases []string) e
 	// get network status before we connect
 	networkStatus := c.getNetworkStatus()
 
+	network, err := c.runtime.network.NetworkInspect(netName)
+	if err != nil {
+		return err
+	}
+	if !network.DNSEnabled && len(aliases) > 0 {
+		return errors.Wrapf(define.ErrInvalidArg, "cannot set network aliases for network %q because dns is disabled", netName)
+	}
+
 	if err := c.runtime.state.NetworkConnect(c, netName, aliases); err != nil {
 		return err
 	}

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -498,6 +498,7 @@ func CreateExitCommandArgs(storageConfig types.StoreOptions, config *config.Conf
 		"--log-level", logrus.GetLevel().String(),
 		"--cgroup-manager", config.Engine.CgroupManager,
 		"--tmpdir", config.Engine.TmpDir,
+		"--cni-config-dir", config.Network.NetworkConfigDir,
 	}
 	if config.Engine.OCIRuntime != "" {
 		command = append(command, []string{"--runtime", config.Engine.OCIRuntime}...)

--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -247,6 +247,7 @@ function podman() {
 	--storage-driver=vfs \
         --root    $WORKDIR/root    \
         --runroot $WORKDIR/runroot \
+        --cni-config-dir $WORKDIR/cni \
         "$@")
     echo -n "$output" >>$WORKDIR/output.log
 }

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -415,6 +415,10 @@ load helpers
     run_podman inspect $cid --format "{{(index .NetworkSettings.Networks \"$netname\").MacAddress}}"
     mac="$output"
 
+    # check network alias for container short id
+    run_podman inspect $cid --format "{{(index .NetworkSettings.Networks \"$netname\").Aliases}}"
+    is "$output" "\[${cid:0:12}\]" "short container id in network aliases"
+
     run_podman network disconnect $netname $cid
 
     # check that we cannot curl (timeout after 3 sec)
@@ -442,6 +446,10 @@ load helpers
 
     # connect a second network
     run_podman network connect $netname2 $cid
+
+    # check network2 alias for container short id
+    run_podman inspect $cid --format "{{(index .NetworkSettings.Networks \"$netname2\").Aliases}}"
+    is "$output" "\[${cid:0:12}\]" "short container id in network aliases"
 
     # curl should work
     run curl --max-time 3 -s $SERVER/index.txt


### PR DESCRIPTION
This matches what docker does. Also make sure the net aliases are also
shown when the container is stopped.

docker-compose uses this special alias entry to check if it is already
correctly connected to the network. [1]
Because we do not support static ips on network connect at the moment
calling disconnect && connect will loose the static ip.

Fixes #11748

[1] https://github.com/docker/compose/blob/0bea52b18dda3de8c28fcfb0c80cc08b8950645e/compose/service.py#L663-L667

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
