### PR TITLE
podman machine: do not join userns

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -212,6 +212,7 @@ can_use_shortcut ()
         continue;
 
       if (strcmp (argv[argc], "mount") == 0
+          || strcmp (argv[argc], "machine") == 0
           || strcmp (argv[argc], "search") == 0
           || (strcmp (argv[argc], "system") == 0 && argv[argc+1] && strcmp (argv[argc+1], "service") != 0))
         {


### PR DESCRIPTION
The go logic already prevents podman from joining the userns for machine
commands but the c shortcut code did not.

[NO TESTS NEEDED]


Fixes #11731
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
