### PR TITLE
stop: Do nothing if container was never created in runtime or in a invalid state.

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -169,6 +169,10 @@ func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []strin
 				logrus.Debugf("Container %s is already stopped", c.ID())
 			case options.All && errors.Cause(err) == define.ErrCtrStateInvalid:
 				logrus.Debugf("Container %s is not running, could not stop", c.ID())
+			// container never created in OCI runtime
+			// docker parity: do nothing just return container id
+			case errors.Cause(err) == define.ErrCtrStateInvalid:
+				logrus.Debugf("Container %s is either not created on runtime or is in a invalid state", c.ID())
 			default:
 				return err
 			}

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -234,6 +234,17 @@ var _ = Describe("Podman stop", func() {
 		Expect(strings.TrimSpace(finalCtrs.OutputToString())).To(Equal(""))
 	})
 
+	It("podman stop should return silent success on stopping configured containers", func() {
+		// following container is not created on OCI runtime
+		// so we return success and assume that is is stopped
+		session2 := podmanTest.Podman([]string{"create", "--name", "stopctr", ALPINE, "/bin/sh"})
+		session2.WaitWithDefaultTimeout()
+		Expect(session2).Should(Exit(0))
+		session3 := podmanTest.Podman([]string{"stop", "stopctr"})
+		session3.WaitWithDefaultTimeout()
+		Expect(session3).Should(Exit(0))
+	})
+
 	It("podman stop --cidfile", func() {
 
 		tmpDir, err := ioutil.TempDir("", "")


### PR DESCRIPTION
Following commit ensures we silently return container id on `stop` if
container was never created in OCI runtime.

Following behavior ensures that we are in parity with docker.

Closes: https://github.com/containers/podman/issues/11740
