### PR TITLE
remote build: EvalSymlinks() the context directory

### DIFF
--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -230,6 +230,9 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 			params.Add("platform", platform)
 		}
 	}
+	if contextDir, err := filepath.EvalSymlinks(options.ContextDirectory); err == nil {
+		options.ContextDirectory = contextDir
+	}
 
 	params.Set("pullpolicy", options.PullPolicy.String())
 

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -956,6 +956,15 @@ EOF
     run_podman build -t build_test $tmpdir
 }
 
+@test "podman build build context is a symlink to a directory" {
+    tmpdir=$PODMAN_TMPDIR/build-test
+    mkdir -p $tmpdir/target
+    ln -s target $tmpdir/link
+    echo FROM alpine > $tmpdir/link/Dockerfile
+    echo RUN echo hello >> $tmpdir/link/Dockerfile
+    run_podman build -t build_test $tmpdir/link
+}
+
 function teardown() {
     # A timeout or other error in 'build' can leave behind stale images
     # that podman can't even see and which will cascade into subsequent


### PR DESCRIPTION
Use EvalSymlinks() to find the context directory, in case there's shenanigans.

Fixes https://github.com/containers/podman/issues/11732.