### PR TITLE
CNI: network remove do not error for ENOENT

### DIFF
--- a/libpod/network/cni/config.go
+++ b/libpod/network/cni/config.go
@@ -170,7 +170,11 @@ func (n *cniNetwork) NetworkRemove(nameOrID string) error {
 	file := network.filename
 	delete(n.networks, network.libpodNet.Name)
 
-	return os.Remove(file)
+	// make sure to not error for ErrNotExist
+	if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 // NetworkList will return all known Networks. Optionally you can

--- a/libpod/network/cni/config_test.go
+++ b/libpod/network/cni/config_test.go
@@ -1021,6 +1021,27 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("subnet 10.10.0.0/24 is already used on the host or by another config"))
 		})
 
+		It("remove network should not error when config file does not exists on disk", func() {
+			name := "mynet"
+			network := types.Network{Name: name}
+			_, err := libpodNet.NetworkCreate(network)
+			Expect(err).To(BeNil())
+
+			path := filepath.Join(cniConfDir, name+".conflist")
+			Expect(path).To(BeARegularFile())
+
+			err = os.Remove(path)
+			Expect(err).To(BeNil())
+			Expect(path).ToNot(BeARegularFile())
+
+			err = libpodNet.NetworkRemove(name)
+			Expect(err).To(BeNil())
+
+			nets, err := libpodNet.NetworkList()
+			Expect(err).To(BeNil())
+			Expect(nets).To(HaveLen(1))
+			Expect(nets).ToNot(ContainElement(HaveNetworkName(name)))
+		})
 	})
 
 	Context("network load valid existing ones", func() {


### PR DESCRIPTION
#### CNI: network remove do not error for ENOENT

Make podman network rm more robust by checking for ENOENT if we cannot
remove the config file. If it does not exists there is no reason to
error. This is especially useful for podman network prune.

#### fix podman network prune integration test flakes

The podman integration tests run in parallel. Because all tests use the
same CNI config dir the podman network prune test will remove networks
which are used by other tests at the moment and thus creating
unexpected flakes.

The solution use an extra cni config dir for the network prune test.