### PR TITLE
Set MSI to be 64-bit only.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -672,7 +672,7 @@ podman-v$(RELEASE_NUMBER).msi: podman-remote-windows podman-remote-windows-docs
 		--directory-ref INSTALLDIR --prefix $(DOCFILE)/ > \
 			$(DOCFILE)/pages.wsx
 	wixl -D VERSION=$(call err_if_empty,RELEASE_VERSION) -D ManSourceDir=$(DOCFILE) \
-		-o $@ contrib/msi/podman.wxs $(DOCFILE)/pages.wsx
+		-o $@ contrib/msi/podman.wxs $(DOCFILE)/pages.wsx --arch x64
 
 .PHONY: package
 package:  ## Build rpm packages

--- a/contrib/msi/podman.wxs
+++ b/contrib/msi/podman.wxs
@@ -11,19 +11,19 @@
 
   <Product Name="Podman $(var.VERSION)" Id="*" UpgradeCode="696BAB5D-CA1F-4B05-B123-320F245B8D6D" Version="$(var.VERSION)" Language="1033" Manufacturer="Red Hat Inc.">
 
-    <Package Id="*" Keywords="Installer" Description="Red Hat's Podman $(var.VERSION) Installer" Comments="Apache 2.0 License" Manufacturer="Red Hat Inc." InstallScope="perMachine" InstallerVersion="100" Compressed="yes"/>
+    <Package Id="*" Keywords="Installer" Description="Red Hat's Podman $(var.VERSION) Installer" Comments="Apache 2.0 License" Manufacturer="Red Hat Inc." InstallScope="perMachine" InstallerVersion="200" Compressed="yes"/>
     <Media Id="1" Cabinet="Podman.cab" EmbedCab="yes"/>
     <Property Id="DiskPrompt" Value="Red Hat's Podman $(var.VERSION) Installation"/>
 
     <Directory Id="TARGETDIR" Name="SourceDir">
 
-      <Directory Id="ProgramFilesFolder" Name="PFiles">
+      <Directory Id="ProgramFiles64Folder" Name="PFiles">
         <Directory Id="RedHatPFiles" Name="RedHat">
           <Directory Id="INSTALLDIR" Name="Podman">
-            <Component Id="INSTALLDIR_Component" Guid="14B310C4-9B5D-4DA5-ADF9-B9D008E4CD82">
+            <Component Id="INSTALLDIR_Component" Guid="14B310C4-9B5D-4DA5-ADF9-B9D008E4CD82" Win64="Yes">
               <CreateFolder/>
             </Component>
-            <Component Id="MainExecutable" Guid="73752F94-6589-4C7B-ABED-39D655A19714">
+            <Component Id="MainExecutable" Guid="73752F94-6589-4C7B-ABED-39D655A19714" Win64="Yes">
               <File Id="520C6E17-77A2-4F41-9611-30FA763A0702" Name="podman.exe" Source="bin/windows/podman.exe" KeyPath="yes"/>
             </Component>
           </Directory>


### PR DESCRIPTION
Hi there! I noticed that the MSI file built for Windows was building in 32-bit mode, even though Podman is 64-bit only. I added a flag to wixl in the Makefile to tell it to build a 64-bit MSI, and I adjusted the podman.wxs file to use the right settings for 64-bit programs.

I forgot to put [NO TESTS NEEDED] in my commit message, but there shouldn't be any tests needed here if I understand CONTRIBUTING.md correctly.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
