### PR TITLE
Add dockerfile.5 as man link to containerfile man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,9 +412,9 @@ completions: podman podman-remote
 	declare -A outfiles=([bash]=%s [zsh]=_%s [fish]=%s.fish [powershell]=%s.ps1);\
 	for shell in $${!outfiles[*]}; do \
 	    for remote in "" "-remote"; do \
-	        podman="podman$$remote"; \
-	        outfile=$$(printf "completions/$$shell/$${outfiles[$$shell]}" $$podman); \
-	        ./bin/$$podman completion $$shell >| $$outfile; \
+		podman="podman$$remote"; \
+		outfile=$$(printf "completions/$$shell/$${outfiles[$$shell]}" $$podman); \
+		./bin/$$podman completion $$shell >| $$outfile; \
 	    done;\
 	done
 
@@ -432,10 +432,10 @@ $(MANPAGES): %: %.md .install.md2man docdir
 ### this ensures that manpages are renderd correctly
 
 	@sed -e 's/\((podman[^)]*\.md\(#.*\)\?)\)//g' \
-         -e 's/\[\(podman[^]]*\)\]/\1/g' \
+	 -e 's/\[\(podman[^]]*\)\]/\1/g' \
 		 -e 's/\[\([^]]*\)](http[^)]\+)/\1/g' \
-         -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g' \
-         -e 's/\\$$/  /g' $<  | \
+	 -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g' \
+	 -e 's/\\$$/  /g' $<  | \
 	$(GOMD2MAN) -in /dev/stdin -out $(subst source/markdown,build/man,$@)
 
 .PHONY: docdir
@@ -759,6 +759,8 @@ install.docker:
 install.docker-docs-nobuild:
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(MANDIR)/man1
 	install ${SELINUXOPT} -m 644 docs/build/man/docker*.1 -t $(DESTDIR)$(MANDIR)/man1
+	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(MANDIR)/man5
+	install ${SELINUXOPT} -m 644 docs/build/man/docker*.5 -t $(DESTDIR)$(MANDIR)/man5
 
 .PHONY: install.docker-docs
 install.docker-docs: docker-docs install.docker-docs-nobuild

--- a/docs/dckrman.sh
+++ b/docs/dckrman.sh
@@ -4,3 +4,4 @@ for i in $@; do
     filename=$(echo $i | sed 's/podman/docker/g')
     echo .so man1/$b > $filename
 done
+echo .so man5/containerfile.5 > $(dirname $1)/dockerfile.5


### PR DESCRIPTION
containers-common package now ships a containerfile man page,
this patch adds a link to dockerfile.5 so that if user
installs podman-docker package `man dockerfile` will work.

[NO TESTS NEEDED] since this is just a man page change.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
