### PR TITLE
Add port configuration to first regular container

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -253,7 +253,9 @@ func (p *Pod) podWithContainers(ctx context.Context, containers []*Container, po
 			// We add the original port declarations from the libpod infra container
 			// to the first kubernetes container description because otherwise we loose
 			// the original container/port bindings.
-			if first && len(ports) > 0 {
+			// Add the port configuration to the first regular container or the first
+			// init container if only init containers have been created in the pod.
+			if first && len(ports) > 0 && (!isInit || len(containers) == 2) {
 				ctr.Ports = ports
 				first = false
 			}


### PR DESCRIPTION
When generating a kube yaml and there is a port configuration
add the configuration to the first regular container in the pod
and not to the init container.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
