### PR TITLE
System tests: speed up. They've gotten too slow.

### DIFF
--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -135,31 +135,38 @@ function _log_test_until() {
     s_after="after_$(random_string)_${driver}"
 
     before=$(date --iso-8601=seconds)
-    sleep 5
+    sleep 1
     run_podman run --log-driver=$driver -d --name test $IMAGE sh -c \
         "echo $s_before; trap 'echo $s_after; exit' SIGTERM; while :; do sleep 1; done"
 
     # sleep a second to make sure the date is after the first echo
     sleep 1
     run_podman stop test
-    # sleep for 20 seconds to get the proper after time
-    sleep 20
+    run_podman wait test
 
-    run_podman logs test
-    is "$output" \
-        "$s_before
+    # Sigh. Stupid journald has a lag. Wait a few seconds for it to catch up.
+    retries=20
+    s_both="$s_before
 $s_after"
+    while [[ $retries -gt 0 ]]; do
+        run_podman logs test
+        if [[ "$output" = "$s_both" ]]; then
+            break
+        fi
+        retries=$((retries - 1))
+        sleep 0.1
+    done
+    if [[ $retries -eq 0 ]]; then
+        die "Timed out waiting for before&after in podman logs: $output"
+    fi
 
     run_podman logs --until $before test
-    is "$output" \
-        ""
+    is "$output" "" "podman logs --until before"
 
-    after=$(date --iso-8601=seconds)
+    after=$(date --date='+1 second' --iso-8601=seconds)
 
     run_podman logs --until $after test
-    is "$output" \
-        "$s_before
-$s_after"
+    is "$output" "$s_both" "podman logs --until after"
     run_podman rm -f test
 }
 

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -90,10 +90,18 @@ load helpers
     is "${#lines[@]}" "1" "setup check: no storage containers at start of test"
 
     # Force a buildah timeout; this leaves a buildah container behind
+    local t0=$SECONDS
     PODMAN_TIMEOUT=5 run_podman 124 build -t thiswillneverexist - <<EOF
 FROM $IMAGE
 RUN sleep 30
 EOF
+    local t1=$SECONDS
+    local delta_t=$((t1 - t0))
+    if [[ $delta_t -gt 10 ]]; then
+        # FIXME FIXME FIXME: when buildah issue 3544 gets fixed and vendored,
+        # change 'echo' to 'die'
+        echo "podman build did not get killed within 10 seconds (actual time: $delta_t seconds)"
+    fi
 
     run_podman ps -a
     is "${#lines[@]}" "1" "podman ps -a does not see buildah container"

--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -125,6 +125,7 @@ load helpers
     run_podman exec $cid find /image-mount/etc/
 
     # Clean up
+    run_podman stop -t 0 $cid
     run_podman rm -f $cid
 }
 
@@ -147,6 +148,7 @@ load helpers
     run_podman inspect --format "{{(index .Mounts 0).RW}}" $cid
     is "$output" "true" "inspect data includes image mount source"
 
+    run_podman stop -t 0 $cid
     run_podman rm -f $cid
 }
 

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -256,6 +256,7 @@ load helpers
 "
 
     # From RUNNING container
+    local -a destcontainers=()
     while read id src dest dest_fullname description; do
         # dest may be "''" for empty table cells
         if [[ $dest == "''" ]];then
@@ -265,26 +266,25 @@ load helpers
         # To RUNNING container
         run_podman run -d $IMAGE sleep infinity
         destcontainer="$output"
+        destcontainers+=($destcontainer)
         run_podman cp cpcontainer:$src $destcontainer:"/$dest"
         run_podman exec $destcontainer cat "/$dest_fullname"
         is "$output" "${randomcontent[$id]}" "$description (cp ctr:$src to /$dest)"
-        run_podman kill $destcontainer
-        run_podman rm -f $destcontainer
 
 	# To CREATED container
         run_podman create $IMAGE sleep infinity
         destcontainer="$output"
+        destcontainers+=($destcontainer)
         run_podman cp cpcontainer:$src $destcontainer:"/$dest"
         run_podman start $destcontainer
         run_podman exec $destcontainer cat "/$dest_fullname"
         is "$output" "${randomcontent[$id]}" "$description (cp ctr:$src to /$dest)"
-        run_podman kill $destcontainer
-        run_podman rm -f $destcontainer
     done < <(parse_table "$tests")
-    run_podman kill cpcontainer
-    run_podman rm -f cpcontainer
+    run_podman kill cpcontainer ${destcontainers[@]}
+    run_podman rm -f cpcontainer ${destcontainers[@]}
 
     # From CREATED container
+    destcontainers=()
     run_podman create --name cpcontainer --workdir=/srv $cpimage
     while read id src dest dest_fullname description; do
         # dest may be "''" for empty table cells
@@ -295,23 +295,21 @@ load helpers
         # To RUNNING container
         run_podman run -d $IMAGE sleep infinity
         destcontainer="$output"
+        destcontainers+=($destcontainer)
         run_podman cp cpcontainer:$src $destcontainer:"/$dest"
         run_podman exec $destcontainer cat "/$dest_fullname"
         is "$output" "${randomcontent[$id]}" "$description (cp ctr:$src to /$dest)"
-        run_podman kill $destcontainer
-        run_podman rm -f $destcontainer
-
 	# To CREATED container
         run_podman create $IMAGE sleep infinity
         destcontainer="$output"
+        destcontainers+=($destcontainer)
         run_podman cp cpcontainer:$src $destcontainer:"/$dest"
         run_podman start $destcontainer
         run_podman exec $destcontainer cat "/$dest_fullname"
         is "$output" "${randomcontent[$id]}" "$description (cp ctr:$src to /$dest)"
-        run_podman kill $destcontainer
-        run_podman rm -f $destcontainer
     done < <(parse_table "$tests")
-    run_podman rm -f cpcontainer
+    run_podman kill ${destcontainers[@]}
+    run_podman rm -f cpcontainer ${destcontainers[@]}
 
     run_podman rmi -f $cpimage
 }
@@ -496,6 +494,7 @@ load helpers
 "
 
     # From RUNNING container
+    local -a destcontainers=()
     while read src dest dest_fullname description; do
         if [[ $src == "''" ]];then
             unset src
@@ -510,28 +509,27 @@ load helpers
         # To RUNNING container
         run_podman run -d $IMAGE sleep infinity
         destcontainer="$output"
+        destcontainers+=($destcontainer)
         run_podman cp cpcontainer:$src $destcontainer:"/$dest"
         run_podman exec $destcontainer cat "/$dest_fullname/containerfile0" "/$dest_fullname/containerfile1"
         is "$output" "${randomcontent[0]}
 ${randomcontent[1]}" "$description"
-        run_podman kill $destcontainer
-        run_podman rm -f $destcontainer
 
 	# To CREATED container
         run_podman create $IMAGE sleep infinity
         destcontainer="$output"
+        destcontainers+=($destcontainer)
         run_podman cp cpcontainer:$src $destcontainer:"/$dest"
         run_podman start $destcontainer
         run_podman exec $destcontainer cat "/$dest_fullname/containerfile0" "/$dest_fullname/containerfile1"
         is "$output" "${randomcontent[0]}
 ${randomcontent[1]}" "$description"
-        run_podman kill $destcontainer
-        run_podman rm -f $destcontainer
     done < <(parse_table "$tests")
-    run_podman kill cpcontainer
-    run_podman rm -f cpcontainer
+    run_podman kill cpcontainer ${destcontainers[@]}
+    run_podman rm -f cpcontainer ${destcontainers[@]}
 
     # From CREATED container
+    destcontainers=()
     run_podman create --name cpcontainer --workdir=/srv $cpimage
     while read src dest dest_fullname description; do
         if [[ $src == "''" ]];then
@@ -547,26 +545,25 @@ ${randomcontent[1]}" "$description"
 	# To RUNNING container
         run_podman run -d $IMAGE sleep infinity
         destcontainer="$output"
+        destcontainers+=($destcontainer)
         run_podman cp cpcontainer:$src $destcontainer:"/$dest"
         run_podman exec $destcontainer cat "/$dest_fullname/containerfile0" "/$dest_fullname/containerfile1"
         is "$output" "${randomcontent[0]}
 ${randomcontent[1]}" "$description"
-        run_podman kill $destcontainer
-        run_podman rm -f $destcontainer
 
 	# To CREATED container
         run_podman create $IMAGE sleep infinity
         destcontainer="$output"
+        destcontainers+=($destcontainer)
         run_podman start $destcontainer
         run_podman cp cpcontainer:$src $destcontainer:"/$dest"
         run_podman exec $destcontainer cat "/$dest_fullname/containerfile0" "/$dest_fullname/containerfile1"
         is "$output" "${randomcontent[0]}
 ${randomcontent[1]}" "$description"
-        run_podman kill $destcontainer
-        run_podman rm -f $destcontainer
     done < <(parse_table "$tests")
 
-    run_podman rm -f cpcontainer
+    run_podman kill ${destcontainers[@]}
+    run_podman rm -f cpcontainer ${destcontainers[@]}
     run_podman rmi -f $cpimage
 }
 

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -960,7 +960,7 @@ EOF
     tmpdir=$PODMAN_TMPDIR/build-test
     mkdir -p $tmpdir/target
     ln -s target $tmpdir/link
-    echo FROM alpine > $tmpdir/link/Dockerfile
+    echo FROM $IMAGE > $tmpdir/link/Dockerfile
     echo RUN echo hello >> $tmpdir/link/Dockerfile
     run_podman build -t build_test $tmpdir/link
 }

--- a/test/system/080-pause.bats
+++ b/test/system/080-pause.bats
@@ -48,6 +48,7 @@ load helpers
     # would imply that the container never paused.
     is "$max_delta" "[3456]" "delta t between paused and restarted"
 
+    run_podman stop -t 0 $cname
     run_podman rm -f $cname
 
     # Pause/unpause on nonexistent name or id - these should all fail
@@ -73,6 +74,7 @@ load helpers
     is "$output" "$cid" "podman unpause output"
     run_podman ps --format '{{.ID}} {{.Names}} {{.Status}}'
     is "$output" "${cid:0:12} $cname Up.*" "podman ps on resumed container"
+    run_podman stop -t 0 $cname
     run_podman rm -f $cname
     run_podman rm -f notrunning
 }

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -108,6 +108,7 @@ Log[-1].Output   |
     is "$output" "unhealthy" "output from 'podman healthcheck run'"
 
     # Clean up
+    run_podman stop -t 0 healthcheck_c
     run_podman rm -f healthcheck_c
     run_podman rmi   healthcheck_i
 }

--- a/test/system/270-socket-activation.bats
+++ b/test/system/270-socket-activation.bats
@@ -69,26 +69,36 @@ function teardown() {
 
 @test "podman system service - socket activation - no container" {
     run curl -s --max-time 3 --unix-socket $SERVICE_SOCK_ADDR http://podman/libpod/_ping
-    is "$output" "OK" "podman service responses normally"
+    is "$output" "OK" "podman service responds normally"
 }
 
-@test "podman system service - socket activation - exist container " {
-    run_podman run $IMAGE sleep 90
+@test "podman system service - socket activation - existing container" {
+    run_podman run -d $IMAGE sleep 90
+    cid="$output"
+
     run curl -s --max-time 3 --unix-socket $SERVICE_SOCK_ADDR http://podman/libpod/_ping
-    is "$output" "OK" "podman service responses normally"
+    is "$output" "OK" "podman service responds normally"
+
+    run_podman stop -t 0 $cid
+    run_podman rm -f $cid
 }
 
-@test "podman system service - socket activation - kill rootless pause " {
+@test "podman system service - socket activation - kill rootless pause" {
     if ! is_rootless; then
         skip "root podman no need pause process"
     fi
-    run_podman run $IMAGE sleep 90
+    run_podman run -d $IMAGE sleep 90
+    cid="$output"
+
     local pause_pid="$XDG_RUNTIME_DIR/libpod/tmp/pause.pid"
     if [ -f $pause_pid ]; then
         kill -9 $(cat $pause_pid) 2> /dev/null
     fi
     run curl -s --max-time 3 --unix-socket $SERVICE_SOCK_ADDR http://podman/libpod/_ping
-    is "$output" "OK" "podman service responses normally"
+    is "$output" "OK" "podman service responds normally"
+
+    run_podman stop -t 0 $cid
+    run_podman rm -f $cid
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
 - logs: remove unnecessary sleeps. This saves ~25s.

 - ps: add placeholder test for once buildah 3544 is fixed

 - cp: bulk-kill containers when finished, instead of one by one.
   This is a big change and only saves about 8s per run, but hey.

 - mount,pause,healthcheck: 'podman stop -t 0' before rm'ing containers.
   Easy 50s.
   Have I mentioned, lately, that 'podman rm -f' needs a '-t 0' flag?

 - play: same, and also 'podman pod stop'. Seems to shave ~20s.

 - socket-activation: UGH! Buggy and useless tests! They were
   running "sleep 90" containers for no reason whatsoever. I
   assume the intention was to run them with "-d", so that's
   what I've done here. Also fixed some language. 180 seconds!

Signed-off-by: Ed Santiago <santiago@redhat.com>
