### PR TITLE
[CI:DOCS] cmd/podman: no dot for short descriptions

### DIFF
--- a/cmd/podman/generate/generate.go
+++ b/cmd/podman/generate/generate.go
@@ -11,7 +11,7 @@ var (
 	// Command: podman _generate_
 	generateCmd = &cobra.Command{
 		Use:   "generate",
-		Short: "Generate structured data based on containers, pods or volumes.",
+		Short: "Generate structured data based on containers, pods or volumes",
 		Long:  "Generate structured data (e.g., Kubernetes YAML or systemd units) based on containers, pods or volumes.",
 		RunE:  validate.SubCommandExists,
 	}

--- a/cmd/podman/play/play.go
+++ b/cmd/podman/play/play.go
@@ -10,7 +10,7 @@ var (
 	// Command: podman _play_
 	playCmd = &cobra.Command{
 		Use:   "play",
-		Short: "Play containers, pods or volumes from a structured file.",
+		Short: "Play containers, pods or volumes from a structured file",
 		Long:  "Play structured data (e.g., Kubernetes YAML) based on containers, pods or volumes.",
 		RunE:  validate.SubCommandExists,
 	}


### PR DESCRIPTION
Remove trailing dots in the short descriptions for the sake of
consistency.  Noticed while parsing `podman help`.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
