### PR TITLE
memory optimization - deep copies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/gorilla/schema v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hpcloud/tail v1.0.0
+	github.com/jinzhu/copier v0.3.2
 	github.com/json-iterator/go v1.1.12
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -271,7 +271,7 @@ type ContainerNetworkDescriptions map[string]int
 // Config returns the configuration used to create the container
 func (c *Container) Config() *ContainerConfig {
 	returnConfig := new(ContainerConfig)
-	if err := JSONDeepCopy(c.config, returnConfig); err != nil {
+	if err := DeepCopy(c.config, returnConfig); err != nil {
 		return nil
 	}
 
@@ -293,7 +293,7 @@ func (c *Container) Runtime() *Runtime {
 // spec may differ slightly as mounts are added based on the image
 func (c *Container) Spec() *spec.Spec {
 	returnSpec := new(spec.Spec)
-	if err := JSONDeepCopy(c.config.Spec, returnSpec); err != nil {
+	if err := DeepCopy(c.config.Spec, returnSpec); err != nil {
 		return nil
 	}
 
@@ -792,7 +792,7 @@ func (c *Container) ExecSession(id string) (*ExecSession, error) {
 	}
 
 	returnSession := new(ExecSession)
-	if err := JSONDeepCopy(session, returnSession); err != nil {
+	if err := DeepCopy(session, returnSession); err != nil {
 		return nil, errors.Wrapf(err, "error copying contents of container %s exec session %s", c.ID(), session.ID())
 	}
 
@@ -1072,7 +1072,7 @@ func (c *Container) ContainerState() (*ContainerState, error) {
 		}
 	}
 	returnConfig := new(ContainerState)
-	if err := JSONDeepCopy(c.state, returnConfig); err != nil {
+	if err := DeepCopy(c.state, returnConfig); err != nil {
 		return nil, errors.Wrapf(err, "error copying container %s state", c.ID())
 	}
 	return c.state, nil

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -201,7 +201,7 @@ func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
 	session.ContainerId = c.ID()
 	session.State = define.ExecStateCreated
 	session.Config = new(ExecConfig)
-	if err := JSONDeepCopy(config, session.Config); err != nil {
+	if err := DeepCopy(config, session.Config); err != nil {
 		return "", errors.Wrapf(err, "error copying exec configuration into exec session")
 	}
 

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -668,7 +668,7 @@ func prepareProcessExec(c *Container, options *ExecOptions, env []string, sessio
 		return nil, err
 	}
 	pspec := new(spec.Process)
-	if err := JSONDeepCopy(c.config.Spec.Process, pspec); err != nil {
+	if err := DeepCopy(c.config.Spec.Process, pspec); err != nil {
 		return nil, err
 	}
 	pspec.SelinuxLabel = c.config.ProcessLabel

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -955,7 +955,7 @@ func WithUserNSFrom(nsCtr *Container) CtrCreateOption {
 		}
 
 		ctr.config.UserNsCtr = nsCtr.ID()
-		if err := JSONDeepCopy(nsCtr.IDMappings(), &ctr.config.IDMappings); err != nil {
+		if err := DeepCopy(nsCtr.IDMappings(), &ctr.config.IDMappings); err != nil {
 			return err
 		}
 		g := generate.Generator{Config: ctr.config.Spec}

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -116,7 +116,7 @@ func (p *Pod) ResourceLim() *specs.LinuxResources {
 	if conf.Linux == nil || conf.Linux.Resources == nil {
 		return empty
 	}
-	if err = JSONDeepCopy(conf.Linux.Resources, resCopy); err != nil {
+	if err = DeepCopy(conf.Linux.Resources, resCopy); err != nil {
 		return nil
 	}
 	if resCopy.CPU != nil {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -718,7 +718,7 @@ func (r *Runtime) GetConfig() (*config.Config, error) {
 	config := new(config.Config)
 
 	// Copy so the caller won't be able to modify the actual config
-	if err := JSONDeepCopy(r.config, config); err != nil {
+	if err := DeepCopy(r.config, config); err != nil {
 		return nil, errors.Wrapf(err, "error copying config")
 	}
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -180,7 +180,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 	} else {
 		// This is a restore from an imported checkpoint
 		ctr.restoreFromCheckpoint = true
-		if err := JSONDeepCopy(config, ctr.config); err != nil {
+		if err := DeepCopy(config, ctr.config); err != nil {
 			return nil, errors.Wrapf(err, "error copying container config for restore")
 		}
 		// If the ID is empty a new name for the restored container was requested
@@ -194,7 +194,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 	}
 
 	ctr.config.Spec = new(spec.Spec)
-	if err := JSONDeepCopy(rSpec, ctr.config.Spec); err != nil {
+	if err := DeepCopy(rSpec, ctr.config.Spec); err != nil {
 		return nil, errors.Wrapf(err, "error copying runtime spec while creating container")
 	}
 	ctr.config.CreatedTime = time.Now()

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/podman/v3/libpod/network/types"
 	"github.com/containers/podman/v3/utils"
 	"github.com/fsnotify/fsnotify"
+	"github.com/jinzhu/copier"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
@@ -130,6 +131,11 @@ func validPodNSOption(p *Pod, ctrPod string) error {
 		return errors.Wrapf(define.ErrInvalidArg, "pod passed in is not the pod the container is associated with")
 	}
 	return nil
+}
+
+// DeepCopy performs a deep copy of the two structs.
+func DeepCopy(from, to interface{}) error {
+	return copier.Copy(to, from)
 }
 
 // JSONDeepCopy performs a deep copy by performing a JSON encode/decode of the

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -223,7 +223,7 @@ func (v *Volume) CreatedTime() time.Time {
 // Config returns the volume's configuration.
 func (v *Volume) Config() (*VolumeConfig, error) {
 	config := VolumeConfig{}
-	err := JSONDeepCopy(v.config, &config)
+	err := DeepCopy(v.config, &config)
 	return &config, err
 }
 


### PR DESCRIPTION
The memory profiles of a simple `podman run --rm busybox ls` indicated
that JSONDeepCopy was responsible for a considerable amount of memory
consumption.

libimage is already using github.com/jinzhu/copier which has a
significantly smaller footprint.  Using the copier package for deep
copies drops the memory consumption from 1245kB to 348kB (~28%).

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
