### PR TITLE
libpod: do not call (*container).Config()

### DIFF
--- a/libpod/container_copy_linux.go
+++ b/libpod/container_copy_linux.go
@@ -174,7 +174,7 @@ func (c *Container) copyToArchive(ctx context.Context, path string, writer io.Wr
 
 // getContainerUser returns the specs.User and ID mappings of the container.
 func getContainerUser(container *Container, mountPoint string) (specs.User, error) {
-	userspec := container.Config().User
+	userspec := container.config.User
 
 	uid, gid, _, err := chrootuser.GetUser(mountPoint, userspec)
 	u := specs.User{

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -923,12 +923,11 @@ func (c *Container) checkDependenciesRunning() ([]string, error) {
 		}
 
 		// Check the status
-		conf := depCtr.Config()
 		state, err := depCtr.State()
 		if err != nil {
 			return nil, errors.Wrapf(err, "error retrieving state of dependency %s of container %s", dep, c.ID())
 		}
-		if state != define.ContainerStateRunning && !conf.IsInfra {
+		if state != define.ContainerStateRunning && !depCtr.config.IsInfra {
 			notRunning = append(notRunning, dep)
 		}
 		depCtrs[dep] = depCtr
@@ -1003,7 +1002,7 @@ func (c *Container) cniHosts() string {
 	for _, status := range c.getNetworkStatus() {
 		for _, netInt := range status.Interfaces {
 			for _, netAddress := range netInt.Networks {
-				hosts += fmt.Sprintf("%s\t%s %s\n", netAddress.Subnet.IP.String(), c.Hostname(), c.Config().Name)
+				hosts += fmt.Sprintf("%s\t%s %s\n", netAddress.Subnet.IP.String(), c.Hostname(), c.config.Name)
 			}
 		}
 	}
@@ -2106,7 +2105,7 @@ func (c *Container) canWithPrevious() error {
 // JSON files for later export
 func (c *Container) prepareCheckpointExport() error {
 	// save live config
-	if _, err := metadata.WriteJSONFile(c.Config(), c.bundlePath(), metadata.ConfigDumpFile); err != nil {
+	if _, err := metadata.WriteJSONFile(c.config, c.bundlePath(), metadata.ConfigDumpFile); err != nil {
 		return err
 	}
 

--- a/libpod/container_path_resolution.go
+++ b/libpod/container_path_resolution.go
@@ -112,7 +112,7 @@ func (c *Container) resolvePath(mountPoint string, containerPath string) (string
 func findVolume(c *Container, containerPath string) (*Volume, error) {
 	runtime := c.Runtime()
 	cleanedContainerPath := filepath.Clean(containerPath)
-	for _, vol := range c.Config().NamedVolumes {
+	for _, vol := range c.config.NamedVolumes {
 		if cleanedContainerPath == filepath.Clean(vol.Dest) {
 			return runtime.GetVolume(vol.Name)
 		}
@@ -124,7 +124,7 @@ func findVolume(c *Container, containerPath string) (*Volume, error) {
 // Volume's destination.
 func isPathOnVolume(c *Container, containerPath string) bool {
 	cleanedContainerPath := filepath.Clean(containerPath)
-	for _, vol := range c.Config().NamedVolumes {
+	for _, vol := range c.config.NamedVolumes {
 		if cleanedContainerPath == filepath.Clean(vol.Dest) {
 			return true
 		}
@@ -141,7 +141,7 @@ func isPathOnVolume(c *Container, containerPath string) bool {
 // path of a Mount.  Returns a matching Mount or nil.
 func findBindMount(c *Container, containerPath string) *specs.Mount {
 	cleanedPath := filepath.Clean(containerPath)
-	for _, m := range c.Config().Spec.Mounts {
+	for _, m := range c.config.Spec.Mounts {
 		if m.Type != "bind" {
 			continue
 		}
@@ -157,7 +157,7 @@ func findBindMount(c *Container, containerPath string) *specs.Mount {
 // Mount's destination.
 func isPathOnBindMount(c *Container, containerPath string) bool {
 	cleanedContainerPath := filepath.Clean(containerPath)
-	for _, m := range c.Config().Spec.Mounts {
+	for _, m := range c.config.Spec.Mounts {
 		if cleanedContainerPath == filepath.Clean(m.Destination) {
 			return true
 		}

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -90,7 +90,7 @@ func (p *Pod) GenerateForKube(ctx context.Context) (*v1.Pod, []v1.ServicePort, e
 	// so set it at here
 	for _, ctr := range allContainers {
 		if !ctr.IsInfra() {
-			switch ctr.Config().RestartPolicy {
+			switch ctr.config.RestartPolicy {
 			case define.RestartPolicyAlways:
 				pod.Spec.RestartPolicy = v1.RestartPolicyAlways
 			case define.RestartPolicyOnFailure:

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -222,7 +222,7 @@ func (r *Runtime) setupSlirp4netns(ctr *Container) error {
 	defer errorhandling.CloseQuiet(syncR)
 	defer errorhandling.CloseQuiet(syncW)
 
-	havePortMapping := len(ctr.Config().PortMappings) > 0
+	havePortMapping := len(ctr.config.PortMappings) > 0
 	logPath := filepath.Join(ctr.runtime.config.Engine.TmpDir, fmt.Sprintf("slirp4netns-%s.log", ctr.config.ID))
 
 	ctrNetworkSlipOpts := []string{}

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1150,7 +1150,7 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 
 	if ctr.config.NetMode.IsSlirp4netns() || rootless.IsRootless() {
 		if ctr.config.PostConfigureNetNS {
-			havePortMapping := len(ctr.Config().PortMappings) > 0
+			havePortMapping := len(ctr.config.PortMappings) > 0
 			if havePortMapping {
 				ctr.rootlessPortSyncR, ctr.rootlessPortSyncW, err = os.Pipe()
 				if err != nil {

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -164,8 +164,7 @@ func (p *Pod) PidMode() string {
 	if err != nil {
 		return ""
 	}
-	conf := infra.Config()
-	ctrSpec := conf.Spec
+	ctrSpec := infra.config.Spec
 	if ctrSpec != nil && ctrSpec.Linux != nil {
 		for _, ns := range ctrSpec.Linux.Namespaces {
 			if ns.Type == specs.PIDNamespace {
@@ -186,8 +185,7 @@ func (p *Pod) UserNSMode() string {
 	if err != nil {
 		return ""
 	}
-	conf := infra.Config()
-	ctrSpec := conf.Spec
+	ctrSpec := infra.config.Spec
 	if ctrSpec != nil && ctrSpec.Linux != nil {
 		for _, ns := range ctrSpec.Linux.Namespaces {
 			if ns.Type == specs.UserNamespace {

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -34,7 +34,7 @@ func (p *Pod) startInitContainers(ctx context.Context) error {
 		}
 		// If the container is a once init container, we need to remove it
 		// after it runs
-		if initCon.Config().InitContainerType == define.OneShotInitContainer {
+		if initCon.config.InitContainerType == define.OneShotInitContainer {
 			icLock := initCon.lock
 			icLock.Lock()
 			if err := p.runtime.removeContainer(ctx, initCon, false, false, true); err != nil {
@@ -590,16 +590,16 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 			return nil, err
 		}
 		infraConfig = new(define.InspectPodInfraConfig)
-		infraConfig.HostNetwork = !infra.Config().ContainerNetworkConfig.UseImageHosts
-		infraConfig.StaticIP = infra.Config().ContainerNetworkConfig.StaticIP
-		infraConfig.NoManageResolvConf = infra.Config().UseImageResolvConf
-		infraConfig.NoManageHosts = infra.Config().UseImageHosts
+		infraConfig.HostNetwork = !infra.config.ContainerNetworkConfig.UseImageHosts
+		infraConfig.StaticIP = infra.config.ContainerNetworkConfig.StaticIP
+		infraConfig.NoManageResolvConf = infra.config.UseImageResolvConf
+		infraConfig.NoManageHosts = infra.config.UseImageHosts
 		infraConfig.CPUPeriod = p.CPUPeriod()
 		infraConfig.CPUQuota = p.CPUQuota()
 		infraConfig.CPUSetCPUs = p.ResourceLim().CPU.Cpus
 		infraConfig.PidNS = p.PidMode()
 		infraConfig.UserNS = p.UserNSMode()
-		namedVolumes, mounts := infra.sortUserVolumes(infra.Config().Spec)
+		namedVolumes, mounts := infra.sortUserVolumes(infra.config.Spec)
 		inspectMounts, err = infra.GetInspectMounts(namedVolumes, infra.config.ImageVolumes, mounts)
 		if err != nil {
 			return nil, err
@@ -611,30 +611,30 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 			return nil, err
 		}
 
-		if len(infra.Config().ContainerNetworkConfig.DNSServer) > 0 {
-			infraConfig.DNSServer = make([]string, 0, len(infra.Config().ContainerNetworkConfig.DNSServer))
-			for _, entry := range infra.Config().ContainerNetworkConfig.DNSServer {
+		if len(infra.config.ContainerNetworkConfig.DNSServer) > 0 {
+			infraConfig.DNSServer = make([]string, 0, len(infra.config.ContainerNetworkConfig.DNSServer))
+			for _, entry := range infra.config.ContainerNetworkConfig.DNSServer {
 				infraConfig.DNSServer = append(infraConfig.DNSServer, entry.String())
 			}
 		}
-		if len(infra.Config().ContainerNetworkConfig.DNSSearch) > 0 {
-			infraConfig.DNSSearch = make([]string, 0, len(infra.Config().ContainerNetworkConfig.DNSSearch))
-			infraConfig.DNSSearch = append(infraConfig.DNSSearch, infra.Config().ContainerNetworkConfig.DNSSearch...)
+		if len(infra.config.ContainerNetworkConfig.DNSSearch) > 0 {
+			infraConfig.DNSSearch = make([]string, 0, len(infra.config.ContainerNetworkConfig.DNSSearch))
+			infraConfig.DNSSearch = append(infraConfig.DNSSearch, infra.config.ContainerNetworkConfig.DNSSearch...)
 		}
-		if len(infra.Config().ContainerNetworkConfig.DNSOption) > 0 {
-			infraConfig.DNSOption = make([]string, 0, len(infra.Config().ContainerNetworkConfig.DNSOption))
-			infraConfig.DNSOption = append(infraConfig.DNSOption, infra.Config().ContainerNetworkConfig.DNSOption...)
+		if len(infra.config.ContainerNetworkConfig.DNSOption) > 0 {
+			infraConfig.DNSOption = make([]string, 0, len(infra.config.ContainerNetworkConfig.DNSOption))
+			infraConfig.DNSOption = append(infraConfig.DNSOption, infra.config.ContainerNetworkConfig.DNSOption...)
 		}
-		if len(infra.Config().HostAdd) > 0 {
-			infraConfig.HostAdd = make([]string, 0, len(infra.Config().HostAdd))
-			infraConfig.HostAdd = append(infraConfig.HostAdd, infra.Config().HostAdd...)
+		if len(infra.config.HostAdd) > 0 {
+			infraConfig.HostAdd = make([]string, 0, len(infra.config.HostAdd))
+			infraConfig.HostAdd = append(infraConfig.HostAdd, infra.config.HostAdd...)
 		}
-		if len(infra.Config().ContainerNetworkConfig.Networks) > 0 {
-			infraConfig.Networks = make([]string, 0, len(infra.Config().ContainerNetworkConfig.Networks))
-			infraConfig.Networks = append(infraConfig.Networks, infra.Config().ContainerNetworkConfig.Networks...)
+		if len(infra.config.ContainerNetworkConfig.Networks) > 0 {
+			infraConfig.Networks = make([]string, 0, len(infra.config.ContainerNetworkConfig.Networks))
+			infraConfig.Networks = append(infraConfig.Networks, infra.config.ContainerNetworkConfig.Networks...)
 		}
-		infraConfig.NetworkOptions = infra.Config().ContainerNetworkConfig.NetworkOptions
-		infraConfig.PortBindings = makeInspectPortBindings(infra.Config().ContainerNetworkConfig.PortMappings, nil)
+		infraConfig.NetworkOptions = infra.config.ContainerNetworkConfig.NetworkOptions
+		infraConfig.PortBindings = makeInspectPortBindings(infra.config.ContainerNetworkConfig.PortMappings, nil)
 	}
 
 	inspectData := define.InspectPodData{


### PR DESCRIPTION
Access the container's config field directly inside of libpod instead of
calling `Config()` which in turn creates expensive JSON deep copies.

Accessing the field directly drops memory consumption of a simple
`podman run --rm busybox true` from 1245kB to 410kB.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->
