### PR TITLE
[3.4] Backport Allow machine options to be set from containers.conf

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -39,7 +39,7 @@ func init() {
 	cpusFlagName := "cpus"
 	flags.Uint64Var(
 		&initOpts.CPUS,
-		cpusFlagName, 1,
+		cpusFlagName, cfg.Machine.CPUs,
 		"Number of CPUs",
 	)
 	_ = initCmd.RegisterFlagCompletionFunc(cpusFlagName, completion.AutocompleteNone)
@@ -47,7 +47,7 @@ func init() {
 	diskSizeFlagName := "disk-size"
 	flags.Uint64Var(
 		&initOpts.DiskSize,
-		diskSizeFlagName, 10,
+		diskSizeFlagName, cfg.Machine.DiskSize,
 		"Disk size in GB",
 	)
 
@@ -56,7 +56,7 @@ func init() {
 	memoryFlagName := "memory"
 	flags.Uint64VarP(
 		&initOpts.Memory,
-		memoryFlagName, "m", 2048,
+		memoryFlagName, "m", cfg.Machine.Memory,
 		"Memory in MB",
 	)
 	_ = initCmd.RegisterFlagCompletionFunc(memoryFlagName, completion.AutocompleteNone)


### PR DESCRIPTION
Depends on: #11772

CPUS, memory, disk size, and image path defaults can be set from
[machine] table in containers.conf

[NO TESTS NEEDED]

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
