### PR TITLE
Pod Volumes From Support

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -656,14 +656,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(mountFlagName, AutocompleteMountFlag)
 
-		volumesFromFlagName := "volumes-from"
-		createFlags.StringArrayVar(
-			&cf.VolumesFrom,
-			volumesFromFlagName, []string{},
-			"Mount volumes from the specified container(s)",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(volumesFromFlagName, AutocompleteContainers)
-
 		workdirFlagName := "workdir"
 		createFlags.StringVarP(
 			&cf.Workdir,
@@ -877,4 +869,11 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		"Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(deviceReadBpsFlagName, completion.AutocompleteDefault)
+	volumesFromFlagName := "volumes-from"
+	createFlags.StringArrayVar(
+		&cf.VolumesFrom,
+		volumesFromFlagName, []string{},
+		"Mount volumes from the specified container(s)",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(volumesFromFlagName, AutocompleteContainers)
 }

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -381,6 +381,39 @@ change propagation properties of source mount. Say `/` is source mount for
 Note: if the user only has access rights via a group, accessing the volume
 from inside a rootless pod will fail.
 
+#### **--volumes-from**[=*CONTAINER*[:*OPTIONS*]]
+
+Mount volumes from the specified container(s). Used to share volumes between
+containers and pods. The *options* is a comma-separated list with the following available elements:
+
+* **rw**|**ro**
+* **z**
+
+Mounts already mounted volumes from a source container into another
+pod. You must supply the source's container-id or container-name.
+To share a volume, use the --volumes-from option when running
+the target container. You can share volumes even if the source container
+is not running.
+
+By default, Podman mounts the volumes in the same mode (read-write or
+read-only) as it is mounted in the source container.
+You can change this by adding a `ro` or `rw` _option_.
+
+Labeling systems like SELinux require that proper labels are placed on volume
+content mounted into a pod. Without a label, the security system might
+prevent the processes running inside the container from using the content. By
+default, Podman does not change the labels set by the OS.
+
+To change a label in the pod context, you can add `z` to the volume mount.
+This suffix tells Podman to relabel file objects on the shared volumes. The `z`
+option tells Podman that two entities share the volume content. As a result,
+Podman labels the content with a shared content label. Shared volume labels allow
+all containers to read/write content.
+
+If the location of the volume from the source container overlaps with
+data residing on a target pod, then the volume hides
+that data on the target.
+
 
 ## EXAMPLES
 

--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -63,6 +63,8 @@ type InspectPodData struct {
 	Devices []InspectDevice `json:"devices,omitempty"`
 	// BlkioDeviceReadBps contains the Read/Access limit for the pod's devices
 	BlkioDeviceReadBps []InspectBlkioThrottleDevice `json:"device_read_bps,omitempty"`
+	// VolumesFrom contains the containers that the pod inherits mounts from
+	VolumesFrom []string `json:"volumes_from,omitempty"`
 }
 
 // InspectPodInfraConfig contains the configuration of the pod's infra

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/containers/podman/v3/libpod/define"
@@ -198,6 +199,21 @@ func (p *Pod) UserNSMode() string {
 		return "host"
 	}
 	return ""
+}
+
+// CPUQuota returns the pod CPU quota
+func (p *Pod) VolumesFrom() []string {
+	if p.state.InfraContainerID == "" {
+		return nil
+	}
+	infra, err := p.runtime.GetContainer(p.state.InfraContainerID)
+	if err != nil {
+		return nil
+	}
+	if ctrs, ok := infra.config.Spec.Annotations[define.InspectAnnotationVolumesFrom]; ok {
+		return strings.Split(ctrs, ",")
+	}
+	return nil
 }
 
 // Labels returns the pod's labels

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -668,6 +668,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		Mounts:             inspectMounts,
 		Devices:            devices,
 		BlkioDeviceReadBps: deviceLimits,
+		VolumesFrom:        p.VolumesFrom(),
 	}
 
 	return &inspectData, nil

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -135,6 +135,7 @@ type PodCreateOptions struct {
 	CpusetCpus         string            `json:"cpuset_cpus,omitempty"`
 	Userns             specgen.Namespace `json:"-"`
 	Volume             []string          `json:"volume,omitempty"`
+	VolumesFrom        []string          `json:"volumes_from,omitempty"`
 }
 
 // PodLogsOptions describes the options to extract pod logs.
@@ -251,7 +252,7 @@ type ContainerCreateOptions struct {
 	UTS               string
 	Mount             []string
 	Volume            []string `json:"volume,omitempty"`
-	VolumesFrom       []string
+	VolumesFrom       []string `json:"volumes_from,omitempty"`
 	Workdir           string
 	SeccompPolicy     string
 	PidFile           string
@@ -308,6 +309,7 @@ func ToPodSpecGen(s specgen.PodSpecGenerator, p *PodCreateOptions) (*specgen.Pod
 	s.InfraImage = p.InfraImage
 	s.SharedNamespaces = p.Share
 	s.PodCreateCommand = p.CreateCommand
+	s.VolumesFrom = p.VolumesFrom
 
 	// Networking config
 

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -72,22 +72,6 @@ type PodBasicConfig struct {
 	// Any containers created within the pod will inherit the pod's userns settings.
 	// Optional
 	Userns Namespace `json:"userns,omitempty"`
-	// Mounts are mounts that will be added to the pod.
-	// These will supersede Image Volumes and VolumesFrom (WIP) volumes where
-	// there are conflicts.
-	// Optional.
-	Mounts []spec.Mount `json:"mounts,omitempty"`
-	// Volumes are named volumes that will be added to the pod.
-	// These will supersede Image Volumes and VolumesFrom  (WIP) volumes where
-	// there are conflicts.
-	// Optional.
-	Volumes []*NamedVolume `json:"volumes,omitempty"`
-	// Overlay volumes are named volumes that will be added to the pod.
-	// Optional.
-	OverlayVolumes []*OverlayVolume `json:"overlay_volumes,omitempty"`
-	// Image volumes bind-mount a container-image mount into the pod's infra container.
-	// Optional.
-	ImageVolumes []*ImageVolume `json:"image_volumes,omitempty"`
 	// Devices contains user specified Devices to be added to the Pod
 	Devices []string `json:"pod_devices,omitempty"`
 }
@@ -174,6 +158,32 @@ type PodNetworkConfig struct {
 	NetworkOptions map[string][]string `json:"network_options,omitempty"`
 }
 
+// PodStorageConfig contains all of the storage related options for the pod and its infra container.
+type PodStorageConfig struct {
+	// Mounts are mounts that will be added to the pod.
+	// These will supersede Image Volumes and VolumesFrom volumes where
+	// there are conflicts.
+	// Optional.
+	Mounts []spec.Mount `json:"mounts,omitempty"`
+	// Volumes are named volumes that will be added to the pod.
+	// These will supersede Image Volumes and VolumesFrom  volumes where
+	// there are conflicts.
+	// Optional.
+	Volumes []*NamedVolume `json:"volumes,omitempty"`
+	// Overlay volumes are named volumes that will be added to the pod.
+	// Optional.
+	OverlayVolumes []*OverlayVolume `json:"overlay_volumes,omitempty"`
+	// Image volumes bind-mount a container-image mount into the pod's infra container.
+	// Optional.
+	ImageVolumes []*ImageVolume `json:"image_volumes,omitempty"`
+	// VolumesFrom is a set of containers whose volumes will be added to
+	// this pod. The name or ID of the container must be provided, and
+	// may optionally be followed by a : and then one or more
+	// comma-separated options. Valid options are 'ro', 'rw', and 'z'.
+	// Options will be used for all volumes sourced from the container.
+	VolumesFrom []string `json:"volumes_from,omitempty"`
+}
+
 // PodCgroupConfig contains configuration options about a pod's cgroups.
 // This will be expanded in future updates to pods.
 type PodCgroupConfig struct {
@@ -191,6 +201,7 @@ type PodSpecGenerator struct {
 	PodNetworkConfig
 	PodCgroupConfig
 	PodResourceConfig
+	PodStorageConfig
 	InfraContainerSpec *SpecGenerator `json:"-"`
 }
 


### PR DESCRIPTION
added support for a volumes from container. this flag just required movement of the volumes-from flag declaration
out of the !IsInfra block, and minor modificaions to container_create.go

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
