### PR TITLE
podman run - avoid calls to JSONDeepCopy

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1095,7 +1095,7 @@ func (c *Container) AutoRemove() bool {
 	if spec.Annotations == nil {
 		return false
 	}
-	return c.Spec().Annotations[define.InspectAnnotationAutoremove] == define.InspectResponseTrue
+	return spec.Annotations[define.InspectAnnotationAutoremove] == define.InspectResponseTrue
 }
 
 // Timezone returns the timezone configured inside the container.

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -774,9 +774,9 @@ func (c *Container) ExecSessions() ([]string, error) {
 	return ids, nil
 }
 
-// ExecSession retrieves detailed information on a single active exec session in
-// a container
-func (c *Container) ExecSession(id string) (*ExecSession, error) {
+// execSessionNoCopy returns the associated exec session to id.
+// Note that the session is not a deep copy.
+func (c *Container) execSessionNoCopy(id string) (*ExecSession, error) {
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()
@@ -789,6 +789,17 @@ func (c *Container) ExecSession(id string) (*ExecSession, error) {
 	session, ok := c.state.ExecSessions[id]
 	if !ok {
 		return nil, errors.Wrapf(define.ErrNoSuchExecSession, "no exec session with ID %s found in container %s", id, c.ID())
+	}
+
+	return session, nil
+}
+
+// ExecSession retrieves detailed information on a single active exec session in
+// a container
+func (c *Container) ExecSession(id string) (*ExecSession, error) {
+	session, err := c.execSessionNoCopy(id)
+	if err != nil {
+		return nil, err
 	}
 
 	returnSession := new(ExecSession)

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -747,7 +747,7 @@ func (c *Container) Exec(config *ExecConfig, streams *define.AttachStreams, resi
 		return -1, err
 	}
 
-	session, err := c.ExecSession(sessionID)
+	session, err := c.execSessionNoCopy(sessionID)
 	if err != nil {
 		if errors.Cause(err) == define.ErrNoSuchExecSession {
 			// TODO: If a proper Context is ever plumbed in here, we

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -2004,7 +2004,7 @@ func (c *Container) setupOCIHooks(ctx context.Context, config *spec.Spec) (map[s
 				}
 				return nil, err
 			}
-			ociHooks, err := manager.Hooks(config, c.Spec().Annotations, len(c.config.UserVolumes) > 0)
+			ociHooks, err := manager.Hooks(config, c.config.Spec.Annotations, len(c.config.UserVolumes) > 0)
 			if err != nil {
 				return nil, err
 			}
@@ -2021,7 +2021,7 @@ func (c *Container) setupOCIHooks(ctx context.Context, config *spec.Spec) (map[s
 			return nil, err
 		}
 
-		allHooks, err = manager.Hooks(config, c.Spec().Annotations, len(c.config.UserVolumes) > 0)
+		allHooks, err = manager.Hooks(config, c.config.Spec.Annotations, len(c.config.UserVolumes) > 0)
 		if err != nil {
 			return nil, err
 		}

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -424,7 +424,7 @@ func containerToV1Container(ctx context.Context, c *Container) (v1.Container, []
 	// NOTE: a privileged container mounts all of /dev/*.
 	if !c.Privileged() && len(c.config.Spec.Linux.Devices) > 0 {
 		// TODO Enable when we can support devices and their names
-		kubeContainer.VolumeDevices = generateKubeVolumeDeviceFromLinuxDevice(c.Spec().Linux.Devices)
+		kubeContainer.VolumeDevices = generateKubeVolumeDeviceFromLinuxDevice(c.config.Spec.Linux.Devices)
 		return kubeContainer, kubeVolumes, nil, errors.Wrapf(define.ErrNotImplemented, "linux devices")
 	}
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -193,10 +193,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 		ctr.config.LogPath = ""
 	}
 
-	ctr.config.Spec = new(spec.Spec)
-	if err := JSONDeepCopy(rSpec, ctr.config.Spec); err != nil {
-		return nil, errors.Wrapf(err, "error copying runtime spec while creating container")
-	}
+	ctr.config.Spec = rSpec
 	ctr.config.CreatedTime = time.Now()
 
 	ctr.state.BindMounts = make(map[string]string)

--- a/pkg/domain/infra/abi/secrets.go
+++ b/pkg/domain/infra/abi/secrets.go
@@ -21,7 +21,7 @@ func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader
 
 	// set defaults from config for the case they are not set by an upper layer
 	// (-> i.e. tests that talk directly to the api)
-	cfg, err := ic.Libpod.GetConfig()
+	cfg, err := ic.Libpod.GetConfigNoCopy()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -54,7 +54,7 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 		}
 	}
 
-	rtc, err := r.GetConfig()
+	rtc, err := r.GetConfigNoCopy()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -23,7 +23,7 @@ import (
 // Returns the created, container and any warnings resulting from creating the
 // container, or an error.
 func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGenerator) (*spec.Spec, *specgen.SpecGenerator, []libpod.CtrCreateOption, error) {
-	rtc, err := rt.GetConfig()
+	rtc, err := rt.GetConfigNoCopy()
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
A series of commits to avoid all calls to JSONDeepCopy when running a simple `podman run --rm -d busybox true`.  After https://github.com/containers/podman/pull/11768/commits/5d6ea90e756cd48c90d9549d25c0150c9bb5c50c this drops another 100kB of memory usage.

Please refer to the individual commits for change descriptions.

Note, this needs a head nod from @mheon.