### PR TITLE
Storage can remove ErrNotAContainer as well

### DIFF
--- a/libpod/runtime_cstorage.go
+++ b/libpod/runtime_cstorage.go
@@ -121,7 +121,7 @@ func (r *Runtime) removeStorageContainer(idOrName string, force bool) error {
 	}
 
 	if err := r.store.DeleteContainer(ctr.ID); err != nil {
-		if errors.Cause(err) == storage.ErrContainerUnknown {
+		if errors.Cause(err) == storage.ErrNotAContainer || errors.Cause(err) == storage.ErrContainerUnknown {
 			// Container again gone, no error
 			logrus.Infof("Storage for container %s already removed", ctr.ID)
 			return nil

--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -184,8 +184,12 @@ func (r *storageService) DeleteContainer(idOrName string) error {
 	}
 	err = r.store.DeleteContainer(container.ID)
 	if err != nil {
-		logrus.Debugf("Failed to delete container %q: %v", container.ID, err)
-		return err
+		if errors.Cause(err) == storage.ErrNotAContainer || errors.Cause(err) == storage.ErrContainerUnknown {
+			logrus.Infof("Storage for container %s already removed", container.ID)
+		} else {
+			logrus.Debugf("Failed to delete container %q: %v", container.ID, err)
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/11775

[NO TESTS NEEDED] No easy way to cause this problem in CI.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
