### PR TITLE
Support selinux options with bind mounts play/gen

### DIFF
--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -90,3 +90,6 @@ const (
 
 // DefaultRlimitValue is the value set by default for nofile and nproc
 const RLimitDefaultValue = uint64(1048576)
+
+// BindMountPrefix distinguishes its annotations from others
+const BindMountPrefix = "bind-mount-options:"

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -241,11 +241,13 @@ func (p *Pod) podWithContainers(ctx context.Context, containers []*Container, po
 
 			isInit := ctr.IsInitCtr()
 
-			ctr, volumes, _, err := containerToV1Container(ctx, ctr)
+			ctr, volumes, _, annotations, err := containerToV1Container(ctx, ctr)
 			if err != nil {
 				return nil, err
 			}
-
+			for k, v := range annotations {
+				podAnnotations[define.BindMountPrefix+k] = v
+			}
 			// Since port bindings for the pod are handled by the
 			// infra container, wipe them here.
 			ctr.Ports = nil
@@ -271,7 +273,7 @@ func (p *Pod) podWithContainers(ctx context.Context, containers []*Container, po
 				deDupPodVolumes[vol.Name] = &vol
 			}
 		} else {
-			_, _, infraDNS, err := containerToV1Container(ctx, ctr)
+			_, _, infraDNS, _, err := containerToV1Container(ctx, ctr)
 			if err != nil {
 				return nil, err
 			}
@@ -359,9 +361,12 @@ func simplePodWithV1Containers(ctx context.Context, ctrs []*Container) (*v1.Pod,
 		if !ctr.HostNetwork() {
 			hostNetwork = false
 		}
-		kubeCtr, kubeVols, ctrDNS, err := containerToV1Container(ctx, ctr)
+		kubeCtr, kubeVols, ctrDNS, annotations, err := containerToV1Container(ctx, ctr)
 		if err != nil {
 			return nil, err
+		}
+		for k, v := range annotations {
+			kubeAnnotations[define.BindMountPrefix+k] = v
 		}
 		if isInit {
 			kubeInitCtrs = append(kubeInitCtrs, kubeCtr)
@@ -369,7 +374,6 @@ func simplePodWithV1Containers(ctx context.Context, ctrs []*Container) (*v1.Pod,
 			kubeCtrs = append(kubeCtrs, kubeCtr)
 		}
 		kubeVolumes = append(kubeVolumes, kubeVols...)
-
 		// Combine DNS information in sum'd structure
 		if ctrDNS != nil {
 			// nameservers
@@ -415,42 +419,44 @@ func simplePodWithV1Containers(ctx context.Context, ctrs []*Container) (*v1.Pod,
 
 // containerToV1Container converts information we know about a libpod container
 // to a V1.Container specification.
-func containerToV1Container(ctx context.Context, c *Container) (v1.Container, []v1.Volume, *v1.PodDNSConfig, error) {
+func containerToV1Container(ctx context.Context, c *Container) (v1.Container, []v1.Volume, *v1.PodDNSConfig, map[string]string, error) {
 	kubeContainer := v1.Container{}
 	kubeVolumes := []v1.Volume{}
+	annotations := make(map[string]string)
 	kubeSec, err := generateKubeSecurityContext(c)
 	if err != nil {
-		return kubeContainer, kubeVolumes, nil, err
+		return kubeContainer, kubeVolumes, nil, annotations, err
 	}
 
 	// NOTE: a privileged container mounts all of /dev/*.
 	if !c.Privileged() && len(c.config.Spec.Linux.Devices) > 0 {
 		// TODO Enable when we can support devices and their names
 		kubeContainer.VolumeDevices = generateKubeVolumeDeviceFromLinuxDevice(c.config.Spec.Linux.Devices)
-		return kubeContainer, kubeVolumes, nil, errors.Wrapf(define.ErrNotImplemented, "linux devices")
+		return kubeContainer, kubeVolumes, nil, annotations, errors.Wrapf(define.ErrNotImplemented, "linux devices")
 	}
 
 	if len(c.config.UserVolumes) > 0 {
-		volumeMounts, volumes, err := libpodMountsToKubeVolumeMounts(c)
+		volumeMounts, volumes, localAnnotations, err := libpodMountsToKubeVolumeMounts(c)
 		if err != nil {
-			return kubeContainer, kubeVolumes, nil, err
+			return kubeContainer, kubeVolumes, nil, nil, err
 		}
+		annotations = localAnnotations
 		kubeContainer.VolumeMounts = volumeMounts
 		kubeVolumes = append(kubeVolumes, volumes...)
 	}
 
 	envVariables, err := libpodEnvVarsToKubeEnvVars(c.config.Spec.Process.Env)
 	if err != nil {
-		return kubeContainer, kubeVolumes, nil, err
+		return kubeContainer, kubeVolumes, nil, annotations, err
 	}
 
 	portmappings, err := c.PortMappings()
 	if err != nil {
-		return kubeContainer, kubeVolumes, nil, err
+		return kubeContainer, kubeVolumes, nil, annotations, err
 	}
 	ports, err := ocicniPortMappingToContainerPort(portmappings)
 	if err != nil {
-		return kubeContainer, kubeVolumes, nil, err
+		return kubeContainer, kubeVolumes, nil, annotations, err
 	}
 
 	// Handle command and arguments.
@@ -469,11 +475,11 @@ func containerToV1Container(ctx context.Context, c *Container) (v1.Container, []
 	kubeContainer.Stdin = c.Stdin()
 	img, _, err := c.runtime.libimageRuntime.LookupImage(image, nil)
 	if err != nil {
-		return kubeContainer, kubeVolumes, nil, err
+		return kubeContainer, kubeVolumes, nil, annotations, err
 	}
 	imgData, err := img.Inspect(ctx, false)
 	if err != nil {
-		return kubeContainer, kubeVolumes, nil, err
+		return kubeContainer, kubeVolumes, nil, annotations, err
 	}
 	if reflect.DeepEqual(imgData.Config.Cmd, kubeContainer.Command) {
 		kubeContainer.Command = nil
@@ -555,7 +561,7 @@ func containerToV1Container(ctx context.Context, c *Container) (v1.Container, []
 		}
 		dns.Options = dnsOptions
 	}
-	return kubeContainer, kubeVolumes, &dns, nil
+	return kubeContainer, kubeVolumes, &dns, annotations, nil
 }
 
 // ocicniPortMappingToContainerPort takes an ocicni portmapping and converts
@@ -606,16 +612,23 @@ func libpodEnvVarsToKubeEnvVars(envs []string) ([]v1.EnvVar, error) {
 }
 
 // libpodMountsToKubeVolumeMounts converts the containers mounts to a struct kube understands
-func libpodMountsToKubeVolumeMounts(c *Container) ([]v1.VolumeMount, []v1.Volume, error) {
+func libpodMountsToKubeVolumeMounts(c *Container) ([]v1.VolumeMount, []v1.Volume, map[string]string, error) {
 	namedVolumes, mounts := c.sortUserVolumes(c.config.Spec)
 	vms := make([]v1.VolumeMount, 0, len(mounts))
 	vos := make([]v1.Volume, 0, len(mounts))
+	annotations := make(map[string]string)
 
 	var suffix string
 	for index, m := range mounts {
+		for _, opt := range m.Options {
+			if opt == "Z" || opt == "z" {
+				annotations[m.Source] = opt
+				break
+			}
+		}
 		vm, vo, err := generateKubeVolumeMount(m)
 		if err != nil {
-			return vms, vos, err
+			return vms, vos, annotations, err
 		}
 		// Name will be the same, so use the index as suffix
 		suffix = fmt.Sprintf("-%d", index)
@@ -629,7 +642,7 @@ func libpodMountsToKubeVolumeMounts(c *Container) ([]v1.VolumeMount, []v1.Volume
 		vms = append(vms, vm)
 		vos = append(vos, vo)
 	}
-	return vms, vos, nil
+	return vms, vos, annotations, nil
 }
 
 // generateKubePersistentVolumeClaim converts a ContainerNamedVolume to a Kubernetes PersistentVolumeClaim

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -319,8 +319,8 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		if err != nil {
 			return nil, err
 		}
-
 		specgenOpts := kube.CtrSpecGenOptions{
+			Annotations:       annotations,
 			Container:         initCtr,
 			Image:             pulledImage,
 			Volumes:           volumes,

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/containers/podman/v3/libpod/define"
+
 	"github.com/containers/podman/v3/pkg/util"
 	. "github.com/containers/podman/v3/test/utils"
 	"github.com/ghodss/yaml"
@@ -554,6 +556,15 @@ var _ = Describe("Podman generate kube", func() {
 		kube := podmanTest.Podman([]string{"generate", "kube", "test1", "-f", outputFile})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(Exit(0))
+
+		b, err := ioutil.ReadFile(outputFile)
+		Expect(err).ShouldNot(HaveOccurred())
+		pod := new(v1.Pod)
+		err = yaml.Unmarshal(b, pod)
+		Expect(err).To(BeNil())
+		val, found := pod.Annotations[define.BindMountPrefix+vol1]
+		Expect(found).To(BeTrue())
+		Expect(val).To(HaveSuffix("z"))
 
 		rm := podmanTest.Podman([]string{"pod", "rm", "-f", "test1"})
 		rm.WaitWithDefaultTimeout()


### PR DESCRIPTION
When using play kube and generate kube, we need to support if bind
mounts have selinux options.  As kubernetes does not support selinux in
this way, we tuck the selinux values into a pod annotation for
generation of the kube yaml.  Then on play, we check annotations to see
if a value for the mount exists and apply it.

Fixes BZ #1984081

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
