### PR TITLE
Allow a value of -1 to set unlimited pids limit

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -421,7 +421,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		pidsLimitFlagName := "pids-limit"
 		createFlags.Int64(
 			pidsLimitFlagName, pidsLimit(),
-			"Tune container pids limit (set 0 for unlimited, -1 for server defaults)",
+			"Tune container pids limit (set -1 for unlimited)",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(pidsLimitFlagName, completion.AutocompleteNone)
 

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -224,6 +224,10 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 
 		if c.Flags().Changed("pids-limit") {
 			val := c.Flag("pids-limit").Value.String()
+			// Convert -1 to 0, so that -1 maps to unlimited pids limit
+			if val == "-1" {
+				val = "0"
+			}
 			pidsLimit, err := strconv.ParseInt(val, 10, 32)
 			if err != nil {
 				return vals, err

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -728,7 +728,7 @@ Default is to create a private PID namespace for the container
 
 #### **--pids-limit**=*limit*
 
-Tune the container's pids limit. Set `0` to have unlimited pids for the container. (default "4096" on systems that support PIDS cgroups).
+Tune the container's pids limit. Set `-1` to have unlimited pids for the container. (default "4096" on systems that support PIDS cgroups).
 
 #### **--platform**=*OS/ARCH*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -751,7 +751,7 @@ The default is to create a private PID namespace for the container.
 
 #### **--pids-limit**=*limit*
 
-Tune the container's pids limit. Set to **0** to have unlimited pids for the container. The default is **4096** on systems that support "pids" cgroup controller.
+Tune the container's pids limit. Set to **-1** to have unlimited pids for the container. The default is **4096** on systems that support "pids" cgroup controller.
 
 #### **--platform**=*OS/ARCH*
 

--- a/pkg/specgen/generate/validate.go
+++ b/pkg/specgen/generate/validate.go
@@ -72,10 +72,9 @@ func verifyContainerResourcesCgroupV1(s *specgen.SpecGenerator) ([]string, error
 
 	// Pids checks
 	if s.ResourceLimits.Pids != nil {
-		pids := s.ResourceLimits.Pids
 		// TODO: Should this be 0, or checking that ResourceLimits.Pids
 		// is set at all?
-		if pids.Limit > 0 && !sysInfo.PidsLimit {
+		if s.ResourceLimits.Pids.Limit >= 0 && !sysInfo.PidsLimit {
 			warnings = append(warnings, "Your kernel does not support pids limit capabilities or the cgroup is not mounted. PIDs limit discarded.")
 			s.ResourceLimits.Pids = nil
 		}


### PR DESCRIPTION
[NO TESTS NEEDED]

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

Users can set --pids-limit to -1 now to set unlimited
pids limit for a container - this matches the convention.

<!---
Please put your overall PR description here
-->

#### How to verify it

```
sh-5.1# ./bin/podman run --rm -ti --pids-limit=0 fedora:34  cat /sys/fs/cgroup/pids/pids.max 
38201
```

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:
Fixes https://github.com/containers/podman/issues/11782

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
