### PR TITLE
test: skip test on rootless cgroupsv1

### DIFF
--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -113,6 +113,10 @@ function check_label() {
 @test "podman selinux: shared context in (some) namespaces" {
     skip_if_no_selinux
 
+    # rootless users have no usable cgroups with cgroupsv1, so containers
+    # must use a pid namespace and not join an existing one.
+    skip_if_rootless_cgroupsv1
+
     run_podman run -d --name myctr $IMAGE top
     run_podman exec myctr cat -v /proc/self/attr/current
     context_c1="$output"

--- a/test/system/420-cgroups.bats
+++ b/test/system/420-cgroups.bats
@@ -8,9 +8,7 @@ load helpers
 @test "podman run, preserves initial --cgroup-manager" {
     skip_if_remote "podman-remote does not support --cgroup-manager"
 
-    if is_rootless && is_cgroupsv1; then
-        skip "not supported as rootless under cgroups v1"
-    fi
+    skip_if_rootless_cgroupsv1
 
     # Find out our default cgroup manager, and from that, get the non-default
     run_podman info --format '{{.Host.CgroupManager}}'

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -428,6 +428,18 @@ function skip_if_cgroupsv1() {
     fi
 }
 
+######################
+#  skip_if_rootless_cgroupsv1  #  ...with an optional message
+######################
+function skip_if_rootless_cgroupsv1() {
+    if is_rootless; then
+        if ! is_cgroupsv2; then
+            local msg=$(_add_label_if_missing "$1" "rootless cgroupvs1")
+            skip "${msg:-not supported as rootless under cgroupsv1}"
+        fi
+    fi
+}
+
 ##################################
 #  skip_if_journald_unavailable  #  rhbz#1895105: rootless journald permissions
 ##################################


### PR DESCRIPTION
skip the test "podman selinux: shared context in (some) namespaces" on
cgroupsv1 when running as rootless since the tests requires
--pid=container:.

If the container runtime cannot use cgroupsv1 and the container has no
pid namespace. then it is not possible to correctly terminate the
container.  Without a cgroup or a pid namespace, the runtime has no
control on what processes are in the container.

Closes: https://github.com/containers/podman/issues/11785

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

fix a failing test on rootless and cgroups v1

#### How to verify it

run the test on cgroups v1 and rootless

#### Which issue(s) this PR fixes:

Fixes #11785


#### Special notes for your reviewer:
