### PR TITLE
kube: fix conversion from milliCPU to period/quota

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -157,7 +157,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		return nil, errors.Wrap(err, "Failed to set CPU quota")
 	}
 	if milliCPU > 0 {
-		period, quota := util.CoresToPeriodAndQuota(float64(milliCPU) / 1000)
+		period, quota := util.CoresToPeriodAndQuota(float64(milliCPU))
 		s.ResourceLimits.CPU = &spec.LinuxCPU{
 			Quota:  &quota,
 			Period: &period,


### PR DESCRIPTION
#### What this PR does / why we need it:

fix the conversion from --cpus to period and quota with "play kube"

#### How to verify it

$ podman pod create -n test
$ podman run --pod test -d --cpus 1 docker.artifactory.schmid.local/alpine sleep infinity
$ podman generate kube test > test.yml
$ podman pod rm -f test
$ podman play kube test.yml

#### Which issue(s) this PR fixes:

Fixes #11803


#### Special notes for your reviewer:
