### PR TITLE
pkg/specgen: cache image in generator

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -102,20 +102,15 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		options = append(options, libpod.WithCreateCommand(s.ContainerCreateCommand))
 	}
 
-	var newImage *libimage.Image
-	var imageData *libimage.ImageData
 	if s.Rootfs != "" {
 		options = append(options, libpod.WithRootFS(s.Rootfs, s.RootfsOverlay))
-	} else {
-		var resolvedImageName string
-		newImage, resolvedImageName, err = rt.LibimageRuntime().LookupImage(s.Image, nil)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		imageData, err = newImage.Inspect(ctx, false)
-		if err != nil {
-			return nil, nil, nil, err
-		}
+	}
+
+	newImage, resolvedImageName, imageData, err := getImageFromSpec(ctx, rt, s)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if newImage != nil {
 		// If the input name changed, we could properly resolve the
 		// image. Otherwise, it must have been an ID where we're
 		// defaulting to the first name or an empty one if no names are

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containers/common/libimage"
 	"github.com/containers/image/v5/manifest"
 	nettypes "github.com/containers/podman/v3/libpod/network/types"
 	"github.com/containers/storage/types"
@@ -512,6 +513,21 @@ type SpecGenerator struct {
 	ContainerNetworkConfig
 	ContainerResourceConfig
 	ContainerHealthCheckConfig
+
+	image             *libimage.Image `json:"-"`
+	resolvedImageName string          `json:"-"`
+}
+
+// SetImage sets the associated for the generator.
+func (s *SpecGenerator) SetImage(image *libimage.Image, resolvedImageName string) {
+	s.image = image
+	s.resolvedImageName = resolvedImageName
+}
+
+// Image returns the associated image for the generator.
+// May be nil if no image has been set yet.
+func (s *SpecGenerator) GetImage() (*libimage.Image, string) {
+	return s.image, s.resolvedImageName
 }
 
 type Secret struct {


### PR DESCRIPTION
To prevent expensive redundant lookups and inspects on the same image,
cache the image in the generator.  Note that once a given image has been
inspected, subsequent calls will use the libimage-internal cache.

[NO TESTS NEEDED] since it is no functional change.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>