### PR TITLE
Add expose type map[uint16]string to description

### DIFF
--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -411,7 +411,7 @@ type ContainerNetworkConfig struct {
 	// Expose is a number of ports that will be forwarded to the container
 	// if PublishExposedPorts is set.
 	// Expose is a map of uint16 (port number) to a string representing
-	// protocol. Allowed protocols are "tcp", "udp", and "sctp", or some
+	// protocol i.e map[uint16]string. Allowed protocols are "tcp", "udp", and "sctp", or some
 	// combination of the three separated by commas.
 	// If protocol is set to "" we will assume TCP.
 	// Only available if NetNS is set to Bridge or Slirp, and


### PR DESCRIPTION
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

[NO TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:
Swagger-go doesn't generate the types correctly for some
complicated structs. We are seeing this with the expose option
for container create, it is showing up as any. Add a line
to the description to highlight that the type is map[uint16]string.

<!---
Please put your overall PR description here
-->

#### How to verify it
Swagger docs should have new line in it https://docs.podman.io/en/latest/_static/api.html#operation/ContainerCreateLibpod
<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:
Fixes #9559

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
