### PR TITLE
Support selinux options with bind mounts play/gen

### DIFF
--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -87,3 +87,6 @@ const (
 
 // DefaultRlimitValue is the value set by default for nofile and nproc
 const RLimitDefaultValue = uint64(1048576)
+
+// BindMountPrefix distinguishes its annotations from others
+const BindMountPrefix = "bind-mount-options:"

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -319,8 +319,8 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		if err != nil {
 			return nil, err
 		}
-
 		specgenOpts := kube.CtrSpecGenOptions{
+			Annotations:       annotations,
 			Container:         initCtr,
 			Image:             pulledImage,
 			Volumes:           volumes,

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/containers/podman/v3/libpod/define"
+
 	"github.com/containers/podman/v3/pkg/util"
 	. "github.com/containers/podman/v3/test/utils"
 	"github.com/ghodss/yaml"
@@ -554,6 +556,15 @@ var _ = Describe("Podman generate kube", func() {
 		kube := podmanTest.Podman([]string{"generate", "kube", "test1", "-f", outputFile})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(Exit(0))
+
+		b, err := ioutil.ReadFile(outputFile)
+		Expect(err).ShouldNot(HaveOccurred())
+		pod := new(v1.Pod)
+		err = yaml.Unmarshal(b, pod)
+		Expect(err).To(BeNil())
+		val, found := pod.Annotations[define.BindMountPrefix+vol1]
+		Expect(found).To(BeTrue())
+		Expect(val).To(HaveSuffix("z"))
 
 		rm := podmanTest.Podman([]string{"pod", "rm", "-f", "test1"})
 		rm.WaitWithDefaultTimeout()


### PR DESCRIPTION
When using play kube and generate kube, we need to support if bind
mounts have selinux options.  As kubernetes does not support selinux in
this way, we tuck the selinux values into a pod annotation for
generation of the kube yaml.  Then on play, we check annotations to see
if a value for the mount exists and apply it.

Fixes BZ #1984081

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
