### PR TITLE
Pod Events Logging Fix

### DIFF
--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -59,6 +59,12 @@ func MakePod(p *entities.PodSpec, rt *libpod.Runtime) (*libpod.Pod, error) {
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		// SavePod is used to save the pod state and trigger a create event even if infra is not created
+		err := rt.SavePod(pod)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return pod, nil
 }

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -199,4 +199,17 @@ var _ = Describe("Podman events", func() {
 
 		wg.Wait()
 	})
+
+	It("podman events pod creation", func() {
+		create := podmanTest.Podman([]string{"pod", "create", "--infra=false", "--name", "foobarpod"})
+		create.WaitWithDefaultTimeout()
+		Expect(create).Should(Exit(0))
+		id := create.OutputToString()
+		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "pod=" + id})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(result.OutputToStringArray()).To(HaveLen(1))
+		Expect(result.OutputToString()).To(ContainSubstring("create"))
+	})
+
 })


### PR DESCRIPTION
on create, libpod was only creating a new event if the pod had an infra container.
now, pod creation triggers a new pod event with or without infra.

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>