### PR TITLE
Cirrus: Fix defunct package metadata breaking cache

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -254,11 +254,11 @@ case "$TEST_FLAVOR" in
         remove_packaged_podman_files
         make install PREFIX=/usr ETCDIR=/etc
 
-        # Need to re-build lists (removed during image production)
-        ooe.sh apt-get -qq -y update
         msg "Installing docker and containerd"
         # N/B: Tests check/expect `docker info` output, and this `!= podman info`
-        ooe.sh apt-get install --yes containerd.io docker-ce docker-ce-cli
+        ooe.sh dpkg -i \
+            $PACKAGE_DOWNLOAD_DIR/containerd.io*.deb \
+            $PACKAGE_DOWNLOAD_DIR/docker-ce*.deb
 
         msg "Disabling docker service and socket activation"
         systemctl stop docker.service docker.socket


### PR DESCRIPTION
#### What this PR does / why we need it:

Original workaround https://github.com/containers/podman/pull/11821

During VM image build, a number of packages are downloaded but not
installed, since they may interfere with some testing.  Then at runtime,
where required, the packages are installed from cache and used.
However, between image build and runtime it's possible the repository
contents change, which will invalidate the package cache.  Since the
`--no-download --ignore-missing` options were used, the install will
fail.

Fortunately, when it comes to the docker packages, no other dependencies
are required and so `apt-get` isn't required.  Switch to using a simple
dpkg install command on the necessary files.  If this ever breaks due
to new dependencies, the list of files may simply be updated.

#### How to verify it

The setup stage of the gitlab test will not fail

#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/automation_images/issues/95

#### Special notes for your reviewer: