### PR TITLE
CNI networks: reload networks if needed

### DIFF
--- a/libpod/network/cni/config_test.go
+++ b/libpod/network/cni/config_test.go
@@ -1020,28 +1020,6 @@ var _ = Describe("Config", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("subnet 10.10.0.0/24 is already used on the host or by another config"))
 		})
-
-		It("remove network should not error when config file does not exists on disk", func() {
-			name := "mynet"
-			network := types.Network{Name: name}
-			_, err := libpodNet.NetworkCreate(network)
-			Expect(err).To(BeNil())
-
-			path := filepath.Join(cniConfDir, name+".conflist")
-			Expect(path).To(BeARegularFile())
-
-			err = os.Remove(path)
-			Expect(err).To(BeNil())
-			Expect(path).ToNot(BeARegularFile())
-
-			err = libpodNet.NetworkRemove(name)
-			Expect(err).To(BeNil())
-
-			nets, err := libpodNet.NetworkList()
-			Expect(err).To(BeNil())
-			Expect(nets).To(HaveLen(1))
-			Expect(nets).ToNot(ContainElement(HaveNetworkName(name)))
-		})
 	})
 
 	Context("network load valid existing ones", func() {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -489,8 +489,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 		DefaultNetwork: runtime.config.Network.DefaultNetwork,
 		DefaultSubnet:  runtime.config.Network.DefaultSubnet,
 		IsMachine:      runtime.config.Engine.MachineEnabled,
-		// TODO use cni.lock
-		LockFile: filepath.Join(runtime.config.Network.NetworkConfigDir, "cni1.lock"),
+		LockFile:       filepath.Join(runtime.config.Network.NetworkConfigDir, "cni.lock"),
 	})
 	if err != nil {
 		return errors.Wrapf(err, "could not create network interface")

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -131,8 +131,8 @@ t DELETE libpod/networks/network2 200 \
   .[0].Err=null
 
 # test until filter - libpod api
-t POST libpod/networks/create name='"network5"' labels='{"xyz":""}' 200 \
-  .name=network5
+# create network via cli to test that the server can use it
+podman network create --label xyz network5
 
 # with date way back in the past, network should not be deleted
 t POST libpod/networks/prune?filters='{"until":["500000"]}' 200


### PR DESCRIPTION




<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

The current implementation of the CNI network interface only loads the
networks on the first call and saves them in a map. This is done to safe
performance and not having to reload all configs every time which will be
costly for many networks.

The problem with this approach is that if a network is created by
another process it will not be picked up by the already running podman
process. This is not a problem for the short lived podman commands but
it is problematic for the podman service.

To make sure we always have the actual networks store the mtime of the
config directory. If it changed since the last read we have to read
again.


#### How to verify it

start the podman service, list the networks via api, create a network via podman network create, list the networks via api again

#### Which issue(s) this PR fixes:

Fixes #11828

#### Special notes for your reviewer:
