### PR TITLE
It really should be no **NEW** tests needed

### DIFF
--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -8,7 +8,10 @@ if [[ "${CIRRUS_CHANGE_TITLE}" =~ CI:DOCS ]]; then
     exit 0
 fi
 
-# So are PRs where 'NO TESTS NEEDED' appears in the Github message
+# So are PRs where 'NO NEW TESTS NEEDED' appears in the Github message
+if [[ "${CIRRUS_CHANGE_MESSAGE}" =~ NO.NEW.TESTS.NEEDED ]]; then
+    exit 0
+fi
 if [[ "${CIRRUS_CHANGE_MESSAGE}" =~ NO.TESTS.NEEDED ]]; then
     exit 0
 fi
@@ -49,8 +52,11 @@ if [[ -z "$filtered_changes" ]]; then
     exit 0
 fi
 
-# One last chance: perhaps the developer included the magic '[NO TESTS NEEDED]'
+# One last chance: perhaps the developer included the magic '[NO (NEW) TESTS NEEDED]'
 # string in an amended commit.
+if git log --format=%B ${base}..${head} | fgrep '[NO NEW TESTS NEEDED]'; then
+   exit 0
+fi
 if git log --format=%B ${base}..${head} | fgrep '[NO TESTS NEEDED]'; then
    exit 0
 fi
@@ -67,7 +73,7 @@ tests, possibly just adding a small step to a similar existing test.
 Every second counts in CI.
 
 If your commit really, truly does not need tests, you can proceed
-by adding '[NO TESTS NEEDED]' to the body of your commit message.
+by adding '[NO NEW TESTS NEEDED]' to the body of your commit message.
 Please think carefully before doing so.
 EOF
 

--- a/contrib/cirrus/pr-should-include-tests.t
+++ b/contrib/cirrus/pr-should-include-tests.t
@@ -36,9 +36,9 @@ tests="
 0  a47515008  ecedda63a   PR 8816, unit tests only
 0  caa84cd35  e55320efd   PR 8565, hack/podman-socat only
 0  c342583da  12f835d12   PR 8523, version.go + podman.spec.in
-0  c342583da  db1d2ff11   version bump to v2.2.0
 0  8f75ed958  7b3ad6d89   PR 8835, only a README.md change
 0  b6db60e58  f06dd45e0   PR 9420, a test rename
+0  c6a896b0c  4ea5d6971   PR 11833, includes magic string
 "
 
 # The script we're testing


### PR DESCRIPTION
Accept both "NO TESTS NEEDED" and "NO NEW TESTS NEEDED".
That was a usability mistake I made on Day One. Fixed it
in Buildah but oops never got around to fixing it here.

Also, fix the test suite script: remove a no-longer-working
test case (changelog.txt, removed in #11467) and add a new
test for commits that include the magic string.

Signed-off-by: Ed Santiago <santiago@redhat.com>
