### PR TITLE
Align install path of podman to the systemd service files

### DIFF
--- a/contrib/systemd/auto-update/podman-auto-update.service
+++ b/contrib/systemd/auto-update/podman-auto-update.service
@@ -6,8 +6,8 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/podman auto-update
-ExecStartPost=/usr/bin/podman image prune -f
+ExecStart=/usr/local/bin/podman auto-update
+ExecStartPost=/usr/local/bin/podman image prune -f
 
 [Install]
 WantedBy=multi-user.target default.target

--- a/contrib/systemd/system/podman-restart.service
+++ b/contrib/systemd/system/podman-restart.service
@@ -6,7 +6,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=oneshot
 Environment=LOGGING="--log-level=info"
-ExecStart=/usr/bin/podman $LOGGING start --all --filter restart-policy=always
+ExecStart=/usr/local/bin/podman $LOGGING start --all --filter restart-policy=always
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/system/podman.service
+++ b/contrib/systemd/system/podman.service
@@ -9,7 +9,7 @@ StartLimitIntervalSec=0
 Type=exec
 KillMode=process
 Environment=LOGGING="--log-level=info"
-ExecStart=/usr/bin/podman $LOGGING system service
+ExecStart=/usr/local/bin/podman $LOGGING system service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
`make && make install`  puts the podman executable in /usr/local/bin and installs systemd service files.  The latter have assumed, that the podman executable is at /usr/bin/podman .

Closes https://github.com/containers/podman/issues/11858.