### PR TITLE
Warn if podman stop timeout expires that sigkill was sent

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -441,7 +441,8 @@ func (r *ConmonOCIRuntime) StopContainer(ctr *Container, timeout uint, all bool)
 		}
 
 		if err := waitContainerStop(ctr, time.Duration(timeout)*time.Second); err != nil {
-			logrus.Infof("Timed out stopping container %s, resorting to SIGKILL: %v", ctr.ID(), err)
+			logrus.Debugf("Timed out stopping container %s with %s, resorting to SIGKILL: %v", ctr.ID(), unix.SignalName(syscall.Signal(stopSignal)), err)
+			logrus.Warnf("StopSignal %s failed to stop container %s in %d seconds, resorting to SIGKILL", unix.SignalName(syscall.Signal(stopSignal)), ctr.Name(), timeout)
 		} else {
 			// No error, the container is dead
 			return nil

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -181,6 +181,18 @@ var _ = Describe("Podman stop", func() {
 		Expect(strings.TrimSpace(finalCtrs.OutputToString())).To(Equal(""))
 	})
 
+	It("podman stop container --timeout Warning", func() {
+		SkipIfRemote("warning will happen only on server side")
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "test5", ALPINE, "sleep", "100"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		session = podmanTest.Podman([]string{"stop", "--timeout", "1", "test5"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		warning := session.ErrorToString()
+		Expect(warning).To(ContainSubstring("StopSignal SIGTERM failed to stop container test5 in 1 seconds, resorting to SIGKILL"))
+	})
+
 	It("podman stop latest containers", func() {
 		SkipIfRemote("--latest flag n/a")
 		session := podmanTest.RunTopContainer("test1")

--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -166,4 +166,11 @@ load helpers
     is "$output" "137" "Exit code of killed container"
 }
 
+@test "podman stop -t 1 Generate warning" {
+    skip_if_remote "warning only happens on server side"
+    run_podman run --rm --name stopme -d $IMAGE sleep 100
+    run_podman stop -t 1 stopme
+    is "$output" ".*StopSignal SIGTERM failed to stop container stopme in 1 seconds, resorting to SIGKILL"  "stopping container should print warning"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Note: the Warning message will not come to podman-remote.
It would be difficult to plumb, and not really worth the effort.

Fixes: https://github.com/containers/podman/issues/11854

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
