### PR TITLE
libpod: deduplicate ports in db

### DIFF
--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -384,6 +384,15 @@ func (s *BoltState) getContainerConfigFromDB(id []byte, config *ContainerConfig,
 		return errors.Wrapf(err, "error unmarshalling container %s config", string(id))
 	}
 
+	// convert ports to the new format if needed
+	if len(config.ContainerNetworkConfig.OldPortMappings) > 0 && len(config.ContainerNetworkConfig.PortMappings) == 0 {
+		config.ContainerNetworkConfig.PortMappings = ocicniPortsToNetTypesPorts(config.ContainerNetworkConfig.OldPortMappings)
+		// keep the OldPortMappings in case an user has to downgrade podman
+
+		// indicate the the config was modified and should be written back to the db when possible
+		config.rewrite = true
+	}
+
 	return nil
 }
 

--- a/libpod/common_test.go
+++ b/libpod/common_test.go
@@ -41,18 +41,20 @@ func getTestContainer(id, name string, manager lock.Manager) (*Container, error)
 			ContainerNetworkConfig: ContainerNetworkConfig{
 				DNSServer: []net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("192.168.2.2")},
 				DNSSearch: []string{"example.com", "example.example.com"},
-				PortMappings: []types.OCICNIPortMapping{
+				PortMappings: []types.PortMapping{
 					{
 						HostPort:      80,
 						ContainerPort: 90,
 						Protocol:      "tcp",
 						HostIP:        "192.168.3.3",
+						Range:         1,
 					},
 					{
 						HostPort:      100,
 						ContainerPort: 110,
 						Protocol:      "udp",
 						HostIP:        "192.168.4.4",
+						Range:         1,
 					},
 				},
 			},

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -465,7 +465,7 @@ func (c *Container) NewNetNS() bool {
 // PortMappings returns the ports that will be mapped into a container if
 // a new network namespace is created
 // If NewNetNS() is false, this value is unused
-func (c *Container) PortMappings() ([]types.OCICNIPortMapping, error) {
+func (c *Container) PortMappings() ([]types.PortMapping, error) {
 	// First check if the container belongs to a network namespace (like a pod)
 	if len(c.config.NetNsCtr) > 0 {
 		netNsCtr, err := c.runtime.GetContainer(c.config.NetNsCtr)

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -78,6 +78,11 @@ type ContainerConfig struct {
 	// These containers must be started before this container is started.
 	Dependencies []string
 
+	// rewrite is an internal bool to indicate that the config was modified after
+	// a read from the db, e.g. to migrate config fields after an upgrade.
+	// This field should never be written to the db, the json tag ensures this.
+	rewrite bool `json:"-"`
+
 	// embedded sub-configs
 	ContainerRootFSConfig
 	ContainerSecurityConfig
@@ -232,7 +237,12 @@ type ContainerNetworkConfig struct {
 	// PortMappings are the ports forwarded to the container's network
 	// namespace
 	// These are not used unless CreateNetNS is true
-	PortMappings []types.OCICNIPortMapping `json:"portMappings,omitempty"`
+	PortMappings []types.PortMapping `json:"newPortMappings,omitempty"`
+	// OldPortMappings are the ports forwarded to the container's network
+	// namespace. As of podman 4.0 this field is deprecated, use PortMappings
+	// instead. The db will convert the old ports to the new structure for you.
+	// These are not used unless CreateNetNS is true
+	OldPortMappings []types.OCICNIPortMapping `json:"portMappings,omitempty"`
 	// ExposedPorts are the ports which are exposed but not forwarded
 	// into the container.
 	// The map key is the port and the string slice contains the protocols,

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -88,10 +89,7 @@ func (c *Container) getNetworkOptions() (types.NetworkOptions, error) {
 		ContainerID:   c.config.ID,
 		ContainerName: getCNIPodName(c),
 	}
-	// TODO remove ocicni PortMappings from container config and store as types PortMappings
-	if len(c.config.PortMappings) > 0 {
-		opts.PortMappings = ocicniPortsToNetTypesPorts(c.config.PortMappings)
-	}
+	opts.PortMappings = c.config.PortMappings
 	networks, _, err := c.networks()
 	if err != nil {
 		return opts, err
@@ -1200,9 +1198,7 @@ func (c *Container) NetworkDisconnect(nameOrID, netName string, force bool) erro
 		ContainerID:   c.config.ID,
 		ContainerName: getCNIPodName(c),
 	}
-	if len(c.config.PortMappings) > 0 {
-		opts.PortMappings = ocicniPortsToNetTypesPorts(c.config.PortMappings)
-	}
+	opts.PortMappings = c.config.PortMappings
 	eth, exists := c.state.NetInterfaceDescriptions.getInterfaceByName(netName)
 	if !exists {
 		return errors.Errorf("no network interface name for container %s on network %s", c.config.ID, netName)
@@ -1294,9 +1290,7 @@ func (c *Container) NetworkConnect(nameOrID, netName string, aliases []string) e
 		ContainerID:   c.config.ID,
 		ContainerName: getCNIPodName(c),
 	}
-	if len(c.config.PortMappings) > 0 {
-		opts.PortMappings = ocicniPortsToNetTypesPorts(c.config.PortMappings)
-	}
+	opts.PortMappings = c.config.PortMappings
 	eth, exists := c.state.NetInterfaceDescriptions.getInterfaceByName(netName)
 	if !exists {
 		return errors.Errorf("no network interface name for container %s on network %s", c.config.ID, netName)
@@ -1364,16 +1358,67 @@ func (r *Runtime) normalizeNetworkName(nameOrID string) (string, error) {
 	return net.Name, nil
 }
 
+// ocicniPortsToNetTypesPorts convert the old port format to the new one
+// while deduplicating ports into ranges
 func ocicniPortsToNetTypesPorts(ports []types.OCICNIPortMapping) []types.PortMapping {
-	newPorts := make([]types.PortMapping, 0, len(ports))
-	for _, port := range ports {
-		newPorts = append(newPorts, types.PortMapping{
-			HostIP:        port.HostIP,
-			HostPort:      uint16(port.HostPort),
-			ContainerPort: uint16(port.ContainerPort),
-			Protocol:      port.Protocol,
-			Range:         1,
-		})
+	if len(ports) == 0 {
+		return nil
 	}
+
+	newPorts := make([]types.PortMapping, 0, len(ports))
+
+	// first sort the ports
+	sort.Slice(ports, func(i, j int) bool {
+		return compareOCICNIPorts(ports[i], ports[j])
+	})
+
+	// we already check if the slice is empty so we can use the first element
+	currentPort := types.PortMapping{
+		HostIP:        ports[0].HostIP,
+		HostPort:      uint16(ports[0].HostPort),
+		ContainerPort: uint16(ports[0].ContainerPort),
+		Protocol:      ports[0].Protocol,
+		Range:         1,
+	}
+
+	for i := 1; i < len(ports); i++ {
+		if ports[i].HostIP == currentPort.HostIP &&
+			ports[i].Protocol == currentPort.Protocol &&
+			ports[i].HostPort-int32(currentPort.Range) == int32(currentPort.HostPort) &&
+			ports[i].ContainerPort-int32(currentPort.Range) == int32(currentPort.ContainerPort) {
+			currentPort.Range = currentPort.Range + 1
+		} else {
+			newPorts = append(newPorts, currentPort)
+			currentPort = types.PortMapping{
+				HostIP:        ports[i].HostIP,
+				HostPort:      uint16(ports[i].HostPort),
+				ContainerPort: uint16(ports[i].ContainerPort),
+				Protocol:      ports[i].Protocol,
+				Range:         1,
+			}
+		}
+	}
+	newPorts = append(newPorts, currentPort)
 	return newPorts
+}
+
+// compareOCICNIPorts will sort the ocicni ports by
+// 1) host ip
+// 2) protocol
+// 3) hostPort
+// 4) container port
+func compareOCICNIPorts(i, j types.OCICNIPortMapping) bool {
+	if i.HostIP != j.HostIP {
+		return i.HostIP < j.HostIP
+	}
+
+	if i.Protocol != j.Protocol {
+		return i.Protocol < j.Protocol
+	}
+
+	if i.HostPort != j.HostPort {
+		return i.HostPort < j.HostPort
+	}
+
+	return i.ContainerPort < j.ContainerPort
 }

--- a/libpod/networking_linux_test.go
+++ b/libpod/networking_linux_test.go
@@ -1,0 +1,323 @@
+package libpod
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/containers/podman/v3/libpod/network/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ocicniPortsToNetTypesPorts(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  []types.OCICNIPortMapping
+		want []types.PortMapping
+	}{
+		{
+			name: "no ports",
+			arg:  nil,
+			want: nil,
+		},
+		{
+			name: "empty ports",
+			arg:  []types.OCICNIPortMapping{},
+			want: nil,
+		},
+		{
+			name: "single port",
+			arg: []types.OCICNIPortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "two separate ports",
+			arg: []types.OCICNIPortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      9000,
+					ContainerPort: 90,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      9000,
+					ContainerPort: 90,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "two ports joined",
+			arg: []types.OCICNIPortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      8081,
+					ContainerPort: 81,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         2,
+				},
+			},
+		},
+		{
+			name: "three ports with different container port are not joined",
+			arg: []types.OCICNIPortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      8081,
+					ContainerPort: 79,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      8082,
+					ContainerPort: 82,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      8081,
+					ContainerPort: 79,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      8082,
+					ContainerPort: 82,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "three ports joined (not sorted)",
+			arg: []types.OCICNIPortMapping{
+				{
+					HostPort:      8081,
+					ContainerPort: 81,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      8082,
+					ContainerPort: 82,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         3,
+				},
+			},
+		},
+		{
+			name: "different protocols ports are not joined",
+			arg: []types.OCICNIPortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      8081,
+					ContainerPort: 81,
+					Protocol:      "udp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      8081,
+					ContainerPort: 81,
+					Protocol:      "udp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "different host ip ports are not joined",
+			arg: []types.OCICNIPortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					HostIP:        "192.168.1.1",
+				},
+				{
+					HostPort:      8081,
+					ContainerPort: 81,
+					Protocol:      "tcp",
+					HostIP:        "192.168.1.2",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+					HostIP:        "192.168.1.1",
+				},
+				{
+					HostPort:      8081,
+					ContainerPort: 81,
+					Protocol:      "tcp",
+					Range:         1,
+					HostIP:        "192.168.1.2",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			result := ocicniPortsToNetTypesPorts(tt.arg)
+			assert.Equal(t, tt.want, result, "ports do not match")
+		})
+	}
+}
+
+func benchmarkOCICNIPortsToNetTypesPorts(b *testing.B, ports []types.OCICNIPortMapping) {
+	for n := 0; n < b.N; n++ {
+		ocicniPortsToNetTypesPorts(ports)
+	}
+}
+
+func Benchmark_ocicniPortsToNetTypesPortsNoPorts(b *testing.B) {
+	benchmarkOCICNIPortsToNetTypesPorts(b, nil)
+}
+
+func Benchmark_ocicniPortsToNetTypesPorts1(b *testing.B) {
+	benchmarkOCICNIPortsToNetTypesPorts(b, []types.OCICNIPortMapping{
+		{
+			HostPort:      8080,
+			ContainerPort: 80,
+			Protocol:      "tcp",
+		},
+	})
+}
+
+func Benchmark_ocicniPortsToNetTypesPorts10(b *testing.B) {
+	ports := make([]types.OCICNIPortMapping, 0, 10)
+	for i := int32(8080); i < 8090; i++ {
+		ports = append(ports, types.OCICNIPortMapping{
+			HostPort:      i,
+			ContainerPort: i,
+			Protocol:      "tcp",
+		})
+	}
+	b.ResetTimer()
+	benchmarkOCICNIPortsToNetTypesPorts(b, ports)
+}
+
+func Benchmark_ocicniPortsToNetTypesPorts100(b *testing.B) {
+	ports := make([]types.OCICNIPortMapping, 0, 100)
+	for i := int32(8080); i < 8180; i++ {
+		ports = append(ports, types.OCICNIPortMapping{
+			HostPort:      i,
+			ContainerPort: i,
+			Protocol:      "tcp",
+		})
+	}
+	b.ResetTimer()
+	benchmarkOCICNIPortsToNetTypesPorts(b, ports)
+}
+
+func Benchmark_ocicniPortsToNetTypesPorts1k(b *testing.B) {
+	ports := make([]types.OCICNIPortMapping, 0, 1000)
+	for i := int32(8080); i < 9080; i++ {
+		ports = append(ports, types.OCICNIPortMapping{
+			HostPort:      i,
+			ContainerPort: i,
+			Protocol:      "tcp",
+		})
+	}
+	b.ResetTimer()
+	benchmarkOCICNIPortsToNetTypesPorts(b, ports)
+}
+
+func Benchmark_ocicniPortsToNetTypesPorts10k(b *testing.B) {
+	ports := make([]types.OCICNIPortMapping, 0, 30000)
+	for i := int32(8080); i < 18080; i++ {
+		ports = append(ports, types.OCICNIPortMapping{
+			HostPort:      i,
+			ContainerPort: i,
+			Protocol:      "tcp",
+		})
+	}
+	b.ResetTimer()
+	benchmarkOCICNIPortsToNetTypesPorts(b, ports)
+}
+
+func Benchmark_ocicniPortsToNetTypesPorts1m(b *testing.B) {
+	ports := make([]types.OCICNIPortMapping, 0, 1000000)
+	for j := 0; j < 20; j++ {
+		for i := int32(1); i <= 50000; i++ {
+			ports = append(ports, types.OCICNIPortMapping{
+				HostPort:      i,
+				ContainerPort: i,
+				Protocol:      "tcp",
+				HostIP:        fmt.Sprintf("192.168.1.%d", j),
+			})
+		}
+	}
+	b.ResetTimer()
+	benchmarkOCICNIPortsToNetTypesPorts(b, ports)
+}

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -38,9 +38,9 @@ type slirpFeatures struct {
 type slirp4netnsCmdArg struct {
 	Proto     string `json:"proto,omitempty"`
 	HostAddr  string `json:"host_addr"`
-	HostPort  int32  `json:"host_port"`
+	HostPort  uint16 `json:"host_port"`
 	GuestAddr string `json:"guest_addr"`
-	GuestPort int32  `json:"guest_port"`
+	GuestPort uint16 `json:"guest_port"`
 }
 
 type slirp4netnsCmd struct {

--- a/libpod/oci_util.go
+++ b/libpod/oci_util.go
@@ -32,93 +32,108 @@ func createUnitName(prefix string, name string) string {
 }
 
 // Bind ports to keep them closed on the host
-func bindPorts(ports []types.OCICNIPortMapping) ([]*os.File, error) {
+func bindPorts(ports []types.PortMapping) ([]*os.File, error) {
 	var files []*os.File
-	notifySCTP := false
-	for _, i := range ports {
-		isV6 := net.ParseIP(i.HostIP).To4() == nil
-		if i.HostIP == "" {
+	sctpWarning := true
+	for _, port := range ports {
+		isV6 := net.ParseIP(port.HostIP).To4() == nil
+		if port.HostIP == "" {
 			isV6 = false
 		}
-		switch i.Protocol {
-		case "udp":
-			var (
-				addr *net.UDPAddr
-				err  error
-			)
-			if isV6 {
-				addr, err = net.ResolveUDPAddr("udp6", fmt.Sprintf("[%s]:%d", i.HostIP, i.HostPort))
-			} else {
-				addr, err = net.ResolveUDPAddr("udp4", fmt.Sprintf("%s:%d", i.HostIP, i.HostPort))
+		protocols := strings.Split(port.Protocol, ",")
+		for _, protocol := range protocols {
+			for i := uint16(0); i < port.Range; i++ {
+				f, err := bindPort(protocol, port.HostIP, port.HostPort+i, isV6, &sctpWarning)
+				if err != nil {
+					return files, err
+				}
+				if f != nil {
+					files = append(files, f)
+				}
 			}
-			if err != nil {
-				return nil, errors.Wrapf(err, "cannot resolve the UDP address")
-			}
-
-			proto := "udp4"
-			if isV6 {
-				proto = "udp6"
-			}
-			server, err := net.ListenUDP(proto, addr)
-			if err != nil {
-				return nil, errors.Wrapf(err, "cannot listen on the UDP port")
-			}
-			f, err := server.File()
-			if err != nil {
-				return nil, errors.Wrapf(err, "cannot get file for UDP socket")
-			}
-			files = append(files, f)
-			// close the listener
-			// note that this does not affect the fd, see the godoc for server.File()
-			err = server.Close()
-			if err != nil {
-				logrus.Warnf("Failed to close connection: %v", err)
-			}
-
-		case "tcp":
-			var (
-				addr *net.TCPAddr
-				err  error
-			)
-			if isV6 {
-				addr, err = net.ResolveTCPAddr("tcp6", fmt.Sprintf("[%s]:%d", i.HostIP, i.HostPort))
-			} else {
-				addr, err = net.ResolveTCPAddr("tcp4", fmt.Sprintf("%s:%d", i.HostIP, i.HostPort))
-			}
-			if err != nil {
-				return nil, errors.Wrapf(err, "cannot resolve the TCP address")
-			}
-
-			proto := "tcp4"
-			if isV6 {
-				proto = "tcp6"
-			}
-			server, err := net.ListenTCP(proto, addr)
-			if err != nil {
-				return nil, errors.Wrapf(err, "cannot listen on the TCP port")
-			}
-			f, err := server.File()
-			if err != nil {
-				return nil, errors.Wrapf(err, "cannot get file for TCP socket")
-			}
-			files = append(files, f)
-			// close the listener
-			// note that this does not affect the fd, see the godoc for server.File()
-			err = server.Close()
-			if err != nil {
-				logrus.Warnf("Failed to close connection: %v", err)
-			}
-
-		case "sctp":
-			if !notifySCTP {
-				notifySCTP = true
-				logrus.Warnf("Port reservation for SCTP is not supported")
-			}
-		default:
-			return nil, fmt.Errorf("unknown protocol %s", i.Protocol)
 		}
 	}
 	return files, nil
+}
+
+func bindPort(protocol, hostIP string, port uint16, isV6 bool, sctpWarning *bool) (*os.File, error) {
+	var file *os.File
+	switch protocol {
+	case "udp":
+		var (
+			addr *net.UDPAddr
+			err  error
+		)
+		if isV6 {
+			addr, err = net.ResolveUDPAddr("udp6", fmt.Sprintf("[%s]:%d", hostIP, port))
+		} else {
+			addr, err = net.ResolveUDPAddr("udp4", fmt.Sprintf("%s:%d", hostIP, port))
+		}
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot resolve the UDP address")
+		}
+
+		proto := "udp4"
+		if isV6 {
+			proto = "udp6"
+		}
+		server, err := net.ListenUDP(proto, addr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot listen on the UDP port")
+		}
+		file, err = server.File()
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot get file for UDP socket")
+		}
+		// close the listener
+		// note that this does not affect the fd, see the godoc for server.File()
+		err = server.Close()
+		if err != nil {
+			logrus.Warnf("Failed to close connection: %v", err)
+		}
+
+	case "tcp":
+		var (
+			addr *net.TCPAddr
+			err  error
+		)
+		if isV6 {
+			addr, err = net.ResolveTCPAddr("tcp6", fmt.Sprintf("[%s]:%d", hostIP, port))
+		} else {
+			addr, err = net.ResolveTCPAddr("tcp4", fmt.Sprintf("%s:%d", hostIP, port))
+		}
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot resolve the TCP address")
+		}
+
+		proto := "tcp4"
+		if isV6 {
+			proto = "tcp6"
+		}
+		server, err := net.ListenTCP(proto, addr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot listen on the TCP port")
+		}
+		file, err = server.File()
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot get file for TCP socket")
+		}
+		// close the listener
+		// note that this does not affect the fd, see the godoc for server.File()
+		err = server.Close()
+		if err != nil {
+			logrus.Warnf("Failed to close connection: %v", err)
+		}
+
+	case "sctp":
+		if *sctpWarning {
+			logrus.Info("Port reservation for SCTP is not supported")
+			*sctpWarning = false
+		}
+	default:
+		return nil, fmt.Errorf("unknown protocol %s", protocol)
+	}
+	return file, nil
 }
 
 func getOCIRuntimeError(runtimeMsg string) error {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1051,7 +1051,7 @@ func WithDependencyCtrs(ctrs []*Container) CtrCreateOption {
 // namespace with a minimal configuration.
 // An optional array of port mappings can be provided.
 // Conflicts with WithNetNSFrom().
-func WithNetNS(portMappings []nettypes.OCICNIPortMapping, exposedPorts map[uint16][]string, postConfigureNetNS bool, netmode string, networks []string) CtrCreateOption {
+func WithNetNS(portMappings []nettypes.PortMapping, exposedPorts map[uint16][]string, postConfigureNetNS bool, netmode string, networks []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
 			return define.ErrCtrFinalized
@@ -2082,21 +2082,6 @@ func WithInfraContainer() PodCreateOption {
 
 		return nil
 	}
-}
-
-// WithInfraContainerPorts tells the pod to add port bindings to the pause container
-func WithInfraContainerPorts(bindings []nettypes.OCICNIPortMapping, infraSpec *specgen.SpecGenerator) []nettypes.PortMapping {
-	bindingSpec := []nettypes.PortMapping{}
-	for _, bind := range bindings {
-		currBind := nettypes.PortMapping{}
-		currBind.ContainerPort = uint16(bind.ContainerPort)
-		currBind.HostIP = bind.HostIP
-		currBind.HostPort = uint16(bind.HostPort)
-		currBind.Protocol = bind.Protocol
-		bindingSpec = append(bindingSpec, currBind)
-	}
-	infraSpec.PortMappings = bindingSpec
-	return infraSpec.PortMappings
 }
 
 // WithVolatile sets the volatile flag for the container storage.

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -193,7 +193,7 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 	}
 
 	if len(restoreOptions.PublishPorts) > 0 {
-		ports, _, _, err := generate.ParsePortMapping(restoreOptions.PublishPorts)
+		ports, err := generate.ParsePortMapping(restoreOptions.PublishPorts, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/domain/entities/container_ps.go
+++ b/pkg/domain/entities/container_ps.go
@@ -54,7 +54,7 @@ type ListContainer struct {
 	// boolean to be set
 	PodName string
 	// Port mappings
-	Ports []types.OCICNIPortMapping
+	Ports []types.PortMapping
 	// Size of the container rootfs.  Requires the size boolean to be true
 	Size *define.ContainerSize
 	// Time when container started

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -422,7 +422,7 @@ type ContainerPortOptions struct {
 // the CLI to output ports
 type ContainerPortReport struct {
 	Id    string //nolint
-	Ports []nettypes.OCICNIPortMapping
+	Ports []nettypes.PortMapping
 }
 
 // ContainerCpOptions describes input options for cp.

--- a/pkg/rootlessport/rootlessport_linux.go
+++ b/pkg/rootlessport/rootlessport_linux.go
@@ -23,7 +23,7 @@ const (
 // Config needs to be provided to the process via stdin as a JSON string.
 // stdin needs to be closed after the message has been written.
 type Config struct {
-	Mappings    []types.OCICNIPortMapping
+	Mappings    []types.PortMapping
 	NetNSPath   string
 	ExitFD      int
 	ReadyFD     int

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -204,11 +204,11 @@ func createPodOptions(p *specgen.PodSpecGenerator, rt *libpod.Runtime, infraSpec
 // replacing necessary values with those specified in pod creation
 func MapSpec(p *specgen.PodSpecGenerator) (*specgen.SpecGenerator, error) {
 	if len(p.PortMappings) > 0 {
-		ports, _, _, err := ParsePortMapping(p.PortMappings)
+		ports, err := ParsePortMapping(p.PortMappings, nil)
 		if err != nil {
 			return nil, err
 		}
-		p.InfraContainerSpec.PortMappings = libpod.WithInfraContainerPorts(ports, p.InfraContainerSpec)
+		p.InfraContainerSpec.PortMappings = ports
 	}
 	switch p.NetNS.NSMode {
 	case specgen.Default, "":

--- a/pkg/specgen/generate/ports_bench_test.go
+++ b/pkg/specgen/generate/ports_bench_test.go
@@ -1,0 +1,197 @@
+package generate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/containers/podman/v3/libpod/network/types"
+)
+
+func benchmarkParsePortMapping(b *testing.B, ports []types.PortMapping) {
+	for n := 0; n < b.N; n++ {
+		ParsePortMapping(ports, nil)
+	}
+}
+
+func BenchmarkParsePortMappingNoPorts(b *testing.B) {
+	benchmarkParsePortMapping(b, nil)
+}
+
+func BenchmarkParsePortMapping1(b *testing.B) {
+	benchmarkParsePortMapping(b, []types.PortMapping{
+		{
+			HostPort:      8080,
+			ContainerPort: 80,
+			Protocol:      "tcp",
+		},
+	})
+}
+
+func BenchmarkParsePortMapping100(b *testing.B) {
+	ports := make([]types.PortMapping, 0, 100)
+	for i := uint16(8080); i < 8180; i++ {
+		ports = append(ports, types.PortMapping{
+			HostPort:      i,
+			ContainerPort: i,
+			Protocol:      "tcp",
+		})
+	}
+	b.ResetTimer()
+	benchmarkParsePortMapping(b, ports)
+}
+
+func BenchmarkParsePortMapping1k(b *testing.B) {
+	ports := make([]types.PortMapping, 0, 1000)
+	for i := uint16(8080); i < 9080; i++ {
+		ports = append(ports, types.PortMapping{
+			HostPort:      i,
+			ContainerPort: i,
+			Protocol:      "tcp",
+		})
+	}
+	b.ResetTimer()
+	benchmarkParsePortMapping(b, ports)
+}
+
+func BenchmarkParsePortMapping10k(b *testing.B) {
+	ports := make([]types.PortMapping, 0, 30000)
+	for i := uint16(8080); i < 18080; i++ {
+		ports = append(ports, types.PortMapping{
+			HostPort:      i,
+			ContainerPort: i,
+			Protocol:      "tcp",
+		})
+	}
+	b.ResetTimer()
+	benchmarkParsePortMapping(b, ports)
+}
+
+func BenchmarkParsePortMapping1m(b *testing.B) {
+	ports := make([]types.PortMapping, 0, 1000000)
+	for j := 0; j < 20; j++ {
+		for i := uint16(1); i <= 50000; i++ {
+			ports = append(ports, types.PortMapping{
+				HostPort:      i,
+				ContainerPort: i,
+				Protocol:      "tcp",
+				HostIP:        fmt.Sprintf("192.168.1.%d", j),
+			})
+		}
+	}
+	b.ResetTimer()
+	benchmarkParsePortMapping(b, ports)
+}
+
+func BenchmarkParsePortMappingReverse100(b *testing.B) {
+	ports := make([]types.PortMapping, 0, 100)
+	for i := uint16(8180); i > 8080; i-- {
+		ports = append(ports, types.PortMapping{
+			HostPort:      i,
+			ContainerPort: i,
+			Protocol:      "tcp",
+		})
+	}
+	b.ResetTimer()
+	benchmarkParsePortMapping(b, ports)
+}
+
+func BenchmarkParsePortMappingReverse1k(b *testing.B) {
+	ports := make([]types.PortMapping, 0, 1000)
+	for i := uint16(9080); i > 8080; i-- {
+		ports = append(ports, types.PortMapping{
+			HostPort:      i,
+			ContainerPort: i,
+			Protocol:      "tcp",
+		})
+	}
+	b.ResetTimer()
+	benchmarkParsePortMapping(b, ports)
+}
+
+func BenchmarkParsePortMappingReverse10k(b *testing.B) {
+	ports := make([]types.PortMapping, 0, 30000)
+	for i := uint16(18080); i > 8080; i-- {
+		ports = append(ports, types.PortMapping{
+			HostPort:      i,
+			ContainerPort: i,
+			Protocol:      "tcp",
+		})
+	}
+	b.ResetTimer()
+	benchmarkParsePortMapping(b, ports)
+}
+
+func BenchmarkParsePortMappingReverse1m(b *testing.B) {
+	ports := make([]types.PortMapping, 0, 1000000)
+	for j := 0; j < 20; j++ {
+		for i := uint16(50000); i > 0; i-- {
+			ports = append(ports, types.PortMapping{
+				HostPort:      i,
+				ContainerPort: i,
+				Protocol:      "tcp",
+				HostIP:        fmt.Sprintf("192.168.1.%d", j),
+			})
+		}
+	}
+	b.ResetTimer()
+	benchmarkParsePortMapping(b, ports)
+}
+
+func BenchmarkParsePortMappingRange1(b *testing.B) {
+	benchmarkParsePortMapping(b, []types.PortMapping{
+		{
+			HostPort:      8080,
+			ContainerPort: 80,
+			Protocol:      "tcp",
+			Range:         1,
+		},
+	})
+}
+
+func BenchmarkParsePortMappingRange100(b *testing.B) {
+	benchmarkParsePortMapping(b, []types.PortMapping{
+		{
+			HostPort:      8080,
+			ContainerPort: 80,
+			Protocol:      "tcp",
+			Range:         100,
+		},
+	})
+}
+
+func BenchmarkParsePortMappingRange1k(b *testing.B) {
+	benchmarkParsePortMapping(b, []types.PortMapping{
+		{
+			HostPort:      8080,
+			ContainerPort: 80,
+			Protocol:      "tcp",
+			Range:         1000,
+		},
+	})
+}
+
+func BenchmarkParsePortMappingRange10k(b *testing.B) {
+	benchmarkParsePortMapping(b, []types.PortMapping{
+		{
+			HostPort:      8080,
+			ContainerPort: 80,
+			Protocol:      "tcp",
+			Range:         10000,
+		},
+	})
+}
+
+func BenchmarkParsePortMappingRange1m(b *testing.B) {
+	ports := make([]types.PortMapping, 0, 1000000)
+	for j := 0; j < 20; j++ {
+		ports = append(ports, types.PortMapping{
+			HostPort:      1,
+			ContainerPort: 1,
+			Protocol:      "tcp",
+			Range:         50000,
+			HostIP:        fmt.Sprintf("192.168.1.%d", j),
+		})
+	}
+	b.ResetTimer()
+	benchmarkParsePortMapping(b, ports)
+}

--- a/pkg/specgen/generate/ports_test.go
+++ b/pkg/specgen/generate/ports_test.go
@@ -1,0 +1,989 @@
+package generate
+
+import (
+	"testing"
+
+	"github.com/containers/podman/v3/libpod/network/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePortMappingWithHostPort(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  []types.PortMapping
+		arg2 map[uint16][]string
+		want []types.PortMapping
+	}{
+		{
+			name: "no ports",
+			arg:  nil,
+			want: nil,
+		},
+		{
+			name: "one tcp port",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "one tcp port no proto",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "one udp port",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "udp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "udp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "one sctp port",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "sctp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "sctp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "one port two protocols",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp,udp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "udp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "one port three protocols",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp,udp,sctp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "udp",
+					Range:         1,
+				},
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "sctp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "one port with range 1",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "one port with range 5",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         5,
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         5,
+				},
+			},
+		},
+		{
+			name: "two ports joined",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      8081,
+					ContainerPort: 81,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         2,
+				},
+			},
+		},
+		{
+			name: "two ports joined with range",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         2,
+				},
+				{
+					HostPort:      8081,
+					ContainerPort: 81,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         2,
+				},
+			},
+		},
+		{
+			name: "two ports with no overlapping range",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         10,
+				},
+				{
+					HostPort:      9090,
+					ContainerPort: 9090,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      9090,
+					ContainerPort: 9090,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         10,
+				},
+			},
+		},
+		{
+			name: "four ports with two overlapping ranges",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         10,
+				},
+				{
+					HostPort:      8085,
+					ContainerPort: 85,
+					Protocol:      "tcp",
+					Range:         10,
+				},
+				{
+					HostPort:      100,
+					ContainerPort: 5,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      101,
+					ContainerPort: 6,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         15,
+				},
+				{
+					HostPort:      100,
+					ContainerPort: 5,
+					Protocol:      "tcp",
+					Range:         2,
+				},
+			},
+		},
+		{
+			name: "two overlapping ranges",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         10,
+				},
+				{
+					HostPort:      8085,
+					ContainerPort: 85,
+					Protocol:      "tcp",
+					Range:         2,
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         10,
+				},
+			},
+		},
+		{
+			name: "four overlapping ranges",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         10,
+				},
+				{
+					HostPort:      8085,
+					ContainerPort: 85,
+					Protocol:      "tcp",
+					Range:         2,
+				},
+				{
+					HostPort:      8090,
+					ContainerPort: 90,
+					Protocol:      "tcp",
+					Range:         7,
+				},
+				{
+					HostPort:      8095,
+					ContainerPort: 95,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         17,
+				},
+			},
+		},
+		{
+			name: "one port range overlaps 5 ports",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Range:         20,
+				},
+				{
+					HostPort:      8085,
+					ContainerPort: 85,
+					Range:         2,
+				},
+				{
+					HostPort:      8090,
+					ContainerPort: 90,
+				},
+				{
+					HostPort:      8095,
+					ContainerPort: 95,
+				},
+				{
+					HostPort:      8096,
+					ContainerPort: 96,
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         20,
+				},
+			},
+		},
+		{
+			name: "different host ip same port",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					HostIP:        "192.168.1.1",
+				},
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					HostIP:        "192.168.2.1",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					HostIP:        "192.168.1.1",
+					Range:         1,
+				},
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					HostIP:        "192.168.2.1",
+					Range:         1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePortMapping(tt.arg, tt.arg2)
+			assert.NoError(t, err, "error is not nil")
+			// use ElementsMatch instead of Equal because the order is not consistent
+			assert.ElementsMatch(t, tt.want, got, "got unexpected port mapping")
+		})
+	}
+}
+
+func TestParsePortMappingWithoutHostPort(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  []types.PortMapping
+		arg2 map[uint16][]string
+		want []types.PortMapping
+	}{
+		{
+			name: "one tcp port",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "one port with two protocols",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp,udp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "udp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "same port twice",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "neighbor ports are not joined",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 81,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 81,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "overlapping range ports are joined",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         2,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 81,
+					Protocol:      "tcp",
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         2,
+				},
+			},
+		},
+		{
+			name: "four overlapping range ports are joined",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         3,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 81,
+					Protocol:      "tcp",
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 82,
+					Protocol:      "tcp",
+					Range:         10,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 90,
+					Protocol:      "tcp",
+					Range:         5,
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         15,
+				},
+			},
+		},
+		{
+			name: "expose one tcp port",
+			arg2: map[uint16][]string{
+				8080: {"tcp"},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 8080,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "expose already defined port",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 8080,
+					Protocol:      "tcp",
+				},
+			},
+			arg2: map[uint16][]string{
+				8080: {"tcp"},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 8080,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+		},
+		{
+			name: "expose different proto",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 8080,
+					Protocol:      "tcp",
+				},
+			},
+			arg2: map[uint16][]string{
+				8080: {"udp"},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 8080,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 8080,
+					Protocol:      "udp",
+					Range:         1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePortMapping(tt.arg, tt.arg2)
+			assert.NoError(t, err, "error is not nil")
+
+			// because we always get random host ports when it is set to 0 we cannot check that exactly
+			// check if it is not 0 and set to to 0 afterwards
+			for i := range got {
+				assert.Greater(t, got[i].HostPort, uint16(0), "host port is zero")
+				got[i].HostPort = 0
+			}
+
+			// use ElementsMatch instead of Equal because the order is not consistent
+			assert.ElementsMatch(t, tt.want, got, "got unexpected port mapping")
+		})
+	}
+}
+
+func TestParsePortMappingMixedHostPort(t *testing.T) {
+	tests := []struct {
+		name           string
+		arg            []types.PortMapping
+		want           []types.PortMapping
+		resetHostPorts []int
+	}{
+		{
+			name: "two ports one without a hostport set",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+				},
+				{
+					HostPort:      8080,
+					ContainerPort: 8080,
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 8080,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+			resetHostPorts: []int{1},
+		},
+		{
+			name: "two ports one without a hostport set, inverted order",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 8080,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 8080,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+			resetHostPorts: []int{1},
+		},
+		{
+			name: "three ports without host ports, one with a hostport set, , inverted order",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 85,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 90,
+				},
+				{
+					HostPort:      8080,
+					ContainerPort: 8080,
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 8080,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 85,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 90,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+			resetHostPorts: []int{1, 2, 3},
+		},
+		{
+			name: "three ports without host ports, one with a hostport set",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 8080,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 90,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 85,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+				},
+			},
+			want: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 8080,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 85,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 90,
+					Protocol:      "tcp",
+					Range:         1,
+				},
+			},
+			resetHostPorts: []int{1, 2, 3},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePortMapping(tt.arg, nil)
+			assert.NoError(t, err, "error is not nil")
+
+			// because we always get random host ports when it is set to 0 we cannot check that exactly
+			// use resetHostPorts to know which port element is 0
+			for _, num := range tt.resetHostPorts {
+				assert.Greater(t, got[num].HostPort, uint16(0), "host port is zero")
+				got[num].HostPort = 0
+			}
+
+			assert.Equal(t, tt.want, got, "got unexpected port mapping")
+		})
+	}
+}
+
+func TestParsePortMappingError(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  []types.PortMapping
+		err  string
+	}{
+		{
+			name: "container port is 0",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 0,
+					Protocol:      "tcp",
+				},
+			},
+			err: "container port number must be non-0",
+		},
+		{
+			name: "container port range exceeds max",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 65000,
+					Protocol:      "tcp",
+					Range:         10000,
+				},
+			},
+			err: "container port range exceeds maximum allowable port number",
+		},
+		{
+			name: "host port range exceeds max",
+			arg: []types.PortMapping{
+				{
+					HostPort:      60000,
+					ContainerPort: 1,
+					Protocol:      "tcp",
+					Range:         10000,
+				},
+			},
+			err: "host port range exceeds maximum allowable port number",
+		},
+		{
+			name: "invalid protocol",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "1",
+				},
+			},
+			err: "unrecognized protocol \"1\" in port mapping",
+		},
+		{
+			name: "invalid protocol 2",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "udp,u",
+				},
+			},
+			err: "unrecognized protocol \"u\" in port mapping",
+		},
+		{
+			name: "invalid ip address",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					HostIP:        "blah",
+				},
+			},
+			err: "invalid IP address \"blah\" in port mapping",
+		},
+		{
+			name: "invalid overalpping range",
+			arg: []types.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Range:         5,
+				},
+				{
+					HostPort:      8081,
+					ContainerPort: 60,
+				},
+			},
+			err: "conflicting port mappings for host port 8081 (protocol tcp)",
+		},
+		{
+			name: "big port range with host port zero does not fit",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 1,
+					Range:         65535,
+				},
+			},
+			err: "failed to find an open port to expose container port 1 with range 65535 on the host",
+		},
+		{
+			name: "big port range with host port zero does not fit",
+			arg: []types.PortMapping{
+				{
+					HostPort:      0,
+					ContainerPort: 80,
+					Range:         1,
+				},
+				{
+					HostPort:      0,
+					ContainerPort: 1000,
+					Range:         64535,
+				},
+			},
+			err: "failed to find an open port to expose container port 1000 with range 64535 on the host",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePortMapping(tt.arg, nil)
+			assert.EqualError(t, err, tt.err, "error does not match")
+		})
+	}
+}

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -97,6 +97,7 @@ podman \$opts run    --name myfailedcontainer  --label mylabel=$LABEL_FAILED \
 podman \$opts run -d --name myrunningcontainer --label mylabel=$LABEL_RUNNING \
                                                --network bridge \
                                                -p $HOST_PORT:80 \
+                                               -p 127.0.0.1:8080-8082:8080-8082 \
                                                -v $pmroot/var/www:/var/www \
                                                -w /var/www \
                                                $IMAGE /bin/busybox-extras httpd -f -p 80
@@ -185,7 +186,7 @@ EOF
     is "${lines[1]}" "mycreatedcontainer--Created----$LABEL_CREATED" "created"
     is "${lines[2]}" "mydonecontainer--Exited (0).*----<no value>" "done"
     is "${lines[3]}" "myfailedcontainer--Exited (17) .*----$LABEL_FAILED" "fail"
-    is "${lines[4]}" "myrunningcontainer--Up .*--0.0.0.0:$HOST_PORT->80/tcp--$LABEL_RUNNING" "running"
+    is "${lines[4]}" "myrunningcontainer--Up .*--0\.0\.0\.0:$HOST_PORT->80\/tcp, 127\.0\.0\.1\:8080-8082->8080-8082\/tcp--$LABEL_RUNNING" "running"
 
     # For debugging: dump containers and IDs
     if [[ -n "$PODMAN_UPGRADE_TEST_DEBUG" ]]; then


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

The OCICNI port format has one big problem: It does not support ranges.
So if a users forwards a range of 1k ports with podman run -p 1001-2000
we have to store each of the thousand ports individually as array element.
This bloats the db and makes the JSON encoding and decoding much slower.
In many places we already use a better port struct type which supports
ranges, e.g. `pkg/specgen` or the new network interface.

Because of this we have to do many runtime conversions between the two
port formats. If everything uses the new format we can skip the runtime
conversions.

This commit adds logic to replace all occurrences of the old format
with the new one. The database will automatically migrate the ports
to new format when the container config is read for the first time
after the update.

The `ParsePortMapping` function is `pkg/specgen/generate` has been
reworked to better work with the new format. The new logic is able
to deduplicate the given ports. This is necessary the ensure we
store them efficiently in the DB. The new code should also be more
performant than the old one.

To prove that the code is fast enough I added go benchmarks. Parsing
1 million ports took less than 0.5 seconds on my laptop.

Benchmark normalize PortMappings in specgen:
Please note that the 1 million ports are actually 20x 50k ranges
because we cannot have bigger ranges than 65535 ports.
```
$ go test -bench=. -benchmem  ./pkg/specgen/generate/
goos: linux
goarch: amd64
pkg: github.com/containers/podman/v3/pkg/specgen/generate
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
BenchmarkParsePortMappingNoPorts-12             480821532                2.230 ns/op           0 B/op          0 allocs/op
BenchmarkParsePortMapping1-12                      38972             30183 ns/op          131584 B/op          9 allocs/op
BenchmarkParsePortMapping100-12                    18752             60688 ns/op          141088 B/op        315 allocs/op
BenchmarkParsePortMapping1k-12                      3104            331719 ns/op          223840 B/op       3018 allocs/op
BenchmarkParsePortMapping10k-12                      376           3122930 ns/op         1223650 B/op      30027 allocs/op
BenchmarkParsePortMapping1m-12                         3         390869926 ns/op        124593840 B/op   4000624 allocs/op
BenchmarkParsePortMappingReverse100-12             18940             63414 ns/op          141088 B/op        315 allocs/op
BenchmarkParsePortMappingReverse1k-12               3015            362500 ns/op          223841 B/op       3018 allocs/op
BenchmarkParsePortMappingReverse10k-12               343           3318135 ns/op         1223650 B/op      30027 allocs/op
BenchmarkParsePortMappingReverse1m-12                  3         403392469 ns/op        124593840 B/op   4000624 allocs/op
BenchmarkParsePortMappingRange1-12                 37635             28756 ns/op          131584 B/op          9 allocs/op
BenchmarkParsePortMappingRange100-12               39604             28935 ns/op          131584 B/op          9 allocs/op
BenchmarkParsePortMappingRange1k-12                38384             29921 ns/op          131584 B/op          9 allocs/op
BenchmarkParsePortMappingRange10k-12               29479             40381 ns/op          131584 B/op          9 allocs/op
BenchmarkParsePortMappingRange1m-12                  927           1279369 ns/op          143022 B/op        164 allocs/op
PASS
ok      github.com/containers/podman/v3/pkg/specgen/generate    25.492s
```

Benchmark convert old port format to new one:
```
go test -bench=. -benchmem  ./libpod/
goos: linux
goarch: amd64
pkg: github.com/containers/podman/v3/libpod
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
Benchmark_ocicniPortsToNetTypesPortsNoPorts-12          663526126                1.663 ns/op           0 B/op          0 allocs/op
Benchmark_ocicniPortsToNetTypesPorts1-12                 7858082               141.9 ns/op            72 B/op          2 allocs/op
Benchmark_ocicniPortsToNetTypesPorts10-12                2065347               571.0 ns/op           536 B/op          4 allocs/op
Benchmark_ocicniPortsToNetTypesPorts100-12                138478              8641 ns/op            4216 B/op          4 allocs/op
Benchmark_ocicniPortsToNetTypesPorts1k-12                   9414            120964 ns/op           41080 B/op          4 allocs/op
Benchmark_ocicniPortsToNetTypesPorts10k-12                   781           1490526 ns/op          401528 B/op          4 allocs/op
Benchmark_ocicniPortsToNetTypesPorts1m-12                      4         250579010 ns/op        40001656 B/op          4 allocs/op
PASS
ok      github.com/containers/podman/v3/libpod  11.727s
```

#### How to verify it

with an old podman verion: create a container with ports
podman with this patch: run the container, check podman ps output, etc... basically make sure the ports are still there and working

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
