### PR TITLE
Not all fields in machine list were set properly

### DIFF
--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -188,11 +188,13 @@ func toHumanFormat(vms []*machine.ListResponse) ([]*machineReporter, error) {
 		response := new(machineReporter)
 		if vm.Name == cfg.Engine.ActiveService {
 			response.Name = vm.Name + "*"
+			response.Default = true
 		} else {
 			response.Name = vm.Name
 		}
 		if vm.Running {
 			response.LastUp = "Currently running"
+			response.Running = true
 		} else {
 			response.LastUp = units.HumanDuration(time.Since(vm.LastUp)) + " ago"
 		}


### PR DESCRIPTION
When using custom output formats like table, some of the booleans
introduced for json format were not initialized correctly (wrong).

BEFORE

```console
$ podman machine ls --format 'table {{ .Name }} {{.Default}}'
NAME                     DEFAULT
podman-machine-default*  false
```

AFTER

```console
$ podman machine ls --format 'table {{ .Name }} {{.Default}}'
NAME                     DEFAULT
podman-machine-default*  true
```

For the _regular_ human output, these booleans are added to the other fields.
So it only affects users with custom format strings, since the JSON was correct.