### PR TITLE
support rootfs contains colon

### DIFF
--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -552,10 +552,10 @@ func NewSpecGenerator(arg string, rootfs bool) *SpecGenerator {
 	if rootfs {
 		csc.Rootfs = arg
 		// check if rootfs is actually overlayed
-		parts := strings.SplitN(csc.Rootfs, ":", 2)
-		if len(parts) > 1 && parts[1] == "O" {
+		lastColonIndex := strings.LastIndex(csc.Rootfs, ":")
+		if lastColonIndex != -1 && lastColonIndex+1 < len(csc.Rootfs) && csc.Rootfs[lastColonIndex+1:] == "O" {
 			csc.RootfsOverlay = true
-			csc.Rootfs = parts[0]
+			csc.Rootfs = csc.Rootfs[:lastColonIndex]
 		}
 	} else {
 		csc.Image = arg

--- a/pkg/specgen/specgen_test.go
+++ b/pkg/specgen/specgen_test.go
@@ -19,7 +19,7 @@ func TestNewSpecGeneratorWithRootfs(t *testing.T) {
 	}
 	for _, args := range tests {
 		val := NewSpecGenerator(args.rootfs, true)
-		assert.Equal(t, val.RootfsOverlay, args.rootfs)
-		assert.Equal(t, val.Rootfs, args.rootfs)
+		assert.Equal(t, val.RootfsOverlay, args.expectedRootfsOverlay)
+		assert.Equal(t, val.Rootfs, args.expectedRootfs)
 	}
 }

--- a/pkg/specgen/specgen_test.go
+++ b/pkg/specgen/specgen_test.go
@@ -1,0 +1,25 @@
+package specgen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSpecGeneratorWithRootfs(t *testing.T) {
+	tests := []struct {
+		rootfs                string
+		expectedRootfsOverlay bool
+		expectedRootfs        string
+	}{
+		{"/root/a:b:O", true, "/root/a:b"},
+		{"/root/a:b/c:O", true, "/root/a:b/c"},
+		{"/root/a:b/c:", false, "/root/a:b/c:"},
+		{"/root/a/b", false, "/root/a/b"},
+	}
+	for _, args := range tests {
+		val := NewSpecGenerator(args.rootfs, true)
+		assert.Equal(t, val.RootfsOverlay, args.rootfs)
+		assert.Equal(t, val.Rootfs, args.rootfs)
+	}
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

For now, we can create a container with a readonly rootfs.
`podman run --rootfs /some/readonly/path:O echo hello`

The rootfs may contains colon `podman run --rootfs /some/a:b/readonly/path:O echo hello`
, it will failed to parse this directory, the error message is 
```
Error: error running container create option: stat /some/a:b/readonly/path:O: no such file or directory
```


#### How to verify it

Run container with a readonly rootfs, and the rootfs path contains colon.


#### Which issue(s) this PR fixes:


Fixes #11913 
#### Special notes for your reviewer:
