### PR TITLE
podman stats: move cgroup validation to server

### DIFF
--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -11,9 +11,7 @@ import (
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/cmd/podman/validate"
 	"github.com/containers/podman/v3/libpod/define"
-	"github.com/containers/podman/v3/pkg/cgroups"
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/containers/podman/v3/pkg/rootless"
 	"github.com/containers/podman/v3/utils"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
@@ -113,16 +111,6 @@ func checkStatOptions(cmd *cobra.Command, args []string) error {
 }
 
 func stats(cmd *cobra.Command, args []string) error {
-	if rootless.IsRootless() {
-		unified, err := cgroups.IsCgroup2UnifiedMode()
-		if err != nil {
-			return err
-		}
-		if !unified {
-			return errors.New("stats is not supported in rootless mode without cgroups v2")
-		}
-	}
-
 	// Convert to the entities options.  We should not leak CLI-only
 	// options into the backend and separate concerns.
 	opts := entities.ContainerStatsOptions{

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1319,6 +1319,15 @@ func (ic *ContainerEngine) ContainerStats(ctx context.Context, namesOrIds []stri
 	if options.Interval < 1 {
 		return nil, errors.New("Invalid interval, must be a positive number greater zero")
 	}
+	if rootless.IsRootless() {
+		unified, err := cgroups.IsCgroup2UnifiedMode()
+		if err != nil {
+			return nil, err
+		}
+		if !unified {
+			return nil, errors.New("stats is not supported in rootless mode without cgroups v2")
+		}
+	}
 	statsChan = make(chan entities.ContainerStatsReport, 1)
 
 	containerFunc := ic.Libpod.GetRunningContainers


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

Podman stats is not supported for rootless cgroupv1 setups. The check
for this must be on the server side and not the client.

#### How to verify it

run podman-remote stats on a cgroupv1 system when the server uses cgroupv2

#### Which issue(s) this PR fixes:

Fixes #11909

#### Special notes for your reviewer:
