### PR TITLE
Use SplitN(2) when copying env variables

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -257,7 +257,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	// Environment Variables
 	envs := map[string]string{}
 	for _, env := range imageData.Config.Env {
-		keyval := strings.Split(env, "=")
+		keyval := strings.SplitN(env, "=", 2)
 		envs[keyval[0]] = keyval[1]
 	}
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/storage/pkg/stringid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	. "github.com/onsi/gomega/gexec"
 	"github.com/opencontainers/selinux/go-selinux"
 )
@@ -2852,4 +2853,45 @@ invalid kube kind
 		Expect(ls).Should(Exit(0))
 		Expect(len(ls.OutputToStringArray())).To(Equal(1))
 	})
+
+	Describe("verify environment variables", func() {
+		var maxLength int
+		BeforeEach(func() {
+			maxLength = format.MaxLength
+			format.MaxLength = 0
+		})
+		AfterEach(func() {
+			format.MaxLength = maxLength
+		})
+
+		It("values containing equal sign", func() {
+			javaToolOptions := `-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal`
+			openj9JavaOptions := `-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal -Dosgi.checkConfiguration=false`
+
+			containerfile := fmt.Sprintf(`FROM %s
+ENV JAVA_TOOL_OPTIONS=%q
+ENV OPENJ9_JAVA_OPTIONS=%q
+`,
+				ALPINE, javaToolOptions, openj9JavaOptions)
+
+			image := "podman-kube-test:env"
+			podmanTest.BuildImage(containerfile, image, "false")
+			ctnr := getCtr(withImage(image))
+			pod := getPod(withCtr(ctnr))
+			Expect(generateKubeYaml("pod", pod, kubeYaml)).Should(Succeed())
+
+			play := podmanTest.Podman([]string{"play", "kube", "--start", kubeYaml})
+			play.WaitWithDefaultTimeout()
+			Expect(play).Should(Exit(0))
+
+			inspect := podmanTest.Podman([]string{"container", "inspect", "--format=json", getCtrNameInPod(pod)})
+			inspect.WaitWithDefaultTimeout()
+			Expect(inspect).Should(Exit(0))
+
+			contents := string(inspect.Out.Contents())
+			Expect(contents).To(ContainSubstring(javaToolOptions))
+			Expect(contents).To(ContainSubstring(openj9JavaOptions))
+		})
+	})
+
 })


### PR DESCRIPTION
Environment variables whose value contained an equal sign where
truncated

Fixes #11891

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
