### PR TITLE
Remove a volume with --force if container is running

### DIFF
--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -230,11 +230,7 @@ func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool, timeo
 
 			logrus.Debugf("Removing container %s (depends on volume %q)", ctr.ID(), v.Name())
 
-			// TODO: do we want to set force here when removing
-			// containers?
-			// I'm inclined to say no, in case someone accidentally
-			// wipes a container they're using...
-			if err := r.removeContainer(ctx, ctr, false, false, false, timeout); err != nil {
+			if err := r.removeContainer(ctx, ctr, force, false, false, timeout); err != nil {
 				return errors.Wrapf(err, "error removing container %s that depends on volume %s", ctr.ID(), v.Name())
 			}
 		}

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -97,6 +97,14 @@ Labels.l       | $mylabel
     run_podman volume rm $myvolume
 }
 
+# Removing volumes with --force
+@test "podman volume rm --force" {
+    run_podman run -d --volume myvol:/myvol $IMAGE top
+    cid=$output
+    run_podman 2 volume rm myvol
+    is "$output" "Error: volume myvol is being used by the following container(s): $cid: volume is being used" "should error since container is running"
+    run_podman volume rm myvol --force
+}
 
 # Running scripts (executables) from a volume
 @test "podman volume: exec/noexec" {


### PR DESCRIPTION
Currently we are not passing the force flag down to the removal of
the running container. If the container is running, and we set
--force when removing the volume, the container should be stopped.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
