### PR TITLE
builder: Add support for builder prune

### DIFF
--- a/cmd/podman/images/buildx.go
+++ b/cmd/podman/images/buildx.go
@@ -14,11 +14,12 @@ var (
 	// If we are adding new buildx features, we will add them by default
 	// to podman build.
 	buildxCmd = &cobra.Command{
-		Use:    "buildx",
-		Short:  "Build images",
-		Long:   "Build images",
-		RunE:   validate.SubCommandExists,
-		Hidden: true,
+		Use:     "buildx",
+		Aliases: []string{"builder"},
+		Short:   "Build images",
+		Long:    "Build images",
+		RunE:    validate.SubCommandExists,
+		Hidden:  true,
 	}
 )
 

--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -36,6 +36,11 @@ var (
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: pruneCmd,
+		Parent:  buildxCmd,
+	})
+
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: pruneCmd,
 		Parent:  imageCmd,
 	})
 

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -446,4 +446,25 @@ RUN > file2
 
 	})
 
+	It("podman builder prune", func() {
+		dockerfile := `FROM quay.io/libpod/alpine:latest
+RUN > file
+`
+		dockerfile2 := `FROM quay.io/libpod/alpine:latest
+RUN > file2
+`
+		podmanTest.BuildImageWithLabel(dockerfile, "foobar.com/workdir:latest", "false", "abc")
+		podmanTest.BuildImageWithLabel(dockerfile2, "foobar.com/workdir:latest", "false", "xyz")
+		// --force used to to avoid y/n question
+		result := podmanTest.Podman([]string{"builder", "prune", "--filter", "label=abc", "--force"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(len(result.OutputToStringArray())).To(Equal(1))
+
+		//check if really abc is removed
+		result = podmanTest.Podman([]string{"image", "list", "--filter", "label=abc"})
+		Expect(len(result.OutputToStringArray())).To(Equal(0))
+
+	})
+
 })


### PR DESCRIPTION
Docker has support for docker builder prune and
docker builder build

This patch will add a hidden command to support scripts using this
syntax. We don't want to encourage this deviation.

Add podman build prune to implement docker builder prune
functionality.

Closes:  #11744