### PR TITLE
cgroups: use cgroup.controllers to read controllers

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -129,8 +129,8 @@ func init() {
 func getAvailableControllers(exclude map[string]controllerHandler, cgroup2 bool) ([]controller, error) {
 	if cgroup2 {
 		controllers := []controller{}
-		subtreeControl := cgroupRoot + "/cgroup.subtree_control"
-		// rootless cgroupv2: check available controllers for current user ,systemd or servicescope will inherit
+		controllersFile := cgroupRoot + "/cgroup.controllers"
+		// rootless cgroupv2: check available controllers for current user, systemd or servicescope will inherit
 		if rootless.IsRootless() {
 			userSlice, err := getCgroupPathForCurrentProcess()
 			if err != nil {
@@ -138,13 +138,13 @@ func getAvailableControllers(exclude map[string]controllerHandler, cgroup2 bool)
 			}
 			//userSlice already contains '/' so not adding here
 			basePath := cgroupRoot + userSlice
-			subtreeControl = fmt.Sprintf("%s/cgroup.subtree_control", basePath)
+			controllersFile = fmt.Sprintf("%s/cgroup.controllers", basePath)
 		}
-		subtreeControlBytes, err := ioutil.ReadFile(subtreeControl)
+		controllersFileBytes, err := ioutil.ReadFile(controllersFile)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed while reading controllers for cgroup v2 from %q", subtreeControl)
+			return nil, errors.Wrapf(err, "failed while reading controllers for cgroup v2 from %q", controllersFile)
 		}
-		for _, controllerName := range strings.Fields(string(subtreeControlBytes)) {
+		for _, controllerName := range strings.Fields(string(controllersFileBytes)) {
 			c := controller{
 				name:    controllerName,
 				symlink: false,


### PR DESCRIPTION
use the cgroup.controllers file instead of cgroup.subtree_control to
read the list of controllers available in the current cgroup.

Closes: https://github.com/containers/podman/issues/11931

[NO TESTS NEEDED] we have disabled this test in the CI because it is
difficult to know what controllers are going to be enabled for
rootless under all conditions we test.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

show the correct cgroup controllers

#### How to verify it

`podman info --format '{{json .}}' | jq .host.cgroupControllers` shows the controllers usable with rootless

#### Which issue(s) this PR fixes:

Fixes #11931

#### Special notes for your reviewer:
