### PR TITLE
libpod: change mountpoint ownership when creating overlays on top of external rootfs

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -259,6 +259,18 @@ var _ = Describe("Podman run", func() {
 		startsession.WaitWithDefaultTimeout()
 		Expect(startsession).Should(Exit(0))
 		Expect(startsession.OutputToString()).To(Equal("hello"))
+
+		// remove container for above test overlay-foo
+		osession = podmanTest.Podman([]string{"rm", "overlay-foo"})
+		osession.WaitWithDefaultTimeout()
+		Expect(osession).Should(Exit(0))
+
+		// Test --rootfs with an external overlay with --uidmap
+		osession = podmanTest.Podman([]string{"run", "--uidmap", "0:1000:1000", "--rm", "--security-opt", "label=disable",
+			"--rootfs", rootfs + ":O", "echo", "hello"})
+		osession.WaitWithDefaultTimeout()
+		Expect(osession).Should(Exit(0))
+		Expect(osession.OutputToString()).To(Equal("hello"))
 	})
 
 	It("podman run a container with --init", func() {


### PR DESCRIPTION
Allow chainging ownership of mountpoint created on top of external overlay
rootfs to support use-cases when custom --uidmap and --gidmap are
specified.

TLDR
Supports `uidmap` and `gidmap` with overlays on top of external rootfs specified with 
`--rootfs </path>:O`

Example 
```
podman run --uidmap 0:1000:1000 --rm --rootfs /tmp/foo:O bash
```
