### PR TITLE
No space in kube annotations for bind mounts

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -246,7 +246,7 @@ func (p *Pod) podWithContainers(ctx context.Context, containers []*Container, po
 				return nil, err
 			}
 			for k, v := range annotations {
-				podAnnotations[define.BindMountPrefix+k] = v
+				podAnnotations[define.BindMountPrefix+k] = strings.TrimSpace(v)
 			}
 			// Since port bindings for the pod are handled by the
 			// infra container, wipe them here.
@@ -366,7 +366,7 @@ func simplePodWithV1Containers(ctx context.Context, ctrs []*Container) (*v1.Pod,
 			return nil, err
 		}
 		for k, v := range annotations {
-			kubeAnnotations[define.BindMountPrefix+k] = v
+			kubeAnnotations[define.BindMountPrefix+k] = strings.TrimSpace(v)
 		}
 		if isInit {
 			kubeInitCtrs = append(kubeInitCtrs, kubeCtr)


### PR DESCRIPTION
Kubernetes fails to deal with an annotation that has a space in it.
Trim these strings to remove spaces.

Fixes: #11929

Signed-off-by: Brent Baude <bbaude@redhat.com>

[NO TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
