### PR TITLE
Kube Gen run as user/group issues

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -485,6 +485,10 @@ func containerToV1Container(ctx context.Context, c *Container) (v1.Container, []
 		kubeContainer.Command = nil
 	}
 
+	if imgData.User == c.User() {
+		kubeSec.RunAsGroup, kubeSec.RunAsUser = nil, nil
+	}
+
 	kubeContainer.WorkingDir = c.WorkingDir()
 	kubeContainer.Ports = ports
 	// This should not be applicable

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -942,7 +942,7 @@ USER test1`
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(kube.Out.Contents(), pod)
 		Expect(err).To(BeNil())
-		Expect(*pod.Spec.Containers[0].SecurityContext.RunAsUser).To(Equal(int64(10001)))
+		Expect(pod.Spec.Containers[0].SecurityContext.RunAsUser).To(BeNil())
 	})
 
 	It("podman generate kube on named volume", func() {


### PR DESCRIPTION
Removed the inclusion of RunAsUser or RunAsGroup unless a container is run with the --user flag. When building from an image
the user will be pulled from there anyway

resolves #11914

Signed-off-by: cdoern <cdoern@redhat.com>