### PR TITLE
Don't add image entrypoint to the generate kube yaml

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -481,7 +481,9 @@ func containerToV1Container(ctx context.Context, c *Container) (v1.Container, []
 	if err != nil {
 		return kubeContainer, kubeVolumes, nil, annotations, err
 	}
-	if reflect.DeepEqual(imgData.Config.Cmd, kubeContainer.Command) {
+	// If the user doesn't set a command/entrypoint when creating the container with podman and
+	// is using the image command or entrypoint from the image, don't add it to the generated kube yaml
+	if reflect.DeepEqual(imgData.Config.Cmd, kubeContainer.Command) || reflect.DeepEqual(imgData.Config.Entrypoint, kubeContainer.Command) {
 		kubeContainer.Command = nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:
If no entrypoint or command is set in the podman create
command, and the image command or entrypoint is being
used as the default, then do not add the image command or
entrypoint to the generated kube yaml.
Kubernetes knows to default to the image command and/or
entrypoint settings when not defined in the kube yaml.
Add and modify tests for this case.

<!---
Please put your overall PR description here
-->

#### How to verify it
Create containers with and without --entrypoint and command with an image that has defaults and based on what is passed to the podman command, the kube yaml will have command and/or args populated accordingly. 

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:
Fixes https://github.com/containers/podman/issues/11915

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
