### PR TITLE
CNI: fix network create --ip-range

### DIFF
--- a/libpod/network/cni/cni_types.go
+++ b/libpod/network/cni/cni_types.go
@@ -182,7 +182,7 @@ func newIPAMLocalHostRange(subnet types.IPNet, leaseRange *types.LeaseRange, gw 
 			hostRange.RangeStart = leaseRange.StartIP.String()
 		}
 		if leaseRange.EndIP != nil {
-			hostRange.RangeStart = leaseRange.EndIP.String()
+			hostRange.RangeEnd = leaseRange.EndIP.String()
 		}
 	}
 

--- a/libpod/network/cni/config_test.go
+++ b/libpod/network/cni/config_test.go
@@ -621,7 +621,7 @@ var _ = Describe("Config", func() {
 			err = libpodNet.NetworkRemove(network1.Name)
 			Expect(err).To(BeNil())
 
-			endIP := "10.0.0.10"
+			endIP := "10.0.0.30"
 			network = types.Network{
 				Driver: "bridge",
 				Subnets: []types.Subnet{
@@ -655,6 +655,22 @@ var _ = Describe("Config", func() {
 				},
 			}
 			network1, err = libpodNet.NetworkCreate(network)
+			Expect(err).To(BeNil())
+			Expect(network1.Name).ToNot(BeEmpty())
+			Expect(network1.ID).ToNot(BeEmpty())
+			Expect(network1.NetworkInterface).ToNot(BeEmpty())
+			Expect(network1.Driver).To(Equal("bridge"))
+			Expect(network1.Subnets).To(HaveLen(1))
+			Expect(network1.Subnets[0].Subnet.String()).To(Equal(subnet))
+			Expect(network1.Subnets[0].Gateway.String()).To(Equal("10.0.0.1"))
+			Expect(network1.Subnets[0].LeaseRange.StartIP.String()).To(Equal(startIP))
+			Expect(network1.Subnets[0].LeaseRange.EndIP.String()).To(Equal(endIP))
+
+			// create a new interface to force a config load from disk
+			libpodNet, err = getNetworkInterface(cniConfDir, false)
+			Expect(err).To(BeNil())
+
+			network1, err = libpodNet.NetworkInspect(network1.Name)
 			Expect(err).To(BeNil())
 			Expect(network1.Name).ToNot(BeEmpty())
 			Expect(network1.ID).ToNot(BeEmpty())

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Podman network create", func() {
 
 	It("podman network create with name and subnet", func() {
 		netName := "subnet-" + stringid.GenerateNonCryptoID()
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", netName})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--ip-range", "10.11.12.0/26", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeCNINetwork(netName)
 		Expect(nc).Should(Exit(0))
@@ -61,7 +61,11 @@ var _ = Describe("Podman network create", func() {
 		result := results[0]
 		Expect(result.Name).To(Equal(netName))
 		Expect(result.Subnets).To(HaveLen(1))
+		Expect(result.Subnets[0].Subnet.String()).To(Equal("10.11.12.0/24"))
 		Expect(result.Subnets[0].Gateway.String()).To(Equal("10.11.12.1"))
+		Expect(result.Subnets[0].LeaseRange).ToNot(BeNil())
+		Expect(result.Subnets[0].LeaseRange.StartIP.String()).To(Equal("10.11.12.1"))
+		Expect(result.Subnets[0].LeaseRange.EndIP.String()).To(Equal("10.11.12.63"))
 
 		// Once a container executes a new network, the nic will be created. We should clean those up
 		// best we can


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:
The --ip-range option did not work correctly. The endIP was accidentally
assigned to the start IP. New tests are added to make sure it works.

#### How to verify it

see tests

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
