### PR TITLE
Display help text on empty subcommand by default

### DIFF
--- a/cmd/podman/validate/args.go
+++ b/cmd/podman/validate/args.go
@@ -27,7 +27,7 @@ func SubCommandExists(cmd *cobra.Command, args []string) error {
 		}
 		return errors.Errorf("unrecognized command `%[1]s %[2]s`\n\nDid you mean this?\n\t%[3]s\n\nTry '%[1]s --help' for more information.", cmd.CommandPath(), args[0], strings.Join(suggestions, "\n\t"))
 	}
-	return errors.Errorf("missing command '%[1]s COMMAND'\nTry '%[1]s --help' for more information.", cmd.CommandPath())
+	return cmd.Help()
 }
 
 // IDOrLatestArgs used to validate a nameOrId was provided or the "--latest" flag

--- a/cmd/podman/validate/args.go
+++ b/cmd/podman/validate/args.go
@@ -27,7 +27,8 @@ func SubCommandExists(cmd *cobra.Command, args []string) error {
 		}
 		return errors.Errorf("unrecognized command `%[1]s %[2]s`\n\nDid you mean this?\n\t%[3]s\n\nTry '%[1]s --help' for more information.", cmd.CommandPath(), args[0], strings.Join(suggestions, "\n\t"))
 	}
-	return cmd.Help()
+	cmd.Help()
+	return errors.Errorf("missing command '%[1]s COMMAND'", cmd.CommandPath())
 }
 
 // IDOrLatestArgs used to validate a nameOrId was provided or the "--latest" flag

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -100,7 +100,7 @@ function setup() {
         skip "only applicable on a local run since this requires no endpoint"
     fi
 
-    run_podman --remote
+    run_podman 125 --remote
     is "$output" ".*Usage:" "podman --remote show usage message without running endpoint"
 }
 

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -100,10 +100,8 @@ function setup() {
         skip "only applicable on a local run since this requires no endpoint"
     fi
 
-    run_podman 125 --remote
-    is "$output" "Error: missing command 'podman COMMAND'
-Try 'podman --help' for more information." \
-       "podman --remote show usage message without running endpoint"
+    run_podman --remote
+    is "$output" ".*Usage:" "podman --remote show usage message without running endpoint"
 }
 
 # This is for development only; it's intended to make sure our timeout

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -143,16 +143,13 @@ function check_help() {
         count=$(expr $count + 1)
     done
 
-    # Any command that takes subcommands, prints its help if called
+    # Any command that takes subcommands, prints its help and errors if called
     # without one.
     dprint "podman $@"
-
-    # Store the output of the actual --help command
-    run_podman "$@" --help
-    local full_help="$output"
-
-    run_podman "$@"
-    is "$output" "$full_help" "'podman $*' without any subcommand - expected help message"
+    run_podman '?' "$@"
+    is "$status" 125 "'podman $*' without any subcommand - exit status"
+    is "$output" ".*Usage:.*Error: missing command '.*$@ COMMAND'" \
+       "'podman $*' without any subcommand - expected error message"
 
     # Assume that 'NoSuchCommand' is not a command
     dprint "podman $@ NoSuchCommand"

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -143,13 +143,16 @@ function check_help() {
         count=$(expr $count + 1)
     done
 
-    # Any command that takes subcommands, must throw error if called
+    # Any command that takes subcommands, prints its help if called
     # without one.
     dprint "podman $@"
-    run_podman '?' "$@"
-    is "$status" 125 "'podman $*' without any subcommand - exit status"
-    is "$output" "Error: missing command .*$@ COMMAND" \
-       "'podman $*' without any subcommand - expected error message"
+
+    # Store the output of the actual --help command
+    run_podman "$@" --help
+    local full_help="$output"
+
+    run_podman "$@"
+    is "$output" "$full_help" "'podman $*' without any subcommand - expected help message"
 
     # Assume that 'NoSuchCommand' is not a command
     dprint "podman $@ NoSuchCommand"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

This is a small quality-of-life improvement, where instead of guiding the user to use `--help` when they didn't enter a specific subcommand, it shows the help text by default.

https://github.com/kubernetes/kubernetes/blob/efce40b931b5250498b9d8bcd67f987095ab6f74/hack/lib/util.sh#L714 in Kubernetes inspired me to do this. The `docker` CLI is behaving this way as well and Kubernetes uses this to check if `docker buildx` exists. I suppose the K8s side could potentially change in this case as well, but I wanted to see if y'all think this is a worthwhile improvement for human users anyway.

#### How to verify it

Run `podman`. It used to output

```
Error: missing command 'podman COMMAND'
Try 'podman --help' for more information.
```

With this it prints the help text immediately.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I realize that this might be contentious in nature and I haven't found an issue relating to this. Please let me know if we should instead open an issue and discuss there first.
