### PR TITLE
Checkpoint/Restore test fixes

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/containers/podman/v3/pkg/checkpoint/crutils"
 	"github.com/containers/podman/v3/pkg/criu"
 	. "github.com/containers/podman/v3/test/utils"
+	"github.com/containers/podman/v3/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -933,18 +935,23 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint and restore container with different port mappings", func() {
-		localRunString := getRunString([]string{"-p", "1234:6379", "--rm", redis})
+		randomPort, err := utils.GetRandomPort()
+		Expect(err).ShouldNot(HaveOccurred())
+		localRunString := getRunString([]string{"-p", fmt.Sprintf("%d:6379", randomPort), "--rm", redis})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		cid := session.OutputToString()
 		fileName := "/tmp/checkpoint-" + cid + ".tar.gz"
 
-		// Open a network connection to the redis server via initial port mapping
-		conn, err := net.Dial("tcp", "localhost:1234")
-		if err != nil {
-			os.Exit(1)
+		if !WaitContainerReady(podmanTest, cid, "Ready to accept connections", 20, 1) {
+			Fail("Container failed to get ready")
 		}
+
+		fmt.Fprintf(os.Stderr, "Trying to connect to redis server at localhost:%d", randomPort)
+		// Open a network connection to the redis server via initial port mapping
+		conn, err := net.DialTimeout("tcp4", fmt.Sprintf("localhost:%d", randomPort), time.Duration(3)*time.Second)
+		Expect(err).ShouldNot(HaveOccurred())
 		conn.Close()
 
 		// Checkpoint the container
@@ -958,7 +965,9 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
 		// Restore container with different port mapping
-		result = podmanTest.Podman([]string{"container", "restore", "-p", "1235:6379", "-i", fileName})
+		newRandomPort, err := utils.GetRandomPort()
+		Expect(err).ShouldNot(HaveOccurred())
+		result = podmanTest.Podman([]string{"container", "restore", "-p", fmt.Sprintf("%d:6379", newRandomPort), "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
 		Expect(result).Should(Exit(0))
@@ -967,13 +976,12 @@ var _ = Describe("Podman checkpoint", func() {
 
 		// Open a network connection to the redis server via initial port mapping
 		// This should fail
-		conn, err = net.Dial("tcp", "localhost:1234")
+		conn, err = net.DialTimeout("tcp4", fmt.Sprintf("localhost:%d", randomPort), time.Duration(3)*time.Second)
 		Expect(err.Error()).To(ContainSubstring("connection refused"))
 		// Open a network connection to the redis server via new port mapping
-		conn, err = net.Dial("tcp", "localhost:1235")
-		if err != nil {
-			os.Exit(1)
-		}
+		fmt.Fprintf(os.Stderr, "Trying to reconnect to redis server at localhost:%d", newRandomPort)
+		conn, err = net.DialTimeout("tcp4", fmt.Sprintf("localhost:%d", newRandomPort), time.Duration(3)*time.Second)
+		Expect(err).ShouldNot(HaveOccurred())
 		conn.Close()
 
 		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})


### PR DESCRIPTION
Moving to Fedora 35 showed test failures (time outs) in the test

"podman checkpoint and restore container with different port mappings"

The test starts a container and maps the internal port 6379 to the local
port 1234 ('-p 1234:6379') and then tries to connect to localhost:1234

On Fedora 35 this failed and blocked the test because the container was
not yet ready. The test was trying to connect to localhost:1234 but
nothing was running there. So the error was not checkpointing related.

Another problem with this test and running ginkgo in parallel was that
it was possible that the port was already in use. Now for each run a
random port is selected to decrease the chance of collisions.

This tries to fix problems seen in #11795 

CC: @cevich 