### PR TITLE
Podman Image SCP rootful to rootless transfer

### DIFF
--- a/docs/source/markdown/podman-image-scp.1.md
+++ b/docs/source/markdown/podman-image-scp.1.md
@@ -8,7 +8,7 @@ podman-image-scp - Securely copy an image from one host to another
 
 ## DESCRIPTION
 **podman image scp** copies container images between hosts on a network. You can load to the remote host or from the remote host as well as in between two remote hosts.
-Note: `::` is used to specify the image name depending on if you are saving or loading.
+Note: `::` is used to specify the image name depending on if you are saving or loading. Images can also be transferred from rootful to rootless storage on the same machine without using sshd. This feature is not supported on the remote client.
 
 **podman image scp [GLOBAL OPTIONS]**
 
@@ -57,6 +57,22 @@ WARN[0000] Unknown connection name given. Please use system connection add to sp
 Getting image source signatures
 Copying blob 9450ef9feb15 [--------------------------------------] 0.0b / 0.0b
 Copying config 1f97f0559c done
+Writing manifest to image destination
+Storing signatures
+Loaded image(s): docker.io/library/alpine:latest
+```
+
+```
+$ sudo podman image scp root@localhost::alpine username@localhost::
+Copying blob e2eb06d8af82 done
+Copying config 696d33ca15 done
+Writing manifest to image destination
+Storing signatures
+Run Directory Obtained: /run/user/1000/
+[Run Root: /var/tmp/containers-user-1000/containers Graph Root: /root/.local/share/containers/storage DB Path: /root/.local/share/containers/storage/libpod/bolt_state.db]
+Getting image source signatures
+Copying blob 5eb901baf107 skipped: already exists
+Copying config 696d33ca15 done
 Writing manifest to image destination
 Storing signatures
 Loaded image(s): docker.io/library/alpine:latest

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -27,6 +27,7 @@ type ImageEngine interface {
 	ShowTrust(ctx context.Context, args []string, options ShowTrustOptions) (*ShowTrustReport, error)
 	Shutdown(ctx context.Context)
 	Tag(ctx context.Context, nameOrID string, tags []string, options ImageTagOptions) error
+	Transfer(ctx context.Context, scpOpts ImageScpOptions) error
 	Tree(ctx context.Context, nameOrID string, options ImageTreeOptions) (*ImageTreeReport, error)
 	Unmount(ctx context.Context, images []string, options ImageUnmountOptions) ([]*ImageUnmountReport, error)
 	Untag(ctx context.Context, nameOrID string, tags []string, options ImageUntagOptions) error

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -328,6 +328,10 @@ type ImageScpOptions struct {
 	Save ImageSaveOptions
 	// Load options used for the second half of the scp operation
 	Load ImageLoadOptions
+	// Rootless determines whether we are loading locally from root storage to rootless storage
+	Rootless bool
+	// User is used in conjunction with Rootless to determine which user to use to obtain the uid
+	User string
 }
 
 // ImageTreeOptions provides options for ImageEngine.Tree()

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
+	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/bindings/images"
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/containers/podman/v3/pkg/domain/entities/reports"
@@ -120,6 +121,10 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, opts entities.
 		return nil, err
 	}
 	return &entities.ImagePullReport{Images: pulledImages}, nil
+}
+
+func (ir *ImageEngine) Transfer(ctx context.Context, scpOpts entities.ImageScpOptions) error {
+	return errors.Wrapf(define.ErrNotImplemented, "cannot use the remote client to transfer images between root and rootless storage")
 }
 
 func (ir *ImageEngine) Tag(ctx context.Context, nameOrID string, tags []string, opt entities.ImageTagOptions) error {

--- a/test/e2e/image_scp_test.go
+++ b/test/e2e/image_scp_test.go
@@ -22,12 +22,14 @@ var _ = Describe("podman image scp", func() {
 	)
 
 	BeforeEach(func() {
+
 		ConfPath.Value, ConfPath.IsSet = os.LookupEnv("CONTAINERS_CONF")
 		conf, err := ioutil.TempFile("", "containersconf")
 		if err != nil {
 			panic(err)
 		}
 		os.Setenv("CONTAINERS_CONF", conf.Name())
+
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)
@@ -38,6 +40,7 @@ var _ = Describe("podman image scp", func() {
 
 	AfterEach(func() {
 		podmanTest.Cleanup()
+
 		os.Remove(os.Getenv("CONTAINERS_CONF"))
 		if ConfPath.IsSet {
 			os.Setenv("CONTAINERS_CONF", ConfPath.Value)
@@ -56,6 +59,25 @@ var _ = Describe("podman image scp", func() {
 		scp := podmanTest.Podman([]string{"image", "scp", "-q", ALPINE})
 		scp.WaitWithDefaultTimeout()
 		Expect(scp).To(Exit(0))
+	})
+
+	It("podman image scp root to rootless transfer", func() {
+		SkipIfNotRootless("this is a rootless only test, transfering from root to rootless using PodmanAsUser")
+		if IsRemote() {
+			Skip("this test is only for non-remote")
+		}
+		env := os.Environ()
+		img := podmanTest.PodmanAsUser([]string{"image", "pull", ALPINE}, 0, 0, "", env) // pull image to root
+		img.WaitWithDefaultTimeout()
+		Expect(img).To(Exit(0))
+		scp := podmanTest.PodmanAsUser([]string{"image", "scp", "root@localhost::" + ALPINE, "1000:1000@localhost::"}, 0, 0, "", env) //transfer from root to rootless (us)
+		scp.WaitWithDefaultTimeout()
+		Expect(scp).To(Exit(0))
+
+		list := podmanTest.Podman([]string{"image", "list"}) // our image should now contain alpine loaded in from root
+		list.WaitWithDefaultTimeout()
+		Expect(list).To(Exit(0))
+		Expect(list.LineInOutputStartsWith("quay.io/libpod/alpine")).To(BeTrue())
 	})
 
 	It("podman image scp bogus image", func() {


### PR DESCRIPTION
Added functionality for users to transfer images from root storage to rootless storage without using sshd. This is
done through rootful podman by running `sudo podman image scp root@localhost::image user@localhost:: the user is needed
in order to find and use their uid/gid to exec a new process.

added necessary tests, and functions for this implementation. Created new image function `Transfer` so that
the underlying code is majorly removed from CLI.

Signed-off-by: cdoern <cdoern@redhat.com>
