### PR TITLE
If CONTAINER_HOST env variable is set default podman --remote=true

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -314,7 +314,15 @@ func rootFlags(cmd *cobra.Command, opts *entities.PodmanConfig) {
 	lFlags.StringVar(&opts.Identity, identityFlagName, ident, "path to SSH identity file, (CONTAINER_SSHKEY)")
 	_ = cmd.RegisterFlagCompletionFunc(identityFlagName, completion.AutocompleteDefault)
 
-	lFlags.BoolVarP(&opts.Remote, "remote", "r", false, "Access remote Podman service (default false)")
+	remote := false
+	if env, ok := os.LookupEnv("CONTAINER_HOST"); ok {
+		logrus.Infof("CONTAINER_HOST==%q, defaulting to '--remote=true'", env)
+		remote = true
+	} else if env, ok := os.LookupEnv("CONTAINER_CONNECTION"); ok {
+		logrus.Infof("CONTAINER_CONNECTION==%q, defaulting to '--remote=true'", env)
+		remote = true
+	}
+	lFlags.BoolVarP(&opts.Remote, "remote", "r", remote, "Access remote Podman service")
 	pFlags := cmd.PersistentFlags()
 	if registry.IsRemote() {
 		if err := lFlags.MarkHidden("remote"); err != nil {

--- a/docs/source/markdown/podman-remote.1.md
+++ b/docs/source/markdown/podman-remote.1.md
@@ -29,6 +29,8 @@ The `containers.conf` file should be placed under `$HOME/.config/containers/cont
 
 Remote connection name
 
+Overrides environment variable `CONTAINER_CONNECTION` if set.
+
 #### **--help**, **-h**
 
 Print usage statement
@@ -70,6 +72,26 @@ URL value resolution precedence:
 #### **--version**
 
 Print the version
+
+## Environment Variables
+
+Podman can set up environment variables from env of [engine] table in containers.conf. These variables can be overridden by passing  environment variables before the `podman` commands.
+
+#### **CONTAINERS_CONF**
+
+Set default locations of containers.conf file
+
+#### **CONTAINER_CONNECTION**
+
+Set default `--connection` value to access Podman service.
+
+#### **CONTAINER_HOST**
+
+Set default `--url` value to access Podman service.
+
+#### **CONTAINER_SSHKEY**
+
+Set default `--identity` path to ssh key file value used to access Podman service.
 
 ## Exit Status
 

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -93,8 +93,9 @@ When namespace is set, created containers and pods will join the given namespace
 Path to the command binary to use for setting up a network.  It is currently only used for setting up a slirp4netns network.  If "" is used then the binary is looked up using the $PATH environment variable.
 
 #### **--remote**, **-r**
-Access Podman service will be remote
-Remote connections use local containers.conf for default.
+When true, access to the Podman service will be remote. Defaults to false.
+Settings can be modified in the containers.conf file. If the CONTAINER_HOST
+environment variable is set, the remote option defaults to true.
 
 #### **--url**=*value*
 URL to access Podman service (default from `containers.conf`, rootless `unix://run/user/$UID/podman/podman.sock` or as root `unix://run/podman/podman.sock`).
@@ -171,6 +172,58 @@ Print the version
 ## Environment Variables
 
 Podman can set up environment variables from env of [engine] table in containers.conf. These variables can be overridden by passing  environment variables before the `podman` commands.
+
+#### **CONTAINERS_CONF**
+
+Set default locations of containers.conf file
+
+#### **CONTAINERS_REGISTRIES_CONF**
+
+Set default location of the registries.conf file.
+
+#### **CONTAINERS_STORAGE_CONF**
+
+Set default location of the storage.conf file.
+
+#### **CONTAINER_CONNECTION**
+
+Override default `--connection` value to access Podman service. Also enabled --remote option.
+
+#### **CONTAINER_HOST**
+
+Set default `--url` value to access Podman service. Also enabled --remote option.
+
+#### **CONTAINER_SSHKEY**
+
+Set default `--identity` path to ssh key file value used to access Podman service.
+
+#### **STORAGE_DRIVER**
+
+Set default `--storage-driver` value.
+
+#### **STORAGE_OPTS**
+
+Set default `--storage-opts` value.
+
+#### **TMPDIR**
+
+Set the the temporary storage location of downloaded container images. Podman defaults to use `/var/tmp`.
+
+#### **XDG_CONFIG_HOME**
+
+In Rootless mode configuration files are read from `XDG_CONFIG_HOME` when
+specified, otherwise in the home directory of the user under
+`$HOME/.config/containers`.
+
+#### **XDG_DATA_HOME**
+
+In Rootless mode images are pulled under `XDG_DATA_HOME` when specified,
+otherwise in the home directory of the user under
+`$HOME/.local/share/containers/storage`.
+
+#### **XDG_RUNTIME_DIR**
+
+In Rootless mode temporary configuration data is stored in `${XDG_RUNTIME_DIR}/containers`.
 
 ## Remote Access
 

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -93,6 +93,15 @@ function setup() {
     is "$output" "Error: unknown flag: --remote" "podman version --remote"
 }
 
+@test "podman-remote: defaults" {
+    if is_remote; then
+        skip "only applicable on a local run"
+    fi
+
+    CONTAINER_HOST=foobar run_podman --log-level=info --help
+    is "$output" ".*defaulting to '--remote=true'" "CONTAINER_HOST sets --remote true"
+}
+
 # Check that just calling "podman-remote" prints the usage message even
 # without a running endpoint. Use "podman --remote" for this as this works the same.
 @test "podman-remote: check for command usage message without a running endpoint" {


### PR DESCRIPTION
Users enabling CONTAINER_HOST==PATH is indicating to podman they intend
to use remote functionality.

Fixes: https://github.com/containers/podman/issues/11196

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
