### PR TITLE
Set targetPort to the port value in the kube yaml

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // GenerateForKube takes a slice of libpod containers and generates
@@ -196,10 +197,11 @@ func containerPortsToServicePorts(containerPorts []v1.ContainerPort) []v1.Servic
 	for _, cp := range containerPorts {
 		nodePort := 30000 + rand.Intn(32767-30000+1)
 		servicePort := v1.ServicePort{
-			Protocol: cp.Protocol,
-			Port:     cp.ContainerPort,
-			NodePort: int32(nodePort),
-			Name:     strconv.Itoa(int(cp.ContainerPort)),
+			Protocol:   cp.Protocol,
+			Port:       cp.ContainerPort,
+			NodePort:   int32(nodePort),
+			Name:       strconv.Itoa(int(cp.ContainerPort)),
+			TargetPort: intstr.Parse(strconv.Itoa(int(cp.ContainerPort))),
 		}
 		sps = append(sps, servicePort)
 	}


### PR DESCRIPTION
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:
When the targetPort is not defined, it is supposed to
be set to the port value according to the k8s docs.
Add tests for targetPort.
Update tests to be able to check the Service yaml that
is generated.

<!---
Please put your overall PR description here
-->

#### How to verify it
Create a container with a port and generate Service for it with generate kube, the targetPort in the kube yaml should match the Port value.

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:
Fixes https://github.com/containers/podman/issues/11930

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
