### PR TITLE
[v1.6.4-rhel] chroot: fix environment value leakage to intermediate processes

### DIFF
--- a/vendor/github.com/containers/buildah/chroot/run.go
+++ b/vendor/github.com/containers/buildah/chroot/run.go
@@ -158,7 +158,7 @@ func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reade
 	cmd := unshare.Command(runUsingChrootCommand)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, stdout, stderr
 	cmd.Dir = "/"
-	cmd.Env = append([]string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())}, os.Environ()...)
+	cmd.Env = []string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())}
 
 	logrus.Debugf("Running %#v in %#v", cmd.Cmd, cmd)
 	confwg.Add(1)
@@ -201,6 +201,11 @@ func runUsingChrootMain() {
 	defer confPipe.Close()
 	if err := json.NewDecoder(confPipe).Decode(&options); err != nil {
 		fmt.Fprintf(os.Stderr, "error decoding options: %v\n", err)
+		os.Exit(1)
+	}
+
+	if options.Spec == nil || options.Spec.Process == nil {
+		fmt.Fprintf(os.Stderr, "invalid options spec in runUsingChrootMain\n")
 		os.Exit(1)
 	}
 
@@ -565,7 +570,7 @@ func runUsingChroot(spec *specs.Spec, bundlePath string, ctty *os.File, stdin io
 	cmd := unshare.Command(append([]string{runUsingChrootExecCommand}, spec.Process.Args...)...)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, stdout, stderr
 	cmd.Dir = "/"
-	cmd.Env = append([]string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())}, os.Environ()...)
+	cmd.Env = []string{fmt.Sprintf("LOGLEVEL=%d", logrus.GetLevel())}
 	cmd.UnshareFlags = syscall.CLONE_NEWUTS | syscall.CLONE_NEWNS
 	requestedUserNS := false
 	for _, ns := range spec.Linux.Namespaces {
@@ -655,6 +660,11 @@ func runUsingChrootExecMain() {
 	// Set the hostname.  We're already in a distinct UTS namespace and are admins in the user
 	// namespace which created it, so we shouldn't get a permissions error, but seccomp policy
 	// might deny our attempt to call sethostname() anyway, so log a debug message for that.
+	if options.Spec == nil || options.Spec.Process == nil {
+		fmt.Fprintf(os.Stderr, "invalid options spec passed in\n")
+		os.Exit(1)
+	}
+
 	if options.Spec.Hostname != "" {
 		if err := unix.Sethostname([]byte(options.Spec.Hostname)); err != nil {
 			logrus.Debugf("failed to set hostname %q for process: %v", options.Spec.Hostname, err)
@@ -803,7 +813,6 @@ func runUsingChrootExecMain() {
 // Output debug messages when that differs from what we're being asked to do.
 func logNamespaceDiagnostics(spec *specs.Spec) {
 	sawMountNS := false
-	sawUserNS := false
 	sawUTSNS := false
 	for _, ns := range spec.Linux.Namespaces {
 		switch ns.Type {
@@ -838,9 +847,8 @@ func logNamespaceDiagnostics(spec *specs.Spec) {
 			}
 		case specs.UserNamespace:
 			if ns.Path != "" {
-				logrus.Debugf("unable to join user namespace %q, creating a new one", ns.Path)
+				logrus.Debugf("unable to join user namespace, sorry about that")
 			}
-			sawUserNS = true
 		case specs.UTSNamespace:
 			if ns.Path != "" {
 				logrus.Debugf("unable to join UTS namespace %q, creating a new one", ns.Path)
@@ -850,9 +858,6 @@ func logNamespaceDiagnostics(spec *specs.Spec) {
 	}
 	if !sawMountNS {
 		logrus.Debugf("mount namespace not requested, but creating a new one anyway")
-	}
-	if !sawUserNS {
-		logrus.Debugf("user namespace not requested, but creating a new one anyway")
 	}
 	if !sawUTSNS {
 		logrus.Debugf("UTS namespace not requested, but creating a new one anyway")


### PR DESCRIPTION
#### What this PR does / why we need it:

Blake Burkhart reports that when running processes using "chroot" isolation, the process being run can examine the environment of its immediate parent and grandparent processes (CVE-2021-3602).

When run in a container in a CI/CD environment, the environment may include sensitive information which was shared with the container in order to be used only by buildah itself.  The command being executed is able to read such information.

This patch reduces the set of environment variables passed to these intermediate processes, from all variables to the one which is used to control the level of debug logging.  It also corrects a misleading debug message and expands the description of chroot isolation in man pages.

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The way we're making security fixes on this branch seems to break `go mod vendor`.