### PR TITLE
Generate Kube should not print default structs

### DIFF
--- a/docs/source/markdown/podman-generate-kube.1.md
+++ b/docs/source/markdown/podman-generate-kube.1.md
@@ -54,13 +54,7 @@ spec:
     - docker-entrypoint.sh
     - mysqld
     env:
-    - name: PATH
-      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - name: TERM
-      value: xterm
     - name: HOSTNAME
-    - name: container
-      value: podman
     - name: GOSU_VERSION
       value: "1.10"
     - name: GPG_KEYS
@@ -77,14 +71,14 @@ spec:
     ports:
     - containerPort: 3306
       hostPort: 36533
-      protocol: TCP
     resources: {}
     securityContext:
-      allowPrivilegeEscalation: true
-      privileged: false
-      readOnlyRootFilesystem: false
+      capabilities:
+        drop:
+        - CAP_MKNOD
+        - CAP_NET_RAW
+        - CAP_AUDIT_WRITE
     tty: true
-    workingDir: /
 status: {}
 ```
 
@@ -106,31 +100,18 @@ spec:
   containers:
   - command:
     - /bin/sh
-    env:
-    - name: PATH
-      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - name: TERM
-      value: xterm
-    - name: container
-      value: podman
     image: docker.io/library/alpine:latest
     name: test-bind-mount
     resources: {}
     securityContext:
-      allowPrivilegeEscalation: true
       capabilities:
         drop:
         - CAP_MKNOD
         - CAP_NET_RAW
         - CAP_AUDIT_WRITE
-      privileged: false
-      readOnlyRootFilesystem: false
-      seLinuxOptions: {}
     volumeMounts:
     - mountPath: /volume
       name: home-user-my-data-host
-    workingDir: /
-  dnsConfig: {}
   restartPolicy: Never
   volumes:
   - hostPath:
@@ -158,31 +139,18 @@ spec:
   containers:
   - command:
     - /bin/sh
-    env:
-    - name: PATH
-      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - name: TERM
-      value: xterm
-    - name: container
-      value: podman
     image: docker.io/library/alpine:latest
     name: test-bind-mount
     resources: {}
     securityContext:
-      allowPrivilegeEscalation: true
       capabilities:
         drop:
         - CAP_MKNOD
         - CAP_NET_RAW
         - CAP_AUDIT_WRITE
-      privileged: false
-      readOnlyRootFilesystem: false
-      seLinuxOptions: {}
     volumeMounts:
     - mountPath: /volume
       name: priceless-data-pvc
-    workingDir: /
-  dnsConfig: {}
   restartPolicy: Never
   volumes:
   - name: priceless-data-pvc
@@ -210,22 +178,9 @@ spec:
   - command:
     - python3
     - /root/code/graph.py
-    env:
-    - name: PATH
-      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - name: TERM
-      value: xterm
-    - name: HOSTNAME
-    - name: container
-      value: podman
     image: quay.io/baude/demoweb:latest
     name: practicalarchimedes
     resources: {}
-    securityContext:
-      allowPrivilegeEscalation: true
-      capabilities: {}
-      privileged: false
-      readOnlyRootFilesystem: false
     tty: true
     workingDir: /root/code
 status: {}
@@ -242,7 +197,6 @@ spec:
   - name: "8050"
     nodePort: 31269
     port: 8050
-    protocol: TCP
     targetPort: 0
   selector:
     app: demoweb


### PR DESCRIPTION
If podman uses Workdir="/" or the workdir specified in the image, it
should not add it to the yaml.
If Podman find environment variables in the image, they should not
get added to the yaml.

If the container or pod do not have changes to SELinux we should not
print seLinuxOpt{}

If the container or pod do not change any dns options the yaml should
not have a dnsOption={}

If the container is not privileged it should not have privileged=false
in the yaml.

Fixes: https://github.com/containers/podman/issues/11995

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
