### PR TITLE
podman run --memory=0 ... should not set memory limit

### DIFF
--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -133,12 +133,14 @@ func getMemoryLimits(s *specgen.SpecGenerator, c *entities.ContainerCreateOption
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid value for memory")
 		}
-		memory.Limit = &ml
-		if c.MemorySwap == "" {
-			limit := 2 * ml
-			memory.Swap = &(limit)
+		if ml > 0 {
+			memory.Limit = &ml
+			if c.MemorySwap == "" {
+				limit := 2 * ml
+				memory.Swap = &(limit)
+			}
+			hasLimits = true
 		}
-		hasLimits = true
 	}
 	if m := c.MemoryReservation; len(m) > 0 {
 		mr, err := units.RAMInBytes(m)

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -67,6 +67,11 @@ echo $rand        |   0 | $rand
     is "$output" ".*invalidflag" "failed when passing undefined flags to the runtime"
 }
 
+@test "podman run --memory=0 runtime option" {
+    run_podman run --memory=0 --rm $IMAGE echo hello
+    is "$output" "hello" "failed to run when --memory is set to 0"
+}
+
 # 'run --preserve-fds' passes a number of additional file descriptors into the container
 @test "podman run --preserve-fds" {
     skip_if_remote "preserve-fds is meaningless over remote"


### PR DESCRIPTION
On Docker this is ignored, and it should be on Podman as
well. This is documented in the man page.

Fixes: https://github.com/containers/podman/issues/12002

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
