### PR TITLE
Change podman connection list to use default field

### DIFF
--- a/cmd/podman/system/connection/list.go
+++ b/cmd/podman/system/connection/list.go
@@ -44,6 +44,7 @@ func init() {
 type namedDestination struct {
 	Name string
 	config.Destination
+	Default bool
 }
 
 func list(cmd *cobra.Command, _ []string) error {
@@ -60,12 +61,14 @@ func list(cmd *cobra.Command, _ []string) error {
 		"Identity": "Identity",
 		"Name":     "Name",
 		"URI":      "URI",
+		"Default":  "Default",
 	}}
 
 	rows := make([]namedDestination, 0)
 	for k, v := range cfg.Engine.ServiceDestinations {
+		def := false
 		if k == cfg.Engine.ActiveService {
-			k += "*"
+			def = true
 		}
 
 		r := namedDestination{
@@ -74,6 +77,7 @@ func list(cmd *cobra.Command, _ []string) error {
 				Identity: v.Identity,
 				URI:      v.URI,
 			},
+			Default: def,
 		}
 		rows = append(rows, r)
 	}
@@ -82,7 +86,7 @@ func list(cmd *cobra.Command, _ []string) error {
 		return rows[i].Name < rows[j].Name
 	})
 
-	format := "{{.Name}}\t{{.Identity}}\t{{.URI}}\n"
+	format := "{{.Name}}\t{{.URI}}\t{{.Identity}}\t{{.Default}}\n"
 	switch {
 	case report.IsJSON(cmd.Flag("format").Value.String()):
 		buf, err := registry.JSONLibrary().MarshalIndent(rows, "", "    ")

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -538,7 +538,7 @@ Not implemented.
 
 #### **--log-driver**="*driver*"
 
-Logging driver for the container. Currently available options are **k8s-file**, **journald**, **none** and **passthrough**, with **json-file** aliased to **k8s-file** for scripting compatibility.
+Logging driver for the container. Currently available options are **k8s-file**, **journald**, **none** and **passthrough**, with **json-file** aliased to **k8s-file** for scripting compatibility. (Default journald)
 
 The **passthrough** driver passes down the standard streams (stdin, stdout, stderr) to the
 container.  It is not allowed with the remote Podman client and on a tty, since it is

--- a/docs/source/markdown/podman-system-connection-list.1.md
+++ b/docs/source/markdown/podman-system-connection-list.1.md
@@ -23,14 +23,14 @@ Valid placeholders for the Go template listed below:
 | *.Name*         | Connection Name/Identifier |
 | *.Identity*     | Path to file containing SSH identity |
 | *.URI*          | URI to podman service. Valid schemes are ssh://[user@]*host*[:port]*Unix domain socket*[?secure=True], unix://*Unix domain socket*, and tcp://localhost[:*port*] |
-
-An asterisk is appended to the default connection.
+| *.Default*      | Indicates whether connection is the default |
 
 ## EXAMPLE
 ```
 $ podman system connection list
-Name URI                                           Identity
-devl ssh://root@example.com/run/podman/podman.sock ~/.ssh/id_rsa
+Name URI                                                      Identity	    Default
+devl ssh://root@example.com:/run/podman/podman.sock           ~/.ssh/id_rsa True
+devl ssh://user@example.com:/run/user/1000/podman/podman.sock ~/.ssh/id_rsa False
 ```
 ## SEE ALSO
 podman-system(1) , containers.conf(5)

--- a/docs/source/markdown/podman-system-connection.1.md
+++ b/docs/source/markdown/podman-system-connection.1.md
@@ -24,8 +24,8 @@ The user will be prompted for the ssh login password or key file pass phrase as 
 ## EXAMPLE
 ```
 $ podman system connection list
-Name URI                                           Identity
-devl ssh://root@example.com/run/podman/podman.sock ~/.ssh/id_rsa
+Name URI                                           Identity	  Default
+devl ssh://root@example.com/run/podman/podman.sock ~/.ssh/id_rsa  true
 ```
 ## SEE ALSO
 podman-system(1) , containers.conf(5)

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -208,13 +208,13 @@ var _ = Describe("podman system connection", func() {
 		session = podmanTest.Podman(cmd)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.Out).Should(Say("Name *Identity *URI"))
+		Expect(session.Out).Should(Say("Name *URI *Identity *Default"))
 
 		cmd = []string{"system", "connection", "list", "--format", "{{.Name}}"}
 		session = podmanTest.Podman(cmd)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).Should(Equal("devl* qe"))
+		Expect(session.OutputToString()).Should(Equal("devl qe"))
 	})
 
 	It("failed default", func() {


### PR DESCRIPTION
Stop using "*" to indicate default.  Add default field to make
it more obvios and the json field more machine usable.

Fixes: https://github.com/containers/podman/issues/12019

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
