### PR TITLE
[CI:DOCS] Change systemd service file to be compatible with rootless mode

### DIFF
--- a/contrib/systemd/system/podman-restart.service.in
+++ b/contrib/systemd/system/podman-restart.service.in
@@ -5,8 +5,9 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=oneshot
+RemainAfterExit=true
 Environment=LOGGING="--log-level=info"
 ExecStart=@@PODMAN@@ $LOGGING start --all --filter restart-policy=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target default.target


### PR DESCRIPTION
#### What this PR does / why we need it:

Add compatibility for rootless mode.

#### How to verify it

Using the modified systemd service file in user mode.

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

Original `journalctl --user -xeu podman-restart` is as follows
```
Oct 19 19:59:29 sg-phi podman[352]: 2021-10-19 19:59:29.941111051 +0800 HKT m=+0.445232351 container init e791421fbc707>
Oct 19 19:59:29 sg-phi podman[352]: 2021-10-19 19:59:29.946369404 +0800 HKT m=+0.450490704 container start e791421fbc70>
Oct 19 19:59:29 sg-phi podman[352]: 2ccf91473516d6ac6045e174a3a3827b8450e0724c7d762e0fc40ed3b4ccb01f
Oct 19 19:59:29 sg-phi podman[352]: 83cf7f9322cf50a9b432deb3b51f5ed166f6383ac1274a4afdb048ad7fe927c3
Oct 19 19:59:29 sg-phi podman[352]: e791421fbc707dcea0f9990c24030928a12d9a148ea275deac2ae4e8874e8dbe
Oct 19 19:59:29 sg-phi conmon[433]: 1:signal-handler (1634644769) Received SIGTERM scheduling shutdown...
Oct 19 19:59:29 sg-phi conmon[420]: Shutting down, got signal: Terminated
```

Changing type to forking allows containers to continue running instead of being killed by the system.

Added a default.target to allow user systems service to be started at boot.