### PR TITLE
system tests: CONTAINER_* and --help: cleanup

### DIFF
--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -94,22 +94,21 @@ function setup() {
 }
 
 @test "podman-remote: defaults" {
-    if is_remote; then
-        skip "only applicable on a local run"
-    fi
+    skip_if_remote "only applicable on a local run"
 
+    # By default, podman should include '--remote' in its help output
+    run_podman --help
+    is "$output" ".* --remote " "podman --help includes the --remote option"
+
+    # When it detects CONTAINER_HOST or _CONNECTION, --remote is not an option
     CONTAINER_HOST=foobar run_podman --help
-    # Should not have --remote flag
-    echo $output  |  grep -v -qw -- "--remote"
-    if [ $? -ne 0 ]; then
-        die "Should not have --remote flag"
+    if grep -- " --remote " <<<"$output"; then
+        die "podman --help, with CONTAINER_HOST set, is showing --remote"
     fi
 
     CONTAINER_CONNECTION=foobar run_podman --help
-    # Should not have --remote flag
-    echo $output  |  grep -v -qw -- "--remote"
-    if [ $? -ne 0 ]; then
-        die "Should not have --remote flag"
+    if grep -- " --remote " <<<"$output"; then
+        die "podman --help, with CONTAINER_CONNECTION set, is showing --remote"
     fi
 }
 


### PR DESCRIPTION
A small part of this test was written in a confusing and fragile
way: it was very hard to understand, and in fact only worked
through pure luck (using 'echo $output', which emitted everything
in one long line, vs the standard quoted 'echo "$output"' which
would've kept the formatting and caused the test to pass,
incorrectly, no matter whether --remote was in the output
or not). Plus, the '$?' check in the next line would never
trigger on failure anyway, so the failure message would've
been unhelpful if the test were ever to fail.

Anyhow. Make it readable and make it work.

(Followup to #11990)

Signed-off-by: Ed Santiago <santiago@redhat.com>
