### PR TITLE
[NO NEW TESTS NEEDED] Remove infra ID from DB before removing containers

### DIFF
--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -263,6 +263,15 @@ func (r *Runtime) removePod(ctx context.Context, p *Pod, removeCtrs, force bool,
 		}
 	}
 
+	// Clear infra container ID before we remove the infra container.
+	// There is a potential issue if we don't do that, and removal is
+	// interrupted between RemoveAllContainers() below and the pod's removal
+	// later - we end up with a reference to a nonexistent infra container.
+	p.state.InfraContainerID = ""
+	if err := p.save(); err != nil {
+		return err
+	}
+
 	// Remove all containers in the pod from the state.
 	if err := r.state.RemovePodContainers(p); err != nil {
 		// If this fails, there isn't much more we can do.


### PR DESCRIPTION
If we interrupt pod removal between removing containers and removing the whole pod, the infra ID was still in the DB, and most pod operations would try to retrieve the infra container (and would this fail). Clear the infra ID from the DB just before we remove all containers to prevent this.

Fixes #12034

[NO NEW TESTS NEEDED] This race is just about impossible to repro.