### PR TITLE
Remove --kernel-memory options

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -319,6 +319,9 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			"Kernel memory limit "+sizeWithUnitFormat,
 		)
 		_ = cmd.RegisterFlagCompletionFunc(kernelMemoryFlagName, completion.AutocompleteNone)
+		// kernel-memory is deprecated in the runtime spec.
+		_ = createFlags.MarkHidden("kernel-memory")
+
 		logDriverFlagName := "log-driver"
 		createFlags.StringVar(
 			&cf.LogDriver,

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/podman/v3/pkg/specgen"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func stringMaptoArray(m map[string]string) []string {
@@ -382,6 +383,9 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 
 	if cc.HostConfig.Memory > 0 {
 		cliOpts.Memory = strconv.Itoa(int(cc.HostConfig.Memory))
+	}
+	if cc.HostConfig.KernelMemory > 0 {
+		logrus.Warnf("The --kernel-memory flag has been deprecated. May not work properly on your system.")
 	}
 
 	if cc.HostConfig.MemoryReservation > 0 {

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -487,18 +487,6 @@ Default is to create a private IPC namespace (POSIX SysV IPC) for the container
 		`host`: use the host shared memory,semaphores and message queues inside the container. Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
 		`ns:<path>` path to an IPC namespace to join.
 
-#### **--kernel-memory**=*number[unit]*
-
-Kernel memory limit (format: `<number>[<unit>]`, where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
-
-Constrains the kernel memory available to a container. If a limit of 0
-is specified (not using `--kernel-memory`), the container's kernel memory
-is not limited. If you specify a limit, it may be rounded up to a multiple
-of the operating system's page size and the value can be very large,
-millions of trillions.
-
-This flag is not supported on cgroups V2 systems.
-
 #### **--label**, **-l**=*label*
 
 Add metadata to a container (e.g., --label com.example.key=value)

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -512,18 +512,6 @@ a private IPC namespace.
 - **host**: use the host shared memory,semaphores and message queues inside the container. Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
 - **ns:**_path_: path to an IPC namespace to join.
 
-#### **--kernel-memory**=_number_[_unit_]
-
-Kernel memory limit. A _unit_ can be **b** (bytes), **k** (kilobytes), **m** (megabytes), or **g** (gigabytes).
-
-Constrains the kernel memory available to a container. If a limit of 0
-is specified (not using *--kernel-memory*), the container's kernel memory
-is not limited. If you specify a limit, it may be rounded up to a multiple
-of the operating system's page size and the value can be very large,
-millions of trillions.
-
-This flag is not supported on cgroups V2 systems.
-
 #### **--label**, **-l**=*key*=*value*
 
 Add metadata to a container.


### PR DESCRIPTION
Kernel memory option has been depracated in runtime-spec,  It is
believed that it will not work properly on certain kernels.  runc
ignores it.

This PR removes documentation of the flag and also prints a warning if
a user uses it.

[NO NO TESTS NEEDED]

Helps Fix: https://github.com/containers/podman/issues/12045

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
