### PR TITLE
tag: Support tagging manifest list instead of resolving to images

### DIFF
--- a/pkg/api/handlers/compat/images_tag.go
+++ b/pkg/api/handlers/compat/images_tag.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/containers/common/libimage"
 	"github.com/containers/podman/v3/libpod"
 	"github.com/containers/podman/v3/pkg/api/handlers/utils"
 	api "github.com/containers/podman/v3/pkg/api/types"
@@ -16,7 +17,9 @@ func TagImage(w http.ResponseWriter, r *http.Request) {
 	// /v1.xx/images/(name)/tag
 	name := utils.GetName(r)
 
-	newImage, _, err := runtime.LibimageRuntime().LookupImage(name, nil)
+	// Allow tagging manifest list instead of resolving instances from manifest
+	lookupOptions := &libimage.LookupImageOptions{ManifestList: true}
+	newImage, _, err := runtime.LibimageRuntime().LookupImage(name, lookupOptions)
 	if err != nil {
 		utils.ImageNotFound(w, name, errors.Wrapf(err, "failed to find image %s", name))
 		return

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -331,7 +331,9 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 }
 
 func (ir *ImageEngine) Tag(ctx context.Context, nameOrID string, tags []string, options entities.ImageTagOptions) error {
-	image, _, err := ir.Libpod.LibimageRuntime().LookupImage(nameOrID, nil)
+	// Allow tagging manifest list instead of resolving instances from manifest
+	lookupOptions := &libimage.LookupImageOptions{ManifestList: true}
+	image, _, err := ir.Libpod.LibimageRuntime().LookupImage(nameOrID, lookupOptions)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -93,6 +93,25 @@ var _ = Describe("Podman manifest", func() {
 		Expect(session.OutputToString()).To(ContainSubstring(imageListARM64InstanceDigest))
 	})
 
+	It("podman manifest tag", func() {
+		session := podmanTest.Podman([]string{"manifest", "create", "foobar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		session = podmanTest.Podman([]string{"manifest", "add", "foobar", "quay.io/libpod/busybox"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		session = podmanTest.Podman([]string{"tag", "foobar", "foobar2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		session = podmanTest.Podman([]string{"manifest", "inspect", "foobar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		session2 := podmanTest.Podman([]string{"manifest", "inspect", "foobar2"})
+		session2.WaitWithDefaultTimeout()
+		Expect(session2).Should(Exit(0))
+		Expect(session2.OutputToString()).To(Equal(session.OutputToString()))
+	})
+
 	It("podman manifest add --all", func() {
 		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Following commit makes sure when podman tag is invoked on a manifest
list, it tags the same manifest list instead of resolving to an image and
tagging it.

Port of: https://github.com/containers/buildah/pull/3483
Closes: https://github.com/containers/podman/issues/12046 
**Needs Backport**: to **v3.4 RPM** and **4.0.0-dev source**
