### PR TITLE
Fix `Podman image trust` tests

### DIFF
--- a/test/e2e/trust_test.go
+++ b/test/e2e/trust_test.go
@@ -45,11 +45,11 @@ var _ = Describe("Podman trust", func() {
 		outArray := session.OutputToStringArray()
 		Expect(len(outArray)).To(Equal(3))
 
-		// image order is not guaranteed. All we can do is check that
-		// these strings appear in output, we can't cross-check them.
-		Expect(session.OutputToString()).To(ContainSubstring("accept"))
-		Expect(session.OutputToString()).To(ContainSubstring("reject"))
-		Expect(session.OutputToString()).To(ContainSubstring("signed"))
+		// Repository order is not guaranteed. So, check that
+		// all expected lines appear in output; we also check total number of lines, so that handles all of them.
+		Expect(string(session.Out.Contents())).To(MatchRegexp(`(?m)^default\s+accept\s*$`))
+		Expect(string(session.Out.Contents())).To(MatchRegexp(`(?m)^docker.io/library/hello-world\s+reject\s*$`))
+		Expect(string(session.Out.Contents())).To(MatchRegexp(`(?m)^registry.access.redhat.com\s+signedBy\s+security@redhat.com, security@redhat.com\s+https://access.redhat.com/webassets/docker/content/sigstore\s*$`))
 	})
 
 	It("podman image trust set", func() {

--- a/test/e2e/trust_test.go
+++ b/test/e2e/trust_test.go
@@ -14,7 +14,8 @@ import (
 
 var _ = Describe("Podman trust", func() {
 	var (
-		tempdir    string
+		tempdir string
+
 		err        error
 		podmanTest *PodmanTestIntegration
 	)
@@ -38,11 +39,7 @@ var _ = Describe("Podman trust", func() {
 	})
 
 	It("podman image trust show", func() {
-		path, err := os.Getwd()
-		if err != nil {
-			os.Exit(1)
-		}
-		session := podmanTest.Podman([]string{"image", "trust", "show", "--registrypath", filepath.Dir(path), "--policypath", filepath.Join(filepath.Dir(path), "policy.json")})
+		session := podmanTest.Podman([]string{"image", "trust", "show", "--registrypath", filepath.Join(INTEGRATION_ROOT, "test"), "--policypath", filepath.Join(INTEGRATION_ROOT, "test/policy.json")})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		outArray := session.OutputToStringArray()


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix `podman image trust` not to assume a specific system-wide configuration, and make the tests a bit stricter. Relevant for #11795 .

#### How to verify it

`podman image trust` tests succeed both on F35 (which has changed the system-wide `policy.json`) and in all other environments.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

See https://github.com/containers/podman/pull/11795#issuecomment-947820380 for more discussion.