### PR TITLE
Prevent systemd from restarting container when checkpointed

### DIFF
--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -125,6 +125,7 @@ Type={{{{.Type}}}}
 {{{{- if .NotifyAccess}}}}
 NotifyAccess={{{{.NotifyAccess}}}}
 {{{{- end}}}}
+RestartPreventExitStatus=137
 
 [Install]
 WantedBy=multi-user.target default.target


### PR DESCRIPTION
#### What this PR does / why we need it:

When a container is `podman container checkpoint`:ed, it will exit with status 137, causing the container to be immediately started again, this PR prevents that.

#### How to verify it

```
podman create --name test docker.io/alpine sleep 3600
podman generate systemd test > /etc/systemd/system/test.service
systemctl enable --now test.service
podman container checkpoint test
podman ps
systemctl status test.service
```

#### Special notes for your reviewer:

If you agree with this change I can try to find where the docs have to be updated too. 