### PR TITLE
[NO NEW TESTS NEEDED] Fix off-by-one index comparision (reported by LGTM)

### DIFF
--- a/libpod/info.go
+++ b/libpod/info.go
@@ -332,7 +332,7 @@ func readKernelVersion() (string, error) {
 		return "", err
 	}
 	f := bytes.Fields(buf)
-	if len(f) < 2 {
+	if len(f) < 3 {
 		return string(bytes.TrimSpace(buf)), nil
 	}
 	return string(f[2]), nil


### PR DESCRIPTION
LGTM alert:

    Off-by-one index comparison against length may lead to out-of-bounds read.

Signed-off-by: Stefan Weil <sw@weilnetz.de>
