### PR TITLE
Allow 'container restore' with '--ipc host'

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -457,10 +457,12 @@ func (c *Container) setupStorage(ctx context.Context) error {
 			options.StorageOpt[split2[0]] = split2[1]
 		}
 	}
-	if c.restoreFromCheckpoint && !c.config.Privileged {
-		// If restoring from a checkpoint, the root file-system
-		// needs to be mounted with the same SELinux labels as
-		// it was mounted previously.
+	if c.restoreFromCheckpoint && c.config.ProcessLabel != "" && c.config.MountLabel != "" {
+		// If restoring from a checkpoint, the root file-system needs
+		// to be mounted with the same SELinux labels as it was mounted
+		// previously. But only if both labels have been set. For
+		// privileged containers or '--ipc host' only ProcessLabel will
+		// be set and so we will skip it for cases like that.
 		if options.Flags == nil {
 			options.Flags = make(map[string]interface{})
 		}


### PR DESCRIPTION
Trying to restore a container that was started with '--ipc host' fails with:

Error: error creating container storage: ProcessLabel and Mountlabel must either not be specified or both specified

We already fixed this exact same error message for containers started with '--privileged'. The previous fix was to check if the to be restored container is a privileged container (c.config.Privileged). Unfortunately this does not work for containers started with '--ipc host'.

This commit changes the check for a privileged container to check if both the ProcessLabel and the MountLabel is actually set and only then re-uses those labels.

Fixes: #12042