### PR TITLE
Record the image stream along with the path

### DIFF
--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -48,6 +48,7 @@ type machineReporter struct {
 	Created  string
 	Running  bool
 	LastUp   string
+	Stream   string
 	VMType   string
 	CPUs     uint64
 	Memory   string
@@ -153,6 +154,13 @@ func strUint(u uint64) string {
 	return strconv.FormatUint(u, 10)
 }
 
+func streamName(imageStream string) string {
+	if imageStream == "" {
+		return "default"
+	}
+	return imageStream
+}
+
 func toMachineFormat(vms []*machine.ListResponse) ([]*machineReporter, error) {
 	cfg, err := config.ReadCustomConfig()
 	if err != nil {
@@ -167,6 +175,7 @@ func toMachineFormat(vms []*machine.ListResponse) ([]*machineReporter, error) {
 		response.Running = vm.Running
 		response.LastUp = strTime(vm.LastUp)
 		response.Created = strTime(vm.CreatedAt)
+		response.Stream = streamName(vm.Stream)
 		response.VMType = vm.VMType
 		response.CPUs = vm.CPUs
 		response.Memory = strUint(vm.Memory * units.MiB)

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -57,6 +57,7 @@ type ListResponse struct {
 	CreatedAt time.Time
 	LastUp    time.Time
 	Running   bool
+	Stream    string
 	VMType    string
 	CPUs      uint64
 	Memory    uint64

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -13,6 +13,8 @@ type MachineVM struct {
 	IdentityPath string
 	// IgnitionFilePath is the fq path to the .ign file
 	IgnitionFilePath string
+	// ImageStream is the update stream for the image
+	ImageStream string
 	// ImagePath is the fq path to
 	ImagePath string
 	// Memory in megabytes assigned to the vm

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -143,6 +143,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) error {
 	switch opts.ImagePath {
 	case "testing", "next", "stable", "":
 		// Get image as usual
+		v.ImageStream = opts.ImagePath
 		dd, err := machine.NewFcosDownloader(vmtype, v.Name, opts.ImagePath)
 		if err != nil {
 			return err
@@ -154,6 +155,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) error {
 	default:
 		// The user has provided an alternate image which can be a file path
 		// or URL.
+		v.ImageStream = "custom"
 		g, err := machine.NewGenericDownloader(vmtype, v.Name, opts.ImagePath)
 		if err != nil {
 			return err
@@ -595,6 +597,7 @@ func GetVMInfos() ([]*machine.ListResponse, error) {
 			listEntry := new(machine.ListResponse)
 
 			listEntry.Name = vm.Name
+			listEntry.Stream = vm.ImageStream
 			listEntry.VMType = "qemu"
 			listEntry.CPUs = vm.CPUs
 			listEntry.Memory = vm.Memory


### PR DESCRIPTION
#### What this PR does / why we need it:

Records the original image stream, and not just the expanded path.

#### How to verify it

`podman machine list --format json`

#### Which issue(s) this PR fixes:

Fixes #12089

#### Special notes for your reviewer:

Should this information be shown to the human as well ?

@ashley-cui 