### PR TITLE
If Dockerfile exists in same directory as service, we should not use it.

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -151,22 +151,19 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		var m = []string{}
 		if err := json.Unmarshal([]byte(query.Dockerfile), &m); err != nil {
 			// it's not json, assume just a string
-			m = append(m, query.Dockerfile)
+			m = []string{filepath.Join(contextDirectory, query.Dockerfile)}
 		}
 		containerFiles = m
 	} else {
-		containerFiles = []string{"Dockerfile"}
+		containerFiles = []string{filepath.Join(contextDirectory, "Dockerfile")}
 		if utils.IsLibpodRequest(r) {
-			containerFiles = []string{"Containerfile"}
-			if _, err = os.Stat(filepath.Join(contextDirectory, "Containerfile")); err != nil {
-				if _, err1 := os.Stat(filepath.Join(contextDirectory, "Dockerfile")); err1 == nil {
-					containerFiles = []string{"Dockerfile"}
-				} else {
+			containerFiles = []string{filepath.Join(contextDirectory, "Containerfile")}
+			if _, err = os.Stat(containerFiles[0]); err != nil {
+				containerFiles = []string{filepath.Join(contextDirectory, "Dockerfile")}
+				if _, err1 := os.Stat(containerFiles[0]); err1 != nil {
 					utils.BadRequest(w, "dockerfile", query.Dockerfile, err)
 				}
 			}
-		} else {
-			containerFiles = []string{"Dockerfile"}
 		}
 	}
 


### PR DESCRIPTION
We should only use the Containerfiles/Dockerfiles found in the context
directory.

Fixes: https://github.com/containers/podman/issues/12054

[NO NEW TEST NEEDED] It is difficult to setup a test for this in the
CI/CD system, but build tests should find if this PR broke anything.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
