### PR TITLE
[CI:DOCS] Document to not set K8S envars for CNI

### DIFF
--- a/libpod/network/cni/run.go
+++ b/libpod/network/cni/run.go
@@ -196,10 +196,8 @@ func getRuntimeConfig(netns, conName, conID, networkName string, ports []cniPort
 		IfName:      opts.InterfaceName,
 		Args: [][2]string{
 			{"IgnoreUnknown", "1"},
-			// FIXME: Should we set the K8S args?
-			//{"K8S_POD_NAMESPACE", conName},
-			//{"K8S_POD_INFRA_CONTAINER_ID", conID},
-			// K8S_POD_NAME is used by dnsname to get the container name
+			// Do not set the K8S env vars, see https://github.com/containers/podman/issues/12083.
+			// Only K8S_POD_NAME is used by dnsname to get the container name.
 			{"K8S_POD_NAME", conName},
 		},
 		CapabilityArgs: map[string]interface{}{},


### PR DESCRIPTION
Setting these environment variables can cause issues with custom CNI
plugins, see #12083.


