### PR TITLE
Set Checkpointed state to false after restore

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1546,6 +1546,7 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 	logrus.Debugf("Restored container %s", c.ID())
 
 	c.state.State = define.ContainerStateRunning
+	c.state.Checkpointed = false
 
 	if !options.Keep {
 		// Delete all checkpoint related files. At this point, in theory, all files


### PR DESCRIPTION
A restored container still had the state set to 'Checkpointed: true' which seems wrong if it running again.