### PR TITLE
Set flags to test 'logs -f' with journald driver

### DIFF
--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -30,6 +30,17 @@ load helpers
     run_podman rm $cid
 }
 
+function _additional_events_backend() {
+    local driver=$1
+    # Since PR#10431, 'logs -f' with journald driver is only supported with journald events backend.
+    if [[ $driver = "journald" ]]; then
+        run_podman info --format '{{.Host.EventLogger}}' >/dev/null
+        if [[ $output != "journald" ]]; then
+            echo "--events-backend journald"
+        fi
+    fi
+}
+
 function _log_test_multi() {
     local driver=$1
 
@@ -42,10 +53,12 @@ function _log_test_multi() {
         etc='.*'
     fi
 
+    local events_backend=$(_additional_events_backend $driver)
+
     # Simple helper to make the container starts, below, easier to read
     local -a cid
     doit() {
-        run_podman run --log-driver=$driver --rm -d --name "$1" $IMAGE sh -c "$2";
+        run_podman ${events_backend} run --log-driver=$driver --rm -d --name "$1" $IMAGE sh -c "$2";
         cid+=($(echo "${output:0:12}"))
     }
 
@@ -57,7 +70,7 @@ function _log_test_multi() {
     doit c1         "echo a;sleep 10;echo d;sleep 3"
     doit c2 "sleep 1;echo b;sleep  2;echo c;sleep 3"
 
-    run_podman logs -f c1 c2
+    run_podman ${events_backend} logs -f c1 c2
     is "$output" \
        "${cid[0]} a$etc
 ${cid[1]} b$etc
@@ -187,15 +200,20 @@ function _log_test_follow() {
     contentA=$(random_string)
     contentB=$(random_string)
     contentC=$(random_string)
+    local events_backend=$(_additional_events_backend $driver)
+
+    if [[ -n "${events_backend}" ]]; then
+        skip_if_remote "remote does not support --events-backend"
+    fi
 
     # Note: it seems we need at least three log lines to hit #11461.
-    run_podman run --log-driver=$driver --name $cname $IMAGE sh -c "echo $contentA; echo $contentB; echo $contentC"
-    run_podman logs -f $cname
+    run_podman ${events_backend} run --log-driver=$driver --name $cname $IMAGE sh -c "echo $contentA; echo $contentB; echo $contentC"
+    run_podman ${events_backend} logs -f $cname
     is "$output" "$contentA
 $contentB
 $contentC" "logs -f on exitted container works"
 
-    run_podman rm -t 0 -f $cname
+    run_podman ${events_backend} rm -t 0 -f $cname
 }
 
 @test "podman logs - --follow k8s-file" {


### PR DESCRIPTION
Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

`logs -f` with `journald` is supported only when `journald` events backend is used. To pass system tests using `logs -f` in an environment where `events_logger` is not set to `journald` in `container.conf`, this fix set `--events-backend` or `--log-driver` temporally.



<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

- Run `035-logs.bats` with `containers.conf` where `events_logger` is not `journald`.
- Run `130-kill.bats` with `containers.conf` where `events_logger` is not `journald` and `log_driver` is `journald`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
