### PR TITLE
volumes: be more tolerant and fix infinite loop

### DIFF
--- a/libpod/container_path_resolution.go
+++ b/libpod/container_path_resolution.go
@@ -161,7 +161,7 @@ func isPathOnBindMount(c *Container, containerPath string) bool {
 		if cleanedContainerPath == filepath.Clean(m.Destination) {
 			return true
 		}
-		for dest := m.Destination; dest != "/"; dest = filepath.Dir(dest) {
+		for dest := m.Destination; dest != "/" && dest != "."; dest = filepath.Dir(dest) {
 			if cleanedContainerPath == dest {
 				return true
 			}

--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -214,9 +214,6 @@ func getImageVolumes(ctx context.Context, img *libimage.Image, s *specgen.SpecGe
 	}
 	for volume := range inspect.Config.Volumes {
 		logrus.Debugf("Image has volume at %q", volume)
-		if err = parse.ValidateVolumeCtrDir(volume); err != nil {
-			return nil, nil, err
-		}
 		cleanDest := filepath.Clean(volume)
 		switch mode {
 		case "", "anonymous":


### PR DESCRIPTION
Make Podman more tolerant when parsing image volumes during container
creation and further fix an infinite loop when checking them.

Consider `VOLUME ['/etc/foo', '/etc/bar']` in a Containerfile.  While
it looks correct to the human eye, the single quotes are wrong and yield
the two volumes to be `[/etc/foo,` and `/etc/bar]` in Podman and Docker.

When running the container, it'll create a directory `bar]` in `/etc`
and a directory `[` in `/` with two subdirectories `etc/foo,`.  This
behavior is surprising to me but how Docker behaves.  We may improve on
that in the future.  Note that the correct way to syntax for volumes in
a Containerfile is `VOLUME /A /B /C` or `VOLUME ["/A", "/B", "/C"]`;
single quotes are not supported.

This change restores this behavior without breaking container creation
or ending up in an infinite loop.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2014149
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>