### PR TITLE
[CI:DOCS] Fix pause usage example

### DIFF
--- a/docs/source/markdown/podman-pause.1.md
+++ b/docs/source/markdown/podman-pause.1.md
@@ -31,7 +31,7 @@ podman pause 860a4b23
 
 Pause all **running** containers.
 ```
-podman stop -a
+podman pause -a
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
#### What this PR does / why we need it:

Current documentation of `pause` command contains a bad example:
```
podman stop -a
```

#### How to verify it

See https://docs.podman.io/en/stable/markdown/podman-pause.1.html

#### Which issue(s) this PR fixes:

Just a small typo, probably due to an old copy&paste.