### PR TITLE
Fix help message case for `podman version`

### DIFF
--- a/cmd/podman/system/version.go
+++ b/cmd/podman/system/version.go
@@ -20,7 +20,7 @@ var (
 	versionCommand = &cobra.Command{
 		Use:               "version [options]",
 		Args:              validate.NoArgs,
-		Short:             "Display the Podman Version Information",
+		Short:             "Display the Podman version information",
 		RunE:              version,
 		ValidArgsFunction: completion.AutocompleteNone,
 	}

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -31,7 +31,6 @@ var _ = Describe("Podman version", func() {
 		f := CurrentGinkgoTestDescription()
 		processTestResult(f)
 		podmanTest.SeedImages()
-
 	})
 
 	It("podman version", func() {
@@ -95,5 +94,14 @@ var _ = Describe("Podman version", func() {
 		session = podmanTest.Podman([]string{"version", "--format", "{{ .Version }}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
+	})
+
+	It("podman help", func() {
+		session := podmanTest.Podman([]string{"help"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.Out.Contents()).Should(
+			ContainSubstring("Display the Podman version information"),
+		)
 	})
 })


### PR DESCRIPTION
#### What this PR does / why we need it:

This is a cosmetic change. The help message for `podman version` is in
title case whereas all other command help messages are not in title
case. This stands out as inconsistent when looking at the output of
`podman help`.

This PR fixes the case for the help message for the `version` subcommand.

#### How to verify it

Run `podman help` and look at the help string for the `version` subcommand.

#### Before

```
podman help | grep version
  version     Display the Podman Version Information
```

#### After

```
podman help | grep version
  version     Display the Podman version information
```

#### Special notes for your reviewer:

Just for comparison, I double checked the help message for the `version` subcommand in `docker`.

```
$ docker help | grep version
  -v, --version            Print version information and quit
  version     Show the Docker version information
```