### PR TITLE
Fix libpod API conformance to swagger

### DIFF
--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -42,9 +42,9 @@ type ContainersPruneReport struct {
 }
 
 type LibpodContainersPruneReport struct {
-	ID             string `json:"id"`
-	SpaceReclaimed int64  `json:"space"`
-	PruneError     string `json:"error"`
+	ID             string `json:"Id"`
+	SpaceReclaimed int64  `json:"Space"`
+	PruneError     string `json:"Err,omitempty"`
 }
 
 type Info struct {

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -43,7 +43,7 @@ type ContainersPruneReport struct {
 
 type LibpodContainersPruneReport struct {
 	ID             string `json:"Id"`
-	SpaceReclaimed int64  `json:"Space"`
+	SpaceReclaimed int64  `json:"Size"`
 	PruneError     string `json:"Err,omitempty"`
 }
 

--- a/pkg/api/handlers/utils/handler.go
+++ b/pkg/api/handlers/utils/handler.go
@@ -145,12 +145,12 @@ func MarshalErrorSliceJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	}
 }
 
-func MarshalErrorJSONIsEmpty(_ unsafe.Pointer) bool {
-	return false
+func MarshalErrorJSONIsEmpty(ptr unsafe.Pointer) bool {
+	return *((*error)(ptr)) == nil
 }
 
-func MarshalErrorSliceJSONIsEmpty(_ unsafe.Pointer) bool {
-	return false
+func MarshalErrorSliceJSONIsEmpty(ptr unsafe.Pointer) bool {
+	return len(*((*[]error)(ptr))) <= 0
 }
 
 // WriteJSON writes an interface value encoded as JSON to w

--- a/pkg/api/handlers/utils/handler_test.go
+++ b/pkg/api/handlers/utils/handler_test.go
@@ -138,3 +138,51 @@ func TestEqualVersion(t *testing.T) {
 			rr.Body.String(), expected)
 	}
 }
+
+func TestErrorEncoderFuncOmit(t *testing.T) {
+	data, err := json.Marshal(struct {
+		Err  error   `json:"err,omitempty"`
+		Errs []error `json:"errs,omitempty"`
+	}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dataAsMap := make(map[string]interface{})
+	err = json.Unmarshal(data, &dataAsMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, ok := dataAsMap["err"]
+	if ok {
+		t.Errorf("the `err` field should have been omitted")
+	}
+	_, ok = dataAsMap["errs"]
+	if ok {
+		t.Errorf("the `errs` field should have been omitted")
+	}
+
+	dataAsMap = make(map[string]interface{})
+	data, err = json.Marshal(struct {
+		Err  error   `json:"err"`
+		Errs []error `json:"errs"`
+	}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = json.Unmarshal(data, &dataAsMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, ok = dataAsMap["err"]
+	if !ok {
+		t.Errorf("the `err` field shouldn't have been omitted")
+	}
+	_, ok = dataAsMap["errs"]
+	if !ok {
+		t.Errorf("the `errs` field shouldn't have been omitted")
+	}
+}

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -1069,7 +1069,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// - application/json
 	// responses:
 	//   200:
-	//     $ref: "#/responses/DocsImageDeleteResponse"
+	//     $ref: "#/responses/DocsLibpodPruneResponse"
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/prune"), s.APIHandler(libpod.PruneImages)).Methods(http.MethodPost)

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -967,7 +967,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// - application/json
 	// responses:
 	//   200:
-	//     $ref: "#/responses/DocsImageDeleteResponse"
+	//     $ref: "#/responses/DocsLibpodImagesRemoveResponse"
 	//   400:
 	//     $ref: "#/responses/BadParamError"
 	//   404:

--- a/pkg/domain/entities/reports/prune.go
+++ b/pkg/domain/entities/reports/prune.go
@@ -1,9 +1,9 @@
 package reports
 
 type PruneReport struct {
-	Id   string //nolint
-	Err  error
-	Size uint64
+	Id   string `json:"Id"` //nolint
+	Err  error  `json:"Err,omitempty"`
+	Size uint64 `json:"Size"`
 }
 
 func PruneReportsIds(r []*PruneReport) []string {

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -57,7 +57,7 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 		pruneOptions.Filters = append(pruneOptions.Filters, "containers=false")
 	}
 
-	var pruneReports []*reports.PruneReport
+	pruneReports := make([]*reports.PruneReport, 0)
 
 	// Now prune all images until we converge.
 	numPreviouslyRemovedImages := 1

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -218,6 +218,9 @@ if ! grep -q '400 Bad Request' "${TMPD}/headers.txt"; then
     BUILD_TEST_ERROR="1"
 fi
 
+t POST libpod/images/prune 200
+t POST libpod/images/prune 200 length=0 []
+
 cleanBuildTest
 if [[ "${BUILD_TEST_ERROR}" ]]; then
     exit 1


### PR DESCRIPTION
* Return empty array when nothing has been pruned.
* Use correct return type swagger doc-comment.

resolves #12112 #12114