### PR TITLE
Make stop message more similar to start

### DIFF
--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -3,6 +3,8 @@
 package machine
 
 import (
+	"fmt"
+
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/pkg/machine"
 	"github.com/containers/podman/v3/pkg/machine/qemu"
@@ -46,5 +48,9 @@ func stop(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return vm.Stop(vmName, machine.StopOptions{})
+	if err := vm.Stop(vmName, machine.StopOptions{}); err != nil {
+		return err
+	}
+	fmt.Printf("Machine %q stopped successfully\n", vmName)
+	return nil
 }

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -398,7 +398,6 @@ func (v *MachineVM) Stop(name string, _ machine.StopOptions) error {
 		return err
 	}
 
-	fmt.Printf("Successfully stopped machine: %s", name)
 	return nil
 }
 


### PR DESCRIPTION
[NO NEW TESTS NEEDED]

The current message from "stop" is printed from the wrong place (library function, instead of command)

And it is also missing a newline, and having a slightly different syntax than the "start" output earlier.

BEFORE
```console
$ podman machine stop
Successfully stopped machine: podman-machine-default$ 
```

AFTER
```console
$ ./bin/podman machine stop
Machine "podman-machine-default" stopped successfully
$
```