### PR TITLE
System tests: enhance volume test, add debug prints

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -444,6 +444,14 @@ load helpers
         die "MAC address did not change after podman network disconnect/connect"
     fi
 
+    # FIXME FIXME FIXME: #11825: bodhi tests are failing, remote+rootless only,
+    # with "dnsmasq: failed to create inotify". This error has never occurred
+    # in CI, and Ed has been unable to reproduce it on 1minutetip. This next
+    # line is a suggestion from Paul Holzinger for trying to shed light on
+    # the system context before the failure. This output will be invisible
+    # if the test passes.
+    for foo in /proc/\*/fd/*; do readlink -f $foo; done |grep '^/proc/.*inotify' |cut -d/ -f3 | xargs -I '{}' -- ps --no-headers -o '%p %U %a' -p '{}' |uniq -c |sort -n
+
     # connect a second network
     run_podman network connect $netname2 $cid
 


### PR DESCRIPTION
Volume test: add a sequence of stat()s to confirm that volumes
are mounted as a different device than root.

Network test: add debugging code for #11825 (dnsmasq inotify
failure in bodhi only).

Signed-off-by: Ed Santiago <santiago@redhat.com>
