### PR TITLE
Pod Err Message Type Conversion

### DIFF
--- a/test/apiv2/python/rest_api/test_v2_0_0_pod.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_pod.py
@@ -60,6 +60,14 @@ class TestApi(APITestCase):
         start = r.json()
         self.assertGreater(len(start["Errs"]), 0, r.text)
 
+        r = requests.post(self.uri(f"/pods/{pod_name[0]}/stop"))
+        self.assertEqual(r.status_code, 200, r.text)
+
+        r = requests.delete(self.uri("/pods/foobar"))
+        self.assertEqual(r.status_code, 404, r.text)
+        out = r.json()
+        self.assertIsInstance(out["Err"], str)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### What this PR does / why we need it:

pods removed via the libpod API endpoint were returning an object rather than a string,
fixed to return a string

#### How to verify it


` podman pod create --name test`

 `podman system service unix:///home/whoami/testing.sock --log-level=debug --time=500`

`curl -v -X DELETE --unix-socket /home/whoami/testing.sock http://d/v3.0.0/libpod/pods/test`


#### Which issue(s) this PR fixes:

resolves #11786

Signed-off-by: cdoern <cdoern@redhat.com>
