### PR TITLE
Avoid RemoteSocket collisions in e2e tests

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -281,8 +281,26 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 			runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
 			pathPrefix = filepath.Join(runtimeDir, "podman")
 		}
-		uuid := stringid.GenerateNonCryptoID()
-		p.RemoteSocket = fmt.Sprintf("unix:%s-%s.sock", pathPrefix, uuid)
+		// We want to avoid collisions in socket paths, but using the
+		// socket directly for a collision check doesn’t work; bind(2) on AF_UNIX
+		// creates the file, and we need to pass a unique path now before the bind(2)
+		// happens. So, use a podman-%s.sock-lock empty file as a marker.
+		tries := 0
+		for {
+			uuid := stringid.GenerateNonCryptoID()
+			lockPath := fmt.Sprintf("%s-%s.sock-lock", pathPrefix, uuid)
+			lockFile, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0700)
+			if err == nil {
+				lockFile.Close()
+				p.RemoteSocketLock = lockPath
+				p.RemoteSocket = fmt.Sprintf("unix:%s-%s.sock", pathPrefix, uuid)
+				break
+			}
+			tries++
+			if tries >= 1000 {
+				panic("Too many RemoteSocket collisions")
+			}
+		}
 	}
 
 	// Setup registries.conf ENV variable

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -274,15 +274,15 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 	}
 
 	if remote {
-		uuid := stringid.GenerateNonCryptoID()
+		var pathPrefix string
 		if !rootless.IsRootless() {
-			p.RemoteSocket = fmt.Sprintf("unix:/run/podman/podman-%s.sock", uuid)
+			pathPrefix = "/run/podman/podman"
 		} else {
 			runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
-			socket := fmt.Sprintf("podman-%s.sock", uuid)
-			fqpath := filepath.Join(runtimeDir, socket)
-			p.RemoteSocket = fmt.Sprintf("unix:%s", fqpath)
+			pathPrefix = filepath.Join(runtimeDir, "podman")
 		}
+		uuid := stringid.GenerateNonCryptoID()
+		p.RemoteSocket = fmt.Sprintf("unix:%s-%s.sock", pathPrefix, uuid)
 	}
 
 	// Setup registries.conf ENV variable

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -1,3 +1,4 @@
+//go:build remote
 // +build remote
 
 package integration
@@ -142,6 +143,11 @@ func (p *PodmanTestIntegration) StopRemoteService() {
 	socket := strings.Split(p.RemoteSocket, ":")[1]
 	if err := os.Remove(socket); err != nil {
 		fmt.Println(err)
+	}
+	if p.RemoteSocketLock != "" {
+		if err := os.Remove(p.RemoteSocketLock); err != nil {
+			fmt.Println(err)
+		}
 	}
 }
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -41,6 +41,7 @@ type PodmanTest struct {
 	RemotePodmanBinary string
 	RemoteSession      *os.Process
 	RemoteSocket       string
+	RemoteSocketLock   string // If not "", should be removed _after_ RemoteSocket is removed
 	RemoteCommand      *exec.Cmd
 	ImageCacheDir      string
 	ImageCacheFS       string

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -470,10 +470,6 @@ func Containerized() bool {
 	return strings.Contains(string(b), "docker")
 }
 
-func init() {
-	rand.Seed(GinkgoRandomSeed())
-}
-
 var randomLetters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 // RandomString returns a string of given length composed of random characters


### PR DESCRIPTION
#### What this PR does / why we need it:

Per #12155, we see `RemoteSocket` collisions. So,
- Add a lock file mechanism to ensure we only generate a RemoteSocket value once, removing even the slightest possibility of a flake due to a collision in ID values
- Add logging on when/where the RemoteSocket values are generated, to maybe help diagnose unexpected `RemoteSocket` reuse.
- Add somewhat desperate logging when a collision in the generated ID happens, to maybe explain how it can happen (with such a fairly high frequency) in the first place.

#### How to verify it

CI should continue to run. (I didn’t test this manually even once.) Probably new log entries.

#### Which issue(s) this PR fixes:

Possibly #12155 , unknown.

#### Special notes for your reviewer:
