### PR TITLE
[CI:DOCS] tweak a couple of flag descriptions in help output

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -410,7 +410,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		createFlags.StringVar(
 			&cf.Variant,
 			variantFlagName, "",
-			"Use _VARIANT_ instead of the running architecture variant for choosing images",
+			"Use `VARIANT` instead of the running architecture variant for choosing images",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(variantFlagName, completion.AutocompleteNone)
 

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -92,7 +92,7 @@ func pullFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(osFlagName, completion.AutocompleteOS)
 
 	variantFlagName := "variant"
-	flags.StringVar(&pullOptions.Variant, variantFlagName, "", " use VARIANT instead of the running architecture variant for choosing images")
+	flags.StringVar(&pullOptions.Variant, variantFlagName, "", "Use VARIANT instead of the running architecture variant for choosing images")
 	_ = cmd.RegisterFlagCompletionFunc(variantFlagName, completion.AutocompleteNone)
 
 	platformFlagName := "platform"


### PR DESCRIPTION
#### What this PR does / why we need it:

Descriptions of flags don't need to start with whitespace of their own.

#### How to verify it

Run `podman pull --help` and observe the alignment of the columns.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Capitalization consistency is probably a lost cause, since we import part of our CLI descriptions wholesale from buildah.