### PR TITLE
Fix rootless cni netns cleanup logic and rename to rootless netns

### DIFF
--- a/cmd/podman/system/unshare.go
+++ b/cmd/podman/system/unshare.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/podman/v3/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -34,7 +35,14 @@ func init() {
 	})
 	flags := unshareCommand.Flags()
 	flags.SetInterspersed(false)
-	flags.BoolVar(&unshareOptions.RootlessCNI, "rootless-cni", false, "Join the rootless network namespace used for CNI networking")
+	flags.BoolVar(&unshareOptions.RootlessNetNS, "rootless-netns", false, "Join the rootless network namespace used for CNI and netavark networking")
+	// backwards compat still allow --rootless-cni
+	flags.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		if name == "rootless-cni" {
+			name = "rootless-netns"
+		}
+		return pflag.NormalizedName(name)
+	})
 }
 
 func unshare(cmd *cobra.Command, args []string) error {

--- a/docs/source/markdown/podman-unshare.1.md
+++ b/docs/source/markdown/podman-unshare.1.md
@@ -30,10 +30,10 @@ The unshare session defines two environment variables:
 
 Print usage statement
 
-#### **--rootless-cni**
+#### **--rootless-netns**
 
-Join the rootless network namespace used for CNI networking. It can be used to
-connect to a rootless container via IP address (CNI networking). This is otherwise
+Join the rootless network namespace used for CNI and netavark networking. It can be used to
+connect to a rootless container via IP address (bridge networking). This is otherwise
 not possible from the host network namespace.
 _Note: Using this option with more than one unshare session can have unexpected results._
 
@@ -78,7 +78,7 @@ $ podman unshare cat /proc/self/uid_map /proc/self/gid_map
          0       1000          1
          1      10000      65536
 
-$ podman unshare --rootless-cni ip addr
+$ podman unshare --rootless-netns ip addr
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
     inet 127.0.0.1/8 scope host lo

--- a/pkg/domain/entities/system.go
+++ b/pkg/domain/entities/system.go
@@ -100,7 +100,7 @@ type SystemVersionReport struct {
 
 // SystemUnshareOptions describes the options for the unshare command
 type SystemUnshareOptions struct {
-	RootlessCNI bool
+	RootlessNetNS bool
 }
 
 type ComponentVersion struct {

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -360,15 +360,15 @@ func (ic *ContainerEngine) Unshare(ctx context.Context, args []string, options e
 		return cmd.Run()
 	}
 
-	if options.RootlessCNI {
-		rootlesscni, err := ic.Libpod.GetRootlessCNINetNs(true)
+	if options.RootlessNetNS {
+		rootlessNetNS, err := ic.Libpod.GetRootlessNetNs(true)
 		if err != nil {
 			return err
 		}
 		// make sure to unlock, unshare can run for a long time
-		rootlesscni.Lock.Unlock()
-		defer rootlesscni.Cleanup(ic.Libpod)
-		return rootlesscni.Do(unshare)
+		rootlessNetNS.Lock.Unlock()
+		defer rootlessNetNS.Cleanup(ic.Libpod)
+		return rootlessNetNS.Do(unshare)
 	}
 	return unshare()
 }

--- a/test/e2e/unshare_test.go
+++ b/test/e2e/unshare_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Podman unshare", func() {
 	})
 
 	It("podman unshare --rootles-cni", func() {
-		session := podmanTest.Podman([]string{"unshare", "--rootless-cni", "ip", "addr"})
+		session := podmanTest.Podman([]string{"unshare", "--rootless-netns", "ip", "addr"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring("tap0"))


### PR DESCRIPTION


#### What this PR does / why we need it:
Fix rootless cni netns cleanup logic

The check if cleanup is needed reads all container and checks if there
are running containers with bridge networking. If we do not find any we
have to cleanup the ns. However there was a problem with this because
the state is empty by default so the running check never worked.
Fortunately the was a second check which relies on the CNI files so we
still did cleanup anyway.

With netavark I noticed that this check is broken because the CNI files
were not present.

mount full XDG_RUNTIME_DIR in rootless cni ns

We should mount the full runtime directory into the namespace instead of
just the netns dir. This allows more use cases.

rename rootless cni ns to rootless netns

Since we want to use the rootless cni ns also for netavark we should
pick a more generic name. The name is now "rootless network namespace"
or short "rootless netns".

The rename might cause some issues after the update but when the
all containers are restarted or the host is rebooted it should work
correctly.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
