### PR TITLE
Log Apache access_log-like entries at Info level

### DIFF
--- a/pkg/api/server/handler_rid.go
+++ b/pkg/api/server/handler_rid.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/containers/podman/v3/pkg/api/types"
@@ -15,7 +16,13 @@ import (
 // and Apache style request logging
 func referenceIDHandler() mux.MiddlewareFunc {
 	return func(h http.Handler) http.Handler {
-		return handlers.CombinedLoggingHandler(logrus.StandardLogger().Out,
+		// Only log Apache access_log-like entries at Info level or below
+		out := ioutil.Discard
+		if logrus.IsLevelEnabled(logrus.InfoLevel) {
+			out = logrus.StandardLogger().Out
+		}
+
+		return handlers.CombinedLoggingHandler(out,
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				rid := r.Header.Get("X-Reference-Id")
 				if rid == "" {


### PR DESCRIPTION
Only log API access entries when --log-level set to Info or below.

Fixes #12181

Signed-off-by: Jhon Honce <jhonce@redhat.com>