### PR TITLE
[CI:DOCS] Fix swagger definition for the new mac address type

### DIFF
--- a/libpod/network/types/network.go
+++ b/libpod/network/types/network.go
@@ -99,6 +99,7 @@ func (n *IPNet) UnmarshalText(text []byte) error {
 // that it adds the json marshal/unmarshal methods.
 // This allows us to read the mac from a json string
 // and a byte array.
+// swagger:model MacAddress
 type HardwareAddr net.HardwareAddr
 
 func (h *HardwareAddr) String() string {

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -99,6 +99,7 @@ type PodNetworkConfig struct {
 	// Only available if NetNS is set to Bridge (the default for root).
 	// As such, conflicts with NoInfra=true by proxy.
 	// Optional.
+	// swagger:strfmt string
 	StaticMAC *types.HardwareAddr `json:"static_mac,omitempty"`
 	// PortMappings is a set of ports to map into the infra container.
 	// As, by default, containers share their network with the infra

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -401,6 +401,7 @@ type ContainerNetworkConfig struct {
 	// StaticMAC is a static MAC address to set in the container.
 	// Only available if NetNS is set to bridge.
 	// Optional.
+	// swagger:strfmt string
 	StaticMAC *nettypes.HardwareAddr `json:"static_mac,omitempty"`
 	// PortBindings is a set of ports to map into the container.
 	// Only available if NetNS is set to bridge or slirp.


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

The new mac address type broke the api docs. While we could
successfully generate the swagger file it could not be viewed in a
browser.

The problem is that the swagger generation create two type definitions
with the name `HardwareAddr` and this pointed back to itself. Thus the
render process was stucked in an endless loop. To fix this manually
rename the new type to MacAddress and overwrite the types to string
because the json unmarshaller accepts the mac as string.
#### How to verify it

```
make pkg/api/swagger.yaml
swagger serve pkg/api/swagger.yaml
```

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
