### PR TITLE
[CI:DOCS] Fix Zsh completion command documentation

### DIFF
--- a/docs/source/markdown/podman-completion.1.md
+++ b/docs/source/markdown/podman-completion.1.md
@@ -40,7 +40,7 @@ Shell completion needs to be already enabled in the environment. The following c
 **echo "autoload -U compinit; compinit" >> ~/.zshrc**
 
 To make it available for all zsh sessions run:\
-**podman completion -f "${fpath[1]}/_podman zsh"**
+**podman completion -f "${fpath[1]}/_podman" zsh**
 
 Once the shell is reloaded the auto-completion should be working.
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Zsh completion command should be 
`podman completion -f "${fpath[1]}/_podman" zsh` 
instead of 
`podman completion -f "${fpath[1]}/_podman zsh"`

#### How to verify it

Run `podman completion -f "${fpath[1]}/_podman zsh"` on Zsh.


#### Which issue(s) this PR fixes:

> Error: accepts 1 arg(s), received 0


