### PR TITLE
podman-generate-kube - remove empty structs from YAML

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -167,9 +167,83 @@ func (v *Volume) GenerateForKube() *v1.PersistentVolumeClaim {
 	}
 }
 
+// YAMLPodSpec represents the same k8s API core PodSpec struct with a small
+// change and that is having Containers as a pointer to YAMLContainer.
+// Because Go doesn't omit empty struct and we want to omit Status in YAML
+// if it's empty. Fixes: GH-11998
+type YAMLPodSpec struct {
+	v1.PodSpec
+	Containers []*YAMLContainer `json:"containers"`
+}
+
+// YAMLPod represents the same k8s API core Pod struct with a small
+// change and that is having Spec as a pointer to YAMLPodSpec and
+// Status as a pointer to k8s API core PodStatus.
+// Because Go doesn't omit empty struct and we want to omit Status in YAML
+// if it's empty. Fixes: GH-11998
+type YAMLPod struct {
+	v1.Pod
+	Spec   *YAMLPodSpec  `json:"spec,omitempty"`
+	Status *v1.PodStatus `json:"status,omitempty"`
+}
+
+// YAMLService represents the same k8s API core Service struct with a small
+// change and that is having Status as a pointer to k8s API core ServiceStatus.
+// Because Go doesn't omit empty struct and we want to omit Status in YAML
+// if it's empty. Fixes: GH-11998
+type YAMLService struct {
+	v1.Service
+	Status *v1.ServiceStatus `json:"status,omitempty"`
+}
+
+// YAMLContainer represents the same k8s API core Container struct with a small
+// change and that is having Resources as a pointer to k8s API core ResourceRequirements.
+// Because Go doesn't omit empty struct and we want to omit Status in YAML
+// if it's empty. Fixes: GH-11998
+type YAMLContainer struct {
+	v1.Container
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
+}
+
+// ConvertV1PodToYAMLPod takes k8s API core Pod and returns a pointer to YAMLPod
+func ConvertV1PodToYAMLPod(pod *v1.Pod) *YAMLPod {
+	cs := []*YAMLContainer{}
+	for _, cc := range pod.Spec.Containers {
+		var res *v1.ResourceRequirements = nil
+		if len(cc.Resources.Limits) > 0 || len(cc.Resources.Requests) > 0 {
+			res = &cc.Resources
+		}
+		cs = append(cs, &YAMLContainer{Container: cc, Resources: res})
+	}
+	mpo := &YAMLPod{Pod: *pod}
+	mpo.Spec = &YAMLPodSpec{PodSpec: (*pod).Spec, Containers: cs}
+	for _, ctr := range pod.Spec.Containers {
+		if ctr.SecurityContext == nil || ctr.SecurityContext.SELinuxOptions == nil {
+			continue
+		}
+		selinuxOpts := ctr.SecurityContext.SELinuxOptions
+		if selinuxOpts.User == "" && selinuxOpts.Role == "" && selinuxOpts.Type == "" && selinuxOpts.Level == "" {
+			ctr.SecurityContext.SELinuxOptions = nil
+		}
+	}
+	dnsCfg := pod.Spec.DNSConfig
+	if dnsCfg != nil && (len(dnsCfg.Nameservers)+len(dnsCfg.Searches)+len(dnsCfg.Options) > 0) {
+		mpo.Spec.DNSConfig = dnsCfg
+	}
+	status := pod.Status
+	if status.Phase != "" || len(status.Conditions) > 0 ||
+		status.Message != "" || status.Reason != "" ||
+		status.NominatedNodeName != "" || status.HostIP != "" ||
+		status.PodIP != "" || status.StartTime != nil ||
+		len(status.InitContainerStatuses) > 0 || len(status.ContainerStatuses) > 0 || status.QOSClass != "" || len(status.EphemeralContainerStatuses) > 0 {
+		mpo.Status = &status
+	}
+	return mpo
+}
+
 // GenerateKubeServiceFromV1Pod creates a v1 service object from a v1 pod object
-func GenerateKubeServiceFromV1Pod(pod *v1.Pod, servicePorts []v1.ServicePort) v1.Service {
-	service := v1.Service{}
+func GenerateKubeServiceFromV1Pod(pod *v1.Pod, servicePorts []v1.ServicePort) YAMLService {
+	service := YAMLService{}
 	selector := make(map[string]string)
 	selector["app"] = pod.Labels["app"]
 	ports := servicePorts

--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -124,8 +124,7 @@ func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrIDs []string,
 		if err != nil {
 			return nil, err
 		}
-
-		b, err := generateKubeYAML(po)
+		b, err := generateKubeYAML(libpod.ConvertV1PodToYAMLPod(po))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:
This PR attempts to remove `status.loadBalancer`, `spec.containers.resources` and `spec.containers.seLinuxOptions` in the YAML if their `struct`s are empty.

<!---
Please put your overall PR description here
-->

#### How to verify it
create or run containers and run `podman generate kube -s <containers>`

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:
fixes #11998 
<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
