### PR TITLE
podman-remote: default PullPolicy must be missing instead of empty str

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -503,7 +503,11 @@ func policy() string {
 	if !registry.IsRemote() {
 		return containerConfig.Engine.PullPolicy
 	}
-	return ""
+	// If registry is remote default pull policy
+	// must be "missing" instead of empty string.
+	// since empty string == PullPolicy {always}
+	// more context: https://github.com/containers/podman/pull/10739
+	return config.DefaultPullPolicy
 }
 
 func shmSize() string {


### PR DESCRIPTION
If registry is remote default pull policy must be `missing` instead of
remote. Since `empty str == pullpolicy {always}` for more context on
this behaviour check https://github.com/containers/podman/pull/10739

[NO TESTS NEEDED]

Closes: https://github.com/containers/podman/issues/12201