### PR TITLE
pod create: read network mode from config

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -117,7 +117,7 @@ func create(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("cannot specify no-hosts without an infra container")
 		}
 		flags := cmd.Flags()
-		createOptions.Net, err = common.NetFlagsToNetOptions(nil, *flags, false)
+		createOptions.Net, err = common.NetFlagsToNetOptions(nil, *flags, createOptions.Infra)
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ func create(cmd *cobra.Command, args []string) error {
 	} else {
 		// reassign certain options for lbpod api, these need to be populated in spec
 		flags := cmd.Flags()
-		infraOptions.Net, err = common.NetFlagsToNetOptions(nil, *flags, false)
+		infraOptions.Net, err = common.NetFlagsToNetOptions(nil, *flags, createOptions.Infra)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/config/containers-netns.conf
+++ b/test/e2e/config/containers-netns.conf
@@ -1,0 +1,3 @@
+[containers]
+
+netns = "host"


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:
When we create a pod we have to parse the network mode form the config
file. This is a regression in commit d28e85741f.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:



Fixes #12207

#### Special notes for your reviewer:
