### PR TITLE
Bump Catatonit up to v0.1.7

### DIFF
--- a/hack/install_catatonit.sh
+++ b/hack/install_catatonit.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 BASE_PATH="/usr/libexec/podman"
 CATATONIT_PATH="${BASE_PATH}/catatonit"
-CATATONIT_VERSION="v0.1.4"
+CATATONIT_VERSION="v0.1.7"
 set -e
 
 if [ -f $CATATONIT_PATH ]; then


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump up catatonia to version 0.1.7 in CI for https://github.com/containers/podman/pull/12218

#### How to verify it

CI tests will pass

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The VM images will pick up and cache the new version when they're built next, after this PR is merged.