### PR TITLE
Podman Image SCP transfer patch

### DIFF
--- a/docs/source/markdown/podman-image-scp.1.md
+++ b/docs/source/markdown/podman-image-scp.1.md
@@ -68,10 +68,22 @@ Copying blob e2eb06d8af82 done
 Copying config 696d33ca15 done
 Writing manifest to image destination
 Storing signatures
-Run Directory Obtained: /run/user/1000/
-[Run Root: /var/tmp/containers-user-1000/containers Graph Root: /root/.local/share/containers/storage DB Path: /root/.local/share/containers/storage/libpod/bolt_state.db]
 Getting image source signatures
 Copying blob 5eb901baf107 skipped: already exists
+Copying config 696d33ca15 done
+Writing manifest to image destination
+Storing signatures
+Loaded image(s): docker.io/library/alpine:latest
+```
+
+```
+$ sudo podman image scp root@localhost::alpine
+Copying blob e2eb06d8af82 done
+Copying config 696d33ca15 done
+Writing manifest to image destination
+Storing signatures
+Getting image source signatures
+Copying blob 5eb901baf107
 Copying config 696d33ca15 done
 Writing manifest to image destination
 Storing signatures

--- a/test/e2e/image_scp_test.go
+++ b/test/e2e/image_scp_test.go
@@ -78,6 +78,10 @@ var _ = Describe("podman image scp", func() {
 		list.WaitWithDefaultTimeout()
 		Expect(list).To(Exit(0))
 		Expect(list.LineInOutputStartsWith("quay.io/libpod/alpine")).To(BeTrue())
+
+		scp = podmanTest.PodmanAsUser([]string{"image", "scp", "root@localhost::" + ALPINE}, 0, 0, "", env) //transfer from root to rootless (us)
+		scp.WaitWithDefaultTimeout()
+		Expect(scp).To(Exit(0))
 	})
 
 	It("podman image scp bogus image", func() {


### PR DESCRIPTION
Fixed syntax so that podman image scp transfer works with no user specified.

This command can only be executed as root so to obtain the default user, I searched for
the SUDO_USER environmental variable. 

If that is not found, we error out and inform the user
to set this variable and make sure they are running as root.

the two functional syntax forms are now:

`sudo podman image scp root@localhost::IMAGE` 

and

`sudo podman image scp root@localhost::IMAGE USER@localhost::`

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>