### PR TITLE
Fix rootless networking with userns and ports

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -290,7 +290,7 @@ func (c *Container) handleRestartPolicy(ctx context.Context) (_ bool, retErr err
 
 	// setup slirp4netns again because slirp4netns will die when conmon exits
 	if c.config.NetMode.IsSlirp4netns() {
-		err := c.runtime.setupSlirp4netns(c)
+		err := c.runtime.setupSlirp4netns(c, c.state.NetNS)
 		if err != nil {
 			return false, err
 		}
@@ -299,7 +299,7 @@ func (c *Container) handleRestartPolicy(ctx context.Context) (_ bool, retErr err
 	// setup rootlesskit port forwarder again since it dies when conmon exits
 	// we use rootlesskit port forwarder only as rootless and when bridge network is used
 	if rootless.IsRootless() && c.config.NetMode.IsBridge() && len(c.config.PortMappings) > 0 {
-		err := c.runtime.setupRootlessPortMappingViaRLK(c, c.state.NetNS.Path())
+		err := c.runtime.setupRootlessPortMappingViaRLK(c, c.state.NetNS.Path(), c.state.NetworkStatus)
 		if err != nil {
 			return false, err
 		}
@@ -998,9 +998,6 @@ func (c *Container) completeNetworkSetup() error {
 	}
 	if err := c.syncContainer(); err != nil {
 		return err
-	}
-	if c.config.NetMode.IsSlirp4netns() {
-		return c.runtime.setupSlirp4netns(c)
 	}
 	if err := c.runtime.setupNetNS(c); err != nil {
 		return err

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -108,15 +108,6 @@ func (c *Container) prepare() error {
 			c.state.NetNS = netNS
 			c.state.NetworkStatus = networkStatus
 		}
-
-		// handle rootless network namespace setup
-		if noNetNS && !c.config.PostConfigureNetNS {
-			if rootless.IsRootless() {
-				createNetNSErr = c.runtime.setupRootlessNetNS(c)
-			} else if c.config.NetMode.IsSlirp4netns() {
-				createNetNSErr = c.runtime.setupSlirp4netns(c)
-			}
-		}
 	}()
 	// Mount storage if not mounted
 	go func() {

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -78,6 +78,9 @@ load helpers
         if [[ -z $cidr ]]; then
             # regex to match that we are in 10.X subnet
             match="10\..*"
+            # force bridge networking also for rootless
+            # this ensures that rootless + bridge + userns + ports works
+            network_arg="--network bridge"
         else
             # Issue #9828 make sure a custom slir4netns cidr also works
             network_arg="--network slirp4netns:cidr=$cidr"


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:
A rootless container created with a custom userns and forwarded ports
did not work. I refactored the network setup to make the setup logic
more clear.

#### How to verify it
1. terminal
`podman run -it --rm --userns keep-id --network bridge   -p 8080:8080  alpine nc -l -p 8080`
2. terminal
`echo test | nc 127.0.0.1 8080`

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
