### PR TITLE
Minor test tweaks

### DIFF
--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -12,9 +12,6 @@ fi
 if [[ "${CIRRUS_CHANGE_MESSAGE}" =~ NO.NEW.TESTS.NEEDED ]]; then
     exit 0
 fi
-if [[ "${CIRRUS_CHANGE_MESSAGE}" =~ NO.TESTS.NEEDED ]]; then
-    exit 0
-fi
 
 # HEAD should be good enough, but the CIRRUS envariable allows us to test
 head=${CIRRUS_CHANGE_IN_REPO:-HEAD}
@@ -52,12 +49,9 @@ if [[ -z "$filtered_changes" ]]; then
     exit 0
 fi
 
-# One last chance: perhaps the developer included the magic '[NO (NEW) TESTS NEEDED]'
+# One last chance: perhaps the developer included the magic '[NO NEW TESTS NEEDED]'
 # string in an amended commit.
 if git log --format=%B ${base}..${head} | fgrep '[NO NEW TESTS NEEDED]'; then
-   exit 0
-fi
-if git log --format=%B ${base}..${head} | fgrep '[NO TESTS NEEDED]'; then
    exit 0
 fi
 

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -167,6 +167,13 @@ load helpers
 	       $IMAGE nc -l -n -v -p $myport
     cid="$output"
 
+    # FIXME: debugging for #11871
+    run_podman exec $cid cat /etc/resolv.conf
+    if is_rootless; then
+        run_podman unshare --rootless-cni cat /etc/resolv.conf
+    fi
+    ps uxww
+
     # check that dns is working inside the container
     run_podman exec $cid nslookup google.com
 


### PR DESCRIPTION
- remove 'NO TESTS NEEDED' as a valid bypass string. Henceforth
  only 'NO NEW TESTS NEEDED' will work.

- add a debugging aid for #11871, in which bodhi tests time out
  in nslookup.

Signed-off-by: Ed Santiago <santiago@redhat.com>
