### PR TITLE
Exclude already built sources for static build

### DIFF
--- a/nix/default-arm64.nix
+++ b/nix/default-arm64.nix
@@ -59,7 +59,8 @@ let
 
   self = with pkgs; buildGoModule rec {
     name = "podman";
-    src = ./..;
+    src = builtins.filterSource
+      (path: type: !(type == "directory" && baseNameOf path == "bin")) ./..;
     vendorSha256 = null;
     doCheck = false;
     enableParallelBuilding = true;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -57,7 +57,8 @@ let
 
   self = with pkgs; buildGoModule rec {
     name = "podman";
-    src = ./..;
+    src = builtins.filterSource
+      (path: type: !(type == "directory" && baseNameOf path == "bin")) ./..;
     vendorSha256 = null;
     doCheck = false;
     enableParallelBuilding = true;


### PR DESCRIPTION
#### What this PR does / why we need it:

We now do not copy the `bin` directory to the target nix sources to  avoid skipping the build because "everything is up to date".

#### How to verify it

```
> make
> nix-build nix
> ldd result/bin/podman
        not a dynamic executable
```

#### Which issue(s) this PR fixes:


Fixes https://github.com/containers/podman/issues/12198


#### Special notes for your reviewer:
None