### PR TITLE
Print headers for system connection ls

### DIFF
--- a/cmd/podman/system/connection/list.go
+++ b/cmd/podman/system/connection/list.go
@@ -53,10 +53,6 @@ func list(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if len(cfg.Engine.ServiceDestinations) == 0 {
-		return nil
-	}
-
 	hdrs := []map[string]string{{
 		"Identity": "Identity",
 		"Name":     "Name",

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -236,7 +236,7 @@ var _ = Describe("podman system connection", func() {
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
-			Expect(session.Out.Contents()).Should(BeEmpty())
+			Expect(len(session.OutputToStringArray())).Should(Equal(1))
 			Expect(session.Err.Contents()).Should(BeEmpty())
 		})
 	})

--- a/test/system/272-system-connection.bats
+++ b/test/system/272-system-connection.bats
@@ -50,7 +50,8 @@ function _run_podman_remote() {
 # Very basic test, does not actually connect at any time
 @test "podman system connection - basic add / ls / remove" {
     run_podman system connection ls
-    is "$output" "" "system connection ls: no connections"
+    is "$output" "Name        URI         Identity    Default" \
+       "system connection ls: no connections"
 
     c1="c1_$(random_string 15)"
     c2="c2_$(random_string 15)"


### PR DESCRIPTION
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

Print out the headers even if the system connection list
is empty to match the behavior of other list commands.

<!---
Please put your overall PR description here
-->

#### How to verify it

Run `podman system connection ls` with no system connections created and the command should return the headers only.

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/podman/issues/12038

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
