### PR TITLE
network reload without ports should not reload ports

### DIFF
--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -678,6 +678,9 @@ func getRootlessPortChildIP(c *Container, netStatus map[string]types.StatusBlock
 // reloadRootlessRLKPortMapping will trigger a reload for the port mappings in the rootlessport process.
 // This should only be called by network connect/disconnect and only as rootless.
 func (c *Container) reloadRootlessRLKPortMapping() error {
+	if len(c.config.PortMappings) == 0 {
+		return nil
+	}
 	childIP := getRootlessPortChildIP(c, c.state.NetworkStatus)
 	logrus.Debugf("reloading rootless ports for container %s, childIP is %s", c.config.ID, childIP)
 

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -686,10 +686,7 @@ func (c *Container) reloadRootlessRLKPortMapping() error {
 
 	conn, err := openUnixSocket(filepath.Join(c.runtime.config.Engine.TmpDir, "rp", c.config.ID))
 	if err != nil {
-		// This is not a hard error for backwards compatibility. A container started
-		// with an old version did not created the rootlessport socket.
-		logrus.Warnf("Could not reload rootless port mappings, port forwarding may no longer work correctly: %v", err)
-		return nil
+		return errors.Wrap(err, "could not reload rootless port mappings, port forwarding may no longer work correctly")
 	}
 	defer conn.Close()
 	enc := json.NewEncoder(conn)

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -87,6 +87,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		dis := podmanTest.Podman([]string{"network", "disconnect", netName, "test"})
 		dis.WaitWithDefaultTimeout()
 		Expect(dis).Should(Exit(0))
+		Expect(dis.ErrorToString()).Should(Equal(""))
 
 		inspect := podmanTest.Podman([]string{"container", "inspect", "test", "--format", "{{len .NetworkSettings.Networks}}"})
 		inspect.WaitWithDefaultTimeout()
@@ -183,6 +184,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		connect := podmanTest.Podman([]string{"network", "connect", newNetName, "test"})
 		connect.WaitWithDefaultTimeout()
 		Expect(connect).Should(Exit(0))
+		Expect(connect.ErrorToString()).Should(Equal(""))
 
 		inspect := podmanTest.Podman([]string{"container", "inspect", "test", "--format", "{{len .NetworkSettings.Networks}}"})
 		inspect.WaitWithDefaultTimeout()

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -430,6 +430,7 @@ load helpers
     is "$output" "[${cid:0:12}]" "short container id in network aliases"
 
     run_podman network disconnect $netname $cid
+    is "$output" "" "Output should be empty (no errors)"
 
     # check that we cannot curl (timeout after 3 sec)
     run curl --max-time 3 -s $SERVER/index.txt
@@ -438,6 +439,7 @@ load helpers
     fi
 
     run_podman network connect $netname $cid
+    is "$output" "" "Output should be empty (no errors)"
 
     # curl should work again
     run curl --max-time 3 -s $SERVER/index.txt
@@ -454,6 +456,12 @@ load helpers
         die "MAC address did not change after podman network disconnect/connect"
     fi
 
+    # Disconnect/reconnect of a container *with no ports* should succeed quietly
+    run_podman network disconnect $netname $background_cid
+    is "$output" "" "disconnect of container with no open ports"
+    run_podman network connect $netname $background_cid
+    is "$output" "" "(re)connect of container with no open ports"
+
     # FIXME FIXME FIXME: #11825: bodhi tests are failing, remote+rootless only,
     # with "dnsmasq: failed to create inotify". This error has never occurred
     # in CI, and Ed has been unable to reproduce it on 1minutetip. This next
@@ -464,6 +472,7 @@ load helpers
 
     # connect a second network
     run_podman network connect $netname2 $cid
+    is "$output" "" "Output should be empty (no errors)"
 
     # check network2 alias for container short id
     run_podman inspect $cid --format "{{(index .NetworkSettings.Networks \"$netname2\").Aliases}}"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

When run as rootless the podman network reload command tries to reload
the rootlessport ports because the childIP could have changed.
However if the containers has no ports we should skip this instead of
printing a warning.

network reload return error if we cannot reload ports 

As rootless we have to reload the port mappings. If it fails we should
return an error instead of the warning.


#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
