### PR TITLE
Forwarding Play Kube HTTP API configmaps query parameter to the container engine

### DIFF
--- a/pkg/api/handlers/libpod/play.go
+++ b/pkg/api/handlers/libpod/play.go
@@ -31,6 +31,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 		StaticIPs  []string `schema:"staticIPs"`
 		StaticMACs []string `schema:"staticMACs"`
 		NoHosts    bool     `schema:"noHosts"`
+		ConfigMaps []string `schema:"configmaps"`
 	}{
 		TLSVerify: true,
 		Start:     true,
@@ -110,6 +111,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 		LogOptions: query.LogOptions,
 		StaticIPs:  staticIPs,
 		StaticMACs: staticMACs,
+		ConfigMaps: query.ConfigMaps,
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)

--- a/pkg/api/server/register_play.go
+++ b/pkg/api/server/register_play.go
@@ -46,6 +46,12 @@ func (s *APIServer) registerPlayHandlers(r *mux.Router) error {
 	//    description: Static MACs used for the pods.
 	//    items:
 	//      type: string
+	//  - in: query
+	//    name: configmaps
+	//    type: array
+	//    description: Paths to kubernetes configmap YAML files, which must be present at the host against which the request is made.
+	//    items:
+	//      type: string
 	//  - in: body
 	//    name: request
 	//    description: Kubernetes YAML file.


### PR DESCRIPTION
#### What this PR does / why we need it:

When I tried to pass correct configmap path via HTTP client while invoking Podman Play Kube API, there was an error returned and the following error reported in Podman logs:
```
Nov 09 18:45:33 fedora podman[2401215]: time="2021-11-09T18:45:33+01:00" level=info msg="Request Failed(Internal Server Error): error playing YAML file: Configmap device-config-map not found"
Nov 09 18:45:33 fedora podman[2401215]: @ - - [09/Nov/2021:18:45:30 +0100] "POST /v4.0.0/libpod/play/kube?configmaps=%2Fvar%2Flocal%2Fyggdrasil%2Fdevice%2Fdevice-config-map.yaml HTTP/1.1" 500 140 "" "Go-http-client/1.1"
```
As a result, the pod was not started and stuck in `Created` status. As it turns out, `configmaps` query parameter for `/v4.0.0/libpod/play/kube` was not forwared to the `ContainerEngine.PlayKube` with `PlayKubeOptions`.

This change addresses that problem by mapping incoming `configmaps` query parameter to `options.ConfigMaps`.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>

#### How to verify it

Create config map with some env variable; for example `/tmp/device-config-map.yaml`
```yaml
apiVersion: v1
data:
  DEVICE_ID: 242e48d0-286b-4170-9b97-95502066e6ae
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: device-config-map
```
Create pod YAML file (/tmp/pod.yaml):
```yaml
kind: Pod
metadata:
  name: edgedeployment-sample
spec:
  containers:
  - envFrom:
    - configMapRef:
        name: device-config-map
    image: quay.io/jdzon/env-printer:latest
    name: printer
```

Execute following  from a go program:
```go
func main() {
	podmanConnection, err := bindings.NewConnection(context.Background(), "unix://run/podman/podman.sock")
	if err != nil {
		log.Fatal(err)
	}
	options := play.KubeOptions{
		ConfigMaps: &[]string{"/tmp/device-config-map.yaml"},
	}
	_, err = play.Kube(podmanConnection, "/tmp/pod.yaml", &options)
	if err != nil {
		log.Fatal(err)
	}
}
```
Without the fix, error described above would be reported.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
