### PR TITLE
create: do not hardcode imageName to DefaultInfraImage

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
-	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/sysinfo"
 	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/containers"
@@ -110,7 +109,7 @@ func create(cmd *cobra.Command, args []string) error {
 		return errors.Wrapf(err, "unable to process labels")
 	}
 
-	imageName = config.DefaultInfraImage
+	imageName = ""
 	img := imageName
 	if !createOptions.Infra {
 		if cmd.Flag("no-hosts").Changed {


### PR DESCRIPTION
#### What this PR does / why we need it:

create: do not hardcode imageName to DefaultInfraImage otherwise the setting in the containers.conf file is not honored.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

Fixes #12245


#### Special notes for your reviewer:
