### PR TITLE
pod create: read infra image from containers.conf

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
-	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/sysinfo"
 	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/containers"
@@ -48,6 +47,7 @@ var (
 var (
 	createOptions     entities.PodCreateOptions
 	infraOptions      entities.ContainerCreateOptions
+	infraImage        string
 	labels, labelFile []string
 	podIDFile         string
 	replace           bool
@@ -72,7 +72,7 @@ func init() {
 	_ = createCommand.RegisterFlagCompletionFunc(nameFlagName, completion.AutocompleteNone)
 
 	infraImageFlagName := "infra-image"
-	flags.String(infraImageFlagName, containerConfig.Engine.InfraImage, "The image of the infra container to associate with the pod")
+	flags.StringVar(&infraImage, infraImageFlagName, containerConfig.Engine.InfraImage, "The image of the infra container to associate with the pod")
 	_ = createCommand.RegisterFlagCompletionFunc(infraImageFlagName, common.AutocompleteImages)
 
 	podIDFileFlagName := "pod-id-file"
@@ -110,7 +110,7 @@ func create(cmd *cobra.Command, args []string) error {
 		return errors.Wrapf(err, "unable to process labels")
 	}
 
-	imageName = config.DefaultInfraImage
+	imageName = infraImage
 	img := imageName
 	if !createOptions.Infra {
 		if cmd.Flag("no-hosts").Changed {
@@ -147,14 +147,6 @@ func create(cmd *cobra.Command, args []string) error {
 			// Only send content to server side if user changed defaults
 			cmdIn, err := cmd.Flags().GetString("infra-command")
 			infraOptions.Entrypoint = &cmdIn
-			if err != nil {
-				return err
-			}
-		}
-		if cmd.Flag("infra-image").Changed {
-			// Only send content to server side if user changed defaults
-			img, err = cmd.Flags().GetString("infra-image")
-			imageName = img
 			if err != nil {
 				return err
 			}

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -60,6 +60,25 @@ function teardown() {
     run_podman pod rm -f -t 0 $podid
 }
 
+
+@test "podman pod create - custom infra image" {
+    image="i.do/not/exist:image"
+
+    tmpdir=$PODMAN_TMPDIR/pod-test
+    run mkdir -p $tmpdir
+    containersconf=$tmpdir/containers.conf
+    cat >$containersconf <<EOF
+[engine]
+infra_image="$image"
+EOF
+
+    run_podman 125 pod create --infra-image $image
+    is "$output" ".*initializing source docker://$image:.*"
+
+    CONTAINERS_CONF=$containersconf run_podman 125 pod create
+    is "$output" ".*initializing source docker://$image:.*"
+}
+
 function rm_podman_pause_image() {
     run_podman version --format "{{.Server.Version}}-{{.Server.Built}}"
     run_podman rmi -f "localhost/podman-pause:$output"


### PR DESCRIPTION
Fix a bug where pods would be created with the hard-coded default infra
image instead of the custom one from containers.conf.  Add a simple
regression test.

Fixes: #12245
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>