### PR TITLE
Cirrus: Update to Ubuntu 21.10 + Disable F33

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -148,11 +148,11 @@ build_task:
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
               # ID for re-use of build output
               _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-        - env: &priorfedora_envvars
-              DISTRO_NV: ${PRIOR_FEDORA_NAME}
-              VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
-              _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+        # - env: &priorfedora_envvars
+        #       DISTRO_NV: ${PRIOR_FEDORA_NAME}
+        #       VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
+        #       CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
+        #       _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
         - env: &ubuntu_envvars
               DISTRO_NV: ${UBUNTU_NAME}
               VM_IMAGE_NAME: ${UBUNTU_CACHE_IMAGE_NAME}
@@ -402,7 +402,7 @@ unit_test_task:
         - validate
     matrix:
         - env: *stdenvars
-        - env: *priorfedora_envvars
+        #- env: *priorfedora_envvars
         - env: *ubuntu_envvars
         # Special-case: Rootless on latest Fedora (standard) VM
         - name: "Rootless unit on $DISTRO_NV"
@@ -522,11 +522,11 @@ container_integration_test_task:
               _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
               VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-        - env:
-              DISTRO_NV: ${PRIOR_FEDORA_NAME}
-              _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-              VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
+        # - env:
+        #       DISTRO_NV: ${PRIOR_FEDORA_NAME}
+        #       _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+        #       VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
+        #       CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
     gce_instance: *standardvm
     timeout_in: 90m
     env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,10 +26,10 @@ env:
     ####
     FEDORA_NAME: "fedora-34"
     PRIOR_FEDORA_NAME: "fedora-33"
-    UBUNTU_NAME: "ubuntu-2104"
+    UBUNTU_NAME: "ubuntu-2110"
 
     # Google-cloud VM Images
-    IMAGE_SUFFIX: "c6431352024203264"
+    IMAGE_SUFFIX: "c4955591916388352"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"


### PR DESCRIPTION
#### What this PR does / why we need it:

Update the Ubuntu CI environment from 21.04 -> 21.10

#### How to verify it

The Ubuntu-based CI tests will all pass

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Does ***NOT*** update the Fedora images, this is being done separately in https://github.com/containers/podman/pull/11795

Ref: https://github.com/containers/automation_images/pull/100