### PR TITLE
Fix flake in upgrade tests

### DIFF
--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -123,8 +123,15 @@ EOF
     # Clean up vestiges of previous run
     $PODMAN rm -f podman_parent || true
 
-    # Not entirely a NOP! This is just so we get /run/crun created on a CI VM
-    $PODMAN run --rm $OLD_PODMAN true
+
+    local netname=testnet-$(random_string 10)
+    $PODMAN network create $netname
+
+    # Not entirely a NOP! This is just so we get the /run/... mount points created on a CI VM
+    # --mac-address is needed to create /run/cni, --network is needed to create /run/containers for dnsname
+    $PODMAN run --rm --mac-address 78:28:a6:8d:24:8a --network $netname $OLD_PODMAN true
+    $PODMAN network rm -f $netname
+
 
     #
     # Use new-podman to run the above script under old-podman.
@@ -136,7 +143,8 @@ EOF
     #
     # mount /etc/containers/storage.conf to use the same storage settings as on the host
     # mount /dev/shm because the container locks are stored there
-    # mount /var/lib/cni and /etc/cni/net.d for cni networking
+    # mount /var/lib/cni, /run/cni and /etc/cni/net.d for cni networking
+    # mount /run/containers for the dnsname plugin
     #
     $PODMAN run -d --name podman_parent --pid=host \
             --privileged \
@@ -147,6 +155,8 @@ EOF
             -v /dev/fuse:/dev/fuse \
             -v /run/crun:/run/crun \
             -v /run/netns:/run/netns:rshared \
+            -v /run/containers:/run/containers \
+            -v /run/cni:/run/cni \
             -v /var/lib/cni:/var/lib/cni \
             -v /etc/cni/net.d:/etc/cni/net.d \
             -v /dev/shm:/dev/shm \


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

The cni plugins need access to /run/cni and the dnsname plugin needs
access to /run/containers.

The race condition was basically that a `podman stop` could either do the
cleanup itself or the spawned cleanup process would do the cleanup if it
was fast enough. The `podman stop` is executed on the host while the
podman cleanup process is executed in the "parent container". The parent
container contains older plugins than on the host. The dnsname plugin
before version 1.3 could error and this would prevent CNI from
doing a proper cleanup. The plugin errors because it could not find its
files in /run/containers. On my system the test always failed because
the cleanup process was always faster than the stop process. However in
the CI VMs the stop process was usually faster and so it failed only
sometimes.
#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:


Fixes #11558


#### Special notes for your reviewer:
