### PR TITLE
--authfile command line argument for image sign command.

### DIFF
--- a/cmd/podman/images/sign.go
+++ b/cmd/podman/images/sign.go
@@ -3,6 +3,7 @@ package images
 import (
 	"os"
 
+	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/registry"
@@ -48,6 +49,10 @@ func init() {
 	flags.StringVar(&signOptions.CertDir, certDirFlagName, "", "`Pathname` of a directory containing TLS certificates and keys")
 	_ = signCommand.RegisterFlagCompletionFunc(certDirFlagName, completion.AutocompleteDefault)
 	flags.BoolVarP(&signOptions.All, "all", "a", false, "Sign all the manifests of the multi-architecture image")
+
+	authfileFlagName := "authfile"
+	flags.StringVar(&signOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	_ = signCommand.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 }
 
 func sign(cmd *cobra.Command, args []string) error {

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -361,6 +361,7 @@ Man pages for the %{name} commands
 Summary: Tests for %{name}
 
 Requires: %{name} = %{epoch}:%{version}-%{release}
+Requires: gnupg
 Requires: bats
 Requires: jq
 Requires: skopeo

--- a/docs/source/markdown/podman-image-sign.1.md
+++ b/docs/source/markdown/podman-image-sign.1.md
@@ -23,6 +23,13 @@ Print usage statement.
 
 Sign all the manifests of the multi-architecture image (default false).
 
+#### **--authfile**=*path*
+
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json
+
+Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
+environment variable. `export REGISTRY_AUTH_FILE=path`
+
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
@@ -40,6 +47,8 @@ Override the default identity of the signature.
 Sign the busybox image with the identity of foo@bar.com with a user's keyring and save the signature in /tmp/signatures/.
 
    sudo podman image sign --sign-by foo@bar.com --directory /tmp/signatures docker://privateregistry.example.com/foobar
+
+   sudo podman image sign --authfile=/tmp/foobar.json --sign-by foo@bar.com --directory /tmp/signatures docker://privateregistry.example.com/foobar
 
 ## RELATED CONFIGURATION
 

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -373,6 +373,7 @@ type SignOptions struct {
 	Directory string
 	SignBy    string
 	CertDir   string
+	Authfile  string
 	All       bool
 }
 

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -641,6 +641,7 @@ func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entitie
 	}
 	sc := ir.Libpod.SystemContext()
 	sc.DockerCertPath = options.CertDir
+	sc.AuthFilePath = options.Authfile
 
 	for _, signimage := range names {
 		err = func() error {

--- a/test/system/011-image.bats
+++ b/test/system/011-image.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+    skip_if_remote "--sign-by does not work with podman-remote"
+
+    basic_setup
+
+    export _GNUPGHOME_TMP=$PODMAN_TMPDIR/.gnupg
+    mkdir --mode=0700 $_GNUPGHOME_TMP $PODMAN_TMPDIR/signatures
+
+    cat >$PODMAN_TMPDIR/keydetails <<EOF
+    %echo Generating a basic OpenPGP key
+    Key-Type: RSA
+    Key-Length: 2048
+    Subkey-Type: RSA
+    Subkey-Length: 2048
+    Name-Real: Foo
+    Name-Comment: Foo
+    Name-Email: foo@bar.com
+    Expire-Date: 0
+    %no-ask-passphrase
+    %no-protection
+    # Do a commit here, so that we can later print "done" :-)
+    %commit
+    %echo done
+EOF
+    GNUPGHOME=$_GNUPGHOME_TMP gpg --verbose --batch --gen-key $PODMAN_TMPDIR/keydetails
+}
+
+function check_signature() {
+    local sigfile=$1
+    ls -laR $PODMAN_TMPDIR/signatures
+    run_podman inspect --format '{{.Digest}}' $PODMAN_TEST_IMAGE_FQN
+    local repodigest=${output/:/=}
+
+    local dir="$PODMAN_TMPDIR/signatures/libpod/${PODMAN_TEST_IMAGE_NAME}@${repodigest}"
+    test -d $dir || die "Missing signature directory $dir"
+    test -e "$dir/$sigfile" || die "Missing signature file '$sigfile'"
+
+    # Confirm good signature
+    run env GNUPGHOME=$_GNUPGHOME_TMP gpg --verify "$dir/$sigfile"
+    is "$output" ".*Good signature from .Foo.*<foo@bar.com>" \
+       "gpg --verify $sigfile"
+}
+
+
+@test "podman image - sign with no sigfile" {
+    GNUPGHOME=$_GNUPGHOME_TMP run_podman image sign --sign-by foo@bar.com --directory $PODMAN_TMPDIR/signatures  "docker://$PODMAN_TEST_IMAGE_FQN"
+    check_signature "signature-1"
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
Adds the --authfile command line argument to allow users to set the location of the auth file to use.

Replaces: https://github.com/containers/podman/pull/10975
Fixes: https://github.com/containers/podman/issues/10866

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
