### PR TITLE
Fix network mode in play kube

### DIFF
--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/podman/v3/libpod"
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/containers/podman/v3/pkg/rootless"
 	"github.com/containers/podman/v3/pkg/specgen"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -216,15 +215,6 @@ func MapSpec(p *specgen.PodSpecGenerator) (*specgen.SpecGenerator, error) {
 			logrus.Debugf("No networking because the infra container is missing")
 			break
 		}
-		if rootless.IsRootless() {
-			logrus.Debugf("Pod will use slirp4netns")
-			if p.InfraContainerSpec.NetNS.NSMode != "host" {
-				p.InfraContainerSpec.NetworkOptions = p.NetworkOptions
-				p.InfraContainerSpec.NetNS.NSMode = specgen.NamespaceMode("slirp4netns")
-			}
-		} else {
-			logrus.Debugf("Pod using bridge network mode")
-		}
 	case specgen.Bridge:
 		p.InfraContainerSpec.NetNS.NSMode = specgen.Bridge
 		logrus.Debugf("Pod using bridge network mode")
@@ -258,7 +248,6 @@ func MapSpec(p *specgen.PodSpecGenerator) (*specgen.SpecGenerator, error) {
 		return nil, errors.Errorf("pods presently do not support network mode %s", p.NetNS.NSMode)
 	}
 
-	libpod.WithPodCgroups()
 	if len(p.InfraCommand) > 0 {
 		p.InfraContainerSpec.Entrypoint = p.InfraCommand
 	}

--- a/test/e2e/config/containers-netns2.conf
+++ b/test/e2e/config/containers-netns2.conf
@@ -1,0 +1,3 @@
+[containers]
+
+netns = "bridge"

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2786,6 +2786,34 @@ invalid kube kind
 		Expect(exists).To(Exit(0))
 	})
 
+	It("podman play kube use network mode from config", func() {
+		confPath, err := filepath.Abs("config/containers-netns2.conf")
+		Expect(err).ToNot(HaveOccurred())
+		os.Setenv("CONTAINERS_CONF", confPath)
+		defer os.Unsetenv("CONTAINERS_CONF")
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+		}
+
+		pod := getPod()
+		err = generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).To(BeNil())
+
+		kube := podmanTest.Podman([]string{"play", "kube", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(Exit(0))
+
+		podInspect := podmanTest.Podman([]string{"pod", "inspect", pod.Name, "--format", "{{.InfraContainerID}}"})
+		podInspect.WaitWithDefaultTimeout()
+		Expect(podInspect).To(Exit(0))
+		infraID := podInspect.OutputToString()
+
+		inspect := podmanTest.Podman([]string{"inspect", "--format", "{{.HostConfig.NetworkMode}}", infraID})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).To(Exit(0))
+		Expect(inspect.OutputToString()).To(Equal("bridge"))
+	})
+
 	It("podman play kube replace", func() {
 		pod := getPod()
 		err := generateKubeYaml("pod", pod, kubeYaml)


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

We need to use the config network mode when no network mode was set. To
do so we have to keep the nsmode empty, MakeContainer() will use the
correct network mode from the config when needed.
#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

Fixes #12248

#### Special notes for your reviewer:
