### PR TITLE
Always create working directory when using compat API

### DIFF
--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -86,6 +86,8 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "fill out specgen"))
 		return
 	}
+	// moby always create the working directory
+	sg.CreateWorkingDir = true
 
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.ContainerCreate(r.Context(), sg)

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -378,6 +378,9 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 	if s.WorkDir == "" {
 		s.WorkDir = "/"
 	}
+	if s.CreateWorkingDir {
+		options = append(options, libpod.WithCreateWorkingDir())
+	}
 	if s.StopSignal != nil {
 		options = append(options, libpod.WithStopSignal(*s.StopSignal))
 	}

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -272,6 +272,10 @@ type ContainerStorageConfig struct {
 	// If unset, the default, /, will be used.
 	// Optional.
 	WorkDir string `json:"work_dir,omitempty"`
+	// Create the working directory if it doesn't exist.
+	// If unset, it doesn't create it.
+	// Optional.
+	CreateWorkingDir bool `json:"create_working_dir,omitempty"`
 	// StorageOpts is the container's storage options
 	// Optional.
 	StorageOpts map[string]string `json:"storage_opts,omitempty"`


### PR DESCRIPTION
Docker/Moby always create the working directory, and some tools
rely on that behavior (example, woodpecker/drone).

Fixes #11842


#### What this PR does / why we need it:

Because it fix a bug that made me very sad, as I would not be able to use podman instead of docker.

#### How to verify it

The original bug report has the API calls that trigger the bug.
Or it can be verified by deploying woodpecker with podman serving as the backend, and try to trigger a CI job.
(I have such setup, and verified the patch).

To trigger, you have to start a container with a named volume, and the workind directory being a subdir on that volume. Eg, having workdir set to /scratch/project, and /scratch being a volume created before. 

#### Which issue(s) this PR fixes:

Fixes #11842

#### Special notes for your reviewer:

