### PR TITLE
play kube: don't force-pull infra image

### DIFF
--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -76,6 +76,12 @@ RELABEL="system_u:object_r:container_file_t:s0"
        is "$output" "${RELABEL} $TESTDIR" "selinux relabel should have happened"
     fi
 
+    # Make sure that the K8s pause image isn't pulled but the local podman-pause is built.
+    run_podman images
+    run_podman 1 image exists k8s.gcr.io/pause
+    run_podman version --format "{{.Server.Version}}-{{.Server.Built}}"
+    run_podman image exists localhost/podman-pause:$output
+
     run_podman stop -a -t 0
     run_podman pod rm -t 0 -f test_pod
 }


### PR DESCRIPTION
Do not force-pull the infra image in `play kube` but let the backend
take care of that when creating the pod(s) which may build a local
`podman-pause` image instead of using the default infra image.

Fixes: #12254
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>