### PR TITLE
fix remote checkpoint/restore

### DIFF
--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/podman/v3/cmd/podman/validate"
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/containers/podman/v3/pkg/rootless"
-	"github.com/containers/podman/v3/pkg/specgenutil"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -120,12 +119,7 @@ func restore(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if len(inputPorts) > 0 {
-		restoreOptions.PublishPorts, err = specgenutil.CreatePortBindings(inputPorts)
-		if err != nil {
-			return err
-		}
-	}
+	restoreOptions.PublishPorts = inputPorts
 
 	argLen := len(args)
 	if restoreOptions.Import != "" {

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -1,9 +1,11 @@
 package libpod
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/containers/podman/v3/libpod"
 	"github.com/containers/podman/v3/libpod/define"
@@ -206,7 +208,9 @@ func ShowMountedContainers(w http.ResponseWriter, r *http.Request) {
 }
 
 func Checkpoint(w http.ResponseWriter, r *http.Request) {
-	var targetFile string
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	containerEngine := abi.ContainerEngine{Libpod: runtime}
+
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := struct {
 		Keep           bool `schema:"keep"`
@@ -224,66 +228,68 @@ func Checkpoint(w http.ResponseWriter, r *http.Request) {
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
+
 	name := utils.GetName(r)
-	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
-	ctr, err := runtime.LookupContainer(name)
-	if err != nil {
+	if _, err := runtime.LookupContainer(name); err != nil {
 		utils.ContainerNotFound(w, name, err)
 		return
 	}
+	names := []string{name}
+
+	options := entities.CheckpointOptions{
+		Keep:           query.Keep,
+		LeaveRunning:   query.LeaveRunning,
+		TCPEstablished: query.TCPEstablished,
+		IgnoreRootFS:   query.IgnoreRootFS,
+		PrintStats:     query.PrintStats,
+	}
+
 	if query.Export {
-		tmpFile, err := ioutil.TempFile("", "checkpoint")
+		f, err := ioutil.TempFile("", "checkpoint")
 		if err != nil {
 			utils.InternalServerError(w, err)
 			return
 		}
-		defer os.Remove(tmpFile.Name())
-		if err := tmpFile.Close(); err != nil {
+		defer os.Remove(f.Name())
+		if err := f.Close(); err != nil {
 			utils.InternalServerError(w, err)
 			return
 		}
-		targetFile = tmpFile.Name()
+		options.Export = f.Name()
 	}
-	options := libpod.ContainerCheckpointOptions{
-		Keep:           query.Keep,
-		KeepRunning:    query.LeaveRunning,
-		TCPEstablished: query.TCPEstablished,
-		IgnoreRootfs:   query.IgnoreRootFS,
-		PrintStats:     query.PrintStats,
-	}
-	if query.Export {
-		options.TargetFile = targetFile
-	}
-	criuStatistics, runtimeCheckpointDuration, err := ctr.Checkpoint(r.Context(), options)
+
+	reports, err := containerEngine.ContainerCheckpoint(r.Context(), names, options)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
 	}
-	if query.Export {
-		f, err := os.Open(targetFile)
-		if err != nil {
-			utils.InternalServerError(w, err)
+
+	if !query.Export {
+		if len(reports) != 1 {
+			utils.InternalServerError(w, fmt.Errorf("expected 1 restore report but got %d", len(reports)))
 			return
 		}
-		defer f.Close()
-		utils.WriteResponse(w, http.StatusOK, f)
+		if reports[0].Err != nil {
+			utils.InternalServerError(w, reports[0].Err)
+			return
+		}
+		utils.WriteResponse(w, http.StatusOK, reports[0])
 		return
 	}
-	utils.WriteResponse(
-		w,
-		http.StatusOK,
-		entities.CheckpointReport{
-			Id:              ctr.ID(),
-			RuntimeDuration: runtimeCheckpointDuration,
-			CRIUStatistics:  criuStatistics,
-		},
-	)
+
+	f, err := os.Open(options.Export)
+	if err != nil {
+		utils.InternalServerError(w, err)
+		return
+	}
+	defer f.Close()
+	utils.WriteResponse(w, http.StatusOK, f)
 }
 
 func Restore(w http.ResponseWriter, r *http.Request) {
-	var (
-		targetFile string
-	)
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	containerEngine := abi.ContainerEngine{Libpod: runtime}
+
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := struct {
 		Keep            bool   `schema:"keep"`
@@ -295,6 +301,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 		IgnoreStaticIP  bool   `schema:"ignoreStaticIP"`
 		IgnoreStaticMAC bool   `schema:"ignoreStaticMAC"`
 		PrintStats      bool   `schema:"printStats"`
+		PublishPorts    string `schema:"publishPorts"`
 	}{
 		// override any golang type defaults
 	}
@@ -303,53 +310,55 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
-	name := utils.GetName(r)
-	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
-	ctr, err := runtime.LookupContainer(name)
-	if err != nil {
-		utils.ContainerNotFound(w, name, err)
-		return
+
+	options := entities.RestoreOptions{
+		Name:            query.Name,
+		Keep:            query.Keep,
+		TCPEstablished:  query.TCPEstablished,
+		IgnoreRootFS:    query.IgnoreRootFS,
+		IgnoreVolumes:   query.IgnoreVolumes,
+		IgnoreStaticIP:  query.IgnoreStaticIP,
+		IgnoreStaticMAC: query.IgnoreStaticMAC,
+		PrintStats:      query.PrintStats,
+		PublishPorts:    strings.Fields(query.PublishPorts),
 	}
+
+	var names []string
 	if query.Import {
 		t, err := ioutil.TempFile("", "restore")
 		if err != nil {
 			utils.InternalServerError(w, err)
 			return
 		}
-		defer t.Close()
+		defer os.Remove(t.Name())
 		if err := compat.SaveFromBody(t, r); err != nil {
 			utils.InternalServerError(w, err)
 			return
 		}
-		targetFile = t.Name()
+		options.Import = t.Name()
+	} else {
+		name := utils.GetName(r)
+		if _, err := runtime.LookupContainer(name); err != nil {
+			utils.ContainerNotFound(w, name, err)
+			return
+		}
+		names = []string{name}
 	}
 
-	options := libpod.ContainerCheckpointOptions{
-		Keep:            query.Keep,
-		TCPEstablished:  query.TCPEstablished,
-		IgnoreRootfs:    query.IgnoreRootFS,
-		IgnoreStaticIP:  query.IgnoreStaticIP,
-		IgnoreStaticMAC: query.IgnoreStaticMAC,
-		PrintStats:      query.PrintStats,
-	}
-	if query.Import {
-		options.TargetFile = targetFile
-		options.Name = query.Name
-	}
-	criuStatistics, runtimeRestoreDuration, err := ctr.Restore(r.Context(), options)
+	reports, err := containerEngine.ContainerRestore(r.Context(), names, options)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
 	}
-	utils.WriteResponse(
-		w,
-		http.StatusOK,
-		entities.RestoreReport{
-			Id:              ctr.ID(),
-			RuntimeDuration: runtimeRestoreDuration,
-			CRIUStatistics:  criuStatistics,
-		},
-	)
+	if len(reports) != 1 {
+		utils.InternalServerError(w, fmt.Errorf("expected 1 restore report but got %d", len(reports)))
+		return
+	}
+	if reports[0].Err != nil {
+		utils.InternalServerError(w, reports[0].Err)
+		return
+	}
+	utils.WriteResponse(w, http.StatusOK, reports[0])
 }
 
 func InitContainer(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -50,12 +50,14 @@ type CheckpointOptions struct {
 	Keep           *bool
 	LeaveRunning   *bool
 	TCPEstablished *bool
+	PrintStats     *bool
 }
 
 //go:generate go run ../generator/generator.go RestoreOptions
 // RestoreOptions are optional options for restoring containers
 type RestoreOptions struct {
 	IgnoreRootfs    *bool
+	IgnoreVolumes   *bool
 	IgnoreStaticIP  *bool
 	IgnoreStaticMAC *bool
 	ImportAchive    *string
@@ -63,6 +65,8 @@ type RestoreOptions struct {
 	Name            *string
 	TCPEstablished  *bool
 	Pod             *string
+	PrintStats      *bool
+	PublishPorts    []string
 }
 
 //go:generate go run ../generator/generator.go CreateOptions
@@ -86,7 +90,8 @@ type ExecInspectOptions struct{}
 //go:generate go run ../generator/generator.go ExecStartOptions
 // ExecStartOptions are optional options for starting
 // exec sessions
-type ExecStartOptions struct{}
+type ExecStartOptions struct {
+}
 
 //go:generate go run ../generator/generator.go HealthCheckOptions
 // HealthCheckOptions are optional options for checking

--- a/pkg/bindings/containers/types_checkpoint_options.go
+++ b/pkg/bindings/containers/types_checkpoint_options.go
@@ -91,3 +91,18 @@ func (o *CheckpointOptions) GetTCPEstablished() bool {
 	}
 	return *o.TCPEstablished
 }
+
+// WithPrintStats set field PrintStats to given value
+func (o *CheckpointOptions) WithPrintStats(value bool) *CheckpointOptions {
+	o.PrintStats = &value
+	return o
+}
+
+// GetPrintStats returns value of field PrintStats
+func (o *CheckpointOptions) GetPrintStats() bool {
+	if o.PrintStats == nil {
+		var z bool
+		return z
+	}
+	return *o.PrintStats
+}

--- a/pkg/bindings/containers/types_restore_options.go
+++ b/pkg/bindings/containers/types_restore_options.go
@@ -32,6 +32,21 @@ func (o *RestoreOptions) GetIgnoreRootfs() bool {
 	return *o.IgnoreRootfs
 }
 
+// WithIgnoreVolumes set field IgnoreVolumes to given value
+func (o *RestoreOptions) WithIgnoreVolumes(value bool) *RestoreOptions {
+	o.IgnoreVolumes = &value
+	return o
+}
+
+// GetIgnoreVolumes returns value of field IgnoreVolumes
+func (o *RestoreOptions) GetIgnoreVolumes() bool {
+	if o.IgnoreVolumes == nil {
+		var z bool
+		return z
+	}
+	return *o.IgnoreVolumes
+}
+
 // WithIgnoreStaticIP set field IgnoreStaticIP to given value
 func (o *RestoreOptions) WithIgnoreStaticIP(value bool) *RestoreOptions {
 	o.IgnoreStaticIP = &value
@@ -135,4 +150,34 @@ func (o *RestoreOptions) GetPod() string {
 		return z
 	}
 	return *o.Pod
+}
+
+// WithPrintStats set field PrintStats to given value
+func (o *RestoreOptions) WithPrintStats(value bool) *RestoreOptions {
+	o.PrintStats = &value
+	return o
+}
+
+// GetPrintStats returns value of field PrintStats
+func (o *RestoreOptions) GetPrintStats() bool {
+	if o.PrintStats == nil {
+		var z bool
+		return z
+	}
+	return *o.PrintStats
+}
+
+// WithPublishPorts set field PublishPorts to given value
+func (o *RestoreOptions) WithPublishPorts(value []string) *RestoreOptions {
+	o.PublishPorts = value
+	return o
+}
+
+// GetPublishPorts returns value of field PublishPorts
+func (o *RestoreOptions) GetPublishPorts() []string {
+	if o.PublishPorts == nil {
+		var z []string
+		return z
+	}
+	return o.PublishPorts
 }

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/podman/v3/pkg/domain/entities"
 	"github.com/containers/podman/v3/pkg/errorhandling"
 	"github.com/containers/podman/v3/pkg/specgen/generate"
+	"github.com/containers/podman/v3/pkg/specgenutil"
 	"github.com/containers/storage/pkg/archive"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -195,7 +196,12 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 	}
 
 	if len(restoreOptions.PublishPorts) > 0 {
-		ports, err := generate.ParsePortMapping(restoreOptions.PublishPorts, nil)
+		pubPorts, err := specgenutil.CreatePortBindings(restoreOptions.PublishPorts)
+		if err != nil {
+			return nil, err
+		}
+
+		ports, err := generate.ParsePortMapping(pubPorts, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -212,7 +212,7 @@ type RestoreOptions struct {
 	Name            string
 	TCPEstablished  bool
 	ImportPrevious  string
-	PublishPorts    []nettypes.PortMapping
+	PublishPorts    []string
 	Pod             string
 	PrintStats      bool
 }


### PR DESCRIPTION
Nothing was working before, and it's too much to summarize.  To make
sure we're not regressing in the future again, enable the remote e2e
tests.

Fixes: #12007
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>