### PR TITLE
podman machine improve port forwarding

### DIFF
--- a/libpod/network/cni/cni_conversion.go
+++ b/libpod/network/cni/cni_conversion.go
@@ -295,10 +295,6 @@ func (n *cniNetwork) createCNIConfigListFromNetwork(network *types.Network, writ
 			// Note: in the future we might like to allow for dynamic domain names
 			plugins = append(plugins, newDNSNamePlugin(defaultPodmanDomainName))
 		}
-		// Add the podman-machine CNI plugin if we are in a machine
-		if n.isMachine {
-			plugins = append(plugins, newPodmanMachinePlugin())
-		}
 
 	case types.MacVLANNetworkDriver:
 		plugins = append(plugins, newVLANPlugin(types.MacVLANNetworkDriver, network.NetworkInterface, vlanPluginMode, mtu, ipamConf))
@@ -368,4 +364,15 @@ func convertSpecgenPortsToCNIPorts(ports []types.PortMapping) ([]cniPortMapEntry
 		}
 	}
 	return cniPorts, nil
+}
+
+func removeMachinePlugin(conf *libcni.NetworkConfigList) *libcni.NetworkConfigList {
+	plugins := make([]*libcni.NetworkConfig, 0, len(conf.Plugins))
+	for _, net := range conf.Plugins {
+		if net.Network.Type != "podman-machine" {
+			plugins = append(plugins, net)
+		}
+	}
+	conf.Plugins = plugins
+	return conf
 }

--- a/libpod/network/cni/cni_types.go
+++ b/libpod/network/cni/cni_types.go
@@ -110,12 +110,6 @@ type dnsNameConfig struct {
 	Capabilities map[string]bool `json:"capabilities"`
 }
 
-//  podmanMachineConfig enables port handling on the host OS
-type podmanMachineConfig struct {
-	PluginType   string          `json:"type"`
-	Capabilities map[string]bool `json:"capabilities"`
-}
-
 // ncList describes a generic map
 type ncList map[string]interface{}
 
@@ -284,13 +278,4 @@ func newVLANPlugin(pluginType, device, mode string, mtu int, ipam ipamConfig) VL
 		m.Capabilities = caps
 	}
 	return m
-}
-
-func newPodmanMachinePlugin() podmanMachineConfig {
-	caps := make(map[string]bool, 1)
-	caps["portMappings"] = true
-	return podmanMachineConfig{
-		PluginType:   "podman-machine",
-		Capabilities: caps,
-	}
 }

--- a/libpod/network/cni/config_test.go
+++ b/libpod/network/cni/config_test.go
@@ -965,19 +965,6 @@ var _ = Describe("Config", func() {
 			Expect(logString).To(ContainSubstring("dnsname and internal networks are incompatible"))
 		})
 
-		It("create config with podman machine plugin", func() {
-			libpodNet, err := getNetworkInterface(cniConfDir, true)
-			Expect(err).To(BeNil())
-
-			network := types.Network{}
-			network1, err := libpodNet.NetworkCreate(network)
-			Expect(err).To(BeNil())
-			Expect(network1.Driver).To(Equal("bridge"))
-			path := filepath.Join(cniConfDir, network1.Name+".conflist")
-			Expect(path).To(BeARegularFile())
-			grepInFile(path, `"type": "podman-machine",`)
-		})
-
 		It("network inspect partial ID", func() {
 			network := types.Network{Name: "net4"}
 			network1, err := libpodNet.NetworkCreate(network)

--- a/libpod/network/cni/network.go
+++ b/libpod/network/cni/network.go
@@ -150,6 +150,13 @@ func (n *cniNetwork) loadNetworks() error {
 			continue
 		}
 
+		// podman < v4.0 used the podman-machine cni plugin for podman machine port forwarding
+		// since this is now build into podman we no longer use the plugin
+		// old configs may still contain it so we just remove it here
+		if n.isMachine {
+			conf = removeMachinePlugin(conf)
+		}
+
 		if _, err := n.cniConf.ValidateNetworkList(context.Background(), conf); err != nil {
 			logrus.Warnf("Error validating CNI config file %s: %v", file, err)
 			continue

--- a/libpod/networking_machine.go
+++ b/libpod/networking_machine.go
@@ -1,0 +1,121 @@
+package libpod
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/containers/podman/v3/libpod/network/types"
+	"github.com/sirupsen/logrus"
+)
+
+const machineGvproxyEndpoint = "gateway.containers.internal"
+
+// machineExpose is the struct for the gvproxy port forwarding api send via json
+type machineExpose struct {
+	// Local is the local address on the vm host, format is ip:port
+	Local string `json:"local"`
+	// Remote is used to specify the vm ip:port
+	Remote string `json:"remote,omitempty"`
+	// Protocol to forward, tcp or udp
+	Protocol string `json:"protocol"`
+}
+
+func requestMachinePorts(expose bool, ports []types.PortMapping) error {
+	url := "http://" + machineGvproxyEndpoint + "/services/forwarder/"
+	if expose {
+		url = url + "expose"
+	} else {
+		url = url + "unexpose"
+	}
+	ctx := context.Background()
+	client := &http.Client{}
+	buf := new(bytes.Buffer)
+	for num, port := range ports {
+		protocols := strings.Split(port.Protocol, ",")
+		for _, protocol := range protocols {
+			for i := uint16(0); i < port.Range; i++ {
+				machinePort := machineExpose{
+					Local:    net.JoinHostPort(port.HostIP, strconv.FormatInt(int64(port.HostPort+i), 10)),
+					Protocol: protocol,
+				}
+				if expose {
+					// only set the remote port the ip will be automatically be set by gvproxy
+					machinePort.Remote = ":" + strconv.FormatInt(int64(port.HostPort+i), 10)
+				}
+
+				// post request
+				if err := json.NewEncoder(buf).Encode(machinePort); err != nil {
+					if expose {
+						// in case of an error make sure to unexpose the other ports
+						if cerr := requestMachinePorts(false, ports[:num]); cerr != nil {
+							logrus.Errorf("failed to free gvproxy machine ports: %v", cerr)
+						}
+					}
+					return err
+				}
+				if err := makeMachineRequest(ctx, client, url, buf); err != nil {
+					if expose {
+						// in case of an error make sure to unexpose the other ports
+						if cerr := requestMachinePorts(false, ports[:num]); cerr != nil {
+							logrus.Errorf("failed to free gvproxy machine ports: %v", cerr)
+						}
+					}
+					return err
+				}
+				buf.Reset()
+			}
+		}
+	}
+	return nil
+}
+
+func makeMachineRequest(ctx context.Context, client *http.Client, url string, buf io.Reader) error {
+	//var buf io.ReadWriter
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return annotateGvproxyResponseError(resp.Body)
+	}
+	return nil
+}
+
+func annotateGvproxyResponseError(r io.Reader) error {
+	b, err := ioutil.ReadAll(r)
+	if err == nil && len(b) > 0 {
+		return fmt.Errorf("something went wrong with the request: %q", string(b))
+	}
+	return errors.New("something went wrong with the request, could not read response")
+}
+
+// exposeMachinePorts exposes the ports for podman machine via gvproxy
+func (r *Runtime) exposeMachinePorts(ports []types.PortMapping) error {
+	if !r.config.Engine.MachineEnabled {
+		return nil
+	}
+	return requestMachinePorts(true, ports)
+}
+
+// unexposeMachinePorts closes the ports for podman machine via gvproxy
+func (r *Runtime) unexposeMachinePorts(ports []types.PortMapping) error {
+	if !r.config.Engine.MachineEnabled {
+		return nil
+	}
+	return requestMachinePorts(false, ports)
+}

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -509,7 +509,7 @@ func (r *Runtime) setupRootlessPortMappingViaRLK(ctr *Container, netnsPath strin
 
 	childIP := getRootlessPortChildIP(ctr, netStatus)
 	cfg := rootlessport.Config{
-		Mappings:    ctr.config.PortMappings,
+		Mappings:    ctr.convertPortMappings(),
 		NetNSPath:   netnsPath,
 		ExitFD:      3,
 		ReadyFD:     4,
@@ -594,7 +594,7 @@ func (r *Runtime) setupRootlessPortMappingViaSlirp(ctr *Container, cmd *exec.Cmd
 
 	// for each port we want to add we need to open a connection to the slirp4netns control socket
 	// and send the add_hostfwd command.
-	for _, i := range ctr.config.PortMappings {
+	for _, i := range ctr.convertPortMappings() {
 		conn, err := net.Dial("unix", apiSocket)
 		if err != nil {
 			return errors.Wrapf(err, "cannot open connection to %s", apiSocket)

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -664,9 +664,6 @@ func (v *MachineVM) startHostNetworking() error {
 		return err
 	}
 
-	// Listen on all at port 7777 for setting up and tearing
-	// down forwarding
-	listenSocket := "tcp://0.0.0.0:7777"
 	qemuSocket, pidFile, err := v.getSocketandPid()
 	if err != nil {
 		return err
@@ -676,7 +673,7 @@ func (v *MachineVM) startHostNetworking() error {
 	files := []*os.File{os.Stdin, os.Stdout, os.Stderr}
 	attr.Files = files
 	cmd := []string{binary}
-	cmd = append(cmd, []string{"-listen", listenSocket, "-listen-qemu", fmt.Sprintf("unix://%s", qemuSocket), "-pid-file", pidFile}...)
+	cmd = append(cmd, []string{"-listen-qemu", fmt.Sprintf("unix://%s", qemuSocket), "-pid-file", pidFile}...)
 	// Add the ssh port
 	cmd = append(cmd, []string{"-ssh-port", fmt.Sprintf("%d", v.Port)}...)
 	if logrus.GetLevel() == logrus.DebugLevel {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

This commits adds port forwarding logic directly into podman. The
podman-machine cni plugin is no longer needed.

The following new features are supported:
 - works with cni, netavark and slirp4netns
 - ports can use the hostIP to bind instead of hard coding 0.0.0.0
 - gvproxy no longer listens on 0.0.0.0:7777 (requires a new gvproxy
   version), the API is only reachable from within the VM via `gateway.containers.internal`
 - support the udp protocol

With this we no longer need podman-machine-cni and should remove it from
the packaging. There is also a change to make sure we are backwards
compatible with old config which include this plugin.

#### How to verify it

We have no podman machine test at the moment.
Please test this manually on your system.
Make sure to copy the new podman and rootlessport binary into the vm
because the server needs the fix. Also make sure your gvproxy is new enough.

#### Which issue(s) this PR fixes:

Fixes #11528
Fixes #11728

#### Special notes for your reviewer:
