### PR TITLE
secret: honor custom `target=` for secrets with `type=mount` for ctr.

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -259,6 +259,8 @@ type ContainerSecret struct {
 	GID uint32
 	// Mode is the mode of the secret file
 	Mode uint32
+	// Secret target inside container
+	Target string
 }
 
 // ContainerNetworkDescriptions describes the relationship between the CNI

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1833,8 +1833,17 @@ rootless=%d
 			return errors.Wrapf(err, "error creating secrets mount")
 		}
 		for _, secret := range c.Secrets() {
+			secretFileName := secret.Name
+			base := "/run/secrets"
+			if secret.Target != "" {
+				secretFileName = secret.Target
+				//If absolute path for target given remove base.
+				if filepath.IsAbs(secretFileName) {
+					base = ""
+				}
+			}
 			src := filepath.Join(c.config.SecretsPath, secret.Name)
-			dest := filepath.Join("/run/secrets", secret.Name)
+			dest := filepath.Join(base, secretFileName)
 			c.state.BindMounts[dest] = src
 		}
 	}

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -474,6 +474,7 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 				UID:    s.UID,
 				GID:    s.GID,
 				Mode:   s.Mode,
+				Target: s.Target,
 			})
 		}
 		options = append(options, libpod.WithSecrets(secrs))

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -540,6 +540,7 @@ func (s *SpecGenerator) GetImage() (*libimage.Image, string) {
 
 type Secret struct {
 	Source string
+	Target string
 	UID    uint32
 	GID    uint32
 	Mode   uint32

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -874,6 +874,7 @@ func parseSecrets(secrets []string) ([]specgen.Secret, map[string]string, error)
 		if len(split) == 1 {
 			mountSecret := specgen.Secret{
 				Source: val,
+				Target: target,
 				UID:    uid,
 				GID:    gid,
 				Mode:   mode,
@@ -939,11 +940,9 @@ func parseSecrets(secrets []string) ([]specgen.Secret, map[string]string, error)
 			return nil, nil, errors.Wrapf(secretParseError, "no source found %s", val)
 		}
 		if secretType == "mount" {
-			if target != "" {
-				return nil, nil, errors.Wrapf(secretParseError, "target option is invalid for mounted secrets")
-			}
 			mountSecret := specgen.Secret{
 				Source: source,
+				Target: target,
 				UID:    uid,
 				GID:    gid,
 				Mode:   mode,

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1723,6 +1723,50 @@ WORKDIR /madethis`, BB)
 
 	})
 
+	It("podman run --secret source=mysecret,type=mount with target", func() {
+		secretsString := "somesecretdata"
+		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
+		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		Expect(err).To(BeNil())
+
+		session := podmanTest.Podman([]string{"secret", "create", "mysecret_target", secretFilePath})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"run", "--secret", "source=mysecret_target,type=mount,target=hello", "--name", "secr_target", ALPINE, "cat", "/run/secrets/hello"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(Equal(secretsString))
+
+		session = podmanTest.Podman([]string{"inspect", "secr_target", "--format", " {{(index .Config.Secrets 0).Name}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("mysecret_target"))
+
+	})
+
+	It("podman run --secret source=mysecret,type=mount with target at /tmp", func() {
+		secretsString := "somesecretdata"
+		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
+		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		Expect(err).To(BeNil())
+
+		session := podmanTest.Podman([]string{"secret", "create", "mysecret_target2", secretFilePath})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"run", "--secret", "source=mysecret_target2,type=mount,target=/tmp/hello", "--name", "secr_target2", ALPINE, "cat", "/tmp/hello"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(Equal(secretsString))
+
+		session = podmanTest.Podman([]string{"inspect", "secr_target2", "--format", " {{(index .Config.Secrets 0).Name}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("mysecret_target2"))
+
+	})
+
 	It("podman run --secret source=mysecret,type=env", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
@@ -1748,10 +1792,6 @@ WORKDIR /madethis`, BB)
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		// target with mount type should fail
-		session = podmanTest.Podman([]string{"run", "--secret", "source=mysecret,type=mount,target=anotherplace", "--name", "secr", ALPINE, "cat", "/run/secrets/mysecret"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"run", "--secret", "source=mysecret,type=env,target=anotherplace", "--name", "secr", ALPINE, "printenv", "anotherplace"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Honor custom `target` if specified while running or creating containers
with secret `type=mount`.

Example:
`podman run -it --secret token,type=mount,target=TOKEN ubi8/ubi:latest
bash`

Closes: https://github.com/containers/podman/issues/12287