### PR TITLE
filters: add basic pattern matching for label keys i.e `--filter label=<pattern>`

### DIFF
--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -45,6 +45,17 @@ var _ = Describe("Podman volume ls", func() {
 		Expect(len(session.OutputToStringArray())).To(Equal(2))
 	})
 
+	It("podman ls volume filter with a key pattern", func() {
+		session := podmanTest.Podman([]string{"volume", "create", "--label", "helloworld=world", "myvol2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "label=hello*"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(2))
+	})
+
 	It("podman ls volume with JSON format", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Following PR adds basic pattern matching to filter by labels for `keys`.
Adds support for use-cases like `--filter label=some.prefix.com/key/*`
where end-users want to match a pattern for keys as compared to exact
value.

Closes: https://github.com/containers/podman/issues/12199