### PR TITLE
Network test: fix podman-remote-rootless corner case

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -172,7 +172,7 @@ load helpers
 
     # FIXME: debugging for #11871
     run_podman exec $cid cat /etc/resolv.conf
-    if is_rootless; then
+    if is_rootless && ! is_remote; then
         run_podman unshare --rootless-cni cat /etc/resolv.conf
     fi
     ps uxww


### PR DESCRIPTION
Followup to #12229, in which I added a podman unshare for
flake debugging. Turns out that doesn't work in podman-remote.
It was not caught because CI doesn't run podman-remote rootless.

Signed-off-by: Ed Santiago <santiago@redhat.com>
