### PR TITLE
volumes: add new option idmap

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -606,7 +606,9 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      · ro, readonly: true or false (default).
 
-        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
+	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
 
        Options specific to image:
 
@@ -622,7 +624,9 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      . relabel: shared, private.
 
-        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
+
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
 
        Options specific to tmpfs:
 
@@ -636,7 +640,7 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      · notmpcopyup: Disable copying files from the image to the tmpfs.
 
-        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
 
        Options specific to devpts:
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -633,7 +633,9 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      · ro, readonly: true or false (default).
 
-        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
+	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
 
        Options specific to image:
 
@@ -649,7 +651,9 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      . relabel: shared, private.
 
-        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
+
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
 
        Options specific to tmpfs:
 
@@ -663,7 +667,7 @@ Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and
 
 	      · notmpcopyup: Disable copying files from the image to the tmpfs.
 
-        . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
 
        Options specific to devpts:
 

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -355,6 +355,8 @@ func getBindMount(args []string) (spec.Mount, error) {
 				newMount.Options = append(newMount.Options, "U")
 			}
 			setOwnership = true
+		case "idmap":
+			newMount.Options = append(newMount.Options, "idmap")
 		case "consistency":
 			// Often used on MACs and mistakenly on Linux platforms.
 			// Since Docker ignores this option so shall we.

--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -33,6 +33,7 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 		// Some options have parameters - size, mode
 		splitOpt := strings.SplitN(opt, "=", 2)
 		switch splitOpt[0] {
+		case "idmap":
 		case "O":
 			if len(options) > 1 {
 				return nil, errors.Wrapf(ErrDupeMntOption, "'O' option can not be used with other options")


### PR DESCRIPTION
pass down the "idmap" mount option to the OCI runtime.

Needs: https://github.com/containers/crun/pull/780

Closes: https://github.com/containers/podman/issues/12154

[NO NEW TESTS NEEDED] there is no crun version yet that support the
new feature.

Test case (must run as root):

podman run --rm -v foo:/foo alpine touch /foo/bar

podman run --uidmap 0:1:1000 --rm -v foo:/foo:idmap alpine ls -l /foo
total 0
-rw-r--r--    1 root     root             0 Nov 15 14:01 bar

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
