### PR TITLE
bindings: reuse context for API requests

### DIFF
--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -145,7 +145,7 @@ func pingNewConnection(ctx context.Context) error {
 		return err
 	}
 	// the ping endpoint sits at / in this case
-	response, err := client.DoRequest(nil, http.MethodGet, "/_ping", nil, nil)
+	response, err := client.DoRequest(ctx, nil, http.MethodGet, "/_ping", nil, nil)
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func unixClient(_url *url.URL) Connection {
 }
 
 // DoRequest assembles the http request and returns the response
-func (c *Connection) DoRequest(httpBody io.Reader, httpMethod, endpoint string, queryParams url.Values, header map[string]string, pathValues ...string) (*APIResponse, error) {
+func (c *Connection) DoRequest(ctx context.Context, httpBody io.Reader, httpMethod, endpoint string, queryParams url.Values, header map[string]string, pathValues ...string) (*APIResponse, error) {
 	var (
 		err      error
 		response *http.Response
@@ -328,7 +328,7 @@ func (c *Connection) DoRequest(httpBody io.Reader, httpMethod, endpoint string, 
 	uri := fmt.Sprintf("http://d/v%d.%d.%d/libpod"+endpoint, params...)
 	logrus.Debugf("DoRequest Method: %s URI: %v", httpMethod, uri)
 
-	req, err := http.NewRequestWithContext(context.WithValue(context.Background(), clientKey, c), httpMethod, uri, httpBody)
+	req, err := http.NewRequestWithContext(ctx, httpMethod, uri, httpBody)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/containers/archive.go
+++ b/pkg/bindings/containers/archive.go
@@ -23,7 +23,7 @@ func Stat(ctx context.Context, nameOrID string, path string) (*entities.Containe
 	params := url.Values{}
 	params.Set("path", path)
 
-	response, err := conn.DoRequest(nil, http.MethodHead, "/containers/%s/archive", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodHead, "/containers/%s/archive", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func CopyFromArchiveWithOptions(ctx context.Context, nameOrID string, path strin
 	params.Set("path", path)
 
 	return func() error {
-		response, err := conn.DoRequest(reader, http.MethodPut, "/containers/%s/archive", params, nil, nameOrID)
+		response, err := conn.DoRequest(ctx, reader, http.MethodPut, "/containers/%s/archive", params, nil, nameOrID)
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func CopyToArchive(ctx context.Context, nameOrID string, path string, writer io.
 	params := url.Values{}
 	params.Set("path", path)
 
-	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/%s/archive", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/containers/%s/archive", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -130,7 +130,7 @@ func Attach(ctx context.Context, nameOrID string, stdin io.Reader, stdout io.Wri
 		IdleConnTimeout: time.Duration(0),
 	}
 	conn.Client.Transport = t
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/attach", params, headers, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/attach", params, headers, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -322,7 +322,7 @@ func resizeTTY(ctx context.Context, endpoint string, height *int, width *int) er
 		params.Set("w", strconv.Itoa(*width))
 	}
 	params.Set("running", "true")
-	rsp, err := conn.DoRequest(nil, http.MethodPost, endpoint, params, nil)
+	rsp, err := conn.DoRequest(ctx, nil, http.MethodPost, endpoint, params, nil)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func ExecStartAndAttach(ctx context.Context, sessionID string, options *ExecStar
 
 	// We need to inspect the exec session first to determine whether to use
 	// -t.
-	resp, err := conn.DoRequest(nil, http.MethodGet, "/exec/%s/json", nil, nil, sessionID)
+	resp, err := conn.DoRequest(ctx, nil, http.MethodGet, "/exec/%s/json", nil, nil, sessionID)
 	if err != nil {
 		return err
 	}
@@ -478,7 +478,7 @@ func ExecStartAndAttach(ctx context.Context, sessionID string, options *ExecStar
 		IdleConnTimeout: time.Duration(0),
 	}
 	conn.Client.Transport = t
-	response, err := conn.DoRequest(bytes.NewReader(bodyJSON), http.MethodPost, "/exec/%s/start", nil, nil, sessionID)
+	response, err := conn.DoRequest(ctx, bytes.NewReader(bodyJSON), http.MethodPost, "/exec/%s/start", nil, nil, sessionID)
 	if err != nil {
 		return err
 	}

--- a/pkg/bindings/containers/checkpoint.go
+++ b/pkg/bindings/containers/checkpoint.go
@@ -23,7 +23,7 @@ func Checkpoint(ctx context.Context, nameOrID string, options *CheckpointOptions
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/checkpoint", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/checkpoint", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func Restore(ctx context.Context, nameOrID string, options *RestoreOptions) (*en
 	if i := options.GetImportAchive(); options.Changed("ImportArchive") {
 		params.Set("import", i)
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/restore", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/restore", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/containers/commit.go
+++ b/pkg/bindings/containers/commit.go
@@ -24,7 +24,7 @@ func Commit(ctx context.Context, nameOrID string, options *CommitOptions) (handl
 		return handlers.IDResponse{}, err
 	}
 	params.Set("container", nameOrID)
-	response, err := conn.DoRequest(nil, http.MethodPost, "/commit", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/commit", params, nil)
 	if err != nil {
 		return id, err
 	}

--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -38,7 +38,7 @@ func List(ctx context.Context, options *ListOptions) ([]entities.ListContainer, 
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/json", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/containers/json", params, nil)
 	if err != nil {
 		return containers, err
 	}
@@ -64,7 +64,7 @@ func Prune(ctx context.Context, options *PruneOptions) ([]*reports.PruneReport, 
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/prune", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/prune", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) error 
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodDelete, "/containers/%s", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodDelete, "/containers/%s", params, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func Inspect(ctx context.Context, nameOrID string, options *InspectOptions) (*de
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/%s/json", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/containers/%s/json", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func Kill(ctx context.Context, nameOrID string, options *KillOptions) error {
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/kill", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/kill", params, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func Pause(ctx context.Context, nameOrID string, options *PauseOptions) error {
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/pause", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/pause", nil, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func Restart(ctx context.Context, nameOrID string, options *RestartOptions) erro
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/restart", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/restart", params, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func Start(ctx context.Context, nameOrID string, options *StartOptions) error {
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/start", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/start", params, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -235,7 +235,7 @@ func Stats(ctx context.Context, containers []string, options *StatsOptions) (cha
 		params.Add("containers", c)
 	}
 
-	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/stats", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/containers/stats", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ func Top(ctx context.Context, nameOrID string, options *TopOptions) ([]string, e
 		psArgs := strings.Join(options.GetDescriptors(), ",")
 		params.Add("ps_args", psArgs)
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/%s/top", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/containers/%s/top", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func Unpause(ctx context.Context, nameOrID string, options *UnpauseOptions) erro
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/unpause", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/unpause", nil, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -351,7 +351,7 @@ func Wait(ctx context.Context, nameOrID string, options *WaitOptions) (int32, er
 	if err != nil {
 		return exitCode, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/wait", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/wait", params, nil, nameOrID)
 	if err != nil {
 		return exitCode, err
 	}
@@ -372,7 +372,7 @@ func Exists(ctx context.Context, nameOrID string, options *ExistsOptions) (bool,
 	if err != nil {
 		return false, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/%s/exists", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/containers/%s/exists", params, nil, nameOrID)
 	if err != nil {
 		return false, err
 	}
@@ -395,7 +395,7 @@ func Stop(ctx context.Context, nameOrID string, options *StopOptions) error {
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/stop", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/stop", params, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -416,7 +416,7 @@ func Export(ctx context.Context, nameOrID string, w io.Writer, options *ExportOp
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/%s/export", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/containers/%s/export", params, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -441,7 +441,7 @@ func ContainerInit(ctx context.Context, nameOrID string, options *InitOptions) e
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/init", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/init", nil, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -462,7 +462,7 @@ func ShouldRestart(ctx context.Context, nameOrID string, options *ShouldRestartO
 	if err != nil {
 		return false, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/shouldrestart", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/shouldrestart", nil, nil, nameOrID)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/bindings/containers/create.go
+++ b/pkg/bindings/containers/create.go
@@ -26,7 +26,7 @@ func CreateWithSpec(ctx context.Context, s *specgen.SpecGenerator, options *Crea
 		return ccr, err
 	}
 	stringReader := strings.NewReader(specgenString)
-	response, err := conn.DoRequest(stringReader, http.MethodPost, "/containers/create", nil, nil)
+	response, err := conn.DoRequest(ctx, stringReader, http.MethodPost, "/containers/create", nil, nil)
 	if err != nil {
 		return ccr, err
 	}

--- a/pkg/bindings/containers/diff.go
+++ b/pkg/bindings/containers/diff.go
@@ -22,7 +22,7 @@ func Diff(ctx context.Context, nameOrID string, options *DiffOptions) ([]archive
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/%s/changes", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/containers/%s/changes", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/containers/exec.go
+++ b/pkg/bindings/containers/exec.go
@@ -35,7 +35,7 @@ func ExecCreate(ctx context.Context, nameOrID string, config *handlers.ExecCreat
 	}
 	jsonReader := strings.NewReader(string(requestJSON))
 
-	resp, err := conn.DoRequest(jsonReader, http.MethodPost, "/containers/%s/exec", nil, nil, nameOrID)
+	resp, err := conn.DoRequest(ctx, jsonReader, http.MethodPost, "/containers/%s/exec", nil, nil, nameOrID)
 	if err != nil {
 		return "", err
 	}
@@ -63,7 +63,7 @@ func ExecInspect(ctx context.Context, sessionID string, options *ExecInspectOpti
 
 	logrus.Debugf("Inspecting session ID %q", sessionID)
 
-	resp, err := conn.DoRequest(nil, http.MethodGet, "/exec/%s/json", nil, nil, sessionID)
+	resp, err := conn.DoRequest(ctx, nil, http.MethodGet, "/exec/%s/json", nil, nil, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func ExecStart(ctx context.Context, sessionID string, options *ExecStartOptions)
 		return err
 	}
 
-	resp, err := conn.DoRequest(bytes.NewReader(bodyJSON), http.MethodPost, "/exec/%s/start", nil, nil, sessionID)
+	resp, err := conn.DoRequest(ctx, bytes.NewReader(bodyJSON), http.MethodPost, "/exec/%s/start", nil, nil, sessionID)
 	if err != nil {
 		return err
 	}

--- a/pkg/bindings/containers/healthcheck.go
+++ b/pkg/bindings/containers/healthcheck.go
@@ -22,7 +22,7 @@ func RunHealthCheck(ctx context.Context, nameOrID string, options *HealthCheckOp
 	var (
 		status define.HealthCheckResults
 	)
-	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/%s/healthcheck", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/containers/%s/healthcheck", nil, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/containers/logs.go
+++ b/pkg/bindings/containers/logs.go
@@ -29,7 +29,7 @@ func Logs(ctx context.Context, nameOrID string, options *LogOptions, stdoutChan,
 	if options.Stdout == nil && options.Stderr == nil {
 		params.Set("stdout", strconv.FormatBool(true))
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/%s/logs", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/containers/%s/logs", params, nil, nameOrID)
 	if err != nil {
 		return err
 	}

--- a/pkg/bindings/containers/mount.go
+++ b/pkg/bindings/containers/mount.go
@@ -21,7 +21,7 @@ func Mount(ctx context.Context, nameOrID string, options *MountOptions) (string,
 	var (
 		path string
 	)
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/mount", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/mount", nil, nil, nameOrID)
 	if err != nil {
 		return path, err
 	}
@@ -41,7 +41,7 @@ func Unmount(ctx context.Context, nameOrID string, options *UnmountOptions) erro
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/unmount", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/unmount", nil, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func GetMountedContainerPaths(ctx context.Context, options *MountedContainerPath
 		return nil, err
 	}
 	mounts := make(map[string]string)
-	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/showmounted", nil, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/containers/showmounted", nil, nil)
 	if err != nil {
 		return mounts, err
 	}

--- a/pkg/bindings/containers/rename.go
+++ b/pkg/bindings/containers/rename.go
@@ -20,7 +20,7 @@ func Rename(ctx context.Context, nameOrID string, options *RenameOptions) error 
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/rename", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/containers/%s/rename", params, nil, nameOrID)
 	if err != nil {
 		return err
 	}

--- a/pkg/bindings/generate/generate.go
+++ b/pkg/bindings/generate/generate.go
@@ -22,7 +22,7 @@ func Systemd(ctx context.Context, nameOrID string, options *SystemdOptions) (*en
 		return nil, err
 	}
 
-	response, err := conn.DoRequest(nil, http.MethodGet, "/generate/%s/systemd", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/generate/%s/systemd", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func Kube(ctx context.Context, nameOrIDs []string, options *KubeOptions) (*entit
 	for _, name := range nameOrIDs {
 		params.Add("names", name)
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/generate/kube", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/generate/kube", params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -392,7 +392,7 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(tarfile, http.MethodPost, "/build", params, headers)
+	response, err := conn.DoRequest(ctx, tarfile, http.MethodPost, "/build", params, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/images/diff.go
+++ b/pkg/bindings/images/diff.go
@@ -19,7 +19,7 @@ func Diff(ctx context.Context, nameOrID string, options *DiffOptions) ([]archive
 		return nil, err
 	}
 
-	response, err := conn.DoRequest(nil, http.MethodGet, "/images/%s/changes", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/images/%s/changes", nil, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -23,7 +23,7 @@ func Exists(ctx context.Context, nameOrID string, options *ExistsOptions) (bool,
 	if err != nil {
 		return false, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/images/%s/exists", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/images/%s/exists", nil, nil, nameOrID)
 	if err != nil {
 		return false, err
 	}
@@ -47,7 +47,7 @@ func List(ctx context.Context, options *ListOptions) ([]*entities.ImageSummary, 
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/images/json", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/images/json", params, nil)
 	if err != nil {
 		return imageSummary, err
 	}
@@ -71,7 +71,7 @@ func GetImage(ctx context.Context, nameOrID string, options *GetOptions) (*entit
 		return nil, err
 	}
 	inspectedData := entities.ImageInspectReport{}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/images/%s/json", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/images/%s/json", params, nil, nameOrID)
 	if err != nil {
 		return &inspectedData, err
 	}
@@ -94,7 +94,7 @@ func Tree(ctx context.Context, nameOrID string, options *TreeOptions) (*entities
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/images/%s/tree", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/images/%s/tree", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func History(ctx context.Context, nameOrID string, options *HistoryOptions) ([]*
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/images/%s/history", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/images/%s/history", nil, nil, nameOrID)
 	if err != nil {
 		return history, err
 	}
@@ -129,7 +129,7 @@ func Load(ctx context.Context, r io.Reader) (*entities.ImageLoadReport, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(r, http.MethodPost, "/images/load", nil, nil)
+	response, err := conn.DoRequest(ctx, r, http.MethodPost, "/images/load", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func Export(ctx context.Context, nameOrIDs []string, w io.Writer, options *Expor
 	for _, ref := range nameOrIDs {
 		params.Add("references", ref)
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/images/export", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/images/export", params, nil)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func Prune(ctx context.Context, options *PruneOptions) ([]*reports.PruneReport, 
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/images/prune", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/images/prune", params, nil)
 	if err != nil {
 		return deleted, err
 	}
@@ -207,7 +207,7 @@ func Tag(ctx context.Context, nameOrID, tag, repo string, options *TagOptions) e
 	params := url.Values{}
 	params.Set("tag", tag)
 	params.Set("repo", repo)
-	response, err := conn.DoRequest(nil, http.MethodPost, "/images/%s/tag", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/images/%s/tag", params, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -229,7 +229,7 @@ func Untag(ctx context.Context, nameOrID, tag, repo string, options *UntagOption
 	params := url.Values{}
 	params.Set("tag", tag)
 	params.Set("repo", repo)
-	response, err := conn.DoRequest(nil, http.MethodPost, "/images/%s/untag", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/images/%s/untag", params, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -257,7 +257,7 @@ func Import(ctx context.Context, r io.Reader, options *ImportOptions) (*entities
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(r, http.MethodPost, "/images/import", params, nil)
+	response, err := conn.DoRequest(ctx, r, http.MethodPost, "/images/import", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +298,7 @@ func Push(ctx context.Context, source string, destination string, options *PushO
 	params.Set("destination", destination)
 
 	path := fmt.Sprintf("/images/%s/push", source)
-	response, err := conn.DoRequest(nil, http.MethodPost, path, params, header)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, path, params, header)
 	if err != nil {
 		return err
 	}
@@ -334,7 +334,7 @@ func Search(ctx context.Context, term string, options *SearchOptions) ([]entitie
 		return nil, err
 	}
 
-	response, err := conn.DoRequest(nil, http.MethodGet, "/images/search", params, header)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/images/search", params, header)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/images/pull.go
+++ b/pkg/bindings/images/pull.go
@@ -47,7 +47,7 @@ func Pull(ctx context.Context, rawImage string, options *PullOptions) ([]string,
 		return nil, err
 	}
 
-	response, err := conn.DoRequest(nil, http.MethodPost, "/images/pull", params, header)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/images/pull", params, header)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/images/rm.go
+++ b/pkg/bindings/images/rm.go
@@ -32,7 +32,7 @@ func Remove(ctx context.Context, images []string, options *RemoveOptions) (*enti
 	for _, image := range images {
 		params.Add("images", image)
 	}
-	response, err := conn.DoRequest(nil, http.MethodDelete, "/images/remove", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodDelete, "/images/remove", params, nil)
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -42,7 +42,7 @@ func Create(ctx context.Context, names, images []string, options *CreateOptions)
 		params.Add("image", i)
 	}
 
-	response, err := conn.DoRequest(nil, http.MethodPost, "/manifests/create", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/manifests/create", params, nil)
 	if err != nil {
 		return "", err
 	}
@@ -57,7 +57,7 @@ func Exists(ctx context.Context, name string, options *ExistsOptions) (bool, err
 	if err != nil {
 		return false, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/manifests/%s/exists", nil, nil, name)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/manifests/%s/exists", nil, nil, name)
 	if err != nil {
 		return false, err
 	}
@@ -77,7 +77,7 @@ func Inspect(ctx context.Context, name string, options *InspectOptions) (*manife
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/manifests/%s/json", nil, nil, name)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/manifests/%s/json", nil, nil, name)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func Add(ctx context.Context, name string, options *AddOptions) (string, error) 
 		return "", err
 	}
 	stringReader := strings.NewReader(optionsString)
-	response, err := conn.DoRequest(stringReader, http.MethodPost, "/manifests/%s/add", nil, nil, name)
+	response, err := conn.DoRequest(ctx, stringReader, http.MethodPost, "/manifests/%s/add", nil, nil, name)
 	if err != nil {
 		return "", err
 	}
@@ -125,7 +125,7 @@ func Remove(ctx context.Context, name, digest string, options *RemoveOptions) (s
 	}
 	params := url.Values{}
 	params.Set("digest", digest)
-	response, err := conn.DoRequest(nil, http.MethodDelete, "/manifests/%s", params, nil, name)
+	response, err := conn.DoRequest(ctx, nil, http.MethodDelete, "/manifests/%s", params, nil, name)
 	if err != nil {
 		return "", err
 	}
@@ -163,7 +163,7 @@ func Push(ctx context.Context, name, destination string, options *images.PushOpt
 	}
 	params.Set("image", name)
 	params.Set("destination", destination)
-	response, err := conn.DoRequest(nil, http.MethodPost, "/manifests/%s/push", params, nil, name)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/manifests/%s/push", params, nil, name)
 	if err != nil {
 		return "", err
 	}
@@ -187,7 +187,7 @@ func Push(ctx context.Context, name, destination string, options *images.PushOpt
 //		return "", err
 //	}
 //	stringReader := strings.NewReader(optionsString)
-//	response, err := conn.DoRequest(stringReader, http.MethodPost, "/manifests/%s/annotate", params, name)
+//	response, err := conn.DoRequest(ctx, stringReader, http.MethodPost, "/manifests/%s/annotate", params, name)
 //	if err != nil {
 //		return "", err
 //	}

--- a/pkg/bindings/network/network.go
+++ b/pkg/bindings/network/network.go
@@ -28,7 +28,7 @@ func Create(ctx context.Context, network *types.Network) (types.Network, error) 
 		return report, err
 	}
 	reader := strings.NewReader(networkConfig)
-	response, err := conn.DoRequest(reader, http.MethodPost, "/networks/create", nil, nil)
+	response, err := conn.DoRequest(ctx, reader, http.MethodPost, "/networks/create", nil, nil)
 	if err != nil {
 		return report, err
 	}
@@ -44,7 +44,7 @@ func Inspect(ctx context.Context, nameOrID string, _ *InspectOptions) (types.Net
 	if err != nil {
 		return net, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/networks/%s/json", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/networks/%s/json", nil, nil, nameOrID)
 	if err != nil {
 		return net, err
 	}
@@ -69,7 +69,7 @@ func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) ([]*en
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodDelete, "/networks/%s", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodDelete, "/networks/%s", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func List(ctx context.Context, options *ListOptions) ([]types.Network, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/networks/json", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/networks/json", params, nil)
 	if err != nil {
 		return netList, err
 	}
@@ -128,7 +128,7 @@ func Disconnect(ctx context.Context, networkName string, ContainerNameOrID strin
 		return err
 	}
 	stringReader := strings.NewReader(body)
-	response, err := conn.DoRequest(stringReader, http.MethodPost, "/networks/%s/disconnect", params, nil, networkName)
+	response, err := conn.DoRequest(ctx, stringReader, http.MethodPost, "/networks/%s/disconnect", params, nil, networkName)
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func Connect(ctx context.Context, networkName string, ContainerNameOrID string, 
 		return err
 	}
 	stringReader := strings.NewReader(body)
-	response, err := conn.DoRequest(stringReader, http.MethodPost, "/networks/%s/connect", params, nil, networkName)
+	response, err := conn.DoRequest(ctx, stringReader, http.MethodPost, "/networks/%s/connect", params, nil, networkName)
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func Exists(ctx context.Context, nameOrID string, options *ExistsOptions) (bool,
 	if err != nil {
 		return false, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/networks/%s/exists", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/networks/%s/exists", nil, nil, nameOrID)
 	if err != nil {
 		return false, err
 	}
@@ -204,7 +204,7 @@ func Prune(ctx context.Context, options *PruneOptions) ([]*entities.NetworkPrune
 		return nil, err
 	}
 
-	response, err := conn.DoRequest(nil, http.MethodPost, "/networks/prune", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/networks/prune", params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/play/play.go
+++ b/pkg/bindings/play/play.go
@@ -45,7 +45,7 @@ func Kube(ctx context.Context, path string, options *KubeOptions) (*entities.Pla
 		return nil, err
 	}
 
-	response, err := conn.DoRequest(f, http.MethodPost, "/play/kube", params, header)
+	response, err := conn.DoRequest(ctx, f, http.MethodPost, "/play/kube", params, header)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func KubeDown(ctx context.Context, path string) (*entities.PlayKubeReport, error
 			logrus.Warn(err)
 		}
 	}()
-	response, err := conn.DoRequest(f, http.MethodDelete, "/play/kube", nil, nil)
+	response, err := conn.DoRequest(ctx, f, http.MethodDelete, "/play/kube", nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/pods/pods.go
+++ b/pkg/bindings/pods/pods.go
@@ -29,7 +29,7 @@ func CreatePodFromSpec(ctx context.Context, spec *entities.PodSpec) (*entities.P
 		return nil, err
 	}
 	stringReader := strings.NewReader(specString)
-	response, err := conn.DoRequest(stringReader, http.MethodPost, "/pods/create", nil, nil)
+	response, err := conn.DoRequest(ctx, stringReader, http.MethodPost, "/pods/create", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func Exists(ctx context.Context, nameOrID string, options *ExistsOptions) (bool,
 	if err != nil {
 		return false, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/pods/%s/exists", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/pods/%s/exists", nil, nil, nameOrID)
 	if err != nil {
 		return false, err
 	}
@@ -66,7 +66,7 @@ func Inspect(ctx context.Context, nameOrID string, options *InspectOptions) (*en
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/pods/%s/json", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/pods/%s/json", nil, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func Kill(ctx context.Context, nameOrID string, options *KillOptions) (*entities
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/pods/%s/kill", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/pods/%s/kill", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func Pause(ctx context.Context, nameOrID string, options *PauseOptions) (*entiti
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/pods/%s/pause", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/pods/%s/pause", nil, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func Prune(ctx context.Context, options *PruneOptions) ([]*entities.PodPruneRepo
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/pods/prune", nil, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/pods/prune", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func List(ctx context.Context, options *ListOptions) ([]*entities.ListPodsReport
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/pods/json", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/pods/json", params, nil)
 	if err != nil {
 		return podsReports, err
 	}
@@ -179,7 +179,7 @@ func Restart(ctx context.Context, nameOrID string, options *RestartOptions) (*en
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/pods/%s/restart", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/pods/%s/restart", nil, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) (*enti
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodDelete, "/pods/%s", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodDelete, "/pods/%s", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func Start(ctx context.Context, nameOrID string, options *StartOptions) (*entiti
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/pods/%s/start", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/pods/%s/start", nil, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func Stop(ctx context.Context, nameOrID string, options *StopOptions) (*entities
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/pods/%s/stop", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/pods/%s/stop", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +279,7 @@ func Top(ctx context.Context, nameOrID string, options *TopOptions) ([]string, e
 	if descriptors := options.GetDescriptors(); len(descriptors) > 0 {
 		params.Set("ps_args", strings.Join(descriptors, ","))
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/pods/%s/top", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/pods/%s/top", params, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +312,7 @@ func Unpause(ctx context.Context, nameOrID string, options *UnpauseOptions) (*en
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/pods/%s/unpause", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/pods/%s/unpause", nil, nil, nameOrID)
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +339,7 @@ func Stats(ctx context.Context, namesOrIDs []string, options *StatsOptions) ([]*
 	}
 
 	var reports []*entities.PodStatsReport
-	response, err := conn.DoRequest(nil, http.MethodGet, "/pods/stats", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/pods/stats", params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/secrets/secrets.go
+++ b/pkg/bindings/secrets/secrets.go
@@ -22,7 +22,7 @@ func List(ctx context.Context, options *ListOptions) ([]*entities.SecretInfoRepo
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/secrets/json", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/secrets/json", params, nil)
 	if err != nil {
 		return secrs, err
 	}
@@ -40,7 +40,7 @@ func Inspect(ctx context.Context, nameOrID string, options *InspectOptions) (*en
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/secrets/%s/json", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/secrets/%s/json", nil, nil, nameOrID)
 	if err != nil {
 		return inspect, err
 	}
@@ -56,7 +56,7 @@ func Remove(ctx context.Context, nameOrID string) error {
 		return err
 	}
 
-	response, err := conn.DoRequest(nil, http.MethodDelete, "/secrets/%s", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodDelete, "/secrets/%s", nil, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func Create(ctx context.Context, reader io.Reader, options *CreateOptions) (*ent
 		return nil, err
 	}
 
-	response, err := conn.DoRequest(reader, http.MethodPost, "/secrets/create", params, nil)
+	response, err := conn.DoRequest(ctx, reader, http.MethodPost, "/secrets/create", params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/system/info.go
+++ b/pkg/bindings/system/info.go
@@ -14,7 +14,7 @@ func Info(ctx context.Context, _ *InfoOptions) (*define.Info, error) {
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/info", nil, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/info", nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/system/system.go
+++ b/pkg/bindings/system/system.go
@@ -27,7 +27,7 @@ func Events(ctx context.Context, eventChan chan entities.Event, cancelChan chan 
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/events", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/events", params, nil)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func Prune(ctx context.Context, options *PruneOptions) (*entities.SystemPruneRep
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/system/prune", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/system/prune", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func Version(ctx context.Context, options *VersionOptions) (*entities.SystemVers
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/version", nil, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/version", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func DiskUsage(ctx context.Context, options *DiskOptions) (*entities.SystemDfRep
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/system/df", nil, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/system/df", nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bindings/test/connection_test.go
+++ b/pkg/bindings/test/connection_test.go
@@ -1,0 +1,68 @@
+package test_bindings
+
+import (
+	"context"
+	"time"
+
+	"github.com/containers/podman/v3/pkg/bindings/containers"
+	"github.com/containers/podman/v3/pkg/bindings/system"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Podman connection", func() {
+	var (
+		bt *bindingTest
+		s  *gexec.Session
+	)
+
+	BeforeEach(func() {
+		bt = newBindingTest()
+		bt.RestoreImagesFromCache()
+		s = bt.startAPIService()
+		time.Sleep(1 * time.Second)
+		err := bt.NewConnection()
+		Expect(err).To(BeNil())
+	})
+
+	AfterEach(func() {
+		s.Kill()
+		bt.cleanup()
+	})
+
+	It("request on cancelled context results in error", func() {
+		ctx, cancel := context.WithCancel(bt.conn)
+		cancel()
+		_, err := system.Version(ctx, nil)
+		Expect(err).To(MatchError(ctx.Err()))
+	})
+
+	It("cancel request in flight reports cancelled context", func() {
+		var name = "top"
+		_, err := bt.RunTopContainer(&name, nil)
+		Expect(err).To(BeNil())
+
+		errChan := make(chan error)
+		ctx, cancel := context.WithCancel(bt.conn)
+
+		go func() {
+			defer close(errChan)
+			_, err := containers.Wait(ctx, name, nil)
+			errChan <- err
+		}()
+
+		// Wait for the goroutine to fire the request
+		time.Sleep(1 * time.Second)
+
+		cancel()
+
+		select {
+		case err, ok := <-errChan:
+			Expect(ok).To(BeTrue())
+			Expect(err).To(MatchError(ctx.Err()))
+		case <-time.NewTimer(1 * time.Second).C:
+			Fail("cancelled request did not return in less than 1 second")
+		}
+	})
+})

--- a/pkg/bindings/volumes/volumes.go
+++ b/pkg/bindings/volumes/volumes.go
@@ -29,7 +29,7 @@ func Create(ctx context.Context, config entities.VolumeCreateOptions, options *C
 		return nil, err
 	}
 	stringReader := strings.NewReader(createString)
-	response, err := conn.DoRequest(stringReader, http.MethodPost, "/volumes/create", nil, nil)
+	response, err := conn.DoRequest(ctx, stringReader, http.MethodPost, "/volumes/create", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func Inspect(ctx context.Context, nameOrID string, options *InspectOptions) (*en
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/volumes/%s/json", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/volumes/%s/json", nil, nil, nameOrID)
 	if err != nil {
 		return &inspect, err
 	}
@@ -74,7 +74,7 @@ func List(ctx context.Context, options *ListOptions) ([]*entities.VolumeListRepo
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/volumes/json", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/volumes/json", params, nil)
 	if err != nil {
 		return vols, err
 	}
@@ -96,7 +96,7 @@ func Prune(ctx context.Context, options *PruneOptions) ([]*reports.PruneReport, 
 	if err != nil {
 		return nil, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/volumes/prune", params, nil)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, "/volumes/prune", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) error 
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodDelete, "/volumes/%s", params, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodDelete, "/volumes/%s", params, nil, nameOrID)
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func Exists(ctx context.Context, nameOrID string, options *ExistsOptions) (bool,
 	if err != nil {
 		return false, err
 	}
-	response, err := conn.DoRequest(nil, http.MethodGet, "/volumes/%s/exists", nil, nil, nameOrID)
+	response, err := conn.DoRequest(ctx, nil, http.MethodGet, "/volumes/%s/exists", nil, nil, nameOrID)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

One of the main uses of context.Context is to provide cancellation for
go-routines, including API requests. While all user-facing bindings
already used a context parameter, it was only used to pass the client
information around.

This commit changes the internal DoRequest wrapper to take an additional
context argument, and pass that to the http request. Previously, the context
was derived from context.Background(), which made it impossible to cancel
once started.

All the convenience wrappers already supported the context parameter, so the
only user facing change is that cancelling those context now works as one
would expect.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz@wanzenbug.xyz>

#### How to verify it

Included new tests that verify that context cancellation works as expected. 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
