### PR TITLE
Add note about volume with unprivileged container

### DIFF
--- a/docs/source/markdown/podman-generate-kube.1.md
+++ b/docs/source/markdown/podman-generate-kube.1.md
@@ -19,6 +19,12 @@ Potential name conflicts between volumes are avoided by using a standard naming 
 Note that if an init container is created with type `once` and the pod has been started, the init container will not show up in the generated kube YAML as `once` type init containers are deleted after they are run. If the pod has only been created and not started, it will be in the generated kube YAML.
 Init containers created with type `always` will always be generated in the kube YAML as they are never deleted, even after running to completion.
 
+*Note*: When using volumes and generating a Kubernetes YAML for an unprivileged and rootless podman container on an **SELinux enabled system**,  one of the following options must be completed:
+  * Add the "privileged: true" option to the pod spec
+  * Add `type: spc_t` under the `securityContext` `seLinuxOptions` in the pod spec
+  * Relabel the volume via the CLI command `chcon -t container_file_t context -R <directory>`
+Once completed, the correct permissions will be in place to access the volume when the pod/container is created in a Kubernetes cluster.
+
 Note that the generated Kubernetes YAML file can be used to re-run the deployment via podman-play-kube(1).
 
 ## OPTIONS

--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -124,6 +124,14 @@ func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrIDs []string,
 		if err != nil {
 			return nil, err
 		}
+		if len(po.Spec.Volumes) != 0 {
+			warning := `
+# NOTE: If you generated this yaml from an unprivileged and rootless podman container on an SELinux
+# enabled system, check the podman generate kube man page for steps to follow to ensure that your pod/container
+# has the right permissions to access the volumes added.
+`
+			content = append(content, []byte(warning))
+		}
 		b, err := generateKubeYAML(libpod.ConvertV1PodToYAMLPod(po))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
NO NEW TESTS NEEDED
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:
Add a note to the generated kube yaml if we detect a
volume is being mounted. The note lets the user know
what needs to be done to avoid permission denied error
when trying to access the volume for an unprivileged
container.
Add the same note to the man pages.

<!---
Please put your overall PR description here
-->

#### How to verify it
Add volumes to your podman container and call `podman generate kube` on it  - the generated yaml should have a note about volumes in it.
<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:
Fixes https://github.com/containers/podman/issues/11916

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
