### PR TITLE
Support EXPOSE with port ranges

### DIFF
--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -314,7 +314,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.Pod = podID
 	}
 
-	expose, err := createExpose(c.Expose)
+	expose, err := CreateExpose(c.Expose)
 	if err != nil {
 		return err
 	}

--- a/pkg/specgenutil/util.go
+++ b/pkg/specgenutil/util.go
@@ -53,11 +53,11 @@ func ParseFilters(filter []string) (map[string][]string, error) {
 	return filters, nil
 }
 
-// createExpose parses user-provided exposed port definitions and converts them
+// CreateExpose parses user-provided exposed port definitions and converts them
 // into SpecGen format.
 // TODO: The SpecGen format should really handle ranges more sanely - we could
 // be massively inflating what is sent over the wire with a large range.
-func createExpose(expose []string) (map[uint16]string, error) {
+func CreateExpose(expose []string) (map[uint16]string, error) {
 	toReturn := make(map[uint16]string)
 
 	for _, e := range expose {


### PR DESCRIPTION
Fixes issue #12293. EXPOSE directive in images should mirror the `--expose` parameter. Specifically `EXPOSE 20000-20100/tcp` should work the sameas `--expose 20000-20100/tcp`

Signed-off-by: Colin Bendell <colin@bendell.ca>

#### What this PR does / why we need it:

Reuses the `specgenutil.CreateExpose` logic for parsing `--expose` parameters when parsing `EXPOSE` image directives.

#### How to verify it

1. Dockerfile with:
```
FROM alpine
EXPOSE 20000-20100
```

2. `podman build --tag portrangetest .`
3. `podman run --rm -it -P portrangetest`

#### Which issue(s) this PR fixes:

Fixes #12293

#### Special notes for your reviewer:
