### PR TITLE
Implement 'podman run --blkio-weight-device'

### DIFF
--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -329,6 +329,14 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		g.AddLinuxResourcesDevice(true, dev.Type, dev.Major, dev.Minor, dev.Access)
 	}
 
+	for k, v := range s.WeightDevice {
+		statT := unix.Stat_t{}
+		if err := unix.Stat(k, &statT); err != nil {
+			return nil, errors.Wrapf(err, "failed to inspect '%s' in --blkio-weight-device", k)
+		}
+		g.AddLinuxResourcesBlockIOWeightDevice((int64(unix.Major(uint64(statT.Rdev)))), (int64(unix.Minor(uint64(statT.Rdev)))), *v.Weight)
+	}
+
 	BlockAccessToKernelFilesystems(s.Privileged, s.PidNS.IsHost(), s.Mask, s.Unmask, &g)
 
 	g.ClearProcessEnv()

--- a/test/system/180-blkio.bats
+++ b/test/system/180-blkio.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# podman blkio-related tests
+#
+
+load helpers
+
+function teardown() {
+    lofile=${PODMAN_TMPDIR}/disk.img
+    if [ -f ${lofile} ]; then
+        run_podman '?' rm -t 0 --all --force
+
+        while read path dev; do
+            if [[ "$path" == "$lofile" ]]; then
+                losetup -d $dev
+            fi
+        done < <(losetup -l --noheadings --output BACK-FILE,NAME)
+
+        rm ${lofile}
+    fi
+    basic_teardown
+}
+
+@test "podman run --blkio-weight-device" {
+
+    skip_if_rootless "cannot create devices in rootless mode"
+
+    # create loopback device
+    lofile=${PODMAN_TMPDIR}/disk.img
+    fallocate -l 1k  ${lofile}
+    losetup -f ${lofile}
+
+    run losetup -l --noheadings --output BACK-FILE,NAME,MAJ:MIN
+    is "$output" ".\+" "Empty output from losetup"
+
+    lodevice=$(awk "\$1 == \"$lofile\" { print \$2 }" <<<"$output")
+    lomajmin=$(awk "\$1 == \"$lofile\" { print \$3 }" <<<"$output")
+
+    is "$lodevice" ".\+" "Could not determine device for $lofile"
+    is "$lomajmin" ".\+" "Could not determine major/minor for $lofile"
+
+    # use bfq io scheduler
+    run grep -w bfq /sys/block/$(basename ${lodevice})/queue/scheduler
+    if [ $status -ne 0 ]; then
+        skip "BFQ scheduler is not supported on the system"
+    fi
+    echo bfq > /sys/block/$(basename ${lodevice})/queue/scheduler
+
+    # run podman
+    if is_cgroupsv2; then
+        if [ ! -f /sys/fs/cgroup/system.slice/io.bfq.weight ]; then
+            skip "Kernel does not support BFQ IO scheduler"
+        fi
+        run_podman run --device ${lodevice}:${lodevice} --blkio-weight-device ${lodevice}:123 --rm $IMAGE \
+            /bin/sh -c "cat /sys/fs/cgroup/\$(sed -e 's/0:://' < /proc/self/cgroup)/io.bfq.weight"
+        is "${lines[1]}" "${lomajmin}\s\+123"
+    else
+        if [ ! -f /sys/fs/cgroup/blkio/system.slice/blkio.bfq.weight_device ]; then
+            skip "Kernel does not support BFQ IO scheduler"
+        fi
+        if [ $(podman_runtime) = "crun" ]; then
+            # As of crun 1.2, crun doesn't support blkio.bfq.weight_device
+            skip "crun doesn't support blkio.bfq.weight_device"
+        fi
+        run_podman run --device ${lodevice}:${lodevice} --blkio-weight-device ${lodevice}:123 --rm $IMAGE \
+            /bin/sh -c "cat /sys/fs/cgroup/blkio/blkio.bfq.weight_device"
+        is "${lines[1]}" "${lomajmin}\s\+123"
+    fi
+}


### PR DESCRIPTION
Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

`--blkio-weight-device` is not fully implemented and this causes an
unexpected panic when specified because an entry is put into an
uninitialized map at parsing.

This fix implements the `--blkio-weight-device` and adds a system test.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->
Run an added system test.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
