### PR TITLE
Share cgroup namespace in pod

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1024,8 +1024,16 @@ func WithCgroupNSFrom(nsCtr *Container) CtrCreateOption {
 			return err
 		}
 
-		ctr.config.CgroupNsCtr = nsCtr.ID()
+		for _, ns := range nsCtr.config.Spec.Linux.Namespaces {
+			if ns.Type == specs.CgroupNamespace {
+				ctr.config.CgroupNsCtr = nsCtr.ID()
+				return nil
+			}
+		}
 
+		// When the given container is in the host cgroup namespace,
+		// the container does't have to re-enter the host cgroup namespace.
+		// (Especially, a rootless container cannot re-enter the host cgroup namespace.)
 		return nil
 	}
 }

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -371,7 +371,7 @@ func (p *Pod) HasInfraContainer() bool {
 // SharesNamespaces checks if the pod has any kernel namespaces set as shared. An infra container will not be
 // created if no kernel namespaces are shared.
 func (p *Pod) SharesNamespaces() bool {
-	return p.SharesPID() || p.SharesIPC() || p.SharesNet() || p.SharesMount() || p.SharesUser() || p.SharesUTS()
+	return p.SharesPID() || p.SharesIPC() || p.SharesNet() || p.SharesMount() || p.SharesUser() || p.SharesUTS() || p.SharesCgroup()
 }
 
 // infraContainerID returns the infra ID without a lock

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -454,7 +454,7 @@ func GetNamespaceOptions(ns []string, netnsIsHost bool) ([]libpod.PodCreateOptio
 	for _, toShare := range ns {
 		switch toShare {
 		case "cgroup":
-			options = append(options, libpod.WithPodCgroups())
+			options = append(options, libpod.WithPodCgroup())
 		case "net":
 			// share the netns setting with other containers in the pod only when it is not set to host
 			if !netnsIsHost {

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -176,6 +176,7 @@ func createPodOptions(p *specgen.PodSpecGenerator, rt *libpod.Runtime, infraSpec
 			options = append(options, libpod.WithPodUser())
 		}
 	}
+	options = append(options, libpod.WithPodCgroups())
 	if len(p.CgroupParent) > 0 {
 		options = append(options, libpod.WithPodCgroupParent(p.CgroupParent))
 	}


### PR DESCRIPTION
Signed-off-by: Hironori Shiina <shiina.hironori@jp.fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->
`podman help pod create` displays `cgroup` as one of default values of
`--share` flag, which specifies shared namespaces in a pod. However,
`cgroup` is not listed in `SharedNameSpaces` of a pod with default
values. Even if `cgroup` is explicitly specified in `--share` flag,
`cgroup` is not listed in pod inspection and actually containers in a
pod don't share a cgreoup namespace.

There are two similar parameters for cgroups in a pod. When `cgroup`
is specified in `--share`, `PodConfig.UsePodCgroup` is set to `true`.
For `SharedNameSpaces` in pod inspection, `PodConfig.UsePodCgroupNS` is
referred to.

In order to share `cgroup` namespace expectedly,
`PodConfig.UsePodCgroupNS` should be set to `true` via
`WithPodCgroup()`. Regarding `PodConfig.UsePodCgroup`, this should be
always `true` via `WithPodCgroups()` as it was in Podman 3.3.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->
Run added integration tests.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
