### PR TITLE
Download image when starting a container using the compat API

### DIFF
--- a/test/python/docker/compat/test_containers.py
+++ b/test/python/docker/compat/test_containers.py
@@ -265,3 +265,19 @@ class TestContainers(unittest.TestCase):
         ctr.start()
         ret, out = ctr.exec_run(["stat", "/workspace/scratch/test"])
         self.assertEqual(ret, 0, "Working directory created if it doesn't exist")
+
+    def test_non_local_image(self):
+        self.assertEqual(len(self.client.images.list(filters={"reference": "alpine"})), 1)
+
+        for c in self.client.containers.list(all=True):
+            c.remove(force=True)
+
+        self.client.images.remove(constant.ALPINE)
+
+        self.assertEqual(len(self.client.images.list(filters={"reference": "alpine"})), 0)
+
+        ctr: Container = self.client.containers.create(image=constant.ALPINE, detach=True,
+                                                       name="non_local", command="top")
+        ctr.start()
+
+        self.assertEqual(len(self.client.images.list(filters={"reference": "alpine"})), 1)


### PR DESCRIPTION
Docker/moby will automatically pull images when using the API (or the CLI, for
that matter) to create a container, but podman don't. This break the compatibility with
some software.

I tested that using woddpecker CI, and when I use docker on F35 as the backend, it doesn't fail. Using podman-docker fail, with "image uknown".

#### What this PR does / why we need it:

Align the compatibility API with moby.

#### How to verify it

There is a attached test case. Otherwise, deploying woodpecker and using podman-docker is the way to go, or do a call the 
/v1.33/containers/xxxx/start API with a image not already downloaded (eg, one not in the output of podman images) and see it fail.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I am not 100% happy with the code, especially with the fact the call to LookupImage is duplicated. I am however not fluent enough in go to write something more idiomatic. 

