### PR TITLE
rename libpod nettypes fields

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1050,8 +1050,8 @@ func (c *Container) cniHosts() string {
 	var hosts string
 	for _, status := range c.getNetworkStatus() {
 		for _, netInt := range status.Interfaces {
-			for _, netAddress := range netInt.Networks {
-				hosts += fmt.Sprintf("%s\t%s %s\n", netAddress.Subnet.IP.String(), c.Hostname(), c.config.Name)
+			for _, netAddress := range netInt.Subnets {
+				hosts += fmt.Sprintf("%s\t%s %s\n", netAddress.IPNet.IP.String(), c.Hostname(), c.config.Name)
 			}
 		}
 	}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1341,8 +1341,8 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 					perNetOpts.StaticMAC = netInt.MacAddress
 				}
 				if !options.IgnoreStaticIP {
-					for _, netAddress := range netInt.Networks {
-						perNetOpts.StaticIPs = append(perNetOpts.StaticIPs, netAddress.Subnet.IP)
+					for _, netAddress := range netInt.Subnets {
+						perNetOpts.StaticIPs = append(perNetOpts.StaticIPs, netAddress.IPNet.IP)
 					}
 				}
 				// Normally interfaces have a length of 1, only for some special cni configs we could get more.
@@ -1943,9 +1943,9 @@ func (c *Container) generateResolvConf() (string, error) {
 	netStatus := c.getNetworkStatus()
 	for _, status := range netStatus {
 		for _, netInt := range status.Interfaces {
-			for _, netAddress := range netInt.Networks {
+			for _, netAddress := range netInt.Subnets {
 				// Note: only using To16() does not work since it also returns a valid ip for ipv4
-				if netAddress.Subnet.IP.To4() == nil && netAddress.Subnet.IP.To16() != nil {
+				if netAddress.IPNet.IP.To4() == nil && netAddress.IPNet.IP.To16() != nil {
 					ipv6 = true
 				}
 			}
@@ -2151,7 +2151,7 @@ func (c *Container) getHosts() string {
 		if depCtr != nil {
 			for _, status := range depCtr.getNetworkStatus() {
 				for _, netInt := range status.Interfaces {
-					for _, netAddress := range netInt.Networks {
+					for _, netAddress := range netInt.Subnets {
 						if netAddress.Gateway != nil {
 							hosts += fmt.Sprintf("%s host.containers.internal\n", netAddress.Gateway.String())
 						}

--- a/libpod/network/cni/run.go
+++ b/libpod/network/cni/run.go
@@ -135,8 +135,8 @@ func CNIResultToStatus(res cnitypes.Result) (types.StatusBlock, error) {
 		cniInt := cniResult.Interfaces[*ip.Interface]
 		netInt, ok := interfaces[cniInt.Name]
 		if ok {
-			netInt.Networks = append(netInt.Networks, types.NetAddress{
-				Subnet:  types.IPNet{IPNet: ip.Address},
+			netInt.Subnets = append(netInt.Subnets, types.NetAddress{
+				IPNet:   types.IPNet{IPNet: ip.Address},
 				Gateway: ip.Gateway,
 			})
 			interfaces[cniInt.Name] = netInt
@@ -147,8 +147,8 @@ func CNIResultToStatus(res cnitypes.Result) (types.StatusBlock, error) {
 			}
 			interfaces[cniInt.Name] = types.NetInterface{
 				MacAddress: types.HardwareAddr(mac),
-				Networks: []types.NetAddress{{
-					Subnet:  types.IPNet{IPNet: ip.Address},
+				Subnets: []types.NetAddress{{
+					IPNet:   types.IPNet{IPNet: ip.Address},
 					Gateway: ip.Gateway,
 				}},
 			}

--- a/libpod/network/cni/run_test.go
+++ b/libpod/network/cni/run_test.go
@@ -133,8 +133,8 @@ var _ = Describe("run CNI", func() {
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(defNet))
 				Expect(res[defNet].Interfaces).To(HaveKey(intName))
-				Expect(res[defNet].Interfaces[intName].Networks).To(HaveLen(1))
-				Expect(res[defNet].Interfaces[intName].Networks[0].Subnet.IP.String()).To(ContainSubstring("10.88.0."))
+				Expect(res[defNet].Interfaces[intName].Subnets).To(HaveLen(1))
+				Expect(res[defNet].Interfaces[intName].Subnets[0].IPNet.IP.String()).To(ContainSubstring("10.88.0."))
 				Expect(res[defNet].Interfaces[intName].MacAddress).To(HaveLen(6))
 				// default network has no dns
 				Expect(res[defNet].DNSServerIPs).To(BeEmpty())
@@ -170,8 +170,8 @@ var _ = Describe("run CNI", func() {
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(defNet))
 				Expect(res[defNet].Interfaces).To(HaveKey(intName))
-				Expect(res[defNet].Interfaces[intName].Networks).To(HaveLen(1))
-				Expect(res[defNet].Interfaces[intName].Networks[0].Subnet.IP).To(Equal(ip))
+				Expect(res[defNet].Interfaces[intName].Subnets).To(HaveLen(1))
+				Expect(res[defNet].Interfaces[intName].Subnets[0].IPNet.IP).To(Equal(ip))
 				Expect(res[defNet].Interfaces[intName].MacAddress).To(HaveLen(6))
 				// default network has no dns
 				Expect(res[defNet].DNSServerIPs).To(BeEmpty())
@@ -209,8 +209,8 @@ var _ = Describe("run CNI", func() {
 					Expect(res).To(HaveLen(1))
 					Expect(res).To(HaveKey(defNet))
 					Expect(res[defNet].Interfaces).To(HaveKey(intName))
-					Expect(res[defNet].Interfaces[intName].Networks).To(HaveLen(1))
-					Expect(res[defNet].Interfaces[intName].Networks[0].Subnet.IP.String()).To(ContainSubstring("10.88.0."))
+					Expect(res[defNet].Interfaces[intName].Subnets).To(HaveLen(1))
+					Expect(res[defNet].Interfaces[intName].Subnets[0].IPNet.IP.String()).To(ContainSubstring("10.88.0."))
 					Expect(res[defNet].Interfaces[intName].MacAddress).To(HaveLen(6))
 					// default network has no dns
 					Expect(res[defNet].DNSServerIPs).To(BeEmpty())
@@ -263,8 +263,8 @@ var _ = Describe("run CNI", func() {
 					Expect(res).To(HaveLen(1))
 					Expect(res).To(HaveKey(defNet))
 					Expect(res[defNet].Interfaces).To(HaveKey(intName))
-					Expect(res[defNet].Interfaces[intName].Networks).To(HaveLen(1))
-					containerIP := res[defNet].Interfaces[intName].Networks[0].Subnet.IP.String()
+					Expect(res[defNet].Interfaces[intName].Subnets).To(HaveLen(1))
+					containerIP := res[defNet].Interfaces[intName].Subnets[0].IPNet.IP.String()
 					Expect(containerIP).To(ContainSubstring("10.88.0."))
 					Expect(res[defNet].Interfaces[intName].MacAddress).To(HaveLen(6))
 					// default network has no dns
@@ -324,8 +324,8 @@ var _ = Describe("run CNI", func() {
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(defNet))
 				Expect(res[defNet].Interfaces).To(HaveKey(intName))
-				Expect(res[defNet].Interfaces[intName].Networks).To(HaveLen(1))
-				Expect(res[defNet].Interfaces[intName].Networks[0].Subnet.IP.String()).To(ContainSubstring("10.88.0."))
+				Expect(res[defNet].Interfaces[intName].Subnets).To(HaveLen(1))
+				Expect(res[defNet].Interfaces[intName].Subnets[0].IPNet.IP.String()).To(ContainSubstring("10.88.0."))
 				Expect(res[defNet].Interfaces[intName].MacAddress).To(HaveLen(6))
 
 				for _, proto := range []string{"tcp", "udp"} {
@@ -386,8 +386,8 @@ var _ = Describe("run CNI", func() {
 
 				Expect(res).To(HaveKey(netName1))
 				Expect(res[netName1].Interfaces).To(HaveKey(intName1))
-				Expect(res[netName1].Interfaces[intName1].Networks).To(HaveLen(1))
-				ipInt1 := res[netName1].Interfaces[intName1].Networks[0].Subnet.IP
+				Expect(res[netName1].Interfaces[intName1].Subnets).To(HaveLen(1))
+				ipInt1 := res[netName1].Interfaces[intName1].Subnets[0].IPNet.IP
 				Expect(ipInt1).ToNot(BeEmpty())
 				macInt1 := res[netName1].Interfaces[intName1].MacAddress
 				Expect(macInt1).To(HaveLen(6))
@@ -436,8 +436,8 @@ var _ = Describe("run CNI", func() {
 
 				Expect(res).To(HaveKey(netName2))
 				Expect(res[netName2].Interfaces).To(HaveKey(intName2))
-				Expect(res[netName2].Interfaces[intName2].Networks).To(HaveLen(1))
-				ipInt2 := res[netName2].Interfaces[intName2].Networks[0].Subnet.IP
+				Expect(res[netName2].Interfaces[intName2].Subnets).To(HaveLen(1))
+				ipInt2 := res[netName2].Interfaces[intName2].Subnets[0].IPNet.IP
 				Expect(ipInt2).ToNot(BeEmpty())
 				macInt2 := res[netName2].Interfaces[intName2].MacAddress
 				Expect(macInt2).To(HaveLen(6))
@@ -576,16 +576,16 @@ var _ = Describe("run CNI", func() {
 
 				Expect(res).To(HaveKey(netName1))
 				Expect(res[netName1].Interfaces).To(HaveKey(intName1))
-				Expect(res[netName1].Interfaces[intName1].Networks).To(HaveLen(1))
-				ipInt1 := res[netName1].Interfaces[intName1].Networks[0].Subnet.IP
+				Expect(res[netName1].Interfaces[intName1].Subnets).To(HaveLen(1))
+				ipInt1 := res[netName1].Interfaces[intName1].Subnets[0].IPNet.IP
 				Expect(ipInt1.String()).To(ContainSubstring("192.168.0."))
 				macInt1 := res[netName1].Interfaces[intName1].MacAddress
 				Expect(macInt1).To(HaveLen(6))
 
 				Expect(res).To(HaveKey(netName2))
 				Expect(res[netName2].Interfaces).To(HaveKey(intName2))
-				Expect(res[netName2].Interfaces[intName2].Networks).To(HaveLen(1))
-				ipInt2 := res[netName2].Interfaces[intName2].Networks[0].Subnet.IP
+				Expect(res[netName2].Interfaces[intName2].Subnets).To(HaveLen(1))
+				ipInt2 := res[netName2].Interfaces[intName2].Subnets[0].IPNet.IP
 				Expect(ipInt2.String()).To(ContainSubstring("192.168.1."))
 				macInt2 := res[netName2].Interfaces[intName2].MacAddress
 				Expect(macInt2).To(HaveLen(6))
@@ -701,13 +701,13 @@ var _ = Describe("run CNI", func() {
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(netName))
 				Expect(res[netName].Interfaces).To(HaveKey(interfaceName))
-				Expect(res[netName].Interfaces[interfaceName].Networks).To(HaveLen(2))
-				Expect(res[netName].Interfaces[interfaceName].Networks[0].Subnet.IP.String()).To(Equal(ip1.String()))
-				Expect(res[netName].Interfaces[interfaceName].Networks[0].Subnet.Mask).To(Equal(subnet1.Mask))
-				Expect(res[netName].Interfaces[interfaceName].Networks[0].Gateway).To(Equal(net.ParseIP("192.168.0.1")))
-				Expect(res[netName].Interfaces[interfaceName].Networks[1].Subnet.IP.String()).To(Equal(ip2.String()))
-				Expect(res[netName].Interfaces[interfaceName].Networks[1].Subnet.Mask).To(Equal(subnet2.Mask))
-				Expect(res[netName].Interfaces[interfaceName].Networks[1].Gateway).To(Equal(net.ParseIP("fd41:0a75:2ca0:48a9::1")))
+				Expect(res[netName].Interfaces[interfaceName].Subnets).To(HaveLen(2))
+				Expect(res[netName].Interfaces[interfaceName].Subnets[0].IPNet.IP.String()).To(Equal(ip1.String()))
+				Expect(res[netName].Interfaces[interfaceName].Subnets[0].IPNet.Mask).To(Equal(subnet1.Mask))
+				Expect(res[netName].Interfaces[interfaceName].Subnets[0].Gateway).To(Equal(net.ParseIP("192.168.0.1")))
+				Expect(res[netName].Interfaces[interfaceName].Subnets[1].IPNet.IP.String()).To(Equal(ip2.String()))
+				Expect(res[netName].Interfaces[interfaceName].Subnets[1].IPNet.Mask).To(Equal(subnet2.Mask))
+				Expect(res[netName].Interfaces[interfaceName].Subnets[1].Gateway).To(Equal(net.ParseIP("fd41:0a75:2ca0:48a9::1")))
 				Expect(res[netName].Interfaces[interfaceName].MacAddress).To(Equal(types.HardwareAddr(mac)))
 				// default network has no dns
 				Expect(res[netName].DNSServerIPs).To(BeEmpty())
@@ -799,9 +799,9 @@ var _ = Describe("run CNI", func() {
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(netName))
 				Expect(res[netName].Interfaces).To(HaveKey(intName))
-				Expect(res[netName].Interfaces[intName].Networks).To(HaveLen(1))
-				Expect(res[netName].Interfaces[intName].Networks[0].Subnet.IP.String()).To(Equal(ip))
-				Expect(res[netName].Interfaces[intName].Networks[0].Subnet.Mask).To(Equal(net.CIDRMask(24, 32)))
+				Expect(res[netName].Interfaces[intName].Subnets).To(HaveLen(1))
+				Expect(res[netName].Interfaces[intName].Subnets[0].IPNet.IP.String()).To(Equal(ip))
+				Expect(res[netName].Interfaces[intName].Subnets[0].IPNet.Mask).To(Equal(net.CIDRMask(24, 32)))
 
 				// check in the container namespace if the settings are applied
 				err = netNSContainer.Do(func(_ ns.NetNS) error {
@@ -902,11 +902,11 @@ var _ = Describe("run CNI", func() {
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(netName))
 				Expect(res[netName].Interfaces).To(HaveKey(interfaceName))
-				Expect(res[netName].Interfaces[interfaceName].Networks).To(HaveLen(2))
-				Expect(res[netName].Interfaces[interfaceName].Networks[0].Subnet.IP.String()).To(Equal(ip1.String()))
-				Expect(res[netName].Interfaces[interfaceName].Networks[0].Subnet.Mask).To(Equal(mask1))
-				Expect(res[netName].Interfaces[interfaceName].Networks[1].Subnet.IP.String()).To(Equal(ip2.String()))
-				Expect(res[netName].Interfaces[interfaceName].Networks[1].Subnet.Mask).To(Equal(mask2))
+				Expect(res[netName].Interfaces[interfaceName].Subnets).To(HaveLen(2))
+				Expect(res[netName].Interfaces[interfaceName].Subnets[0].IPNet.IP.String()).To(Equal(ip1.String()))
+				Expect(res[netName].Interfaces[interfaceName].Subnets[0].IPNet.Mask).To(Equal(mask1))
+				Expect(res[netName].Interfaces[interfaceName].Subnets[1].IPNet.IP.String()).To(Equal(ip2.String()))
+				Expect(res[netName].Interfaces[interfaceName].Subnets[1].IPNet.Mask).To(Equal(mask2))
 				// dualstack network dns
 				Expect(res[netName].DNSServerIPs).To(HaveLen(2))
 				Expect(res[netName].DNSSearchDomains).To(HaveLen(1))

--- a/libpod/network/netavark/run_test.go
+++ b/libpod/network/netavark/run_test.go
@@ -131,10 +131,10 @@ var _ = Describe("run netavark", func() {
 			Expect(res).To(HaveLen(1))
 			Expect(res).To(HaveKey(defNet))
 			Expect(res[defNet].Interfaces).To(HaveKey(intName))
-			Expect(res[defNet].Interfaces[intName].Networks).To(HaveLen(1))
-			ip := res[defNet].Interfaces[intName].Networks[0].Subnet.IP
+			Expect(res[defNet].Interfaces[intName].Subnets).To(HaveLen(1))
+			ip := res[defNet].Interfaces[intName].Subnets[0].IPNet.IP
 			Expect(ip.String()).To(ContainSubstring("10.88.0."))
-			gw := res[defNet].Interfaces[intName].Networks[0].Gateway
+			gw := res[defNet].Interfaces[intName].Subnets[0].Gateway
 			util.NormalizeIP(&gw)
 			Expect(gw.String()).To(Equal("10.88.0.1"))
 			macAddress := res[defNet].Interfaces[intName].MacAddress
@@ -222,8 +222,8 @@ var _ = Describe("run netavark", func() {
 			Expect(res).To(HaveLen(1))
 			Expect(res).To(HaveKey(defNet))
 			Expect(res[defNet].Interfaces).To(HaveKey(intName))
-			Expect(res[defNet].Interfaces[intName].Networks).To(HaveLen(1))
-			ip1 := res[defNet].Interfaces[intName].Networks[0].Subnet.IP
+			Expect(res[defNet].Interfaces[intName].Subnets).To(HaveLen(1))
+			ip1 := res[defNet].Interfaces[intName].Subnets[0].IPNet.IP
 			Expect(ip1.String()).To(ContainSubstring("10.88.0."))
 			Expect(res[defNet].Interfaces[intName].MacAddress).To(HaveLen(6))
 
@@ -246,8 +246,8 @@ var _ = Describe("run netavark", func() {
 			Expect(res).To(HaveLen(1))
 			Expect(res).To(HaveKey(defNet))
 			Expect(res[defNet].Interfaces).To(HaveKey(intName))
-			Expect(res[defNet].Interfaces[intName].Networks).To(HaveLen(1))
-			ip2 := res[defNet].Interfaces[intName].Networks[0].Subnet.IP
+			Expect(res[defNet].Interfaces[intName].Subnets).To(HaveLen(1))
+			ip2 := res[defNet].Interfaces[intName].Subnets[0].IPNet.IP
 			Expect(ip2.String()).To(ContainSubstring("10.88.0."))
 			Expect(res[defNet].Interfaces[intName].MacAddress).To(HaveLen(6))
 			Expect(ip1.Equal(ip2)).To(BeFalse(), "IP1 %s should not be equal to IP2 %s", ip1.String(), ip2.String())
@@ -286,14 +286,14 @@ var _ = Describe("run netavark", func() {
 			Expect(res).To(HaveLen(1))
 			Expect(res).To(HaveKey(netName))
 			Expect(res[netName].Interfaces).To(HaveKey(intName))
-			Expect(res[netName].Interfaces[intName].Networks).To(HaveLen(2))
-			ip1 := res[netName].Interfaces[intName].Networks[0].Subnet.IP
+			Expect(res[netName].Interfaces[intName].Subnets).To(HaveLen(2))
+			ip1 := res[netName].Interfaces[intName].Subnets[0].IPNet.IP
 			Expect(ip1.String()).To(ContainSubstring("10.0.0."))
-			gw1 := res[netName].Interfaces[intName].Networks[0].Gateway
+			gw1 := res[netName].Interfaces[intName].Subnets[0].Gateway
 			Expect(gw1.String()).To(Equal("10.0.0.1"))
-			ip2 := res[netName].Interfaces[intName].Networks[1].Subnet.IP
+			ip2 := res[netName].Interfaces[intName].Subnets[1].IPNet.IP
 			Expect(ip2.String()).To(ContainSubstring("fd10:88:a::"))
-			gw2 := res[netName].Interfaces[intName].Networks[0].Gateway
+			gw2 := res[netName].Interfaces[intName].Subnets[0].Gateway
 			Expect(gw2.String()).To(Equal("fd10:88:a::1"))
 			Expect(res[netName].Interfaces[intName].MacAddress).To(HaveLen(6))
 
@@ -380,14 +380,14 @@ var _ = Describe("run netavark", func() {
 			Expect(res).To(HaveKey(netName2))
 			Expect(res[netName1].Interfaces).To(HaveKey(intName1))
 			Expect(res[netName2].Interfaces).To(HaveKey(intName2))
-			Expect(res[netName1].Interfaces[intName1].Networks).To(HaveLen(1))
-			ip1 := res[netName1].Interfaces[intName1].Networks[0].Subnet.IP
+			Expect(res[netName1].Interfaces[intName1].Subnets).To(HaveLen(1))
+			ip1 := res[netName1].Interfaces[intName1].Subnets[0].IPNet.IP
 			Expect(ip1.String()).To(ContainSubstring("10.0.0."))
-			gw1 := res[netName1].Interfaces[intName1].Networks[0].Gateway
+			gw1 := res[netName1].Interfaces[intName1].Subnets[0].Gateway
 			Expect(gw1.String()).To(Equal("10.0.0.1"))
-			ip2 := res[netName2].Interfaces[intName2].Networks[0].Subnet.IP
+			ip2 := res[netName2].Interfaces[intName2].Subnets[0].IPNet.IP
 			Expect(ip2.String()).To(ContainSubstring("10.1.0."))
-			gw2 := res[netName2].Interfaces[intName2].Networks[0].Gateway
+			gw2 := res[netName2].Interfaces[intName2].Subnets[0].Gateway
 			Expect(gw2.String()).To(Equal("10.1.0.1"))
 			mac1 := res[netName1].Interfaces[intName1].MacAddress
 			Expect(mac1).To(HaveLen(6))
@@ -481,8 +481,8 @@ var _ = Describe("run netavark", func() {
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(defNet))
 				Expect(res[defNet].Interfaces).To(HaveKey(intName))
-				Expect(res[defNet].Interfaces[intName].Networks).To(HaveLen(1))
-				Expect(res[defNet].Interfaces[intName].Networks[0].Subnet.IP.String()).To(ContainSubstring("10.88.0."))
+				Expect(res[defNet].Interfaces[intName].Subnets).To(HaveLen(1))
+				Expect(res[defNet].Interfaces[intName].Subnets[0].IPNet.IP.String()).To(ContainSubstring("10.88.0."))
 				Expect(res[defNet].Interfaces[intName].MacAddress).To(HaveLen(6))
 				// default network has no dns
 				Expect(res[defNet].DNSServerIPs).To(BeEmpty())
@@ -535,8 +535,8 @@ var _ = Describe("run netavark", func() {
 				Expect(res).To(HaveLen(1))
 				Expect(res).To(HaveKey(defNet))
 				Expect(res[defNet].Interfaces).To(HaveKey(intName))
-				Expect(res[defNet].Interfaces[intName].Networks).To(HaveLen(1))
-				containerIP := res[defNet].Interfaces[intName].Networks[0].Subnet.IP.String()
+				Expect(res[defNet].Interfaces[intName].Subnets).To(HaveLen(1))
+				containerIP := res[defNet].Interfaces[intName].Subnets[0].IPNet.IP.String()
 				Expect(containerIP).To(ContainSubstring("10.88.0."))
 				Expect(res[defNet].Interfaces[intName].MacAddress).To(HaveLen(6))
 				// default network has no dns
@@ -593,10 +593,10 @@ var _ = Describe("run netavark", func() {
 			Expect(res).To(HaveLen(1))
 			Expect(res).To(HaveKey(defNet))
 			Expect(res[defNet].Interfaces).To(HaveKey(intName))
-			Expect(res[defNet].Interfaces[intName].Networks).To(HaveLen(1))
-			ip := res[defNet].Interfaces[intName].Networks[0].Subnet.IP
+			Expect(res[defNet].Interfaces[intName].Subnets).To(HaveLen(1))
+			ip := res[defNet].Interfaces[intName].Subnets[0].IPNet.IP
 			Expect(ip.String()).To(ContainSubstring("10.88.0."))
-			gw := res[defNet].Interfaces[intName].Networks[0].Gateway
+			gw := res[defNet].Interfaces[intName].Subnets[0].Gateway
 			Expect(gw.String()).To(Equal("10.88.0.1"))
 			macAddress := res[defNet].Interfaces[intName].MacAddress
 			Expect(macAddress).To(HaveLen(6))

--- a/libpod/network/types/network.go
+++ b/libpod/network/types/network.go
@@ -38,11 +38,11 @@ type Network struct {
 	ID string `json:"id"`
 	// Driver for this Network, e.g. bridge, macvlan...
 	Driver string `json:"driver"`
-	// InterfaceName is the network interface name on the host.
+	// NetworkInterface is the network interface name on the host.
 	NetworkInterface string `json:"network_interface,omitempty"`
 	// Created contains the timestamp when this network was created.
 	Created time.Time `json:"created,omitempty"`
-	// Subnets to use.
+	// Subnets to use for this network.
 	Subnets []Subnet `json:"subnets,omitempty"`
 	// IPv6Enabled if set to true an ipv6 subnet should be created for this net.
 	IPv6Enabled bool `json:"ipv6_enabled"`
@@ -177,24 +177,24 @@ type StatusBlock struct {
 
 // NetInterface contains the settings for a given network interface.
 type NetInterface struct {
-	// Networks list of assigned subnets with their gateway.
-	Networks []NetAddress `json:"networks,omitempty"`
+	// Subnets list of assigned subnets with their gateway.
+	Subnets []NetAddress `json:"subnets,omitempty"`
 	// MacAddress for this Interface.
 	MacAddress HardwareAddr `json:"mac_address"`
 }
 
-// NetAddress contains the subnet and gateway.
+// NetAddress contains the ip address, subnet and gateway.
 type NetAddress struct {
-	// Subnet of this NetAddress. Note that the subnet contains the
-	// actual ip of the net interface and not the network address.
-	Subnet IPNet `json:"subnet"`
-	// Gateway for the Subnet. This can be nil if there is no gateway, e.g. internal network.
+	// IPNet of this NetAddress. Note that this is a subnet but it has to contain the
+	// actual ip of the network interface and not the network address.
+	IPNet IPNet `json:"ipnet"`
+	// Gateway for the network. This can be empty if there is no gateway, e.g. internal network.
 	Gateway net.IP `json:"gateway,omitempty"`
 }
 
 // PerNetworkOptions are options which should be set on a per network basis.
 type PerNetworkOptions struct {
-	// StaticIPv4 for this container. Optional.
+	// StaticIPs for this container. Optional.
 	StaticIPs []net.IP `json:"static_ips,omitempty"`
 	// Aliases contains a list of names which the dns server should resolve
 	// to this container. Should only be set when DNSEnabled is true on the Network.

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -937,8 +937,8 @@ func (r *Runtime) reloadContainerNetwork(ctr *Container) (map[string]types.Statu
 				Aliases:       aliases[network],
 				StaticMAC:     netInt.MacAddress,
 			}
-			for _, netAddress := range netInt.Networks {
-				perNetOpts.StaticIPs = append(perNetOpts.StaticIPs, netAddress.Subnet.IP)
+			for _, netAddress := range netInt.Subnets {
+				perNetOpts.StaticIPs = append(perNetOpts.StaticIPs, netAddress.IPNet.IP)
 			}
 			// Normally interfaces have a length of 1, only for some special cni configs we could get more.
 			// For now just use the first interface to get the ips this should be good enough for most cases.
@@ -1124,25 +1124,25 @@ func (c *Container) setupNetworkDescriptions(networks []string) error {
 func resultToBasicNetworkConfig(result types.StatusBlock) (define.InspectBasicNetworkConfig, error) {
 	config := define.InspectBasicNetworkConfig{}
 	for _, netInt := range result.Interfaces {
-		for _, netAddress := range netInt.Networks {
-			size, _ := netAddress.Subnet.Mask.Size()
-			if netAddress.Subnet.IP.To4() != nil {
+		for _, netAddress := range netInt.Subnets {
+			size, _ := netAddress.IPNet.Mask.Size()
+			if netAddress.IPNet.IP.To4() != nil {
 				//ipv4
 				if config.IPAddress == "" {
-					config.IPAddress = netAddress.Subnet.IP.String()
+					config.IPAddress = netAddress.IPNet.IP.String()
 					config.IPPrefixLen = size
 					config.Gateway = netAddress.Gateway.String()
 				} else {
-					config.SecondaryIPAddresses = append(config.SecondaryIPAddresses, netAddress.Subnet.IP.String())
+					config.SecondaryIPAddresses = append(config.SecondaryIPAddresses, netAddress.IPNet.IP.String())
 				}
 			} else {
 				//ipv6
 				if config.GlobalIPv6Address == "" {
-					config.GlobalIPv6Address = netAddress.Subnet.IP.String()
+					config.GlobalIPv6Address = netAddress.IPNet.IP.String()
 					config.GlobalIPv6PrefixLen = size
 					config.IPv6Gateway = netAddress.Gateway.String()
 				} else {
-					config.SecondaryIPv6Addresses = append(config.SecondaryIPv6Addresses, netAddress.Subnet.IP.String())
+					config.SecondaryIPv6Addresses = append(config.SecondaryIPv6Addresses, netAddress.IPNet.IP.String())
 				}
 			}
 		}

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -660,12 +660,12 @@ func getRootlessPortChildIP(c *Container, netStatus map[string]types.StatusBlock
 	var ipv6 net.IP
 	for _, status := range netStatus {
 		for _, netInt := range status.Interfaces {
-			for _, netAddress := range netInt.Networks {
-				ipv4 := netAddress.Subnet.IP.To4()
+			for _, netAddress := range netInt.Subnets {
+				ipv4 := netAddress.IPNet.IP.To4()
 				if ipv4 != nil {
 					return ipv4.String()
 				}
-				ipv6 = netAddress.Subnet.IP
+				ipv6 = netAddress.IPNet.IP
 			}
 		}
 	}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:
Some field names are confusing. Change them so that they make more sense
to the reader.
Since these fields are only in the main branch we can safly rename them
without worrying about backwards compatibility.
Note we have to change the field names in netavark too.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
