### PR TITLE
Add docker.io to unqualified image name

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -255,6 +255,10 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 	// without this early check this function would return 200 but reported error via body stream soon after
 	// it's better to let caller know early via HTTP status code that request cannot be processed
 	_, err := shortnames.Resolve(runtime.SystemContext(), fromImage)
+	if err != nil && shortnames.IsShortName(fromImage) {
+		fromImage = fmt.Sprintf("%s/%s", "docker.io", fromImage)
+		_, err = shortnames.Resolve(runtime.SystemContext(), fromImage)
+	}
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrap(err, "failed to resolve image name"))
 		return


### PR DESCRIPTION
Since that's the default behavior of moby engine, the compat
API need to reflect that.

[ NO NEW TESTS NEEDED ]

Signed-off-by: Michael Scherer <misc@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

This PR should fixe #12320

#### How to verify it

Same as my other PR, trying to get woodpecker running.

#### Which issue(s) this PR fixes:

Fixes #12320

#### Special notes for your reviewer:

There is no test added, because adding them would requires to download image from docker.io, but this doesn't seems wise due to the rate limit in place on the registry.