### PR TITLE
hack/bats: deal with new bin helpers

### DIFF
--- a/hack/bats
+++ b/hack/bats
@@ -93,19 +93,25 @@ done
 
 rc=0
 
+# As of 2021-11 podman has a bunch of external helper binaries
+if [[ -z "$CONTAINERS_HELPER_BINARY_DIR" ]]; then
+    export CONTAINERS_HELPER_BINARY_DIR=$(pwd)/bin
+fi
+
 # Root
 if [ -z "$ROOTLESS_ONLY" ]; then
     echo "# bats ${bats_filter[@]} $TESTS"
     sudo    --preserve-env=PODMAN \
             --preserve-env=PODMAN_TEST_DEBUG \
             --preserve-env=OCI_RUNTIME \
+            --preserve-env=CONTAINERS_HELPER_BINARY_DIR \
             bats "${bats_opts[@]}" "${bats_filter[@]}" $TESTS
     rc=$?
 fi
 
-# Rootless
-echo "--------------------------------------------------"
-if [ -z "$ROOT_ONLY" ]; then
+# Rootless. (Only if we're not already root)
+if [[ -z "$ROOT_ONLY" && "$(id -u)" != 0 ]]; then
+    echo "--------------------------------------------------"
     echo "\$ bats ${bats_filter[@]} $TESTS"
     bats "${bats_opts[@]}" "${bats_filter[@]}" $TESTS
     rc=$((rc | $?))

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -11,7 +11,7 @@ function teardown() {
     run_podman rm -t 0 -f -a
     run_podman image list --format '{{.ID}} {{.Repository}}'
     while read id name; do
-        if [[ "$name" =~ /pause ]]; then
+        if [[ "$name" =~ /podman-pause ]]; then
             run_podman rmi $id
         fi
     done <<<"$output"


### PR DESCRIPTION
Some time in the last month, podman started to depend on a bunch
of external helper binaries: rootlessport, pause, catatonit.
System tests fail without these.

Update the hack/bats script to pass $CONTAINERS_HELPER_BINARIES_DIR
(set to ./bin); podman will then use locally-built helpers. (This
requires https://github.com/containers/common/pull/823 , which as
of this PR is not yet vendored into podman. There is no harm in
merging this while we wait.)

Also: if bats helper is invoked as root, run only once; i.e.,
skip the "rootless" step.

Also (piggybacked): the name of the podman pause image has
changed, from pause to podman-pause. Adjust that in our
teardown so we don't leave droppings.

Signed-off-by: Ed Santiago <santiago@redhat.com>
