### PR TITLE
utils: use podman-pause-$RANDOM.scope name

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"strconv"
@@ -203,7 +204,16 @@ func moveProcessToScope(pidPath, slice, scope string) error {
 // MovePauseProcessToScope moves the pause process used for rootless mode to keep the namespaces alive to
 // a separate scope.
 func MovePauseProcessToScope(pausePidPath string) {
-	err := moveProcessToScope(pausePidPath, "user.slice", "podman-pause.scope")
+	var err error
+
+	for i := 0; i < 3; i++ {
+		r := rand.Int()
+		err = moveProcessToScope(pausePidPath, "user.slice", fmt.Sprintf("podman-pause-%d.scope", r))
+		if err == nil {
+			return
+		}
+	}
+
 	if err != nil {
 		unified, err2 := cgroups.IsCgroup2UnifiedMode()
 		if err2 != nil {

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -44,15 +44,6 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 	ch := make(chan string)
 	_, err = conn.StartTransientUnit(unitName, "replace", properties, ch)
 	if err != nil {
-		// On errors check if the cgroup already exists, if it does move the process there
-		if props, err := conn.GetUnitTypeProperties(unitName, "Scope"); err == nil {
-			if cgroup, ok := props["ControlGroup"].(string); ok && cgroup != "" {
-				if err := moveUnderCgroup(cgroup, "", []uint32{uint32(pid)}); err == nil {
-					return nil
-				}
-				// On errors return the original error message we got from StartTransientUnit.
-			}
-		}
 		return err
 	}
 


### PR DESCRIPTION
we try hard to re-use the existing podman-pause.scope name when it
already exists, causing any sort of race errors when the already
existing scope is terminating.

There is no such a requirement though, so just try with a random
name.

Closes: https://github.com/containers/podman/issues/12065

[NO NEW TESTS NEEDED] it fixes a race in the CI

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
