### PR TITLE
rootless: use catatonit to maintain user+mnt namespace

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -106,6 +106,11 @@ do_pause ()
   for (i = 0; sig[i]; i++)
     sigaction (sig[i], &act, NULL);
 
+  /* Attempt to execv catatonit to keep the pause process alive.  */
+  execl ("/usr/libexec/podman/catatonit", "catatonit", "-P", NULL);
+  execl ("/usr/bin/catatonit", "catatonit", "-P", NULL);
+  /* and if the catatonit executable could not be found, fallback here... */
+
   prctl (PR_SET_NAME, "podman pause", NULL, NULL, NULL);
   while (1)
     pause ();


### PR DESCRIPTION
if catatonit is present, use it to keep the rootless user+mnt
namespace alive.

[NO NEW TESTS NEEDED] no new features added.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
