### PR TITLE
Backport #11976 to 3.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,15 @@ define go-get
 		$(GO) get -u ${1}
 endef
 
+# Need to use CGO for mDNS resolution, but cross builds need CGO disabled
+# See https://github.com/golang/go/issues/12524 for details
+DARWIN_GCO := 0
+ifeq ($(NATIVE_GOOS),darwin)
+ifdef HOMEBREW_PREFIX
+	DARWIN_GCO := 1
+endif
+endif
+
 ###
 ### Primary entry-point targets
 ###
@@ -349,7 +358,7 @@ podman-remote-windows: ## Build podman-remote for Windows
 .PHONY: podman-remote-darwin
 podman-remote-darwin: ## Build podman-remote for macOS
 	$(MAKE) \
-		CGO_ENABLED=0 \
+		CGO_ENABLED=$(DARWIN_GCO) \
 		GOOS=darwin \
 		bin/darwin/podman
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

Backport #11976 (DNS fix for macOS) to 3.4 branch.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->
Builds can use private DNS servers or mDNS available only on the macOS side to pull images from (private) registries.

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

Fixes #10737


#### Special notes for your reviewer:

