### PR TITLE
compat: Add subnet mask behind IP address to match Docker API

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -2,6 +2,7 @@ package compat
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 
@@ -69,12 +70,20 @@ func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, network nettyp
 			return nil, err
 		}
 		if netData, ok := data.NetworkSettings.Networks[network.Name]; ok {
+			ipv4Address := ""
+			if netData.IPAddress != "" {
+				ipv4Address = fmt.Sprintf("%s/%d", netData.IPAddress, netData.IPPrefixLen)
+			}
+			ipv6Address := ""
+			if netData.GlobalIPv6Address != "" {
+				ipv6Address = fmt.Sprintf("%s/%d", netData.GlobalIPv6Address, netData.GlobalIPv6PrefixLen)
+			}
 			containerEndpoint := types.EndpointResource{
-				Name:        netData.NetworkID,
+				Name:        con.Name(),
 				EndpointID:  netData.EndpointID,
 				MacAddress:  netData.MacAddress,
-				IPv4Address: netData.IPAddress,
-				IPv6Address: netData.GlobalIPv6Address,
+				IPv4Address: ipv4Address,
+				IPv6Address: ipv6Address,
 			}
 			containerEndpoints[con.ID()] = containerEndpoint
 		}

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -170,4 +170,31 @@ t DELETE libpod/networks/macvlan1 200 \
   .[0].Name~macvlan1 \
   .[0].Err=null
 
+#
+# test networks with containers
+#
+podman pull $IMAGE &>/dev/null
+
+# Ensure clean slate
+podman rm -a -f &>/dev/null
+
+# create a network
+podman network create --subnet 10.10.253.0/24 --gateway 10.10.253.1 network5
+t GET libpod/networks/json?filters='{"name":["network5"]}' 200 \
+  .[0].id~[0-9a-f]\\{64\\}
+nid=$(jq -r '.[0].id' <<<"$output")
+# create a pod on a network
+CNAME=mynettest
+podman run --network network5 --name $CNAME --ip 10.10.253.2 --mac-address 0a:01:73:78:43:18 -td $IMAGE top
+t GET libpod/containers/json?all=true 200 \
+  .[0].Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.[0].Id' <<<"$output")
+# compat api inspect network
+t GET networks/$nid 200 .Name="network5" \
+  .Containers[\"$cid\"].Name=$CNAME \
+  .Containers[\"$cid\"].MacAddress=0a:01:73:78:43:18 \
+  .Containers[\"$cid\"].IPv4Address=10.10.253.2/24
+# clean the network
+podman network rm -f network5
+
 # vim: filetype=sh


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

Mismatch between Podman and Docker APIs when listing network containers.

<!---
Please put your overall PR description here
-->

#### How to verify it

On both Docker and Podman, create a container on a network and run:
```
curl -X GET --unix-socket /var/run/docker.sock http://d/networks/<id> | jq
```
<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

Docker (20.10.10):
<img width="400" alt="Screenshot 2021-11-17 at 20 09 49" src="https://user-images.githubusercontent.com/1705906/142198851-894b19af-b045-449b-b3f2-092c9331fa4e.png">
Podman:
<img width="400" alt="Screenshot 2021-11-17 at 20-11-56" src="https://user-images.githubusercontent.com/1705906/142198946-17bb8d82-73d0-4493-b635-7aa477798c0c.png">

#### Which issue(s) this PR

Fixes: None

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

(Sidenote: I'm working on compatibility with `k3d`) 

#### Special notes for your reviewer:
