### PR TITLE
fix: take absolute path for dd on apple silicon

### DIFF
--- a/pkg/machine/qemu/options_darwin_arm64.go
+++ b/pkg/machine/qemu/options_darwin_arm64.go
@@ -24,7 +24,7 @@ func (v *MachineVM) addArchOptions() []string {
 
 func (v *MachineVM) prepare() error {
 	ovmfDir := getOvmfDir(v.ImagePath, v.Name)
-	cmd := []string{"dd", "if=/dev/zero", "conv=sync", "bs=1m", "count=64", "of=" + ovmfDir}
+	cmd := []string{"/bin/dd", "if=/dev/zero", "conv=sync", "bs=1m", "count=64", "of=" + ovmfDir}
 	return exec.Command(cmd[0], cmd[1:]...).Run()
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Change the path for dd to absolute if dd has been overwritten (e.g. by coreutils)

#### How to verify it

On Apple silicon
```
brew install coreutils
podman machine init
```

#### Which issue(s) this PR fixes:

Fixes #12329
