### PR TITLE
Add --file-locks checkpoint/restore option

### DIFF
--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -55,6 +55,7 @@ func init() {
 	flags.BoolVarP(&checkpointOptions.Keep, "keep", "k", false, "Keep all temporary checkpoint files")
 	flags.BoolVarP(&checkpointOptions.LeaveRunning, "leave-running", "R", false, "Leave the container running after writing checkpoint to disk")
 	flags.BoolVar(&checkpointOptions.TCPEstablished, "tcp-established", false, "Checkpoint a container with established TCP connections")
+	flags.BoolVar(&checkpointOptions.FileLocks, "file-locks", false, "Checkpoint a container with file locks")
 	flags.BoolVarP(&checkpointOptions.All, "all", "a", false, "Checkpoint all running containers")
 
 	exportFlagName := "export"

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -53,6 +53,7 @@ func init() {
 	flags.BoolVarP(&restoreOptions.All, "all", "a", false, "Restore all checkpointed containers")
 	flags.BoolVarP(&restoreOptions.Keep, "keep", "k", false, "Keep all temporary checkpoint files")
 	flags.BoolVar(&restoreOptions.TCPEstablished, "tcp-established", false, "Restore a container with established TCP connections")
+	flags.BoolVar(&restoreOptions.FileLocks, "file-locks", false, "Restore a container with file locks")
 
 	importFlagName := "import"
 	flags.StringVarP(&restoreOptions.Import, importFlagName, "i", "", "Restore from exported checkpoint archive (tar.gz)")

--- a/docs/source/markdown/podman-container-checkpoint.1.md
+++ b/docs/source/markdown/podman-container-checkpoint.1.md
@@ -110,6 +110,14 @@ restore. Defaults to not checkpointing *containers* with established TCP
 connections.\
 The default is **false**.
 
+#### **--file-locks**
+
+Checkpoint a *container* with file locks. If an application running in the container
+is using file locks, this OPTION is required during checkpoint and restore. Otherwise
+checkpointing *containers* with file locks is expected to fail. If file locks are not
+used, this option is ignored.\
+The default is **false**.
+
 #### **--with-previous**
 
 Check out the *container* with previous criu image files in pre-dump. It only works on `runc 1.0-rc3` or `higher`.\

--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -143,6 +143,14 @@ option is ignored. Defaults to not restoring *containers* with established TCP
 connections.\
 The default is **false**.
 
+#### **--file-locks**
+
+Restore a *container* with file locks. This option is required to
+restore file locks from a checkpoint image. If the checkpoint image
+does not contain file locks, this option is ignored. Defaults to not
+restoring file locks.\
+The default is **false**.
+
 ## EXAMPLE
 Restores the container "mywebserver".
 ```

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -798,6 +798,9 @@ type ContainerCheckpointOptions struct {
 	// how much time each component in the stack requires to
 	// checkpoint a container.
 	PrintStats bool
+	// FileLocks tells the API to checkpoint/restore a container
+	// with file-locks
+	FileLocks bool
 }
 
 // Checkpoint checkpoints a container

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -794,6 +794,9 @@ func (r *ConmonOCIRuntime) CheckpointContainer(ctr *Container, options Container
 	if options.TCPEstablished {
 		args = append(args, "--tcp-established")
 	}
+	if options.FileLocks {
+		args = append(args, "--file-locks")
+	}
 	if !options.PreCheckPoint && options.KeepRunning {
 		args = append(args, "--leave-running")
 	}
@@ -1100,6 +1103,9 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 		args = append(args, "--restore", ctr.CheckpointPath())
 		if restoreOptions.TCPEstablished {
 			args = append(args, "--runtime-opt", "--tcp-established")
+		}
+		if restoreOptions.FileLocks {
+			args = append(args, "--runtime-opt", "--file-locks")
 		}
 		if restoreOptions.Pod != "" {
 			mountLabel := ctr.config.MountLabel

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -53,6 +53,7 @@ type CheckpointOptions struct {
 	PrintStats     *bool
 	PreCheckpoint  *bool
 	WithPrevious   *bool
+	FileLocks      *bool
 }
 
 //go:generate go run ../generator/generator.go RestoreOptions
@@ -69,6 +70,7 @@ type RestoreOptions struct {
 	Pod             *string
 	PrintStats      *bool
 	PublishPorts    []string
+	FileLocks       *bool
 }
 
 //go:generate go run ../generator/generator.go CreateOptions

--- a/pkg/bindings/containers/types_checkpoint_options.go
+++ b/pkg/bindings/containers/types_checkpoint_options.go
@@ -136,3 +136,18 @@ func (o *CheckpointOptions) GetWithPrevious() bool {
 	}
 	return *o.WithPrevious
 }
+
+// WithFileLocks set field FileLocks to given value
+func (o *CheckpointOptions) WithFileLocks(value bool) *CheckpointOptions {
+	o.FileLocks = &value
+	return o
+}
+
+// GetFileLocks returns value of field FileLocks
+func (o *CheckpointOptions) GetFileLocks() bool {
+	if o.FileLocks == nil {
+		var z bool
+		return z
+	}
+	return *o.FileLocks
+}

--- a/pkg/bindings/containers/types_restore_options.go
+++ b/pkg/bindings/containers/types_restore_options.go
@@ -181,3 +181,18 @@ func (o *RestoreOptions) GetPublishPorts() []string {
 	}
 	return o.PublishPorts
 }
+
+// WithFileLocks set field FileLocks to given value
+func (o *RestoreOptions) WithFileLocks(value bool) *RestoreOptions {
+	o.FileLocks = &value
+	return o
+}
+
+// GetFileLocks returns value of field FileLocks
+func (o *RestoreOptions) GetFileLocks() bool {
+	if o.FileLocks == nil {
+		var z bool
+		return z
+	}
+	return *o.FileLocks
+}

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -191,6 +191,7 @@ type CheckpointOptions struct {
 	WithPrevious   bool
 	Compression    archive.Compression
 	PrintStats     bool
+	FileLocks      bool
 }
 
 type CheckpointReport struct {
@@ -215,6 +216,7 @@ type RestoreOptions struct {
 	PublishPorts    []string
 	Pod             string
 	PrintStats      bool
+	FileLocks       bool
 }
 
 type RestoreReport struct {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -516,6 +516,7 @@ func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds [
 		WithPrevious:   options.WithPrevious,
 		Compression:    options.Compression,
 		PrintStats:     options.PrintStats,
+		FileLocks:      options.FileLocks,
 	}
 
 	if options.All {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -303,6 +303,7 @@ func (ic *ContainerEngine) ContainerExport(ctx context.Context, nameOrID string,
 
 func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds []string, opts entities.CheckpointOptions) ([]*entities.CheckpointReport, error) {
 	options := new(containers.CheckpointOptions)
+	options.WithFileLocks(opts.FileLocks)
 	options.WithIgnoreRootfs(opts.IgnoreRootFS)
 	options.WithKeep(opts.Keep)
 	options.WithExport(opts.Export)
@@ -352,6 +353,7 @@ func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []st
 	}
 
 	options := new(containers.RestoreOptions)
+	options.WithFileLocks(opts.FileLocks)
 	options.WithIgnoreRootfs(opts.IgnoreRootFS)
 	options.WithIgnoreVolumes(opts.IgnoreVolumes)
 	options.WithIgnoreStaticIP(opts.IgnoreStaticIP)


### PR DESCRIPTION
#### What this PR does / why we need it:

CRIU supports checkpoint/restore of file locks. This feature is required to checkpoint/restore containers running applications such MySQL.

#### How to verify it?

```bash
sudo podman run --name some-mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:latest

sudo podman container checkpoint --file-locks some-mysql
```
