### PR TITLE
remote checkpoint/restore: more fixes

### DIFF
--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -81,6 +81,7 @@ to import a checkpointed *container* from another host.\
 
 Import a pre-checkpoint tar.gz file which was exported by Podman. This option
 must be used with **-i** or **--import**. It only works on `runc 1.0-rc3` or `higher`.
+*IMPORTANT: This OPTION is not supported on the remote client.*
 
 #### **--name**, **-n**=*name*
 

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -219,6 +219,8 @@ func Checkpoint(w http.ResponseWriter, r *http.Request) {
 		Export         bool `schema:"export"`
 		IgnoreRootFS   bool `schema:"ignoreRootFS"`
 		PrintStats     bool `schema:"printStats"`
+		PreCheckpoint  bool `schema:"preCheckpoint"`
+		WithPrevious   bool `schema:"withPrevious"`
 	}{
 		// override any golang type defaults
 	}
@@ -242,6 +244,8 @@ func Checkpoint(w http.ResponseWriter, r *http.Request) {
 		TCPEstablished: query.TCPEstablished,
 		IgnoreRootFS:   query.IgnoreRootFS,
 		PrintStats:     query.PrintStats,
+		PreCheckPoint:  query.PreCheckpoint,
+		WithPrevious:   query.WithPrevious,
 	}
 
 	if query.Export {

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -51,6 +51,8 @@ type CheckpointOptions struct {
 	LeaveRunning   *bool
 	TCPEstablished *bool
 	PrintStats     *bool
+	PreCheckpoint  *bool
+	WithPrevious   *bool
 }
 
 //go:generate go run ../generator/generator.go RestoreOptions

--- a/pkg/bindings/containers/types_checkpoint_options.go
+++ b/pkg/bindings/containers/types_checkpoint_options.go
@@ -106,3 +106,33 @@ func (o *CheckpointOptions) GetPrintStats() bool {
 	}
 	return *o.PrintStats
 }
+
+// WithPreCheckpoint set field PreCheckpoint to given value
+func (o *CheckpointOptions) WithPreCheckpoint(value bool) *CheckpointOptions {
+	o.PreCheckpoint = &value
+	return o
+}
+
+// GetPreCheckpoint returns value of field PreCheckpoint
+func (o *CheckpointOptions) GetPreCheckpoint() bool {
+	if o.PreCheckpoint == nil {
+		var z bool
+		return z
+	}
+	return *o.PreCheckpoint
+}
+
+// WithWithPrevious set field WithPrevious to given value
+func (o *CheckpointOptions) WithWithPrevious(value bool) *CheckpointOptions {
+	o.WithPrevious = &value
+	return o
+}
+
+// GetWithPrevious returns value of field WithPrevious
+func (o *CheckpointOptions) GetWithPrevious() bool {
+	if o.WithPrevious == nil {
+		var z bool
+		return z
+	}
+	return *o.WithPrevious
+}

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -308,7 +308,9 @@ func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds [
 	options.WithExport(opts.Export)
 	options.WithTCPEstablished(opts.TCPEstablished)
 	options.WithPrintStats(opts.PrintStats)
+	options.WithPreCheckpoint(opts.PreCheckPoint)
 	options.WithLeaveRunning(opts.LeaveRunning)
+	options.WithWithPrevious(opts.WithPrevious)
 
 	var (
 		err  error
@@ -345,6 +347,10 @@ func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds [
 }
 
 func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []string, opts entities.RestoreOptions) ([]*entities.RestoreReport, error) {
+	if opts.ImportPrevious != "" {
+		return nil, fmt.Errorf("--import-previous is not supported on the remote client")
+	}
+
 	options := new(containers.RestoreOptions)
 	options.WithIgnoreRootfs(opts.IgnoreRootFS)
 	options.WithIgnoreVolumes(opts.IgnoreVolumes)

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -899,6 +899,7 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint container with --pre-checkpoint and export (migration)", func() {
+		SkipIfRemote("--import-previous is not yet supported on the remote client")
 		if !strings.Contains(podmanTest.OCIRuntime, "runc") {
 			Skip("Test only works on runc 1.0-rc3 or higher.")
 		}


### PR DESCRIPTION
* Support `checkpoint --pre-checkpoint`

* Support `checkpoint --with-previous`

* Disable `restore --import-previous` for the remote client since we had
  to send two files which in turn would require to tar them up and hence
  be a breaking change.  Podman 4.0 would be the chance and I hope we'll
  find time before that to remote-restore prettier.

Note that I did not run over swagger yet to check whether all parameters
are actually documented due to time constraints.

Fixes: #12334
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>