### PR TITLE
fix CI

### DIFF
--- a/contrib/fedora-minimal/Dockerfile
+++ b/contrib/fedora-minimal/Dockerfile
@@ -1,1 +1,0 @@
-FROM registry.fedoraproject.org/fedora-minimal:latest

--- a/contrib/fedora-minimal/README.md
+++ b/contrib/fedora-minimal/README.md
@@ -1,4 +1,0 @@
-This dockerfile exists so that the container image can be "mirrored"
-onto quay.io automatically, so automated testing can be more resilient.
-
-https://quay.io/repository/libpod/fedora-minimal?tab=builds

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -2,7 +2,7 @@ package integration
 
 var (
 	redis             = "quay.io/libpod/redis:alpine"
-	fedoraMinimal     = "quay.io/libpod/fedora-minimal:latest"
+	fedoraMinimal     = "registry.fedoraproject.org/fedora-minimal:34"
 	ALPINE            = "quay.io/libpod/alpine:latest"
 	ALPINELISTTAG     = "quay.io/libpod/alpine:3.10.2"
 	ALPINELISTDIGEST  = "quay.io/libpod/alpine@sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Podman images", func() {
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "reference=quay.io*"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(len(result.OutputToStringArray())).To(Equal(8))
+		Expect(len(result.OutputToStringArray())).To(Equal(7))
 
 		retalpine := podmanTest.Podman([]string{"images", "-f", "reference=a*pine"})
 		retalpine.WaitWithDefaultTimeout()

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1516,7 +1516,7 @@ USER mail`, BB)
 	})
 
 	It("podman run --privileged and --group-add", func() {
-		groupName := "kvm"
+		groupName := "mail"
 		session := podmanTest.Podman([]string{"run", "-t", "-i", "--group-add", groupName, "--privileged", fedoraMinimal, "groups"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))


### PR DESCRIPTION
Our fedora-minimal image on Quay bases on fedora-minimal:latest which
starting with F35 removed a number of binaries that our CI depends on.
Fix that by pulling `fedora-minimal:34` from the Fedora registry
directly.

Once the build bot on Quay has been disabled, we move the image over
there to make sure that it will not change over time.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>