### PR TITLE
Semiperiodic cleanup of obsolete Skip()s

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -320,7 +320,7 @@ func (p *PodmanTestIntegration) createArtifact(image string) {
 	}
 	dest := strings.Split(image, "/")
 	destName := fmt.Sprintf("/tmp/%s.tar", strings.Replace(strings.Join(strings.Split(dest[len(dest)-1], "/"), ""), ":", "-", -1))
-	fmt.Printf("Caching %s at %s...", image, destName)
+	fmt.Printf("Caching %s at %s...\n", image, destName)
 	if _, err := os.Stat(destName); os.IsNotExist(err) {
 		pull := p.PodmanNoCache([]string{"pull", image})
 		pull.Wait(440)
@@ -466,6 +466,9 @@ func (p *PodmanTestIntegration) BuildImageWithLabel(dockerfile, imageName string
 // PodmanPID execs podman and returns its PID
 func (p *PodmanTestIntegration) PodmanPID(args []string) (*PodmanSessionIntegration, int) {
 	podmanOptions := p.MakeOptions(args, false, false)
+	if p.RemoteTest {
+		podmanOptions = append([]string{"--remote", "--url", p.RemoteSocket}, podmanOptions...)
+	}
 	fmt.Printf("Running: %s %s\n", p.PodmanBinary, strings.Join(podmanOptions, " "))
 	command := exec.Command(p.PodmanBinary, podmanOptions...)
 	session, err := Start(command, GinkgoWriter, GinkgoWriter)

--- a/test/e2e/import_test.go
+++ b/test/e2e/import_test.go
@@ -18,7 +18,6 @@ var _ = Describe("Podman import", func() {
 	)
 
 	BeforeEach(func() {
-		SkipIfRemote("FIXME: These look like it is supposed to work in remote")
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)
@@ -156,6 +155,8 @@ var _ = Describe("Podman import", func() {
 	})
 
 	It("podman import with signature", func() {
+		SkipIfRemote("FIXME: remote ignores --signature-policy, #12357")
+
 		outfile := filepath.Join(podmanTest.TempDir, "container.tar")
 		_, ec, cid := podmanTest.RunLsContainer("")
 		Expect(ec).To(Equal(0))

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Podman logs", func() {
 
 		It("two containers showing short container IDs: "+log, func() {
 			skipIfJournaldInContainer()
-			SkipIfRemote("FIXME: podman-remote logs does not support showing two containers at the same time")
+			SkipIfRemote("podman-remote logs does not support showing two containers at the same time")
 
 			log1 := podmanTest.Podman([]string{"run", "--log-driver", log, "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 			log1.WaitWithDefaultTimeout()

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to local registry with authorization", func() {
-		SkipIfRootless("FIXME: Creating content in certs.d we use directories in homedir")
+		SkipIfRootless("volume-mounting a certs.d file N/A over remote")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -48,21 +48,22 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		run := podmanTest.Podman([]string{"run", "--cgroupns=host", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/self/cgroup"})
 		run.WaitWithDefaultTimeout()
 		Expect(run).Should(Exit(0))
-		ok, _ := run.GrepString(cgroup)
-		Expect(ok).To(BeTrue())
+		Expect(run.OutputToString()).To(ContainSubstring(cgroup))
 	})
 
 	Specify("no --cgroup-parent", func() {
-		SkipIfRootless("FIXME This seems to be broken in rootless mode")
 		cgroup := "/libpod_parent"
 		if !Containerized() && podmanTest.CgroupManager != "cgroupfs" {
-			cgroup = "/machine.slice"
+			if isRootless() {
+				cgroup = "/user.slice"
+			} else {
+				cgroup = "/machine.slice"
+			}
 		}
 		run := podmanTest.Podman([]string{"run", "--cgroupns=host", fedoraMinimal, "cat", "/proc/self/cgroup"})
 		run.WaitWithDefaultTimeout()
 		Expect(run).Should(Exit(0))
-		ok, _ := run.GrepString(cgroup)
-		Expect(ok).To(BeTrue())
+		Expect(run.OutputToString()).To(ContainSubstring(cgroup))
 	})
 
 	Specify("always honor --cgroup-parent", func() {
@@ -114,7 +115,6 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		run := podmanTest.Podman([]string{"run", "--cgroupns=host", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/1/cgroup"})
 		run.WaitWithDefaultTimeout()
 		Expect(run).Should(Exit(0))
-		ok, _ := run.GrepString(cgroup)
-		Expect(ok).To(BeTrue())
+		Expect(run.OutputToString()).To(ContainSubstring(cgroup))
 	})
 })

--- a/test/e2e/run_cleanup_test.go
+++ b/test/e2e/run_cleanup_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Podman run exit", func() {
 
 	It("podman run -d mount cleanup test", func() {
 		SkipIfRemote("podman-remote does not support mount")
-		SkipIfRootless("FIXME podman mount requires podman unshare first")
+		SkipIfRootless("TODO rootless podman mount requires podman unshare first")
 
 		result := podmanTest.Podman([]string{"run", "-dt", ALPINE, "top"})
 		result.WaitWithDefaultTimeout()

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -128,7 +128,6 @@ var _ = Describe("Podman privileged container tests", func() {
 	})
 
 	It("podman privileged should inherit host devices", func() {
-		SkipIfRootless("FIXME: This seems to be broken for rootless mode, /dev/ is close to the same")
 		session := podmanTest.Podman([]string{"run", "--privileged", ALPINE, "ls", "-l", "/dev"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -45,7 +45,6 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 	})
 
 	Specify("signals are forwarded to container using sig-proxy", func() {
-		SkipIfRemote("FIXME: This looks like it is supposed to work in remote")
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("Doesn't work on ppc64le")
 		}
@@ -111,7 +110,6 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 	})
 
 	Specify("signals are not forwarded to container with sig-proxy false", func() {
-		SkipIfRemote("FIXME: This looks like it is supposed to work in remote")
 		signal := syscall.SIGFPE
 		if rootless.IsRootless() {
 			podmanTest.RestoreArtifact(fedoraMinimal)

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -681,7 +681,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-read-bps test", func() {
-		SkipIfRootless("FIXME: Missing /sys/fs/cgroup/user.slice/user-14467.slice/user@14467.service/cgroup.subtree_control")
+		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-read-bps not supported on cgroupv1 for rootless users")
 
 		var session *PodmanSessionIntegration
@@ -700,7 +700,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-write-bps test", func() {
-		SkipIfRootless("FIXME /sys/fs/cgroup/user.slice/user-14467.slice/user@14467.service/cgroup.subtree_control does not exist")
+		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-write-bps not supported on cgroupv1 for rootless users")
 
 		var session *PodmanSessionIntegration
@@ -718,7 +718,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-read-iops test", func() {
-		SkipIfRootless("FIXME /sys/fs/cgroup/user.slice/user-14467.slice/user@14467.service/cgroup.subtree_control does not exist")
+		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-read-iops not supported on cgroupv1 for rootless users")
 		var session *PodmanSessionIntegration
 
@@ -736,7 +736,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-write-iops test", func() {
-		SkipIfRootless("FIXME /sys/fs/cgroup/user.slice/user-14467.slice/user@14467.service/cgroup.subtree_control does not exist")
+		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-write-iops not supported on cgroupv1 for rootless users")
 		var session *PodmanSessionIntegration
 

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -282,8 +282,8 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman run with tmpfs named volume mounts and unmounts", func() {
-		SkipIfRootless("FIXME:  rootless podman mount requires you to be in a user namespace")
-		SkipIfRemote("podman-remote does not support --volumes this test could be simplified to be tested on Remote.")
+		SkipIfRootless("rootless podman mount requires you to be in a user namespace")
+		SkipIfRemote("podman-remote does not support --volumes. This test could be simplified to be tested on Remote.")
 		volName := "testvol"
 		mkVolume := podmanTest.Podman([]string{"volume", "create", "--opt", "type=tmpfs", "--opt", "device=tmpfs", "--opt", "o=nodev", "testvol"})
 		mkVolume.WaitWithDefaultTimeout()

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -236,7 +236,7 @@ echo $rand        |   0 | $rand
 }
 
 @test "podman run docker-archive" {
-    skip_if_remote "podman-remote does not support docker-archive (#7116)"
+    skip_if_remote "podman-remote does not support docker-archive"
 
     # Create an image that, when run, outputs a random magic string
     expect=$(random_string 20)

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -101,11 +101,6 @@ EOF
 
 # #6957 - mask out /proc/acpi, /sys/dev, and other sensitive system files
 @test "sensitive mount points are masked without --privileged" {
-    # Weird error, maybe a flake?
-    #   can only attach to created or running containers: container state improper
-    # https://github.com/containers/podman/pull/7111#issuecomment-666858715
-    skip_if_remote "FIXME: Weird flake"
-
     # FIXME: this should match the list in pkg/specgen/generate/config_linux.go
     local -a mps=(
         /proc/acpi

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -121,6 +121,7 @@ func (p *PodmanTest) WaitForContainer() bool {
 		}
 		time.Sleep(1 * time.Second)
 	}
+	fmt.Printf("WaitForContainer(): timed out\n")
 	return false
 }
 


### PR DESCRIPTION
Found by my find-obsolete-skips script. Let's see which, if any,
of these skipped tests can be reenabled.

Some Skips are "this will never work", not "this is expected to
work one day". Update the message on those to reflect that.

Signed-off-by: Ed Santiago <santiago@redhat.com>
