### PR TITLE
Restore runtime verification

### DIFF
--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -77,6 +77,12 @@ Import a checkpoint tar.gz file, which was exported by Podman. This can be used
 to import a checkpointed *container* from another host.\
 *IMPORTANT: This OPTION does not need a container name or ID as input argument.*
 
+During the import of a checkpoint file Podman will select the same container runtime
+which was used during checkpointing. This is especially important if a specific
+(non-default) container runtime was specified during container creation. Podman will
+also abort the restore if the container runtime specified during restore does
+not much the container runtime used for container creation.
+
 #### **--import-previous**=*file*
 
 Import a pre-checkpoint tar.gz file which was exported by Podman. This option

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	metadata "github.com/checkpoint-restore/checkpointctl/lib"
-	"github.com/checkpoint-restore/go-criu/v5/stats"
 	"github.com/containers/common/libimage"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v3/libpod"
@@ -14,10 +13,8 @@ import (
 	"github.com/containers/podman/v3/pkg/checkpoint/crutils"
 	"github.com/containers/podman/v3/pkg/criu"
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/containers/podman/v3/pkg/errorhandling"
 	"github.com/containers/podman/v3/pkg/specgen/generate"
 	"github.com/containers/podman/v3/pkg/specgenutil"
-	"github.com/containers/storage/pkg/archive"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -30,24 +27,6 @@ import (
 func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOptions entities.RestoreOptions) ([]*libpod.Container, error) {
 	// First get the container definition from the
 	// tarball to a temporary directory
-	archiveFile, err := os.Open(restoreOptions.Import)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to open checkpoint archive for import")
-	}
-	defer errorhandling.CloseQuiet(archiveFile)
-	options := &archive.TarOptions{
-		// Here we only need the files config.dump and spec.dump
-		ExcludePatterns: []string{
-			"volumes",
-			"ctr.log",
-			"artifacts",
-			stats.StatsDump,
-			metadata.RootFsDiffTar,
-			metadata.DeletedFilesFile,
-			metadata.NetworkStatusFile,
-			metadata.CheckpointDirectory,
-		},
-	}
 	dir, err := ioutil.TempDir("", "checkpoint")
 	if err != nil {
 		return nil, err
@@ -57,9 +36,8 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 			logrus.Errorf("Could not recursively remove %s: %q", dir, err)
 		}
 	}()
-	err = archive.Untar(archiveFile, dir, options)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Unpacking of checkpoint archive %s failed", restoreOptions.Import)
+	if err := crutils.CRImportCheckpointConfigOnly(dir, restoreOptions.Import); err != nil {
+		return nil, err
 	}
 
 	// Load spec.dump from temporary directory


### PR DESCRIPTION
There are at least two runtimes that support checkpoint and restore: runc and crun. Although the checkpoints created by these are almost compatible, it is not (yet) possible to restore a checkpoint created with one runtime with the other runtime. To make checkpoint/restore usage more comfortable this adds code to look into the checkpoint archive during restore and to set the runtime to the one used during checkpointing.

This also adds a check, if the user explicitly sets a runtime during restore, that the runtime is also the same as used during checkpointing.

If a different runtime is selected than the one used during checkpointing the restore will fail early.

If runc and crun will create compatible checkpoints in the future the check can be changed to treat crun and runc as compatible checkpoint/restore runtimes.

Fixes: #11945