### PR TITLE
Fix netavark error handling and teardown issue

### DIFF
--- a/libpod/network/netavark/run.go
+++ b/libpod/network/netavark/run.go
@@ -55,7 +55,15 @@ func (n *netavarkNetwork) Setup(namespacePath string, options types.SetupOptions
 
 	result := map[string]types.StatusBlock{}
 	err = n.execNetavark([]string{"setup", namespacePath}, netavarkOpts, &result)
+	if err != nil {
+		// lets dealloc ips to prevent leaking
+		if err := n.deallocIPs(&options.NetworkOptions); err != nil {
+			logrus.Error(err)
+		}
+		return nil, err
+	}
 
+	// make sure that the result makes sense
 	if len(result) != len(options.Networks) {
 		logrus.Errorf("unexpected netavark result: %v", result)
 		return nil, fmt.Errorf("unexpected netavark result length, want (%d), got (%d) networks", len(options.Networks), len(result))

--- a/pkg/specgenutil/util.go
+++ b/pkg/specgenutil/util.go
@@ -295,6 +295,7 @@ func CreateExitCommandArgs(storageConfig storageTypes.StoreOptions, config *conf
 		"--cgroup-manager", config.Engine.CgroupManager,
 		"--tmpdir", config.Engine.TmpDir,
 		"--cni-config-dir", config.Network.NetworkConfigDir,
+		"--network-backend", config.Network.NetworkBackend,
 	}
 	if config.Engine.OCIRuntime != "" {
 		command = append(command, []string{"--runtime", config.Engine.OCIRuntime}...)


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

The return error was not returned by podman , instead a different error
was created. Also make sure to free assigned ips on an error to not leak
them.

Lastly podman container cleanup uses the default network backend instead
of the provided one, we need to add `--network-backend` to the exit
command.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
