### PR TITLE
fix duplicated logs command

### DIFF
--- a/cmd/podman/pods/logs.go
+++ b/cmd/podman/pods/logs.go
@@ -27,11 +27,11 @@ type logsOptionsWrapper struct {
 var (
 	logsPodOptions     logsOptionsWrapper
 	logsPodDescription = `Displays logs for pod with one or more containers.`
-	logsPodCommand     = &cobra.Command{
+	podLogsCommand     = &cobra.Command{
 		Use:   "logs [options] POD",
 		Short: "Fetch logs for pod with one or more containers",
 		Long:  logsPodDescription,
-		// We dont want users to invoke latest and pod togather
+		// We dont want users to invoke latest and pod together
 		Args: func(cmd *cobra.Command, args []string) error {
 			switch {
 			case registry.IsRemote() && logsPodOptions.Latest:
@@ -53,35 +53,16 @@ var (
 		podman pod logs --follow=true --since 10m podID
 		podman pod logs mywebserver`,
 	}
-
-	containerLogsCommand = &cobra.Command{
-		Use:               logsPodCommand.Use,
-		Short:             logsPodCommand.Short,
-		Long:              logsPodCommand.Long,
-		Args:              logsPodCommand.Args,
-		RunE:              logsPodCommand.RunE,
-		ValidArgsFunction: logsPodCommand.ValidArgsFunction,
-		Example: `podman pod logs podId
-		podman pod logs -c ctrname podName
-		podman pod logs --tail 2 mywebserver
-		podman pod logs --follow=true --since 10m podID`,
-	}
 )
 
 func init() {
+	// pod logs
 	registry.Commands = append(registry.Commands, registry.CliCommand{
-		Command: logsPodCommand,
-	})
-	logsFlags(logsPodCommand)
-	validate.AddLatestFlag(logsPodCommand, &logsPodOptions.Latest)
-
-	// container logs
-	registry.Commands = append(registry.Commands, registry.CliCommand{
-		Command: containerLogsCommand,
+		Command: podLogsCommand,
 		Parent:  podCmd,
 	})
-	logsFlags(containerLogsCommand)
-	validate.AddLatestFlag(containerLogsCommand, &logsPodOptions.Latest)
+	logsFlags(podLogsCommand)
+	validate.AddLatestFlag(podLogsCommand, &logsPodOptions.Latest)
 }
 
 func logsFlags(cmd *cobra.Command) {

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -242,6 +242,13 @@ sub podman_help {
             if ($line =~ /^\s{1,4}(\S+)\s/) {
                 my $subcommand = $1;
                 print "> podman @_ $subcommand\n"               if $debug;
+
+                # check that the same subcommand is not listed twice (#12356)
+                if (exists $help{$subcommand}) {
+                    warn "$ME: 'podman @_ help' lists '$subcommand' twice\n";
+                    ++$Errs;
+                }
+
                 $help{$subcommand} = podman_help(@_, $subcommand)
                     unless $subcommand eq 'help';       # 'help' not in man
             }


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

Podman logs was defined twice, once for container logs and once for pod
logs. This causes problems with the shell completion. Also `podman --help`
showed this command twice.
#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
