### PR TITLE
Don't use a global RNG, and avoid conflicts, when generating NodePorts

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -277,12 +277,14 @@ func GenerateKubeServiceFromV1Pod(pod *v1.Pod, servicePorts []v1.ServicePort) (Y
 type servicePortState struct {
 	// A program using the shared math/rand state with the default seed will produce the same sequence of pseudo-random numbers
 	// for each execution. Use a private RNG state not to interfere with other users.
-	rng *rand.Rand
+	rng       *rand.Rand
+	usedPorts map[int]struct{}
 }
 
 func newServicePortState() servicePortState {
 	return servicePortState{
-		rng: rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:       rand.New(rand.NewSource(time.Now().UnixNano())),
+		usedPorts: map[int]struct{}{},
 	}
 }
 
@@ -291,8 +293,20 @@ func newServicePortState() servicePortState {
 func (state *servicePortState) containerPortsToServicePorts(containerPorts []v1.ContainerPort) ([]v1.ServicePort, error) {
 	sps := make([]v1.ServicePort, 0, len(containerPorts))
 	for _, cp := range containerPorts {
-		// Legal nodeport range is 30000-32767
-		nodePort := 30000 + state.rng.Intn(32767-30000+1)
+		var nodePort int
+		attempt := 0
+		for {
+			// Legal nodeport range is 30000-32767
+			nodePort = 30000 + state.rng.Intn(32767-30000+1)
+			if _, found := state.usedPorts[nodePort]; !found {
+				state.usedPorts[nodePort] = struct{}{}
+				break
+			}
+			attempt++
+			if attempt >= 100 {
+				return nil, fmt.Errorf("too many attempts trying to generate a unique NodePort number")
+			}
+		}
 		servicePort := v1.ServicePort{
 			Protocol:   cp.Protocol,
 			Port:       cp.ContainerPort,

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -270,6 +270,7 @@ func GenerateKubeServiceFromV1Pod(pod *v1.Pod, servicePorts []v1.ServicePort) YA
 func containerPortsToServicePorts(containerPorts []v1.ContainerPort) []v1.ServicePort {
 	sps := make([]v1.ServicePort, 0, len(containerPorts))
 	for _, cp := range containerPorts {
+		// Legal nodeport range is 30000-32767
 		nodePort := 30000 + rand.Intn(32767-30000+1)
 		servicePort := v1.ServicePort{
 			Protocol:   cp.Protocol,
@@ -287,7 +288,7 @@ func containerPortsToServicePorts(containerPorts []v1.ContainerPort) []v1.Servic
 // inclusive list of serviceports to expose
 func containersToServicePorts(containers []v1.Container) []v1.ServicePort {
 	// Without the call to rand.Seed, a program will produce the same sequence of pseudo-random numbers
-	// for each execution. Legal nodeport range is 30000-32767
+	// for each execution.
 	rand.Seed(time.Now().UnixNano())
 
 	sps := make([]v1.ServicePort, 0, len(containers))

--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -139,7 +139,11 @@ func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrIDs []string,
 
 		podContent = append(podContent, b)
 		if options.Service {
-			b, err := generateKubeYAML(libpod.GenerateKubeServiceFromV1Pod(po, []k8sAPI.ServicePort{}))
+			svc, err := libpod.GenerateKubeServiceFromV1Pod(po, []k8sAPI.ServicePort{})
+			if err != nil {
+				return nil, err
+			}
+			b, err := generateKubeYAML(svc)
 			if err != nil {
 				return nil, err
 			}
@@ -177,7 +181,11 @@ func getKubePods(ctx context.Context, pods []*libpod.Pod, getService bool) ([][]
 		pos = append(pos, b)
 
 		if getService {
-			b, err := generateKubeYAML(libpod.GenerateKubeServiceFromV1Pod(po, sp))
+			svc, err := libpod.GenerateKubeServiceFromV1Pod(po, sp)
+			if err != nil {
+				return nil, nil, err
+			}
+			b, err := generateKubeYAML(svc)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:

- Don't make any assumptions about, and don't affect, the global math/rand RNG state when generating NodePort values
- Instead of just relying on randomness, make sure to generate unique values within a single Service.

Compare the plight at #12155 .

#### How to verify it

No regressions in existing tests, at least.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
