### PR TITLE
test: Update error string for --file-locks test

### DIFF
--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -221,6 +221,7 @@ func Checkpoint(w http.ResponseWriter, r *http.Request) {
 		PrintStats     bool `schema:"printStats"`
 		PreCheckpoint  bool `schema:"preCheckpoint"`
 		WithPrevious   bool `schema:"withPrevious"`
+		FileLocks      bool `schema:"fileLocks"`
 	}{
 		// override any golang type defaults
 	}
@@ -246,6 +247,7 @@ func Checkpoint(w http.ResponseWriter, r *http.Request) {
 		PrintStats:     query.PrintStats,
 		PreCheckPoint:  query.PreCheckpoint,
 		WithPrevious:   query.WithPrevious,
+		FileLocks:      query.FileLocks,
 	}
 
 	if query.Export {
@@ -305,6 +307,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 		IgnoreStaticIP  bool   `schema:"ignoreStaticIP"`
 		IgnoreStaticMAC bool   `schema:"ignoreStaticMAC"`
 		PrintStats      bool   `schema:"printStats"`
+		FileLocks       bool   `schema:"fileLocks"`
 		PublishPorts    string `schema:"publishPorts"`
 	}{
 		// override any golang type defaults
@@ -324,6 +327,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 		IgnoreStaticIP:  query.IgnoreStaticIP,
 		IgnoreStaticMAC: query.IgnoreStaticMAC,
 		PrintStats:      query.PrintStats,
+		FileLocks:       query.FileLocks,
 		PublishPorts:    strings.Fields(query.PublishPorts),
 	}
 

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -1355,7 +1355,7 @@ var _ = Describe("Podman checkpoint", func() {
 		result := podmanTest.Podman([]string{"container", "checkpoint", "test_name"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(125))
-		Expect(result.ErrorToString()).To(ContainSubstring("criu failed"))
+		Expect(result.ErrorToString()).To(ContainSubstring("failed: exit status 1"))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		// Checkpoint is expected to succeed with --file-locks


### PR DESCRIPTION
Add `fileLocks` api option and replace the update the substring test to match the end of the error message.

Closes: #12366