### PR TITLE
Make sure netavark output is logged to the syslog 

### DIFF
--- a/libpod/network/netavark/network.go
+++ b/libpod/network/netavark/network.go
@@ -37,6 +37,10 @@ type netavarkNetwork struct {
 	// isMachine describes whenever podman runs in a podman machine environment.
 	isMachine bool
 
+	// syslog describes whenever the netavark debbug output should be log to the syslog as well.
+	// This will use logrus to do so, make sure logrus is set up to log to the syslog.
+	syslog bool
+
 	// lock is a internal lock for critical operations
 	lock lockfile.Locker
 
@@ -68,6 +72,10 @@ type InitConfig struct {
 
 	// LockFile is the path to lock file.
 	LockFile string
+
+	// Syslog describes whenever the netavark debbug output should be log to the syslog as well.
+	// This will use logrus to do so, make sure logrus is set up to log to the syslog.
+	Syslog bool
 }
 
 // NewNetworkInterface creates the ContainerNetwork interface for the netavark backend.
@@ -122,6 +130,7 @@ func NewNetworkInterface(conf InitConfig) (types.ContainerNetwork, error) {
 		defaultSubnet:    defaultNet,
 		isMachine:        conf.IsMachine,
 		lock:             lock,
+		syslog:           conf.Syslog,
 	}
 
 	return n, nil

--- a/libpod/network/netavark/run.go
+++ b/libpod/network/netavark/run.go
@@ -54,7 +54,7 @@ func (n *netavarkNetwork) Setup(namespacePath string, options types.SetupOptions
 	}
 
 	result := map[string]types.StatusBlock{}
-	err = execNetavark(n.netavarkBinary, []string{"setup", namespacePath}, netavarkOpts, &result)
+	err = n.execNetavark([]string{"setup", namespacePath}, netavarkOpts, &result)
 
 	if len(result) != len(options.Networks) {
 		logrus.Errorf("unexpected netavark result: %v", result)
@@ -86,7 +86,7 @@ func (n *netavarkNetwork) Teardown(namespacePath string, options types.TeardownO
 		return errors.Wrap(err, "failed to convert net opts")
 	}
 
-	retErr := execNetavark(n.netavarkBinary, []string{"teardown", namespacePath}, netavarkOpts, nil)
+	retErr := n.execNetavark([]string{"teardown", namespacePath}, netavarkOpts, nil)
 
 	// when netavark returned an error we still free the used ips
 	// otherwise we could end up in a state where block the ips forever

--- a/libpod/network/netavark/run_test.go
+++ b/libpod/network/netavark/run_test.go
@@ -89,6 +89,10 @@ var _ = Describe("run netavark", func() {
 		if err != nil {
 			Fail("Failed to create netns")
 		}
+
+		// Force iptables driver, firewalld is broken inside the extra
+		// namespace because it still connects to firewalld on the host.
+		_ = os.Setenv("NETAVARK_FW", "iptables")
 	})
 
 	JustBeforeEach(func() {
@@ -109,6 +113,8 @@ var _ = Describe("run netavark", func() {
 
 		netns.UnmountNS(netNSContainer)
 		netNSContainer.Close()
+
+		_ = os.Unsetenv("NETAVARK_FW")
 	})
 
 	It("test basic setup", func() {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -578,6 +578,14 @@ func WithEnableSDNotify() RuntimeOption {
 	}
 }
 
+// WithSyslog sets a runtime option so we know that we have to log to the syslog as well
+func WithSyslog() RuntimeOption {
+	return func(rt *Runtime) error {
+		rt.syslog = true
+		return nil
+	}
+}
+
 // WithRuntimeFlags adds the global runtime flags to the container config
 func WithRuntimeFlags(runtimeFlags []string) RuntimeOption {
 	return func(rt *Runtime) error {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -88,6 +88,11 @@ type Runtime struct {
 	libimageEventsShutdown chan bool
 	lockManager            lock.Manager
 
+	// syslog describes whenever logrus should log to the syslog as well.
+	// Note that the syslog hook will be enabled early in cmd/podman/syslog_linux.go
+	// This bool is just needed so that we can set it for netavark interface.
+	syslog bool
+
 	// doRenumber indicates that the runtime should perform a lock renumber
 	// during initialization.
 	// Once the runtime has been initialized and returned, this variable is
@@ -517,6 +522,7 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (retErr error) {
 			DefaultSubnet:    runtime.config.Network.DefaultSubnet,
 			IsMachine:        runtime.config.Engine.MachineEnabled,
 			LockFile:         filepath.Join(runtime.config.Network.NetworkConfigDir, "netavark.lock"),
+			Syslog:           runtime.syslog,
 		})
 		if err != nil {
 			return errors.Wrapf(err, "could not create network interface")

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -236,6 +236,11 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 		options = append(options, libpod.WithRegistriesConf(cfg.RegistriesConf))
 	}
 
+	// no need to handle the error, it will return false anyway
+	if syslog, _ := fs.GetBool("syslog"); syslog {
+		options = append(options, libpod.WithSyslog())
+	}
+
 	// TODO flag to set CNI plugins dir?
 
 	if !opts.withFDS {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

Create a custom writer which logs the netavark output to logrus. This
will log to the syslog when it is enabled. Without this we get zero output from netavark on teardown.

Force iptables driver for netavark tests
Firewalld cannot be used because it can connect to the dbus api but
talks to firewalld in the host namespace. This will affact your host
badly and also causes tests to fail.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
