### PR TITLE
[CI:DOCS] Add java TZ note to run manpage

### DIFF
--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1848,6 +1848,25 @@ $ podman run --name container1 --personaity=LINUX32 fedora bash
 $ podman run --name container1 --rootfs /path/to/rootfs:O bash
 ```
 
+### Handling Timezones in java applications in a container.
+
+In order to use a timezone other than UTC when running a
+Java application within a container, the `TZ` environment variable must be
+set within the container. Java applications will ignore the value set with the
+`--tz` option.  This will be corrected in a later relase.
+
+```
+# Example run
+podman run -ti --rm  -e TZ=EST mytzimage
+lrwxrwxrwx. 1 root root 29 Nov  3 08:51 /etc/localtime -> ../usr/share/zoneinfo/Etc/UTC
+Now with default timezone:
+Fri Nov 19 18:10:55 EST 2021
+Java default sees the following timezone:
+2021-11-19T18:10:55.651130-05:00
+Forcing UTC:
+Fri Nov 19 23:10:55 UTC 2021
+```
+
 ### Rootless Containers
 
 Podman runs as a non root user on most systems. This feature requires that a new enough version of **shadow-utils**


### PR DESCRIPTION
Add a note to show how to workaround the `--tz` option
being ignored in the run command.

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1984251

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
