### PR TITLE
compat: add layer caching compatiblity for `non-podman` clients.

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -134,6 +134,15 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// if layers field not set assume its not from a valid podman-client
+	// could be a docker client, set `layers=true` since that is the default
+	// expected behviour
+	if !utils.IsLibpodRequest(r) {
+		if _, found := r.URL.Query()["layers"]; !found {
+			query.Layers = true
+		}
+	}
+
 	// convert addcaps formats
 	var addCaps = []string{}
 	if _, found := r.URL.Query()["addcaps"]; found {

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -1523,6 +1523,13 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//      JSON map of key, value pairs to set as labels on the new image
 	//      (As of version 1.xx)
 	//  - in: query
+	//    name: layers
+	//    type: boolean
+	//    default: true
+	//    description: |
+	//      Cache intermediate layers during build.
+	//      (As of version 1.xx)
+	//  - in: query
 	//    name: networkmode
 	//    type: string
 	//    default: bridge


### PR DESCRIPTION
Non podman clients do not set `layers` while making request. This is
supposed to be `true` by default but `non-podman-clients i.e Docker` dont
know about this field as a result they end up setting this value to
`false`. Causing builds to never use cache for layers.

Adds compatibility for `non-podman (docker SDK)`.

[NO NEW TESTS NEEDED]
Cant find any convenient way to add a new test for this via podman client.

Closes: https://github.com/containers/podman/issues/12378