### PR TITLE
Rename pod on generate of container

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -427,7 +427,9 @@ func simplePodWithV1Containers(ctx context.Context, ctrs []*Container) (*v1.Pod,
 	hostNetwork := true
 	podDNS := v1.PodDNSConfig{}
 	kubeAnnotations := make(map[string]string)
+	ctrNames := make([]string, 0, len(ctrs))
 	for _, ctr := range ctrs {
+		ctrNames = append(ctrNames, strings.ReplaceAll(ctr.Name(), "_", ""))
 		// Convert auto-update labels into kube annotations
 		for k, v := range getAutoUpdateAnnotations(removeUnderscores(ctr.Name()), ctr.Labels()) {
 			kubeAnnotations[k] = v
@@ -484,8 +486,15 @@ func simplePodWithV1Containers(ctx context.Context, ctrs []*Container) (*v1.Pod,
 			}
 		} // end if ctrDNS
 	}
+	podName := strings.ReplaceAll(ctrs[0].Name(), "_", "")
+	// Check if the pod name and container name will end up conflicting
+	// Append _pod if so
+	if util.StringInSlice(podName, ctrNames) {
+		podName = podName + "_pod"
+	}
+
 	return newPodObject(
-		strings.ReplaceAll(ctrs[0].Name(), "_", ""),
+		podName,
 		kubeAnnotations,
 		kubeInitCtrs,
 		kubeCtrs,

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -71,6 +71,7 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(pod.Spec.DNSConfig).To(BeNil())
 		Expect(pod.Spec.Containers[0].WorkingDir).To(Equal(""))
 		Expect(pod.Spec.Containers[0].Env).To(BeNil())
+		Expect(pod.Name).To(Equal("top_pod"))
 
 		numContainers := 0
 		for range pod.Spec.Containers {


### PR DESCRIPTION
When generating kube of a container, the podname and container name in
the yaml are identical.  This offends rules in podman where pods and
containers cannot have the same name.  We now append _pod to the
podname to avoid that collision.

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
