### PR TITLE
Unset SocketLabel after system finishes checkpointing 

### DIFF
--- a/test/system/600-completion.bats
+++ b/test/system/600-completion.bats
@@ -258,10 +258,10 @@ function _check_completion_end() {
     # create pods for each state
     run_podman pod create --name created-$random_pod_name
     run_podman pod create --name running-$random_pod_name
-    run_podman run -d --name running-$random_pod_name-con --pod running-$random_pod_name $IMAGE top
     run_podman pod create --name degraded-$random_pod_name
-    run_podman run -d --name degraded-$random_pod_name-con --pod degraded-$random_pod_name $IMAGE echo degraded
     run_podman pod create --name exited-$random_pod_name
+    run_podman run -d --name running-$random_pod_name-con --pod running-$random_pod_name $IMAGE top
+    run_podman run -d --name degraded-$random_pod_name-con --pod degraded-$random_pod_name $IMAGE echo degraded
     run_podman run -d --name exited-$random_pod_name-con --pod exited-$random_pod_name $IMAGE echo exited
     run_podman pod stop exited-$random_pod_name
 


### PR DESCRIPTION
This should fix the SELinux issue we are seeing with talking to
/run/systemd/private.

Fixes: #12362

Also unset the XDG_RUNTIME_DIR if set, since we don't know when running
as a service if this will cause issue.s

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
