### PR TITLE
continue e2e test cleanup

### DIFF
--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Podman commit", func() {
 		check := podmanTest.Podman([]string{"inspect", "foobar.com/test1-image:latest"})
 		check.WaitWithDefaultTimeout()
 		data := check.InspectImageJSON()
-		Expect(StringInSlice("foobar.com/test1-image:latest", data[0].RepoTags)).To(BeTrue())
+		Expect(data[0].RepoTags).To(ContainElement("foobar.com/test1-image:latest"))
 	})
 
 	It("podman commit single letter container", func() {
@@ -62,7 +62,7 @@ var _ = Describe("Podman commit", func() {
 		check := podmanTest.Podman([]string{"inspect", "localhost/a:latest"})
 		check.WaitWithDefaultTimeout()
 		data := check.InspectImageJSON()
-		Expect(StringInSlice("localhost/a:latest", data[0].RepoTags)).To(BeTrue())
+		Expect(data[0].RepoTags).To(ContainElement("localhost/a:latest"))
 	})
 
 	It("podman container commit container", func() {
@@ -77,7 +77,7 @@ var _ = Describe("Podman commit", func() {
 		check := podmanTest.Podman([]string{"image", "inspect", "foobar.com/test1-image:latest"})
 		check.WaitWithDefaultTimeout()
 		data := check.InspectImageJSON()
-		Expect(StringInSlice("foobar.com/test1-image:latest", data[0].RepoTags)).To(BeTrue())
+		Expect(data[0].RepoTags).To(ContainElement("foobar.com/test1-image:latest"))
 	})
 
 	It("podman commit container with message", func() {

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -62,12 +61,10 @@ var _ = Describe("Podman events", func() {
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "event=start"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(len(result.OutputToStringArray()) >= 1)
+		Expect(len(result.OutputToStringArray())).To(BeNumerically(">=", 1), "Number of events")
 	})
 
 	It("podman events with an event filter and container=cid", func() {
-		Skip("Does not work on v2")
-		SkipIfNotFedora()
 		_, ec, cid := podmanTest.RunLsContainer("")
 		Expect(ec).To(Equal(0))
 		_, ec2, cid2 := podmanTest.RunLsContainer("")
@@ -76,8 +73,10 @@ var _ = Describe("Podman events", func() {
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "event=start", "--filter", fmt.Sprintf("container=%s", cid)})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(len(result.OutputToStringArray())).To(Equal(1))
-		Expect(!strings.Contains(result.OutputToString(), cid2))
+		events := result.OutputToStringArray()
+		Expect(len(events)).To(Equal(1), "number of events")
+		Expect(events[0]).To(ContainSubstring(cid), "event log includes CID")
+		Expect(events[0]).To(Not(ContainSubstring(cid2)), "event log does not include second CID")
 	})
 
 	It("podman events with a type and filter container=id", func() {
@@ -101,8 +100,12 @@ var _ = Describe("Podman events", func() {
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "type=pod", "--filter", "pod=foobarpod"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		fmt.Println(result.OutputToStringArray())
-		Expect(len(result.OutputToStringArray()) >= 2)
+		events := result.OutputToStringArray()
+		fmt.Println(events)
+		Expect(len(events)).To(BeNumerically(">=", 2), "Number of events")
+		Expect(events).To(ContainElement(ContainSubstring(" pod create ")))
+		Expect(events).To(ContainElement(ContainSubstring(" pod stop ")))
+		Expect(events).To(ContainElement(ContainSubstring("name=foobarpod")))
 	})
 
 	It("podman events --since", func() {

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -775,8 +775,8 @@ var _ = Describe("Podman generate kube", func() {
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
 		Expect(err).To(BeNil())
 
-		Expect(StringInSlice("8.8.8.8", pod.Spec.DNSConfig.Nameservers)).To(BeTrue())
-		Expect(StringInSlice("foobar.com", pod.Spec.DNSConfig.Searches)).To(BeTrue())
+		Expect(pod.Spec.DNSConfig.Nameservers).To(ContainElement("8.8.8.8"))
+		Expect(pod.Spec.DNSConfig.Searches).To(ContainElement("foobar.com"))
 		Expect(len(pod.Spec.DNSConfig.Options)).To(BeNumerically(">", 0))
 		Expect(pod.Spec.DNSConfig.Options[0].Name).To(Equal("color"))
 		Expect(*pod.Spec.DNSConfig.Options[0].Value).To(Equal("blue"))
@@ -799,10 +799,10 @@ var _ = Describe("Podman generate kube", func() {
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
 		Expect(err).To(BeNil())
 
-		Expect(StringInSlice("8.8.8.8", pod.Spec.DNSConfig.Nameservers)).To(BeTrue())
-		Expect(StringInSlice("8.7.7.7", pod.Spec.DNSConfig.Nameservers)).To(BeTrue())
-		Expect(StringInSlice("foobar.com", pod.Spec.DNSConfig.Searches)).To(BeTrue())
-		Expect(StringInSlice("homer.com", pod.Spec.DNSConfig.Searches)).To(BeTrue())
+		Expect(pod.Spec.DNSConfig.Nameservers).To(ContainElement("8.8.8.8"))
+		Expect(pod.Spec.DNSConfig.Nameservers).To(ContainElement("8.7.7.7"))
+		Expect(pod.Spec.DNSConfig.Searches).To(ContainElement("foobar.com"))
+		Expect(pod.Spec.DNSConfig.Searches).To(ContainElement("homer.com"))
 	})
 
 	It("podman generate kube on a pod with dns options", func() {
@@ -818,8 +818,8 @@ var _ = Describe("Podman generate kube", func() {
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
 		Expect(err).To(BeNil())
 
-		Expect(StringInSlice("8.8.8.8", pod.Spec.DNSConfig.Nameservers)).To(BeTrue())
-		Expect(StringInSlice("foobar.com", pod.Spec.DNSConfig.Searches)).To(BeTrue())
+		Expect(pod.Spec.DNSConfig.Nameservers).To(ContainElement("8.8.8.8"))
+		Expect(pod.Spec.DNSConfig.Searches).To(ContainElement("foobar.com"))
 		Expect(len(pod.Spec.DNSConfig.Options)).To(BeNumerically(">", 0))
 		Expect(pod.Spec.DNSConfig.Options[0].Name).To(Equal("color"))
 		Expect(*pod.Spec.DNSConfig.Options[0].Value).To(Equal("blue"))

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"os"
-	"strings"
 
 	. "github.com/containers/podman/v3/test/utils"
 	. "github.com/onsi/ginkgo"
@@ -61,7 +60,7 @@ var _ = Describe("Podman inspect", func() {
 		Expect(inspect).Should(Exit(0))
 		// output should not be empty
 		// test validates fix for https://github.com/containers/podman/issues/8785
-		Expect(strings.Contains(inspect.OutputToString(), "TEST"))
+		Expect(inspect.OutputToString()).To(ContainSubstring("TEST="), ".Config.Env")
 
 		session = podmanTest.Podman([]string{"rmi", "envwithtab"})
 		session.WaitWithDefaultTimeout()
@@ -76,7 +75,7 @@ var _ = Describe("Podman inspect", func() {
 		result := podmanTest.Podman([]string{"images", "-q", "--no-trunc", ALPINE})
 		result.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(strings.Contains(result.OutputToString(), session.OutputToString()))
+		Expect(result.OutputToStringArray()).To(ContainElement("sha256:"+session.OutputToString()), "'podman images -q --no-truncate' includes 'podman inspect --format .ID'")
 	})
 
 	It("podman inspect specified type", func() {

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -756,7 +756,7 @@ ENTRYPOINT ["sleep","99999"]
 		session := podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "cat", "/proc/self/uid_map"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		ok, _ := session.GrepString("500")
+		Expect(session.OutputToString()).To(ContainSubstring("500"))
 
 		podName = "testPod-1"
 		podCreate = podmanTest.Podman([]string{"pod", "create", "--userns=auto:size=3000", "--name", podName})
@@ -765,9 +765,7 @@ ENTRYPOINT ["sleep","99999"]
 		session = podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "cat", "/proc/self/uid_map"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		ok, _ = session.GrepString("3000")
-
-		Expect(ok).To(BeTrue())
+		Expect(session.OutputToString()).To(ContainSubstring("3000"))
 	})
 
 	It("podman pod create --userns=auto:uidmapping=", func() {

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -792,29 +792,29 @@ var _ = Describe("Podman ps", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(2))
-		Expect(StringInSlice(pod1.OutputToString(), session.OutputToStringArray()))
+		Expect(session.OutputToStringArray()).To(ContainElement(con1.OutputToString()))
 
 		// filter by full pod id
 		session = podmanTest.Podman([]string{"ps", "-q", "--no-trunc", "--filter", "pod=" + pod1.OutputToString()})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(2))
-		Expect(StringInSlice(pod1.OutputToString(), session.OutputToStringArray()))
+		Expect(session.OutputToStringArray()).To(ContainElement(con1.OutputToString()))
 
 		// filter by partial pod id
 		session = podmanTest.Podman([]string{"ps", "-q", "--no-trunc", "--filter", "pod=" + pod1.OutputToString()[0:12]})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(2))
-		Expect(StringInSlice(pod1.OutputToString(), session.OutputToStringArray()))
+		Expect(session.OutputToStringArray()).To(ContainElement(con1.OutputToString()))
 
 		// filter by multiple pods is inclusive
 		session = podmanTest.Podman([]string{"ps", "-q", "--no-trunc", "--filter", "pod=pod1", "--filter", "pod=pod2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(4))
-		Expect(StringInSlice(pod1.OutputToString(), session.OutputToStringArray()))
-		Expect(StringInSlice(pod2.OutputToString(), session.OutputToStringArray()))
+		Expect(session.OutputToStringArray()).To(ContainElement(con1.OutputToString()))
+		Expect(session.OutputToStringArray()).To(ContainElement(con2.OutputToString()))
 
 	})
 

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -230,7 +230,7 @@ default-docker:
 		Expect(session).Should(Exit(0))
 		ids := session.OutputToStringArray()
 
-		Expect(len(RESTORE_IMAGES), len(ids))
+		Expect(len(ids)).To(BeNumerically(">", 1), "We need to have *some* images to save")
 		multiImageSave(podmanTest, ids)
 	})
 })

--- a/test/e2e/tag_test.go
+++ b/test/e2e/tag_test.go
@@ -42,8 +42,8 @@ var _ = Describe("Podman tag", func() {
 		results.WaitWithDefaultTimeout()
 		Expect(results).Should(Exit(0))
 		inspectData := results.InspectImageJSON()
-		Expect(StringInSlice("quay.io/libpod/alpine:latest", inspectData[0].RepoTags)).To(BeTrue())
-		Expect(StringInSlice("localhost/foobar:latest", inspectData[0].RepoTags)).To(BeTrue())
+		Expect(inspectData[0].RepoTags).To(ContainElement("quay.io/libpod/alpine:latest"))
+		Expect(inspectData[0].RepoTags).To(ContainElement("localhost/foobar:latest"))
 	})
 
 	It("podman tag shortname", func() {
@@ -55,8 +55,8 @@ var _ = Describe("Podman tag", func() {
 		results.WaitWithDefaultTimeout()
 		Expect(results).Should(Exit(0))
 		inspectData := results.InspectImageJSON()
-		Expect(StringInSlice("quay.io/libpod/alpine:latest", inspectData[0].RepoTags)).To(BeTrue())
-		Expect(StringInSlice("localhost/foobar:latest", inspectData[0].RepoTags)).To(BeTrue())
+		Expect(inspectData[0].RepoTags).To(ContainElement("quay.io/libpod/alpine:latest"))
+		Expect(inspectData[0].RepoTags).To(ContainElement("localhost/foobar:latest"))
 	})
 
 	It("podman tag shortname:tag", func() {
@@ -68,8 +68,8 @@ var _ = Describe("Podman tag", func() {
 		results.WaitWithDefaultTimeout()
 		Expect(results).Should(Exit(0))
 		inspectData := results.InspectImageJSON()
-		Expect(StringInSlice("quay.io/libpod/alpine:latest", inspectData[0].RepoTags)).To(BeTrue())
-		Expect(StringInSlice("localhost/foobar:new", inspectData[0].RepoTags)).To(BeTrue())
+		Expect(inspectData[0].RepoTags).To(ContainElement("quay.io/libpod/alpine:latest"))
+		Expect(inspectData[0].RepoTags).To(ContainElement("localhost/foobar:new"))
 	})
 
 	It("podman tag shortname image no tag", func() {


### PR DESCRIPTION
Some more cleanup of assertions in e2e tests.

The original intent was maintainability: make it so tests emit useful diagnostics. But in the process I discovered various tests that were NOPs. I've tried to fix those to the best of my ability, but some need further tweaking.