### PR TITLE
libpod: improve heuristic to detect cgroup

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -97,6 +97,16 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 		return nil, err
 	}
 
+	cgroupPath, err := c.cGroupPath()
+	if err != nil {
+		// Handle the case where the container is not running or has no cgroup.
+		if errors.Is(err, define.ErrNoCgroups) || errors.Is(err, define.ErrCtrStopped) {
+			cgroupPath = ""
+		} else {
+			return nil, err
+		}
+	}
+
 	data := &define.InspectContainerData{
 		ID:      config.ID,
 		Created: config.CreatedTime,
@@ -116,6 +126,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 			StartedAt:    runtimeInfo.StartedTime,
 			FinishedAt:   runtimeInfo.FinishedTime,
 			Checkpointed: runtimeInfo.Checkpointed,
+			CgroupPath:   cgroupPath,
 		},
 		Image:           config.RootfsImageID,
 		ImageName:       config.RootfsImageName,

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2618,7 +2618,7 @@ func (c *Container) getOCICgroupPath() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return filepath.Join(selfCgroup, "container"), nil
+		return filepath.Join(selfCgroup, fmt.Sprintf("libpod-payload-%s", c.ID())), nil
 	case cgroupManager == config.SystemdCgroupsManager:
 		// When the OCI runtime is set to use Systemd as a cgroup manager, it
 		// expects cgroups to be passed as follows:

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -204,6 +204,7 @@ type InspectContainerState struct {
 	FinishedAt   time.Time          `json:"FinishedAt"`
 	Health       HealthCheckResults `json:"Health,omitempty"`
 	Checkpointed bool               `json:"Checkpointed,omitempty"`
+	CgroupPath   string             `json:"CgroupPath,omitempty"`
 }
 
 // Healthcheck returns the HealthCheckResults. This is used for old podman compat

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -109,6 +109,11 @@ WantedBy=multi-user.target
 		stats := podmanTest.Podman([]string{"stats", "--no-stream", ctrName})
 		stats.WaitWithDefaultTimeout()
 		Expect(stats).Should(Exit(0))
+
+		cgroupPath := podmanTest.Podman([]string{"inspect", "--format='{{.State.CgroupPath}}'", ctrName})
+		cgroupPath.WaitWithDefaultTimeout()
+		Expect(cgroupPath).Should(Exit(0))
+		Expect(result.OutputToString()).To(Not(ContainSubstring("init.scope")))
 	})
 
 	It("podman create container with systemd entrypoint triggers systemd mode", func() {


### PR DESCRIPTION
improve the heuristic to detect the scope that was created for the container.

This is necessary with systemd running as PID 1, since it moves itself to a different sub-cgroup, thus stats would not account for other processes in the same container.

Closes: https://github.com/containers/podman/issues/12400

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
