### PR TITLE
compat: Add compatiblity with `Docker/Moby` API for scenarios where build fails.

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containers/podman/v3/pkg/auth"
 	"github.com/containers/podman/v3/pkg/channel"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/gorilla/schema"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -546,8 +547,10 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 
 	for {
 		m := struct {
-			Stream string `json:"stream,omitempty"`
-			Error  string `json:"error,omitempty"`
+			Stream string                 `json:"stream,omitempty"`
+			Error  *jsonmessage.JSONError `json:"errorDetail,omitempty"`
+			// NOTE: `error` is being deprecated check https://github.com/moby/moby/blob/master/pkg/jsonmessage/jsonmessage.go#L148
+			ErrorMessage string `json:"error,omitempty"` // deprecate this slowly
 		}{}
 
 		select {
@@ -570,7 +573,10 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			}
 			flush()
 		case e := <-stderr.Chan():
-			m.Error = string(e)
+			m.ErrorMessage = string(e)
+			m.Error = &jsonmessage.JSONError{
+				Message: m.ErrorMessage,
+			}
 			if err := enc.Encode(m); err != nil {
 				logrus.Warnf("Failed to json encode error %v", err)
 			}


### PR DESCRIPTION
In order to maintain compatiblity with `moby API` we must the field
`errorDetail` which is primary error reporting field with stream.

Currently podman is using `error` which is already deprecated by moby.

Check: https://github.com/moby/moby/blob/master/pkg/jsonmessage/jsonmessage.go#L147

[NO NEW TESTS NEEDED]
We can't test this in podman CI since we dont have a docker client.

Closes: https://github.com/containers/podman/issues/12392