### PR TITLE
tunnel: allow `remote` and `API` to accept `--secrets`

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -122,6 +122,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		Target                 string   `schema:"target"`
 		Timestamp              int64    `schema:"timestamp"`
 		Ulimits                string   `schema:"ulimits"`
+		Secrets                string   `schema:"secrets"`
 	}{
 		Dockerfile: "Dockerfile",
 		Registry:   "docker.io",
@@ -237,6 +238,16 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		dnssearch = m
+	}
+
+	var secrets = []string{}
+	if _, found := r.URL.Query()["secrets"]; found {
+		var m = []string{}
+		if err := json.Unmarshal([]byte(query.Secrets), &m); err != nil {
+			utils.BadRequest(w, "secrets", query.Secrets, err)
+			return
+		}
+		secrets = m
 	}
 
 	var output string
@@ -447,6 +458,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			SeccompProfilePath: seccomp,
 			ShmSize:            strconv.Itoa(query.ShmSize),
 			Ulimit:             ulimits,
+			Secrets:            secrets,
 		},
 		CNIConfigDir:                   rtc.Network.CNIPluginDirs[0],
 		CNIPluginPath:                  util.DefaultCNIPluginPath,

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -116,6 +116,13 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		}
 		params.Add("dnsservers", c)
 	}
+	if secrets := options.CommonBuildOpts.Secrets; len(secrets) > 0 {
+		c, err := jsoniter.MarshalToString(secrets)
+		if err != nil {
+			return nil, err
+		}
+		params.Add("secrets", c)
+	}
 	if dnsoptions := options.CommonBuildOpts.DNSOptions; len(dnsoptions) > 0 {
 		c, err := jsoniter.MarshalToString(dnsoptions)
 		if err != nil {

--- a/test/e2e/build/Dockerfile.with-multiple-secret
+++ b/test/e2e/build/Dockerfile.with-multiple-secret
@@ -1,0 +1,3 @@
+FROM alpine
+RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret
+RUN --mount=type=secret,id=mysecret2 cat /run/secrets/mysecret2

--- a/test/e2e/build/Dockerfile.with-secret
+++ b/test/e2e/build/Dockerfile.with-secret
@@ -1,0 +1,2 @@
+FROM alpine
+RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret

--- a/test/e2e/build/Dockerfile.with-secret-verify-leak
+++ b/test/e2e/build/Dockerfile.with-secret-verify-leak
@@ -1,0 +1,3 @@
+FROM alpine
+COPY * /
+RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret

--- a/test/e2e/build/anothersecret.txt
+++ b/test/e2e/build/anothersecret.txt
@@ -1,0 +1,1 @@
+anothersecret

--- a/test/e2e/build/secret.txt
+++ b/test/e2e/build/secret.txt
@@ -1,0 +1,1 @@
+somesecret

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -59,6 +59,29 @@ var _ = Describe("Podman build", func() {
 		Expect(session).Should(Exit(0))
 	})
 
+	It("podman build with a secret from file", func() {
+		session := podmanTest.Podman([]string{"build", "-f", "build/Dockerfile.with-secret", "-t", "secret-test", "--secret", "id=mysecret,src=build/secret.txt", "build/"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("somesecret"))
+
+		session = podmanTest.Podman([]string{"rmi", "secret-test"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+	})
+
+	It("podman build with multiple secrets from files", func() {
+		session := podmanTest.Podman([]string{"build", "-f", "build/Dockerfile.with-multiple-secret", "-t", "multiple-secret-test", "--secret", "id=mysecret,src=build/secret.txt", "--secret", "id=mysecret2,src=build/anothersecret.txt", "build/"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("somesecret"))
+		Expect(session.OutputToString()).To(ContainSubstring("anothersecret"))
+
+		session = podmanTest.Podman([]string{"rmi", "multiple-secret-test"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+	})
+
 	It("podman build with logfile", func() {
 		logfile := filepath.Join(podmanTest.TempDir, "logfile")
 		session := podmanTest.Podman([]string{"build", "--pull-never", "--tag", "test", "--logfile", logfile, "build/basicalpine"})


### PR DESCRIPTION
Following commit makes sure that `build` api can accept external
secret and allows currently `NOOP` `podman-remote build -t tag
--secret id=mysecret,src=/path/on/host` to become functional.

#### TLDR:
Adds support for 
`podman-remote build -t tag
--secret id=mysecret,src=/path/on/host .`

---

Just like `docker` following api is a hidden field and only exposed to
`podman-remote` but could document it if it needs exposed on `swagger`.

Closes: https://github.com/containers/podman/issues/12415