### PR TITLE
Fixed the containerfile not found during remote build

### DIFF
--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -345,6 +345,11 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 			}
 			c = tmpFile.Name()
 		}
+		cfDir := filepath.Dir(c)
+		if absDir, err := filepath.EvalSymlinks(cfDir); err == nil {
+			name := filepath.ToSlash(strings.TrimPrefix(c, cfDir+string(filepath.Separator)))
+			c = filepath.Join(absDir, name)
+		}
 		containerfile, err := filepath.Abs(c)
 		if err != nil {
 			logrus.Errorf("Cannot find absolute path of %v: %v", c, err)


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixed the `containerfile` not found during remote build when the context directory is symlink.

#### How to verify it
- Prepare the podman remote environment for the client and server.
- Put the context directory and Containerfile on the client side only.
- Create a symlink for the context directory. (e.g. ln -s target link)
- Execute a remote build by specifying symlink for the context directory.(e.g. podman -r build -t remote-build link)

#### Which issue(s) this PR fixes:
Fixes #12409

#### Special notes for your reviewer:
#11755 is insufficient to fix Issue #11732.

#11755 only works in the following cases.
(e.g. The client and server have the same context directory and Containerfile.)

Signed-off-by: Shion Tanaka <shtanaka@redhat.com>