### PR TITLE
fix: error reporting for archive endpoint

### DIFF
--- a/pkg/api/handlers/compat/containers_archive.go
+++ b/pkg/api/handlers/compat/containers_archive.go
@@ -133,8 +133,10 @@ func handlePut(w http.ResponseWriter, r *http.Request, decoder *schema.Decoder, 
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
 	if err := copyFunc(); err != nil {
 		logrus.Error(err.Error())
+		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		return
 	}
+	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Returning 500 when copying to read-only destination.

resolves #12420