### PR TITLE
systemd: replace multi-user with default.target

### DIFF
--- a/contrib/systemd/auto-update/podman-auto-update.service.in
+++ b/contrib/systemd/auto-update/podman-auto-update.service.in
@@ -10,4 +10,4 @@ ExecStart=@@PODMAN@@ auto-update
 ExecStartPost=@@PODMAN@@ image prune -f
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target

--- a/contrib/systemd/system/podman-restart.service.in
+++ b/contrib/systemd/system/podman-restart.service.in
@@ -10,4 +10,4 @@ Environment=LOGGING="--log-level=info"
 ExecStart=@@PODMAN@@ $LOGGING start --all --filter restart-policy=always
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target

--- a/contrib/systemd/system/podman.service.in
+++ b/contrib/systemd/system/podman.service.in
@@ -12,4 +12,4 @@ Environment=LOGGING="--log-level=info"
 ExecStart=@@PODMAN@@ $LOGGING system service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -98,7 +98,7 @@ Type=forking
 PIDFile=/run/user/1000/overlay-containers/de1e3223b1b888bc02d0962dd6cb5855eb00734061013ffdd3479d225abacdc6/userdata/conmon.pid
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 ```
 
 ### Generate systemd unit file for a container with `--new` flag
@@ -130,7 +130,7 @@ KillMode=none
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 ```
 
 ### Generate systemd unit files for a pod with two simple alpine containers
@@ -169,7 +169,7 @@ Type=forking
 PIDFile=/run/user/1000/overlay-containers/ccfd5c71a088768774ca7bd05888d55cc287698dde06f475c8b02f696a25adcd/userdata/conmon.pid
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 ```
 
 ### Installation of generated systemd unit files.

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -89,7 +89,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/sh -c '/usr/bin/echo Ready >/dev/%s'
 [Install]
-RequiredBy=multi-user.target
+RequiredBy=default.target
 `
 	deMoby := `[Unit]
 Description=Remove moby-engine
@@ -106,7 +106,7 @@ ExecStart=/usr/bin/rpm-ostree ex apply-live --allow-replacement
 ExecStartPost=/bin/touch /var/lib/%N.stamp
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
  `
 	_ = ready
 	ignSystemd := Systemd{

--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -134,7 +134,7 @@ NotifyAccess={{{{.NotifyAccess}}}}
 {{{{- end}}}}
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 // ContainerUnit generates a systemd unit for the specified container.  Based

--- a/pkg/systemd/generate/containers_test.go
+++ b/pkg/systemd/generate/containers_test.go
@@ -62,7 +62,7 @@ PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 	goodID := serviceInfo + headerInfo + goodIDContent
 	goodIDNoHeaderInfo := serviceInfo + goodIDContent
@@ -88,7 +88,7 @@ PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNameBoundTo := `# container-foobar.service
@@ -114,7 +114,7 @@ PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodWithNameAndGeneric := `# jadda-jadda.service
@@ -139,7 +139,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodWithNameAndSdnotify := `# jadda-jadda.service
@@ -164,7 +164,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodWithExplicitShortDetachParam := `# jadda-jadda.service
@@ -189,7 +189,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNameNewWithPodFile := `# jadda-jadda.service
@@ -214,7 +214,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNameNewDetach := `# jadda-jadda.service
@@ -239,7 +239,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodIDNew := `# container-639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401.service
@@ -264,7 +264,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	genGoodNewDetach := func(detachparam string) string {
@@ -292,7 +292,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 		return goodNewDetach
 	}
@@ -319,7 +319,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewRootFlags := `# jadda-jadda.service
@@ -344,7 +344,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodContainerCreate := `# jadda-jadda.service
@@ -369,7 +369,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithJournaldTag := `# jadda-jadda.service
@@ -394,7 +394,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithSpecialChars := `# jadda-jadda.service
@@ -419,7 +419,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithIDFiles := `# jadda-jadda.service
@@ -444,7 +444,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithPodIDFiles := `# jadda-jadda.service
@@ -469,7 +469,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithEnvar := `# jadda-jadda.service
@@ -495,7 +495,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithRestartPolicy := `# jadda-jadda.service
@@ -521,7 +521,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	templateGood := `# container-foo@.service
@@ -547,7 +547,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 	tests := []struct {
 		name     string

--- a/pkg/systemd/generate/pods.go
+++ b/pkg/systemd/generate/pods.go
@@ -103,7 +103,7 @@ PIDFile={{{{.PIDFile}}}}
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 // PodUnits generates systemd units for the specified pod and its containers.

--- a/pkg/systemd/generate/pods_test.go
+++ b/pkg/systemd/generate/pods_test.go
@@ -62,7 +62,7 @@ PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 	podGood := serviceInfo + headerInfo + podContent
 	podGoodNoHeaderInfo := serviceInfo + podContent
@@ -92,7 +92,7 @@ PIDFile=%t/pod-123abc.pid
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	podGoodNamedNewWithRootArgs := `# pod-123abc.service
@@ -120,7 +120,7 @@ PIDFile=%t/pod-123abc.pid
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	podGoodNamedNewWithReplaceFalse := `# pod-123abc.service
@@ -148,7 +148,7 @@ PIDFile=%t/pod-123abc.pid
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	podNewLabelWithCurlyBraces := `# pod-123abc.service
@@ -176,7 +176,7 @@ PIDFile=%t/pod-123abc.pid
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	tests := []struct {

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -35,7 +35,7 @@ ExecStart=/usr/bin/podman start -a redis
 ExecStop=/usr/bin/podman stop -t 10 redis
 KillMode=process
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 `
 	})
 

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -34,6 +34,12 @@ function service_setup() {
 
     systemctl daemon-reload
 
+    # Also test enabling services (see #12438).
+    run systemctl enable "$SERVICE_NAME"
+    if [ $status -ne 0 ]; then
+        die "Error enabling systemd unit $SERVICE_NAME, output: $output"
+    fi
+
     run systemctl start "$SERVICE_NAME"
     if [ $status -ne 0 ]; then
         die "Error starting systemd unit $SERVICE_NAME, output: $output"
@@ -51,6 +57,11 @@ function service_cleanup() {
     run systemctl stop "$SERVICE_NAME"
     if [ $status -ne 0 ]; then
         die "Error stopping systemd unit $SERVICE_NAME, output: $output"
+    fi
+
+    run systemctl disable "$SERVICE_NAME"
+    if [ $status -ne 0 ]; then
+        die "Error disbling systemd unit $SERVICE_NAME, output: $output"
     fi
 
     if [[ -z "$status" ]]; then

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -366,7 +366,7 @@ Type=oneshot
 ExecStart=/usr/bin/podman auto-update
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 EOF
 
     echo "podman-auto-update-$cname" >> $SNAME_FILE

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -767,7 +767,7 @@ Type=simple
 ExecStart=/bin/bash -c '/bin/busctl monitor --system --match "interface=org.fedoraproject.FirewallD1,member=Reloaded" --match "interface=org.fedoraproject.FirewallD1,member=PropertiesChanged" | while read -r line ; do podman network reload --all ; done'
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 2) For "systemctl restart firewalld", create a systemd unit file with the following
 ```
@@ -783,7 +783,7 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/podman network reload --all
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 However, If you use busctl monitor then you can't get machine-readable output on `RHEL 8`.
 Since it doesn't have `busctl -j` as mentioned here by [@yrro](https://github.com/containers/podman/issues/5431#issuecomment-896943018).
@@ -802,7 +802,7 @@ ExecStart=/bin/bash -c "dbus-monitor --profile --system 'type=signal,sender=org.
 Restart=Always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 `busctl-monitor` is almost usable in `RHEL 8`, except that it always outputs two bogus events when it starts up,
 one of which is (in its only machine-readable format) indistinguishable from the `NameOwnerChanged` that you get when firewalld starts up.
@@ -823,7 +823,7 @@ ExecStart=/usr/bin/python  /path/to/python/code/podman-redo-nat.py
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 The code reloads podman network twice when you use `systemctl restart firewalld`.
 ```


### PR DESCRIPTION
Replace `multi-user.target` with `default.target` across the code base.
It seems like the multi-user one is not available for (rootless) users
on F35 anymore is causing issues in all kinds of ways, for instance,
enabling the podman.service or generated systemd units.

Fixes: #12438
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@Luap99 PTAL