### PR TITLE
podman, push: expose --compression-format

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1289,3 +1289,9 @@ func AutocompleteCheckpointCompressType(cmd *cobra.Command, args []string, toCom
 	types := []string{"gzip", "none", "zstd"}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
+
+// AutocompleteCompressionFormat - Autocomplete compression-format type options.
+func AutocompleteCompressionFormat(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	types := []string{"gzip", "zstd", "zstd:chunked"}
+	return types, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -108,6 +108,10 @@ func pushFlags(cmd *cobra.Command) {
 
 	flags.BoolVar(&pushOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 
+	compressionFormat := "compression-format"
+	flags.StringVar(&pushOptions.CompressionFormat, compressionFormat, "", "compression format to use")
+	_ = cmd.RegisterFlagCompletionFunc(compressionFormat, common.AutocompleteCompressionFormat)
+
 	if registry.IsRemote() {
 		_ = flags.MarkHidden("cert-dir")
 		_ = flags.MarkHidden("compress")

--- a/docs/source/markdown/podman-push.1.md
+++ b/docs/source/markdown/podman-push.1.md
@@ -71,6 +71,10 @@ Please refer to containers-certs.d(5) for details. (This option is not available
 Compress tarball image layers when pushing to a directory using the 'dir' transport. (default is same compression type, compressed or uncompressed, as source)
 Note: This flag can only be set when using the **dir** transport
 
+#### **--compression-format** *COMPRESSION*
+
+Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip`.
+
 #### **--digestfile** *Digestfile*
 
 After copying the image, write the digest of the resulting image to the file.  (This option is not available with the remote Podman client)

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -208,6 +208,8 @@ type ImagePushOptions struct {
 	SkipTLSVerify types.OptionalBool
 	// Progress to get progress notifications
 	Progress chan types.ProgressProperties
+	// CompressionFormat is the format to use for the compression of the blobs
+	CompressionFormat string
 }
 
 // ImageSearchOptions are the arguments for searching images.

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/compression"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -304,6 +305,14 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 	pushOptions.RemoveSignatures = options.RemoveSignatures
 	pushOptions.SignBy = options.SignBy
 	pushOptions.InsecureSkipTLSVerify = options.SkipTLSVerify
+
+	if options.CompressionFormat != "" {
+		algo, err := compression.AlgorithmByName(options.CompressionFormat)
+		if err != nil {
+			return err
+		}
+		pushOptions.CompressionFormat = &algo
+	}
 
 	if !options.Quiet {
 		pushOptions.Writer = os.Stderr

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -2,12 +2,14 @@ package integration
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/containers/podman/v3/pkg/rootless"
 	. "github.com/containers/podman/v3/test/utils"
+	"github.com/containers/storage/pkg/archive"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -61,6 +63,36 @@ var _ = Describe("Podman push", func() {
 			fmt.Sprintf("dir:%s", bbdir)})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
+	})
+
+	It("podman push to oci with compression-format", func() {
+		SkipIfRemote("Remote push does not support dir transport")
+		bbdir := filepath.Join(podmanTest.TempDir, "busybox-oci")
+		session := podmanTest.Podman([]string{"push", "--compression-format=zstd", "--remove-signatures", ALPINE,
+			fmt.Sprintf("oci:%s", bbdir)})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		foundZstdFile := false
+
+		blobsDir := filepath.Join(bbdir, "blobs/sha256")
+
+		blobs, err := ioutil.ReadDir(blobsDir)
+		Expect(err).To(BeNil())
+
+		for _, f := range blobs {
+			blobPath := filepath.Join(blobsDir, f.Name())
+
+			sourceFile, err := ioutil.ReadFile(blobPath)
+			Expect(err).To(BeNil())
+
+			compressionType := archive.DetectCompression(sourceFile)
+			if compressionType == archive.Zstd {
+				foundZstdFile = true
+				break
+			}
+		}
+		Expect(foundZstdFile).To(BeTrue())
 	})
 
 	It("podman push to local registry", func() {


### PR DESCRIPTION
support overriding the compression format at push time.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
