### PR TITLE
Refactor podman image command output

### DIFF
--- a/cmd/podman/images/mount.go
+++ b/cmd/podman/images/mount.go
@@ -87,7 +87,7 @@ func mount(cmd *cobra.Command, args []string) error {
 	case report.IsJSON(mountOpts.Format):
 		return printJSON(reports)
 	case mountOpts.Format == "":
-		break // default format
+		break // see default format below
 	default:
 		return errors.Errorf("unknown --format argument: %q", mountOpts.Format)
 	}
@@ -97,19 +97,12 @@ func mount(cmd *cobra.Command, args []string) error {
 		mrs = append(mrs, mountReporter{r})
 	}
 
-	row := "{{range . }}{{.ID}}\t{{.Path}}\n{{end -}}"
-	tmpl, err := report.NewTemplate("mounts").Parse(row)
+	rpt, err := report.New(os.Stdout, cmd.Name()).Parse(report.OriginPodman, "{{range . }}{{.ID}}\t{{.Path}}\n{{end -}}")
 	if err != nil {
 		return err
 	}
-
-	w, err := report.NewWriterDefault(os.Stdout)
-	if err != nil {
-		return err
-	}
-	defer w.Flush()
-
-	return tmpl.Execute(w, mrs)
+	defer rpt.Flush()
+	return rpt.Execute(mrs)
 }
 
 func printJSON(reports []*entities.ImageMountReport) error {

--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -215,8 +215,10 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 	case report.IsJSON(i.options.Format) || i.options.Format == "":
 		err = printJSON(data)
 	default:
+		// Landing here implies user has given a custom --format
 		row := inspectNormalize(i.options.Format)
-		row = "{{range . }}" + report.NormalizeFormat(row) + "{{end -}}"
+		row = report.NormalizeFormat(row)
+		row = report.EnforceRange(row)
 		err = printTmpl(tmpType, row, data)
 	}
 	if err != nil {

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -116,7 +116,15 @@ func outputTemplate(cmd *cobra.Command, responses []*machineReporter) error {
 		"DiskSize": "DISK SIZE",
 	})
 
-	row := report.NormalizeFormat(listFlag.format)
+	var row string
+	switch {
+	case cmd.Flags().Changed("format"):
+		row = cmd.Flag("format").Value.String()
+		listFlag.noHeading = !report.HasTable(row)
+		row = report.NormalizeFormat(row)
+	default:
+		row = cmd.Flag("format").Value.String()
+	}
 	format := report.EnforceRange(row)
 
 	tmpl, err := report.NewTemplate("list").Parse(format)
@@ -129,10 +137,6 @@ func outputTemplate(cmd *cobra.Command, responses []*machineReporter) error {
 		return err
 	}
 	defer w.Flush()
-
-	if cmd.Flags().Changed("format") && !report.HasTable(listFlag.format) {
-		listFlag.noHeading = true
-	}
 
 	if !listFlag.noHeading {
 		if err := tmpl.Execute(w, headers); err != nil {

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -64,11 +64,13 @@ func inspect(cmd *cobra.Command, args []string) error {
 	}
 
 	if report.IsJSON(inspectOptions.Format) {
+		json.MarshalIndent(responses, "", "     ")
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "     ")
 		return enc.Encode(responses)
 	}
 
+	// cmd.Flags().Changed("format") must be true to reach this code
 	row := report.NormalizeFormat(inspectOptions.Format)
 
 	t, err := report.NewTemplate("inspect").Parse(row)

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -136,11 +136,12 @@ func pods(cmd *cobra.Command, _ []string) error {
 		renderHeaders = report.HasTable(psInput.Format)
 		row = report.NormalizeFormat(psInput.Format)
 	}
+	format := report.EnforceRange(row)
+
 	noHeading, _ := cmd.Flags().GetBool("noheading")
 	if noHeading {
 		renderHeaders = false
 	}
-	format := report.EnforceRange(row)
 
 	tmpl, err := report.NewTemplate("list").Parse(format)
 	if err != nil {

--- a/cmd/podman/pods/stats.go
+++ b/cmd/podman/pods/stats.go
@@ -67,9 +67,7 @@ func stats(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	row := report.NormalizeFormat(statsOptions.Format)
-	doJSON := report.IsJSON(row)
-
+	doJSON := report.IsJSON(cmd.Flag("format").Value.String())
 	headers := report.Headers(entities.PodStatsReport{}, map[string]string{
 		"CPU":           "CPU %",
 		"MemUsage":      "MEM USAGE/ LIMIT",
@@ -96,6 +94,8 @@ func stats(cmd *cobra.Command, args []string) error {
 				goterm.Flush()
 			}
 			if cmd.Flags().Changed("format") {
+				row := report.NormalizeFormat(statsOptions.Format)
+				row = report.EnforceRange(row)
 				if err := printFormattedPodStatsLines(headers, row, reports); err != nil {
 					return err
 				}
@@ -142,8 +142,6 @@ func printFormattedPodStatsLines(headerNames []map[string]string, row string, st
 	if len(stats) == 0 {
 		return nil
 	}
-
-	row = report.EnforceRange(row)
 
 	tmpl, err := report.NewTemplate("stats").Parse(row)
 	if err != nil {

--- a/cmd/podman/secrets/list.go
+++ b/cmd/podman/secrets/list.go
@@ -71,7 +71,10 @@ func outputTemplate(cmd *cobra.Command, responses []*entities.SecretListReport) 
 		"UpdatedAt": "UPDATED",
 	})
 
-	row := report.NormalizeFormat(listFlag.format)
+	row := cmd.Flag("format").Value.String()
+	if cmd.Flags().Changed("format") {
+		row = report.NormalizeFormat(row)
+	}
 	format := report.EnforceRange(row)
 
 	tmpl, err := report.NewTemplate("list").Parse(format)

--- a/cmd/podman/system/connection/list.go
+++ b/cmd/podman/system/connection/list.go
@@ -82,7 +82,7 @@ func list(cmd *cobra.Command, _ []string) error {
 		return rows[i].Name < rows[j].Name
 	})
 
-	format := "{{.Name}}\t{{.URI}}\t{{.Identity}}\t{{.Default}}\n"
+	var format string
 	switch {
 	case report.IsJSON(cmd.Flag("format").Value.String()):
 		buf, err := registry.JSONLibrary().MarshalIndent(rows, "", "    ")
@@ -90,11 +90,10 @@ func list(cmd *cobra.Command, _ []string) error {
 			fmt.Println(string(buf))
 		}
 		return err
+	case cmd.Flags().Changed("format"):
+		format = report.NormalizeFormat(cmd.Flag("format").Value.String())
 	default:
-		if cmd.Flag("format").Changed {
-			format = cmd.Flag("format").Value.String()
-			format = report.NormalizeFormat(format)
-		}
+		format = "{{.Name}}\t{{.URI}}\t{{.Identity}}\t{{.Default}}\n"
 	}
 	format = report.EnforceRange(format)
 

--- a/cmd/podman/system/version.go
+++ b/cmd/podman/system/version.go
@@ -59,7 +59,7 @@ func version(cmd *cobra.Command, args []string) error {
 	}
 	defer w.Flush()
 
-	if cmd.Flag("format").Changed {
+	if cmd.Flags().Changed("format") {
 		row := report.NormalizeFormat(versionFormat)
 		tmpl, err := report.NewTemplate("version 2.0.0").Parse(row)
 		if err != nil {

--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -97,9 +97,14 @@ func outputTemplate(cmd *cobra.Command, responses []*entities.VolumeListReport) 
 		"Name": "VOLUME NAME",
 	})
 
-	row := report.NormalizeFormat(cliOpts.Format)
-	if cliOpts.Quiet {
+	var row string
+	switch {
+	case cliOpts.Quiet:
 		row = "{{.Name}}\n"
+	case cmd.Flags().Changed("format"):
+		row = report.NormalizeFormat(cliOpts.Format)
+	default:
+		row = cmd.Flag("format").Value.String()
 	}
 	format := report.EnforceRange(row)
 

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -221,9 +221,7 @@ Labels.created_at | 20[0-9-]\\\+T[0-9:]\\\+Z
     iid=${output:0:12}
 
     # Run the test: this will output three column-aligned rows. Test them.
-    # Tab character (\t) should have the same effect as the 'table' directive
     _run_format_test 'table' 'table {{.Repository}} {{.Tag}} {{.ID}}'
-    _run_format_test 'tabs'  '{{.Repository}}\t{{.Tag}}\t{{.ID}}'
 
     # Clean up.
     run_podman rmi ${aaa_name}:${aaa_tag} ${zzz_name}:${zzz_tag}

--- a/test/system/110-history.bats
+++ b/test/system/110-history.bats
@@ -21,6 +21,14 @@ load helpers
     done
 }
 
+@test "podman history - custom format" {
+    run_podman history --format "{{.ID}}\t{{.ID}}" $IMAGE
+    od -c <<<$output
+    while IFS= read -r row; do
+        is "$row" ".*	.*$"
+    done <<<$output
+}
+
 @test "podman history - json" {
     # Sigh. Timestamp in .created can be '...Z' or '...-06:00'
     tests="


### PR DESCRIPTION
Leverage new report.Formatter allowing better compatibility from
podman command output.

Follow on PR's will cover containers, etc.

See #10974
Depends on containers/common#831

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
