### PR TITLE
[NO NEW TESTS NEEDED] Refactor podman container command output

### DIFF
--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -81,7 +81,7 @@ func init() {
 	validate.AddLatestFlag(containerMountCommand, &mountOpts.Latest)
 }
 
-func mount(_ *cobra.Command, args []string) error {
+func mount(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && mountOpts.Latest {
 		return errors.Errorf("--latest and containers cannot be used together")
 	}
@@ -116,18 +116,14 @@ func mount(_ *cobra.Command, args []string) error {
 		mrs = append(mrs, mountReporter{r})
 	}
 
-	format := "{{range . }}{{.ID}}\t{{.Path}}\n{{end -}}"
-	tmpl, err := report.NewTemplate("mounts").Parse(format)
-	if err != nil {
-		return err
-	}
+	rpt := report.New(os.Stdout, cmd.Name())
+	defer rpt.Flush()
 
-	w, err := report.NewWriterDefault(os.Stdout)
+	rpt, err = rpt.Parse(report.OriginPodman, "{{range . }}{{.ID}}\t{{.Path}}\n{{end -}}")
 	if err != nil {
 		return err
 	}
-	defer w.Flush()
-	return tmpl.Execute(w, mrs)
+	return rpt.Execute(mrs)
 }
 
 func printJSON(reports []*entities.ContainerMountReport) error {

--- a/cmd/podman/containers/top.go
+++ b/cmd/podman/containers/top.go
@@ -77,7 +77,7 @@ func init() {
 	validate.AddLatestFlag(containerTopCommand, &topOptions.Latest)
 }
 
-func top(_ *cobra.Command, args []string) error {
+func top(cmd *cobra.Command, args []string) error {
 	if topOptions.ListDescriptors {
 		descriptors, err := util.GetContainerPidInformationDescriptors()
 		if err != nil {
@@ -103,15 +103,13 @@ func top(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	w, err := report.NewWriterDefault(os.Stdout)
-	if err != nil {
-		return err
-	}
+	rpt := report.New(os.Stdout, cmd.Name()).Init(os.Stdout, 12, 2, 2, ' ', 0)
+	defer rpt.Flush()
 
 	for _, proc := range topResponse.Value {
-		if _, err := fmt.Fprintln(w, proc); err != nil {
+		if _, err := fmt.Fprintln(rpt.Writer(), proc); err != nil {
 			return err
 		}
 	}
-	return w.Flush()
+	return nil
 }


### PR DESCRIPTION
Leverage new report.Formatter allowing better compatibility from
podman command output.

See #10974
See #12455

Depends on containers/common#831

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
