### PR TITLE
top: parse ps(1) args correctly

### DIFF
--- a/test/e2e/top_test.go
+++ b/test/e2e/top_test.go
@@ -101,6 +101,11 @@ var _ = Describe("Podman top", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
 		Expect(len(result.OutputToStringArray())).To(BeNumerically(">", 1))
+
+		result = podmanTest.Podman([]string{"top", session.OutputToString(), "ax -o args"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(result.OutputToStringArray()).To(Equal([]string{"COMMAND", "top -d 2"}))
 	})
 
 	It("podman top with comma-separated options", func() {


### PR DESCRIPTION
The arguments of ps(1) should be shlexed.

Fixes: #12452
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>