### PR TITLE
[3.4] systemd: replace multi-user with default.target

### DIFF
--- a/contrib/systemd/auto-update/podman-auto-update.service
+++ b/contrib/systemd/auto-update/podman-auto-update.service
@@ -10,4 +10,4 @@ ExecStart=/usr/bin/podman auto-update
 ExecStartPost=/usr/bin/podman image prune -f
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target

--- a/contrib/systemd/system/podman-restart.service
+++ b/contrib/systemd/system/podman-restart.service
@@ -10,4 +10,4 @@ Environment=LOGGING="--log-level=info"
 ExecStart=/usr/bin/podman $LOGGING start --all --filter restart-policy=always
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target

--- a/contrib/systemd/system/podman.service
+++ b/contrib/systemd/system/podman.service
@@ -12,4 +12,4 @@ Environment=LOGGING="--log-level=info"
 ExecStart=/usr/bin/podman $LOGGING system service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -88,7 +88,7 @@ Type=forking
 PIDFile=/run/user/1000/overlay-containers/de1e3223b1b888bc02d0962dd6cb5855eb00734061013ffdd3479d225abacdc6/userdata/conmon.pid
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 ```
 
 ### Generate systemd unit file for a container with `--new` flag
@@ -120,7 +120,7 @@ KillMode=none
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 ```
 
 ### Generate systemd unit files for a pod with two simple alpine containers
@@ -159,7 +159,7 @@ Type=forking
 PIDFile=/run/user/1000/overlay-containers/ccfd5c71a088768774ca7bd05888d55cc287698dde06f475c8b02f696a25adcd/userdata/conmon.pid
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 ```
 
 ### Installation of generated systemd unit files.
@@ -181,7 +181,6 @@ $ podman generate systemd --files --name systemd-pod
 
 $ sudo cp pod-systemd-pod.service container-great_payne.service /etc/systemd/system
 $ systemctl enable pod-systemd-pod.service
-Created symlink /etc/systemd/system/multi-user.target.wants/pod-systemd-pod.service → /etc/systemd/system/pod-systemd-pod.service.
 Created symlink /etc/systemd/system/default.target.wants/pod-systemd-pod.service → /etc/systemd/system/pod-systemd-pod.service.
 $ systemctl is-enabled pod-systemd-pod.service
 enabled

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -89,7 +89,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/sh -c '/usr/bin/echo Ready >/dev/%s'
 [Install]
-RequiredBy=multi-user.target
+RequiredBy=default.target
 `
 	deMoby := `[Unit]
 Description=Remove moby-engine
@@ -106,7 +106,7 @@ ExecStart=/usr/bin/rpm-ostree ex apply-live --allow-replacement
 ExecStartPost=/bin/touch /var/lib/%N.stamp
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
  `
 	_ = ready
 	ignSystemd := Systemd{

--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -127,7 +127,7 @@ NotifyAccess={{{{.NotifyAccess}}}}
 {{{{- end}}}}
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 // ContainerUnit generates a systemd unit for the specified container.  Based

--- a/pkg/systemd/generate/containers_test.go
+++ b/pkg/systemd/generate/containers_test.go
@@ -61,7 +61,7 @@ PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 	goodID := serviceInfo + headerInfo + goodIDContent
 	goodIDNoHeaderInfo := serviceInfo + goodIDContent
@@ -87,7 +87,7 @@ PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNameBoundTo := `# container-foobar.service
@@ -113,7 +113,7 @@ PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodWithNameAndGeneric := `# jadda-jadda.service
@@ -138,7 +138,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodWithNameAndSdnotify := `# jadda-jadda.service
@@ -163,7 +163,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodWithExplicitShortDetachParam := `# jadda-jadda.service
@@ -188,7 +188,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNameNewWithPodFile := `# jadda-jadda.service
@@ -213,7 +213,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNameNewDetach := `# jadda-jadda.service
@@ -238,7 +238,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodIDNew := `# container-639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401.service
@@ -263,7 +263,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	genGoodNewDetach := func(detachparam string) string {
@@ -291,7 +291,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 		return goodNewDetach
 	}
@@ -318,7 +318,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewRootFlags := `# jadda-jadda.service
@@ -343,7 +343,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodContainerCreate := `# jadda-jadda.service
@@ -368,7 +368,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithJournaldTag := `# jadda-jadda.service
@@ -393,7 +393,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithSpecialChars := `# jadda-jadda.service
@@ -418,7 +418,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithIDFiles := `# jadda-jadda.service
@@ -443,7 +443,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithPodIDFiles := `# jadda-jadda.service
@@ -468,7 +468,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithEnvar := `# jadda-jadda.service
@@ -494,7 +494,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	goodNewWithRestartPolicy := `# jadda-jadda.service
@@ -520,7 +520,7 @@ Type=notify
 NotifyAccess=all
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 	tests := []struct {
 		name     string

--- a/pkg/systemd/generate/pods.go
+++ b/pkg/systemd/generate/pods.go
@@ -101,7 +101,7 @@ PIDFile={{{{.PIDFile}}}}
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 // PodUnits generates systemd units for the specified pod and its containers.

--- a/pkg/systemd/generate/pods_test.go
+++ b/pkg/systemd/generate/pods_test.go
@@ -62,7 +62,7 @@ PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 	podGood := serviceInfo + headerInfo + podContent
 	podGoodNoHeaderInfo := serviceInfo + podContent
@@ -92,7 +92,7 @@ PIDFile=%t/pod-123abc.pid
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	podGoodNamedNewWithRootArgs := `# pod-123abc.service
@@ -120,7 +120,7 @@ PIDFile=%t/pod-123abc.pid
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	podGoodNamedNewWithReplaceFalse := `# pod-123abc.service
@@ -148,7 +148,7 @@ PIDFile=%t/pod-123abc.pid
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	podNewLabelWithCurlyBraces := `# pod-123abc.service
@@ -176,7 +176,7 @@ PIDFile=%t/pod-123abc.pid
 Type=forking
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 `
 
 	tests := []struct {

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -35,7 +35,7 @@ ExecStart=/usr/bin/podman start -a redis
 ExecStop=/usr/bin/podman stop -t 10 redis
 KillMode=process
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 `
 	})
 

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -366,7 +366,7 @@ Type=oneshot
 ExecStart=/usr/bin/podman auto-update
 
 [Install]
-WantedBy=multi-user.target default.target
+WantedBy=default.target
 EOF
 
     echo "podman-auto-update-$cname" >> $SNAME_FILE

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -767,7 +767,7 @@ Type=simple
 ExecStart=/bin/bash -c '/bin/busctl monitor --system --match "interface=org.fedoraproject.FirewallD1,member=Reloaded" --match "interface=org.fedoraproject.FirewallD1,member=PropertiesChanged" | while read -r line ; do podman network reload --all ; done'
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 2) For "systemctl restart firewalld", create a systemd unit file with the following
 ```
@@ -783,7 +783,7 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/podman network reload --all
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 However, If you use busctl monitor then you can't get machine-readable output on `RHEL 8`.
 Since it doesn't have `busctl -j` as mentioned here by [@yrro](https://github.com/containers/podman/issues/5431#issuecomment-896943018).
@@ -802,7 +802,7 @@ ExecStart=/bin/bash -c "dbus-monitor --profile --system 'type=signal,sender=org.
 Restart=Always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 `busctl-monitor` is almost usable in `RHEL 8`, except that it always outputs two bogus events when it starts up,
 one of which is (in its only machine-readable format) indistinguishable from the `NameOwnerChanged` that you get when firewalld starts up.
@@ -823,7 +823,7 @@ ExecStart=/usr/bin/python  /path/to/python/code/podman-redo-nat.py
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 The code reloads podman network twice when you use `systemctl restart firewalld`.
 ```


### PR DESCRIPTION
Replace multi-user.target with default.target across the code base.
It seems like the multi-user one is not available for (rootless) users
on F35 anymore is causing issues in all kinds of ways, for instance,
enabling the podman.service or generated systemd units.

Backport of commit 9a10e2124bb11027fc71db4c495c116277b8b7e3.

Fixes: #12438
Signed-off-by: Valentin Rothberg rothberg@redhat.com