### PR TITLE
container, cgroup: detect pid termination

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -939,6 +939,11 @@ func (c *Container) cGroupPath() (string, error) {
 	procPath := fmt.Sprintf("/proc/%d/cgroup", c.state.PID)
 	lines, err := ioutil.ReadFile(procPath)
 	if err != nil {
+		// If the file doesn't exist, it means the container could have been terminated
+		// so report it.
+		if os.IsNotExist(err) {
+			return "", errors.Wrapf(define.ErrCtrStopped, "cannot get cgroup path unless container %s is running", c.ID())
+		}
 		return "", err
 	}
 


### PR DESCRIPTION
If the /proc/$PID/cgroup file doesn't exist, then it is likely the
container was terminated in the meanwhile so report ErrCtrStopped that
is already handled instead of ENOENT.

commit a66f40b4df039e94572fa38c070207a435cfa466 introduced the regression.

Closes: https://github.com/containers/podman/issues/12457

[NO NEW TESTS NEEDED] it solves a race in the CI that is difficult to reproduce.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
