### PR TITLE
Hostname in `spec.hostname` should be passed to infra ctr init opt

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -287,6 +287,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 	if podOpt.Infra {
 		infraImage := util.DefaultContainerConfig().Engine.InfraImage
 		infraOptions := entities.NewInfraContainerCreateOptions()
+		infraOptions.Hostname = podSpec.PodSpecGen.PodBasicConfig.Hostname
 		podSpec.PodSpecGen.InfraImage = infraImage
 		podSpec.PodSpecGen.NoInfra = false
 		podSpec.PodSpecGen.InfraContainerSpec = specgen.NewSpecGenerator(infraImage, false)

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1762,6 +1762,11 @@ var _ = Describe("Podman play kube", func() {
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(Exit(0))
 		Expect(inspect.OutputToString()).To(Equal(hostname))
+
+		hostnameInCtr := podmanTest.Podman([]string{"exec", getCtrNameInPod(pod), "hostname"})
+		hostnameInCtr.WaitWithDefaultTimeout()
+		Expect(hostnameInCtr).Should(Exit(0))
+		Expect(hostnameInCtr.OutputToString()).To(Equal(hostname))
 	})
 
 	It("podman play kube test HostAliases", func() {


### PR DESCRIPTION
Pass `spec.hostname` to infra ctr init options so we can set hostname as user expected.

Fixes https://github.com/containers/podman/issues/12393

Signed-off-by: Qiang Wang <sunsetmask@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

When create pod with yaml file by `play kube` cmd. `hostname` setted on yaml spec did not passed to infra hostname opt. This cause the UTS namespace use default pod name as hostname.
<!---
Please put your overall PR description here
-->

#### How to verify it

In the issue I submitted enough info already.
<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

Fixes #12393 

#### Special notes for your reviewer:
N/A