### PR TITLE
Fix possible rootless netns cleanup race

### DIFF
--- a/docs/source/markdown/podman-unshare.1.md
+++ b/docs/source/markdown/podman-unshare.1.md
@@ -35,7 +35,6 @@ Print usage statement
 Join the rootless network namespace used for CNI and netavark networking. It can be used to
 connect to a rootless container via IP address (bridge networking). This is otherwise
 not possible from the host network namespace.
-_Note: Using this option with more than one unshare session can have unexpected results._
 
 ## Exit Codes
 
@@ -57,13 +56,13 @@ the exit codes follow the `chroot` standard, see below:
 
   **127** Executing a _contained command_ and the _command_ cannot be found
 
-    $ podman run busybox foo; echo $?
+    $ podman unshare foo; echo $?
     Error: fork/exec /usr/bin/bogus: no such file or directory
     127
 
   **Exit code** _contained command_ exit code
 
-    $ podman run busybox /bin/sh -c 'exit 3'; echo $?
+    $ podman unshare /bin/sh -c 'exit 3'; echo $?
     3
 
 ## EXAMPLE

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -365,9 +365,12 @@ func (ic *ContainerEngine) Unshare(ctx context.Context, args []string, options e
 		if err != nil {
 			return err
 		}
-		// make sure to unlock, unshare can run for a long time
+		// Make sure to unlock, unshare can run for a long time.
 		rootlessNetNS.Lock.Unlock()
-		defer rootlessNetNS.Cleanup(ic.Libpod)
+		// We do not want to cleanup the netns after unshare.
+		// The problem is that we cannot know if we need to cleanup and
+		// secondly unshare should allow user to setup the namespace with
+		// special things, e.g. potentially macvlan or something like that.
 		return rootlessNetNS.Do(unshare)
 	}
 	return unshare()


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

rootlessNetNS.Cleanup() has an issue with how it detects if cleanup
is needed, reading the container state is not good ebough because
containers are first stopped and than cleanup will be called. So at one
time two containers could wait for cleanup but the second one will fail
because the first one triggered already the cleanup thus making rootless
netns unavailable for the second container resulting in an teardown
error. Instead of checking the container state we need to check the
netns state.

Secondly, podman unshare --rootless-netns should not do the cleanup.
This causes more issues than it is worth fixing. Users also might want
to use this to setup the namespace in a special way. If unshare also
cleans this up right away we cannot do this.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

Fixes #12459

#### Special notes for your reviewer:
