### PR TITLE
e2e tmpdir cleanup

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -36,7 +36,6 @@ var (
 	PODMAN_BINARY      string                        //nolint:golint,stylecheck
 	INTEGRATION_ROOT   string                        //nolint:golint,stylecheck
 	CGROUP_MANAGER     = "systemd"                   //nolint:golint,stylecheck
-	ARTIFACT_DIR       = "/tmp/.artifacts"           //nolint:golint,stylecheck
 	RESTORE_IMAGES     = []string{ALPINE, BB, nginx} //nolint:golint,stylecheck
 	defaultWaitTimeout = 90
 	CGROUPSV2, _       = cgroups.IsCgroup2UnifiedMode() //nolint:golint,stylecheck
@@ -111,13 +110,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	cwd, _ := os.Getwd()
 	INTEGRATION_ROOT = filepath.Join(cwd, "../../")
 	podman := PodmanTestSetup("/tmp")
-	podman.ArtifactPath = ARTIFACT_DIR
-	if _, err := os.Stat(ARTIFACT_DIR); os.IsNotExist(err) {
-		if err = os.Mkdir(ARTIFACT_DIR, 0777); err != nil {
-			fmt.Printf("%q\n", err)
-			os.Exit(1)
-		}
-	}
 
 	// Pull cirros but don't put it into the cache
 	pullImages := []string{cirros, fedoraToolbox, volumeTest}
@@ -170,7 +162,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 func (p *PodmanTestIntegration) Setup() {
 	cwd, _ := os.Getwd()
 	INTEGRATION_ROOT = filepath.Join(cwd, "../../")
-	p.ArtifactPath = ARTIFACT_DIR
 }
 
 var _ = SynchronizedAfterSuite(func() {},
@@ -265,7 +256,6 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 		PodmanTest: PodmanTest{
 			PodmanBinary:       podmanBinary,
 			RemotePodmanBinary: podmanRemoteBinary,
-			ArtifactPath:       ARTIFACT_DIR,
 			TempDir:            tempDir,
 			RemoteTest:         remote,
 			ImageCacheFS:       storageFs,

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -164,15 +164,16 @@ func (p *PodmanTestIntegration) SeedImages() error {
 
 // RestoreArtifact puts the cached image into our test store
 func (p *PodmanTestIntegration) RestoreArtifact(image string) error {
-	fmt.Printf("Restoring %s...\n", image)
-	dest := strings.Split(image, "/")
-	destName := fmt.Sprintf("/tmp/%s.tar", strings.Replace(strings.Join(strings.Split(dest[len(dest)-1], "/"), ""), ":", "-", -1))
-	args := []string{"load", "-q", "-i", destName}
-	podmanOptions := getRemoteOptions(p, args)
-	command := exec.Command(p.PodmanBinary, podmanOptions...)
-	fmt.Printf("Running: %s %s\n", p.PodmanBinary, strings.Join(podmanOptions, " "))
-	command.Start()
-	command.Wait()
+	tarball := imageTarPath(image)
+	if _, err := os.Stat(tarball); err == nil {
+		fmt.Printf("Restoring %s...\n", image)
+		args := []string{"load", "-q", "-i", tarball}
+		podmanOptions := getRemoteOptions(p, args)
+		command := exec.Command(p.PodmanBinary, podmanOptions...)
+		fmt.Printf("Running: %s %s\n", p.PodmanBinary, strings.Join(podmanOptions, " "))
+		command.Start()
+		command.Wait()
+	}
 	return nil
 }
 

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -148,7 +148,7 @@ func (p *PodmanTestIntegration) StopRemoteService() {
 //MakeOptions assembles all the podman main options
 func getRemoteOptions(p *PodmanTestIntegration, args []string) []string {
 	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --cni-config-dir %s --cgroup-manager %s",
-		p.CrioRoot, p.RunRoot, p.OCIRuntime, p.ConmonBinary, p.CNIConfigDir, p.CgroupManager), " ")
+		p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, p.CNIConfigDir, p.CgroupManager), " ")
 	if os.Getenv("HOOK_OPTION") != "" {
 		podmanOptions = append(podmanOptions, os.Getenv("HOOK_OPTION"))
 	}

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/containers/podman/v3/pkg/rootless"
 )
@@ -59,11 +58,12 @@ func PodmanTestCreate(tempDir string) *PodmanTestIntegration {
 
 // RestoreArtifact puts the cached image into our test store
 func (p *PodmanTestIntegration) RestoreArtifact(image string) error {
-	fmt.Printf("Restoring %s...\n", image)
-	dest := strings.Split(image, "/")
-	destName := fmt.Sprintf("/tmp/%s.tar", strings.Replace(strings.Join(strings.Split(dest[len(dest)-1], "/"), ""), ":", "-", -1))
-	restore := p.PodmanNoEvents([]string{"load", "-q", "-i", destName})
-	restore.Wait(90)
+	tarball := imageTarPath(image)
+	if _, err := os.Stat(tarball); err == nil {
+		fmt.Printf("Restoring %s...\n", image)
+		restore := p.PodmanNoEvents([]string{"load", "-q", "-i", tarball})
+		restore.Wait(90)
+	}
 	return nil
 }
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -36,7 +36,6 @@ type PodmanTestCommon interface {
 type PodmanTest struct {
 	PodmanMakeOptions  func(args []string, noEvents, noCache bool) []string
 	PodmanBinary       string
-	ArtifactPath       string
 	TempDir            string
 	RemoteTest         bool
 	RemotePodmanBinary string


### PR DESCRIPTION
My initial goal was to allow caching the e2e images in a directory other than /tmp.
In the process of doing so I discovered some very confusing and/or unnecessary code.
I took the liberty of cleaning it up.

These are three separate easily-reviewed commits, I recommend reviewing each separately:

- Rename CrioRoot as just Root
- Image caches: allow overriding cache dir
- remove ARTIFACT_DIR and ArtifactPath
