### PR TITLE
Update docker cli message for case where user creates directory

### DIFF
--- a/docker
+++ b/docker
@@ -1,4 +1,4 @@
 #!/bin/sh
-[ -f /etc/containers/nodocker ] || \
+[ -e /etc/containers/nodocker ] || \
 echo "Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg." >&2
 exec /usr/bin/podman "$@"


### PR DESCRIPTION
Check for any existing system object in docker script to clear warning message (Resolving PR comments)
[NO NEW TESTS NEEDED]
Signed-off-by: Stephen Person <stephen.person.12@cnu.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:
The `echo` message in docker cli script does not specify whether to create a directory or file, so I've added an extra check if the directory /etc/containers/nodocker exists.
<!---
Please put your overall PR description here
-->

#### How to verify it

Create /etc/containers/nodocker directory,  run `docker`, and verify warning message is not displayed.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
