### PR TITLE
[CI:DOCS] logformatter: fix corner case with links

### DIFF
--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -37,12 +37,15 @@ table.synopsis { border: none; border-collapse: collapse; margin-left: 2em; marg
 .synopsis td   { font-weight: bold;   font-size: 120%; font-family: monospace; }
 
 /* test results */
+.testname  { font-size: 125%; color: #444; }
 .boring    { color: #999; }
 .timestamp { color: #999; }
 .log-debug { color: #999; }
 .log-info  { color: #333; }
 .log-warn  { color: #f60; }
 .log-error { color: #900; font-weight: bold; }
+.log-skip  { color: #F90; }
+.log-slow  { background: #FF0; color: #000; font-weight: bold; }
 .subtest   { background: #eee; }
 .subsubtest { color: #F39; font-weight: bold; }
 .string    { color: #00c; }
@@ -205,10 +208,16 @@ END_HTML
 
     print { $out_fh } "<pre> <!-- begin processed output -->\n";
 
+    # Assume rootful prompt, check for rootless (here and in log itself, below)
+    my $Prompt = '#';
+    $Prompt = '$' if $test_name =~ /rootless/;
+
     # Main loop: read input, one line at a time, and write out reformatted
   LINE:
     while (my $line = <STDIN>) {
         print $line;                    # Immediately dump back to stdout
+
+        $Prompt = '$' if $line =~ /Runner executing .* as rootless /;
 
         # Remain robust in face of errors: always write stdout even if no HTML
         next LINE if ! $out_fh;
@@ -328,7 +337,7 @@ END_HTML
             next LINE;
         }
         # (bindings test sometimes emits 'Running' with leading bullet char)
-        elsif ($line =~ /^•?Running:/) {
+        elsif ($line =~ s!^•?Running:!<span class="boring">$Prompt</span>!) {
             # Highlight the important (non-boilerplate) podman command.
             $line =~ s/\s+--remote\s+/ /g;      # --remote takes no args
             # Strip out the global podman options, but show them on hover
@@ -365,19 +374,27 @@ END_HTML
         # an anchor so we can link to it later.
         if ($after_divider++ == 2) {
             # Sigh. There is no actual marker. Assume that anything with
-            ## two leading spaces then alpha (not slashes) is a test name.
-            if ($line =~ /^  [a-zA-Z]/) {
+            ## two leading spaces then alpha or hyphen (not slashes) is
+            ## a test name.
+            if ($line =~ /^  [a-zA-Z-]/) {
                 my $id = make_id($line, 'anchor');
 
                 $line = "<a name='t--$id'><h2>$line</h2></a>";
             }
         }
 
+        # Make SKIPPING and SLOW TEST visible
+        $line =~ s!(\[SKIPPING\].*)!<span class="log-skip">$1</span>!;
+        $line =~ s!(\[SLOW TEST.*\])!<span class="log-slow">$1</span>!;
+
+        # Highlight test name when it appears in the middle of commands.
+        # But make it boring, because we already have the test name in large
+        # bold just above. (Except in skipped tests).
+        $line =~ s!^(\s*)(\[It\]\s+.*)!$1<span class="testname">$2</span>!;
+
         # Failure name corresponds to a previously-seen block.
-        ## FIXME: sometimes there are three failures with the same name.
-        ##        ...I have no idea why or how to link to the right ones.
-        #              1  2           2        3             3   14          4
-        if ($line =~ /^(\[(Fail|Panic!)\] .* \[(It|BeforeEach)\] )([A-Za-z].*)/) {
+        #              1  2           2        3             3   14           4
+        if ($line =~ /^(\[(Fail|Panic!)\] .* \[(It|BeforeEach)\] )([A-Za-z-].*)/) {
             my ($lhs, $type, $ginkgo_fluff, $testname) = ($1, $2, $3, $4);
             my $id = make_id($testname, 'link');
 
@@ -486,7 +503,10 @@ sub make_id {
     state %counter;
 
     $name =~ s/^\s+|\s+$//g;            # strip leading/trailing whitespace
+    $name =~ s/\&#\d+;//g;              # 'doesn&#39;t' -> 'doesnt'
+    $name =~ s/\&quot;/-/g;             # '&quot;path&quot;' -> '-path-'
     $name =~ s/[^a-zA-Z0-9_-]/-/g;      # Convert non-alphanumeric to dash
+    $name =~ s/-{3,}/-/g;               # '------' to just '-'
 
     # Keep a running tally of how many times we've seen this identifier
     # for this given type! This lets us cross-match, in the bottom of

--- a/contrib/cirrus/logformatter.t
+++ b/contrib/cirrus/logformatter.t
@@ -134,9 +134,35 @@ $SCRIPT_BASE/integration_test.sh |& ${TIMESTAMP}
 [+0103s] 4810be0cfbd42241e349dbe7d50fbc54405cd320a6637c65fd5323f34d64af89
 [+0104s] Running: /var/tmp/go/src/github.com/containers/libpod/bin/podman-remote --storage-opt vfs.imagestore=/tmp/podman/imagecachedir --root /tmp/podman_test553496330/crio --runroot /tmp/podman_test553496330/crio-run --runtime /usr/bin/runc --conmon /usr/bin/conmon --cni-config-dir /etc/cni/net.d --cgroup-manager systemd --tmpdir /tmp/podman_test553496330 --events-backend file --storage-driver vfs --remote --url unix:/run/user/12345/podman-xyz.sock pod rm -fa
 [+0104s] 4810be0cfbd42241e349dbe7d50fbc54405cd320a6637c65fd5323f34d64af89 again
+
+
 [+0107s] •
-[+0107s] ------------------------------
-[+0107s] podman system reset
+[+0523s] ------------------------------
+[+0523s] Podman play kube with build
+[+0523s]   --build should override image in store
+[+0523s]   /var/tmp/go/src/github.com/containers/podman/test/e2e/play_build_test.go:215
+
+
+[+0479s] •
+[+0479s] ------------------------------
+[+0479s] Podman pod rm
+[+0479s]   podman pod rm -a doesn't remove a running container
+[+0479s]   /var/tmp/go/src/github.com/containers/podman/test/e2e/pod_rm_test.go:119
+
+
+[+1405s] •
+[+1405s] ------------------------------
+[+1405s] Podman run entrypoint
+[+1405s]   podman run entrypoint == [""]
+[+1405s]   /var/tmp/go/src/github.com/containers/podman/test/e2e/run_entrypoint_test.go:47
+
+[+0184s] S [SKIPPING] [3.086 seconds]
+[+1385s] S [SKIPPING] in Spec Setup (BeforeEach) [0.001 seconds]
+
+[+1512s] Summarizing 6 Failures:
+[+1512s]
+[+1512s] [Fail] Podman play kube with build [It] --build should override image in store
+[+1512s] /var/tmp/go/src/github.com/containers/podman/test/e2e/play_build_test.go:259
 >>>
 $SCRIPT_BASE/integration_test.sh |&amp; ${TIMESTAMP}
 [08:26:19] START - All [+xxxx] lines that follow are relative to right now.
@@ -150,9 +176,9 @@ $SCRIPT_BASE/integration_test.sh |&amp; ${TIMESTAMP}
 <span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L41'>/containers/podman/test/e2e/pod_restart_test.go:41</a>
 <span class="timestamp">         </span>[BeforeEach] Podman pod restart
 <span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L18'>/containers/podman/test/e2e/pod_restart_test.go:18</a>
-<span class="timestamp">         </span>[It] podman pod restart single empty pod
+<span class="timestamp">         </span><span class="testname">[It] podman pod restart single empty pod</span>
 <span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L41'>/containers/podman/test/e2e/pod_restart_test.go:41</a>
-<span class="timestamp">         </span>Running: <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/podman/imagecachedir
+<span class="timestamp">         </span><span class="boring">#</span> <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/podman/imagecachedir
 --root /tmp/podman_test553496330/crio
 --runroot /tmp/podman_test553496330/crio-run
 --runtime /usr/bin/runc
@@ -163,7 +189,7 @@ $SCRIPT_BASE/integration_test.sh |&amp; ${TIMESTAMP}
 --events-backend file
 --storage-driver vfs">[options]</span><b> pod create --infra=false --share</b>
 <span class="timestamp">         </span>4810be0cfbd42241e349dbe7d50fbc54405cd320a6637c65fd5323f34d64af89
-<span class="timestamp">         </span>Running: <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/podman/imagecachedir
+<span class="timestamp">         </span><span class="boring">#</span> <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/podman/imagecachedir
 --root /tmp/podman_test553496330/crio
 --runroot /tmp/podman_test553496330/crio-run
 --runtime /usr/bin/runc
@@ -177,7 +203,7 @@ $SCRIPT_BASE/integration_test.sh |&amp; ${TIMESTAMP}
 <span class="timestamp">         </span>output:
 <span class="timestamp">         </span>[AfterEach] Podman pod restart
 <span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_restart_test.go#L28'>/containers/podman/test/e2e/pod_restart_test.go:28</a>
-<span class="timestamp">         </span>Running: <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/podman/imagecachedir
+<span class="timestamp">         </span><span class="boring">#</span> <span title="/var/tmp/go/src/github.com/containers/podman/bin/podman"><b>podman</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/podman/imagecachedir
 --root /tmp/podman_test553496330/crio
 --runroot /tmp/podman_test553496330/crio-run
 --runtime /usr/bin/runc
@@ -189,7 +215,7 @@ $SCRIPT_BASE/integration_test.sh |&amp; ${TIMESTAMP}
 --storage-driver vfs">[options]</span><b> pod rm -fa</b>
 <span class="timestamp">         </span>4810be0cfbd42241e349dbe7d50fbc54405cd320a6637c65fd5323f34d64af89
 
-<span class="timestamp">[+0104s] </span>Running: <span title="/var/tmp/go/src/github.com/containers/libpod/bin/podman-remote"><b>podman-remote</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/podman/imagecachedir
+<span class="timestamp">[+0104s] </span><span class="boring">#</span> <span title="/var/tmp/go/src/github.com/containers/libpod/bin/podman-remote"><b>podman-remote</b></span> <span class="boring" title="--storage-opt vfs.imagestore=/tmp/podman/imagecachedir
 --root /tmp/podman_test553496330/crio
 --runroot /tmp/podman_test553496330/crio-run
 --runtime /usr/bin/runc
@@ -207,4 +233,34 @@ $SCRIPT_BASE/integration_test.sh |&amp; ${TIMESTAMP}
 </pre>
 <hr />
 <pre>
-<span class="timestamp">[+0107s] </span>podman system reset
+<span class="timestamp">[+0523s] </span>Podman play kube with build
+<span class="timestamp">         </span><a name='t----build-should-override-image-in-store--1'><h2>  --build should override image in store</h2></a>
+<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/play_build_test.go#L215'>/containers/podman/test/e2e/play_build_test.go:215</a>
+
+
+<span class="timestamp">[+0479s] </span>•
+</pre>
+<hr />
+<pre>
+<span class="timestamp">[+0479s] </span>Podman pod rm
+<span class="timestamp">         </span><a name='t--podman-pod-rm--a-doesnt-remove-a-running-container--1'><h2>  podman pod rm -a doesn&#39;t remove a running container</h2></a>
+<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/pod_rm_test.go#L119'>/containers/podman/test/e2e/pod_rm_test.go:119</a>
+
+
+<span class="timestamp">[+1405s] </span>•
+</pre>
+<hr />
+<pre>
+<span class="timestamp">[+1405s] </span>Podman run entrypoint
+<span class="timestamp">         </span><a name='t--podman-run-entrypoint---1'><h2>  podman run entrypoint == [&quot;&quot;]</h2></a>
+<span class="timestamp">         </span>  /var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/run_entrypoint_test.go#L47'>/containers/podman/test/e2e/run_entrypoint_test.go:47</a>
+
+
+<span class="timestamp">[+0184s] </span>S <span class="log-skip">[SKIPPING] [3.086 seconds]</span>
+<span class="timestamp">[+1385s] </span>S <span class="log-skip">[SKIPPING] in Spec Setup (BeforeEach) [0.001 seconds]</span>
+
+
+<span class="timestamp">[+1512s] </span>Summarizing 6 Failures:
+[+1512s]
+<span class="timestamp">         </span><b>[Fail] Podman play kube with build [It] <a href='#t----build-should-override-image-in-store--1'>--build should override image in store</a></b>
+<span class="timestamp">         </span>/var/tmp/go/src/github.com<a class="codelink" href='https://github.com/containers/podman/blob/40f5d8b1becd381c4e8283ed3940d09193e4fe06/test/e2e/play_build_test.go#L259'>/containers/podman/test/e2e/play_build_test.go:259</a>


### PR DESCRIPTION
A test name beginning with non-alpha, e.g., "--build should ...",
was not being recognized and linkified:

   https://storage.googleapis.com/cirrus-ci-6707778565701632-fcae48/artifacts/containers/podman/6500723916537856/html/int-podman-fedora-34-rootless-host.log.html

Fix that. Also fix two other cases (single/double quotes) that were
resulting in weird unreliable links.

While I'm at it, add a few usability enhancements:

  * Colorize [SKIPPING] and [SLOW TEST]
  * Deemphasize '[It] testname' when it appears mid-test
  * Replace 'Running:' with a (deemphasized) '#' or '$' prompt

Add regression tests

Signed-off-by: Ed Santiago <santiago@redhat.com>
