### PR TITLE
[WIP] Fix CVE-2021-4024 - v3.4 branch

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -659,7 +659,7 @@ func (v *MachineVM) startHostNetworking() error {
 
 	// Listen on all at port 7777 for setting up and tearing
 	// down forwarding
-	listenSocket := "tcp://0.0.0.0:7777"
+	listenSocket := "tcp://127.0.0.1:7777"
 	qemuSocket, pidFile, err := v.getSocketandPid()
 	if err != nil {
 		return err


### PR DESCRIPTION
This resolves CVE-2021-4024, where an attacker could access the API externally and forward any port they desired to the VM from `podman machine`.

This is only required on v3.4 and v3.4.2-rhel branches, as main already has a similar fix from @Luap99 rewriting this code. Unfortunately we can't backport that, as it's an extensive rewrite that depends on the even more extensive rewrites of the network code.

[NO NEW TESTS NEEDED] gvproxy is not tested directly at this time.
