### PR TITLE
centos 9 stream cannot use %autochangelog

### DIFF
--- a/.autocopr/podman.spec
+++ b/.autocopr/podman.spec
@@ -202,4 +202,5 @@ rm -f %{_sharedstatedir}/containers/storage/libpod/defaultCNINetExists
 exit 0
 
 %changelog
-%autochangelog
+* Fri Dec 03 2021 Lokesh Mandvekar <lsm5@fedoraproject.org> - %{version}-%{release}
+- auto copr build


### PR DESCRIPTION
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

centos 9 stream can't use `%autochangelog` yet so this is needed to make centos9 copr build happy.

@containers/podman-maintainers PTAL 