### PR TITLE
Fixes #11416 - Trailing quote on PATH added by Windows MSI 

### DIFF
--- a/contrib/msi/podman.wxs
+++ b/contrib/msi/podman.wxs
@@ -32,7 +32,8 @@
     </Directory>
 
     <Property Id="setx" Value="setx.exe"/>
-    <CustomAction Id="ChangePath" ExeCommand="PATH &quot;%PATH%;[INSTALLDIR]&quot;" Property="setx" Execute="deferred" Impersonate="yes" Return="check"/>
+    <!-- Directory table entries have a trailing slash, so an extra backslash is needed to prevent escaping the quote -->
+    <CustomAction Id="ChangePath" ExeCommand="PATH &quot;%PATH%;[INSTALLDIR]\&quot;" Property="setx" Execute="deferred" Impersonate="yes" Return="check"/>
 
     <Feature Id="Complete" Level="1">
       <ComponentRef Id="INSTALLDIR_Component"/>


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes trailing quote added by windows installer  (#11416)

Directory table entries in a windows installer end in a trailing backslash, so will be interpreted as an escape for the setx closing quote, forcing its inclusion on the path. To prevent this, it can be escaped by adding an extra backslash. 

Note, this PR does not address other issues with the setx approach (e.g. possibility to overwrite previous path values, and a missing uninstall operation).  The other issues could be addressed in the future by a powershell or helper executable executed as custom actions (aside from direct support in wxl)

#### How to verify it

Querying the path does not return a trailing slash after running the windows installer

```
reg query HKCU\Environment /v Path

HKEY_CURRENT_USER\Environment
    Path    REG_EXPAND_SZ    %PATH%;C:\Program Files\RedHat\Podman\

```

#### Which issue(s) this PR fixes:

Fixes #11416

