### PR TITLE
podman machine: use gvproxy for host.containers.internal

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2022,33 +2022,37 @@ func (c *Container) getHosts() string {
 		}
 	}
 
-	// Add gateway entry
-	var depCtr *Container
-	if c.config.NetNsCtr != "" {
-		// ignoring the error because there isn't anything to do
-		depCtr, _ = c.getRootNetNsDepCtr()
-	} else if len(c.state.NetworkStatus) != 0 {
-		depCtr = c
-	} else {
-		depCtr = nil
-	}
-
-	if depCtr != nil {
-		for _, pluginResultsRaw := range depCtr.state.NetworkStatus {
-			pluginResult, _ := cnitypes.GetResult(pluginResultsRaw)
-			for _, ip := range pluginResult.IPs {
-				hosts += fmt.Sprintf("%s host.containers.internal\n", ip.Gateway)
-			}
-		}
-	} else if c.config.NetMode.IsSlirp4netns() {
-		gatewayIP, err := GetSlirp4netnsGateway(c.slirp4netnsSubnet)
-		if err != nil {
-			logrus.Warn("failed to determine gatewayIP: ", err.Error())
+	// Add gateway entry if we are not in a machine. If we use podman machine
+	// the gvproxy dns server will take care of host.containers.internal.
+	// https://github.com/containers/gvisor-tap-vsock/commit/1108ea45162281046d239047a6db9bc187e64b08
+	if !c.runtime.config.Engine.MachineEnabled {
+		var depCtr *Container
+		if c.config.NetNsCtr != "" {
+			// ignoring the error because there isn't anything to do
+			depCtr, _ = c.getRootNetNsDepCtr()
+		} else if len(c.state.NetworkStatus) != 0 {
+			depCtr = c
 		} else {
-			hosts += fmt.Sprintf("%s host.containers.internal\n", gatewayIP.String())
+			depCtr = nil
 		}
-	} else {
-		logrus.Debug("network configuration does not support host.containers.internal address")
+
+		if depCtr != nil {
+			for _, pluginResultsRaw := range depCtr.state.NetworkStatus {
+				pluginResult, _ := cnitypes.GetResult(pluginResultsRaw)
+				for _, ip := range pluginResult.IPs {
+					hosts += fmt.Sprintf("%s host.containers.internal\n", ip.Gateway)
+				}
+			}
+		} else if c.config.NetMode.IsSlirp4netns() {
+			gatewayIP, err := GetSlirp4netnsGateway(c.slirp4netnsSubnet)
+			if err != nil {
+				logrus.Warn("failed to determine gatewayIP: ", err.Error())
+			} else {
+				hosts += fmt.Sprintf("%s host.containers.internal\n", gatewayIP.String())
+			}
+		} else {
+			logrus.Debug("network configuration does not support host.containers.internal address")
+		}
 	}
 
 	return hosts


### PR DESCRIPTION



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

Backport of https://github.com/containers/podman/pull/11649

Let the gvproxy dns server handle the host.containers.internal entry.
Support for this is already added to gvproxy. [1]

To make sure the container uses the dns response from gvproxy we should
not add host.containers.internal to /etc/hosts in this case.


[1] https://github.com/containers/gvisor-tap-vsock/commit/1108ea45162281046d239047a6db9bc187e64b08

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:


Fixes #12507


#### Special notes for your reviewer:
