### PR TITLE
Backport CVE-2021-4024 fix to RHEL branch

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -659,7 +659,7 @@ func (v *MachineVM) startHostNetworking() error {
 
 	// Listen on all at port 7777 for setting up and tearing
 	// down forwarding
-	listenSocket := "tcp://0.0.0.0:7777"
+	listenSocket := "tcp://127.0.0.1:7777"
 	qemuSocket, pidFile, err := v.getSocketandPid()
 	if err != nil {
 		return err


### PR DESCRIPTION
This already landed in v3.4, and we also want it in v3.4.2-rhel