### PR TITLE
tests: clean up FIXMEs and noise

### DIFF
--- a/test/e2e/import_test.go
+++ b/test/e2e/import_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Podman import", func() {
 	})
 
 	It("podman import with signature", func() {
-		SkipIfRemote("FIXME: remote ignores --signature-policy, #12357")
+		SkipIfRemote("--signature-policy N/A for remote")
 
 		outfile := filepath.Join(podmanTest.TempDir, "container.tar")
 		_, ec, cid := podmanTest.RunLsContainer("")

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -103,7 +103,7 @@ ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
 	})
 
 	It("podman run user entrypoint overrides image entrypoint and image cmd", func() {
-		SkipIfRemote("FIXME: podman-remote not handling passing --entrypoint=\"\" flag correctly")
+		SkipIfRemote("#12521: podman-remote not handling passing empty --entrypoint")
 		dockerfile := `FROM quay.io/libpod/alpine:latest
 CMD ["-i"]
 ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -514,9 +514,9 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 	})
 
 	It("podman run network expose duplicate host port results in error", func() {
-		SkipIfRootless("FIXME we should be able to run this test in rootless mode with different ports")
+		port := "8190" // Make sure this isn't used anywhere else
 
-		session := podmanTest.Podman([]string{"run", "--name", "test", "-dt", "-p", "80", ALPINE, "/bin/sh"})
+		session := podmanTest.Podman([]string{"run", "--name", "test", "-dt", "-p", port, ALPINE, "/bin/sh"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -526,8 +526,8 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 		containerConfig := inspect.InspectContainerToJSON()
 		Expect(containerConfig[0].NetworkSettings.Ports).To(Not(BeNil()))
-		Expect(containerConfig[0].NetworkSettings.Ports).To(HaveKeyWithValue("80/tcp", Not(BeNil())))
-		Expect(containerConfig[0].NetworkSettings.Ports["80/tcp"][0].HostPort).ToNot(Equal(80))
+		Expect(containerConfig[0].NetworkSettings.Ports).To(HaveKeyWithValue(port+"/tcp", Not(BeNil())))
+		Expect(containerConfig[0].NetworkSettings.Ports[port+"/tcp"][0].HostPort).ToNot(Equal(port))
 	})
 
 	It("podman run forward sctp protocol", func() {

--- a/test/system/600-completion.bats
+++ b/test/system/600-completion.bats
@@ -309,7 +309,7 @@ function _check_completion_end() {
     # Clean up the pod pause image
     run_podman image list --format '{{.ID}} {{.Repository}}'
     while read id name; do
-        if [[ "$name" =~ /pause ]]; then
+        if [[ "$name" =~ /podman-pause ]]; then
             run_podman rmi $id
         fi
     done <<<"$output"


### PR DESCRIPTION
e2e tests:
 * remove two FIXMEs:
   * one of them is expected behavior, not a FIXME
   * the other is easily fixed

 * File issue #12521 for a real podman-remote bug, and
   update the Skip() message

system tests:
 * in command-completion test, clean up stray podman-pause image
   (followup to #12322, in which I missed this instance). This
   removes distracting warnings from test logs.

Signed-off-by: Ed Santiago <santiago@redhat.com>
