### PR TITLE
remove runlabel test for global opts

### DIFF
--- a/pkg/domain/infra/abi/containers_runlabel.go
+++ b/pkg/domain/infra/abi/containers_runlabel.go
@@ -111,7 +111,6 @@ func generateRunlabelCommand(runlabel string, img *libimage.Image, inputName str
 	var (
 		err             error
 		name, imageName string
-		globalOpts      string
 		cmd             []string
 	)
 
@@ -144,7 +143,7 @@ func generateRunlabelCommand(runlabel string, img *libimage.Image, inputName str
 		runlabel = fmt.Sprintf("%s %s", runlabel, strings.Join(args, " "))
 	}
 
-	cmd, err = generateCommand(runlabel, imageName, name, globalOpts)
+	cmd, err = generateCommand(runlabel, imageName, name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -209,7 +208,7 @@ func replaceImage(arg, image string) string {
 }
 
 // generateCommand takes a label (string) and converts it to an executable command
-func generateCommand(command, imageName, name, globalOpts string) ([]string, error) {
+func generateCommand(command, imageName, name string) ([]string, error) {
 	if name == "" {
 		name = imageName
 	}
@@ -231,8 +230,6 @@ func generateCommand(command, imageName, name, globalOpts string) ([]string, err
 			newArg = fmt.Sprintf("IMAGE=%s", imageName)
 		case "NAME=NAME":
 			newArg = fmt.Sprintf("NAME=%s", name)
-		case "$GLOBAL_OPTS":
-			newArg = globalOpts
 		default:
 			newArg = replaceName(arg, name)
 			newArg = replaceImage(newArg, imageName)

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -18,10 +18,6 @@ var LsDockerfile = fmt.Sprintf(`
 FROM  %s
 LABEL RUN ls -la`, ALPINE)
 
-var GlobalDockerfile = fmt.Sprintf(`
-FROM %s
-LABEL RUN echo \$GLOBAL_OPTS`, ALPINE)
-
 var PodmanRunlabelNameDockerfile = fmt.Sprintf(`
 FROM  %s
 LABEL RUN podman run --name NAME IMAGE`, ALPINE)
@@ -102,22 +98,6 @@ var _ = Describe("podman container runlabel", func() {
 		Expect(result).To(ExitWithError())
 		// should not panic when label missing the value or don't have the label
 		Expect(result.OutputToString()).To(Not(ContainSubstring("panic")))
-	})
-
-	It("podman container runlabel global options", func() {
-		fmt.Printf("FIXME: for lint. Remove when you fix this test: %s", GlobalDockerfile)
-		Skip("FIXME: $GLOBAL_OPTS does not work at all, #12436")
-		image := "podman-global-test:ls"
-		podmanTest.BuildImage(GlobalDockerfile, image, "false")
-		result := podmanTest.Podman([]string{"--syslog", "--log-level", "debug", "container", "runlabel", "RUN", image})
-		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
-
-		Expect(result.OutputToString()).To(ContainSubstring("--syslog true"))
-		Expect(result.OutputToString()).To(ContainSubstring("--log-level debug"))
-		result = podmanTest.Podman([]string{"rmi", image})
-		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
 	})
 
 	It("runlabel should fail with nonexistent authfile", func() {


### PR DESCRIPTION
GLOBAL_OPTS haven't been supported for at least two major versions of
Podman.  The runlabel code is extremely fragile and I think it should
be rewritten before adding new features.

Fixes: #12436
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>