### PR TITLE
autocopr: distro conditionals for containers-common

### DIFF
--- a/.autocopr/podman.spec
+++ b/.autocopr/podman.spec
@@ -51,7 +51,11 @@ BuildRequires: ostree-devel
 BuildRequires: systemd
 BuildRequires: systemd-devel
 Requires: conmon >= 2:2.0.30-2
-Requires: containers-common >= 4:1-30
+%if 0%{?fedora}
+Requires: containers-common >= 4:1-21
+%else
+Requires: containers-common >= 2:1-13
+%endif
 Requires: containernetworking-plugins >= 1.0.0-15.1
 Requires: iptables
 Requires: nftables


### PR DESCRIPTION
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@containers/podman-maintainers @Luap99 @mheon @rhatdan @baude @vrothberg @edsantiago @cevich PTAL.

This will get build automatically on merge.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

Handle containers-common dependency in `rhcontainerbot/podman-next` copr.

#### How to verify it
```bash
$ sudo dnf copr enable rhcontainerbot/podman-next -y
$ sudo dnf install netavark podman -y
```
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

None