### PR TITLE
specgen: honor empty args for entrypoint specified as `--entrypoint ""`

### DIFF
--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -409,11 +409,9 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	s.WorkDir = c.Workdir
 	if c.Entrypoint != nil {
 		entrypoint := []string{}
-		if ep := *c.Entrypoint; len(ep) > 0 {
-			// Check if entrypoint specified is json
-			if err := json.Unmarshal([]byte(*c.Entrypoint), &entrypoint); err != nil {
-				entrypoint = append(entrypoint, ep)
-			}
+		// Check if entrypoint specified is json
+		if err := json.Unmarshal([]byte(*c.Entrypoint), &entrypoint); err != nil {
+			entrypoint = append(entrypoint, *c.Entrypoint)
 		}
 		s.Entrypoint = entrypoint
 	}

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -103,7 +103,6 @@ ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
 	})
 
 	It("podman run user entrypoint overrides image entrypoint and image cmd", func() {
-		SkipIfRemote("#12521: podman-remote not handling passing empty --entrypoint")
 		dockerfile := `FROM quay.io/libpod/alpine:latest
 CMD ["-i"]
 ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]


### PR DESCRIPTION
Users should be able to override containers entrypoint using
`--entrypoint ""` following works fine for **podman** but not for **podman
remote** since `CreateOptions` is not passed over to remote server.

Specgen ignores empty argument for entrypoint so make specgen honor
empty arguments.

Closes: https://github.com/containers/podman/issues/12521