### PR TITLE
generate systemd: support entrypoint JSON strings

### DIFF
--- a/pkg/systemd/generate/common.go
+++ b/pkg/systemd/generate/common.go
@@ -101,7 +101,7 @@ func escapeSystemdArguments(command []string) []string {
 func escapeSystemdArg(arg string) string {
 	arg = strings.ReplaceAll(arg, "$", "$$")
 	arg = strings.ReplaceAll(arg, "%", "%%")
-	if strings.ContainsAny(arg, " \t") {
+	if strings.ContainsAny(arg, " \t\"") {
 		arg = strconv.Quote(arg)
 	} else if strings.Contains(arg, `\`) {
 		// strconv.Quote also escapes backslashes so

--- a/pkg/systemd/generate/common_test.go
+++ b/pkg/systemd/generate/common_test.go
@@ -146,7 +146,7 @@ func TestEscapeSystemdArguments(t *testing.T) {
 	}{
 		{
 			[]string{"foo", "bar=\"arg\""},
-			[]string{"foo", "bar=\"arg\""},
+			[]string{"foo", "\"bar=\\\"arg\\\"\""},
 		},
 		{
 			[]string{"foo", "bar=\"arg with space\""},
@@ -191,6 +191,22 @@ func TestEscapeSystemdArguments(t *testing.T) {
 		{
 			[]string{"foo", `command with two backslashes \\`},
 			[]string{"foo", `"command with two backslashes \\\\"`},
+		},
+		{
+			[]string{"podman", "create", "--entrypoint", "foo"},
+			[]string{"podman", "create", "--entrypoint", "foo"},
+		},
+		{
+			[]string{"podman", "create", "--entrypoint=foo"},
+			[]string{"podman", "create", "--entrypoint=foo"},
+		},
+		{
+			[]string{"podman", "create", "--entrypoint", "[\"foo\"]"},
+			[]string{"podman", "create", "--entrypoint", "\"[\\\"foo\\\"]\""},
+		},
+		{
+			[]string{"podman", "create", "--entrypoint", "[\"sh\", \"-c\", \"date '+%s'\"]"},
+			[]string{"podman", "create", "--entrypoint", "\"[\\\"sh\\\", \\\"-c\\\", \\\"date '+%%s'\\\"]\""},
 		},
 	}
 

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -104,8 +104,9 @@ function service_cleanup() {
 }
 
 @test "podman autoupdate local" {
+    # Note that the entrypoint may be a JSON string which requires preserving the quotes (see #12477)
     cname=$(random_string)
-    run_podman create --name $cname --label "io.containers.autoupdate=local" $IMAGE top
+    run_podman create --name $cname --label "io.containers.autoupdate=local" --entrypoint '["top"]' $IMAGE
 
     # Start systemd service to run this container
     service_setup


### PR DESCRIPTION
Make sure to preserve the quoting of entrypoint JSON strings.

Fixes: #12477
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>