### PR TITLE
[3.4] Fix failing tests

### DIFF
--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -91,6 +91,10 @@ ${cid[0]} d"   "Sequential output from logs"
 
 function _log_test_restarted() {
     run_podman run --log-driver=$1 --name logtest $IMAGE sh -c 'start=0; if test -s log; then start=`tail -n 1 log`; fi; seq `expr $start + 1` `expr $start + 10` | tee -a log'
+    # FIXME: #9597
+    # run/start is flaking for remote so let's wait for the container condition
+    # to stop wasting energy until the root cause gets fixed.
+    run_podman container wait --condition=exited logtest
     run_podman start -a logtest
     logfile=$(mktemp -p ${PODMAN_TMPDIR} logfileXXXXXXXX)
     $PODMAN $_PODMAN_TEST_OPTS logs -f logtest > $logfile

--- a/test/system/450-interactive.bats
+++ b/test/system/450-interactive.bats
@@ -49,6 +49,8 @@ function teardown() {
 # BEGIN tests
 
 @test "podman detects correct tty size" {
+    skip "FIXME: #10710. As of 2021-12-08, stty fails >75% of the time."
+
     # Set the pty to a random size. Make rows/columns odd/even, to guarantee
     # that they can never be the same
     rows=$(( 15 + RANDOM % 60 |   1 ))


### PR DESCRIPTION
Disable the stty system test: it's failing much too much.

And, backport #12519, which fixes a flake that I'm seeing often on this branch.