### PR TITLE
Bump to v3.4.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 3.4.4
+### Bugfixes
+- Fixed a bug where the `podman exec` command would, under some circumstances, print a warning message about failing to move `conmon` to the appropriate cgroup ([#12535](https://github.com/containers/podman/issues/12535)).
+- Fixed a bug where named volumes created as part of container creation (e.g. `podman run --volume avolume:/a/mountpoint` or similar) would be mounted with incorrect permissions ([#12523](https://github.com/containers/podman/issues/12523)).
+- Fixed a bug where the `podman-remote create` and `podman-remote run` commands did not properly handle the `--entrypoint=""` option (to clear the container's entrypoint) ([#12521](https://github.com/containers/podman/issues/12521)).
+
 ## 3.4.3
 ### Security
 - This release addresses CVE-2021-4024, where the `podman machine` command opened the `gvproxy` API (used to forward ports to `podman machine` VMs) to the public internet on port 7777.

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -36,7 +36,7 @@ Epoch: 99
 %else
 Epoch: 0
 %endif
-Version: 3.4.4
+Version: 3.4.5
 Release: #COMMITDATE#.git%{shortcommit0}%{?dist}
 Summary: Manage Pods, Containers and Container Images
 License: ASL 2.0

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2678,7 +2678,7 @@ func (c *Container) fixVolumePermissions(v *ContainerNamedVolume) error {
 					return err
 				}
 			}
-			if err := os.Chmod(mountPoint, st.Mode()|0111); err != nil {
+			if err := os.Chmod(mountPoint, st.Mode()); err != nil {
 				return err
 			}
 			stat := st.Sys().(*syscall.Stat_t)

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -397,11 +397,9 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	s.WorkDir = c.Workdir
 	if c.Entrypoint != nil {
 		entrypoint := []string{}
-		if ep := *c.Entrypoint; len(ep) > 0 {
-			// Check if entrypoint specified is json
-			if err := json.Unmarshal([]byte(*c.Entrypoint), &entrypoint); err != nil {
-				entrypoint = append(entrypoint, ep)
-			}
+		// Check if entrypoint specified is json
+		if err := json.Unmarshal([]byte(*c.Entrypoint), &entrypoint); err != nil {
+			entrypoint = append(entrypoint, *c.Entrypoint)
 		}
 		s.Entrypoint = entrypoint
 	}

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -103,7 +103,6 @@ ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]
 	})
 
 	It("podman run user entrypoint overrides image entrypoint and image cmd", func() {
-		SkipIfRemote("FIXME: podman-remote not handling passing --entrypoint=\"\" flag correctly")
 		dockerfile := `FROM quay.io/libpod/alpine:latest
 CMD ["-i"]
 ENTRYPOINT ["grep", "Alpine", "/etc/os-release"]

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -691,6 +691,18 @@ USER testuser`, fedoraMinimal)
 
 	})
 
+	It("podman run with named volume check if we honor permission of target dir", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "stat", "-c", "%a %Y", "/var/tmp"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		perms := session.OutputToString()
+
+		session = podmanTest.Podman([]string{"run", "--rm", "-v", "test:/var/tmp", ALPINE, "stat", "-c", "%a %Y", "/var/tmp"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(Equal(perms))
+	})
+
 	It("podman volume with uid and gid works", func() {
 		volName := "testVol"
 		volCreate := podmanTest.Podman([]string{"volume", "create", "--opt", "o=uid=1000", volName})

--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ const (
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-var Version = semver.MustParse("3.4.4")
+var Version = semver.MustParse("3.4.5-dev")
 
 // See https://docs.docker.com/engine/api/v1.40/
 // libpod compat handlers are expected to honor docker API versions

--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ const (
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-var Version = semver.MustParse("3.4.4-dev")
+var Version = semver.MustParse("3.4.4")
 
 // See https://docs.docker.com/engine/api/v1.40/
 // libpod compat handlers are expected to honor docker API versions


### PR DESCRIPTION
We had a serious regression in `podman exec` with v3.4.3 (https://github.com/containers/podman/issues/12535) so we need a fresh release. Pick up two extra bugfixes at the same time.