### PR TITLE
--hostname should be set with podman create --pod new:PODNAME 

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -141,7 +141,7 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 	s.RawImageName = rawImageName
 
-	if _, err := createPodIfNecessary(s, cliVals.Net); err != nil {
+	if _, err := createPodIfNecessary(cmd, s, cliVals.Net); err != nil {
 		return err
 	}
 
@@ -335,7 +335,7 @@ func PullImage(imageName string, cliVals entities.ContainerCreateOptions) (strin
 // createPodIfNecessary automatically creates a pod when requested.  if the pod name
 // has the form new:ID, the pod ID is created and the name in the spec generator is replaced
 // with ID.
-func createPodIfNecessary(s *specgen.SpecGenerator, netOpts *entities.NetOptions) (*entities.PodCreateReport, error) {
+func createPodIfNecessary(cmd *cobra.Command, s *specgen.SpecGenerator, netOpts *entities.NetOptions) (*entities.PodCreateReport, error) {
 	if !strings.HasPrefix(s.Pod, "new:") {
 		return nil, nil
 	}
@@ -379,6 +379,10 @@ func createPodIfNecessary(s *specgen.SpecGenerator, netOpts *entities.NetOptions
 	infraOpts := entities.NewInfraContainerCreateOptions()
 	infraOpts.Net = netOpts
 	infraOpts.Quiet = true
+	infraOpts.Hostname, err = cmd.Flags().GetString("hostname")
+	if err != nil {
+		return nil, err
+	}
 	imageName := config.DefaultInfraImage
 	podGen.InfraImage = imageName
 	podGen.InfraContainerSpec = specgen.NewSpecGenerator(imageName, false)

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -193,7 +193,7 @@ func run(cmd *cobra.Command, args []string) error {
 	s.RawImageName = rawImageName
 	runOpts.Spec = s
 
-	if _, err := createPodIfNecessary(s, cliVals.Net); err != nil {
+	if _, err := createPodIfNecessary(cmd, s, cliVals.Net); err != nil {
 		return err
 	}
 

--- a/pkg/domain/entities/types.go
+++ b/pkg/domain/entities/types.go
@@ -29,8 +29,6 @@ type PodDeleteReport struct{ Report }
 type VolumeDeleteOptions struct{}
 type VolumeDeleteReport struct{ Report }
 
-// NetOptions reflect the shared network options between
-// pods and containers
 type NetFlags struct {
 	AddHosts     []string `json:"add-host,omitempty"`
 	DNS          []string `json:"dns,omitempty"`
@@ -43,6 +41,9 @@ type NetFlags struct {
 	Network      string   `json:"network,omitempty"`
 	NetworkAlias []string `json:"network-alias,omitempty"`
 }
+
+// NetOptions reflect the shared network options between
+// pods and containers
 type NetOptions struct {
 	AddHosts           []string            `json:"hostadd,omitempty"`
 	Aliases            []string            `json:"network_alias,omitempty"`

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -474,7 +474,7 @@ func GetNamespaceOptions(ns []string, netnsIsHost bool) ([]libpod.PodCreateOptio
 		case "none":
 			return erroredOptions, nil
 		default:
-			return erroredOptions, errors.Errorf("Invalid kernel namespace to share: %s. Options are: net, pid, ipc, uts or none", toShare)
+			return erroredOptions, errors.Errorf("Invalid kernel namespace to share: %s. Options are: cgroup, ipc, net, pid, uts or none", toShare)
 		}
 	}
 	return options, nil


### PR DESCRIPTION
 --hostname should be set when using --pod new:foobar

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2030599

When you create pod, it shares the UTS namespace with Containers.
Currently the --hostname is not passed to the pod created when
you create a container and pod in the same command.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>