### PR TITLE
inotify: make sure to remove files

### DIFF
--- a/libpod/util.go
+++ b/libpod/util.go
@@ -56,6 +56,7 @@ func WaitForFile(path string, chWait chan error, timeout time.Duration) (bool, e
 			inotifyEvents = watcher.Events
 		}
 		defer watcher.Close()
+		defer watcher.Remove(filepath.Dir(path))
 	}
 
 	var timeoutChan <-chan time.Time


### PR DESCRIPTION
Issue #11825 suggests that *rootless* Podman can run into situations
where too many inotify fds are open.  Indeed, rootless Podman has a
slightly higher usage of inotify watchers than the root counterpart
when using slirp4netns

Make sure to not only close all watchers but to also remove the files
from being watched.  Otherwise, the fds only get closed
when the files are removed.

[NO NEW TESTS NEEDED] since we don't have a way to test it.

Fixes: #11825
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>