### PR TITLE
rootless: declare TEMP_FAILURE_RETRY before usage (Fixes: #12563)

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -19,6 +19,15 @@
 #include <sys/select.h>
 #include <stdio.h>
 
+#ifndef TEMP_FAILURE_RETRY
+#define TEMP_FAILURE_RETRY(expression) \
+  (__extension__                                                              \
+    ({ long int __result;                                                     \
+       do __result = (long int) (expression);                                 \
+       while (__result == -1L && errno == EINTR);                             \
+       __result; }))
+#endif
+
 #define cleanup_free __attribute__ ((cleanup (cleanup_freep)))
 #define cleanup_close __attribute__ ((cleanup (cleanup_closep)))
 #define cleanup_dir __attribute__ ((cleanup (cleanup_dirp)))
@@ -71,15 +80,6 @@ int rename_noreplace (int olddirfd, const char *oldpath, int newdirfd, const cha
   /* We are sure we created the file, let's overwrite it.  */
   return rename (oldpath, newpath);
 }
-
-#ifndef TEMP_FAILURE_RETRY
-#define TEMP_FAILURE_RETRY(expression) \
-  (__extension__                                                              \
-    ({ long int __result;                                                     \
-       do __result = (long int) (expression);                                 \
-       while (__result == -1L && errno == EINTR);                             \
-       __result; }))
-#endif
 
 static const char *_max_user_namespaces = "/proc/sys/user/max_user_namespaces";
 static const char *_unprivileged_user_namespaces = "/proc/sys/kernel/unprivileged_userns_clone";


### PR DESCRIPTION
Signed-off-by: Nguyen Marc <nguyen_marc@live.fr>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

This makes Musl-based systems capable of building podman.

#### How to verify it

Sadly, I don't have much time to write tests. I can only attest that it compiles on my machine using [portage patches](https://wiki.gentoo.org/wiki//etc/portage/patches).

The condition is: "If `TEMP_FAILURE_RETRY` is not defined, it should compile and link successfully."

#### Which issue(s) this PR fixes:

Fixes: #12563 

#### Special notes for your reviewer:

I don't have much time to write tests, follow the codestyle, read the doc, ..., so feel free to edit my PR.