### PR TITLE
Remove two GetImages functions from API

### DIFF
--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -184,46 +184,6 @@ type ExecStartConfig struct {
 	Width  uint16 `json:"w"`
 }
 
-func ImageToImageSummary(l *libimage.Image) (*entities.ImageSummary, error) {
-	options := &libimage.InspectOptions{WithParent: true, WithSize: true}
-	imageData, err := l.Inspect(context.TODO(), options)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to obtain summary for image %s", l.ID())
-	}
-
-	containers, err := l.Containers()
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to obtain Containers for image %s", l.ID())
-	}
-	containerCount := len(containers)
-
-	isDangling, err := l.IsDangling(context.TODO())
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to check if image %s is dangling", l.ID())
-	}
-
-	is := entities.ImageSummary{
-		// docker adds sha256: in front of the ID
-		ID:           "sha256:" + l.ID(),
-		ParentId:     imageData.Parent,
-		RepoTags:     imageData.RepoTags,
-		RepoDigests:  imageData.RepoDigests,
-		Created:      l.Created().Unix(),
-		Size:         imageData.Size,
-		SharedSize:   0,
-		VirtualSize:  imageData.VirtualSize,
-		Labels:       imageData.Labels,
-		Containers:   containerCount,
-		ReadOnly:     l.IsReadOnly(),
-		Dangling:     isDangling,
-		Names:        l.Names(),
-		Digest:       string(imageData.Digest),
-		ConfigDigest: "", // TODO: libpod/image didn't set it but libimage should
-		History:      imageData.NamesHistory,
-	}
-	return &is, nil
-}
-
 func ImageDataToImageInspect(ctx context.Context, l *libimage.Image) (*ImageInspect, error) {
 	options := &libimage.InspectOptions{WithParent: true, WithSize: true}
 	info, err := l.Inspect(context.Background(), options)

--- a/pkg/api/handlers/utils/images.go
+++ b/pkg/api/handlers/utils/images.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/containers/common/libimage"
-	"github.com/containers/common/pkg/filters"
 	"github.com/containers/image/v5/docker"
 	storageTransport "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -16,7 +15,6 @@ import (
 	"github.com/containers/podman/v3/pkg/util"
 	"github.com/containers/storage"
 	"github.com/docker/distribution/reference"
-	"github.com/gorilla/schema"
 	"github.com/pkg/errors"
 )
 
@@ -89,44 +87,6 @@ func ParseStorageReference(name string) (types.ImageReference, error) {
 		}
 	}
 	return imageRef, nil
-}
-
-// GetImages is a common function used to get images for libpod and other compatibility
-// mechanisms
-func GetImages(w http.ResponseWriter, r *http.Request) ([]*libimage.Image, error) {
-	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
-	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
-	query := struct {
-		All     bool
-		Digests bool
-		Filter  string // Docker 1.24 compatibility
-	}{
-		// This is where you can override the golang default value for one of fields
-	}
-
-	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		return nil, err
-	}
-	if _, found := r.URL.Query()["digests"]; found && query.Digests {
-		UnSupportedParameter("digests")
-	}
-
-	filterList, err := filters.FiltersFromRequest(r)
-	if err != nil {
-		return nil, err
-	}
-	if !IsLibpodRequest(r) && len(query.Filter) > 0 { // Docker 1.24 compatibility
-		filterList = append(filterList, "reference="+query.Filter)
-	}
-
-	if !query.All {
-		// Filter intermediate images unless we want to list *all*.
-		// NOTE: it's a positive filter, so `intermediate=false` means
-		// to display non-intermediate images.
-		filterList = append(filterList, "intermediate=false")
-	}
-	listOptions := &libimage.ListImagesOptions{Filters: filterList}
-	return runtime.LibimageRuntime().ListImages(r.Context(), nil, listOptions)
 }
 
 func GetImage(r *http.Request, name string) (*libimage.Image, error) {

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -840,7 +840,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/LibpodImageSummaryResponse"
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/json"), s.APIHandler(libpod.GetImages)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/images/json"), s.APIHandler(compat.GetImages)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/images/load libpod ImageLoadLibpod
 	// ---
 	// tags:

--- a/pkg/domain/infra/abi/images_list.go
+++ b/pkg/domain/infra/abi/images_list.go
@@ -26,9 +26,9 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 
 	summaries := []*entities.ImageSummary{}
 	for _, img := range images {
-		digests := make([]string, len(img.Digests()))
-		for j, d := range img.Digests() {
-			digests[j] = string(d)
+		repoDigests, err := img.RepoDigests()
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting repoDigests from image %q", img.ID())
 		}
 		isDangling, err := img.IsDangling(ctx)
 		if err != nil {
@@ -37,11 +37,12 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 
 		e := entities.ImageSummary{
 			ID: img.ID(),
-			//			ConfigDigest: string(img.ConfigDigest),
+			// TODO: libpod/image didn't set it but libimage should
+			// ConfigDigest: string(img.ConfigDigest),
 			Created:     img.Created().Unix(),
 			Dangling:    isDangling,
 			Digest:      string(img.Digest()),
-			RepoDigests: digests,
+			RepoDigests: repoDigests,
 			History:     img.NamesHistory(),
 			Names:       img.Names(),
 			ReadOnly:    img.IsReadOnly(),


### PR DESCRIPTION
[NO NEW TESTS NEEDED] This is just code cleanup.

The remote API has three different GetImages functions, which I believe
can be handled by just one function.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
