### PR TITLE
fix e2e test missing network cleanup

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -355,13 +355,12 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network remove after disconnect when container initially created with the network", func() {
-		SkipIfRootless("disconnect works only in non rootless container")
-
 		container := "test"
-		network := "foo"
+		network := "foo" + stringid.GenerateNonCryptoID()
 
 		session := podmanTest.Podman([]string{"network", "create", network})
 		session.WaitWithDefaultTimeout()
+		defer podmanTest.removeCNINetwork(network)
 		Expect(session).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"run", "--name", container, "--network", network, "-d", ALPINE, "top"})


### PR DESCRIPTION



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

I noticed that this test will fail its flake rerun because the network
was not removed and it tried to create a network with the same name.
Also network disconnect works rootless now.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
