### PR TITLE
network ls: show networks in deterministic order

### DIFF
--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
@@ -72,6 +73,11 @@ func networkList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// sort the networks to make sure the order is deterministic
+	sort.Slice(responses, func(i, j int) bool {
+		return responses[i].Name < responses[j].Name
+	})
 
 	switch {
 	// quiet means we only print the network names

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -16,6 +16,21 @@ load helpers
     if  [[ ${output} = ${heading} ]]; then
        die "network ls --noheading did not remove heading: $output"
     fi
+
+    # check deterministic list order
+    local net1=a-$(random_string 10)
+    local net2=b-$(random_string 10)
+    local net3=c-$(random_string 10)
+    run_podman network create $net1
+    run_podman network create $net2
+    run_podman network create $net3
+
+    run_podman network ls --quiet
+    # just check the the order of the created networks is correct
+    # we cannot do an exact match since developer and CI systems could contain more networks
+    is "$output" ".*$net1.*$net2.*$net3.*podman.*" "networks sorted alphabetically"
+
+    run_podman network rm $net1 $net2 $net3
 }
 
 # Copied from tsweeney's https://github.com/containers/podman/issues/4827


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

The new network backend stores the networks in a map so the returned
order is not deterministic. Lets sort the network names alphabetically
to ensure a deterministic order.
#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
