### PR TITLE
pprof flakes: bump timeout to 20 seconds

### DIFF
--- a/test/e2e/system_service_test.go
+++ b/test/e2e/system_service_test.go
@@ -20,7 +20,7 @@ var _ = Describe("podman system service", func() {
 
 	// The timeout used to for the service to respond. As shown in #12167,
 	// this may take some time on machines under high load.
-	var timeout = 5
+	var timeout = 20
 
 	BeforeEach(func() {
 		tempdir, err := CreateTempDirInTempDir()


### PR DESCRIPTION
This is the third and hopefully the last attempt to address the flakes
in the pprof tests.  We first bumped the timeouts to 2 seconds, then to
5, and since I am running out of ideas let's bump it now to 20 seconds.

Since the timeouts poll, the tests will terminate much earlier but 20
seconds should now really be enough even under highly loaded CI VMs.

Fixes: #12167
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>