### PR TITLE
[3.4] Backport podman machine ls 

### DIFF
--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -48,6 +48,7 @@ type machineReporter struct {
 	Created  string
 	Running  bool
 	LastUp   string
+	Stream   string
 	VMType   string
 	CPUs     uint64
 	Memory   string
@@ -153,6 +154,13 @@ func strUint(u uint64) string {
 	return strconv.FormatUint(u, 10)
 }
 
+func streamName(imageStream string) string {
+	if imageStream == "" {
+		return "default"
+	}
+	return imageStream
+}
+
 func toMachineFormat(vms []*machine.ListResponse) ([]*machineReporter, error) {
 	cfg, err := config.ReadCustomConfig()
 	if err != nil {
@@ -167,6 +175,7 @@ func toMachineFormat(vms []*machine.ListResponse) ([]*machineReporter, error) {
 		response.Running = vm.Running
 		response.LastUp = strTime(vm.LastUp)
 		response.Created = strTime(vm.CreatedAt)
+		response.Stream = streamName(vm.Stream)
 		response.VMType = vm.VMType
 		response.CPUs = vm.CPUs
 		response.Memory = strUint(vm.Memory * units.MiB)

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -188,11 +188,13 @@ func toHumanFormat(vms []*machine.ListResponse) ([]*machineReporter, error) {
 		response := new(machineReporter)
 		if vm.Name == cfg.Engine.ActiveService {
 			response.Name = vm.Name + "*"
+			response.Default = true
 		} else {
 			response.Name = vm.Name
 		}
 		if vm.Running {
 			response.LastUp = "Currently running"
+			response.Running = true
 		} else {
 			response.LastUp = units.HumanDuration(time.Since(vm.LastUp)) + " ago"
 		}

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/report"
+	"github.com/containers/podman/v3/cmd/podman/common"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/cmd/podman/validate"
 	"github.com/containers/podman/v3/pkg/machine"
@@ -62,7 +63,7 @@ func init() {
 	flags := lsCmd.Flags()
 	formatFlagName := "format"
 	flags.StringVar(&listFlag.format, formatFlagName, "{{.Name}}\t{{.VMType}}\t{{.Created}}\t{{.LastUp}}\t{{.CPUs}}\t{{.Memory}}\t{{.DiskSize}}\n", "Format volume output using JSON or a Go template")
-	_ = lsCmd.RegisterFlagCompletionFunc(formatFlagName, completion.AutocompleteNone)
+	_ = lsCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(machineReporter{}))
 	flags.BoolVar(&listFlag.noHeading, "noheading", false, "Do not print headers")
 }
 

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -57,6 +57,7 @@ type ListResponse struct {
 	CreatedAt time.Time
 	LastUp    time.Time
 	Running   bool
+	Stream    string
 	VMType    string
 	CPUs      uint64
 	Memory    uint64

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -13,6 +13,8 @@ type MachineVM struct {
 	IdentityPath string
 	// IgnitionFilePath is the fq path to the .ign file
 	IgnitionFilePath string
+	// ImageStream is the update stream for the image
+	ImageStream string
 	// ImagePath is the fq path to
 	ImagePath string
 	// Memory in megabytes assigned to the vm

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -143,6 +143,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) error {
 	switch opts.ImagePath {
 	case "testing", "next", "stable", "":
 		// Get image as usual
+		v.ImageStream = opts.ImagePath
 		dd, err := machine.NewFcosDownloader(vmtype, v.Name, opts.ImagePath)
 		if err != nil {
 			return err
@@ -154,6 +155,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) error {
 	default:
 		// The user has provided an alternate image which can be a file path
 		// or URL.
+		v.ImageStream = "custom"
 		g, err := machine.NewGenericDownloader(vmtype, v.Name, opts.ImagePath)
 		if err != nil {
 			return err
@@ -590,6 +592,7 @@ func GetVMInfos() ([]*machine.ListResponse, error) {
 			listEntry := new(machine.ListResponse)
 
 			listEntry.Name = vm.Name
+			listEntry.Stream = vm.ImageStream
 			listEntry.VMType = "qemu"
 			listEntry.CPUs = vm.CPUs
 			listEntry.Memory = vm.Memory


### PR DESCRIPTION
Needed since the GUI relies on --format=json, so back porting a few commits that do that. 

[NO NEW TESTS NEEDED]