### PR TITLE
pause scope: don't use the global math/rand RNG

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/containers/common/pkg/cgroups"
 	"github.com/containers/podman/v3/libpod/define"
@@ -204,8 +205,9 @@ func moveProcessToScope(pidPath, slice, scope string) error {
 func MovePauseProcessToScope(pausePidPath string) {
 	var err error
 
-	for i := 0; i < 3; i++ {
-		r := rand.Int()
+	state := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 10; i++ {
+		r := state.Int()
 		err = moveProcessToScope(pausePidPath, "user.slice", fmt.Sprintf("podman-pause-%d.scope", r))
 		if err == nil {
 			return


### PR DESCRIPTION
Otherwise, we'll always get the same sequence of random numbers which
may lead to conflicts.  Also bump the number of maximum attempts to 10
instead of 3.

[NO NEW TESTS NEEDED] as I cannot enforce random number collisions.
Existing tests should continue be green and flake slightly less.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>