### PR TITLE
netavark: add macvlan driver support

### DIFF
--- a/libpod/network/cni/cni_conversion.go
+++ b/libpod/network/cni/cni_conversion.go
@@ -256,11 +256,11 @@ func (n *cniNetwork) createCNIConfigListFromNetwork(network *types.Network, writ
 		case "mode":
 			switch network.Driver {
 			case types.MacVLANNetworkDriver:
-				if !pkgutil.StringInSlice(v, []string{"", "bridge", "private", "vepa", "passthru"}) {
+				if !pkgutil.StringInSlice(v, types.ValidMacVLANModes) {
 					return nil, "", errors.Errorf("unknown macvlan mode %q", v)
 				}
 			case types.IPVLANNetworkDriver:
-				if !pkgutil.StringInSlice(v, []string{"", "l2", "l3", "l3s"}) {
+				if !pkgutil.StringInSlice(v, types.ValidIPVLANModes) {
 					return nil, "", errors.Errorf("unknown ipvlan mode %q", v)
 				}
 			default:

--- a/libpod/network/cni/config.go
+++ b/libpod/network/cni/config.go
@@ -196,7 +196,7 @@ func createIPMACVLAN(network *types.Network) error {
 			return err
 		}
 		if !pkgutil.StringInSlice(network.NetworkInterface, interfaceNames) {
-			return errors.Errorf("parent interface %s does not exists", network.NetworkInterface)
+			return errors.Errorf("parent interface %s does not exist", network.NetworkInterface)
 		}
 	}
 	if len(network.Subnets) == 0 {

--- a/libpod/network/cni/config_test.go
+++ b/libpod/network/cni/config_test.go
@@ -318,7 +318,7 @@ var _ = Describe("Config", func() {
 			}
 			_, err := libpodNet.NetworkCreate(network)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("parent interface idonotexists does not exists"))
+			Expect(err.Error()).To(ContainSubstring("parent interface idonotexists does not exist"))
 		})
 
 		It("create macvlan config with internal should fail", func() {

--- a/libpod/network/netavark/config.go
+++ b/libpod/network/netavark/config.go
@@ -128,7 +128,7 @@ func (n *netavarkNetwork) networkCreate(newNetwork types.Network, defaultNet boo
 		for key, value := range newNetwork.Options {
 			switch key {
 			case "mode":
-				if !util.StringInSlice(value, []string{"", "bridge", "private", "vepa", "passthru"}) {
+				if !util.StringInSlice(value, types.ValidMacVLANModes) {
 					return nil, errors.Errorf("unknown macvlan mode %q", value)
 				}
 			default:

--- a/libpod/network/netavark/network.go
+++ b/libpod/network/netavark/network.go
@@ -139,7 +139,7 @@ func NewNetworkInterface(conf InitConfig) (types.ContainerNetwork, error) {
 // Drivers will return the list of supported network drivers
 // for this interface.
 func (n *netavarkNetwork) Drivers() []string {
-	return []string{types.BridgeNetworkDriver}
+	return []string{types.BridgeNetworkDriver, types.MacVLANNetworkDriver}
 }
 
 func (n *netavarkNetwork) loadNetworks() error {

--- a/libpod/network/types/const.go
+++ b/libpod/network/types/const.go
@@ -20,4 +20,21 @@ const (
 	DefaultNetworkName = "podman"
 	// DefaultSubnet is the subnet that will be used for the default CNI network.
 	DefaultSubnet = "10.88.0.0/16"
+
+	// valid macvlan driver mode values
+	MacVLANModeBridge   = "bridge"
+	MacVLANModePrivate  = "private"
+	MacVLANModeVepa     = "vepa"
+	MacVLANModePassthru = "passthru"
+
+	// valid ipvlan driver modes
+	IPVLANModeL2  = "l2"
+	IPVLANModeL3  = "l3"
+	IPVLANModeL3s = "l3s"
 )
+
+// ValidMacVLANModes is the list of valid mode options for the macvlan driver
+var ValidMacVLANModes = []string{MacVLANModeBridge, MacVLANModePrivate, MacVLANModeVepa, MacVLANModePassthru}
+
+// ValidIPVLANModes is the list of valid mode options for the ipvlan driver
+var ValidIPVLANModes = []string{IPVLANModeL2, IPVLANModeL3, IPVLANModeL3s}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

Netvark supports macvlan networks now so podman should be able to create
them. Unfortunately netavark does not support DHCP yet so we have force
that the user specifies a subnet.

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
