### PR TITLE
Warn on use of --kernel-memory

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -327,13 +327,10 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(ipcFlagName, AutocompleteNamespace)
 
-		kernelMemoryFlagName := "kernel-memory"
-		createFlags.StringVar(
-			&cf.KernelMemory,
-			kernelMemoryFlagName, "",
-			"Kernel memory limit "+sizeWithUnitFormat,
+		createFlags.String(
+			"kernel-memory", "",
+			"DEPRECATED: Option is just hear for compatibility with Docker",
 		)
-		_ = cmd.RegisterFlagCompletionFunc(kernelMemoryFlagName, completion.AutocompleteNone)
 		// kernel-memory is deprecated in the runtime spec.
 		_ = createFlags.MarkHidden("kernel-memory")
 

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -18,7 +18,6 @@ import (
 	"github.com/containers/podman/v3/pkg/specgen"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 func stringMaptoArray(m map[string]string) []string {
@@ -385,9 +384,6 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 	if cc.HostConfig.Memory > 0 {
 		cliOpts.Memory = strconv.Itoa(int(cc.HostConfig.Memory))
 	}
-	if cc.HostConfig.KernelMemory > 0 {
-		logrus.Warnf("The --kernel-memory flag has been deprecated. May not work properly on your system.")
-	}
 
 	if cc.HostConfig.MemoryReservation > 0 {
 		cliOpts.MemoryReservation = strconv.Itoa(int(cc.HostConfig.MemoryReservation))
@@ -409,9 +405,6 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 		cliOpts.ShmSize = strconv.Itoa(int(cc.HostConfig.ShmSize))
 	}
 
-	if cc.HostConfig.KernelMemory > 0 {
-		cliOpts.KernelMemory = strconv.Itoa(int(cc.HostConfig.KernelMemory))
-	}
 	if len(cc.HostConfig.RestartPolicy.Name) > 0 {
 		policy := cc.HostConfig.RestartPolicy.Name
 		// only add restart count on failure

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containers/podman/v3/pkg/util"
 	"github.com/mattn/go-isatty"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -191,6 +192,10 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 			vals.UserNS = "private"
 		}
 	}
+	if c.Flag("kernel-memory") != nil && c.Flag("kernel-memory").Changed {
+		logrus.Warnf("The --kernel-memory flag is no longer supported. This flag is a noop.")
+	}
+
 	if cliVals.LogDriver == define.PassthroughLogging {
 		if isatty.IsTerminal(0) || isatty.IsTerminal(1) || isatty.IsTerminal(2) {
 			return vals, errors.New("the '--log-driver passthrough' option cannot be used on a TTY")

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -493,9 +493,6 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 				if ctrSpec.Linux.Resources.Memory.Limit != nil {
 					hostConfig.Memory = *ctrSpec.Linux.Resources.Memory.Limit
 				}
-				if ctrSpec.Linux.Resources.Memory.Kernel != nil {
-					hostConfig.KernelMemory = *ctrSpec.Linux.Resources.Memory.Kernel
-				}
 				if ctrSpec.Linux.Resources.Memory.Reservation != nil {
 					hostConfig.MemoryReservation = *ctrSpec.Linux.Resources.Memory.Reservation
 				}

--- a/pkg/api/handlers/compat/info.go
+++ b/pkg/api/handlers/compat/info.go
@@ -84,7 +84,6 @@ func GetInfo(w http.ResponseWriter, r *http.Request) {
 		InitBinary:         "",
 		InitCommit:         docker.Commit{},
 		Isolation:          "",
-		KernelMemory:       sysInfo.KernelMemory,
 		KernelMemoryTCP:    false,
 		KernelVersion:      infoData.Host.Kernel,
 		Labels:             nil,

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -195,7 +195,6 @@ type ContainerCreateOptions struct {
 	InitPath          string
 	Interactive       bool
 	IPC               string
-	KernelMemory      string
 	Label             []string
 	LabelFile         []string
 	LogDriver         string

--- a/pkg/specgen/generate/validate.go
+++ b/pkg/specgen/generate/validate.go
@@ -60,10 +60,6 @@ func verifyContainerResourcesCgroupV1(s *specgen.SpecGenerator) ([]string, error
 		if memory.Limit != nil && memory.Reservation != nil && *memory.Limit < *memory.Reservation {
 			return warnings, errors.New("minimum memory limit cannot be less than memory reservation limit, see usage")
 		}
-		if memory.Kernel != nil && !sysInfo.KernelMemory {
-			warnings = append(warnings, "Your kernel does not support kernel memory limit capabilities or the cgroup is not mounted. Limitation discarded.")
-			memory.Kernel = nil
-		}
 		if memory.DisableOOMKiller != nil && *memory.DisableOOMKiller && !sysInfo.OomKillDisable {
 			warnings = append(warnings, "Your kernel does not support OomKillDisable. OomKillDisable discarded.")
 			memory.DisableOOMKiller = nil

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -163,14 +163,6 @@ func getMemoryLimits(s *specgen.SpecGenerator, c *entities.ContainerCreateOption
 			hasLimits = true
 		}
 	}
-	if m := c.KernelMemory; len(m) > 0 {
-		mk, err := units.RAMInBytes(m)
-		if err != nil {
-			return nil, errors.Wrapf(err, "invalid value for kernel-memory")
-		}
-		memory.Kernel = &mk
-		hasLimits = true
-	}
 	if c.MemorySwappiness >= 0 {
 		swappiness := uint64(c.MemorySwappiness)
 		memory.Swappiness = &swappiness

--- a/test/e2e/run_memory_test.go
+++ b/test/e2e/run_memory_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"fmt"
 	"os"
-	"strconv"
 
 	. "github.com/containers/podman/v3/test/utils"
 	. "github.com/onsi/ginkgo"
@@ -79,45 +78,4 @@ var _ = Describe("Podman run memory", func() {
 			Expect(session.OutputToString()).To(Equal(limit))
 		})
 	}
-
-	It("podman run kernel-memory test", func() {
-		if podmanTest.Host.Distribution == "ubuntu" {
-			Skip("Unable to perform test on Ubuntu distributions due to memory management")
-		}
-
-		var session *PodmanSessionIntegration
-
-		if CGROUPSV2 {
-			session = podmanTest.Podman([]string{"run", "--net=none", "--memory-reservation=40m", ALPINE, "sh", "-c", "cat /sys/fs/cgroup/$(sed -e 's|0::||' < /proc/self/cgroup)/memory.low"})
-		} else {
-			session = podmanTest.Podman([]string{"run", "--memory-reservation=40m", ALPINE, "cat", "/sys/fs/cgroup/memory/memory.soft_limit_in_bytes"})
-		}
-
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(Equal("41943040"))
-	})
-
-	It("podman run kernel-memory test", func() {
-		if podmanTest.Host.Distribution == "ubuntu" {
-			Skip("Unable to perform test on Ubuntu distributions due to memory management")
-		}
-		var session *PodmanSessionIntegration
-		if CGROUPSV2 {
-			session = podmanTest.Podman([]string{"run", "--memory", "256m", "--memory-swap", "-1", ALPINE, "cat", "/sys/fs/cgroup/memory.swap.max"})
-		} else {
-			session = podmanTest.Podman([]string{"run", "--cgroupns=private", ALPINE, "cat", "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes"})
-		}
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-		output := session.OutputToString()
-		Expect(err).To(BeNil())
-		if CGROUPSV2 {
-			Expect(output).To(Equal("max"))
-		} else {
-			crazyHighNumber, err := strconv.ParseInt(output, 10, 64)
-			Expect(err).To(BeZero())
-			Expect(crazyHighNumber).To(BeNumerically(">", 936854771712))
-		}
-	})
 })

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -766,4 +766,10 @@ EOF
     is "$output" "1.2.3.4 foo.com.*" "users can add hosts even without /etc/hosts"
 }
 
+@test "podman run --kernel-memory warning" {
+    # Not sure what situations this fails in, but want to make sure warning shows.
+    run_podman '?' run --rm --kernel-memory 100 $IMAGE false
+    is "$output" ".*The --kernel-memory flag is no longer supported. This flag is a noop." "warn on use of --kernel-memory"
+
+}
 # vim: filetype=sh


### PR DESCRIPTION
It has been depracated and is no longer supported.  Fully remove it and
only print a warning if a user uses it.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2011695

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>