### PR TITLE
Show --external containers even without --all option

### DIFF
--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -34,7 +34,7 @@ Note: Podman shares containers storage with other tools such as Buildah and CRI-
 
 #### **--external**
 
-Display external containers that are not controlled by Podman but are stored in containers storage.  These external containers are generally created via other container technology such as Buildah or CRI-O and may depend on the same container images that Podman is also using.  External containers are denoted with either a 'buildah' or 'storage' in the COMMAND and STATUS column of the ps output. Only used with the --all option.
+Display external containers that are not controlled by Podman but are stored in containers storage.  These external containers are generally created via other container technology such as Buildah or CRI-O and may depend on the same container images that Podman is also using.  External containers are denoted with either a 'buildah' or 'storage' in the COMMAND and STATUS column of the ps output.
 
 #### **--filter**, **-f**
 

--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -74,7 +74,7 @@ func GetContainerLists(runtime *libpod.Runtime, options entities.ContainerListOp
 		}
 	}
 
-	if options.All && options.External {
+	if options.External {
 		listCon, err := GetExternalContainerLists(runtime)
 		if err != nil {
 			return nil, err

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -83,10 +83,10 @@ load helpers
     run_podman rm -a
 }
 
-@test "podman ps -a --external" {
+@test "podman ps --external" {
 
     # Setup: ensure that we have no hidden storage containers
-    run_podman ps --external -a
+    run_podman ps --external
     is "${#lines[@]}" "1" "setup check: no storage containers at start of test"
 
     # Force a buildah timeout; this leaves a buildah container behind
@@ -107,7 +107,7 @@ EOF
     run_podman ps -a
     is "${#lines[@]}" "1" "podman ps -a does not see buildah containers"
 
-    run_podman ps --external -a
+    run_podman ps --external
     is "${#lines[@]}" "3" "podman ps -a --external sees buildah containers"
     is "${lines[1]}" \
        "[0-9a-f]\{12\} \+$IMAGE *buildah .* seconds ago .* storage .* ${PODMAN_TEST_IMAGE_NAME}-working-container" \
@@ -115,7 +115,7 @@ EOF
 
     # 'rm -a' should be a NOP
     run_podman rm -a
-    run_podman ps --external -a
+    run_podman ps --external
     is "${#lines[@]}" "3" "podman ps -a --external sees buildah containers"
 
     # Cannot prune intermediate image as it's being used by a buildah
@@ -128,7 +128,7 @@ EOF
     is "${#lines[@]}" "1" "Image used by build container is pruned"
 
     # One buildah container has been removed.
-    run_podman ps --external -a
+    run_podman ps --external
     is "${#lines[@]}" "2" "podman ps -a --external sees buildah containers"
 
     cid="${lines[1]:0:12}"
@@ -140,7 +140,7 @@ EOF
     # With -f, we can remove it.
     run_podman rm -t 0 -f "$cid"
 
-    run_podman ps --external -a
+    run_podman ps --external
     is "${#lines[@]}" "1" "storage container has been removed"
 }
 


### PR DESCRIPTION
We currently do not show --external containers when the user specifies
it, unless they also specify the --all flag. This has led to confusion.
I see no reason not to list them without the --all flag if the user
specifies the option.

Fixes: https://github.com/containers/podman/issues/12353

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
