### PR TITLE
APIv2 tests: fail on syntax/logic errors

### DIFF
--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -82,7 +82,7 @@ else
 fi
 
 # Simple events test (see #7078)
-t GET "events?stream=false"  200
-t GET "libpod/events?stream=false"  200
+t GET "events?stream=false&since=30s"  200
+t GET "libpod/events?stream=false&since=30s"  200
 
 # vim: filetype=sh

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -62,7 +62,7 @@ old_iid=$(podman image inspect --format "{{.ID}}" docker.io/library/alpine:lates
 podman rmi -f docker.io/library/alpine:latest
 podman tag $IMAGE docker.io/library/alpine:latest
 t POST "images/create?fromImage=alpine" 200 .error~null .status~".*$old_iid.*"
-podman untag $IMAGE docker.io/library/alpine:latest
+podman untag docker.io/library/alpine:latest
 
 t POST "images/create?fromImage=quay.io/libpod/alpine&tag=sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f" 200
 

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -97,7 +97,7 @@ t GET    libpod/containers/${cid}/json 200 \
 t DELETE libpod/containers/$cid 204
 
 CNAME=myfoo
-podman run --name $CNAME $IMAGE -td top
+podman run -d --name $CNAME $IMAGE top
 t GET libpod/containers/json?all=true 200 \
   .[0].Id~[0-9a-f]\\{64\\}
 cid=$(jq -r '.[0].Id' <<<"$output")
@@ -184,7 +184,7 @@ t GET containers/myctr/json 200 \
 t DELETE images/localhost/newrepo:latest?force=true 200
 t DELETE images/localhost/newrepo:v1?force=true 200
 t DELETE images/localhost/newrepo:v2?force=true 200
-t DELETE libpod/containers/$cid 204
+t DELETE libpod/containers/$cid?force=true 204
 t DELETE libpod/containers/myctr 204
 t DELETE libpod/containers/bogus 404
 

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -48,6 +48,30 @@ TESTS_DIR=$(realpath $(dirname $0))
 # Path to podman binary
 PODMAN_BIN=${PODMAN:-${TESTS_DIR}/../../bin/podman}
 
+# Cleanup handlers
+clean_up_server() {
+    if [ -n "$service_pid" ]; then
+        # Remove any containers and images; this prevents the following warning:
+        #  'rm: cannot remove '/.../overlay': Device or resource busy
+        podman rm -a
+        podman rmi -af
+
+        stop_registry
+        stop_service
+    fi
+}
+
+# Any non-test-related error, be it syntax or podman-command, fails here.
+err_handler() {
+    echo "Fatal error in ${BASH_SOURCE[1]}:${BASH_LINENO[0]}"
+    echo "Log:"
+    sed -e 's/^/  >/' <$WORKDIR/output.log
+    echo "Bailing."
+    clean_up_server
+}
+
+trap err_handler ERR
+
 # END   setup
 ###############################################################################
 # BEGIN infrastructure code - the helper functions used in tests themselves
@@ -237,14 +261,15 @@ function t() {
     echo "\$ $testname"                                                  >>$LOG
     rm -f $WORKDIR/curl.*
     # -s = silent, but --write-out 'format' gives us important response data
-    response=$(curl -s -X $method ${curl_args}                   \
+    # The hairy "{ ...;rc=$?; } || :" lets us capture curl's exit code and
+    # give a helpful diagnostic if it fails.
+    { response=$(curl -s -X $method ${curl_args}                 \
                     -H "Content-type: $content_type"             \
-                    --dump-header $WORKDIR/curl.headers.out       \
+                    --dump-header $WORKDIR/curl.headers.out      \
                     --write-out '%{http_code}^%{content_type}^%{time_total}' \
-                    -o $WORKDIR/curl.result.out "$url")
+                    -o $WORKDIR/curl.result.out "$url"); rc=$?; } || :
 
     # Any error from curl is instant bad news, from which we can't recover
-    rc=$?
     if [[ $rc -ne 0 ]]; then
         echo "FATAL: curl failure ($rc) on $url - cannot continue" >&2
         exit 1
@@ -353,8 +378,8 @@ function start_service() {
 function stop_service() {
     # Stop the server
     if [[ -n $service_pid ]]; then
-        kill $service_pid
-        wait $service_pid
+        kill $service_pid || :
+        wait $service_pid || :
     fi
 }
 
@@ -471,7 +496,7 @@ function wait_for_port() {
 #  podman  #  Needed by some test scripts to invoke the actual podman binary
 ############
 function podman() {
-    echo "\$ $PODMAN_BIN $*"                       >>$WORKDIR/output.log
+    echo "\$ $PODMAN_BIN $*"                           >>$WORKDIR/output.log
     env CONTAINERS_REGISTRIES_CONF=$TESTS_DIR/../registries.conf \
         $PODMAN_BIN --root $WORKDIR/server_root "$@"   >>$WORKDIR/output.log 2>&1
 }
@@ -529,23 +554,17 @@ start_service
 
 for i in ${tests_to_run[@]}; do
     TEST_CONTEXT="[$(basename $i .at)]"
+
+    # Clear output from 'podman' helper
+    >| $WORKDIR/output.log
+
     source $i
 done
 
 # END   entry handler
 ###############################################################################
 
-# Clean up
-
-if [ -n "$service_pid" ]; then
-    # Remove any containers and images; this prevents the following warning:
-    #  'rm: cannot remove '/.../overlay': Device or resource busy
-    podman rm -a
-    podman rmi -af
-
-    stop_registry
-    stop_service
-fi
+clean_up_server
 
 test_count=$(<$testcounter_file)
 failure_count=$(<$failures_file)


### PR DESCRIPTION
(i.e. not test failures, but actual programming bugs).

We've had a number of syntax errors creep into this test, usually
caused by a missing backslash on a test command. I've long wanted
to 'set -e' but that causes other problems. This PR introduces
error handling via 'trap', with useful diagnostics on failure.

This PR also catches and fixes two previously-unknown bugs that
were causing tests to not actually run.

And, since /events takes eons on my high-uptime laptop, add /since

Signed-off-by: Ed Santiago <santiago@redhat.com>
