### PR TITLE
kill: fix output

### DIFF
--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -108,10 +108,13 @@ func kill(_ *cobra.Command, args []string) error {
 		return err
 	}
 	for _, r := range responses {
-		if r.Err == nil {
-			fmt.Println(r.RawInput)
-		} else {
+		switch {
+		case r.Err != nil:
 			errs = append(errs, r.Err)
+		case r.RawInput != "":
+			fmt.Println(r.RawInput)
+		default:
+			fmt.Println(r.Id)
 		}
 	}
 	return errs.PrintErrors()

--- a/test/system/130-kill.bats
+++ b/test/system/130-kill.bats
@@ -116,4 +116,18 @@ load helpers
     is "$output" "Error: valid signals are 1 through 64" "podman create"
 }
 
+@test "podman kill - print IDs or raw input" {
+    # kill -a must print the IDs
+    run_podman run --rm -d $IMAGE top
+    ctrID="$output"
+    run_podman kill -a
+    is "$output" "$ctrID"
+
+    # kill $input must print $input
+    cname=$(random_string)
+    run_podman run --rm -d --name $cname $IMAGE top
+    run_podman kill $cname
+    is "$output" $cname
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Make sure that `kill -a` is printing the IDs of killed containers.
Previously, it was only printing empty lines.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@containers/podman-maintainers PTAL