### PR TITLE
Set machine timezone

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -38,7 +38,6 @@ func init() {
 	})
 	flags := initCmd.Flags()
 	cfg := registry.PodmanConfig()
-
 	cpusFlagName := "cpus"
 	flags.Uint64Var(
 		&initOpts.CPUS,
@@ -69,6 +68,13 @@ func init() {
 		"now", false,
 		"Start machine now",
 	)
+	timezoneFlagName := "timezone"
+	defaultTz := cfg.TZ()
+	if len(defaultTz) < 1 {
+		defaultTz = "local"
+	}
+	flags.StringVar(&initOpts.TimeZone, timezoneFlagName, defaultTz, "Set timezone")
+	_ = initCmd.RegisterFlagCompletionFunc(timezoneFlagName, completion.AutocompleteDefault)
 
 	ImagePathFlagName := "image-path"
 	flags.StringVar(&initOpts.ImagePath, ImagePathFlagName, cfg.Machine.Image, "Path to qcow image")

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -55,6 +55,12 @@ Memory (in MB).
 
 Start the virtual machine immediately after it has been initialized.
 
+#### **--timezone**
+
+Set the timezone for the machine and containers.  Valid values are `local` or
+a `timezone` such as `America/Chicago`.  A value of `local`, which is the default,
+means to use the timezone of the machine host.
+
 #### **--help**
 
 Print usage statement.

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -21,6 +21,7 @@ type InitOptions struct {
 	IsDefault    bool
 	Memory       uint64
 	Name         string
+	TimeZone     string
 	URI          url.URL
 	Username     string
 }

--- a/pkg/machine/ignition_darwin.go
+++ b/pkg/machine/ignition_darwin.go
@@ -1,0 +1,16 @@
+//+build darwin
+
+package machine
+
+import (
+	"os"
+	"strings"
+)
+
+func getLocalTimeZone() (string, error) {
+	tzPath, err := os.Readlink("/etc/localtime")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(tzPath, "/var/db/timezone/zoneinfo"), nil
+}

--- a/pkg/machine/ignition_linux.go
+++ b/pkg/machine/ignition_linux.go
@@ -1,0 +1,15 @@
+package machine
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func getLocalTimeZone() (string, error) {
+	output, err := exec.Command("timedatectl", "show", "--property=Timezone").Output()
+	if err != nil {
+		return "", err
+	}
+	// Remove prepended field and the newline
+	return strings.TrimPrefix(strings.TrimSuffix(string(output), "\n"), "Timezone="), nil
+}

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -145,6 +145,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) error {
 		// Get image as usual
 		v.ImageStream = opts.ImagePath
 		dd, err := machine.NewFcosDownloader(vmtype, v.Name, opts.ImagePath)
+
 		if err != nil {
 			return err
 		}
@@ -235,6 +236,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) error {
 		Name:      opts.Username,
 		Key:       key,
 		VMName:    v.Name,
+		TimeZone:  opts.TimeZone,
 		WritePath: v.IgnitionFilePath,
 	}
 	return machine.NewIgnitionFile(ign)


### PR DESCRIPTION
Added an option to podman machine init to declare the timezone of the
resulting machine.  the default is to use the value of the host name or
else a given timezone name like America/Chicago.

Fixes: #11895

Signed-off-by: Brent Baude <bbaude@redhat.com>

[NO NEW TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
