### PR TITLE
add --ip6 flag to podman create/run

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -474,18 +474,23 @@ Path to the container-init binary.
 
 Keep STDIN open even if not attached. The default is *false*.
 
-#### **--ip6**=*ip*
+#### **--ip**=*ipv4*
 
-Not implemented
-
-#### **--ip**=*ip*
-
-Specify a static IP address for the container, for example **10.88.64.128**.
+Specify a static IPv4 address for the container, for example **10.88.64.128**.
 This option can only be used if the container is joined to only a single network - i.e., **--network=network-name** is used at most once -
 and if the container is not joining another container's network namespace via **--network=container:_id_**.
 The address must be within the network's IP address pool (default **10.88.0.0/16**).
 
 To specify multiple static IP addresses per container, set multiple networks using the **--network** option with a static IP address specified for each using the `ip` mode for that option.
+
+#### **--ip6**=*ipv6*
+
+Specify a static IPv6 address for the container, for example **fd46:db93:aa76:ac37::10**.
+This option can only be used if the container is joined to only a single network - i.e., **--network=network-name** is used at most once -
+and if the container is not joining another container's network namespace via **--network=container:_id_**.
+The address must be within the network's IPv6 address pool.
+
+To specify multiple static IPv6 addresses per container, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
 
 
 #### **--ipc**=*ipc*

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -127,6 +127,15 @@ The address must be within the network's IP address pool (default **10.88.0.0/16
 
 To specify multiple static IP addresses per pod, set multiple networks using the **--network** option with a static IP address specified for each using the `ip` mode for that option.
 
+#### **--ip6**=*ipv6*
+
+Specify a static IPv6 address for the pod, for example **fd46:db93:aa76:ac37::10**.
+This option can only be used if the pod is joined to only a single network - i.e., **--network=network-name** is used at most once -
+and if the pod is not joining another container's network namespace via **--network=container:_id_**.
+The address must be within the network's IPv6 address pool.
+
+To specify multiple static IPv6 addresses per pod, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
+
 #### **--label**=*label*, **-l**
 
 Add metadata to a pod (e.g., --label com.example.key=value).

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -497,18 +497,23 @@ Path to the container-init binary.
 
 When set to **true**, keep stdin open even if not attached. The default is **false**.
 
-#### **--ip6**=*ip*
+#### **--ip**=*ipv4*
 
-Not implemented.
-
-#### **--ip**=*ip*
-
-Specify a static IP address for the container, for example **10.88.64.128**.
+Specify a static IPv4 address for the container, for example **10.88.64.128**.
 This option can only be used if the container is joined to only a single network - i.e., **--network=network-name** is used at most once -
 and if the container is not joining another container's network namespace via **--network=container:_id_**.
 The address must be within the network's IP address pool (default **10.88.0.0/16**).
 
 To specify multiple static IP addresses per container, set multiple networks using the **--network** option with a static IP address specified for each using the `ip` mode for that option.
+
+#### **--ip6**=*ipv6*
+
+Specify a static IPv6 address for the container, for example **fd46:db93:aa76:ac37::10**.
+This option can only be used if the container is joined to only a single network - i.e., **--network=network-name** is used at most once -
+and if the container is not joining another container's network namespace via **--network=container:_id_**.
+The address must be within the network's IPv6 address pool.
+
+To specify multiple static IPv6 addresses per container, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
 
 #### **--ipc**=*mode*
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

Add the --ipv6 flag to podman create/run and pod create. We support the
`--network name:ip6=<ip>` syntax now but for docker compat we should also
support the --ip6 flag.
Note that there is no validation if the ip is actually a v6 or v4 address
because the backend does not care either.


#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:


Fixes #7511

#### Special notes for your reviewer:
