### PR TITLE
fix healthcheck timeouts and ut8 coercion

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -257,7 +257,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		healthIntervalFlagName := "health-interval"
 		createFlags.StringVar(
 			&cf.HealthInterval,
-			healthIntervalFlagName, DefaultHealthCheckInterval,
+			healthIntervalFlagName, define.DefaultHealthCheckInterval,
 			"set an interval for the healthchecks (a value of disable results in no automatic timer setup)",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(healthIntervalFlagName, completion.AutocompleteNone)
@@ -265,7 +265,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		healthRetriesFlagName := "health-retries"
 		createFlags.UintVar(
 			&cf.HealthRetries,
-			healthRetriesFlagName, DefaultHealthCheckRetries,
+			healthRetriesFlagName, define.DefaultHealthCheckRetries,
 			"the number of retries allowed before a healthcheck is considered to be unhealthy",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(healthRetriesFlagName, completion.AutocompleteNone)
@@ -273,7 +273,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		healthStartPeriodFlagName := "health-start-period"
 		createFlags.StringVar(
 			&cf.HealthStartPeriod,
-			healthStartPeriodFlagName, DefaultHealthCheckStartPeriod,
+			healthStartPeriodFlagName, define.DefaultHealthCheckStartPeriod,
 			"the initialization time needed for a container to bootstrap",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(healthStartPeriodFlagName, completion.AutocompleteNone)
@@ -281,7 +281,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		healthTimeoutFlagName := "health-timeout"
 		createFlags.StringVar(
 			&cf.HealthTimeout,
-			healthTimeoutFlagName, DefaultHealthCheckTimeout,
+			healthTimeoutFlagName, define.DefaultHealthCheckTimeout,
 			"the maximum time allowed to complete the healthcheck before an interval is considered failed",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(healthTimeoutFlagName, completion.AutocompleteNone)

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/common/pkg/cgroups"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v3/cmd/podman/registry"
+	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/libpod/network/types"
 	"github.com/containers/podman/v3/pkg/api/handlers"
 	"github.com/containers/podman/v3/pkg/domain/entities"
@@ -304,10 +305,10 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 		VolumesFrom:       cc.HostConfig.VolumesFrom,
 		Workdir:           cc.Config.WorkingDir,
 		Net:               &netInfo,
-		HealthInterval:    DefaultHealthCheckInterval,
-		HealthRetries:     DefaultHealthCheckRetries,
-		HealthTimeout:     DefaultHealthCheckTimeout,
-		HealthStartPeriod: DefaultHealthCheckStartPeriod,
+		HealthInterval:    define.DefaultHealthCheckInterval,
+		HealthRetries:     define.DefaultHealthCheckRetries,
+		HealthTimeout:     define.DefaultHealthCheckTimeout,
+		HealthStartPeriod: define.DefaultHealthCheckStartPeriod,
 	}
 	if !rootless.IsRootless() {
 		var ulimits []string

--- a/cmd/podman/common/default.go
+++ b/cmd/podman/common/default.go
@@ -5,14 +5,7 @@ import (
 )
 
 var (
-	// DefaultHealthCheckInterval default value
-	DefaultHealthCheckInterval = "30s"
-	// DefaultHealthCheckRetries default value
-	DefaultHealthCheckRetries uint = 3
-	// DefaultHealthCheckStartPeriod default value
-	DefaultHealthCheckStartPeriod = "0s"
-	// DefaultHealthCheckTimeout default value
-	DefaultHealthCheckTimeout = "30s"
+
 	// DefaultImageVolume default value
 	DefaultImageVolume = "bind"
 	// Pull in configured json library

--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -237,12 +237,12 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 }
 
 func printJSON(data []interface{}) error {
-	buf, err := json.MarshalIndent(data, "", "    ")
-	if err != nil {
-		return err
-	}
-	_, err = fmt.Println(string(buf))
-	return err
+	enc := json.NewEncoder(os.Stdout)
+	// by default, json marshallers will force utf=8 from
+	// a string. this breaks healthchecks that use <,>, &&.
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "     ")
+	return enc.Encode(data)
 }
 
 func printTmpl(typ, row string, data []interface{}) error {

--- a/libpod/define/healthchecks.go
+++ b/libpod/define/healthchecks.go
@@ -34,3 +34,16 @@ const (
 	// HealthCheckDefined means the healthcheck was found on the container
 	HealthCheckDefined HealthCheckStatus = iota
 )
+
+// Healthcheck defaults.  These are used both in the cli as well in
+// libpod and were moved from cmd/podman/common
+const (
+	// DefaultHealthCheckInterval default value
+	DefaultHealthCheckInterval = "30s"
+	// DefaultHealthCheckRetries default value
+	DefaultHealthCheckRetries uint = 3
+	// DefaultHealthCheckStartPeriod default value
+	DefaultHealthCheckStartPeriod = "0s"
+	// DefaultHealthCheckTimeout default value
+	DefaultHealthCheckTimeout = "30s"
+)

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/containers/common/libimage"
 	"github.com/containers/podman/v3/libpod"
@@ -64,6 +65,13 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 			// NOTE: the health check is only set for Docker images
 			// but inspect will take care of it.
 			s.HealthConfig = inspectData.HealthCheck
+			if s.HealthConfig != nil && s.HealthConfig.Timeout == 0 {
+				hct, err := time.ParseDuration(define.DefaultHealthCheckTimeout)
+				if err != nil {
+					return nil, err
+				}
+				s.HealthConfig.Timeout = hct
+			}
 		}
 
 		// Image stop signal


### PR DESCRIPTION
this commit fixes two bugs and adds regression tests.

when getting healthcheck values from an image, if the image does not
have a timeout defined, this resulted in a 0 value for timeout.  The
default as described in the man pages is 30s.

when inspecting a container with a healthcheck command, a customer
observed that the &, <, and > characters were being converted into a
unicode escape value.  It turns out json marshalling will by default
coerce string values to ut8.

Fixes: bz2028408

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
