### PR TITLE
oci: configure the devices cgroup with default devices

### DIFF
--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -325,8 +325,12 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 	s.HostDeviceList = s.Devices
 
-	for _, dev := range s.DeviceCGroupRule {
-		g.AddLinuxResourcesDevice(true, dev.Type, dev.Major, dev.Minor, dev.Access)
+	// set the devices cgroup when not running in a user namespace
+	if !inUserNS && !s.Privileged {
+		g.AddLinuxResourcesDevice(false, "", nil, nil, "rwm")
+		for _, dev := range s.DeviceCGroupRule {
+			g.AddLinuxResourcesDevice(true, dev.Type, dev.Major, dev.Minor, dev.Access)
+		}
 	}
 
 	for k, v := range s.WeightDevice {

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -119,4 +119,11 @@ var _ = Describe("Podman run device", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})
+
+	It("podman run cannot access non default devices", func() {
+		session := podmanTest.Podman([]string{"run", "-v /dev:/dev-host", ALPINE, "head", "-1", "/dev-host/kmsg"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Not(Exit(0)))
+	})
+
 })


### PR DESCRIPTION
always set the default devices to the devices cgroup when not running
in a user namespace.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

