### PR TITLE
e2e: search flake: skip test on registry.redhat.io

### DIFF
--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -459,12 +459,8 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search with wildcards", func() {
-		search := podmanTest.Podman([]string{"search", "--limit", "30", "registry.redhat.io/*"})
-		search.WaitWithDefaultTimeout()
-		Expect(search).Should(Exit(0))
-		Expect(search.OutputToStringArray()).To(HaveLen(31))
-
-		search = podmanTest.Podman([]string{"search", "registry.redhat.io/*openshift*"})
+		Skip("FIXME: search on registry.redhat.io is broken (Dec 16 '21)")
+		search := podmanTest.Podman([]string{"search", "registry.redhat.io/*openshift*"})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
 		Expect(len(search.OutputToStringArray())).To(BeNumerically(">", 1))
@@ -491,9 +487,9 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search with limit over 100", func() {
-		search := podmanTest.Podman([]string{"search", "--limit", "130", "registry.redhat.io/rhel"})
+		search := podmanTest.Podman([]string{"search", "--limit", "100", "quay.io/podman"})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
-		Expect(len(search.OutputToStringArray())).To(BeNumerically("<=", 131))
+		Expect(len(search.OutputToStringArray())).To(BeNumerically("<=", 101))
 	})
 })


### PR DESCRIPTION
The search endpoint on registry.redhat.io is broken.
Skip one test and update another to avoid hitting it.
Also leave some breadcrumbs to revert once it's back
in a working state.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>