### PR TITLE
specgen: honor userns=auto from containers.conf

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -9,6 +9,7 @@ import (
 	cdi "github.com/container-orchestrated-devices/container-device-interface/pkg"
 	"github.com/containers/common/libimage"
 	"github.com/containers/podman/v3/libpod"
+	"github.com/containers/podman/v3/pkg/namespaces"
 	"github.com/containers/podman/v3/pkg/specgen"
 	"github.com/containers/podman/v3/pkg/util"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -96,6 +97,12 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 			return nil, nil, nil, err
 		}
 		s.UserNS = defaultNS
+
+		mappings, err := util.ParseIDMapping(namespaces.UsernsMode(s.UserNS.NSMode), nil, nil, "", "")
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		s.IDMappings = mappings
 	}
 	if s.NetNS.IsDefault() {
 		defaultNS, err := GetDefaultNamespaceMode("net", rtc, pod)

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -17,7 +17,7 @@ function _require_crun() {
     skip_if_rootless "chroot is not allowed in rootless mode"
     skip_if_remote "--group-add keep-groups not supported in remote mode"
     _require_crun
-    run chroot --groups 1234 / ${PODMAN} run --uidmap 0:200000:5000 --group-add keep-groups $IMAGE id
+    run chroot --groups 1234 / ${PODMAN} run --rm --uidmap 0:200000:5000 --group-add keep-groups $IMAGE id
     is "$output" ".*65534(nobody)" "Check group leaked into user namespace"
 }
 
@@ -25,30 +25,30 @@ function _require_crun() {
     skip_if_rootless "chroot is not allowed in rootless mode"
     skip_if_remote "--group-add keep-groups not supported in remote mode"
     _require_crun
-    run chroot --groups 1234,5678 / ${PODMAN} run --group-add keep-groups $IMAGE id
+    run chroot --groups 1234,5678 / ${PODMAN} run --rm --group-add keep-groups $IMAGE id
     is "$output" ".*1234" "Check group leaked into container"
 }
 
 @test "podman --group-add without keep-groups while in a userns" {
     skip_if_rootless "chroot is not allowed in rootless mode"
     skip_if_remote "--group-add keep-groups not supported in remote mode"
-    run chroot --groups 1234,5678 / ${PODMAN} run --uidmap 0:200000:5000 --group-add 457 $IMAGE id
+    run chroot --groups 1234,5678 / ${PODMAN} run --rm --uidmap 0:200000:5000 --group-add 457 $IMAGE id
     is "$output" ".*457" "Check group leaked into container"
 }
 
 @test "podman --remote --group-add keep-groups " {
     if is_remote; then
-        run_podman 125 run --group-add keep-groups $IMAGE id
+        run_podman 125 run --rm --group-add keep-groups $IMAGE id
         is "$output" ".*not supported in remote mode" "Remote check --group-add keep-groups"
     fi
 }
 
 @test "podman --group-add without keep-groups " {
-    run_podman run --group-add 457 $IMAGE id
+    run_podman run --rm --group-add 457 $IMAGE id
     is "$output" ".*457" "Check group leaked into container"
 }
 
 @test "podman --group-add keep-groups plus added groups " {
-    run_podman 125 run --group-add keep-groups --group-add 457 $IMAGE id
+    run_podman 125 run --rm --group-add keep-groups --group-add 457 $IMAGE id
     is "$output" ".*the '--group-add keep-groups' option is not allowed with any other --group-add options" "Check group leaked into container"
 }

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -52,3 +52,29 @@ function _require_crun() {
     run_podman 125 run --rm --group-add keep-groups --group-add 457 $IMAGE id
     is "$output" ".*the '--group-add keep-groups' option is not allowed with any other --group-add options" "Check group leaked into container"
 }
+
+@test "podman userns=auto in config file" {
+    skip_if_remote "userns=auto is set on the server"
+
+    if is_rootless; then
+        egrep -q "^$(id -un):" /etc/subuid || skip "no IDs allocated for current user"
+    else
+        egrep -q "^containers:" /etc/subuid || skip "no IDs allocated for user 'containers'"
+    fi
+
+    cat > $PODMAN_TMPDIR/userns_auto.conf <<EOF
+[containers]
+userns="auto"
+EOF
+    # First make sure a user namespace is created
+    CONTAINERS_CONF=$PODMAN_TMPDIR/userns_auto.conf run_podman run -d $IMAGE sleep infinity
+    cid=$output
+
+    run_podman inspect --format '{{.HostConfig.UsernsMode}}' $cid
+    is "$output" "private" "Check that a user namespace was created for the container"
+
+    run_podman rm -t 0 -f $cid
+
+    # Then check that the main user is not mapped into the user namespace
+    CONTAINERS_CONF=$PODMAN_TMPDIR/userns_auto.conf run_podman 0 run --rm $IMAGE awk '{if($2 == "0"){exit 1}}' /proc/self/uid_map /proc/self/gid_map
+}


### PR DESCRIPTION
when using the default userns value, make sure its value is parsed so
that userns=auto is parsed and the options for the storage are filled.

Closes: https://github.com/containers/podman/issues/12615

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
