### PR TITLE
build: relay `exitcode` from imagebuildah to registry

### DIFF
--- a/cmd/podman/utils/error.go
+++ b/cmd/podman/utils/error.go
@@ -1,8 +1,13 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
+
+	buildahCLI "github.com/containers/buildah/pkg/cli"
 )
 
 type OutputErrors []error
@@ -16,4 +21,25 @@ func (o OutputErrors) PrintErrors() (lastError error) {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", o[e])
 	}
 	return
+}
+
+/* For remote client, server does not returns error with exit code
+   instead returns a message and we cast it to a new error.
+
+   Following function performs parsing on build error and returns
+   exit status which was exepected for this current build
+*/
+func ExitCodeFromBuildError(errorMsg string) (int, error) {
+	if strings.Contains(errorMsg, "exit status") {
+		errorSplit := strings.Split(errorMsg, " ")
+		if errorSplit[len(errorSplit)-2] == "status" {
+			tmpSplit := strings.Split(errorSplit[len(errorSplit)-1], "\n")
+			exitCodeRemote, err := strconv.Atoi(tmpSplit[0])
+			if err == nil {
+				return exitCodeRemote, nil
+			}
+			return buildahCLI.ExecErrorCodeGeneric, err
+		}
+	}
+	return buildahCLI.ExecErrorCodeGeneric, errors.New("error message does not contains a valid exit code")
 }

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -275,8 +275,8 @@ RUN printenv http_proxy`, ALPINE)
 
 	It("podman build relay exit code to process", func() {
 		if IsRemote() {
-			// following states true for all the remote commands
-			Skip("Remote server does not emits error with exit status")
+			podmanTest.StopRemoteService()
+			podmanTest.StartRemoteService()
 		}
 		podmanTest.AddImageToRWStore(ALPINE)
 		dockerfile := fmt.Sprintf(`FROM %s
@@ -663,7 +663,7 @@ RUN ls /dev/fuse`, ALPINE)
 		Expect(err).To(BeNil())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
+		Expect(session).Should(Exit(1))
 
 		session = podmanTest.Podman([]string{"build", "--pull-never", "--device", "/dev/fuse", "-t", "test", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -679,7 +679,7 @@ RUN ls /dev/test1`, ALPINE)
 		Expect(err).To(BeNil())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(125))
+		Expect(session).Should(Exit(1))
 
 		session = podmanTest.Podman([]string{"build", "--pull-never", "--device", "/dev/zero:/dev/test1", "-t", "test", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -273,6 +273,23 @@ RUN printenv http_proxy`, ALPINE)
 		os.Unsetenv("http_proxy")
 	})
 
+	It("podman build relay exit code to process", func() {
+		if IsRemote() {
+			// following states true for all the remote commands
+			Skip("Remote server does not emits error with exit status")
+		}
+		podmanTest.AddImageToRWStore(ALPINE)
+		dockerfile := fmt.Sprintf(`FROM %s
+RUN exit 5`, ALPINE)
+
+		dockerfilePath := filepath.Join(podmanTest.TempDir, "Dockerfile")
+		err := ioutil.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
+		Expect(err).To(BeNil())
+		session := podmanTest.Podman([]string{"build", "-t", "error-test", "--file", dockerfilePath, podmanTest.TempDir})
+		session.Wait(120)
+		Expect(session).Should(Exit(5))
+	})
+
 	It("podman build and check identity", func() {
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-f", "build/basicalpine/Containerfile.path", "--no-cache", "-t", "test", "build/basicalpine"})
 		session.WaitWithDefaultTimeout()

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -115,7 +115,7 @@ FROM $IMAGE
 RUN echo $rand_content
 EOF
 
-    run_podman 125 --runtime-flag invalidflag build -t build_test $tmpdir
+    run_podman 1 --runtime-flag invalidflag build -t build_test $tmpdir
     is "$output" ".*invalidflag" "failed when passing undefined flags to the runtime"
 }
 


### PR DESCRIPTION
Podman does not relay exit code from buildah instead returns a generic
error code `125`. Following PR allows `podman` to relay exit code from
`imagebuildah` to `registry` as it is.

Closes: https://github.com/containers/podman/issues/12616