### PR TITLE
Allow users to add host user accounts to /etc/passwd

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -292,6 +292,14 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			"Set proxy environment variables in the container based on the host proxy vars",
 		)
 
+		hostUserFlagName := "hostuser"
+		createFlags.StringSliceVar(
+			&cf.HostUsers,
+			hostUserFlagName, []string{},
+			"Host user account to add to /etc/passwd within container",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(hostUserFlagName, completion.AutocompleteNone)
+
 		imageVolumeFlagName := "image-volume"
 		createFlags.StringVar(
 			&cf.ImageVolume,

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -410,6 +410,11 @@ Container host name
 
 Sets the container host name that is available inside the container. Can only be used with a private UTS namespace `--uts=private` (default). If `--pod` is specified and the pod shares the UTS namespace (default) the pod's hostname will be used.
 
+#### **--hostuser**=*name*
+
+Add a user account to /etc/passwd from the host to the container. The Username
+or UID must exist on the host system.
+
 #### **--help**
 
 Print usage statement

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -446,6 +446,11 @@ The initialization time needed for a container to bootstrap. The value can be ex
 The maximum time allowed to complete the healthcheck before an interval is considered failed. Like start-period, the
 value can be expressed in a time format such as **1m22s**. The default value is **30s**.
 
+#### **--hostuser**=*name*
+
+Add a user account to /etc/passwd from the host to the container. The Username
+or UID must exist on the host system.
+
 #### **--help**
 
 Print usage statement

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -198,6 +198,8 @@ type ContainerSecurityConfig struct {
 	// Groups are additional groups to add the container's user to. These
 	// are resolved within the container using the container's /etc/passwd.
 	Groups []string `json:"groups,omitempty"`
+	// HostUsers are a list of host user accounts to add to /etc/passwd
+	HostUsers []string `json:"HostUsers,omitempty"`
 	// AddCurrentUserPasswdEntry indicates that Libpod should ensure that
 	// the container's /etc/passwd contains an entry for the user running
 	// Libpod - mostly used in rootless containers where the user running

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1768,6 +1768,17 @@ func WithPidFile(pidFile string) CtrCreateOption {
 	}
 }
 
+// WithHostUsers indicates host users to add to /etc/passwd
+func WithHostUsers(hostUsers []string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+		ctr.config.HostUsers = hostUsers
+		return nil
+	}
+}
+
 // WithInitCtrType indicates the container is a initcontainer
 func WithInitCtrType(containerType string) CtrCreateOption {
 	return func(ctr *Container) error {

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -189,6 +189,7 @@ type ContainerCreateOptions struct {
 	HealthTimeout     string
 	Hostname          string `json:"hostname,omitempty"`
 	HTTPProxy         bool
+	HostUsers         []string
 	ImageVolume       string
 	Init              bool
 	InitContainerType string

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -156,6 +156,10 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		return nil, nil, nil, err
 	}
 
+	if len(s.HostUsers) > 0 {
+		options = append(options, libpod.WithHostUsers(s.HostUsers))
+	}
+
 	command, err := makeCommand(ctx, s, imageData, rtc)
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -152,6 +152,9 @@ type ContainerBasicConfig struct {
 	// Conflicts with UtsNS if UtsNS is not set to private.
 	// Optional.
 	Hostname string `json:"hostname,omitempty"`
+	// HostUses is a list of host usernames or UIDs to add to the container
+	// /etc/passwd file
+	HostUsers []string `json:"hostusers,omitempty"`
 	// Sysctl sets kernel parameters for the container
 	Sysctl map[string]string `json:"sysctl,omitempty"`
 	// Remove indicates if the container should be removed once it has been started

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -437,6 +437,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.NetworkOptions = c.Net.NetworkOptions
 		s.UseImageHosts = c.Net.NoHosts
 	}
+	s.HostUsers = c.HostUsers
 	s.ImageVolumeMode = c.ImageVolume
 	if s.ImageVolumeMode == "bind" {
 		s.ImageVolumeMode = "anonymous"

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -723,3 +723,11 @@ func SocketPath() (string, error) {
 	// Glue the socket path together
 	return filepath.Join(xdg, "podman", "podman.sock"), nil
 }
+
+func LookupUser(name string) (*user.User, error) {
+	// Assume UID look up first, if it fails lookup by username
+	if u, err := user.LookupId(name); err == nil {
+		return u, err
+	}
+	return user.Lookup(name)
+}

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -711,6 +711,18 @@ EOF
     run_podman rmi nomtab
 }
 
+@test "podman run --hostuser tests" {
+    skip_if_not_rootless "test whether hostuser is successfully added"
+    user=$(id -un)
+    run_podman 1 run --rm $IMAGE grep $user /etc/passwd
+    run_podman run --hostuser=$user --rm $IMAGE grep $user /etc/passwd
+    user=$(id -u)
+    run_podman run --hostuser=$user --rm $IMAGE grep $user /etc/passwd
+    run_podman run --hostuser=$user --user $user --rm $IMAGE grep $user /etc/passwd
+    user=bogus
+    run_podman 126 run --hostuser=$user --rm $IMAGE grep $user /etc/passwd
+}
+
 @test "podman run --device-cgroup-rule tests" {
     skip_if_rootless "cannot add devices in rootless mode"
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -398,6 +398,16 @@ function skip_if_rootless() {
     fi
 }
 
+######################
+#  skip_if_not_rootless  #  ...with an optional message
+######################
+function skip_if_not_rootless() {
+    if ! is_rootless; then
+        local msg=$(_add_label_if_missing "$1" "rootfull")
+        skip "${msg:-not applicable under rootlfull podman}"
+    fi
+}
+
 ####################
 #  skip_if_remote  #  ...with an optional message
 ####################


### PR DESCRIPTION
Some containers require certain user account(s) to exist within the
container when they are run. This option will allow callers to add a
bunch of passwd entries from the host to the container even if the
entries are not in the local /etc/passwd file on the host.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1935831

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### What this PR does / why we need it:

<!---
Please put your overall PR description here
-->

#### How to verify it

<!---
Please specify the precise conditions and/or the specific test(s) which must pass.
-->

#### Which issue(s) this PR fixes:

<!--
Please uncomment this block and include only one of the following on a
line by itself:

None

-OR-

Fixes #<issue number>

*** Please also put 'Fixes #' in the commit and PR description***

-->

#### Special notes for your reviewer:
