### PR TITLE
Removed .service file for healthchecks

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1877,7 +1877,7 @@ func (c *Container) cleanupStorage() error {
 	return cleanupErr
 }
 
-// Unmount the a container and free its resources
+// Unmount the container and free its resources
 func (c *Container) cleanup(ctx context.Context) error {
 	var lastError error
 
@@ -1885,7 +1885,7 @@ func (c *Container) cleanup(ctx context.Context) error {
 
 	// Remove healthcheck unit/timer file if it execs
 	if c.config.HealthCheckConfig != nil {
-		if err := c.removeTimer(); err != nil {
+		if err := c.removeTransientFiles(ctx); err != nil {
 			logrus.Errorf("Removing timer for container %s healthcheck: %v", c.ID(), err)
 		}
 	}

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -242,4 +242,20 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(ps.OutputToStringArray()).To(HaveLen(2))
 		Expect(ps.OutputToString()).To(ContainSubstring("hc"))
 	})
+
+	It("stopping and then starting a container with healthcheck cmd", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-cmd", "[\"ls\", \"/foo\"]", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		stop := podmanTest.Podman([]string{"stop", "-t0", "hc"})
+		stop.WaitWithDefaultTimeout()
+		Expect(stop).Should(Exit(0))
+
+		startAgain := podmanTest.Podman([]string{"start", "hc"})
+		startAgain.WaitWithDefaultTimeout()
+		Expect(startAgain).Should(Exit(0))
+		Expect(startAgain.OutputToString()).To(Equal("hc"))
+		Expect(startAgain.ErrorToString()).To(Equal(""))
+	})
 })


### PR DESCRIPTION
when a container with healthchecks exits due to stopping or failure, we
need the cleanup process to remove both the timer file and the service
file.

Bz#:2024229

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
