### PR TITLE
apiv2 tests: use quay.io/libpod/testimage:20210610 for platform tests

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -53,8 +53,8 @@ t POST "images/create?fromImage=alpine" 200 .error~null .status~".*Download comp
 t POST "images/create?fromImage=alpine&tag=latest" 200
 
 # 10977 - handle platform parameter correctly
-t POST "images/create?fromImage=alpine&platform=linux/arm64" 200
-t GET  "images/alpine/json" 200 \
+t POST "images/create?fromImage=testimage:20210610&platform=linux/arm64" 200
+t GET  "images/testimage:20210610/json" 200 \
   .Architecture=arm64
 
 # Make sure that new images are pulled


### PR DESCRIPTION
The quay.io/libpod/testimage:20210610 is known not to change and to
remain stable over time.  While the same should apply for alpine image
on quay.io/libpod, we've seen it flake and return the wrong image.

The reasons for that observation are unknown.

Fixes: #12631
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
