### PR TITLE
rootless: include the args in the debug message

### DIFF
--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -145,8 +145,8 @@ func tryMappingTool(uid bool, pid int, hostID int, mappings []idtools.IDMap) err
 	}
 
 	if output, err := cmd.CombinedOutput(); err != nil {
-		logrus.Debugf("error from %s: %s", tool, output)
-		return errors.Wrapf(err, "cannot setup namespace using %s", tool)
+		logrus.Errorf("error running `%s`: %s", strings.Join(args, " "), output)
+		return errors.Wrapf(err, "cannot setup namespace using %q", path)
 	}
 	return nil
 }


### PR DESCRIPTION
include the arguments used to create the user namespace to help
debugging.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
