### PR TITLE
fix(generate): fix up podman generate kube missing env field bug

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -747,7 +747,7 @@ func libpodEnvVarsToKubeEnvVars(envs []string, imageEnvs []string) ([]v1.EnvVar,
 	defaultEnv := env.DefaultEnvVariables()
 	envVars := make([]v1.EnvVar, 0, len(envs))
 	imageMap := make(map[string]string, len(imageEnvs))
-	for _, ie := range envs {
+	for _, ie := range imageEnvs {
 		split := strings.SplitN(ie, "=", 2)
 		imageMap[split[0]] = split[1]
 	}


### PR DESCRIPTION
**Description**

after version >= 3.4.2, `podman generate kube container-name` does not generate yaml file with environment vars anymore.

test with the old version like `3.4.1` it works fine.

maybe related commit:

https://github.com/containers/podman/commit/b3eaa08c5f#diff-4e2259d2c3a8a7fad49c3f395c21ebdb014f01f538ad0b4898b8d759670e38f3L450

after a small `printf` debug, I found the bug is a simple typo.

the logic is if the process env vars key exists in podman default or in image defined, and the value is equal, skip the env var key.

the typo make it compare to itself -_-

so, here comes the fixup.

related issue:  https://github.com/containers/podman/issues/12647