### PR TITLE
docker-py listing of images was failing.

### DIFF
--- a/test/python/docker/compat/test_images.py
+++ b/test/python/docker/compat/test_images.py
@@ -79,6 +79,7 @@ class TestImages(unittest.TestCase):
         # Add more images
         self.client.images.pull(constant.BB)
         self.assertEqual(len(self.client.images.list()), 2)
+        self.assertEqual(len(self.client.images.list(all=True)), 2)
 
         # List images with filter
         self.assertEqual(len(self.client.images.list(filters={"reference": "alpine"})), 1)


### PR DESCRIPTION
The following script was blowing up against the podman socket
```
cat images.py
import docker
client=docker.from_env()
print(client.images.list(all=True))
```

This seems to be working with the release, but when I try to run it
against the main branch it blows up.

```
export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
$ python images.py
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/docker/api/client.py", line 268, in _raise_for_status
    response.raise_for_status()
  File "/usr/lib/python3.10/site-packages/requests/models.py", line 953, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http+docker://localhost/v1.40/images/sha256:c059bfaa849c4d8e4aecaeb3a10c2d9b3d85f5165c66ad3a4d937758128c4d18/json

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dwalsh/Documents/book/images.py", line 3, in <module>
    print(client.images.list(all=True))
  File "/usr/lib/python3.10/site-packages/docker/models/images.py", line 362, in list
    return [self.get(r["Id"]) for r in resp]
  File "/usr/lib/python3.10/site-packages/docker/models/images.py", line 362, in <listcomp>
    return [self.get(r["Id"]) for r in resp]
  File "/usr/lib/python3.10/site-packages/docker/models/images.py", line 314, in get
    return self.prepare_model(self.client.api.inspect_image(name))
  File "/usr/lib/python3.10/site-packages/docker/utils/decorators.py", line 19, in wrapped
    return f(self, resource_id, *args, **kwargs)
  File "/usr/lib/python3.10/site-packages/docker/api/image.py", line 251, in inspect_image
    return self._result(
  File "/usr/lib/python3.10/site-packages/docker/api/client.py", line 274, in _result
    self._raise_for_status(response)
  File "/usr/lib/python3.10/site-packages/docker/api/client.py", line 270, in _raise_for_status
    raise create_api_error_from_http_exception(e)
  File "/usr/lib/python3.10/site-packages/docker/errors.py", line 31, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation)
docker.errors.ImageNotFound: 404 Client Error for http+docker://localhost/v1.40/images/sha256:c059bfaa849c4d8e4aecaeb3a10c2d9b3d85f5165c66ad3a4d937758128c4d18/json: Not Found ("failed to find image sha256:c059bfaa849c4d8e4aecaeb3a10c2d9b3d85f5165c66ad3a4d937758128c4d18: docker.io/library/sha256:c059bfaa849c4d8e4aecaeb3a10c2d9b3d85f5165c66ad3a4d937758128c4d18: No such image")
```

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
