### PR TITLE
[CI:DOCS] Small checkpoint/restore man page fixes

### DIFF
--- a/docs/source/markdown/podman-container-checkpoint.1.md
+++ b/docs/source/markdown/podman-container-checkpoint.1.md
@@ -37,7 +37,7 @@ root file-system, if not explicitly disabled using **--ignore-rootfs**.
 
 If a checkpoint is exported to a tar.gz file it is possible with the help of **--ignore-rootfs** to explicitly disable including changes to the root file-system into the checkpoint archive file.\
 The default is **false**.\
-*IMPORTANT: This OPTION only works in combination with **--export, -e**.*
+*IMPORTANT: This OPTION only works in combination with __--export, -e__.*
 
 #### **--ignore-volumes**
 
@@ -122,7 +122,7 @@ The default is **false**.
 
 Check out the *container* with previous criu image files in pre-dump. It only works on `runc 1.0-rc3` or `higher`.\
 The default is **false**.\
-*IMPORTANT: This OPTION is not available with **--pre-checkpoint***.
+*IMPORTANT: This OPTION is not available with __--pre-checkpoint__*.
 
 
 ## EXAMPLES

--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -39,7 +39,7 @@ The default is **false**.\
 
 If a *container* is restored from a checkpoint tar.gz file it is possible that it also contains all root file-system changes. With **--ignore-rootfs** it is possible to explicitly disable applying these root file-system changes to the restored *container*.\
 The default is **false**.\
-*IMPORTANT: This OPTION is only available in combination with **--import, -i**.*
+*IMPORTANT: This OPTION is only available in combination with __--import, -i__.*
 
 #### **--ignore-static-ip**
 
@@ -98,14 +98,14 @@ If the **--name, -n** option is used, Podman will not attempt to assign the same
 address to the *container* it was using before checkpointing as each IP address can only
 be used once and the restored *container* will have another IP address. This also means
 that **--name, -n** cannot be used in combination with **--tcp-established**.\
-*IMPORTANT: This OPTION is only available in combination with **--import, -i**.*
+*IMPORTANT: This OPTION is only available in combination with __--import, -i__.*
 
 #### **--pod**=*name*
 
 Restore a container into the pod *name*. The destination pod for this restore
 has to have the same namespaces shared as the pod this container was checkpointed
-from (see **[podman pod create --share](podman-pod-create.1.md#--share)**).
-*IMPORTANT: This OPTION is only available in combination with **--import, -i**.*
+from (see **[podman pod create --share](podman-pod-create.1.md#--share)**).\
+*IMPORTANT: This OPTION is only available in combination with __--import, -i__.*
 
 This option requires at least CRIU 3.16.
 
@@ -168,7 +168,7 @@ Import a checkpoint file and a pre-checkpoint file.
 # podman container restore --import-previous pre-checkpoint.tar.gz --import checkpoint.tar.gz
 ```
 
-Remove the container "mywebserver". Make a checkpoint of the container and export it. Restore the container with other port ranges from the exported file.
+Start the container "mywebserver". Make a checkpoint of the container and export it. Restore the container with other port ranges from the exported file.
 ```
 $ podman run --rm -p 2345:80 -d webserver
 # podman container checkpoint -l --export=dump.tar


### PR DESCRIPTION
At some places the checkpoint restore man pages were using the markdown modifier `**` inside `*..*`. This does not seem to work as intended and results in markdown modifiers present in the final man page. Switching to `__` inside of `*..*` seems to fix this.