### PR TITLE
compat: image normalization: handle sha256 prefix

### DIFF
--- a/pkg/api/handlers/utils/images.go
+++ b/pkg/api/handlers/utils/images.go
@@ -35,7 +35,7 @@ func NormalizeToDockerHub(r *http.Request, nameOrID string) (string, error) {
 		if errors.Cause(err) != storage.ErrImageUnknown {
 			return "", fmt.Errorf("normalizing name for compat API: %v", err)
 		}
-	} else if strings.HasPrefix(img.ID(), nameOrID) {
+	} else if strings.HasPrefix(img.ID(), strings.TrimPrefix(nameOrID, "sha256:")) {
 		return img.ID(), nil
 	}
 

--- a/test/python/docker/compat/test_images.py
+++ b/test/python/docker/compat/test_images.py
@@ -79,6 +79,7 @@ class TestImages(unittest.TestCase):
         # Add more images
         self.client.images.pull(constant.BB)
         self.assertEqual(len(self.client.images.list()), 2)
+        self.assertEqual(len(self.client.images.list(all=True)), 2)
 
         # List images with filter
         self.assertEqual(len(self.client.images.list(filters={"reference": "alpine"})), 1)


### PR DESCRIPTION
When normalizing image names on the compat API, make sure to take the
`sha256:` prefix into account when matching against the image ID.
Otherwise, the name will mistakingly be subject to docker.io
normalization.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

@containers/podman-maintainers 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
