### PR TITLE
Podman run --passwd

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -83,6 +83,9 @@ func runFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(gpuFlagName, completion.AutocompleteNone)
 	_ = flags.MarkHidden("gpus")
 
+	passwdFlagName := "passwd"
+	flags.BoolVar(&runOpts.Passwd, passwdFlagName, true, "add entries to /etc/passwd and /etc/group")
+
 	if registry.IsRemote() {
 		_ = flags.MarkHidden("preserve-fds")
 		_ = flags.MarkHidden("conmon-pidfile")
@@ -191,6 +194,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	s.RawImageName = rawImageName
+	s.Passwd = &runOpts.Passwd
 	runOpts.Spec = s
 
 	if _, err := createPodIfNecessary(cmd, s, cliVals.Net); err != nil {

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -762,6 +762,11 @@ Tune the host's OOM preferences for containers (accepts values from **-1000** to
 #### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
 
+#### **--passwd**
+
+Allow Podman to add entries to /etc/passwd and /etc/group when used in conjunction with the --user option.
+This is used to override the Podman provided user setup in favor of entrypoint configurations such as libnss-extrausers.
+
 #### **--personality**=*persona*
 
 Personality sets the execution domain via Linux personality(2).

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -163,6 +163,8 @@ type ContainerRootFSConfig struct {
 	// Volatile specifies whether the container storage can be optimized
 	// at the cost of not syncing all the dirty files in memory.
 	Volatile bool `json:"volatile,omitempty"`
+	// Passwd allows to user to override podman's passwd/group file setup
+	Passwd *bool `json:"passwd,omitempty"`
 }
 
 // ContainerSecurityConfig is an embedded sub-config providing security configuration

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -377,6 +377,8 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 		ctrConfig.Umask = c.config.Umask
 	}
 
+	ctrConfig.Passwd = c.config.Passwd
+
 	return ctrConfig
 }
 

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1767,21 +1767,23 @@ func (c *Container) makeBindMounts() error {
 	// SHM is always added when we mount the container
 	c.state.BindMounts["/dev/shm"] = c.config.ShmDir
 
-	newPasswd, newGroup, err := c.generatePasswdAndGroup()
-	if err != nil {
-		return errors.Wrapf(err, "error creating temporary passwd file for container %s", c.ID())
-	}
-	if newPasswd != "" {
-		// Make /etc/passwd
-		// If it already exists, delete so we can recreate
-		delete(c.state.BindMounts, "/etc/passwd")
-		c.state.BindMounts["/etc/passwd"] = newPasswd
-	}
-	if newGroup != "" {
-		// Make /etc/group
-		// If it already exists, delete so we can recreate
-		delete(c.state.BindMounts, "/etc/group")
-		c.state.BindMounts["/etc/group"] = newGroup
+	if c.config.Passwd != nil && *c.config.Passwd {
+		newPasswd, newGroup, err := c.generatePasswdAndGroup()
+		if err != nil {
+			return errors.Wrapf(err, "error creating temporary passwd file for container %s", c.ID())
+		}
+		if newPasswd != "" {
+			// Make /etc/passwd
+			// If it already exists, delete so we can recreate
+			delete(c.state.BindMounts, "/etc/passwd")
+			c.state.BindMounts["/etc/passwd"] = newPasswd
+		}
+		if newGroup != "" {
+			// Make /etc/group
+			// If it already exists, delete so we can recreate
+			delete(c.state.BindMounts, "/etc/group")
+			c.state.BindMounts["/etc/group"] = newGroup
+		}
 	}
 
 	// Make /etc/hostname

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -68,6 +68,8 @@ type InspectContainerConfig struct {
 	Timeout uint `json:"Timeout"`
 	// StopTimeout is time before container is stopped when calling stop
 	StopTimeout uint `json:"StopTimeout"`
+	// Passwd determines whether or not podman can add entries to /etc/passwd and /etc/group
+	Passwd *bool `json:"Passwd,omitempty"`
 }
 
 // InspectRestartPolicy holds information about the container's restart policy.

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1794,6 +1794,17 @@ func WithHostDevice(dev []specs.LinuxDevice) CtrCreateOption {
 	}
 }
 
+// WithSelectedPasswordManagement makes it so that the container either does or does not setup /etc/passwd or /etc/group
+func WithSelectedPasswordManagement(passwd *bool) CtrCreateOption {
+	return func(c *Container) error {
+		if c.valid {
+			return define.ErrCtrFinalized
+		}
+		c.config.Passwd = passwd
+		return nil
+	}
+}
+
 // Pod Creation Options
 
 // WithPodCreateCommand adds the full command plus arguments of the current

--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -19,11 +19,15 @@ import (
 func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	var sg specgen.SpecGenerator
+
 	if err := json.NewDecoder(r.Body).Decode(&sg); err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
-
+	if sg.Passwd == nil {
+		t := true
+		sg.Passwd = &t
+	}
 	warn, err := generate.CompleteSpec(r.Context(), runtime, &sg)
 	if err != nil {
 		utils.InternalServerError(w, err)

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -341,6 +341,7 @@ type ContainerRunOptions struct {
 	Rm           bool
 	SigProxy     bool
 	Spec         *specgen.SpecGenerator
+	Passwd       bool
 }
 
 // ContainerRunReport describes the results of running

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -927,6 +927,7 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 	for _, w := range warn {
 		fmt.Fprintf(os.Stderr, "%s\n", w)
 	}
+
 	rtSpec, spec, optsN, err := generate.MakeContainer(ctx, ic.Libpod, opts.Spec)
 	if err != nil {
 		return nil, err

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -482,5 +482,8 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 	if s.PidFile != "" {
 		options = append(options, libpod.WithPidFile(s.PidFile))
 	}
+
+	options = append(options, libpod.WithSelectedPasswordManagement(s.Passwd))
+
 	return options, nil
 }

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -201,6 +201,8 @@ type ContainerBasicConfig struct {
 	// UnsetEnvAll unsets all default environment variables from the image or from buildin
 	// Optional.
 	UnsetEnvAll bool `json:"unsetenvall,omitempty"`
+	// Passwd is a container run option that determines if we are validating users/groups before running the container
+	Passwd *bool `json:"manage_password,omitempty"`
 }
 
 // ContainerStorageConfig contains information on the storage configuration of a

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -698,6 +698,9 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 
 	// Initcontainers
 	s.InitContainerType = c.InitContainerType
+
+	t := true
+	s.Passwd = &t
 	return nil
 }
 

--- a/test/e2e/run_passwd_test.go
+++ b/test/e2e/run_passwd_test.go
@@ -125,4 +125,16 @@ USER 1000`, ALPINE)
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(Not(ContainSubstring("/etc/group")))
 	})
+
+	It("podman run --no-manage-passwd flag", func() {
+		run := podmanTest.Podman([]string{"run", "--user", "1234:1234", ALPINE, "cat", "/etc/passwd"})
+		run.WaitWithDefaultTimeout()
+		Expect(run).Should(Exit(0))
+		Expect(run.OutputToString()).To(ContainSubstring("1234:1234"))
+
+		run = podmanTest.Podman([]string{"run", "--passwd=false", "--user", "1234:1234", ALPINE, "cat", "/etc/passwd"})
+		run.WaitWithDefaultTimeout()
+		Expect(run).Should(Exit(0))
+		Expect(run.OutputToString()).NotTo((ContainSubstring("1234:1234")))
+	})
 })


### PR DESCRIPTION
added support for a new flag --passwd which, when false, prohibits podman from creating entries in
/etc/passwd and /etc/groups allowing users to modify those files in the container entrypoint

resolves #11805

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
