### PR TITLE
Add option for ign override

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -83,6 +83,10 @@ func init() {
 	IgnitionPathFlagName := "ignition-path"
 	flags.StringVar(&initOpts.IgnitionPath, IgnitionPathFlagName, "", "Path to ignition file")
 	_ = initCmd.RegisterFlagCompletionFunc(IgnitionPathFlagName, completion.AutocompleteDefault)
+
+	IgnitionOverridePathFlagName := "ignition-override-path"
+	flags.StringSliceVar(&initOpts.IgnitionOverridePaths, IgnitionOverridePathFlagName, []string{}, "Path to ignition override files")
+	_ = initCmd.RegisterFlagCompletionFunc(IgnitionOverridePathFlagName, completion.AutocompleteDefault)
 }
 
 // TODO should we allow for a users to append to the qemu cmdline?

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -32,6 +32,12 @@ Number of CPUs.
 
 Size of the disk for the guest VM in GB.
 
+#### **--ignition-override-path**
+
+A path to a complete or partial ignition file that will be merged with the ignition
+file created with `podman init`.  The merging of fields and values are to add them rather
+than replace the original entries. More than one override may be specified.
+
 #### **--ignition-path**
 
 Fully qualified path of the ignition file.

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/vbauerster/mpb/v6 v6.0.4
+	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 	go.etcd.io/bbolt v1.3.6
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5

--- a/go.sum
+++ b/go.sum
@@ -1031,6 +1031,8 @@ github.com/vbauerster/mpb/v7 v7.1.3/go.mod h1:X5GlohZw2fIpypMXWaKart+HGSAjpz49sk
 github.com/vbauerster/mpb/v7 v7.1.5/go.mod h1:4M8+qAoQqV60WDNktBM5k05i1iTrXE7rjKOHEVkVlec=
 github.com/vbauerster/mpb/v7 v7.2.0 h1:WfCkVMNQfDZy8ZZ2r7YFXP7bi5+mnCiSecakBDYGW+E=
 github.com/vbauerster/mpb/v7 v7.2.0/go.mod h1:WxlpgTrbnxiIjm5xn7IGYOopqP57hs0MhzBoGFC5ek4=
+github.com/vincent-petithory/dataurl v1.0.0 h1:cXw+kPto8NLuJtlMsI152irrVw9fRDX8AbShPRpg2CI=
+github.com/vincent-petithory/dataurl v1.0.0/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -14,16 +14,17 @@ import (
 )
 
 type InitOptions struct {
-	CPUS         uint64
-	DiskSize     uint64
-	IgnitionPath string
-	ImagePath    string
-	IsDefault    bool
-	Memory       uint64
-	Name         string
-	TimeZone     string
-	URI          url.URL
-	Username     string
+	CPUS                  uint64
+	DiskSize              uint64
+	IgnitionPath          string
+	IgnitionOverridePaths []string
+	ImagePath             string
+	IsDefault             bool
+	Memory                uint64
+	Name                  string
+	TimeZone              string
+	URI                   url.URL
+	Username              string
 }
 
 type RemoteConnectionType string

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -45,6 +45,7 @@ func getNodeGrp(grpName string) NodeGroup {
 type DynamicIgnition struct {
 	Name      string
 	Key       string
+	Resources []Resource
 	TimeZone  string
 	VMName    string
 	WritePath string
@@ -55,7 +56,7 @@ func NewIgnitionFile(ign DynamicIgnition) error {
 	if len(ign.Name) < 1 {
 		ign.Name = DefaultIgnitionUserName
 	}
-	ignVersion := Ignition{
+	ignition := Ignition{
 		Version: "3.2.0",
 	}
 
@@ -169,8 +170,15 @@ WantedBy=default.target
 				Contents: &deMoby,
 			},
 		}}
+
+	if ign.Resources != nil && len(ign.Resources) > 0 {
+		ignitionConfig := IgnitionConfig{
+			Merge: ign.Resources,
+		}
+		ignition.Config = ignitionConfig
+	}
 	ignConfig := Config{
-		Ignition: ignVersion,
+		Ignition: ignition,
 		Passwd:   ignPassword,
 		Storage:  ignStorage,
 		Systemd:  ignSystemd,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -672,6 +672,9 @@ github.com/vbauerster/mpb/v7
 github.com/vbauerster/mpb/v7/cwriter
 github.com/vbauerster/mpb/v7/decor
 github.com/vbauerster/mpb/v7/internal
+# github.com/vincent-petithory/dataurl v1.0.0
+## explicit
+github.com/vincent-petithory/dataurl
 # github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 ## explicit
 github.com/vishvananda/netlink


### PR DESCRIPTION
Users suggested we add the ability to merge a user's ignition file with
the ignition fie created by podman init.  You can now specify one or
more override files which will be added to the default ignition file.

Fixes: #11383

[NO NEW TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
