### PR TITLE
clarify `io.podman.annotations.seccomp`

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -949,11 +949,12 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 - `no-new-privileges` : Disable container processes from gaining additional privileges
 
-- `seccomp=unconfined` : Turn off seccomp confinement for the container
-- `seccomp=profile.json` :  White listed syscalls seccomp Json file to be used as a seccomp filter
+- `seccomp=unconfined` : Turn off seccomp confinement for the container.
+- `seccomp=profile.json` : JSON file to be used as a seccomp filter. Note that the `io.podman.annotations.seccomp` annotation is set with the specified value as shown in `podman inspect`.
 
 - `proc-opts=OPTIONS` : Comma-separated list of options to use for the /proc mount. More details for the
   possible mount options are specified in the **proc(5)** man page.
+
 
 - **unmask**=_ALL_ or _/path/1:/path/2_, or shell expanded paths (/proc/*): Paths to unmask separated by a colon. If set to **ALL**, it will unmask all the paths that are masked or made read only by default.
   The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.**  The default paths that are read only are **/proc/asound, /proc/bus, /proc/fs, /proc/irq, /proc/sys, /proc/sysrq-trigger, /sys/fs/cgroup**.

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -997,8 +997,8 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 - **no-new-privileges**: Disable container processes from gaining additional privileges
 
-- **seccomp=unconfined**: Turn off seccomp confinement for the container
-- **seccomp**=_profile.json_: Allowed syscall list seccomp JSON file to be used as a seccomp filter
+- **seccomp=unconfined**: Turn off seccomp confinement for the container.
+- **seccomp=profile.json**: JSON file to be used as a seccomp filter. Note that the `io.podman.annotations.seccomp` annotation is set with the specified value as shown in `podman inspect`.
 
 - **proc-opts**=_OPTIONS_ : Comma-separated list of options to use for the /proc mount. More details
   for the possible mount options are specified in the **proc(5)** man page.

--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -66,3 +66,15 @@ const (
 	// annotation.
 	InspectResponseFalse = "FALSE"
 )
+
+// IsReservedAnnotation returns true if the specified value corresponds to an
+// already reserved annotation that Podman sets during container creation.
+func IsReservedAnnotation(value string) bool {
+	switch value {
+	case InspectAnnotationCIDFile, InspectAnnotationAutoremove, InspectAnnotationVolumesFrom, InspectAnnotationPrivileged, InspectAnnotationPublishAll, InspectAnnotationInit, InspectAnnotationLabel, InspectAnnotationSeccomp, InspectAnnotationApparmor, InspectResponseTrue, InspectResponseFalse:
+		return true
+
+	default:
+		return false
+	}
+}

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -156,7 +156,9 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 
 		// Add annotations from the image
 		for k, v := range inspectData.Annotations {
-			annotations[k] = v
+			if !define.IsReservedAnnotation(k) {
+				annotations[k] = v
+			}
 		}
 	}
 


### PR DESCRIPTION
Clarify the semantics of the `io.podman.annotations.seccomp` annotation
which is set when a container has been created with a custom seccomp
profile.

Fixes: #12671
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

