### PR TITLE
mountOpts: dont do early failure while getting `DefaultMountOpts`

### DIFF
--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -136,7 +137,8 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 	}
 	defaults, err := getDefaultMountOptions(sourcePath)
 	if err != nil {
-		return nil, err
+		logrus.Warnf("Unable to get default mount options: %v", err)
+		logrus.Warnf("If not specified podman will fallback to default [noexec=%v, nosuid=%v, nodev=%v] for mount source: %s", defaults.noexec, defaults.nosuid, defaults.nodev, sourcePath)
 	}
 	if !foundExec && defaults.noexec {
 		newOptions = append(newOptions, "noexec")

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -491,6 +491,13 @@ RUN sh -c "cd /etc/apk && ln -s ../../testfile"`, ALPINE)
 		Expect(volMount).To(ExitWithError())
 	})
 
+	It("podman mount with invalid path must be failed from OCI not early", func() {
+		volMount := podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:/tmp", "/not/a/real/path"), ALPINE, "ls"})
+		volMount.WaitWithDefaultTimeout()
+		Expect(volMount.ErrorToString()).To(ContainSubstring("OCI runtime"))
+		Expect(volMount).To(ExitWithError())
+	})
+
 	It("Podman fix for CVE-2020-1726", func() {
 		volName := "testVol"
 		volCreate := podmanTest.Podman([]string{"volume", "create", volName})


### PR DESCRIPTION
OCI `hooks` can still do magic to source mount paths, so if they are not
accessible do not fail for getting `DefaultMountOpts` instead `warn`
and fallback to programmed `defaults`.

If anything bad happens let OCI runtime perform failure.

Closes: https://github.com/containers/podman/issues/12650