### PR TITLE
Always run passwd management code when DB value is nil

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1763,7 +1763,7 @@ func (c *Container) makeBindMounts() error {
 	// SHM is always added when we mount the container
 	c.state.BindMounts["/dev/shm"] = c.config.ShmDir
 
-	if c.config.Passwd != nil && *c.config.Passwd {
+	if c.config.Passwd == nil || *c.config.Passwd {
 		newPasswd, newGroup, err := c.generatePasswdAndGroup()
 		if err != nil {
 			return errors.Wrapf(err, "error creating temporary passwd file for container %s", c.ID())


### PR DESCRIPTION
This ensures that existing containers will still manage `/etc/passwd` by default, as they have been doing until now. New containers that explicitly set `false` will still have passwd management disabled, but otherwise the code will run.

[NO NEW TESTS NEEDED] This will only be caught on upgrade and I don't really know how to write update tests - and Ed is on PTO.