### PR TITLE
Add podman rm --depend

### DIFF
--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -61,7 +61,8 @@ func rmFlags(cmd *cobra.Command) {
 
 	flags.BoolVarP(&rmOptions.All, "all", "a", false, "Remove all containers")
 	flags.BoolVarP(&rmOptions.Ignore, "ignore", "i", false, "Ignore errors when a specified container is missing")
-	flags.BoolVarP(&rmOptions.Force, "force", "f", false, "Force removal of a running or unusable container.  The default is false")
+	flags.BoolVarP(&rmOptions.Force, "force", "f", false, "Force removal of a running or unusable container")
+	flags.BoolVar(&rmOptions.Depend, "depend", false, "Remove container and all containers that depend on the selected container")
 	timeFlagName := "time"
 	flags.UintVarP(&stopTimeout, timeFlagName, "t", containerConfig.Engine.StopTimeout, "Seconds to wait for stop before killing the container")
 	_ = cmd.RegisterFlagCompletionFunc(timeFlagName, completion.AutocompleteNone)

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -137,7 +137,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 				runtimeFlag := cmd.Root().Flags().Lookup("runtime")
 				if runtimeFlag == nil {
 					return errors.Errorf(
-						"Unexcpected error setting runtime to '%s' for restore",
+						"setting runtime to '%s' for restore",
 						*runtime,
 					)
 				}
@@ -217,7 +217,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 
 	context := cmd.Root().LocalFlags().Lookup("context")
 	if context.Value.String() != "default" {
-		return errors.New("Podman does not support swarm, the only --context value allowed is \"default\"")
+		return errors.New("podman does not support swarm, the only --context value allowed is \"default\"")
 	}
 	if !registry.IsRemote() {
 		if cmd.Flag("cpu-profile").Changed {

--- a/cmd/podman/utils/error.go
+++ b/cmd/podman/utils/error.go
@@ -27,7 +27,7 @@ func (o OutputErrors) PrintErrors() (lastError error) {
    instead returns a message and we cast it to a new error.
 
    Following function performs parsing on build error and returns
-   exit status which was exepected for this current build
+   exit status which was expected for this current build
 */
 func ExitCodeFromBuildError(errorMsg string) (int, error) {
 	if strings.Contains(errorMsg, "exit status") {

--- a/cmd/winpath/main.go
+++ b/cmd/winpath/main.go
@@ -114,7 +114,7 @@ func addPathToRegistry(dir string) error {
 	return err
 }
 
-// Removes all occurences of a directory path from the Windows path stored in the registry
+// Removes all occurrences of a directory path from the Windows path stored in the registry
 func removePathFromRegistry(path string) error {
 	k, err := registry.OpenKey(registry.CURRENT_USER, Environment, registry.READ|registry.WRITE)
 	if err != nil {
@@ -155,7 +155,7 @@ func removePathFromRegistry(path string) error {
 	return err
 }
 
-// Sends a notification message to all top level windows informing them the environmental setings have changed.
+// Sends a notification message to all top level windows informing them the environmental settings have changed.
 // Applications such as the Windows command prompt and powershell will know to stop caching stale values on
 // subsequent restarts. Since applications block the sender when receiving a message, we set a 3 second timeout
 func broadcastEnvironmentChange() {

--- a/docs/source/markdown/podman-rm.1.md
+++ b/docs/source/markdown/podman-rm.1.md
@@ -18,6 +18,10 @@ Running or unusable containers will not be removed without the **-f** option.
 
 Remove all containers.  Can be used in conjunction with **-f** as well.
 
+#### **--depend**
+
+Remove selected container and recursively remove all containers that depend on it.
+
 #### **--cidfile**
 
 Read container ID from the specified file and remove the container.  Can be specified multiple times.
@@ -54,6 +58,11 @@ created with **podman volume create**, or the **--volume** option of **podman ru
 Remove a container by its name *mywebserver*
 ```
 $ podman rm mywebserver
+```
+
+Remove a *mywebserver* container and all of the containers that depend on it
+```
+$ podman rm --depend mywebserver
 ```
 
 Remove several containers by name and container id.

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -138,7 +138,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 
 	// if layers field not set assume its not from a valid podman-client
 	// could be a docker client, set `layers=true` since that is the default
-	// expected behviour
+	// expected behaviour
 	if !utils.IsLibpodRequest(r) {
 		if _, found := r.URL.Query()["layers"]; !found {
 			query.Layers = true

--- a/pkg/api/handlers/swagger/swagger.go
+++ b/pkg/api/handlers/swagger/swagger.go
@@ -111,6 +111,13 @@ type swagLibpodInspectImageResponse struct {
 	}
 }
 
+// Rm containers
+// swagger:response DocsLibpodContainerRmReport
+type swagLibpodContainerRmReport struct {
+	// in: body
+	Body []handlers.LibpodContainersRmReport
+}
+
 // Prune containers
 // swagger:response DocsContainerPruneReport
 type swagContainerPruneReport struct {

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -53,6 +53,17 @@ type LibpodContainersPruneReport struct {
 	PruneError string `json:"Err,omitempty"`
 }
 
+type LibpodContainersRmReport struct {
+	ID string `json:"Id"`
+	// Error which occurred during Rm operation (if any).
+	// This field is optional and may be omitted if no error occurred.
+	//
+	// Extensions:
+	// x-omitempty: true
+	// x-nullable: true
+	RmError string `json:"Err,omitempty"`
+}
+
 type Info struct {
 	docker.Info
 	BuildahVersion     string

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -817,9 +817,22 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    required: true
 	//    description: the name or ID of the container
 	//  - in: query
+	//    name: depend
+	//    type: boolean
+	//    description: additionally remove containers that depend on the container to be removed
+	//  - in: query
 	//    name: force
 	//    type: boolean
-	//    description: need something
+	//    description: force stop container if running
+	//  - in: query
+	//    name: ignore
+	//    type: boolean
+	//    description: ignore errors when the container to be removed does not existxo
+	//  - in: query
+	//    name: timeout
+	//    type: integer
+	//    default: 10
+	//    description: number of seconds to wait before killing container when force removing
 	//  - in: query
 	//    name: v
 	//    type: boolean
@@ -827,6 +840,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// produces:
 	// - application/json
 	// responses:
+	//   200:
+	//     $ref: "#/responses/DocsLibpodContainerRmReport"
 	//   204:
 	//     description: no error
 	//   400:

--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -78,25 +78,26 @@ func Prune(ctx context.Context, options *PruneOptions) ([]*reports.PruneReport, 
 // The volumes bool dictates that a container's volumes should also be removed.
 // The All option indicates that all containers should be removed
 // The Ignore option indicates that if a container did not exist, ignore the error
-func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) error {
+func Remove(ctx context.Context, nameOrID string, options *RemoveOptions) ([]*reports.RmReport, error) {
 	if options == nil {
 		options = new(RemoveOptions)
 	}
+	var reports []*reports.RmReport
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
-		return err
+		return reports, err
 	}
 	params, err := options.ToParams()
 	if err != nil {
-		return err
+		return reports, err
 	}
 	response, err := conn.DoRequest(ctx, nil, http.MethodDelete, "/containers/%s", params, nil, nameOrID)
 	if err != nil {
-		return err
+		return reports, err
 	}
 	defer response.Body.Close()
 
-	return response.Process(nil)
+	return reports, response.Process(&reports)
 }
 
 // Inspect returns low level information about a Container.  The nameOrID can be a container name

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -138,6 +138,7 @@ type PruneOptions struct {
 //go:generate go run ../generator/generator.go RemoveOptions
 // RemoveOptions are optional options for removing containers
 type RemoveOptions struct {
+	Depend  *bool
 	Ignore  *bool
 	Force   *bool
 	Volumes *bool

--- a/pkg/bindings/containers/types_remove_options.go
+++ b/pkg/bindings/containers/types_remove_options.go
@@ -17,6 +17,21 @@ func (o *RemoveOptions) ToParams() (url.Values, error) {
 	return util.ToParams(o)
 }
 
+// WithDepend set field Depend to given value
+func (o *RemoveOptions) WithDepend(value bool) *RemoveOptions {
+	o.Depend = &value
+	return o
+}
+
+// GetDepend returns value of field Depend
+func (o *RemoveOptions) GetDepend() bool {
+	if o.Depend == nil {
+		var z bool
+		return z
+	}
+	return *o.Depend
+}
+
 // WithIgnore set field Ignore to given value
 func (o *RemoveOptions) WithIgnore(value bool) *RemoveOptions {
 	o.Ignore = &value

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -129,16 +129,12 @@ type RestartReport struct {
 
 type RmOptions struct {
 	All     bool
+	Depend  bool
 	Force   bool
 	Ignore  bool
 	Latest  bool
 	Timeout *uint
 	Volumes bool
-}
-
-type RmReport struct {
-	Err error
-	Id  string //nolint
 }
 
 type ContainerInspectReport struct {

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -40,7 +40,7 @@ type ContainerEngine interface {
 	ContainerRename(ctr context.Context, nameOrID string, options ContainerRenameOptions) error
 	ContainerRestart(ctx context.Context, namesOrIds []string, options RestartOptions) ([]*RestartReport, error)
 	ContainerRestore(ctx context.Context, namesOrIds []string, options RestoreOptions) ([]*RestoreReport, error)
-	ContainerRm(ctx context.Context, namesOrIds []string, options RmOptions) ([]*RmReport, error)
+	ContainerRm(ctx context.Context, namesOrIds []string, options RmOptions) ([]*reports.RmReport, error)
 	ContainerRun(ctx context.Context, opts ContainerRunOptions) (*ContainerRunReport, error)
 	ContainerRunlabel(ctx context.Context, label string, image string, args []string, opts ContainerRunlabelOptions) error
 	ContainerStart(ctx context.Context, namesOrIds []string, options ContainerStartOptions) ([]*ContainerStartReport, error)

--- a/pkg/domain/entities/reports/containers.go
+++ b/pkg/domain/entities/reports/containers.go
@@ -1,0 +1,28 @@
+package reports
+
+type RmReport struct {
+	Id  string `json:"Id"` //nolint
+	Err error  `json:"Err,omitempty"`
+}
+
+func RmReportsIds(r []*RmReport) []string {
+	ids := make([]string, 0, len(r))
+	for _, v := range r {
+		if v == nil || v.Id == "" {
+			continue
+		}
+		ids = append(ids, v.Id)
+	}
+	return ids
+}
+
+func RmReportsErrs(r []*RmReport) []error {
+	errs := make([]error, 0, len(r))
+	for _, v := range r {
+		if v == nil || v.Err == nil {
+			continue
+		}
+		errs = append(errs, v.Err)
+	}
+	return errs
+}

--- a/pkg/specgen/generate/ports.go
+++ b/pkg/specgen/generate/ports.go
@@ -206,7 +206,7 @@ func ParsePortMapping(portMappings []types.PortMapping, exposePorts map[uint16][
 	}
 
 	// we do no longer need the original port mappings
-	// set it to 0 length so we can resuse it to populate
+	// set it to 0 length so we can reuse it to populate
 	// the slice again while keeping the underlying capacity
 	portMappings = portMappings[:0]
 

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -95,7 +95,7 @@ type PodNetworkConfig struct {
 	// Map of networks names ot ids the container should join to.
 	// You can request additional settings for each network, you can
 	// set network aliases, static ips, static mac address  and the
-	// network interface name for this container on the specifc network.
+	// network interface name for this container on the specific network.
 	// If the map is empty and the bridge network mode is set the container
 	// will be joined to the default network.
 	Networks map[string]types.PerNetworkOptions

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -426,7 +426,7 @@ type ContainerNetworkConfig struct {
 	// Map of networks names ot ids the container should join to.
 	// You can request additional settings for each network, you can
 	// set network aliases, static ips, static mac address  and the
-	// network interface name for this container on the specifc network.
+	// network interface name for this container on the specific network.
 	// If the map is empty and the bridge network mode is set the container
 	// will be joined to the default network.
 	Networks map[string]nettypes.PerNetworkOptions

--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -53,7 +53,7 @@ t GET libpod/images/$IMAGE/json 200 \
   .RepoTags[-1]=$IMAGE
 
 # Remove the registry container
-t DELETE libpod/containers/registry?force=true 204
+t DELETE libpod/containers/registry?force=true 200
 
 # Remove images
 t DELETE libpod/images/$IMAGE 200 \

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -85,7 +85,7 @@ else
     fi
 fi
 
-t DELETE libpod/containers/$cid 204
+t DELETE libpod/containers/$cid 200 .[0].Id=$cid
 
 # Issue #6799: it should be possible to start a container, even w/o args.
 t POST libpod/containers/create?name=test_noargs Image=${IMAGE} 201 \
@@ -100,7 +100,7 @@ t GET    libpod/containers/${cid}/json 200 \
   .State.Status~\\\(exited\\\|stopped\\\) \
   .State.Running=false \
   .State.ExitCode=0
-t DELETE libpod/containers/$cid 204
+t DELETE libpod/containers/$cid 200 .[0].Id=$cid
 
 CNAME=myfoo
 podman run -d --name $CNAME $IMAGE top
@@ -190,8 +190,8 @@ t GET containers/myctr/json 200 \
 t DELETE images/localhost/newrepo:latest?force=true 200
 t DELETE images/localhost/newrepo:v1?force=true 200
 t DELETE images/localhost/newrepo:v2?force=true 200
-t DELETE libpod/containers/$cid?force=true 204
-t DELETE libpod/containers/myctr 204
+t DELETE libpod/containers/$cid?force=true 200 .[0].Id=$cid
+t DELETE libpod/containers/myctr 200
 t DELETE libpod/containers/bogus 404
 
 

--- a/test/apiv2/22-stop.at
+++ b/test/apiv2/22-stop.at
@@ -11,7 +11,7 @@ podman run -dt --name mytop $IMAGE top &>/dev/null
 t GET  libpod/containers/mytop/json 200 .State.Status=running
 t POST libpod/containers/mytop/stop 204
 t GET  libpod/containers/mytop/json 200 .State.Status~\\\(exited\\\|stopped\\\)
-t DELETE libpod/containers/mytop    204
+t DELETE libpod/containers/mytop    200
 
 # stop, by ID
 # Remember that podman() hides all output; we need to get our CID via inspect
@@ -21,4 +21,4 @@ t GET  libpod/containers/mytop/json 200 .State.Status=running
 cid=$(jq -r .Id <<<"$output")
 t POST libpod/containers/$cid/stop  204
 t GET  libpod/containers/mytop/json 200 .State.Status~\\\(exited\\\|stopped\\\)
-t DELETE libpod/containers/mytop    204
+t DELETE libpod/containers/mytop    200

--- a/test/apiv2/25-containersMore.at
+++ b/test/apiv2/25-containersMore.at
@@ -51,7 +51,7 @@ like "$output" ".*merged" "Check container mount"
 # Unmount the container
 t POST libpod/containers/foo/unmount 204
 
-t DELETE libpod/containers/foo?force=true 204
+t DELETE libpod/containers/foo?force=true 200
 
 podman run $IMAGE true
 
@@ -79,7 +79,7 @@ like "$output" ".*metadata:.*" "Check generated kube yaml(service=true) - metada
 like "$output" ".*spec:.*" "Check generated kube yaml(service=true) - spec"
 like "$output" ".*kind:\\sService.*" "Check generated kube yaml(service=true) - kind: Service"
 
-t DELETE libpod/containers/$cid 204
+t DELETE libpod/containers/$cid 200 .[0].Id=$cid
 
 # Create 3 stopped containers to test containers prune
 podman run $IMAGE true

--- a/test/apiv2/python/rest_api/test_v2_0_0_container.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_container.py
@@ -99,7 +99,7 @@ class ContainerTestCase(APITestCase):
 
     def test_delete(self):
         r = requests.delete(self.uri(self.resolve_container("/containers/{}?force=true")))
-        self.assertEqual(r.status_code, 204, r.text)
+        self.assertEqual(r.status_code, 200, r.text)
 
     def test_stop(self):
         r = requests.post(self.uri(self.resolve_container("/containers/{}/start")))

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -41,7 +41,7 @@ function setup() {
     # This one must fail
     run_podman 125 --context=swarm version
     is "$output" \
-       "Error: Podman does not support swarm, the only --context value allowed is \"default\"" \
+       "Error: podman does not support swarm, the only --context value allowed is \"default\"" \
        "--context=default or fail"
 }
 

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -58,6 +58,18 @@ load helpers
     run_podman rm -af
 }
 
+@test "podman rm --depend" {
+    run_podman create $IMAGE
+    dependCid=$output
+    run_podman create --net=container:$dependCid $IMAGE
+    cid=$output
+    run_podman 125 rm $dependCid
+    is "$output" "Error: container $dependCid has dependent containers which must be removed before it:.*" "Fail to remove because of dependencies"
+    run_podman rm --depend $dependCid
+    is "$output" ".*$cid" "Container should have been removed"
+    is "$output" ".*$dependCid" "Depend container should have been removed"
+}
+
 # I'm sorry! This test takes 13 seconds. There's not much I can do about it,
 # please know that I think it's justified: podman 1.5.0 had a strange bug
 # in with exit status was not preserved on some code paths with 'rm -f'


### PR DESCRIPTION
This option causes Podman to not only remove the specified containers
but all of the containers that depend on the specified
containers.
Fixes: https://github.com/containers/podman/issues/10360

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
