### PR TITLE
fix: fix up memory usage for cgroup v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.0.1
 	github.com/containernetworking/plugins v1.0.1
 	github.com/containers/buildah v1.23.1
-	github.com/containers/common v0.46.1-0.20211209220542-24f363480347
+	github.com/containers/common v0.46.1-0.20211226134707-c7fd073cc020
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.17.1-0.20211207161909-6f3c8453e1a7
 	github.com/containers/ocicrypt v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -283,8 +283,8 @@ github.com/containernetworking/plugins v1.0.1/go.mod h1:QHCfGpaTwYTbbH+nZXKVTxNB
 github.com/containers/buildah v1.23.1 h1:Tpc9DsRuU+0Oofewpxb6OJVNQjCu7yloN/obUqzfDTY=
 github.com/containers/buildah v1.23.1/go.mod h1:4WnrN0yrA7ab0ppgunixu2WM1rlD2rG8QLJAKbEkZlQ=
 github.com/containers/common v0.44.2/go.mod h1:7sdP4vmI5Bm6FPFxb3lvAh1Iktb6tiO1MzjUzhxdoGo=
-github.com/containers/common v0.46.1-0.20211209220542-24f363480347 h1:6CS7RroQLJu/SgUJXGZ3bOs2vnh9rxEnxczDcGjStBw=
-github.com/containers/common v0.46.1-0.20211209220542-24f363480347/go.mod h1:SoHWZESBD7dbqIOkvKrIg5D8EuVIQgL6vkOvv0Yebws=
+github.com/containers/common v0.46.1-0.20211226134707-c7fd073cc020 h1:+OZWnt3sFdo6q4pB77UV1uKRMGGaH+8sWNSKuIx+NjY=
+github.com/containers/common v0.46.1-0.20211226134707-c7fd073cc020/go.mod h1:Nkfv5+UF8cjymQuH++qPLi8S5XE4KJu5heDZE2be8D8=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.16.0/go.mod h1:XgTpfAPLRGOd1XYyCU5cISFr777bLmOerCSpt/v7+Q4=

--- a/vendor/github.com/containers/common/libimage/copier.go
+++ b/vendor/github.com/containers/common/libimage/copier.go
@@ -218,15 +218,7 @@ func (r *Runtime) newCopier(options *CopyOptions) (*copier, error) {
 
 	c.systemContext.DockerArchiveAdditionalTags = options.dockerArchiveAdditionalTags
 
-	if options.Architecture != "" {
-		c.systemContext.ArchitectureChoice = options.Architecture
-	}
-	if options.OS != "" {
-		c.systemContext.OSChoice = options.OS
-	}
-	if options.Variant != "" {
-		c.systemContext.VariantChoice = options.Variant
-	}
+	c.systemContext.OSChoice, c.systemContext.ArchitectureChoice, c.systemContext.VariantChoice = NormalizePlatform(options.OS, options.Architecture, options.Variant)
 
 	if options.SignaturePolicyPath != "" {
 		c.systemContext.SignaturePolicyPath = options.SignaturePolicyPath

--- a/vendor/github.com/containers/common/libimage/filters.go
+++ b/vendor/github.com/containers/common/libimage/filters.go
@@ -19,26 +19,53 @@ import (
 // indicates that the image matches the criteria.
 type filterFunc func(*Image) (bool, error)
 
-// filterImages returns a slice of images which are passing all specified
-// filters.
-func filterImages(images []*Image, filters []filterFunc) ([]*Image, error) {
-	if len(filters) == 0 {
-		return images, nil
-	}
-	result := []*Image{}
-	for i := range images {
-		include := true
-		var err error
-		for _, filter := range filters {
-			include, err = filter(images[i])
+// Apply the specified filters.  At least one filter of each key must apply.
+func (i *Image) applyFilters(filters map[string][]filterFunc) (bool, error) {
+	matches := false
+	for key := range filters { // and
+		matches = false
+		for _, filter := range filters[key] { // or
+			var err error
+			matches, err = filter(i)
 			if err != nil {
-				return nil, err
+				// Some images may have been corrupted in the
+				// meantime, so do an extra check and make the
+				// error non-fatal (see containers/podman/issues/12582).
+				if errCorrupted := i.isCorrupted(""); errCorrupted != nil {
+					logrus.Errorf(errCorrupted.Error())
+					return false, nil
+				}
+				return false, err
 			}
-			if !include {
+			if matches {
 				break
 			}
 		}
-		if include {
+		if !matches {
+			return false, nil
+		}
+	}
+	return matches, nil
+}
+
+// filterImages returns a slice of images which are passing all specified
+// filters.
+func (r *Runtime) filterImages(ctx context.Context, images []*Image, options *ListImagesOptions) ([]*Image, error) {
+	if len(options.Filters) == 0 || len(images) == 0 {
+		return images, nil
+	}
+
+	filters, err := r.compileImageFilters(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	result := []*Image{}
+	for i := range images {
+		match, err := images[i].applyFilters(filters)
+		if err != nil {
+			return nil, err
+		}
+		if match {
 			result = append(result, images[i])
 		}
 	}
@@ -48,7 +75,7 @@ func filterImages(images []*Image, filters []filterFunc) ([]*Image, error) {
 // compileImageFilters creates `filterFunc`s for the specified filters.  The
 // required format is `key=value` with the following supported keys:
 //           after, since, before, containers, dangling, id, label, readonly, reference, intermediate
-func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOptions) ([]filterFunc, error) {
+func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOptions) (map[string][]filterFunc, error) {
 	logrus.Tracef("Parsing image filters %s", options.Filters)
 
 	var tree *layerTree
@@ -63,12 +90,14 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 		return tree, nil
 	}
 
-	filterFuncs := []filterFunc{}
-	for _, filter := range options.Filters {
+	filters := map[string][]filterFunc{}
+	duplicate := map[string]bool{}
+	for _, f := range options.Filters {
 		var key, value string
-		split := strings.SplitN(filter, "=", 2)
+		var filter filterFunc
+		split := strings.SplitN(f, "=", 2)
 		if len(split) != 2 {
-			return nil, errors.Errorf("invalid image filter %q: must be in the format %q", filter, "filter=value")
+			return nil, errors.Errorf("invalid image filter %q: must be in the format %q", f, "filter=value")
 		}
 
 		key = split[0]
@@ -76,87 +105,149 @@ func (r *Runtime) compileImageFilters(ctx context.Context, options *ListImagesOp
 		switch key {
 
 		case "after", "since":
-			img, _, err := r.LookupImage(value, nil)
+			img, err := r.time(key, value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "could not find local image for filter %q", filter)
+				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterAfter(img.Created()))
+			key = "since"
+			filter = filterAfter(img.Created())
 
 		case "before":
-			img, _, err := r.LookupImage(value, nil)
+			img, err := r.time(key, value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "could not find local image for filter %q", filter)
+				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterBefore(img.Created()))
+			filter = filterBefore(img.Created())
 
 		case "containers":
-			switch value {
-			case "false", "true":
-			case "external":
-				if options.IsExternalContainerFunc == nil {
-					return nil, fmt.Errorf("libimage error: external containers filter without callback")
-				}
-			default:
-				return nil, fmt.Errorf("unsupported value %q for containers filter", value)
+			if err := r.containers(duplicate, key, value, options.IsExternalContainerFunc); err != nil {
+				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterContainers(value, options.IsExternalContainerFunc))
+			filter = filterContainers(value, options.IsExternalContainerFunc)
 
 		case "dangling":
-			dangling, err := strconv.ParseBool(value)
+			dangling, err := r.bool(duplicate, key, value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "non-boolean value %q for dangling filter", value)
+				return nil, err
 			}
 			t, err := getTree()
 			if err != nil {
 				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterDangling(ctx, dangling, t))
+
+			filter = filterDangling(ctx, dangling, t)
 
 		case "id":
-			filterFuncs = append(filterFuncs, filterID(value))
+			filter = filterID(value)
 
 		case "intermediate":
-			intermediate, err := strconv.ParseBool(value)
+			intermediate, err := r.bool(duplicate, key, value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "non-boolean value %q for intermediate filter", value)
+				return nil, err
 			}
 			t, err := getTree()
 			if err != nil {
 				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterIntermediate(ctx, intermediate, t))
+
+			filter = filterIntermediate(ctx, intermediate, t)
 
 		case "label":
-			filterFuncs = append(filterFuncs, filterLabel(ctx, value))
+			filter = filterLabel(ctx, value)
 
 		case "readonly":
-			readOnly, err := strconv.ParseBool(value)
+			readOnly, err := r.bool(duplicate, key, value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "non-boolean value %q for readonly filter", value)
+				return nil, err
 			}
-			filterFuncs = append(filterFuncs, filterReadOnly(readOnly))
+			filter = filterReadOnly(readOnly)
+
+		case "manifest":
+			manifest, err := r.bool(duplicate, key, value)
+			if err != nil {
+				return nil, err
+			}
+			duplicate[key] = true
+			filter = filterManifest(ctx, manifest)
 
 		case "reference":
-			filterFuncs = append(filterFuncs, filterReferences(value))
+			filter = filterReferences(value)
 
 		case "until":
-			ts, err := timetype.GetTimestamp(value, time.Now())
+			until, err := r.until(value)
 			if err != nil {
 				return nil, err
 			}
-			seconds, nanoseconds, err := timetype.ParseTimestamps(ts, 0)
-			if err != nil {
-				return nil, err
-			}
-			until := time.Unix(seconds, nanoseconds)
-			filterFuncs = append(filterFuncs, filterBefore(until))
+			filter = filterBefore(until)
 
 		default:
 			return nil, errors.Errorf("unsupported image filter %q", key)
 		}
+		filters[key] = append(filters[key], filter)
 	}
 
-	return filterFuncs, nil
+	return filters, nil
+}
+
+func (r *Runtime) containers(duplicate map[string]bool, key, value string, externalFunc IsExternalContainerFunc) error {
+	if duplicate[key] {
+		return errors.Errorf("specifying %q filter more then once is not supported", key)
+	}
+	duplicate[key] = true
+	switch value {
+	case "false", "true":
+	case "external":
+		if externalFunc == nil {
+			return fmt.Errorf("libimage error: external containers filter without callback")
+		}
+	default:
+		return fmt.Errorf("unsupported value %q for containers filter", value)
+	}
+	return nil
+}
+
+func (r *Runtime) until(value string) (time.Time, error) {
+	var until time.Time
+	ts, err := timetype.GetTimestamp(value, time.Now())
+	if err != nil {
+		return until, err
+	}
+	seconds, nanoseconds, err := timetype.ParseTimestamps(ts, 0)
+	if err != nil {
+		return until, err
+	}
+	return time.Unix(seconds, nanoseconds), nil
+}
+
+func (r *Runtime) time(key, value string) (*Image, error) {
+	img, _, err := r.LookupImage(value, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not find local image for filter filter %q=%q", key, value)
+	}
+	return img, nil
+}
+
+func (r *Runtime) bool(duplicate map[string]bool, key, value string) (bool, error) {
+	if duplicate[key] {
+		return false, errors.Errorf("specifying %q filter more then once is not supported", key)
+	}
+	duplicate[key] = true
+	set, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, errors.Wrapf(err, "non-boolean value %q for %s filter", key, value)
+	}
+	return set, nil
+}
+
+// filterManifest filters whether or not the image is a manifest list
+func filterManifest(ctx context.Context, value bool) filterFunc {
+	return func(img *Image) (bool, error) {
+		isManifestList, err := img.IsManifestList(ctx)
+		if err != nil {
+			return false, err
+		}
+		return isManifestList == value, nil
+	}
 }
 
 // filterReferences creates a reference filter for matching the specified value.

--- a/vendor/github.com/containers/common/libimage/load.go
+++ b/vendor/github.com/containers/common/libimage/load.go
@@ -35,17 +35,6 @@ func (r *Runtime) Load(ctx context.Context, path string, options *LoadOptions) (
 	var loadErrors []error
 
 	for _, f := range []func() ([]string, string, error){
-		// DOCKER-ARCHIVE - must be first (see containers/podman/issues/10809)
-		func() ([]string, string, error) {
-			logrus.Debugf("-> Attempting to load %q as a Docker archive", path)
-			ref, err := dockerArchiveTransport.ParseReference(path)
-			if err != nil {
-				return nil, dockerArchiveTransport.Transport.Name(), err
-			}
-			images, err := r.loadMultiImageDockerArchive(ctx, ref, &options.CopyOptions)
-			return images, dockerArchiveTransport.Transport.Name(), err
-		},
-
 		// OCI
 		func() ([]string, string, error) {
 			logrus.Debugf("-> Attempting to load %q as an OCI directory", path)
@@ -66,6 +55,17 @@ func (r *Runtime) Load(ctx context.Context, path string, options *LoadOptions) (
 			}
 			images, err := r.copyFromDefault(ctx, ref, &options.CopyOptions)
 			return images, ociArchiveTransport.Transport.Name(), err
+		},
+
+		// DOCKER-ARCHIVE
+		func() ([]string, string, error) {
+			logrus.Debugf("-> Attempting to load %q as a Docker archive", path)
+			ref, err := dockerArchiveTransport.ParseReference(path)
+			if err != nil {
+				return nil, dockerArchiveTransport.Transport.Name(), err
+			}
+			images, err := r.loadMultiImageDockerArchive(ctx, ref, &options.CopyOptions)
+			return images, dockerArchiveTransport.Transport.Name(), err
 		},
 
 		// DIR

--- a/vendor/github.com/containers/common/libimage/runtime.go
+++ b/vendor/github.com/containers/common/libimage/runtime.go
@@ -253,6 +253,8 @@ func (r *Runtime) LookupImage(name string, options *LookupImageOptions) (*Image,
 	if options.Variant == "" {
 		options.Variant = r.systemContext.VariantChoice
 	}
+	// Normalize platform to be OCI compatible (e.g., "aarch64" -> "arm64").
+	options.OS, options.Architecture, options.Variant = NormalizePlatform(options.OS, options.Architecture, options.Variant)
 
 	// First, check if we have an exact match in the storage. Maybe an ID
 	// or a fully-qualified image name.
@@ -489,13 +491,16 @@ func (r *Runtime) imageReferenceMatchesContext(ref types.ImageReference, options
 	}
 
 	if options.Architecture != "" && options.Architecture != data.Architecture {
-		return false, err
+		logrus.Debugf("architecture %q does not match architecture %q of image %s", options.Architecture, data.Architecture, ref)
+		return false, nil
 	}
 	if options.OS != "" && options.OS != data.Os {
-		return false, err
+		logrus.Debugf("OS %q does not match OS %q of image %s", options.OS, data.Os, ref)
+		return false, nil
 	}
 	if options.Variant != "" && options.Variant != data.Variant {
-		return false, err
+		logrus.Debugf("variant %q does not match variant %q of image %s", options.Variant, data.Variant, ref)
+		return false, nil
 	}
 
 	return true, nil
@@ -551,16 +556,7 @@ func (r *Runtime) ListImages(ctx context.Context, names []string, options *ListI
 		}
 	}
 
-	var filters []filterFunc
-	if len(options.Filters) > 0 {
-		compiledFilters, err := r.compileImageFilters(ctx, options)
-		if err != nil {
-			return nil, err
-		}
-		filters = append(filters, compiledFilters...)
-	}
-
-	return filterImages(images, filters)
+	return r.filterImages(ctx, images, options)
 }
 
 // RemoveImagesOptions allow for customizing image removal.

--- a/vendor/github.com/containers/common/pkg/cgroups/cgroups_unsupported.go
+++ b/vendor/github.com/containers/common/pkg/cgroups/cgroups_unsupported.go
@@ -2,6 +2,10 @@
 
 package cgroups
 
+import (
+	"os"
+)
+
 // IsCgroup2UnifiedMode returns whether we are running in cgroup 2 cgroup2 mode.
 func IsCgroup2UnifiedMode() (bool, error) {
 	return false, nil
@@ -11,4 +15,8 @@ func IsCgroup2UnifiedMode() (bool, error) {
 // current cgroup.
 func UserOwnsCurrentSystemdCgroup() (bool, error) {
 	return false, nil
+}
+
+func rmDirRecursively(path string) error {
+	return os.RemoveAll(path)
 }

--- a/vendor/github.com/containers/common/pkg/cgroups/pids.go
+++ b/vendor/github.com/containers/common/pkg/cgroups/pids.go
@@ -34,6 +34,9 @@ func (c *pidHandler) Apply(ctr *CgroupControl, res *spec.LinuxResources) error {
 
 // Create the cgroup
 func (c *pidHandler) Create(ctr *CgroupControl) (bool, error) {
+	if ctr.cgroup2 {
+		return false, nil
+	}
 	return ctr.createCgroupDirectory(Pids)
 }
 

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/containers/common/pkg/apparmor"
 	"github.com/containers/common/pkg/cgroupv2"
+	"github.com/containers/common/pkg/util"
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/containers/storage/types"
@@ -371,7 +372,7 @@ func defaultTmpDir() (string, error) {
 		return "/run/libpod", nil
 	}
 
-	runtimeDir, err := getRuntimeDir()
+	runtimeDir, err := util.GetRuntimeDir()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/containers/common/pkg/seccomp/errno_list.go
+++ b/vendor/github.com/containers/common/pkg/seccomp/errno_list.go
@@ -1,3 +1,5 @@
+// +build linux,seccomp
+
 package seccomp
 
 import (

--- a/vendor/github.com/containers/common/pkg/util/util.go
+++ b/vendor/github.com/containers/common/pkg/util/util.go
@@ -1,0 +1,24 @@
+package util
+
+import "regexp"
+
+// StringInSlice determines if a string is in a string slice, returns bool
+func StringInSlice(s string, sl []string) bool {
+	for _, i := range sl {
+		if i == s {
+			return true
+		}
+	}
+	return false
+}
+
+// StringMatchRegexSlice determines if a given string matches one of the given regexes, returns bool
+func StringMatchRegexSlice(s string, re []string) bool {
+	for _, r := range re {
+		m, err := regexp.MatchString(r, s)
+		if err == nil && m {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/containers/common/pkg/util/util_supported.go
+++ b/vendor/github.com/containers/common/pkg/util/util_supported.go
@@ -1,6 +1,6 @@
 // +build linux darwin
 
-package config
+package util
 
 import (
 	"fmt"
@@ -19,8 +19,8 @@ var (
 	rootlessRuntimeDir     string
 )
 
-// getRuntimeDir returns the runtime directory
-func getRuntimeDir() (string, error) {
+// GetRuntimeDir returns the runtime directory
+func GetRuntimeDir() (string, error) {
 	var rootlessRuntimeDirError error
 
 	rootlessRuntimeDirOnce.Do(func() {

--- a/vendor/github.com/containers/common/pkg/util/util_windows.go
+++ b/vendor/github.com/containers/common/pkg/util/util_windows.go
@@ -1,12 +1,12 @@
 // +build windows
 
-package config
+package util
 
 import (
 	"github.com/pkg/errors"
 )
 
 // getRuntimeDir returns the runtime directory
-func getRuntimeDir() (string, error) {
+func GetRuntimeDir() (string, error) {
 	return "", errors.New("this function is not implemented for windows")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -106,7 +106,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.46.1-0.20211209220542-24f363480347
+# github.com/containers/common v0.46.1-0.20211226134707-c7fd073cc020
 ## explicit
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
@@ -139,6 +139,7 @@ github.com/containers/common/pkg/supplemented
 github.com/containers/common/pkg/sysinfo
 github.com/containers/common/pkg/timetype
 github.com/containers/common/pkg/umask
+github.com/containers/common/pkg/util
 github.com/containers/common/version
 # github.com/containers/conmon v2.0.20+incompatible
 ## explicit


### PR DESCRIPTION

2022-01-15 update:

this PR has been included in https://github.com/containers/podman/pull/12786 , so this one could be closed

https://github.com/containers/podman/pull/12786/files#diff-e4a5be3ec14dc0340e98adece8398a26007a4e9aaed9f12a285e2c0690262a01L44

-----------------------------------------

as described in https://github.com/containers/podman/issues/12702

this PR depends on upstream PR  https://github.com/containers/common/pull/870

related file:

```
 M vendor/github.com/containers/common/pkg/cgroups/cgroups.go
 M vendor/github.com/containers/common/pkg/cgroups/memory.go
```