### PR TITLE
Compat api containers ImageId missing sha256

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -360,7 +360,7 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 		ID:         l.ID(),
 		Names:      []string{fmt.Sprintf("/%s", l.Name())},
 		Image:      imageName,
-		ImageID:    imageID,
+		ImageID:    "sha256:" + imageID,
 		Command:    strings.Join(l.Command(), " "),
 		Created:    l.CreatedTime().Unix(),
 		Ports:      ports,

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -46,6 +46,10 @@ t GET /containers/json?all=true 200 \
   .[0].Image=$IMAGE \
   $network_expect
 
+# compat API imageid with sha256: prefix
+t GET containers/json?limit=1 200 \
+  .[0].ImageID~sha256:[0-9a-f]\\{64\\}
+
 # Make sure `limit` works.
 t GET libpod/containers/json?limit=1 200 \
   length=1 \


### PR DESCRIPTION

/kind bug

**Description**

The Docker API /containers/json return the ImageId with a `sha256:` prefix. Podman compat API does not. Similar to #11656
 
**Steps to reproduce the issue:**

1. `curl -X GET --unix-socket /var/run/docker.sock "v1.40/containers/json` returns

         ...
          "ImageID": "sha256:26b77e58432b01665d7e876248c9056fa58bf4a7ab82576a024f5cf3dac146d6",
          ...    
2. podman compat API returns

        ...
        "ImageID": "0b87dc6f7a5f36edbd7cb920b7e2de73566f96c58b88a4a8ae4865e392cb2080",
        ...


**Describe the results you received:**
see above

**Describe the results you expected:**
podman prefixes ImageId with sha256:

**Additional information you deem important (e.g. issue happens only occasionally):**

**Output of `podman version`:**
Version:      3.4.2
API Version:  3.4.2
Go Version:   go1.16.6
Built:        Thu Jan  1 01:00:00 1970
OS/Arch:      linux/amd64

**Output of `podman info --debug`:**

**Package info (e.g. output of `rpm -q podman` or `apt list podman`):**

**Have you tested with the latest version of Podman and have you checked the Podman Troubleshooting Guide? (https://github.com/containers/podman/blob/master/troubleshooting.md)**
Tested with main branch

Yes

**Additional environment details (AWS, VirtualBox, physical, etc.):**
