### PR TITLE
[CI:DOCS]: sort swagger operations alpabetically

### DIFF
--- a/docs/source/_static/api.html
+++ b/docs/source/_static/api.html
@@ -18,7 +18,7 @@
     </style>
   </head>
   <body>
-    <redoc spec-url='https://storage.googleapis.com/libpod-master-releases/swagger-latest.yaml' sort-props-alphabetically></redoc>
+    <redoc spec-url='https://storage.googleapis.com/libpod-master-releases/swagger-latest.yaml' sort-props-alphabetically sort-operations-alphabetically></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
Use `sort-operations-alphabetically` to sort swagger operations
alphabetically

Wait for: https://github.com/Redocly/redoc/pull/1843
Closes: https://github.com/containers/podman/issues/7404

[CI:DOCS]
[NO-NEW-TESTS-NEEDED]