### PR TITLE
volume: add support for non-volatile `upperdir`,`workdir` for overlay volumes

### DIFF
--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1394,6 +1394,10 @@ directory will be the lower, and the container storage directory will be the
 upper. Modifications to the mount point are destroyed when the container
 finishes executing, similar to a tmpfs mount point being unmounted.
 
+  For advanced users overlay option also supports custom non-volatile `upperdir` and `workdir`
+for the overlay mount. Custom `upperdir` and `workdir` can be fully managed by the users themselves
+and `podman` will not remove it on lifecycle completion. Example `:O,upperdir=/some/upper,workdir=/some/work`
+
   Subsequent executions of the container will see the original source directory
 content, any changes from previous container executions no longer exist.
 

--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -25,16 +25,30 @@ type defaultMountOptions struct {
 // The sourcePath variable, if not empty, contains a bind mount source.
 func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string, error) {
 	var (
-		foundWrite, foundSize, foundProp, foundMode, foundExec, foundSuid, foundDev, foundCopyUp, foundBind, foundZ, foundU bool
+		foundWrite, foundSize, foundProp, foundMode, foundExec, foundSuid, foundDev, foundCopyUp, foundBind, foundZ, foundU, foundOverlay bool
 	)
 
 	newOptions := make([]string, 0, len(options))
 	for _, opt := range options {
 		// Some options have parameters - size, mode
 		splitOpt := strings.SplitN(opt, "=", 2)
+
+		// add advanced options such as upperdir=/path and workdir=/path, when overlay is specified
+		if foundOverlay {
+			if strings.Contains(opt, "upperdir") {
+				newOptions = append(newOptions, opt)
+				continue
+			}
+			if strings.Contains(opt, "workdir") {
+				newOptions = append(newOptions, opt)
+				continue
+			}
+		}
+
 		switch splitOpt[0] {
-		case "idmap":
 		case "O":
+			foundOverlay = true
+		case "idmap":
 			if len(options) > 1 {
 				return nil, errors.Wrapf(ErrDupeMntOption, "'O' option can not be used with other options")
 			}


### PR DESCRIPTION
Often users want their overlayed volumes to be `non-volatile` in nature
that means that same `upper` dir can be re-used by one or more
containers but overall of nature of volumes still have to be `overlay`
so work done is still on a overlay not on the actual volume.

Following PR adds support for more advanced options i.e custom `workdir`
and `upperdir` for overlayed volumes. So that users can re-use `workdir`
and `upperdir` across new containers as well.

Usage
```console

$ podman run -it -v myvol:/data:O,upperdir=/path/persistant/upper,workdir=/path/persistant/work alpine sh

```

This PR is draft till vendor is updated:

- [ ] Vendor `c/common`
- [ ] Vendor `c/buidlah`

Closes: https://github.com/containers/podman/issues/12150