### PR TITLE
[CI:DOCS] Add example of cpus to init command

### DIFF
--- a/docs/tutorials/mac_experimental.md
+++ b/docs/tutorials/mac_experimental.md
@@ -90,7 +90,7 @@ that you were given.  It will be used in two of the steps below.
 
 ## Test podman
 
-1. podman machine init --image-path /path/to/image
+1. podman machine init --image-path /path/to/image --cpus 2
 2. podman machine start
 3. podman images
 4. git clone http://github.com/baude/alpine_nginx && cd alpine_nginx


### PR DESCRIPTION
For #12713

Linked from https://podman.io/getting-started/installation#macos

> "More advanced information can be found here."