### PR TITLE
test/system: podman run with log-opt option

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -778,6 +778,13 @@ EOF
     is "$output" "1.2.3.4 foo.com.*" "users can add hosts even without /etc/hosts"
 }
 
+# rhbz#1854566 : $IMAGE has incorrect permission 555 on the root '/' filesystem
+@test "podman run image with filesystem permission" {
+    # make sure the IMAGE image have permissiong of 555 like filesystem RPM expects
+    run_podman run --rm $IMAGE stat -c %a /
+    is "$output" "555" "directory permissions on /"
+}
+
 # rhbz#1763007 : the --log-opt for podman run does not work as expected
 @test "podman run with log-opt option" {
     # Pseudorandom size of the form N.NNN. The '| 1' handles '0.NNN' or 'N.NN0',


### PR DESCRIPTION
This test case is used for covering rhbz#1763007.
Replaces: #12221

Signed-off-by: Alex Jia <ajia@redhat.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
