### PR TITLE
Don't rename pod if container has the same name

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -178,16 +178,9 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		return nil, err
 	}
 
-	// check for name collision between pod and container
+	// Assert the pod has a name
 	if podName == "" {
 		return nil, errors.Errorf("pod does not have a name")
-	}
-	for _, n := range podYAML.Spec.Containers {
-		if n.Name == podName {
-			playKubePod.Logs = append(playKubePod.Logs,
-				fmt.Sprintf("a container exists with the same name (%q) as the pod in your YAML file; changing pod name to %s_pod\n", podName, podName))
-			podName = fmt.Sprintf("%s_pod", podName)
-		}
 	}
 
 	podOpt := entities.PodCreateOptions{Infra: true, Net: &entities.NetOptions{NoHosts: options.NoHosts}}


### PR DESCRIPTION
We enforce the naming scheme "podname-containername" here [1].
Therefore we must not rename the pod in case of a naming conflict
between pod name and container name. Not renaming the pod increases the
usability for the user and easies scripting based on the name. Otherwise
a user must set some label to reliable find a pod after creation. Or
have to implement the renaming logic in the script.

[1] https://github.com/containers/podman/blob/main/pkg/specgen/generate/kube/kube.go#L140

Fixes #12722

Signed-off-by: Christoph Petrausch <chrobbert@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
