### PR TITLE
fix misleading comment regarding default value of cpu period

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -665,8 +665,8 @@ func CreateCidFile(cidfile string, id string) error {
 	return nil
 }
 
-// DefaultCPUPeriod is the default CPU period is 100us, which is the same default
-// as Kubernetes.
+// DefaultCPUPeriod is the default CPU period (100ms) in microseconds, which is
+// the same default as Kubernetes.
 const DefaultCPUPeriod uint64 = 100000
 
 // CoresToPeriodAndQuota converts a fraction of cores to the equivalent


### PR DESCRIPTION
I am lead to believe the following code comment is incorrect. It claims the value is 100us, but the value itself is 100000 us which is 100ms. This matches the Kubernetes default value in their documentation:

![image](https://user-images.githubusercontent.com/16336790/147932561-6104b85f-c46e-4131-b7af-6c3b146804e4.png)

Following the commit history, we can see a previous code comment stated this value was 100 milliseconds. So it looks like a slight mistake was made when centralising this conversion code:

https://github.com/containers/podman/commit/03579649063d669f9f57d534f74136befef98c62#diff-d3fb054de60fb7550ae0554fc1c99ac63b8434f960b49b5b7f0352f1d0fcb8f0L39