### PR TITLE
Set volume NeedsCopyUp to false iff data was copied up

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1700,13 +1700,6 @@ func (c *Container) mountNamedVolume(v *ContainerNamedVolume, mountpoint string)
 	if vol.state.NeedsCopyUp {
 		logrus.Debugf("Copying up contents from container %s to volume %s", c.ID(), vol.Name())
 
-		// Set NeedsCopyUp to false immediately, so we don't try this
-		// again when there are already files copied.
-		vol.state.NeedsCopyUp = false
-		if err := vol.save(); err != nil {
-			return nil, err
-		}
-
 		// If the volume is not empty, we should not copy up.
 		volMount := vol.mountPoint()
 		contents, err := ioutil.ReadDir(volMount)
@@ -1751,6 +1744,13 @@ func (c *Container) mountNamedVolume(v *ContainerNamedVolume, mountpoint string)
 		}
 		if len(srcContents) == 0 {
 			return vol, nil
+		}
+
+		// Set NeedsCopyUp to false since we are about to do first copy
+		// Do not copy second time.
+		vol.state.NeedsCopyUp = false
+		if err := vol.save(); err != nil {
+			return nil, err
 		}
 
 		// Buildah Copier accepts a reader, so we'll need a pipe.

--- a/libpod/define/volume_inspect.go
+++ b/libpod/define/volume_inspect.go
@@ -48,4 +48,12 @@ type InspectVolumeData struct {
 	// volume for a specific container, and will be be removed when any
 	// container using it is removed.
 	Anonymous bool `json:"Anonymous,omitempty"`
+	// MountCount is the number of times this volume has been mounted.
+	MountCount uint `json:"MountCount"`
+	// NeedsCopyUp indicates that the next time the volume is mounted into
+	NeedsCopyUp bool `json:"NeedsCopyUp,omitempty"`
+	// NeedsChown indicates that the next time the volume is mounted into
+	// a container, the container will chown the volume to the container process
+	// UID/GID.
+	NeedsChown bool `json:"NeedsChown,omitempty"`
 }

--- a/libpod/volume_inspect.go
+++ b/libpod/volume_inspect.go
@@ -60,6 +60,9 @@ func (v *Volume) Inspect() (*define.InspectVolumeData, error) {
 	data.UID = v.uid()
 	data.GID = v.gid()
 	data.Anonymous = v.config.IsAnon
+	data.MountCount = v.state.MountCount
+	data.NeedsCopyUp = v.state.NeedsCopyUp
+	data.NeedsChown = v.state.NeedsChown
 
 	return data, nil
 }


### PR DESCRIPTION
Currently Docker copies up the first volume on a mountpoint with
data.

Fixes: https://github.com/containers/podman/issues/12714

Also added NeedsCopyUP, NeedsChown and MountCount to the podman volume
inspect code.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
