### PR TITLE
Fix Container List API call to return mount info

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -356,6 +356,15 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 		return nil, err
 	}
 
+	m, err := json.Marshal(inspect.Mounts)
+	if err != nil {
+		return nil, err
+	}
+	mounts := []types.MountPoint{}
+	if err := json.Unmarshal(m, &mounts); err != nil {
+		return nil, err
+	}
+
 	return &handlers.Container{Container: types.Container{
 		ID:         l.ID(),
 		Names:      []string{fmt.Sprintf("/%s", l.Name())},
@@ -374,7 +383,7 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 		}{
 			"host"},
 		NetworkSettings: &networkSettings,
-		Mounts:          nil,
+		Mounts:          mounts,
 	},
 		ContainerCreateConfig: types.ContainerCreateConfig{},
 	}, nil

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -18,7 +18,7 @@ podman rm -a -f &>/dev/null
 
 t GET "libpod/containers/json (at start: clean slate)" 200 length=0
 
-podman run $IMAGE true
+podman run -v /tmp:/tmp $IMAGE true
 
 t GET libpod/containers/json 200 length=0
 
@@ -33,6 +33,7 @@ t GET libpod/containers/json?all=true 200 \
   .[0].Command[0]="true" \
   .[0].State~\\\(exited\\\|stopped\\\) \
   .[0].ExitCode=0 \
+  .[0].Mounts~.*/tmp \
   .[0].IsInfra=false
 
 # Test compat API for Network Settings (.Network is N/A when rootless)
@@ -44,6 +45,7 @@ t GET /containers/json?all=true 200 \
   length=1 \
   .[0].Id~[0-9a-f]\\{64\\} \
   .[0].Image=$IMAGE \
+  .[0].Mounts~.*/tmp \
   $network_expect
 
 # compat API imageid with sha256: prefix


### PR DESCRIPTION
We are hard coding mounts to return nil in compat API,
since we have the data, we should return it.

Fixes: https://github.com/containers/podman/issues/12734

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
