### PR TITLE
[CI:DOCS] Fix wrong 'podman search --format' placeholder

### DIFF
--- a/docs/source/markdown/podman-search.1.md
+++ b/docs/source/markdown/podman-search.1.md
@@ -62,7 +62,7 @@ Valid placeholders for the Go template are listed below:
 | --------------- | ---------------------------- |
 | .Index          | Registry                     |
 | .Name           | Image name                   |
-| .Descriptions   | Image description            |
+| .Description    | Image description            |
 | .Stars          | Star count of image          |
 | .Official       | "[OK]" if image is official  |
 | .Automated      | "[OK]" if image is automated |


### PR DESCRIPTION
Hello,

I noticed that in `podman-search` manual page there is a typo in `--format` .Description~s~ placeholder.

E.g. instead of:
```
$ podman search --no-trunc --format "table {{.Name}} {{.Descriptions}}" tumbleweed
Error: Template parsing error: template: image:1:12: executing "image" at <.Descriptions>: can't evaluate field Descriptions in type entities.ImageSearchReport
```
we need:
```
$ podman search --no-trunc --format "table {{.Name}} {{.Description}}" tumbleweed
docker.io/opensuse/tumbleweed   Official openSUSE Tumbleweed images
```