### PR TITLE
[v3.4.2-rhel] Backports for health check files

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1814,7 +1814,7 @@ func (c *Container) cleanupStorage() error {
 	return cleanupErr
 }
 
-// Unmount the a container and free its resources
+// Unmount the container and free its resources
 func (c *Container) cleanup(ctx context.Context) error {
 	var lastError error
 
@@ -1822,8 +1822,8 @@ func (c *Container) cleanup(ctx context.Context) error {
 
 	// Remove healthcheck unit/timer file if it execs
 	if c.config.HealthCheckConfig != nil {
-		if err := c.removeTimer(); err != nil {
-			logrus.Errorf("Error removing timer for container %s healthcheck: %v", c.ID(), err)
+		if err := c.removeTransientFiles(ctx); err != nil {
+			logrus.Errorf("Removing timer for container %s healthcheck: %v", c.ID(), err)
 		}
 	}
 

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -227,4 +227,20 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(len(ps.OutputToStringArray())).To(Equal(2))
 		Expect(ps.OutputToString()).To(ContainSubstring("hc"))
 	})
+
+	It("stopping and then starting a container with healthcheck cmd", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--health-cmd", "[\"ls\", \"/foo\"]", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		stop := podmanTest.Podman([]string{"stop", "-t0", "hc"})
+		stop.WaitWithDefaultTimeout()
+		Expect(stop).Should(Exit(0))
+
+		startAgain := podmanTest.Podman([]string{"start", "hc"})
+		startAgain.WaitWithDefaultTimeout()
+		Expect(startAgain).Should(Exit(0))
+		Expect(startAgain.OutputToString()).To(Equal("hc"))
+		Expect(startAgain.ErrorToString()).To(Equal(""))
+	})
 })


### PR DESCRIPTION
Prodding bz #2024229 a little more, it turns out the service file is NOT deleted when it is in a failed state (i.e the healtch check has failed for some reason).  The state must be reset before the service is stopped on container removal and then the files will be removed properly.

when a container with healthchecks exits due to stopping or failure, we need the cleanup process to remove both the timer file and the service file.

Bz#:2024229
