### PR TITLE
Prevent double decoding of storage options

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -447,17 +447,8 @@ func (c *Container) setupStorage(ctx context.Context) error {
 		LabelOpts: c.config.LabelOpts,
 	}
 
-	nopts := len(c.config.StorageOpts)
-	if nopts > 0 {
-		options.StorageOpt = make(map[string]string, nopts)
-		for _, opt := range c.config.StorageOpts {
-			split2 := strings.SplitN(opt, "=", 2)
-			if len(split2) > 2 {
-				return errors.Wrapf(define.ErrInvalidArg, "invalid storage options %q for %s", opt, c.ID())
-			}
-			options.StorageOpt[split2[0]] = split2[1]
-		}
-	}
+	options.StorageOpt = c.config.StorageOpts
+
 	if c.restoreFromCheckpoint && c.config.ProcessLabel != "" && c.config.MountLabel != "" {
 		// If restoring from a checkpoint, the root file-system needs
 		// to be mounted with the same SELinux labels as it was mounted


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Storage options are already being decoded in [pkg/specgenutil/specgen.go:397](https://github.com/rhatdan/podman/blob/087f8fc73bec664a30dcf0757cd3cb44ea150582/pkg/specgenutil/specgen.go#L397).

Fixes #12766