### PR TITLE
Podman System Reset --run-root --graph-root

### DIFF
--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -7,7 +7,7 @@ podman\-system\-reset - Reset storage back to initial state
 **podman system reset** [*options*]
 
 ## DESCRIPTION
-**podman system reset** removes all pods, containers, images, networks and volumes.
+**podman system reset** removes all pods, containers, images and volumes. Can also be used to instantiate new directories for storing images and information about Podmans's state.
 
 This command must be run **before** changing any of the following fields in the
 `containers.conf` or `storage.conf` files: `driver`, `static_dir`, `tmp_dir`
@@ -22,11 +22,23 @@ of the relevant configurations. If the administrator modified the configuration 
 
 Do not prompt for confirmation
 
+#### **--graph-root**
+
+Establishes a new graph root directory and storage.conf file once the system is reset
+
 #### **--help**, **-h**
 
 Print usage statement
 
+#### **--run-root**
+
+Establishes a new run root directory and storage.conf file once the system is reset
+
 ## EXAMPLES
+Reset the system and create a new storage.conf file with the given run and graph root.
+```
+$ podman system reset --run-root=/run/user/1000/containers --graph-root=/home/charliedoern/.local/share/containers
+```
 
 ```
 $ podman system reset

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -408,12 +408,7 @@ func (s *BoltState) ValidateDBConfig(runtime *Runtime) error {
 	}
 	defer s.deferredCloseDBCon(db)
 
-	// Check runtime configuration
-	if err := checkRuntimeConfig(db, runtime); err != nil {
-		return err
-	}
-
-	return nil
+	return checkRuntimeConfig(db, runtime)
 }
 
 // SetNamespace sets the namespace that will be used for container and pod

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -532,6 +532,16 @@ func WithRuntimeFlags(runtimeFlags []string) RuntimeOption {
 	}
 }
 
+func WithNewDB() RuntimeOption {
+	return func(rt *Runtime) error {
+		if rt.valid {
+			return define.ErrRuntimeFinalized
+		}
+		rt.newDB = true
+		return nil
+	}
+}
+
 // Container Creation Options
 
 // WithMaxLogSize sets the maximum size of container logs.

--- a/pkg/domain/entities/engine_system.go
+++ b/pkg/domain/entities/engine_system.go
@@ -9,6 +9,6 @@ import (
 type SystemEngine interface {
 	Renumber(ctx context.Context, flags *pflag.FlagSet, config *PodmanConfig) error
 	Migrate(ctx context.Context, flags *pflag.FlagSet, config *PodmanConfig, options SystemMigrateOptions) error
-	Reset(ctx context.Context) error
+	Reset(ctx context.Context, updateConf bool) error
 	Shutdown(ctx context.Context)
 }

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -312,8 +312,8 @@ func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.System
 	}, nil
 }
 
-func (se *SystemEngine) Reset(ctx context.Context) error {
-	return se.Libpod.Reset(ctx)
+func (se *SystemEngine) Reset(ctx context.Context, updateConf bool) error {
+	return se.Libpod.Reset(ctx, updateConf)
 }
 
 func (se *SystemEngine) Renumber(ctx context.Context, flags *pflag.FlagSet, config *entities.PodmanConfig) error {

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -127,12 +127,15 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 		storageSet = true
 	}
 
-	if fs.Changed("root") {
+	if fs.Changed("root") || fs.Lookup("graph-root") != nil {
+		options = append(options, libpod.WithNewDB())
 		storageSet = true
 		storageOpts.GraphRoot = cfg.Engine.StaticDir
 		storageOpts.GraphDriverOptions = []string{}
 	}
-	if fs.Changed("runroot") {
+
+	if fs.Changed("runroot") || fs.Lookup("run-root") != nil {
+		options = append(options, libpod.WithNewDB())
 		storageSet = true
 		storageOpts.RunRoot = cfg.Runroot
 	}


### PR DESCRIPTION
added options to reinstantiate storage after resetting the podman system using
podman system reset. --run-root and --graph-root define the runRoot and graphRoot to initiate
a new runtime with. these values, once populated into a new libpd runtime, then are used to create a new storage.conf
file at the proper location (root or rootless default location).

These options allow for a more interactive and useful reset program and ill help eliminate many questions regarding how to configure the basic entities
of container storage.

depends on containers/storage#1096

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
