### PR TITLE
[CI:DOCS] fixes indentation of example pod yaml

### DIFF
--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -96,9 +96,9 @@ spec:
     name: container-1
     image: foobar
     envFrom:
-      - configMapRef:
-      name: foo
-      optional: false
+    - configMapRef:
+        name: foo
+        optional: false
 ```
 
 and as a result environment variable `FOO` will be set to `bar` for container `container-1`.


### PR DESCRIPTION
The example as previously shown would result in "Error: multi doc yaml
could not be split". The change here has been tested to work, and it
matches the example in the [kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables).

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
