### PR TITLE
Use the InfraImage defined in containers.conf

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -388,10 +388,7 @@ func createPodIfNecessary(cmd *cobra.Command, s *specgen.SpecGenerator, netOpts 
 	if err != nil {
 		return nil, err
 	}
-	imageName := config.DefaultInfraImage
-	podGen.InfraImage = imageName
-	podGen.InfraContainerSpec = specgen.NewSpecGenerator(imageName, false)
-	podGen.InfraContainerSpec.RawImageName = imageName
+	podGen.InfraContainerSpec = specgen.NewSpecGenerator("", false)
 	podGen.InfraContainerSpec.NetworkOptions = podGen.NetworkOptions
 	err = specgenutil.FillOutSpecGen(podGen.InfraContainerSpec, &infraOpts, []string{})
 	if err != nil {

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -71,7 +71,11 @@ func init() {
 	_ = createCommand.RegisterFlagCompletionFunc(nameFlagName, completion.AutocompleteNone)
 
 	infraImageFlagName := "infra-image"
-	flags.StringVar(&infraImage, infraImageFlagName, containerConfig.Engine.InfraImage, "The image of the infra container to associate with the pod")
+	var defInfraImage string
+	if !registry.IsRemote() {
+		defInfraImage = containerConfig.Engine.InfraImage
+	}
+	flags.StringVar(&infraImage, infraImageFlagName, defInfraImage, "The image of the infra container to associate with the pod")
 	_ = createCommand.RegisterFlagCompletionFunc(infraImageFlagName, common.AutocompleteImages)
 
 	podIDFileFlagName := "pod-id-file"
@@ -109,7 +113,9 @@ func create(cmd *cobra.Command, args []string) error {
 		return errors.Wrapf(err, "unable to process labels")
 	}
 
-	imageName = infraImage
+	if cmd.Flag("infra-image").Changed {
+		imageName = infraImage
+	}
 	img := imageName
 	if !createOptions.Infra {
 		if cmd.Flag("no-hosts").Changed {

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -595,7 +595,7 @@ func containerToV1Container(ctx context.Context, c *Container) (v1.Container, []
 	// pause one and make sure it's in the storage by pulling it down if
 	// missing.
 	if image == "" && c.IsInfra() {
-		image = config.DefaultInfraImage
+		image = c.runtime.config.Engine.InfraImage
 		if _, err := c.runtime.libimageRuntime.Pull(ctx, image, config.PullPolicyMissing, nil); err != nil {
 			return kubeContainer, nil, nil, nil, err
 		}

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v3/libpod"
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/containers/podman/v3/pkg/api/handlers"
@@ -62,15 +61,8 @@ func PodCreate(w http.ResponseWriter, r *http.Request) {
 		psg.InfraContainerSpec.Name = psg.InfraName
 		psg.InfraContainerSpec.ConmonPidFile = psg.InfraConmonPidFile
 		psg.InfraContainerSpec.ContainerCreateCommand = psg.InfraCommand
-		imageName := psg.InfraImage
-		rawImageName := psg.InfraImage
-		if imageName == "" {
-			imageName = config.DefaultInfraImage
-			rawImageName = config.DefaultInfraImage
-		}
-		psg.InfraImage = imageName
-		psg.InfraContainerSpec.Image = imageName
-		psg.InfraContainerSpec.RawImageName = rawImageName
+		psg.InfraContainerSpec.Image = psg.InfraImage
+		psg.InfraContainerSpec.RawImageName = psg.InfraImage
 	}
 	podSpecComplete := entities.PodSpec{PodSpecGen: psg}
 	pod, err := generate.MakePod(&podSpecComplete, runtime)

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -62,8 +62,8 @@ function teardown() {
 
 
 @test "podman pod create - custom infra image" {
+    skip_if_remote "CONTAINERS_CONF only effects server side"
     image="i.do/not/exist:image"
-
     tmpdir=$PODMAN_TMPDIR/pod-test
     run mkdir -p $tmpdir
     containersconf=$tmpdir/containers.conf
@@ -76,6 +76,9 @@ EOF
     is "$output" ".*initializing source docker://$image:.*"
 
     CONTAINERS_CONF=$containersconf run_podman 125 pod create
+    is "$output" ".*initializing source docker://$image:.*"
+
+    CONTAINERS_CONF=$containersconf run_podman 125 create --pod new:test $IMAGE
     is "$output" ".*initializing source docker://$image:.*"
 }
 


### PR DESCRIPTION
Remove hard code use of the DefaultInfraImage and rely on
getting this from containers.conf.

Fixes: https://github.com/containers/podman/issues/12771

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
