### PR TITLE
[NO TESTS NEEDED] Fix type-o in podman.wxs

### DIFF
--- a/contrib/msi/podman.wxs
+++ b/contrib/msi/podman.wxs
@@ -50,7 +50,7 @@
     <InstallExecuteSequence>
       <RemoveExistingProducts Before="InstallInitialize"/>
       <Custom Action="AddPath" After="InstallFiles">NOT Installed</Custom>
-      <Custom Action="RemovePath" Before="RemoveFiles" After="InstallInitiailize">(REMOVE="ALL") AND (NOT UPGRADINGPRODUCTCODE)</Custom>
+      <Custom Action="RemovePath" Before="RemoveFiles" After="InstallInitialize">(REMOVE="ALL") AND (NOT UPGRADINGPRODUCTCODE)</Custom>
     </InstallExecuteSequence>
 
   </Product>


### PR DESCRIPTION
Fixes an intermittent uninstall issue caused by unreliable ordering from a type-o of InstallInitialize.