### PR TITLE
System tests: fix RHEL8 gating tests

### DIFF
--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -272,6 +272,10 @@ Deleted: $pauseID" "infra images gets removed as well"
     is "$output" ""
 
     run_podman create --pod new:$pname $IMAGE
+    # Clean up
+    run_podman rm "${lines[-1]}"
+    run_podman pod rm -a
+    run_podman rmi $pauseImage
 }
 
 @test "podman images - rmi -f can remove infra images" {


### PR DESCRIPTION
Add a fix for RHEL8 gating tests. This resolves yet another
journald/file events/logger mismatch bug.

Also, while I'm at it, more log cleanup: a recently-added test was
missing final rm/rmi, resulting in big red scary output in test logs.

Signed-off-by: Ed Santiago <santiago@redhat.com>
