### PR TITLE
Tests for podman image scp (the sudo form)

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -177,18 +177,25 @@ esac
 
 # Required to be defined by caller: Are we testing as root or a regular user
 case "$PRIV_NAME" in
-    root) ;;
+    root)
+        if [[ "$TEST_FLAVOR" = "sys" ]]; then
+            # Used in local image-scp testing
+            setup_rootless
+            echo "PODMAN_ROOTLESS_USER=$ROOTLESS_USER" >> /etc/ci_environment
+        fi
+        ;;
     rootless)
         # load kernel modules since the rootless user has no permission to do so
         modprobe ip6_tables || :
         modprobe ip6table_nat || :
-        # Needs to exist for setup_rootless()
-        ROOTLESS_USER="${ROOTLESS_USER:-some${RANDOM}dude}"
-        echo "ROOTLESS_USER=$ROOTLESS_USER" >> /etc/ci_environment
         setup_rootless
         ;;
     *) die_unknown PRIV_NAME
 esac
+
+if [[ -n "$ROOTLESS_USER" ]]; then
+    echo "ROOTLESS_USER=$ROOTLESS_USER" >> /etc/ci_environment
+fi
 
 # Required to be defined by caller: Are we testing podman or podman-remote client
 # shellcheck disable=SC2154

--- a/hack/bats
+++ b/hack/bats
@@ -98,6 +98,9 @@ if [[ -z "$CONTAINERS_HELPER_BINARY_DIR" ]]; then
     export CONTAINERS_HELPER_BINARY_DIR=$(pwd)/bin
 fi
 
+# Used in 120-load test to identify rootless destination for podman image scp
+export PODMAN_ROOTLESS_USER=$(id -un)
+
 # Root
 if [ -z "$ROOTLESS_ONLY" ]; then
     echo "# bats ${bats_filter[@]} $TESTS"
@@ -105,6 +108,7 @@ if [ -z "$ROOTLESS_ONLY" ]; then
             --preserve-env=PODMAN_TEST_DEBUG \
             --preserve-env=OCI_RUNTIME \
             --preserve-env=CONTAINERS_HELPER_BINARY_DIR \
+            --preserve-env=PODMAN_ROOTLESS_USER \
             bats "${bats_opts[@]}" "${bats_filter[@]}" $TESTS
     rc=$?
 fi

--- a/test/system/272-system-connection.bats
+++ b/test/system/272-system-connection.bats
@@ -124,10 +124,14 @@ $c2[ ]\+tcp://localhost:54321[ ]\+true" \
 
 # If we have ssh access to localhost (unlikely in CI), test that.
 @test "podman system connection - ssh" {
-    rand=$(random_string 20)
-    echo $rand >$PODMAN_TMPDIR/testfile
+    # system connection only really works if we have an agent
+    run ssh-add -l
+    test "$status"      -eq 0 || skip "Not running under ssh-agent"
+    test "${#lines[@]}" -ge 1 || skip "ssh agent has no identities"
 
     # Can we actually ssh to localhost?
+    rand=$(random_string 20)
+    echo $rand >$PODMAN_TMPDIR/testfile
     run ssh -q -o BatchMode=yes \
         -o UserKnownHostsFile=/dev/null \
         -o StrictHostKeyChecking=no \


### PR DESCRIPTION
Start inching our way back to having tests for the sudo form
of podman image scp. Basically, copy an image to another user
and then back, using a pseudorandom name. Confirm that the
image makes it to the remote end, and that when we copy it
back, the original image digest is preserved.

When scp'ing as root, we identify the destination rootless
user account via the $PODMAN_ROOTLESS_USER envariable. Setting
this and creating the account is left as an exercise for the
CI framework (be it github, or Fedora/CentOS/RHEL gating, or
other).

Also: amend hack/bats to set and relay $PODMAN_ROOTLESS_USER,
so developers can test locally.

Also: remove what I'm 99% sure is a debugging printf.

Signed-off-by: Ed Santiago <santiago@redhat.com>
