### PR TITLE
It takes some time to start a VM

### DIFF
--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -60,9 +60,9 @@ func start(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	fmt.Printf("Starting machine %q\n", vmName)
 	if err := vm.Start(vmName, machine.StartOptions{}); err != nil {
 		return err
 	}
-	fmt.Printf("Machine %q started successfully\n", vmName)
 	return nil
 }


### PR DESCRIPTION
We are seeing some issues with users not understanding which VM they are
starting, and if the VM takes a long time to start, they do not know
where to look.

Moving the name to before the VM starts at least allows them to realize
they are starting the wrong VM.

[NO NEW TESTS NEEDED]

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
