### PR TITLE
Cirrus: Add e2e task w/ upstream netavark

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,6 +9,8 @@ env:
     DEST_BRANCH: "main"
     # Netavark branch to use when TEST_ENVIRON=host-netavark
     NETAVARK_BRANCH: "main"
+    # Aardvark branch to use
+    AARDVARK_BRANCH: "main"
     # Overrides default location (/tmp/cirrus) for repo clone
     GOPATH: &gopath "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"
@@ -528,6 +530,8 @@ netavark_integration_test_task:
         TEST_ENVIRON: host-netavark
         NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
         NETAVARK_DEBUG: 0  # set non-zero to use the debug-mode binary
+        AARDVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/aardvark-dns/success/binary.zip?branch=${AARDVARK_BRANCH}"
+        AARDVARK_DEBUG: 0  # set non-zero to use the debug-mode binary
     clone_script: *noop  # Comes from cache
     gopath_cache: *ro_gopath_cache
     setup_script: *setup

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,8 @@ env:
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
     DEST_BRANCH: "main"
+    # Netavark branch to use when TEST_ENVIRON=host-netavark
+    NETAVARK_BRANCH: "main"
     # Overrides default location (/tmp/cirrus) for repo clone
     GOPATH: &gopath "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"
@@ -44,7 +46,7 @@ env:
     #### N/B: Required ALL of these are set for every single task.
     ####
     TEST_FLAVOR:             # int, sys, ext_svc, validate, automation, etc.
-    TEST_ENVIRON: host       # 'host' or 'container'
+    TEST_ENVIRON: host       # 'host', 'host-netavark', or 'container'
     PODBIN_NAME: podman      # 'podman' or 'remote'
     PRIV_NAME: root          # 'root' or 'rootless'
     DISTRO_NV:               # any {PRIOR_,}{FEDORA,UBUNTU}_NAME value
@@ -508,6 +510,30 @@ container_integration_test_task:
     main_script: *main
     always: *int_logs_artifacts
 
+# Run the integration tests using the latest upstream build of netavark.
+netavark_integration_test_task:
+    name: "Netavark integration"  # using *std_name_fmt here is unreadable
+    alias: netavark_integration_test
+    only_if: *not_docs
+    skip: *branches_and_tags
+    depends_on:
+        - unit_test
+    gce_instance: *standardvm
+    env:
+        DISTRO_NV: ${FEDORA_NAME}
+        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
+        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+        TEST_FLAVOR: int
+        TEST_ENVIRON: host-netavark
+        NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
+        NETAVARK_DEBUG: 0  # set non-zero to use the debug-mode binary
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: *int_logs_artifacts
+
 
 # Execute most integration tests as a regular (non-root) user.
 rootless_integration_test_task:
@@ -713,6 +739,7 @@ success_task:
         - remote_integration_test
         - rootless_integration_test
         - container_integration_test
+        - netavark_integration_test
         - local_system_test
         - remote_system_test
         - rootless_system_test

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -12,7 +12,7 @@ set -eo pipefail
 # most notably:
 #
 #    PODBIN_NAME  : "podman" (i.e. local) or "remote"
-#    TEST_ENVIRON : 'host' or 'container'; desired environment in which to run
+#    TEST_ENVIRON : 'host', 'host-netavark', or 'container'; desired environment in which to run
 #    CONTAINER    : 1 if *currently* running inside a container, 0 if host
 #
 


### PR DESCRIPTION
Add CI task + setup for running (rootfull) podman e2e tests with both `netavark` and `aardvark-dns` installed.  The binaries are downloaded from the most recent successful branch-level CI runs on the respective repos.  This PR does *not* actually perform any actual testing with the binaries, this will be enabled in another future PR.