### PR TITLE
podman container rm: remove pod

### DIFF
--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -110,6 +110,11 @@ func rm(cmd *cobra.Command, args []string) error {
 		args = append(args, id)
 	}
 
+	if rmOptions.All {
+		logrus.Debug("--all is set: enforcing --depend=true")
+		rmOptions.Depend = true
+	}
+
 	return removeContainers(args, rmOptions, true)
 }
 


### PR DESCRIPTION
Support removing the entire pod when --depend is used on an infra
container.  --all now implies --depend to properly support removing all
containers and not error out when hitting infra containers.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@containers/podman-maintainers PTAL