### PR TITLE
libpod: drop check for empty pod cgroup

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2728,6 +2728,24 @@ func isRootlessCgroupSet(cgroup string) bool {
 	return cgroup != CgroupfsDefaultCgroupParent && filepath.Dir(cgroup) != CgroupfsDefaultCgroupParent
 }
 
+func (c *Container) expectPodCgroup() (bool, error) {
+	unified, err := cgroups.IsCgroup2UnifiedMode()
+	if err != nil {
+		return false, err
+	}
+	cgroupManager := c.CgroupManager()
+	switch {
+	case c.config.NoCgroups:
+		return false, nil
+	case cgroupManager == config.SystemdCgroupsManager:
+		return !rootless.IsRootless() || unified, nil
+	case cgroupManager == config.CgroupfsCgroupsManager:
+		return !rootless.IsRootless(), nil
+	default:
+		return false, errors.Wrapf(define.ErrInvalidArg, "invalid cgroup mode %s requested for pods", cgroupManager)
+	}
+}
+
 // Get cgroup path in a format suitable for the OCI spec
 func (c *Container) getOCICgroupPath() (string, error) {
 	unified, err := cgroups.IsCgroup2UnifiedMode()

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -356,7 +356,11 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 					if err != nil {
 						return nil, errors.Wrapf(err, "error retrieving pod %s cgroup", pod.ID())
 					}
-					if podCgroup == "" {
+					expectPodCgroup, err := ctr.expectPodCgroup()
+					if err != nil {
+						return nil, err
+					}
+					if expectPodCgroup && podCgroup == "" {
 						return nil, errors.Wrapf(define.ErrInternal, "pod %s cgroup is not set", pod.ID())
 					}
 					canUseCgroup := !rootless.IsRootless() || isRootlessCgroupSet(podCgroup)


### PR DESCRIPTION
rootless containers do not use cgroups on cgroupv1 or if using
cgroupfs, so drop the redundant check for an empty pod cgroup.

Closes: https://github.com/containers/podman/issues/10800
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2028243

[NO NEW TESTS NEEDED] it requires rebooting and the rundir on a non
tmpfs file system.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
