### PR TITLE
[v3.4.2-rhel] buildah bud tests: skip failing tests

### DIFF
--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -191,6 +191,16 @@ skip_if_remote "--stdin option will not be implemented in podman-remote" \
 # BEGIN tests which are skipped due to actual podman-remote bugs.
 
 ###############################################################################
+# BEGIN emergency handling of github git-protocol shutdown
+#
+# Please remove this as soon as we vendor buildah with #3701
+
+skip "emergency workaround until buildah #3701 gets vendored in" \
+     "bud-git-context" \
+     "bud using gitrepo and branch"
+
+# END   emergency handling of github git-protocol shutdown
+###############################################################################
 # Done.
 
 exit $RC


### PR DESCRIPTION
[backport of #12818]

Emergency workaround for github's deprecation of git://

   https://github.blog/2021-09-01-improving-git-protocol-security-github/

Two buildah tests rely on 'git://' URLs. These now fail. They
have been fixed in the buildah repo[1] but it will take time
to vendor that in. ITM, we need to get CI passing. Skip those
two failing tests.

 [1] https://github.com/containers/buildah/pull/3701

Signed-off-by: Ed Santiago <santiago@redhat.com>