### PR TITLE
libpod: fix check for systemd session

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -170,7 +170,6 @@ func NewRuntime(ctx context.Context, options ...RuntimeOption) (*Runtime, error)
 	if err != nil {
 		return nil, err
 	}
-	conf.CheckCgroupsAndAdjustConfig()
 	return newRuntimeFromConfig(ctx, conf, options...)
 }
 
@@ -227,6 +226,8 @@ func newRuntimeFromConfig(ctx context.Context, conf *config.Config, options ...R
 	if err := makeRuntime(ctx, runtime); err != nil {
 		return nil, err
 	}
+
+	runtime.config.CheckCgroupsAndAdjustConfig()
 
 	return runtime, nil
 }

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -276,4 +276,9 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
     is "$output" ".*--template cannot be set" "Error message should be '--template requires --new'"
 }
 
+@test "podman --cgroup=cgroupfs doesn't show systemd warning" {
+    DBUS_SESSION_BUS_ADDRESS= run_podman --log-level warning --cgroup-manager=cgroupfs info -f ''
+    is "$output" "" "output should be empty"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
move the check after the cgroup manager is set, so to correctly detect
--cgroup-manager=cgroupfs and do not raise a warning about dbus not
being present.

Closes: https://github.com/containers/podman/issues/12802

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
