### PR TITLE
Wait for podman stop to complete

### DIFF
--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -29,6 +29,15 @@ type InitOptions struct {
 	ReExec       bool
 }
 
+type QemuMachineStatus = string
+
+const (
+	// Running indicates the qemu vm is running
+	Running QemuMachineStatus = "running"
+	//	Stopped indicates the vm has stopped
+	Stopped QemuMachineStatus = "stopped"
+)
+
 type Provider interface {
 	NewMachine(opts InitOptions) (VM, error)
 	LoadVMByName(name string) (VM, error)


### PR DESCRIPTION
if users run podman machine stop && podman machine ls, the status of the
machine in the subsequent ls command would running.  now we wait for
everything to complete for stop so that scripting is more accurate.

Fixes: #12815

[NO NEW TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
