### PR TITLE
Podman Pod Create --sysctl support

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -563,15 +563,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(stopTimeoutFlagName, completion.AutocompleteNone)
 
-		sysctlFlagName := "sysctl"
-		createFlags.StringSliceVar(
-			&cf.Sysctl,
-			sysctlFlagName, []string{},
-			"Sysctl options",
-		)
-		//TODO: Add function for sysctl completion.
-		_ = cmd.RegisterFlagCompletionFunc(sysctlFlagName, completion.AutocompleteNone)
-
 		systemdFlagName := "systemd"
 		createFlags.StringVar(
 			&cf.Systemd,
@@ -712,6 +703,16 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			`If a container with the same name exists, replace it`,
 		)
 	}
+
+	sysctlFlagName := "sysctl"
+	createFlags.StringSliceVar(
+		&cf.Sysctl,
+		sysctlFlagName, []string{},
+		"Sysctl options",
+	)
+	//TODO: Add function for sysctl completion.
+	_ = cmd.RegisterFlagCompletionFunc(sysctlFlagName, completion.AutocompleteNone)
+
 	securityOptFlagName := "security-opt"
 	createFlags.StringArrayVar(
 		&cf.SecurityOpt,

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -276,6 +276,28 @@ podman generates a UUID for each pod, and if a name is not assigned
 to the container with **--name** then a random string name will be generated
 for it. The name is useful any place you need to identify a pod.
 
+#### **--sysctl**=_name_=_value_
+
+Configure namespace kernel parameters for all containers in the pod.
+
+For the IPC namespace, the following sysctls are allowed:
+
+- kernel.msgmax
+- kernel.msgmnb
+- kernel.msgmni
+- kernel.sem
+- kernel.shmall
+- kernel.shmmax
+- kernel.shmmni
+- kernel.shm_rmid_forced
+- Sysctls beginning with fs.mqueue.\*
+
+Note: if the ipc namespace is not shared within the pod, these sysctls are not allowed.
+
+For the network namespace, only sysctls beginning with net.\* are allowed.
+
+Note: if the network namespace is not shared within the pod, these sysctls are not allowed.
+
 #### **--userns**=*mode*
 
 Set the user namespace mode for all the containers in a pod. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled.

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -139,6 +139,7 @@ type PodCreateOptions struct {
 	Volume             []string          `json:"volume,omitempty"`
 	VolumesFrom        []string          `json:"volumes_from,omitempty"`
 	SecurityOpt        []string          `json:"security_opt,omitempty"`
+	Sysctl             []string          `json:"sysctl,omitempty"`
 }
 
 // PodLogsOptions describes the options to extract pod logs.
@@ -240,7 +241,7 @@ type ContainerCreateOptions struct {
 	StorageOpts       []string
 	SubUIDName        string
 	SubGIDName        string
-	Sysctl            []string
+	Sysctl            []string `json:"sysctl,omitempty"`
 	Systemd           string
 	Timeout           uint
 	TLSVerify         commonFlag.OptionalBool
@@ -360,6 +361,15 @@ func ToPodSpecGen(s specgen.PodSpecGenerator, p *PodCreateOptions) (*specgen.Pod
 		}
 	}
 	s.Userns = p.Userns
+	sysctl := map[string]string{}
+	if ctl := p.Sysctl; len(ctl) > 0 {
+		sysctl, err = util.ValidateSysctls(ctl)
+		if err != nil {
+			return nil, err
+		}
+	}
+	s.Sysctl = sysctl
+
 	return &s, nil
 }
 

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -74,6 +74,8 @@ type PodBasicConfig struct {
 	Userns Namespace `json:"userns,omitempty"`
 	// Devices contains user specified Devices to be added to the Pod
 	Devices []string `json:"pod_devices,omitempty"`
+	// Sysctl sets kernel parameters for the pod
+	Sysctl map[string]string `json:"sysctl,omitempty"`
 }
 
 // PodNetworkConfig contains networking configuration for a pod.


### PR DESCRIPTION
added support for pod wide sysctls. The sysctls supported are the same as the container run controls.

These controls are only valid if the proper namespaces are shared within the pod, otherwise only the infra ctr gets the sysctl

resolves #12747

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
