### PR TITLE
exec: retry rm -rf on ENOTEMPTY and EBUSY

### DIFF
--- a/libpod/oci_attach_linux.go
+++ b/libpod/oci_attach_linux.go
@@ -273,9 +273,11 @@ func readStdio(conn *net.UnixConn, streams *define.AttachStreams, receiveStdoutE
 	var err error
 	select {
 	case err = <-receiveStdoutError:
+		conn.CloseWrite()
 		return err
 	case err = <-stdinDone:
 		if err == define.ErrDetach {
+			conn.CloseWrite()
 			return err
 		}
 		if err == nil {

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -389,6 +389,7 @@ func (r *ConmonOCIRuntime) startExec(c *Container, sessionID string, options *Ex
 	if err != nil {
 		return nil, nil, err
 	}
+	defer processFile.Close()
 
 	args := r.sharedConmonArgs(c, sessionID, c.execBundlePath(sessionID), c.execPidPath(sessionID), c.execLogPath(sessionID), c.execExitFileDir(sessionID), ociLog, define.NoLogging, "")
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -653,6 +653,20 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 		}
 	}
 
+	// Check that no other containers depend on the container.
+	// Only used if not removing a pod - pods guarantee that all
+	// deps will be evicted at the same time.
+	if !removePod {
+		deps, err := r.state.ContainerInUse(c)
+		if err != nil {
+			return err
+		}
+		if len(deps) != 0 {
+			depsStr := strings.Join(deps, ", ")
+			return errors.Wrapf(define.ErrCtrExists, "container %s has dependent containers which must be removed before it: %s", c.ID(), depsStr)
+		}
+	}
+
 	// Check that the container's in a good state to be removed.
 	if c.state.State == define.ContainerStateRunning {
 		time := c.StopTimeout()
@@ -675,25 +689,6 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 		}
 	}
 
-	// Remove all active exec sessions
-	if err := c.removeAllExecSessions(); err != nil {
-		return err
-	}
-
-	// Check that no other containers depend on the container.
-	// Only used if not removing a pod - pods guarantee that all
-	// deps will be evicted at the same time.
-	if !removePod {
-		deps, err := r.state.ContainerInUse(c)
-		if err != nil {
-			return err
-		}
-		if len(deps) != 0 {
-			depsStr := strings.Join(deps, ", ")
-			return errors.Wrapf(define.ErrCtrExists, "container %s has dependent containers which must be removed before it: %s", c.ID(), depsStr)
-		}
-	}
-
 	var cleanupErr error
 
 	// Clean up network namespace, cgroups, mounts.
@@ -711,6 +706,14 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 			logrus.Errorf(err.Error())
 		}
 		return errors.Wrapf(err, "unable to set container %s removing state in database", c.ID())
+	}
+
+	// Remove all active exec sessions
+	// removing the exec sessions might temporarily unlock the container's lock.  Using it
+	// after setting the state to ContainerStateRemoving will prevent that the container is
+	// restarted
+	if err := c.removeAllExecSessions(); err != nil {
+		return err
 	}
 
 	// Stop the container's storage


### PR DESCRIPTION
when running on NFS, a RemoveAll could cause EBUSY because of some unlinked files that are still kept open and "silly renamed" to .nfs$ID.
    
This is only half of the fix, as conmon needs to be fixed too.
    
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2040379
Related: https://github.com/containers/conmon/pull/319
    
[NO NEW TESTS NEEDED] as it requires NFS as the underlying storage.
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
