### PR TITLE
switch podman image scp from depending on machinectl to just os/exec

### DIFF
--- a/cmd/podman/images/scp.go
+++ b/cmd/podman/images/scp.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/system/connection"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/utils"
 	scpD "github.com/dtylman/scp"
 	"github.com/pkg/errors"
@@ -337,21 +336,9 @@ func GetServiceInformation(cliConnections []string, cfg *config.Config) (map[str
 
 // execPodman executes the podman save/load command given the podman binary
 func execPodman(podman string, command []string) error {
-	if rootless.IsRootless() {
-		cmd := exec.Command(podman)
-		utils.CreateSCPCommand(cmd, command[1:])
-		logrus.Debug("Executing podman command")
-		return cmd.Run()
-	}
-	machinectl, err := exec.LookPath("machinectl")
-	if err != nil {
-		cmd := exec.Command("su", "-l", "root", "--command")
-		cmd = utils.CreateSCPCommand(cmd, []string{strings.Join(command, " ")})
-		return cmd.Run()
-	}
-	cmd := exec.Command(machinectl, "shell", "-q", "root@.host")
-	cmd = utils.CreateSCPCommand(cmd, command)
-	logrus.Debug("Executing load command machinectl")
+	cmd := exec.Command(podman)
+	utils.CreateSCPCommand(cmd, command[1:])
+	logrus.Debugf("Executing podman command: %q", cmd)
 	return cmd.Run()
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -238,3 +238,18 @@ func CreateSCPCommand(cmd *exec.Cmd, command []string) *exec.Cmd {
 	cmd.Stdout = os.Stdout
 	return cmd
 }
+
+// LoginUser starts the user process on the host so that image scp can use systemd-run
+func LoginUser(user string) (*exec.Cmd, error) {
+	sleep, err := exec.LookPath("sleep")
+	if err != nil {
+		return nil, err
+	}
+	machinectl, err := exec.LookPath("machinectl")
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(machinectl, "shell", "-q", user+"@.host", sleep, "inf")
+	err = cmd.Start()
+	return cmd, err
+}


### PR DESCRIPTION
switch podman image scp from depending on machinectl to just os/exec

machinectl does not propogate error messages and adds extra lines in the output, exec.Cmd is able to clear the env besides PATH and TERM, and use the given UID and GID to execute the command properly.

machinectl is still used to create a user session. Ubuntu support is limited by this.

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
