### PR TITLE
Use PODMAN_USERNS environment variable when running as a service

### DIFF
--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -6,6 +6,11 @@ import (
 	"github.com/containers/image/v5/manifest"
 )
 
+type InspectIDMappings struct {
+	UIDMap []string `json:"UidMap"`
+	GIDMap []string `json:"GidMap"`
+}
+
 // InspectContainerConfig holds further data about how a container was initially
 // configured.
 type InspectContainerConfig struct {
@@ -401,7 +406,10 @@ type InspectContainerHostConfig struct {
 	// TODO Rootless has an additional 'keep-id' option, presently not
 	// reflected here.
 	UsernsMode string `json:"UsernsMode"`
+	// IDMappings is the UIDMapping and GIDMapping used within the container
+	IDMappings *InspectIDMappings `json:"IDMappings,omitempty"`
 	// ShmSize is the size of the container's SHM device.
+
 	ShmSize int64 `json:"ShmSize"`
 	// Runtime is provided purely for Docker compatibility.
 	// It is set unconditionally to "oci" as Podman does not presently

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -205,9 +205,13 @@ func setNamespaces(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions)
 			return err
 		}
 	}
-	// userns must be treated differently
+	userns := os.Getenv("PODMAN_USERNS")
 	if c.UserNS != "" {
-		s.UserNS, err = specgen.ParseUserNamespace(c.UserNS)
+		userns = c.UserNS
+	}
+	// userns must be treated differently
+	if userns != "" {
+		s.UserNS, err = specgen.ParseUserNamespace(userns)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -301,5 +301,34 @@ var _ = Describe("Podman UserNS support", func() {
 			Expect(inspectGID).Should(Exit(0))
 			Expect(inspectGID.OutputToString()).To(Equal(tt.gid))
 		}
+
+	})
+	It("podman PODMAN_USERNS", func() {
+		SkipIfNotRootless("keep-id only works in rootless mode")
+
+		podmanUserns, podmanUserusSet := os.LookupEnv("PODMAN_USERNS")
+		os.Setenv("PODMAN_USERNS", "keep-id")
+		defer func() {
+			if podmanUserusSet {
+				os.Setenv("PODMAN_USERNS", podmanUserns)
+			} else {
+				os.Unsetenv("PODMAN_USERNS")
+			}
+		}()
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+		}
+
+		result := podmanTest.Podman([]string{"create", ALPINE, "true"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", "--format", "{{ .HostConfig.IDMappings }}", result.OutputToString()})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.OutputToString()).To(Not(Equal("<nil>")))
+
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+		}
 	})
 })


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/11350#issuecomment-1011562526

Also add inspect information about the idmappings if they exists.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
