### PR TITLE
Engine.Remote from containers.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,6 +554,7 @@ test: localunit localintegration remoteintegration localsystem remotesystem  ## 
 
 .PHONY: ginkgo-run
 ginkgo-run:
+	$(GOBIN)/ginkgo version
 	$(GOBIN)/ginkgo -v $(TESTFLAGS) -tags "$(TAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes 3 -debug test/e2e/. $(HACK)
 
 .PHONY: ginkgo

--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -52,6 +52,12 @@ func newPodmanConfig() {
 		os.Exit(1)
 	}
 
+	cfg, err := config.NewConfig("")
+	if err != nil {
+		fmt.Fprint(os.Stderr, "Failed to obtain podman configuration: "+err.Error())
+		os.Exit(1)
+	}
+
 	var mode entities.EngineMode
 	switch runtime.GOOS {
 	case "darwin", "windows":
@@ -64,16 +70,15 @@ func newPodmanConfig() {
 		} else {
 			mode = entities.TunnelMode
 		}
-
 	default:
 		fmt.Fprintf(os.Stderr, "%s is not a supported OS", runtime.GOOS)
 		os.Exit(1)
 	}
 
-	cfg, err := config.NewConfig("")
-	if err != nil {
-		fmt.Fprint(os.Stderr, "Failed to obtain podman configuration: "+err.Error())
-		os.Exit(1)
+	// If EngineMode==Tunnel has not been set on the command line or environment
+	// but has been set in containers.conf...
+	if mode == entities.ABIMode && cfg.Engine.Remote {
+		mode = entities.TunnelMode
 	}
 
 	cfg.Network.NetworkConfigDir = cfg.Network.CNIPluginDirs[0]


### PR DESCRIPTION
Heuristic to initialize TunnelMode/remote podman:
- Podman built with remote tag
- Podman running on darwin or windows GOOS
- CONTAINER_HOST or CONTAINER_CONNECTION set in environment
- --remote flag given on command line
- From containers.conf, Engine.Remote == true and GOOS == linux

Otherwise, podman will run in ABIMode/linked against libpod library.

Fixes #12866

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
