### PR TITLE
Unify the method of parsing filters in cmd

### DIFF
--- a/cmd/podman/containers/prune.go
+++ b/cmd/podman/containers/prune.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v3/cmd/podman/common"
+	"github.com/containers/podman/v3/cmd/podman/parse"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/cmd/podman/utils"
 	"github.com/containers/podman/v3/cmd/podman/validate"
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/containers/podman/v3/pkg/specgenutil"
 	"github.com/spf13/cobra"
 )
 
@@ -64,7 +64,7 @@ func prune(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	pruneOptions.Filters, err = specgenutil.ParseFilters(filter)
+	pruneOptions.Filters, err = parse.FilterArgumentsIntoFilters(filter)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/images/prune.go
+++ b/cmd/podman/images/prune.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v3/cmd/podman/common"
+	"github.com/containers/podman/v3/cmd/podman/parse"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/cmd/podman/utils"
 	"github.com/containers/podman/v3/cmd/podman/validate"
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/containers/podman/v3/pkg/specgenutil"
 	"github.com/spf13/cobra"
 )
 
@@ -66,7 +66,7 @@ func prune(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 	}
-	filterMap, err := specgenutil.ParseFilters(filter)
+	filterMap, err := parse.FilterArgumentsIntoFilters(filter)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -10,10 +10,10 @@ import (
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/report"
 	"github.com/containers/podman/v3/cmd/podman/common"
+	"github.com/containers/podman/v3/cmd/podman/parse"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/cmd/podman/validate"
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -61,14 +61,12 @@ func init() {
 }
 
 func networkList(cmd *cobra.Command, args []string) error {
-	networkListOptions.Filters = make(map[string][]string)
-	for _, f := range filters {
-		split := strings.SplitN(f, "=", 2)
-		if len(split) == 1 {
-			return errors.Errorf("invalid filter %q", f)
-		}
-		networkListOptions.Filters[split[0]] = append(networkListOptions.Filters[split[0]], split[1])
+	var err error
+	networkListOptions.Filters, err = parse.FilterArgumentsIntoFilters(filters)
+	if err != nil {
+		return err
 	}
+
 	responses, err := registry.ContainerEngine().NetworkList(registry.Context(), networkListOptions)
 	if err != nil {
 		return err

--- a/cmd/podman/networks/prune.go
+++ b/cmd/podman/networks/prune.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	"github.com/containers/podman/v3/cmd/podman/common"
+	"github.com/containers/podman/v3/cmd/podman/parse"
 	"github.com/containers/podman/v3/cmd/podman/registry"
 	"github.com/containers/podman/v3/cmd/podman/utils"
 	"github.com/containers/podman/v3/cmd/podman/validate"
 	"github.com/containers/podman/v3/pkg/domain/entities"
-	"github.com/containers/podman/v3/pkg/specgenutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -68,7 +68,7 @@ func networkPrune(cmd *cobra.Command, _ []string) error {
 			return nil
 		}
 	}
-	networkPruneOptions.Filters, err = specgenutil.ParseFilters(filter)
+	networkPruneOptions.Filters, err = parse.FilterArgumentsIntoFilters(filter)
 	if err != nil {
 		return err
 	}

--- a/pkg/specgenutil/util.go
+++ b/pkg/specgenutil/util.go
@@ -38,21 +38,6 @@ func ReadPodIDFiles(files []string) ([]string, error) {
 	return ids, nil
 }
 
-// ParseFilters transforms one filter format to another and validates input
-func ParseFilters(filter []string) (map[string][]string, error) {
-	// TODO Remove once filter refactor is finished and url.Values done.
-	filters := map[string][]string{}
-	for _, f := range filter {
-		t := strings.SplitN(f, "=", 2)
-		filters = make(map[string][]string)
-		if len(t) < 2 {
-			return map[string][]string{}, errors.Errorf("filter input must be in the form of filter=value: %s is invalid", f)
-		}
-		filters[t[0]] = append(filters[t[0]], t[1])
-	}
-	return filters, nil
-}
-
 // CreateExpose parses user-provided exposed port definitions and converts them
 // into SpecGen format.
 // TODO: The SpecGen format should really handle ranges more sanely - we could


### PR DESCRIPTION
This commit unifies the method of filters parsing in cmd.
It removes also the function redundancy.
[NO NEW TESTS NEEDED]

Signed-off-by: Jakub Guzik <jguzik@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
