### PR TITLE
[CI:DOCS] Cirrus: Temporarily disable OSX Cross task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -327,6 +327,7 @@ alt_build_task:
 osx_alt_build_task:
     name: "OSX Cross"
     alias: osx_alt_build
+    only_if: $CI != $CI  # Temporarily disabled while infra. non-functional
     depends_on:
         - build
     env:


### PR DESCRIPTION
At the time of this commit, something is broken within Cirrus-CI or
dependent infrastructure.  This appears to be causing all OSX tasks
to hang in the scheduling queue indefinitely.  Workaround this by
disabling the task to allow development work to proceed while a
fix is realized.