### PR TITLE
[CI:DOCS] Restore OSX cross-build task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -327,7 +327,6 @@ alt_build_task:
 osx_alt_build_task:
     name: "OSX Cross"
     alias: osx_alt_build
-    only_if: $CI != $CI  # Temporarily disabled while infra. non-functional
     depends_on:
         - build
     env:


### PR DESCRIPTION
The infra. outage was resolved manually by Cirrus-CI support around 3pm on the 17th.  This commit re-enables the OSX tasks which were perpetually queuing due to the outage.