### PR TITLE
compat attach: fix write on closed channel

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -660,13 +660,13 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 			}
 			errChan <- err
 		}()
+		if err := ctr.ReadLog(context.Background(), logOpts, logChan); err != nil {
+			return err
+		}
 		go func() {
 			logOpts.WaitGroup.Wait()
 			close(logChan)
 		}()
-		if err := ctr.ReadLog(context.Background(), logOpts, logChan); err != nil {
-			return err
-		}
 		logrus.Debugf("Done reading logs for container %s, %d bytes", ctr.ID(), logSize)
 		if err := <-errChan; err != nil {
 			return err

--- a/test/apiv2/python/rest_api/test_v2_0_0_container.py
+++ b/test/apiv2/python/rest_api/test_v2_0_0_container.py
@@ -130,7 +130,7 @@ class ContainerTestCase(APITestCase):
 
     def test_attach(self):
         self.skipTest("FIXME: Test timeouts")
-        r = requests.post(self.uri(self.resolve_container("/containers/{}/attach")), timeout=5)
+        r = requests.post(self.uri(self.resolve_container("/containers/{}/attach?logs=true")), timeout=5)
         self.assertIn(r.status_code, (101, 500), r.text)
 
     def test_logs(self):


### PR DESCRIPTION
Waiting on an initialized sync.WaitGroup returns immediately.
Hence, move the goroutine to wait and close *after* reading
the logs.

Fixes: #12904
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@mheon PTAL
