### PR TITLE
[CI:DOCS] Update troubleshooting.md

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -912,4 +912,4 @@ Resolution steps
 
 ### Solution
 
-You will need to remove the hanging gv-proxy process bound to the port in question. For example, if the port mentioned in the error message is 127.0.0.1:7777, you can use the command $ kill -9 $(lsof -i:7777) in order to identify and remove the hanging process which prevents you from starting a new VM on that default port.
+You will need to remove the hanging gv-proxy process bound to the port in question. For example, if the port mentioned in the error message is 127.0.0.1:7777, you can use the command `kill -9 $(lsof -i:7777)` in order to identify and remove the hanging process which prevents you from starting a new VM on that default port.

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -908,12 +908,8 @@ Resolution steps
 * Before invoking Podman command create a valid login session for your rootless user using `loginctl enable-linger <username>`
 * If `loginctl` is unavailable you can also try logging in via `ssh` i.e `ssh <username>@localhost`.
 
-### 31) After deletion of a client VM on MacOS via podman machine stop && podman machine rm, attempting to init a new client VM leads to an error with the 127.0.0.1:7777 port already bound. 
+### 31) After deletion of a client VM on MacOS via podman machine stop && podman machine rm, attempting to init a new client VM leads to an error with the 127.0.0.1:7777 port already bound.
 
-### Solution 
+### Solution
 
 You will need to remove the hanging gv-proxy process bound to the port in question. For example, if the port mentioned in the error message is 127.0.0.1:7777, you can use the command $ kill -9 $(lsof -i:7777) in order to identify and remove the hanging process which prevents you from starting a new VM on that default port.
-
-
-
-

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -907,3 +907,13 @@ Resolution steps
 
 * Before invoking Podman command create a valid login session for your rootless user using `loginctl enable-linger <username>`
 * If `loginctl` is unavailable you can also try logging in via `ssh` i.e `ssh <username>@localhost`.
+
+### 31) After deletion of a client VM on MacOS via podman machine stop && podman machine rm, attempting to init a new client VM leads to an error with the 127.0.0.1:7777 port already bound. 
+
+### Solution 
+
+You will need to remove the hanging gv-proxy process bound to the port in question. For example, if the port mentioned in the error message is 127.0.0.1:7777, you can use the command $ kill -9 $(lsof -i:7777) in order to identify and remove the hanging process which prevents you from starting a new VM on that default port.
+
+
+
+

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -908,7 +908,13 @@ Resolution steps
 * Before invoking Podman command create a valid login session for your rootless user using `loginctl enable-linger <username>`
 * If `loginctl` is unavailable you can also try logging in via `ssh` i.e `ssh <username>@localhost`.
 
-### 31) After deletion of a client VM on MacOS via podman machine stop && podman machine rm, attempting to init a new client VM leads to an error with the 127.0.0.1:7777 port already bound.
+### 31) 127.0.0.1:7777 port already bound
+
+After deleting a VM on macOS, the initialization of subsequent VM's fails.
+
+#### Symptom 
+
+After deleting a client VM on macOS via `podman machine stop` && `podman machine rm`, attempting to init a new client VM leads to an error with the 127.0.0.1:7777 port already bound.
 
 ### Solution
 


### PR DESCRIPTION
Added troubleshooting FAQ for killing a hanging process bound to the default port preventing users from starting a new VM with podman machine start after previously removing a podman client VM on MacOS.

Signed-off-by: Bart Zhang <bazhang@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

