### PR TITLE
Add --context-dir option to podman play kube

### DIFF
--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -119,9 +119,11 @@ func init() {
 
 		buildFlagName := "build"
 		flags.BoolVar(&kubeOptions.BuildCLI, buildFlagName, false, "Build all images in a YAML (given Containerfiles exist)")
-	}
 
-	if !registry.IsRemote() {
+		contextDirFlagName := "context-dir"
+		flags.StringVar(&kubeOptions.ContextDir, contextDirFlagName, "", "Path to top level of context directory")
+		_ = kubeCmd.RegisterFlagCompletionFunc(contextDirFlagName, completion.AutocompleteDefault)
+
 		flags.StringVar(&kubeOptions.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
 
 		_ = flags.MarkHidden("signature-policy")
@@ -146,6 +148,9 @@ func kube(cmd *cobra.Command, args []string) error {
 		if _, err := os.Stat(kubeOptions.Authfile); err != nil {
 			return err
 		}
+	}
+	if kubeOptions.ContextDir != "" && kubeOptions.Build != types.OptionalBoolTrue {
+		return errors.New("--build must be specified when using --context-dir option")
 	}
 	if kubeOptions.CredentialsCLI != "" {
 		creds, err := util.ParseRegistryCreds(kubeOptions.CredentialsCLI)

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -115,7 +115,7 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 
 #### **--build**
 
-Build images even if they are found in the local storage. Use `--build=false` to completely disable builds.
+Build images even if they are found in the local storage. Use `--build=false` to completely disable builds. (This option is not available with the remote Podman client)
 
 #### **--cert-dir**=*path*
 
@@ -124,9 +124,13 @@ Please refer to containers-certs.d(5) for details. (This option is not available
 
 #### **--configmap**=*path*
 
-Use Kubernetes configmap YAML at path to provide a source for environment variable values within the containers of the pod.
+Use Kubernetes configmap YAML at path to provide a source for environment variable values within the containers of the pod.  (This option is not available with the remote Podman client)
 
 Note: The *--configmap* option can be used multiple times or a comma-separated list of paths can be used to pass multiple Kubernetes configmap YAMLs.
+
+#### **--context-dir**=*path*
+
+Use *path* as the build context directory for each image. Requires --build option be true. (This option is not available with the remote Podman client)
 
 #### **--creds**
 

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -14,6 +14,8 @@ type PlayKubeOptions struct {
 	Build types.OptionalBool
 	// CertDir - to a directory containing TLS certifications and keys.
 	CertDir string
+	// ContextDir - directory containing image contexts used for Build
+	ContextDir string
 	// Down indicates whether to bring contents of a yaml file "down"
 	// as in stop
 	Down bool

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -354,9 +354,15 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 
 	containers := make([]*libpod.Container, 0, len(podYAML.Spec.Containers))
 	initContainers := make([]*libpod.Container, 0, len(podYAML.Spec.InitContainers))
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, err
+
+	var cwd string
+	if options.ContextDir != "" {
+		cwd = options.ContextDir
+	} else {
+		cwd, err = os.Getwd()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	for _, initCtr := range podYAML.Spec.InitContainers {


### PR DESCRIPTION
This option was requested so that users could specify alternate
locations to find context directories for each image build. It
requites the --build option to be set.

Partial Fix: https://github.com/containers/podman/issues/12485

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
