### PR TITLE
Implement API forwarding for podman machine on Windows

### DIFF
--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine
@@ -64,5 +65,6 @@ func start(cmd *cobra.Command, args []string) error {
 	if err := vm.Start(vmName, machine.StartOptions{}); err != nil {
 		return err
 	}
+	fmt.Printf("Machine %q started successfully\n", vmName)
 	return nil
 }

--- a/contrib/msi/podman.wxs
+++ b/contrib/msi/podman.wxs
@@ -29,6 +29,9 @@
             <Component Id="WinPathExecutable" Guid="00F5B731-D4A6-4B69-87B0-EA4EBAB89F95" Win64="Yes">
               <File Id="8F507E28-A61D-4E64-A92B-B5A00F023AE8" Name="winpath.exe" Source="bin/windows/winpath.exe" KeyPath="yes"/>
             </Component>
+            <Component Id="WinSshProxyExecutable" Guid="0DA730AB-2F97-40E8-A8FC-356E88EAA4D2" Win64="Yes">
+              <File Id="4A2AD125-34E7-4BD8-BE28-B2A9A5EDBEB5" Name="win-sshproxy.exe" Source="bin/windows/win-sshproxy.exe" KeyPath="yes"/>
+            </Component>
           </Directory>
         </Directory>
       </Directory>
@@ -41,6 +44,7 @@
       <ComponentRef Id="INSTALLDIR_Component"/>
       <ComponentRef Id="MainExecutable"/>
       <ComponentRef Id="WinPathExecutable"/>
+      <ComponentRef Id="WinSshProxyExecutable"/>
       <ComponentGroupRef Id="ManFiles"/>
     </Feature>
 


### PR DESCRIPTION
Implements API forwarding for podman machine on Windows, providing out of the box Docker API client access (the windows variant of #11462, and portion of #11422) 

This support builds on the standalone ssh proxying facility for windows (win-sshproxy.exe) that was contributed to gvproxy (containers/gvisor-tap-vsock#88). A standalone approach is necessary since:

-  Podman doesn't implement daemons
- There is no vsock layer involved since WSL handles networking transparently

It does however share the same implementation with the ssh facility that was added to gvproxy. 

This approach prefers to bind to the default pipe address expected by Docker API clients, if it is available:
\\.\pipe\docker_engine

However, if a user is running a process which has it bound (e.g. they are running something like Docker Desktop, or using multiple instances of podman machine), then it will fall back to a machine namespaces pipe name that should be unique.

Helpful messages are provided in both scenarios:

1.  Default global pipe is available

```
PS C:\Users\User> podman machine start
Starting machine "podman-machine-default"
API forwarding listening on: npipe:////./pipe/docker_engine

Docker API clients default to this address. You do not need to set DOCKER_HOST.
Machine "podman-machine-default" started successfully
```

2. Default global pipe is taken by another process ATM

```
PS C:\Users\User> podman machine start
Starting machine "podman-machine-default"
API forwarding listening on: npipe:////./pipe/podman-machine-default

Another process was listening on the default Docker API pipe address.
You can still connect Docker API clients by setting DOCKER HOST using the
following powershell command in your terminal session:

        $Env:DOCKER_HOST = 'npipe:////./pipe/podman-machine-default'

Or in a classic CMD prompt:

        set DOCKER_HOST = 'npipe:////./pipe/podman-machine-default'

Alternatively terminate the other process and restart podman machine.
Machine "podman-machine-default" started successfully
```

Example Docker API Client Output
----------------------------------

```
PS C:\Users\User\docker\docker> .\docker.exe version
Client:
 Version:           20.10.12
 API version:       1.40
 Go version:        go1.16.12
 Git commit:        e91ed57
 Built:             Mon Dec 13 11:44:07 2021
 OS/Arch:           windows/amd64
 Context:           default
 Experimental:      true

Server: linux/amd64/fedora-35
 Podman Engine:
  Version:          3.4.4
  APIVersion:       3.4.4
  Arch:             amd64
  BuildTime:        2021-12-08T15:45:07-06:00
  Experimental:     false
  GitCommit:
  GoVersion:        go1.16.8
  KernelVersion:    5.10.60.1-microsoft-standard-WSL2
  MinAPIVersion:    3.1.0
  Os:               linux
```

win-sshproxy.exe Details
-------------------------
See specific implementation details in containers/gvisor-tap-vsock#88 

The ssh proxy is implemented as a background service, so there is no attached console. Logging goes to the windows event log, which can be viewed using either the windows event viewer or powershell commands like the following:

```
TimeCreated                      Id LevelDisplayName Message
-----------                      -- ---------------- -------
1/18/2022 4:44:27 PM           1000 Information      [info ] podman-machine-default: Listening on: \\.\pipe\docker_engine...
1/18/2022 4:44:28 PM           1000 Information      [info ] podman-machine-default: Socket forward established: //./pipe/docker_engine to /run/podman/podman.sock
```

Important Build Process Note
-----------------------------
A possible controversial change is the new Makefile target which does a git checkout of a specific SHA of containers/gvisor-tap-vsock to build the helper executable.  This action is *only* performed when building the Windows Installer (podman.msi task) which needs to include the executable with podman.exe (an external dependency would be a major usability hurdle)

The other approach I had first attempted was to just add a dependency on single package in gvisor-tap and use a thin cmd/ impl. However the problem with this approach is the transitive deps conflict and would require alignment between the two projects. This seems like a no-go since the only reason for the dependency is just the single command. 

Another alternative approach would be to break out a separate project that both gvisor-tap-vsock and podman could depend on, but this seems like an unnecessary overhead for something with small scope that is likely to have minimal changes. 

[NO NEW TESTS NEEDED] , waiting on ephermal azure capabilities in Cirrus CI 
