### PR TITLE
apiv2 test: add regression test for #12904

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -18,6 +18,11 @@ podman rm -a -f &>/dev/null
 
 t GET "libpod/containers/json (at start: clean slate)" 200 length=0
 
+# Regression test for #12904
+podman run --rm -d --replace --name foo $IMAGE sh -c "echo 123;sleep 42"
+t POST "containers/foo/attach?logs=true&stream=false" 200
+t POST "containers/foo/kill" 204
+
 podman run -v /tmp:/tmp $IMAGE true
 
 t GET libpod/containers/json 200 length=0


### PR DESCRIPTION
Add a regression test for issue #12904 to make sure that attaching with
logs=true to the compact endpoint does not blow up.  Note that I did not
find a way to test the output (i.e., '123'); logs are sent in a binary
format and I did not find a way to compare the control characters.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
