### PR TITLE
APIv2 tests: followup to recent log test

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -18,9 +18,12 @@ podman rm -a -f &>/dev/null
 
 t GET "libpod/containers/json (at start: clean slate)" 200 length=0
 
-# Regression test for #12904
-podman run --rm -d --replace --name foo $IMAGE sh -c "echo 123;sleep 42"
-t POST "containers/foo/attach?logs=true&stream=false" 200
+# Regression test for #12904 (race condition in logging code)
+mytext="hi-there-$(random_string 15)"
+podman run --rm -d --replace --name foo $IMAGE sh -c "echo $mytext;sleep 42"
+# Logs output is prepended by ^A^X
+t POST "containers/foo/attach?logs=true&stream=false" 200 \
+  $'\001\030'$mytext
 t POST "containers/foo/kill" 204
 
 podman run -v /tmp:/tmp $IMAGE true
@@ -236,11 +239,16 @@ t GET containers/$cid/json 200 \
 t POST containers/create Image=$IMAGE Entrypoint='["top"]' 201 \
   .Id~[0-9a-f]\\{64\\}
 cid_top=$(jq -r '.Id' <<<"$output")
+# .Network is N/A when rootless
+network_expect=
+if root; then
+    network_expect='.NetworkSettings.Networks.podman.NetworkID=podman'
+fi
 t GET containers/${cid_top}/json 200 \
   .Config.Entrypoint[0]="top" \
   .Config.Cmd='[]' \
   .Path="top" \
-  .NetworkSettings.Networks.podman.NetworkID=podman
+  $network_expect
 t POST  containers/${cid_top}/start 204
 # make sure the container is running
 t GET containers/${cid_top}/json 200 \
@@ -364,11 +372,15 @@ t GET containers/$cid/json 200 \
 t DELETE containers/$cid?v=true 204
 
 # Test Compat Create with default network mode (#10569)
+networkmode=slirp4netns
+if root; then
+    networkmode=bridge
+fi
 t POST containers/create Image=$IMAGE HostConfig='{"NetworkMode":"default"}' 201 \
   .Id~[0-9a-f]\\{64\\}
 cid=$(jq -r '.Id' <<<"$output")
 t GET containers/$cid/json 200 \
-  .HostConfig.NetworkMode="bridge"
+  .HostConfig.NetworkMode="$networkmode"
 
 t DELETE containers/$cid?v=true 204
 

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -45,8 +45,14 @@ echo 0 >$failures_file
 # Where the tests live
 TESTS_DIR=$(realpath $(dirname $0))
 
+# As of 2021-11 podman has one external helper binary, rootlessport, needed
+# for rootless networking.
+if [[ -z "$CONTAINERS_HELPER_BINARY_DIR" ]]; then
+    export CONTAINERS_HELPER_BINARY_DIR=$(realpath ${TESTS_DIR}/../../bin)
+fi
+
 # Path to podman binary
-PODMAN_BIN=${PODMAN:-${TESTS_DIR}/../../bin/podman}
+PODMAN_BIN=${PODMAN:-${CONTAINERS_HELPER_BINARY_DIR}/podman}
 
 # Cleanup handlers
 clean_up_server() {
@@ -289,7 +295,8 @@ function t() {
         output="[$(file --brief $WORKDIR/curl.result.out)]"
         echo "$output" >>$LOG
     elif [[ -e $WORKDIR/curl.result.out ]]; then
-        output=$(< $WORKDIR/curl.result.out)
+        # Output from /logs sometimes includes NULs. Strip them.
+        output=$(tr -d '\0' < $WORKDIR/curl.result.out)
 
         if [[ $content_type =~ application/json ]] && [[ $method != "HEAD" ]]; then
             jq . <<<"$output" >>$LOG


### PR DESCRIPTION
Followup to #12919, which merged while I was writing
review feedback. This actually confirms log output.
This required a minor change to the 't' helper: stripping
NUL chars from the http result.

And, while I'm at it, a bunch of cleanup for running rootless:
- set $CONTAINERS_HELPER_BINARY_DIR, so we can find rootlessport
- add a few conditionals for different expectations

Signed-off-by: Ed Santiago <santiago@redhat.com>
