### PR TITLE
rootless: report correctly the error

### DIFF
--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -390,11 +390,11 @@ func becomeRootInUserNS(pausePid, fileToRead string, fileOutput *os.File) (_ boo
 				return joinUserAndMountNS(uint(pid), "")
 			}
 		}
-		return false, -1, errors.Wrapf(err, "error setting up the process")
+		return false, -1, errors.New("error setting up the process")
 	}
 
 	if b[0] != '0' {
-		return false, -1, errors.Wrapf(err, "error setting up the process")
+		return false, -1, errors.New("error setting up the process")
 	}
 
 	signals := []os.Signal{}


### PR DESCRIPTION
`err` is nil at this point, so errors.Wrapf() would return nil
ignoring the remaining arguments.  This would prevent SetupRootless()
to fail causing podman to run without capabilities but believing so,
and it would end up in a crash when accessing the local store.

Closes: https://github.com/containers/podman/discussions/12923

[NO NEW TESTS NEEDED] it requires running in the environment created
by bazel linux-sandbox.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
