### PR TITLE
Don't segfault if an image layer has no creation timestamp

### DIFF
--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -94,7 +94,9 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 func toDomainHistoryLayer(layer *libimage.ImageHistory) entities.ImageHistoryLayer {
 	l := entities.ImageHistoryLayer{}
 	l.ID = layer.ID
-	l.Created = *layer.Created
+	if layer.Created != nil {
+		l.Created = *layer.Created
+	}
 	l.CreatedBy = layer.CreatedBy
 	copy(l.Tags, layer.Tags)
 	l.Size = layer.Size

--- a/pkg/domain/infra/abi/images_test.go
+++ b/pkg/domain/infra/abi/images_test.go
@@ -1,5 +1,22 @@
 package abi
 
+import (
+	"testing"
+
+	"github.com/containers/common/libimage"
+	"github.com/stretchr/testify/assert"
+)
+
+// This is really intended to verify what happens with a
+// nil pointer in layer.Created, but we'll just sanity
+// check round tripping 42.
+func TestToDomainHistoryLayer(t *testing.T) {
+	var layer libimage.ImageHistory
+	layer.Size = 42
+	newLayer := toDomainHistoryLayer(&layer)
+	assert.Equal(t, layer.Size, newLayer.Size)
+}
+
 //
 // import (
 // 	"context"


### PR DESCRIPTION
It's optional in the specification, and I initially omitted
it in the ostree code.  Now I've fixed the ostree code
to inject a timestamp, but we should clearly avoid segfaulting
on this case.
