### PR TITLE
compat: `images/load` must be able to load tar with multiple images

### DIFF
--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -503,8 +503,8 @@ func LoadImages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(loadReport.Names) != 1 {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Errorf("%d instead of 1 were loaded", len(loadReport.Names)))
+	if len(loadReport.Names) < 1 {
+		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Errorf("one or more images are required"))
 		return
 	}
 

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -511,7 +511,7 @@ func LoadImages(w http.ResponseWriter, r *http.Request) {
 	utils.WriteResponse(w, http.StatusOK, struct {
 		Stream string `json:"stream"`
 	}{
-		Stream: fmt.Sprintf("Loaded image: %s\n", loadReport.Names[0]),
+		Stream: fmt.Sprintf("Loaded image: %s", strings.Join(loadReport.Names, ",")),
 	})
 }
 

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -197,6 +197,14 @@ t POST "build?dockerfile=containerfile" $CONTAINERFILE_TAR 200 \
 t POST libpod/images/prune 200
 t POST libpod/images/prune 200 length=0 []
 
+# compat api must allow loading tar which contain multiple images
+podman pull quay.io/libpod/alpine:latest quay.io/libpod/busybox:latest
+podman save -o ${TMPD}/test.tar quay.io/libpod/alpine:latest quay.io/libpod/busybox:latest
+t POST "images/load" ${TMPD}/test.tar 200 \
+  .stream="Loaded image: quay.io/libpod/busybox:latest,quay.io/libpod/alpine:latest"
+t GET libpod/images/quay.io/libpod/alpine:latest/exists  204
+t GET libpod/images/quay.io/libpod/busybox:latest/exists  204
+
 cleanBuildTest
 
 # vim: filetype=sh


### PR DESCRIPTION
`http:/host:port/images/load` fails to accept tar with more than one
images however manual load works as expected. Remove explicit check for
`1` image and only fail if result set has value less than `1`.

Closes: https://github.com/containers/podman/issues/12638