### PR TITLE
Fix nil pointer dereference for configmap optional

### DIFF
--- a/pkg/specgen/generate/kube/volume.go
+++ b/pkg/specgen/generate/kube/volume.go
@@ -122,7 +122,7 @@ func VolumeFromConfigMap(configMapVolumeSource *v1.ConfigMapVolumeSource, config
 
 	if configMap == nil {
 		// If the volumeSource was optional, move on even if a matching configmap wasn't found
-		if *configMapVolumeSource.Optional {
+		if configMapVolumeSource.Optional != nil && *configMapVolumeSource.Optional {
 			kv.Source = configMapVolumeSource.Name
 			kv.Optional = *configMapVolumeSource.Optional
 			return kv, nil


### PR DESCRIPTION
This PR fixes nil pointer dereference for configmap optional parameter.
When optional parameter is not passed, the code tried to acces the
parameter which caused nil pointer dereference.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Make sure configmap `mycm` don't exist and run following code:
```yaml
kind: Pod
metadata:
  name: cm-nginx
spec:
  containers:
  - envFrom:
    - configMapRef:
        name: foo
    image: quay.io/bitnami/nginx:latest
    name: nginx
    ports:
    - containerPort: 8080
      hostPort: 8886
      protocol: TCP
    volumeMounts:
      - name: mycm
        mountPath: /mycm
  volumes:
    - name: mycm
      configMap:
        name: mycm

```

```bash
$ podman play kube /tmp/cm.yaml
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1619e02]

goroutine 1 [running]:
github.com/containers/podman/v4/pkg/specgen/generate/kube.VolumeFromConfigMap(0xc00003cb40, 0x0, 0x0, 0x0, 0xc00080c890, 0x41b56d, 0x1c135a0)
	/home/omachace/go/src/github.com/containers/podman/pkg/specgen/generate/kube/volume.go:125 +0x362
github.com/containers/podman/v4/pkg/specgen/generate/kube.VolumeFromSource(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/omachace/go/src/github.com/containers/podman/pkg/specgen/generate/kube/volume.go:156 +0x86
github.com/containers/podman/v4/pkg/specgen/generate/kube.InitializeVolumes(0xc000621000, 0x1, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/omachace/go/src/github.com/containers/podman/pkg/specgen/generate/kube/volume.go:167 +0x114
github.com/containers/podman/v4/pkg/domain/infra/abi.(*ContainerEngine).playKubePod(0xc0000107d0, 0x1fcbd28, 0xc0007bfcb0, 0xc00017e7a8, 0x8, 0xc00080f670, 0x0, 0x0, 0x0, 0x0, ...)
	/home/omachace/go/src/github.com/containers/podman/pkg/domain/infra/abi/play.go:272 +0xd46
github.com/containers/podman/v4/pkg/domain/infra/abi.(*ContainerEngine).PlayKube(0xc0000107d0, 0x1fcbd28, 0xc0007bfcb0, 0x7ffd8627d76d, 0x1d, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/omachace/go/src/github.com/containers/podman/pkg/domain/infra/abi/play.go:82 +0x505
github.com/containers/podman/v4/cmd/podman/play.playkube(0x7ffd8627d76d, 0x1d, 0x5, 0xc0007b8800)
	/home/omachace/go/src/github.com/containers/podman/cmd/podman/play/kube.go:217 +0xbe
github.com/containers/podman/v4/cmd/podman/play.kube(0x2a8ad80, 0xc00040c9e0, 0x1, 0x1, 0x0, 0x0)
	/home/omachace/go/src/github.com/containers/podman/cmd/podman/play/kube.go:175 +0x25e
github.com/spf13/cobra.(*Command).execute(0x2a8ad80, 0xc000142030, 0x1, 0x1, 0x2a8ad80, 0xc000142030)
	/home/omachace/go/src/github.com/containers/podman/vendor/github.com/spf13/cobra/command.go:856 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0x2a93980, 0xc00013a030, 0x1a7ca40, 0x2b57938)
	/home/omachace/go/src/github.com/containers/podman/vendor/github.com/spf13/cobra/command.go:974 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/home/omachace/go/src/github.com/containers/podman/vendor/github.com/spf13/cobra/command.go:902
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/home/omachace/go/src/github.com/containers/podman/vendor/github.com/spf13/cobra/command.go:895
main.Execute()
	/home/omachace/go/src/github.com/containers/podman/cmd/podman/root.go:100 +0xe7
main.main()
	/home/omachace/go/src/github.com/containers/podman/cmd/podman/main.go:40 +0x9e
```

