### PR TITLE
Remove rootless_networking option from containers.conf

### DIFF
--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -243,7 +243,6 @@ ExecStart=/usr/bin/sleep infinity
 `
 	containers := `[containers]
 netns="bridge"
-rootless_networking="cni"
 `
 	rootContainers := `[engine]
 machine_enabled=true

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -353,11 +353,11 @@ func ParseNetworkFlag(networks []string) (Namespace, map[string]types.PerNetwork
 		toReturn.NSMode = FromPod
 	case ns == "" || ns == string(Default) || ns == string(Private):
 		// Net defaults to Slirp on rootless
-		if rootless.IsRootless() && containerConfig.Containers.RootlessNetworking != "cni" {
+		if rootless.IsRootless() {
 			toReturn.NSMode = Slirp
 			break
 		}
-		// if not slirp we use bridge
+		// if root we use bridge
 		fallthrough
 	case ns == string(Bridge), strings.HasPrefix(ns, string(Bridge)+":"):
 		toReturn.NSMode = Bridge


### PR DESCRIPTION
This field was only needed for machine to force cni, however you can set
netns="bridge" in the config to have the same effect. This is already
done in the machine setup.

see https://github.com/containers/common/pull/895

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
