### PR TITLE
System tests: fix for new systemd on rawhide

### DIFF
--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -373,8 +373,10 @@ EOF
     systemctl enable --now podman-auto-update-$cname.timer
     systemctl list-timers --all
 
-    # While systemd v245 and later uses 'Finished', older versions uses 'Started' for oneshot services
-    local expect='(Finished|Started) Podman auto-update testing service'
+    # systemd       <245 displays 'Started Podman auto-update ...'
+    # systemd 245 - <250 displays 'Finished Podman auto-update ...'
+    # systemd 250 - ???? displays 'Finished <unit name> - Podman auto-...'
+    local expect='(Started|Finished.*) Podman auto-update testing service'
     local failed_start=failed
     local count=0
     while [ $count -lt 120 ]; do


### PR DESCRIPTION
systemd 250 on f36 has changed the output format of a message
our tests rely on. This breaks bodhi gating tests. Fix test
so it accepts a continually-growing set of systemd outputs.

Signed-off-by: Ed Santiago <santiago@redhat.com>
