### PR TITLE
Restore machine start logic that was hanging

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -390,12 +390,14 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		if err != nil {
 			return err
 		}
-		for running || !v.isListening() {
+		listening := v.isListening()
+		for !running || !listening {
 			time.Sleep(100 * time.Millisecond)
 			running, err = v.isRunning()
 			if err != nil {
 				return err
 			}
+			listening = v.isListening()
 		}
 	}
 	for _, mount := range v.Mounts {


### PR DESCRIPTION
After refactoring Stop(), mounting volumes was hanging in Start().

Restore the conditional, and add error reporting from isListening.

---

Fixes issue from https://github.com/containers/podman/pull/12835#issuecomment-1016841650

```
Starting machine "podman-machine-default"
INFO[0000] waiting for clients...                       
Waiting for VM ...
INFO[0000] new connection from @ to /run/user/1000/podman/qemu_podman-machine-default.sock 
Mounting volume... /home/anders/mywork:/tmp/workspace
Machine "podman-machine-default" started successfully
```