### PR TITLE
Fix handling of duplicate matches on id expansion

### DIFF
--- a/pkg/api/handlers/utils/errors.go
+++ b/pkg/api/handlers/utils/errors.go
@@ -40,10 +40,12 @@ func VolumeNotFound(w http.ResponseWriter, name string, err error) {
 }
 
 func ContainerNotFound(w http.ResponseWriter, name string, err error) {
-	if errors.Cause(err) != define.ErrNoSuchCtr {
+	switch errors.Cause(err) {
+	case define.ErrNoSuchCtr, define.ErrCtrExists:
+		Error(w, http.StatusNotFound, err)
+	default:
 		InternalServerError(w, err)
 	}
-	Error(w, http.StatusNotFound, err)
 }
 
 func ImageNotFound(w http.ResponseWriter, name string, err error) {


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/12963

[NO NEW TESTS NEEDED] I don't know how to create two
containers with the same first digit of the digest,
which I could them attempt to remove.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
