### PR TITLE
Remove unused param from utils.Error in pkg/api and clean API handlers

### DIFF
--- a/pkg/api/handlers/compat/auth.go
+++ b/pkg/api/handlers/compat/auth.go
@@ -28,7 +28,7 @@ func Auth(w http.ResponseWriter, r *http.Request) {
 	var authConfig docker.AuthConfig
 	err := json.NewDecoder(r.Body).Decode(&authConfig)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to parse request"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse request"))
 		return
 	}
 

--- a/pkg/api/handlers/compat/changes.go
+++ b/pkg/api/handlers/compat/changes.go
@@ -20,7 +20,7 @@ func Changes(w http.ResponseWriter, r *http.Request) {
 		DiffType string `schema:"diffType"`
 	}{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	var diffType define.DiffType
@@ -32,7 +32,7 @@ func Changes(w http.ResponseWriter, r *http.Request) {
 	case "image":
 		diffType = define.DiffImage
 	default:
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Errorf("invalid diffType value %q", query.DiffType))
+		utils.Error(w, http.StatusBadRequest, errors.Errorf("invalid diffType value %q", query.DiffType))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -46,8 +46,7 @@ func RemoveContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -61,8 +60,7 @@ func RemoveContainer(w http.ResponseWriter, r *http.Request) {
 		options.Depend = query.Depend
 	} else {
 		if query.Link {
-			utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-				utils.ErrLinkNotSupport)
+			utils.Error(w, http.StatusBadRequest, utils.ErrLinkNotSupport)
 			return
 		}
 		options.Volumes = query.DockerVolumes
@@ -112,12 +110,12 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to decode filter parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to decode filter parameters for %s", r.URL.String()))
 		return
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -189,7 +187,7 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -217,7 +215,7 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 		Signal: "KILL",
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -232,7 +230,7 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Cause(err) == define.ErrCtrStateInvalid ||
 			errors.Cause(err) == define.ErrCtrStopped {
-			utils.Error(w, fmt.Sprintf("Container %s is not running", name), http.StatusConflict, err)
+			utils.Error(w, http.StatusConflict, err)
 			return
 		}
 		if errors.Cause(err) == define.ErrNoSuchCtr {
@@ -262,7 +260,7 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 				Interval:  time.Millisecond * 250,
 			}
 			if _, err := containerEngine.ContainerWait(r.Context(), []string{name}, opts); err != nil {
-				utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+				utils.Error(w, http.StatusInternalServerError, err)
 				return
 			}
 		}
@@ -613,7 +611,7 @@ func RenameContainer(w http.ResponseWriter, r *http.Request) {
 		Name string `schema:"name"`
 	}{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -625,7 +623,7 @@ func RenameContainer(w http.ResponseWriter, r *http.Request) {
 
 	if _, err := runtime.RenameContainer(r.Context(), ctr, query.Name); err != nil {
 		if errors.Cause(err) == define.ErrPodExists || errors.Cause(err) == define.ErrCtrExists {
-			utils.Error(w, "Something went wrong.", http.StatusConflict, err)
+			utils.Error(w, http.StatusConflict, err)
 			return
 		}
 		utils.InternalServerError(w, err)

--- a/pkg/api/handlers/compat/containers_archive.go
+++ b/pkg/api/handlers/compat/containers_archive.go
@@ -28,7 +28,7 @@ func Archive(w http.ResponseWriter, r *http.Request) {
 	case http.MethodHead, http.MethodGet:
 		handleHeadAndGet(w, r, decoder, runtime)
 	default:
-		utils.Error(w, fmt.Sprintf("unsupported method: %v", r.Method), http.StatusNotImplemented, errors.New(fmt.Sprintf("unsupported method: %v", r.Method)))
+		utils.Error(w, http.StatusNotImplemented, errors.New(fmt.Sprintf("unsupported method: %v", r.Method)))
 	}
 }
 
@@ -39,12 +39,12 @@ func handleHeadAndGet(w http.ResponseWriter, r *http.Request, decoder *schema.De
 
 	err := decoder.Decode(&query, r.URL.Query())
 	if err != nil {
-		utils.Error(w, "Bad Request.", http.StatusBadRequest, errors.Wrap(err, "couldn't decode the query"))
+		utils.Error(w, http.StatusBadRequest, errors.Wrap(err, "couldn't decode the query"))
 		return
 	}
 
 	if query.Path == "" {
-		utils.Error(w, "Bad Request.", http.StatusBadRequest, errors.New("missing `path` parameter"))
+		utils.Error(w, http.StatusBadRequest, errors.New("missing `path` parameter"))
 		return
 	}
 
@@ -59,7 +59,7 @@ func handleHeadAndGet(w http.ResponseWriter, r *http.Request, decoder *schema.De
 	if statReport != nil {
 		statHeader, err := copy.EncodeFileInfo(&statReport.FileInfo)
 		if err != nil {
-			utils.Error(w, "Something went wrong", http.StatusInternalServerError, err)
+			utils.Error(w, http.StatusInternalServerError, err)
 			return
 		}
 		w.Header().Add(copy.XDockerContainerPathStatHeader, statHeader)
@@ -68,10 +68,10 @@ func handleHeadAndGet(w http.ResponseWriter, r *http.Request, decoder *schema.De
 	if errors.Cause(err) == define.ErrNoSuchCtr || errors.Cause(err) == copy.ErrENOENT {
 		// 404 is returned for an absent container and path.  The
 		// clients must deal with it accordingly.
-		utils.Error(w, "Not found.", http.StatusNotFound, err)
+		utils.Error(w, http.StatusNotFound, err)
 		return
 	} else if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -83,7 +83,7 @@ func handleHeadAndGet(w http.ResponseWriter, r *http.Request, decoder *schema.De
 
 	copyFunc, err := containerEngine.ContainerCopyToArchive(r.Context(), containerName, query.Path, w)
 	if err != nil {
-		utils.Error(w, "Something went wrong", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/x-tar")
@@ -106,14 +106,14 @@ func handlePut(w http.ResponseWriter, r *http.Request, decoder *schema.Decoder, 
 
 	err := decoder.Decode(&query, r.URL.Query())
 	if err != nil {
-		utils.Error(w, "Bad Request.", http.StatusBadRequest, errors.Wrap(err, "couldn't decode the query"))
+		utils.Error(w, http.StatusBadRequest, errors.Wrap(err, "couldn't decode the query"))
 		return
 	}
 
 	var rename map[string]string
 	if query.Rename != "" {
 		if err := json.Unmarshal([]byte(query.Rename), &rename); err != nil {
-			utils.Error(w, "Bad Request.", http.StatusBadRequest, errors.Wrap(err, "couldn't decode the query"))
+			utils.Error(w, http.StatusBadRequest, errors.Wrap(err, "couldn't decode the query"))
 			return
 		}
 	}
@@ -126,16 +126,16 @@ func handlePut(w http.ResponseWriter, r *http.Request, decoder *schema.Decoder, 
 	if errors.Cause(err) == define.ErrNoSuchCtr || os.IsNotExist(err) {
 		// 404 is returned for an absent container and path.  The
 		// clients must deal with it accordingly.
-		utils.Error(w, "Not found.", http.StatusNotFound, errors.Wrap(err, "the container doesn't exists"))
+		utils.Error(w, http.StatusNotFound, errors.Wrap(err, "the container doesn't exists"))
 		return
 	} else if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 
 	if err := copyFunc(); err != nil {
 		logrus.Error(err.Error())
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/pkg/api/handlers/compat/containers_attach.go
+++ b/pkg/api/handlers/compat/containers_attach.go
@@ -28,7 +28,7 @@ func AttachContainer(w http.ResponseWriter, r *http.Request) {
 		Stream: true,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Error parsing parameters", http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -60,13 +60,13 @@ func AttachContainer(w http.ResponseWriter, r *http.Request) {
 		streams = nil
 	}
 	if useStreams && !streams.Stdout && !streams.Stderr && !streams.Stdin {
-		utils.Error(w, "Parameter conflict", http.StatusBadRequest, errors.Errorf("at least one of stdin, stdout, stderr must be true"))
+		utils.Error(w, http.StatusBadRequest, errors.Errorf("at least one of stdin, stdout, stderr must be true"))
 		return
 	}
 
 	// At least one of these must be set
 	if !query.Stream && !query.Logs {
-		utils.Error(w, "Unsupported parameter", http.StatusBadRequest, errors.Errorf("at least one of Logs or Stream must be set"))
+		utils.Error(w, http.StatusBadRequest, errors.Errorf("at least one of Logs or Stream must be set"))
 		return
 	}
 
@@ -85,7 +85,7 @@ func AttachContainer(w http.ResponseWriter, r *http.Request) {
 	// For Docker compatibility, we need to re-initialize containers in these states.
 	if state == define.ContainerStateConfigured || state == define.ContainerStateExited {
 		if err := ctr.Init(r.Context(), ctr.PodID() != ""); err != nil {
-			utils.Error(w, "Container in wrong state", http.StatusConflict, errors.Wrapf(err, "error preparing container %s for attach", ctr.ID()))
+			utils.Error(w, http.StatusConflict, errors.Wrapf(err, "error preparing container %s for attach", ctr.ID()))
 			return
 		}
 	} else if !(state == define.ContainerStateCreated || state == define.ContainerStateRunning) {

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -27,15 +27,14 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
 	// compatible configuration
 	body := handlers.CreateContainerConfig{}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 
@@ -43,18 +42,18 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	body.Name = query.Name
 
 	if len(body.HostConfig.Links) > 0 {
-		utils.Error(w, utils.ErrLinkNotSupport.Error(), http.StatusBadRequest, errors.Wrapf(utils.ErrLinkNotSupport, "bad parameter"))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(utils.ErrLinkNotSupport, "bad parameter"))
 		return
 	}
 	rtc, err := runtime.GetConfig()
 	if err != nil {
-		utils.Error(w, "unable to obtain runtime config", http.StatusInternalServerError, errors.Wrap(err, "unable to get runtime config"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to get runtime config"))
 		return
 	}
 
 	imageName, err := utils.NormalizeToDockerHub(r, body.Config.Image)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 		return
 	}
 	body.Config.Image = imageName
@@ -62,18 +61,18 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	newImage, resolvedName, err := runtime.LibimageRuntime().LookupImage(body.Config.Image, nil)
 	if err != nil {
 		if errors.Cause(err) == storage.ErrImageUnknown {
-			utils.Error(w, "No such image", http.StatusNotFound, errors.Wrap(err, "No such image"))
+			utils.Error(w, http.StatusNotFound, errors.Wrap(err, "No such image"))
 			return
 		}
 
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error looking up image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error looking up image"))
 		return
 	}
 
 	// Take body structure and convert to cliopts
 	cliOpts, args, err := common.ContainerCreateToContainerCLIOpts(body, rtc)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "make cli opts()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "make cli opts()"))
 		return
 	}
 
@@ -81,7 +80,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	// if the img had multi names with the same sha256 ID, should use the InputName, not the ID
 	if len(newImage.Names()) > 1 {
 		if err := utils.IsRegistryReference(resolvedName); err != nil {
-			utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, err)
+			utils.Error(w, http.StatusBadRequest, err)
 			return
 		}
 		// maybe the InputName has no tag, so use full name to display
@@ -90,7 +89,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 
 	sg := specgen.NewSpecGenerator(imgNameOrID, cliOpts.RootFS)
 	if err := specgenutil.FillOutSpecGen(sg, cliOpts, args); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "fill out specgen"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "fill out specgen"))
 		return
 	}
 	// moby always create the working directory
@@ -99,7 +98,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.ContainerCreate(r.Context(), sg)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "container create"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "container create"))
 		return
 	}
 	createResponse := entities.ContainerCreateResponse{

--- a/pkg/api/handlers/compat/containers_export.go
+++ b/pkg/api/handlers/compat/containers_export.go
@@ -21,21 +21,21 @@ func ExportContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	tmpfile, err := ioutil.TempFile("", "api.tar")
 	if err != nil {
-		utils.Error(w, "unable to create tarball tempfile", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
 		return
 	}
 	defer os.Remove(tmpfile.Name())
 	if err := tmpfile.Close(); err != nil {
-		utils.Error(w, "unable to close tempfile", http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
 		return
 	}
 	if err := con.Export(tmpfile.Name()); err != nil {
-		utils.Error(w, "failed to save the image", http.StatusInternalServerError, errors.Wrap(err, "failed to save image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to save image"))
 		return
 	}
 	rdr, err := os.Open(tmpfile.Name())
 	if err != nil {
-		utils.Error(w, "failed to read temp tarball", http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
 		return
 	}
 	defer rdr.Close()

--- a/pkg/api/handlers/compat/containers_logs.go
+++ b/pkg/api/handlers/compat/containers_logs.go
@@ -36,13 +36,13 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 		Tail: "all",
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
 	if !(query.Stdout || query.Stderr) {
 		msg := fmt.Sprintf("%s: you must choose at least one stream", http.StatusText(http.StatusBadRequest))
-		utils.Error(w, msg, http.StatusBadRequest, errors.Errorf("%s for %s", msg, r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Errorf("%s for %s", msg, r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_prune.go
+++ b/pkg/api/handlers/compat/containers_prune.go
@@ -18,7 +18,7 @@ func PruneContainers(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	filtersMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_restart.go
+++ b/pkg/api/handlers/compat/containers_restart.go
@@ -29,8 +29,7 @@ func RestartContainer(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_stats.go
+++ b/pkg/api/handlers/compat/containers_stats.go
@@ -29,11 +29,11 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		Stream: true,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	if query.Stream && query.OneShot { // mismatch. one-shot can only be passed with stream=false
-		utils.Error(w, "invalid combination of stream and one-shot", http.StatusBadRequest, define.ErrInvalidArg)
+		utils.Error(w, http.StatusBadRequest, define.ErrInvalidArg)
 		return
 	}
 
@@ -52,7 +52,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if state != define.ContainerStateRunning {
-		utils.Error(w, "Container not running and streaming requested", http.StatusConflict, define.ErrCtrStateInvalid)
+		utils.Error(w, http.StatusConflict, define.ErrCtrStateInvalid)
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_stop.go
+++ b/pkg/api/handlers/compat/containers_stop.go
@@ -29,8 +29,7 @@ func StopContainer(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_top.go
+++ b/pkg/api/handlers/compat/containers_top.go
@@ -33,14 +33,12 @@ func TopContainer(w http.ResponseWriter, r *http.Request) {
 		PsArgs: psArgs,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
 	if query.Delay < 1 {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			fmt.Errorf("\"delay\" parameter of value %d < 1", query.Delay))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("\"delay\" parameter of value %d < 1", query.Delay))
 		return
 	}
 

--- a/pkg/api/handlers/compat/events.go
+++ b/pkg/api/handlers/compat/events.go
@@ -34,7 +34,7 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 		Stream: true,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "failed to parse parameters", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -44,7 +44,7 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 
 	libpodFilters, err := util.FiltersFromRequest(r)
 	if err != nil {
-		utils.Error(w, "failed to parse parameters", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	eventChannel := make(chan *events.Event)

--- a/pkg/api/handlers/compat/exec.go
+++ b/pkg/api/handlers/compat/exec.go
@@ -2,7 +2,6 @@ package compat
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -48,7 +47,7 @@ func ExecCreateHandler(w http.ResponseWriter, r *http.Request) {
 	for _, envStr := range input.Env {
 		split := strings.SplitN(envStr, "=", 2)
 		if len(split) != 2 {
-			utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, errors.Errorf("environment variable %q badly formed, must be key=value", envStr))
+			utils.Error(w, http.StatusBadRequest, errors.Errorf("environment variable %q badly formed, must be key=value", envStr))
 			return
 		}
 		libpodConfig.Environment[split[0]] = split[1]
@@ -85,7 +84,7 @@ func ExecCreateHandler(w http.ResponseWriter, r *http.Request) {
 				// Ignore the error != nil case. We're already
 				// throwing an InternalServerError below.
 				if state == define.ContainerStatePaused {
-					utils.Error(w, "Container is paused", http.StatusConflict, errors.Errorf("cannot create exec session as container %s is paused", ctr.ID()))
+					utils.Error(w, http.StatusConflict, errors.Errorf("cannot create exec session as container %s is paused", ctr.ID()))
 					return
 				}
 			}
@@ -107,7 +106,7 @@ func ExecInspectHandler(w http.ResponseWriter, r *http.Request) {
 	sessionID := mux.Vars(r)["id"]
 	sessionCtr, err := runtime.GetExecSessionContainer(sessionID)
 	if err != nil {
-		utils.Error(w, fmt.Sprintf("No such exec session: %s", sessionID), http.StatusNotFound, err)
+		utils.Error(w, http.StatusNotFound, err)
 		return
 	}
 
@@ -138,15 +137,14 @@ func ExecStartHandler(w http.ResponseWriter, r *http.Request) {
 	bodyParams := new(handlers.ExecStartConfig)
 
 	if err := json.NewDecoder(r.Body).Decode(&bodyParams); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to decode parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to decode parameters for %s", r.URL.String()))
 		return
 	}
 	// TODO: Verify TTY setting against what inspect session was made with
 
 	sessionCtr, err := runtime.GetExecSessionContainer(sessionID)
 	if err != nil {
-		utils.Error(w, fmt.Sprintf("No such exec session: %s", sessionID), http.StatusNotFound, err)
+		utils.Error(w, http.StatusNotFound, err)
 		return
 	}
 
@@ -158,7 +156,7 @@ func ExecStartHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if state != define.ContainerStateRunning {
-		utils.Error(w, http.StatusText(http.StatusConflict), http.StatusConflict, errors.Errorf("cannot exec in a container that is not running; container %s is %s", sessionCtr.ID(), state.String()))
+		utils.Error(w, http.StatusConflict, errors.Errorf("cannot exec in a container that is not running; container %s is %s", sessionCtr.ID(), state.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -50,7 +50,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 
 	tmpfile, err := ioutil.TempFile("", "api.tar")
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
 		return
 	}
 	defer os.Remove(tmpfile.Name())
@@ -58,7 +58,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 		return
 	}
 
@@ -74,18 +74,18 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 			utils.ImageNotFound(w, name, errors.Wrapf(err, "failed to find image %s", name))
 			return
 		}
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
 		return
 	}
 
 	if err := tmpfile.Close(); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
 		return
 	}
 
 	rdr, err := os.Open(tmpfile.Name())
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
 		return
 	}
 	defer rdr.Close()
@@ -110,12 +110,12 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	rtc, err := runtime.GetConfig()
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 	sc := runtime.SystemContext()
@@ -131,7 +131,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 
 	input := handlers.CreateContainerConfig{}
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 
@@ -143,7 +143,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	ctr, err := runtime.LookupContainer(query.Container)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusNotFound, err)
+		utils.Error(w, http.StatusNotFound, err)
 		return
 	}
 
@@ -152,7 +152,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 		destImage = fmt.Sprintf("%s:%s", query.Repo, query.Tag)
 		possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, destImage)
 		if err != nil {
-			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 			return
 		}
 		destImage = possiblyNormalizedName
@@ -160,7 +160,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 
 	commitImage, err := ctr.Commit(r.Context(), destImage, options)
 	if err != nil && !strings.Contains(err.Error(), "is not running") {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "CommitFailure"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "CommitFailure"))
 		return
 	}
 	utils.WriteResponse(w, http.StatusCreated, handlers.IDResponse{ID: commitImage.ID()}) // nolint
@@ -184,7 +184,7 @@ func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	// fromSrc – Source to import. The value may be a URL from which the image can be retrieved or - to read the image from the request body. This parameter may only be used when importing an image.
@@ -192,13 +192,13 @@ func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
 	if source == "-" {
 		f, err := ioutil.TempFile("", "api_load.tar")
 		if err != nil {
-			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to create tempfile"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to create tempfile"))
 			return
 		}
 
 		source = f.Name()
 		if err := SaveFromBody(f, r); err != nil {
-			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to write temporary file"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to write temporary file"))
 		}
 	}
 
@@ -206,7 +206,7 @@ func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
 	if query.Repo != "" {
 		possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, reference)
 		if err != nil {
-			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 			return
 		}
 		reference = possiblyNormalizedName
@@ -227,7 +227,7 @@ func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 	report, err := imageEngine.Import(r.Context(), opts)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to import tarball"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to import tarball"))
 		return
 	}
 	// Success
@@ -263,19 +263,19 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 		// This is where you can override the golang default value for one of fields
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, mergeNameAndTagOrDigest(query.FromImage, query.Tag))
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 		return
 	}
 
 	authConf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)
@@ -386,7 +386,7 @@ func GetImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 		return
 	}
 
@@ -395,12 +395,12 @@ func GetImage(w http.ResponseWriter, r *http.Request) {
 		// Here we need to fiddle with the error message because docker-py is looking for "No
 		// such image" to determine on how to raise the correct exception.
 		errMsg := strings.ReplaceAll(err.Error(), "image not known", "No such image")
-		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Errorf("failed to find image %s: %s", name, errMsg))
+		utils.Error(w, http.StatusNotFound, errors.Errorf("failed to find image %s: %s", name, errMsg))
 		return
 	}
 	inspect, err := handlers.ImageDataToImageInspect(r.Context(), newImage)
 	if err != nil {
-		utils.Error(w, "Server error", http.StatusInternalServerError, errors.Wrapf(err, "failed to convert ImageData to ImageInspect '%s'", inspect.ID))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to convert ImageData to ImageInspect '%s'", inspect.ID))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, inspect)
@@ -418,7 +418,7 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
+		utils.Error(w, http.StatusBadRequest,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
@@ -429,7 +429,7 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 
 	filterList, err := filters.FiltersFromRequest(r)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	if !utils.IsLibpodRequest(r) {
@@ -444,7 +444,7 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 	listOptions := entities.ImageListOptions{All: query.All, Filter: filterList}
 	summaries, err := imageEngine.List(r.Context(), listOptions)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -472,7 +472,7 @@ func LoadImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -480,7 +480,7 @@ func LoadImages(w http.ResponseWriter, r *http.Request) {
 	// to load.
 	f, err := ioutil.TempFile("", "api_load.tar")
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to create tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to create tempfile"))
 		return
 	}
 	defer func() {
@@ -490,7 +490,7 @@ func LoadImages(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 	if err := SaveFromBody(f, r); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to write temporary file"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to write temporary file"))
 		return
 	}
 
@@ -499,12 +499,12 @@ func LoadImages(w http.ResponseWriter, r *http.Request) {
 	loadOptions := entities.ImageLoadOptions{Input: f.Name()}
 	loadReport, err := imageEngine.Load(r.Context(), loadOptions)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to load image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to load image"))
 		return
 	}
 
 	if len(loadReport.Names) < 1 {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Errorf("one or more images are required"))
+		utils.Error(w, http.StatusInternalServerError, errors.Errorf("one or more images are required"))
 		return
 	}
 
@@ -527,11 +527,11 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 		// This is where you can override the golang default value for one of fields
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	if len(query.Names) <= 0 {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, fmt.Errorf("no images to download"))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("no images to download"))
 		return
 	}
 
@@ -539,7 +539,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 	for i, img := range query.Names {
 		possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, img)
 		if err != nil {
-			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 			return
 		}
 		images[i] = possiblyNormalizedName
@@ -547,12 +547,12 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 
 	tmpfile, err := ioutil.TempFile("", "api.tar")
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
 		return
 	}
 	defer os.Remove(tmpfile.Name())
 	if err := tmpfile.Close(); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
 		return
 	}
 
@@ -566,7 +566,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 
 	rdr, err := os.Open(tmpfile.Name())
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
 		return
 	}
 	defer rdr.Close()

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -133,7 +133,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -291,7 +291,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	if len(tags) > 0 {
 		possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, tags[0])
 		if err != nil {
-			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 			return
 		}
 		output = possiblyNormalizedName
@@ -314,7 +314,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	for i := 1; i < len(tags); i++ {
 		possiblyNormalizedTag, err := utils.NormalizeToDockerHub(r, tags[i])
 		if err != nil {
-			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 			return
 		}
 		additionalTags = append(additionalTags, possiblyNormalizedTag)
@@ -457,7 +457,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	creds, authfile, err := auth.GetCredentials(r)
 	if err != nil {
 		// Credential value(s) not returned as their value is not human readable
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)
@@ -466,7 +466,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	if fromImage != "" {
 		possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, fromImage)
 		if err != nil {
-			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 			return
 		}
 		fromImage = possiblyNormalizedName

--- a/pkg/api/handlers/compat/images_history.go
+++ b/pkg/api/handlers/compat/images_history.go
@@ -16,7 +16,7 @@ func HistoryImage(w http.ResponseWriter, r *http.Request) {
 
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 		return
 	}
 

--- a/pkg/api/handlers/compat/images_prune.go
+++ b/pkg/api/handlers/compat/images_prune.go
@@ -24,7 +24,7 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -28,7 +28,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 
 	digestFile, err := ioutil.TempFile("", "digest.txt")
 	if err != nil {
-		utils.Error(w, "unable to create digest tempfile", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
 		return
 	}
 	defer digestFile.Close()
@@ -50,7 +50,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -63,14 +63,13 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := utils.ParseStorageReference(imageName); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "image source %q is not a containers-storage-transport reference", imageName))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "image source %q is not a containers-storage-transport reference", imageName))
 		return
 	}
 
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, imageName)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 		return
 	}
 	imageName = possiblyNormalizedName
@@ -81,13 +80,13 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	}
 	rawManifest, _, err := localImage.Manifest(r.Context())
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 
 	authconf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)

--- a/pkg/api/handlers/compat/images_remove.go
+++ b/pkg/api/handlers/compat/images_remove.go
@@ -25,7 +25,7 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	if _, found := r.URL.Query()["noprune"]; found {
@@ -36,7 +36,7 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 		return
 	}
 
@@ -53,7 +53,7 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	response := make([]map[string]string, 0, len(report.Untagged)+1)

--- a/pkg/api/handlers/compat/images_search.go
+++ b/pkg/api/handlers/compat/images_search.go
@@ -30,13 +30,13 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
 	_, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)
@@ -58,7 +58,7 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 	ir := abi.ImageEngine{Libpod: runtime}
 	reports, err := ir.Search(r.Context(), query.Term, options)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	if !utils.IsLibpodRequest(r) {

--- a/pkg/api/handlers/compat/images_tag.go
+++ b/pkg/api/handlers/compat/images_tag.go
@@ -17,7 +17,7 @@ func TagImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 		return
 	}
 
@@ -34,7 +34,7 @@ func TagImage(w http.ResponseWriter, r *http.Request) {
 		tag = r.Form.Get("tag")
 	}
 	if len(r.Form.Get("repo")) < 1 {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.New("repo parameter is required to tag an image"))
+		utils.Error(w, http.StatusBadRequest, errors.New("repo parameter is required to tag an image"))
 		return
 	}
 	repo := r.Form.Get("repo")
@@ -42,12 +42,12 @@ func TagImage(w http.ResponseWriter, r *http.Request) {
 
 	possiblyNormalizedTag, err := utils.NormalizeToDockerHub(r, tagName)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
 		return
 	}
 
 	if err := newImage.Tag(possiblyNormalizedTag); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	utils.WriteResponse(w, http.StatusCreated, "")

--- a/pkg/api/handlers/compat/info.go
+++ b/pkg/api/handlers/compat/info.go
@@ -33,18 +33,18 @@ func GetInfo(w http.ResponseWriter, r *http.Request) {
 
 	infoData, err := runtime.Info()
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain system memory info"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain system memory info"))
 		return
 	}
 
 	configInfo, err := runtime.GetConfig()
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain runtime config"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain runtime config"))
 		return
 	}
 	versionInfo, err := define.GetVersion()
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain podman versions"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain podman versions"))
 		return
 	}
 	stateInfo := getContainersState(runtime)

--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -36,12 +36,12 @@ func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
 	if query.scope != "local" {
-		utils.Error(w, "Invalid scope value. Can only be local.", http.StatusBadRequest, define.ErrInvalidArg)
+		utils.Error(w, http.StatusBadRequest, define.ErrInvalidArg)
 		return
 	}
 	name := utils.GetName(r)
@@ -133,7 +133,7 @@ func ListNetworks(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -166,7 +166,7 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 	)
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	if err := json.NewDecoder(r.Body).Decode(&networkCreate); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 
@@ -262,7 +262,7 @@ func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -274,17 +274,17 @@ func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	reports, err := ic.NetworkRm(r.Context(), []string{name}, options)
 	if err != nil {
-		utils.Error(w, "remove Network failed", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	if len(reports) == 0 {
-		utils.Error(w, "remove Network failed", http.StatusInternalServerError, errors.Errorf("internal error"))
+		utils.Error(w, http.StatusInternalServerError, errors.Errorf("internal error"))
 		return
 	}
 	report := reports[0]
 	if report.Err != nil {
 		if errors.Cause(report.Err) == define.ErrNoSuchNetwork {
-			utils.Error(w, "network not found", http.StatusNotFound, define.ErrNoSuchNetwork)
+			utils.Error(w, http.StatusNotFound, define.ErrNoSuchNetwork)
 			return
 		}
 		utils.InternalServerError(w, report.Err)
@@ -302,7 +302,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 		netConnect types.NetworkConnect
 	)
 	if err := json.NewDecoder(r.Body).Decode(&netConnect); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 
@@ -318,7 +318,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 		if len(netConnect.EndpointConfig.IPAddress) > 0 {
 			staticIP := net.ParseIP(netConnect.EndpointConfig.IPAddress)
 			if staticIP == nil {
-				utils.Error(w, "failed to parse the ip address", http.StatusInternalServerError,
+				utils.Error(w, http.StatusInternalServerError,
 					errors.Errorf("failed to parse the ip address %q", netConnect.EndpointConfig.IPAddress))
 				return
 			}
@@ -330,7 +330,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 			if len(netConnect.EndpointConfig.IPAMConfig.IPv4Address) > 0 {
 				staticIP := net.ParseIP(netConnect.EndpointConfig.IPAMConfig.IPv4Address)
 				if staticIP == nil {
-					utils.Error(w, "failed to parse the ipv4 address", http.StatusInternalServerError,
+					utils.Error(w, http.StatusInternalServerError,
 						errors.Errorf("failed to parse the ipv4 address %q", netConnect.EndpointConfig.IPAMConfig.IPv4Address))
 					return
 				}
@@ -340,7 +340,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 			if len(netConnect.EndpointConfig.IPAMConfig.IPv6Address) > 0 {
 				staticIP := net.ParseIP(netConnect.EndpointConfig.IPAMConfig.IPv6Address)
 				if staticIP == nil {
-					utils.Error(w, "failed to parse the ipv6 address", http.StatusInternalServerError,
+					utils.Error(w, http.StatusInternalServerError,
 						errors.Errorf("failed to parse the ipv6 address %q", netConnect.EndpointConfig.IPAMConfig.IPv6Address))
 					return
 				}
@@ -351,7 +351,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 		if len(netConnect.EndpointConfig.MacAddress) > 0 {
 			staticMac, err := net.ParseMAC(netConnect.EndpointConfig.MacAddress)
 			if err != nil {
-				utils.Error(w, "failed to parse the mac address", http.StatusInternalServerError,
+				utils.Error(w, http.StatusInternalServerError,
 					errors.Errorf("failed to parse the mac address %q", netConnect.EndpointConfig.IPAMConfig.IPv6Address))
 				return
 			}
@@ -365,10 +365,10 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if errors.Cause(err) == define.ErrNoSuchNetwork {
-			utils.Error(w, "network not found", http.StatusNotFound, err)
+			utils.Error(w, http.StatusNotFound, err)
 			return
 		}
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, "OK")
@@ -380,7 +380,7 @@ func Disconnect(w http.ResponseWriter, r *http.Request) {
 
 	var netDisconnect types.NetworkDisconnect
 	if err := json.NewDecoder(r.Body).Decode(&netDisconnect); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 
@@ -388,14 +388,14 @@ func Disconnect(w http.ResponseWriter, r *http.Request) {
 	err := runtime.DisconnectContainerFromNetwork(netDisconnect.Container, name, netDisconnect.Force)
 	if err != nil {
 		if errors.Cause(err) == define.ErrNoSuchCtr {
-			utils.Error(w, "container not found", http.StatusNotFound, err)
+			utils.Error(w, http.StatusNotFound, err)
 			return
 		}
 		if errors.Cause(err) == define.ErrNoSuchNetwork {
-			utils.Error(w, "network not found", http.StatusNotFound, err)
+			utils.Error(w, http.StatusNotFound, err)
 			return
 		}
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, "OK")
@@ -406,7 +406,7 @@ func Prune(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 
@@ -416,7 +416,7 @@ func Prune(w http.ResponseWriter, r *http.Request) {
 	}
 	pruneReports, err := ic.NetworkPrune(r.Context(), pruneOptions)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	type response struct {

--- a/pkg/api/handlers/compat/resize.go
+++ b/pkg/api/handlers/compat/resize.go
@@ -28,8 +28,7 @@ func ResizeTTY(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -51,7 +50,7 @@ func ResizeTTY(w http.ResponseWriter, r *http.Request) {
 			if errors.Cause(err) != define.ErrCtrStateInvalid {
 				utils.InternalServerError(w, errors.Wrapf(err, "cannot resize container"))
 			} else {
-				utils.Error(w, "Container not running", http.StatusConflict, err)
+				utils.Error(w, http.StatusConflict, err)
 			}
 			return
 		}
@@ -69,8 +68,7 @@ func ResizeTTY(w http.ResponseWriter, r *http.Request) {
 			utils.InternalServerError(w, errors.Wrapf(err, "cannot obtain session container state"))
 			return
 		} else if state != define.ContainerStateRunning && !query.IgnoreNotRunning {
-			utils.Error(w, "Container not running", http.StatusConflict,
-				fmt.Errorf("container %q in wrong state %q", name, state.String()))
+			utils.Error(w, http.StatusConflict, fmt.Errorf("container %q in wrong state %q", name, state.String()))
 			return
 		}
 		if err := ctnr.ExecResize(name, sz); err != nil {

--- a/pkg/api/handlers/compat/secrets.go
+++ b/pkg/api/handlers/compat/secrets.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
@@ -22,8 +21,7 @@ func ListSecrets(w http.ResponseWriter, r *http.Request) {
 	)
 	filtersMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	ic := abi.ContainerEngine{Libpod: runtime}
@@ -116,12 +114,11 @@ func CreateSecret(w http.ResponseWriter, r *http.Request) {
 	}{}
 
 	if err := json.NewDecoder(r.Body).Decode(&createParams); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 	if len(createParams.Labels) > 0 {
-		utils.Error(w, "labels not supported", http.StatusBadRequest,
-			errors.Wrapf(errors.New("bad parameter"), "labels not supported"))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(errors.New("bad parameter"), "labels not supported"))
 		return
 	}
 
@@ -133,7 +130,7 @@ func CreateSecret(w http.ResponseWriter, r *http.Request) {
 	report, err := ic.SecretCreate(r.Context(), createParams.Name, reader, opts)
 	if err != nil {
 		if errors.Cause(err).Error() == "secret name in use" {
-			utils.Error(w, "name conflicts with an existing object", http.StatusConflict, err)
+			utils.Error(w, http.StatusConflict, err)
 			return
 		}
 		utils.InternalServerError(w, err)
@@ -143,5 +140,5 @@ func CreateSecret(w http.ResponseWriter, r *http.Request) {
 }
 
 func UpdateSecret(w http.ResponseWriter, r *http.Request) {
-	utils.Error(w, fmt.Sprintf("unsupported endpoint: %v", r.Method), http.StatusNotImplemented, errors.New("update is not supported"))
+	utils.Error(w, http.StatusNotImplemented, errors.New("update is not supported"))
 }

--- a/pkg/api/handlers/compat/version.go
+++ b/pkg/api/handlers/compat/version.go
@@ -22,13 +22,13 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 
 	running, err := define.GetVersion()
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 
 	info, err := runtime.Info()
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain system memory info"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain system memory info"))
 		return
 	}
 

--- a/pkg/api/handlers/compat/volumes.go
+++ b/pkg/api/handlers/compat/volumes.go
@@ -26,7 +26,7 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 
 	filtersMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+		utils.Error(w, http.StatusInternalServerError,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
@@ -35,7 +35,7 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 	// happily parse them for us.
 	for filter := range *filtersMap {
 		if filter == "opts" {
-			utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+			utils.Error(w, http.StatusInternalServerError,
 				errors.Errorf("unsupported libpod filters passed to docker endpoint"))
 			return
 		}
@@ -85,14 +85,14 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 	/* No query string data*/
 	query := struct{}{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+		utils.Error(w, http.StatusInternalServerError,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	// decode params from body
 	input := docker_api_types_volume.VolumeCreateBody{}
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 
@@ -220,7 +220,7 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+		utils.Error(w, http.StatusInternalServerError,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
@@ -242,7 +242,7 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 		// As above, we do not pass `force` from the query parameters here
 		if err := runtime.RemoveVolume(r.Context(), vol, false, query.Timeout); err != nil {
 			if errors.Cause(err) == define.ErrVolumeBeingUsed {
-				utils.Error(w, "volumes being used", http.StatusConflict, err)
+				utils.Error(w, http.StatusConflict, err)
 			} else {
 				utils.InternalServerError(w, err)
 			}
@@ -268,14 +268,14 @@ func PruneVolumes(w http.ResponseWriter, r *http.Request) {
 	)
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 
 	f := (url.Values)(*filterMap)
 	filterFuncs, err := filters.GeneratePruneVolumeFilters(f)
 	if err != nil {
-		utils.Error(w, "Something when wrong.", http.StatusInternalServerError, errors.Wrapf(err, "failed to parse filters for %s", f.Encode()))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse filters for %s", f.Encode()))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -35,8 +35,7 @@ func ContainerExists(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -76,14 +75,12 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
-			errors.Wrapf(err, "failed to decode filter parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to decode filter parameters for %s", r.URL.String()))
 		return
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -134,8 +131,7 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
@@ -227,8 +223,7 @@ func Checkpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -313,8 +308,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -379,7 +373,7 @@ func InitContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	err = ctr.Init(r.Context(), ctr.PodID() != "")
 	if errors.Cause(err) == define.ErrCtrStateInvalid {
-		utils.Error(w, "container already initialized", http.StatusNotModified, err)
+		utils.Error(w, http.StatusNotModified, err)
 		return
 	}
 	if err != nil {

--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -21,7 +21,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	var sg specgen.SpecGenerator
 
 	if err := json.NewDecoder(r.Body).Decode(&sg); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 	if sg.Passwd == nil {

--- a/pkg/api/handlers/libpod/containers_stats.go
+++ b/pkg/api/handlers/libpod/containers_stats.go
@@ -25,7 +25,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		// if so, then verify cgroup v2 available (more expensive check)
 		if isV2, _ := cgroups.IsCgroup2UnifiedMode(); !isV2 {
 			msg := "Container stats resource only available for cgroup v2"
-			utils.Error(w, msg, http.StatusConflict, errors.New(msg))
+			utils.Error(w, http.StatusConflict, errors.New(msg))
 			return
 		}
 	}
@@ -39,7 +39,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		Interval: 5,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/generate.go
+++ b/pkg/api/handlers/libpod/generate.go
@@ -40,8 +40,7 @@ func GenerateSystemd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -65,7 +64,7 @@ func GenerateSystemd(w http.ResponseWriter, r *http.Request) {
 
 	report, err := containerEngine.GenerateSystemd(r.Context(), utils.GetName(r), options)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error generating systemd units"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error generating systemd units"))
 		return
 	}
 
@@ -83,8 +82,7 @@ func GenerateKube(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -92,7 +90,7 @@ func GenerateKube(w http.ResponseWriter, r *http.Request) {
 	options := entities.GenerateKubeOptions{Service: query.Service}
 	report, err := containerEngine.GenerateKube(r.Context(), query.Names, options)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error generating YAML"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error generating YAML"))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/healthcheck.go
+++ b/pkg/api/handlers/libpod/healthcheck.go
@@ -19,11 +19,11 @@ func RunHealthCheck(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if status == define.HealthCheckNotDefined {
-			utils.Error(w, "no healthcheck defined", http.StatusConflict, err)
+			utils.Error(w, http.StatusConflict, err)
 			return
 		}
 		if status == define.HealthCheckContainerStopped {
-			utils.Error(w, "container not running", http.StatusConflict, err)
+			utils.Error(w, http.StatusConflict, err)
 			return
 		}
 		utils.InternalServerError(w, err)

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -48,11 +48,11 @@ func ImageExists(w http.ResponseWriter, r *http.Request) {
 	ir := abi.ImageEngine{Libpod: runtime}
 	report, err := ir.Exists(r.Context(), name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
+		utils.Error(w, http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
 		return
 	}
 	if !report.Value {
-		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Errorf("failed to find image %s", name))
+		utils.Error(w, http.StatusNotFound, errors.Errorf("failed to find image %s", name))
 		return
 	}
 	utils.WriteResponse(w, http.StatusNoContent, "")
@@ -68,8 +68,7 @@ func ImageTree(w http.ResponseWriter, r *http.Request) {
 		WhatRequires: false,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	ir := abi.ImageEngine{Libpod: runtime}
@@ -77,10 +76,10 @@ func ImageTree(w http.ResponseWriter, r *http.Request) {
 	report, err := ir.Tree(r.Context(), name, options)
 	if err != nil {
 		if errors.Cause(err) == storage.ErrImageUnknown {
-			utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
+			utils.Error(w, http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
 			return
 		}
-		utils.Error(w, "Server error", http.StatusInternalServerError, errors.Wrapf(err, "failed to generate image tree for %s", name))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to generate image tree for %s", name))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, report)
@@ -90,13 +89,13 @@ func GetImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	newImage, err := utils.GetImage(r, name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
+		utils.Error(w, http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
 		return
 	}
 	options := &libimage.InspectOptions{WithParent: true, WithSize: true}
 	inspect, err := newImage.Inspect(r.Context(), options)
 	if err != nil {
-		utils.Error(w, "Server error", http.StatusInternalServerError, errors.Wrapf(err, "failed in inspect image %s", inspect.ID))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed in inspect image %s", inspect.ID))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, inspect)
@@ -117,14 +116,14 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+		utils.Error(w, http.StatusInternalServerError,
 			errors.
 				Wrapf(err, "failed to decode filter parameters for %s", r.URL.String()))
 		return
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+		utils.Error(w, http.StatusInternalServerError,
 			errors.
 				Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
@@ -156,7 +155,7 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 	}
 	imagePruneReports, err := imageEngine.Prune(r.Context(), pruneOptions)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, imagePruneReports)
@@ -176,7 +175,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
+		utils.Error(w, http.StatusBadRequest,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
@@ -191,23 +190,23 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 	case define.OCIArchive, define.V2s2Archive:
 		tmpfile, err := ioutil.TempFile("", "api.tar")
 		if err != nil {
-			utils.Error(w, "unable to create tmpfile", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
 			return
 		}
 		output = tmpfile.Name()
 		if err := tmpfile.Close(); err != nil {
-			utils.Error(w, "unable to close tmpfile", http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
 			return
 		}
 	case define.OCIManifestDir, define.V2s2ManifestDir:
 		tmpdir, err := ioutil.TempDir("", "save")
 		if err != nil {
-			utils.Error(w, "unable to create tmpdir", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempdir"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempdir"))
 			return
 		}
 		output = tmpdir
 	default:
-		utils.Error(w, "unknown format", http.StatusInternalServerError, errors.Errorf("unknown format %q", query.Format))
+		utils.Error(w, http.StatusInternalServerError, errors.Errorf("unknown format %q", query.Format))
 		return
 	}
 
@@ -219,7 +218,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 		Output:   output,
 	}
 	if err := imageEngine.Save(r.Context(), name, nil, saveOptions); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 	defer os.RemoveAll(output)
@@ -236,7 +235,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 	}
 	rdr, err := os.Open(output)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
 		return
 	}
 	defer rdr.Close()
@@ -259,22 +258,20 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
 	// References are mandatory!
 	if len(query.References) == 0 {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.New("No references"))
+		utils.Error(w, http.StatusBadRequest, errors.New("No references"))
 		return
 	}
 
 	// Format is mandatory! Currently, we only support multi-image docker
 	// archives.
 	if len(query.References) > 1 && query.Format != define.V2s2Archive {
-		utils.Error(w, "unsupported format", http.StatusInternalServerError, errors.Errorf("multi-image archives must use format of %s", define.V2s2Archive))
+		utils.Error(w, http.StatusInternalServerError, errors.Errorf("multi-image archives must use format of %s", define.V2s2Archive))
 		return
 	}
 
@@ -292,23 +289,23 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 	case define.V2s2Archive, define.OCIArchive:
 		tmpfile, err := ioutil.TempFile("", "api.tar")
 		if err != nil {
-			utils.Error(w, "unable to create tmpfile", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
 			return
 		}
 		output = tmpfile.Name()
 		if err := tmpfile.Close(); err != nil {
-			utils.Error(w, "unable to close tmpfile", http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
 			return
 		}
 	case define.OCIManifestDir, define.V2s2ManifestDir:
 		tmpdir, err := ioutil.TempDir("", "save")
 		if err != nil {
-			utils.Error(w, "unable to create tmpdir", http.StatusInternalServerError, errors.Wrap(err, "unable to create tmpdir"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tmpdir"))
 			return
 		}
 		output = tmpdir
 	default:
-		utils.Error(w, "unsupported format", http.StatusInternalServerError, errors.Errorf("unsupported format %q", query.Format))
+		utils.Error(w, http.StatusInternalServerError, errors.Errorf("unsupported format %q", query.Format))
 		return
 	}
 	defer os.RemoveAll(output)
@@ -324,13 +321,13 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 	if err := imageEngine.Save(r.Context(), query.References[0], query.References[1:], opts); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 
 	rdr, err := os.Open(output)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
 		return
 	}
 	defer rdr.Close()
@@ -342,7 +339,7 @@ func ImagesLoad(w http.ResponseWriter, r *http.Request) {
 
 	tmpfile, err := ioutil.TempFile("", "libpod-images-load.tar")
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
 		return
 	}
 	defer os.Remove(tmpfile.Name())
@@ -351,7 +348,7 @@ func ImagesLoad(w http.ResponseWriter, r *http.Request) {
 	tmpfile.Close()
 
 	if err != nil && err != io.EOF {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to write archive to temporary file"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to write archive to temporary file"))
 		return
 	}
 
@@ -360,7 +357,7 @@ func ImagesLoad(w http.ResponseWriter, r *http.Request) {
 	loadOptions := entities.ImageLoadOptions{Input: tmpfile.Name()}
 	loadReport, err := imageEngine.Load(r.Context(), loadOptions)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to load image"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to load image"))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, loadReport)
@@ -379,8 +376,7 @@ func ImagesImport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -389,14 +385,14 @@ func ImagesImport(w http.ResponseWriter, r *http.Request) {
 	if len(query.URL) == 0 {
 		tmpfile, err := ioutil.TempFile("", "libpod-images-import.tar")
 		if err != nil {
-			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
 			return
 		}
 		defer os.Remove(tmpfile.Name())
 		defer tmpfile.Close()
 
 		if _, err := io.Copy(tmpfile, r.Body); err != nil && err != io.EOF {
-			utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to write archive to temporary file"))
+			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to write archive to temporary file"))
 			return
 		}
 
@@ -413,7 +409,7 @@ func ImagesImport(w http.ResponseWriter, r *http.Request) {
 	}
 	report, err := imageEngine.Import(r.Context(), importOptions)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to import tarball"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to import tarball"))
 		return
 	}
 
@@ -434,13 +430,13 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		// This is where you can override the golang default value for one of fields
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
 	source := strings.TrimSuffix(utils.GetName(r), "/push") // GetName returns the entire path
 	if _, err := utils.ParseStorageReference(source); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -450,13 +446,13 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := utils.IsRegistryReference(destination); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 
 	authconf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)
@@ -479,7 +475,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 	if err := imageEngine.Push(context.Background(), source, destination, options); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "error pushing image %q", destination))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "error pushing image %q", destination))
 		return
 	}
 
@@ -508,12 +504,12 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	rtc, err := runtime.GetConfig()
 	if err != nil {
-		utils.Error(w, "failed to get runtime config", http.StatusInternalServerError, errors.Wrap(err, "failed to get runtime config"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to get runtime config"))
 		return
 	}
 	sc := runtime.SystemContext()
@@ -550,7 +546,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	options.Changes = query.Changes
 	ctr, err := runtime.LookupContainer(query.Container)
 	if err != nil {
-		utils.Error(w, "failed to lookup container", http.StatusNotFound, err)
+		utils.Error(w, http.StatusNotFound, err)
 		return
 	}
 
@@ -559,7 +555,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	commitImage, err := ctr.Commit(r.Context(), destImage, options)
 	if err != nil && !strings.Contains(err.Error(), "is not running") {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrapf(err, "CommitFailure"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "CommitFailure"))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, handlers.IDResponse{ID: commitImage.ID()}) // nolint
@@ -576,7 +572,7 @@ func UntagImage(w http.ResponseWriter, r *http.Request) {
 	switch {
 	// If tag is set, repo must be as well.
 	case len(repo) == 0 && len(tag) > 0:
-		utils.Error(w, "repo tag is required", http.StatusBadRequest, errors.New("repo parameter is required to tag an image"))
+		utils.Error(w, http.StatusBadRequest, errors.New("repo parameter is required to tag an image"))
 		return
 
 	case len(repo) == 0:
@@ -601,7 +597,7 @@ func UntagImage(w http.ResponseWriter, r *http.Request) {
 		if errors.Cause(err) == storage.ErrImageUnknown {
 			utils.ImageNotFound(w, name, errors.Wrapf(err, "failed to find image %s", name))
 		} else {
-			utils.Error(w, "failed to untag", http.StatusInternalServerError, err)
+			utils.Error(w, http.StatusInternalServerError, err)
 		}
 		return
 	}
@@ -619,8 +615,7 @@ func ImagesBatchRemove(w http.ResponseWriter, r *http.Request) {
 	}{}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -643,8 +638,7 @@ func ImagesRemove(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -662,12 +656,12 @@ func ImagesRemove(w http.ResponseWriter, r *http.Request) {
 		utils.WriteResponse(w, http.StatusOK, report)
 	case 1:
 		// 404 - no such image
-		utils.Error(w, "error removing image", http.StatusNotFound, errorhandling.JoinErrors(rmErrors))
+		utils.Error(w, http.StatusNotFound, errorhandling.JoinErrors(rmErrors))
 	case 2:
 		// 409 - conflict error (in use by containers)
-		utils.Error(w, "error removing image", http.StatusConflict, errorhandling.JoinErrors(rmErrors))
+		utils.Error(w, http.StatusConflict, errorhandling.JoinErrors(rmErrors))
 	default:
 		// 500 - internal error
-		utils.Error(w, "failed to remove image", http.StatusInternalServerError, errorhandling.JoinErrors(rmErrors))
+		utils.Error(w, http.StatusInternalServerError, errorhandling.JoinErrors(rmErrors))
 	}
 }

--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -41,8 +41,7 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -53,7 +52,7 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 
 	// Make sure that the reference has no transport or the docker one.
 	if err := utils.IsRegistryReference(query.Reference); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -70,7 +69,7 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 	// Do the auth dance.
 	authConf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)
@@ -89,7 +88,7 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 
 	pullPolicy, err := config.ParsePullPolicy(query.PullPolicy)
 	if err != nil {
-		utils.Error(w, "failed to parse pull policy", http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 

--- a/pkg/api/handlers/libpod/networks.go
+++ b/pkg/api/handlers/libpod/networks.go
@@ -20,7 +20,7 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	network := types.Network{}
 	if err := json.NewDecoder(r.Body).Decode(&network); err != nil {
-		utils.Error(w, "unable to marshall input", http.StatusInternalServerError, errors.Wrap(err, "decode body"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "decode body"))
 		return
 	}
 
@@ -36,7 +36,7 @@ func ListNetworks(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+		utils.Error(w, http.StatusInternalServerError,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
@@ -62,7 +62,7 @@ func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+		utils.Error(w, http.StatusInternalServerError,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
@@ -80,7 +80,7 @@ func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 	if reports[0].Err != nil {
 		// If the network cannot be found, we return a 404.
 		if errors.Cause(reports[0].Err) == define.ErrNoSuchNetwork {
-			utils.Error(w, "Something went wrong", http.StatusNotFound, reports[0].Err)
+			utils.Error(w, http.StatusNotFound, reports[0].Err)
 			return
 		}
 	}
@@ -95,7 +95,7 @@ func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+		utils.Error(w, http.StatusInternalServerError,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
@@ -105,7 +105,7 @@ func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 	reports, errs, err := ic.NetworkInspect(r.Context(), []string{name}, options)
 	// If the network cannot be found, we return a 404.
 	if len(errs) > 0 {
-		utils.Error(w, "Something went wrong", http.StatusNotFound, define.ErrNoSuchNetwork)
+		utils.Error(w, http.StatusNotFound, define.ErrNoSuchNetwork)
 		return
 	}
 	if err != nil {
@@ -121,7 +121,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 
 	var netConnect entities.NetworkConnectOptions
 	if err := json.NewDecoder(r.Body).Decode(&netConnect); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 	name := utils.GetName(r)
@@ -132,10 +132,10 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if errors.Cause(err) == define.ErrNoSuchNetwork {
-			utils.Error(w, "network not found", http.StatusNotFound, err)
+			utils.Error(w, http.StatusNotFound, err)
 			return
 		}
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, "OK")
@@ -149,11 +149,11 @@ func ExistsNetwork(w http.ResponseWriter, r *http.Request) {
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.NetworkExists(r.Context(), name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	if !report.Value {
-		utils.Error(w, "network not found", http.StatusNotFound, define.ErrNoSuchNetwork)
+		utils.Error(w, http.StatusNotFound, define.ErrNoSuchNetwork)
 		return
 	}
 	utils.WriteResponse(w, http.StatusNoContent, "")
@@ -165,7 +165,7 @@ func Prune(w http.ResponseWriter, r *http.Request) {
 
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -175,7 +175,7 @@ func Prune(w http.ResponseWriter, r *http.Request) {
 	ic := abi.ContainerEngine{Libpod: runtime}
 	pruneReports, err := ic.NetworkPrune(r.Context(), pruneOptions)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	if pruneReports == nil {

--- a/pkg/api/handlers/libpod/play.go
+++ b/pkg/api/handlers/libpod/play.go
@@ -37,8 +37,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -46,8 +45,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	for _, ipString := range query.StaticIPs {
 		ip := net.ParseIP(ipString)
 		if ip == nil {
-			utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-				errors.Errorf("Invalid IP address %s", ipString))
+			utils.Error(w, http.StatusBadRequest, errors.Errorf("Invalid IP address %s", ipString))
 			return
 		}
 		staticIPs = append(staticIPs, ip)
@@ -57,8 +55,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	for _, macString := range query.StaticMACs {
 		mac, err := net.ParseMAC(macString)
 		if err != nil {
-			utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-				err)
+			utils.Error(w, http.StatusBadRequest, err)
 			return
 		}
 		staticMACs = append(staticMACs, mac)
@@ -67,7 +64,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	// Fetch the K8s YAML file from the body, and copy it to a temp file.
 	tmpfile, err := ioutil.TempFile("", "libpod-play-kube.yml")
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
 		return
 	}
 	defer func() {
@@ -79,16 +76,16 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 		if err := tmpfile.Close(); err != nil {
 			logrus.Warn(err)
 		}
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to write archive to temporary file"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to write archive to temporary file"))
 		return
 	}
 	if err := tmpfile.Close(); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error closing temporary file"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error closing temporary file"))
 		return
 	}
 	authConf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, "failed to retrieve repository credentials", http.StatusBadRequest, err)
+		utils.Error(w, http.StatusBadRequest, err)
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)
@@ -119,7 +116,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	}
 	report, err := containerEngine.PlayKube(r.Context(), tmpfile.Name(), options)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error playing YAML file"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error playing YAML file"))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, report)
@@ -129,7 +126,7 @@ func PlayKubeDown(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	tmpfile, err := ioutil.TempFile("", "libpod-play-kube.yml")
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
 		return
 	}
 	defer func() {
@@ -141,18 +138,18 @@ func PlayKubeDown(w http.ResponseWriter, r *http.Request) {
 		if err := tmpfile.Close(); err != nil {
 			logrus.Warn(err)
 		}
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "unable to write archive to temporary file"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to write archive to temporary file"))
 		return
 	}
 	if err := tmpfile.Close(); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error closing temporary file"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error closing temporary file"))
 		return
 	}
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
 	options := new(entities.PlayKubeDownOptions)
 	report, err := containerEngine.PlayKubeDown(r.Context(), tmpfile.Name(), *options)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "error tearing down YAML file"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error tearing down YAML file"))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, report)

--- a/pkg/api/handlers/libpod/secrets.go
+++ b/pkg/api/handlers/libpod/secrets.go
@@ -35,8 +35,7 @@ func CreateSecret(w http.ResponseWriter, r *http.Request) {
 	}
 	opts := entities.SecretCreateOptions{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/system.go
+++ b/pkg/api/handlers/libpod/system.go
@@ -24,13 +24,13 @@ func SystemPrune(w http.ResponseWriter, r *http.Request) {
 	}{}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
+		utils.Error(w, http.StatusBadRequest,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
+		utils.Error(w, http.StatusBadRequest,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -30,7 +30,7 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+		utils.Error(w, http.StatusInternalServerError,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
@@ -38,7 +38,7 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 	input := entities.VolumeCreateOptions{}
 	// decode params from body
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
 
@@ -112,7 +112,7 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 	)
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+		utils.Error(w, http.StatusInternalServerError,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
@@ -187,7 +187,7 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError,
+		utils.Error(w, http.StatusInternalServerError,
 			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
@@ -199,7 +199,7 @@ func RemoveVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := runtime.RemoveVolume(r.Context(), vol, query.Force, query.Timeout); err != nil {
 		if errors.Cause(err) == define.ErrVolumeBeingUsed {
-			utils.Error(w, "volumes being used", http.StatusConflict, err)
+			utils.Error(w, http.StatusConflict, err)
 			return
 		}
 		utils.InternalServerError(w, err)
@@ -216,11 +216,11 @@ func ExistsVolume(w http.ResponseWriter, r *http.Request) {
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.VolumeExists(r.Context(), name)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}
 	if !report.Value {
-		utils.Error(w, "volume not found", http.StatusNotFound, define.ErrNoSuchVolume)
+		utils.Error(w, http.StatusNotFound, define.ErrNoSuchVolume)
 		return
 	}
 	utils.WriteResponse(w, http.StatusNoContent, "")

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -39,7 +39,7 @@ func WaitContainerDocker(w http.ResponseWriter, r *http.Request) {
 
 	decoder := ctx.Value(api.DecoderKey).(*schema.Decoder)
 	if err = decoder.Decode(&query, r.URL.Query()); err != nil {
-		Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 
@@ -107,7 +107,7 @@ func WaitContainerLibpod(w http.ResponseWriter, r *http.Request) {
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := waitQueryLibpod{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
 

--- a/pkg/api/handlers/utils/errors.go
+++ b/pkg/api/handlers/utils/errors.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod/define"
@@ -22,7 +21,7 @@ var (
 //
 // apiMessage and code must match the container API, and are sent to client
 // err is logged on the system running the podman service
-func Error(w http.ResponseWriter, apiMessage string, code int, err error) {
+func Error(w http.ResponseWriter, code int, err error) {
 	// Log detailed message of what happened to machine running podman service
 	log.Infof("Request Failed(%s): %s", http.StatusText(code), err.Error())
 	em := errorhandling.ErrorModel{
@@ -37,70 +36,62 @@ func VolumeNotFound(w http.ResponseWriter, name string, err error) {
 	if errors.Cause(err) != define.ErrNoSuchVolume {
 		InternalServerError(w, err)
 	}
-	msg := fmt.Sprintf("No such volume: %s", name)
-	Error(w, msg, http.StatusNotFound, err)
+	Error(w, http.StatusNotFound, err)
 }
 
 func ContainerNotFound(w http.ResponseWriter, name string, err error) {
 	if errors.Cause(err) != define.ErrNoSuchCtr {
 		InternalServerError(w, err)
 	}
-	msg := fmt.Sprintf("No such container: %s", name)
-	Error(w, msg, http.StatusNotFound, err)
+	Error(w, http.StatusNotFound, err)
 }
 
 func ImageNotFound(w http.ResponseWriter, name string, err error) {
 	if errors.Cause(err) != storage.ErrImageUnknown {
 		InternalServerError(w, err)
 	}
-	msg := fmt.Sprintf("No such image: %s", name)
-	Error(w, msg, http.StatusNotFound, err)
+	Error(w, http.StatusNotFound, err)
 }
 
 func NetworkNotFound(w http.ResponseWriter, name string, err error) {
 	if errors.Cause(err) != define.ErrNoSuchNetwork {
 		InternalServerError(w, err)
 	}
-	msg := fmt.Sprintf("No such network: %s", name)
-	Error(w, msg, http.StatusNotFound, err)
+	Error(w, http.StatusNotFound, err)
 }
 
 func PodNotFound(w http.ResponseWriter, name string, err error) {
 	if errors.Cause(err) != define.ErrNoSuchPod {
 		InternalServerError(w, err)
 	}
-	msg := fmt.Sprintf("No such pod: %s", name)
-	Error(w, msg, http.StatusNotFound, err)
+	Error(w, http.StatusNotFound, err)
 }
 
 func SessionNotFound(w http.ResponseWriter, name string, err error) {
 	if errors.Cause(err) != define.ErrNoSuchExecSession {
 		InternalServerError(w, err)
 	}
-	msg := fmt.Sprintf("No such exec session: %s", name)
-	Error(w, msg, http.StatusNotFound, err)
+	Error(w, http.StatusNotFound, err)
 }
 
 func SecretNotFound(w http.ResponseWriter, nameOrID string, err error) {
 	if errors.Cause(err).Error() != "no such secret" {
 		InternalServerError(w, err)
 	}
-	msg := fmt.Sprintf("No such secret: %s", nameOrID)
-	Error(w, msg, http.StatusNotFound, err)
+	Error(w, http.StatusNotFound, err)
 }
 
 func ContainerNotRunning(w http.ResponseWriter, containerID string, err error) {
-	msg := fmt.Sprintf("Container %s is not running", containerID)
-	Error(w, msg, http.StatusConflict, err)
+	Error(w, http.StatusConflict, err)
 }
 
 func InternalServerError(w http.ResponseWriter, err error) {
-	Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError, err)
+	Error(w, http.StatusInternalServerError, err)
 }
 
 func BadRequest(w http.ResponseWriter, key string, value string, err error) {
 	e := errors.Wrapf(err, "failed to parse query parameter '%s': %q", key, value)
-	Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, e)
+	Error(w, http.StatusBadRequest, e)
 }
 
 // UnsupportedParameter logs a given param by its string name as not supported.

--- a/pkg/api/server/register_swarm.go
+++ b/pkg/api/server/register_swarm.go
@@ -31,5 +31,5 @@ func (s *APIServer) registerSwarmHandlers(r *mux.Router) error {
 // this allows the client to decide if they still can talk to us
 func noSwarm(w http.ResponseWriter, r *http.Request) {
 	logrus.Errorf("%s is not a podman supported service", r.URL.String())
-	utils.Error(w, "node is not part of a swarm", http.StatusServiceUnavailable, errors.New("Podman does not support service: "+r.URL.String()))
+	utils.Error(w, http.StatusServiceUnavailable, errors.New("Podman does not support service: "+r.URL.String()))
 }


### PR DESCRIPTION
This commit removes error message string from utils.Error in pkg/api.
Param was not used inside a function for quite a long time
[NO NEW TESTS NEEDED]

Signed-off-by: Jakub Guzik <jguzik@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
