### PR TITLE
pkg/specgen/generate/security: fix error message text

### DIFF
--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -246,7 +246,7 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 
 		// Ignore net sysctls if --net=host
 		if s.NetNS.IsHost() && strings.HasPrefix(sysctlKey, "net.") {
-			return errors.Wrapf(define.ErrInvalidArg, "sysctl %s=%s can't be set since Host Namespace set to host", sysctlKey, sysctlVal)
+			return errors.Wrapf(define.ErrInvalidArg, "sysctl %s=%s can't be set since Network Namespace set to host", sysctlKey, sysctlVal)
 		}
 
 		// Ignore uts sysctls if --uts=host


### PR DESCRIPTION
This should be Network Namespace, not Host Namespace.

Fixes: 0d70df11
