### PR TITLE
Show correct default values or show none

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -415,12 +415,12 @@ func rootFlags(cmd *cobra.Command, opts *entities.PodmanConfig) {
 		_ = cmd.RegisterFlagCompletionFunc(runrootFlagName, completion.AutocompleteDefault)
 
 		runtimeFlagName := "runtime"
-		pFlags.StringVar(&opts.RuntimePath, runtimeFlagName, "", "Path to the OCI-compatible binary used to run containers, default is /usr/bin/runc")
+		pFlags.StringVar(&opts.RuntimePath, runtimeFlagName, cfg.Engine.OCIRuntime, "Path to the OCI-compatible binary used to run containers.")
 		_ = cmd.RegisterFlagCompletionFunc(runtimeFlagName, completion.AutocompleteDefault)
 
 		// -s is deprecated due to conflict with -s on subcommands
 		storageDriverFlagName := "storage-driver"
-		pFlags.StringVar(&opts.StorageDriver, storageDriverFlagName, "", "Select which storage driver is used to manage storage of images and containers (default is overlay)")
+		pFlags.StringVar(&opts.StorageDriver, storageDriverFlagName, "", "Select which storage driver is used to manage storage of images and containers")
 		_ = cmd.RegisterFlagCompletionFunc(storageDriverFlagName, completion.AutocompleteNone) //TODO: what can we recommend here?
 
 		tmpdirFlagName := "tmpdir"

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -719,6 +719,14 @@ func SkipIfRemote(reason string) {
 	Skip("[remote]: " + reason)
 }
 
+func SkipIfNotRemote(reason string) {
+	checkReason(reason)
+	if IsRemote() {
+		return
+	}
+	Skip("[local]: " + reason)
+}
+
 // SkipIfInContainer skips a test if the test is run inside a container
 func SkipIfInContainer(reason string) {
 	checkReason(reason)


### PR DESCRIPTION
Before this PR, the podman --help command shows the defaults
as runc and overlay even if the storage.conf and containers.conf
files do not match. This PR changes them to show the actual defaults
and in the case of storage driver, does not show the default at all.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
