### PR TITLE
container create: do not check for network dns support

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1198,13 +1198,6 @@ func (c *Container) NetworkConnect(nameOrID, netName string, netOpts types.PerNe
 	// get network status before we connect
 	networkStatus := c.getNetworkStatus()
 
-	network, err := c.runtime.network.NetworkInspect(netName)
-	if err != nil {
-		return err
-	}
-	if !network.DNSEnabled && len(netOpts.Aliases) > 0 {
-		return errors.Wrapf(define.ErrInvalidArg, "cannot set network aliases for network %q because dns is disabled", netName)
-	}
 	// always add the short id as alias for docker compat
 	netOpts.Aliases = append(netOpts.Aliases, c.config.ID[:12])
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -254,15 +254,6 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 			if err != nil {
 				return nil, err
 			}
-			if len(opts.Aliases) > 0 {
-				network, err := r.network.NetworkInspect(netName)
-				if err != nil {
-					return nil, err
-				}
-				if !network.DNSEnabled {
-					return nil, errors.Wrapf(define.ErrInvalidArg, "cannot set network aliases for network %q because dns is disabled", netName)
-				}
-			}
 			// assign interface name if empty
 			if opts.InterfaceName == "" {
 				for i < 100000 {

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -867,4 +867,17 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		Expect(inspectOut[0].NetworkSettings.Networks).To(HaveLen(1))
 		Expect(inspectOut[0].NetworkSettings.Networks).To(HaveKey("podman"))
 	})
+
+	// see https://github.com/containers/podman/issues/12972
+	It("podman run check network-alias works on networks without dns", func() {
+		net := "dns" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", "--disable-dns", net})
+		session.WaitWithDefaultTimeout()
+		defer podmanTest.removeCNINetwork(net)
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"run", "--network", net, "--network-alias", "abcdef", ALPINE, "true"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+	})
 })


### PR DESCRIPTION
We should not check if the network supports dns when we create a
container with network aliases. This could be the case for containers
created by docker-compose for example if the dnsname plugin is not
installed or the user uses a macvlan config where we do not support dns.

Fixes #12972

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
