### PR TITLE
CI: enable rootless-remote system tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -561,6 +561,26 @@ remote_system_test_task:
         TEST_FLAVOR: sys
         PODBIN_NAME: remote
 
+rootless_remote_system_test_task:
+    <<: *local_system_test_task
+    alias: rootless_remote_system_test
+    depends_on:
+      - remote_integration_test
+    matrix:
+      # Minimal sanity testing: only the latest Fedora
+      - env:
+          DISTRO_NV: ${FEDORA_NAME}
+          # Not used here, is used in other tasks
+          VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
+          CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+          # ID for re-use of build output
+          _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+    gce_instance: *standardvm
+    env:
+        TEST_FLAVOR: sys
+        PODBIN_NAME: remote
+        PRIV_NAME: rootless
+
 buildah_bud_test_task:
     name: *std_name_fmt
     alias: buildah_bud_test
@@ -716,6 +736,7 @@ success_task:
         - local_system_test
         - remote_system_test
         - rootless_system_test
+        - rootless_remote_system_test
         - rootless_gitlab_test
         - upgrade_test
         - buildah_bud_test

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -213,6 +213,8 @@ EOF
 # Podman volume user test
 @test "podman volume user test" {
     is_rootless || skip "only meaningful when run rootless"
+    skip_if_remote "not applicable on podman-remote"
+
     user="1000:2000"
     newuser="100:200"
     tmpdir=${PODMAN_TMPDIR}/volume_$(random_string)

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -245,7 +245,8 @@ function check_label() {
     is "$output" "system_u:object_r:container_file_t:$level $tmpdir" \
        "Confined Relabel Correctly"
 
-    if is_rootless; then
+    # podman-remote has no 'unshare'
+    if is_rootless && ! is_remote; then
        run_podman unshare touch $tmpdir/test1
        # Relabel entire directory
        run_podman unshare chcon system_u:object_r:usr_t:s0 $tmpdir


### PR DESCRIPTION
Minimal: only test Fedora.Latest.

Reason: podman 4.0.0-0.2.rc2 broke bodhi gating tests:
        https://github.com/containers/podman/issues/12989

Signed-off-by: Ed Santiago <santiago@redhat.com>
