### PR TITLE
remote build: set rootless oci isolation correctly

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -183,12 +183,6 @@ func buildFlags(cmd *cobra.Command) {
 	completion.CompleteCommandFlags(cmd, fromAndBudFlagsCompletions)
 	flags.SetNormalizeFunc(buildahCLI.AliasFlags)
 	if registry.IsRemote() {
-		flag = flags.Lookup("isolation")
-		buildOpts.Isolation = buildahDefine.OCI
-		if err := flag.Value.Set(buildahDefine.OCI); err != nil {
-			logrus.Errorf("Unable to set --isolation to %v: %v", buildahDefine.OCI, err)
-		}
-		flag.DefValue = buildahDefine.OCI
 		_ = flags.MarkHidden("disable-content-trust")
 		_ = flags.MarkHidden("cache-from")
 		_ = flags.MarkHidden("sign-by")


### PR DESCRIPTION
When we run rootless buildah needs to have IsolationOCIRootless set
otherwise it will run code which cannot be used as rootless user.
Podman should use the buildah default if possible and change it to
rootless mode if needed.

[NO NEW TESTS NEEDED] Should be covered by existing tests once we have
podman-remote rootless tests.

Fixes #12989


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
