### PR TITLE
[CI:DOCS] Github workflow: Update Cirrus-cron GraphQL query

### DIFF
--- a/.github/actions/check_cirrus_cron/cron_failures.sh
+++ b/.github/actions/check_cirrus_cron/cron_failures.sh
@@ -22,7 +22,7 @@ mkdir -p artifacts
 cat > ./artifacts/query_raw.json << "EOF"
 {"query":"
   query CronNameStatus($owner: String!, $repo: String!) {
-    githubRepository(owner: $owner, name: $repo) {
+    ownerRepository(platform: \"LINUX\", owner: $owner, name: $repo) {
       cronSettings {
         name
         lastInvocationBuild {


### PR DESCRIPTION
Related: https://github.com/containers/podman/pull/12997 #13005

**Note**: Due to the way this workflow is implemented, there is no way
easy way to test it other than directly on the `main` repo. branch.

Sometime on Jan. 14th the GraphQL schema for Cirrus-CI changed, leading
to the following error:

`Validation error of type FieldUndefined: Field 'githubRepository' in
type 'Root' is undefined @ 'githubRepository'`

After some exploration, it was determined the field had been replaced
with a new root-level field `ownerRepository`.  Manual experimentation
revealed the scalar value `LINUX` was appropriate to use for the new
`platform` parameter.  The query reply appears to remain compatible.

Update the script which performs this query to use the new field name
and parameter.  ***NOTE*** This script is shared across multiple
containers-org repos. All of which are/were affected by the schema
change.

Signed-off-by: Chris Evich <cevich@redhat.com>