### PR TITLE
Update godoc, swagger using wrong struct

### DIFF
--- a/pkg/api/server/swagger.go
+++ b/pkg/api/server/swagger.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
@@ -189,7 +188,7 @@ type swagVolumeCreateResponse struct {
 // swagger:response VolumeList
 type swagVolumeListResponse struct {
 	// in:body
-	Body []libpod.Volume
+	Body []entities.VolumeConfigResponse
 }
 
 // Healthcheck


### PR DESCRIPTION
Documentation for API volume list, pointed to a different struct than
the code.

Fixes #12987

Signed-off-by: Jhon Honce <jhonce@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
