### PR TITLE
[CI:DOCS] Github-workflow: Fix YAML syntax

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -89,4 +89,4 @@ jobs:
                 subject: Github workflow error on ${{github.repository}}
                 to: ${{env.RCPTCSV}}
                 from: ${{secrets.ACTION_MAIL_SENDER}}
-                body: Job failed: https://github.com/${{github.repository}}/runs/${{github.job}}?check_suite_focus=true
+                body: "Job failed: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"


### PR DESCRIPTION
The `body` string value must be quoted because it contains a colon :cry: 

Also, a few components of the URL were wrong.  I successfully tested these changes on another repository.