### PR TITLE
[CI:DOCS] Github workflow: Fix parsing of GraphQL response JSON

### DIFF
--- a/.github/actions/check_cirrus_cron/cron_failures.sh
+++ b/.github/actions/check_cirrus_cron/cron_failures.sh
@@ -75,7 +75,7 @@ fi
 # e.x. reply.json
 # {
 #   "data": {
-#     "githubRepository": {
+#     "ownerRepository": {
 #       "cronSettings": [
 #         {
 #           "name": "Keepalive_v2.0",
@@ -102,7 +102,7 @@ fi
 #     }
 #   }
 # }
-_filt='.data.githubRepository.cronSettings | map(select(.lastInvocationBuild.status=="FAILED") | { name:.name, id:.lastInvocationBuild.id} | join(" ")) | join("\n")'
+_filt='.data.ownerRepository.cronSettings | map(select(.lastInvocationBuild.status=="FAILED") | { name:.name, id:.lastInvocationBuild.id} | join(" ")) | join("\n")'
 jq --raw-output "$_filt" ./artifacts/reply.json > "$NAME_ID_FILEPATH"
 
 echo "<Cron Name> <Failed Build ID>"


### PR DESCRIPTION
While #12998 fixed the query string, it neglected to address
presence of the old `githubRepository` field name in the reply.  This
resulted in the job throwing an error:

`jq: error (at ./artifacts/reply.json:0): Cannot iterate over null`

However, the job did preserve an artifacts archive containing the new
response data.  As a test for the fix in this commit, I ran the
raw response data through the corrected jq command-line.  This
confirmed the change by properly parsing the data as expected by
the workflow.

Signed-off-by: Chris Evich <cevich@redhat.com>