### PR TITLE
[CI:DOCS] change location of where make outputs podman binary on osx

### DIFF
--- a/build_osx.md
+++ b/build_osx.md
@@ -28,7 +28,7 @@ can now be built.
 ```
 $ cd go/src/github.com/containers/podman
 $ make podman-remote-darwin
-$ mv bin/podman-remote-darwin bin/podman
+$ mv bin/darwin/podman bin/podman
 ```
 
 The binary will be located in bin/


### PR DESCRIPTION
Signed-off-by: Daniel Helfand <helfand.4@gmail.com>

Update the location of where `make podman-remote-darwin` outputs podman binary on osx in build_osx.md.
