### PR TITLE
Pass configmaps from API query to play kube

### DIFF
--- a/pkg/api/handlers/libpod/play.go
+++ b/pkg/api/handlers/libpod/play.go
@@ -31,6 +31,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 		StaticIPs  []string `schema:"staticIPs"`
 		StaticMACs []string `schema:"staticMACs"`
 		NoHosts    bool     `schema:"noHosts"`
+		ConfigMaps []string `schema:"configMaps"`
 	}{
 		TLSVerify: true,
 		Start:     true,
@@ -110,6 +111,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 		LogOptions: query.LogOptions,
 		StaticIPs:  staticIPs,
 		StaticMACs: staticMACs,
+		ConfigMaps: query.ConfigMaps,
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)

--- a/pkg/api/server/register_play.go
+++ b/pkg/api/server/register_play.go
@@ -48,6 +48,12 @@ func (s *APIServer) registerPlayHandlers(r *mux.Router) error {
 	//    description: Static MACs used for the pods.
 	//    items:
 	//      type: string
+	//  - in: query
+	//    name: configMaps
+	//    type: array
+	//    description: ConfigMaps path to be used by pods.
+	//    items:
+	//      type: string
 	//  - in: body
 	//    name: request
 	//    description: Kubernetes YAML file.


### PR DESCRIPTION
This PR fixes the passing of the configmaps via the REST API, previously
the configmaps wasn't able to pass because the query with configmaps
wasn't parsed.

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]

Signed-off-by: Ondra Machacek <omachace@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

When running code such as:
```golang
        manifestPath := "podyaml"
	configMaps := []string{"configmap.yaml"}
	options := play.KubeOptions{
		ConfigMaps: &configMaps,
	}
	report, err := play.Kube(connText, manifestPath, &options)
	if err != nil {
	  fmt.Printf("Error: %v", err)
	}
	fmt.Printf("Report: %v", report)

```

previously the configmaps wasn't passed, with this code it is.
