### PR TITLE
Makefile: fix darwin detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ endef
 # Need to use CGO for mDNS resolution, but cross builds need CGO disabled
 # See https://github.com/golang/go/issues/12524 for details
 DARWIN_GCO := 0
-ifeq ($(NATIVE_GOOS),darwin)
+ifeq ($(GOOS),darwin)
 ifdef HOMEBREW_PREFIX
 	DARWIN_GCO := 1
 endif


### PR DESCRIPTION
NATIVE_GOOS does not exist in the 3.4 branch, only on main.
Fixes my backport #12327. Verified to fix #12975 (again) for me.

Signed-off-by: Chris Hofstaedtler <chris.hofstaedtler@deduktiva.com>
