### PR TITLE
rootless: drop permission check for devices

### DIFF
--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -47,17 +47,6 @@ func addPrivilegedDevices(g *generate.Generator) error {
 			if _, found := mounts[d.Path]; found {
 				continue
 			}
-			st, err := os.Stat(d.Path)
-			if err != nil {
-				if err == unix.EPERM {
-					continue
-				}
-				return err
-			}
-			// Skip devices that the user has not access to.
-			if st.Mode()&0007 == 0 {
-				continue
-			}
 			newMounts = append(newMounts, devMnt)
 		}
 		g.Config.Mounts = append(newMounts, g.Config.Mounts...)


### PR DESCRIPTION
commit 350ede1eeb6ab33bce2918d7768b940c255e63c6 added the feature.

Do not check whether the device is usable by the rootless user before
adding to the container.

Closes: https://github.com/containers/podman/issues/12704

[NO NEW TESTS NEEDED] it requires changes on the host to test it

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
