### PR TITLE
network create: allow multiple subnets

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -46,7 +46,8 @@ The `macvlan` and `ipvlan` driver support the following options:
 #### **--gateway**
 
 Define a gateway for the subnet. If you want to provide a gateway address, you must also provide a
-*subnet* option.
+*subnet* option. Can be specified multiple times.
+The argument order of the **--subnet**, **--gateway** and **--ip-range** options must match.
 
 #### **--internal**
 
@@ -56,7 +57,8 @@ automatically disabled.
 #### **--ip-range**
 
 Allocate container IP from a range.  The range must be a complete subnet and in CIDR notation.  The *ip-range* option
-must be used with a *subnet* option.
+must be used with a *subnet* option. Can be specified multiple times.
+The argument order of the **--subnet**, **--gateway** and **--ip-range** options must match.
 
 #### **--label**
 
@@ -64,11 +66,13 @@ Set metadata for a network (e.g., --label mykey=value).
 
 #### **--subnet**
 
-The subnet in CIDR notation.
+The subnet in CIDR notation. Can be specified multiple times to allocate more than one subnet for this network.
+The argument order of the **--subnet**, **--gateway** and **--ip-range** options must match.
+This is useful to set a static ipv4 and ipv6 subnet.
 
 #### **--ipv6**
 
-Enable IPv6 (Dual Stack) networking.
+Enable IPv6 (Dual Stack) networking. If not subnets are given it will allocate a ipv4 and ipv6 subnet.
 
 ## EXAMPLE
 
@@ -100,6 +104,12 @@ Create a network that uses a *192.168.55.0/24** subnet and has an IP address ran
 ```
 $ podman network create --subnet 192.168.55.0/24 --ip-range 192.168.55.128/25
 cni-podman5
+```
+
+Create a network with a static ipv4 and ipv6 subnet and set a gateway.
+```
+$ podman network create --subnet 192.168.55.0/24 --gateway 192.168.55.3 --subnet fd52:2a5a:747e:3acd::/64 --gateway fd52:2a5a:747e:3acd::10
+podman4
 ```
 
 Create a Macvlan based network using the host interface eth0. Macvlan networks can only be used as root.

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -43,12 +43,12 @@ type NetworkRmReport struct {
 type NetworkCreateOptions struct {
 	DisableDNS bool
 	Driver     string
-	Gateway    net.IP
+	Gateways   []net.IP
 	Internal   bool
 	Labels     map[string]string
 	MacVLAN    string
-	Range      net.IPNet
-	Subnet     net.IPNet
+	Ranges     []string
+	Subnets    []string
 	IPv6       bool
 	// Mapping of driver options and values.
 	Options map[string]string


### PR DESCRIPTION
podman network create --subnet, --gateway and --ip-range can now be
specified multiple times to join the network to more than one subnet.
This is very useful if you want to use a dual stack network and assign a
fixed ipv4 and ipv6 subnet. The order of the options is important here,
the first --gateway/--ip-range will be assigned to the first subnet and
so on.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
