### PR TITLE
correction output of podman pod create --help

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
+	"github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/sysinfo"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/containers"
@@ -71,11 +72,13 @@ func init() {
 	_ = createCommand.RegisterFlagCompletionFunc(nameFlagName, completion.AutocompleteNone)
 
 	infraImageFlagName := "infra-image"
-	var defInfraImage string
+	defInfraImage := ""
 	if !registry.IsRemote() {
-		defInfraImage = containerConfig.Engine.InfraImage
+		if containerConfig.Engine.InfraImage != config.DefaultInfraImage {
+			defInfraImage = containerConfig.Engine.InfraImage
+		}
 	}
-	flags.StringVar(&infraImage, infraImageFlagName, defInfraImage, "The image of the infra container to associate with the pod")
+	flags.StringVar(&infraImage, infraImageFlagName, defInfraImage, "Image to use for infra container, rather than builtin")
 	_ = createCommand.RegisterFlagCompletionFunc(infraImageFlagName, common.AutocompleteImages)
 
 	podIDFileFlagName := "pod-id-file"


### PR DESCRIPTION
because of issue #13037 

should fixed by #13064

this PR is history

before correction
```
$ podman pod create --help | grep infra-image
      --infra-image string            The image of the infra container to associate with the pod (default "k8s.gcr.io/pause:3.5")
```

should be like this after correction
```
$ podman pod create --help | grep infra-image
      --infra-image string            Image to use for infra container, rather than builtin
```

if infra-image set via containers.conf
```
$ podman pod create --help | grep infra-image
      --infra-image string            Image to use for infra container, rather than builtin (default "registry.access.redhat.com/ubi8/pause")
```

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
