### PR TITLE
issue template: add platform

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,6 +27,14 @@ maintainers are best equipped to handle these bugs.
 
 /kind feature
 
+**Platforms**
+
+/kind linux
+
+/kind macos
+
+/kind windows
+
 **Description**
 
 <!--


### PR DESCRIPTION
Extend the issue template to make it (more) obvious to which platform a
given issue or feature request relates to.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@mheon PTAL

Do I interpret `/kind` correctly to apply the specified label?