### PR TITLE
podman image scp syntax correction

### DIFF
--- a/cmd/podman/images/scp.go
+++ b/cmd/podman/images/scp.go
@@ -147,6 +147,17 @@ func scp(cmd *cobra.Command, args []string) (finalErr error) {
 		return err
 	}
 
+	allLocal := true // if we are all localhost, do not validate connections but if we are using one localhost and one non we need to use sshd
+	for _, val := range cliConnections {
+		if !strings.Contains(val, "@localhost::") {
+			allLocal = false
+			break
+		}
+	}
+	if allLocal {
+		cliConnections = []string{}
+	}
+
 	var serv map[string]config.Destination
 	serv, err = GetServiceInformation(cliConnections, cfg)
 	if err != nil {

--- a/cmd/podman/images/scp_utils.go
+++ b/cmd/podman/images/scp_utils.go
@@ -17,12 +17,13 @@ func parseImageSCPArg(arg string) (*entities.ImageScpOptions, []string, error) {
 	cliConnections := []string{}
 
 	switch {
-	case strings.Contains(arg, "@localhost"): // image transfer between users
+	case strings.Contains(arg, "@localhost::"): // image transfer between users
 		location.User = strings.Split(arg, "@")[0]
 		location, err = validateImagePortion(location, arg)
 		if err != nil {
 			return nil, nil, err
 		}
+		cliConnections = append(cliConnections, arg)
 	case strings.Contains(arg, "::"):
 		location, err = validateImagePortion(location, arg)
 		if err != nil {


### PR DESCRIPTION
[NO NEW TESTS NEEDED] image scp was reading the localhost syntax too loosely causing some errors with domains or hosts containing the word
localhost. Fixed that and added a few lines to make sure the pure localhost connections do not touch sshd

I left this as a no tests PR since it does not change any functionality. I am not sure where I would test this if I did since the integration tests don't use sshd and the system tests are not to be messed with for scp...

resolves #13021

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
