### PR TITLE
[CI:DOCS] Cirrus: Fix get_ci_vm.sh initial setup

### DIFF
--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -47,11 +47,10 @@ elif [[ "$1" == "--setup" ]]; then
     cd $REPO_DIRPATH
     echo "+ Loading ./contrib/cirrus/lib.sh" > /dev/stderr
     source ./contrib/cirrus/lib.sh
-    echo "+ Mimicking .cirrus.yml clone_script and build_task" > /dev/stderr
+    echo "+ Mimicking .cirrus.yml build_task" > /dev/stderr
     make install.tools
-    make vendor
-    make podman
-    make podman-remote
+    make binaries
+    make docs
     echo "+ Running environment setup" > /dev/stderr
     ./contrib/cirrus/setup_environment.sh
 else


### PR DESCRIPTION
Due to some recent changes in the Makefile, the setup part of the script
is now breaking with the error:

```
install: cannot stat 'bin/rootlessport': No such file or directory
make: *** [Makefile:767: install.bin] Error 1
```

The root-cause seems to be the `install` targets not
properly specifying their build dependencies.  This may lead to other
problems WRT automation, but for now I'm just patching this tool to
workaround the issue.