### PR TITLE
System tests: emergency skip of checkpoint tests

### DIFF
--- a/test/system/520-checkpoint.bats
+++ b/test/system/520-checkpoint.bats
@@ -15,6 +15,10 @@ function setup() {
         skip "FIXME: checkpointing broken in Ubuntu 2004, 2104, 2110, ..."
     fi
 
+    if [[ "$(uname -r)" =~ "5.17" ]]; then
+        skip "FIXME: checkpointing broken on kernel 5.17 (#12949)"
+    fi
+
     # None of these tests work rootless....
     if is_rootless; then
         # ...however, is that a genuine cast-in-stone limitation, or one


### PR DESCRIPTION
...on kernel 5.17, because it's broken. Needed for gating tests on rawhide.

Signed-off-by: Ed Santiago <santiago@redhat.com>
