### PR TITLE
[CI:DOCS] github: label issues based on os

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,10 @@
+# List of labels which should be assigned to issues based on a regex
+windows:
+  - 'Os\/Arch:\s*windows'
+
+macos:
+  - 'Os\/Arch:\s*darwin'
+
+remote:
+  # podman-remote version prints Client:\nVersion:...
+  - 'Client:\sVersion:'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,15 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v2.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/issue-labeler.yml
+        not-before: 2022-01-27T00:00:00Z
+        enable-versioned-regex: 0


### PR DESCRIPTION
We get a lot of issues for podman-remote on macos. Since the fact that
this is a remote client is often overlooked by us lets add windows, macos
and remote label automatically based on a regex which should match the
output of podman version.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
