### PR TITLE
[CI:DOCS] github: label issues based on os fix regex

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,10 +1,13 @@
 # List of labels which should be assigned to issues based on a regex
 windows:
-  - 'Os\/Arch:\s*windows'
-
+  # info prints OsArch: ...
+  # version prints OS/Arch: ...
+  - 'O[Ss]\/?Arch:\s*windows'
 macos:
-  - 'Os\/Arch:\s*darwin'
+  # info prints OsArch: ...
+  # version prints OS/Arch: ...
+  - 'O[Ss]\/?Arch:\s*darwin'
 
 remote:
-  # podman-remote version prints Client:\nVersion:...
-  - 'Client:\sVersion:'
+  # we cannot use multiline regex so we check for serviceIsRemote in podman info
+  - 'serviceIsRemote:\strue'


### PR DESCRIPTION
Good news the github action works, however I noticed that we cannot use
a multiline regex so we have to use serviceIsRemote to detect if this is
a remote client. Also change the os regex so that it matches both the
output of podman version and podman info.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
