### PR TITLE
Implement Podman Container Clone

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1308,3 +1308,17 @@ func AutocompleteCompressionFormat(cmd *cobra.Command, args []string, toComplete
 	types := []string{"gzip", "zstd", "zstd:chunked"}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
+
+// AutocompleteClone - Autocomplete container and image names
+func AutocompleteClone(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if !validCurrentCmdLine(cmd, args, toComplete) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	switch len(args) {
+	case 0:
+		return getContainers(cmd, toComplete, completeDefault)
+	case 2:
+		return getImages(cmd, toComplete)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/podman/containers/clone.go
+++ b/cmd/podman/containers/clone.go
@@ -1,0 +1,80 @@
+package containers
+
+import (
+	"fmt"
+
+	"github.com/containers/podman/v4/cmd/podman/common"
+	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/libpod/define"
+	"github.com/containers/podman/v4/pkg/domain/entities"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cloneDescription = `Creates a copy of an existing container.`
+
+	containerCloneCommand = &cobra.Command{
+		Use:               "clone [options] CONTAINER NAME IMAGE",
+		Short:             "Clone an existing container",
+		Long:              cloneDescription,
+		RunE:              clone,
+		Args:              cobra.RangeArgs(1, 3),
+		ValidArgsFunction: common.AutocompleteClone,
+		Example:           `podman container clone container_name new_name image_name`,
+	}
+)
+
+var (
+	ctrClone entities.ContainerCloneOptions
+)
+
+func cloneFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
+	destroyFlagName := "destroy"
+	flags.BoolVar(&ctrClone.Destroy, destroyFlagName, false, "destroy the original container")
+
+	runFlagName := "run"
+	flags.BoolVar(&ctrClone.Run, runFlagName, false, "run the new container")
+
+	common.DefineCreateFlags(cmd, &ctrClone.CreateOpts, false, true)
+}
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: containerCloneCommand,
+		Parent:  containerCmd,
+	})
+
+	cloneFlags(containerCloneCommand)
+}
+
+func clone(cmd *cobra.Command, args []string) error {
+	switch len(args) {
+	case 0:
+		return errors.Wrapf(define.ErrInvalidArg, "Must Specify at least 1 argument")
+	case 2:
+		ctrClone.CreateOpts.Name = args[1]
+	case 3:
+		ctrClone.CreateOpts.Name = args[1]
+		ctrClone.Image = args[2]
+		rawImageName := ""
+		if !cliVals.RootFS {
+			rawImageName = args[0]
+			name, err := PullImage(ctrClone.Image, ctrClone.CreateOpts)
+			if err != nil {
+				return err
+			}
+			ctrClone.Image = name
+			ctrClone.RawImageName = rawImageName
+		}
+	}
+	ctrClone.ID = args[0]
+	ctrClone.CreateOpts.IsClone = true
+	rep, err := registry.ContainerEngine().ContainerClone(registry.GetContext(), ctrClone)
+	if err != nil {
+		return err
+	}
+	fmt.Println(rep.Id)
+	return nil
+}

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -70,7 +70,7 @@ func createFlags(cmd *cobra.Command) {
 	)
 
 	flags.SetInterspersed(false)
-	common.DefineCreateFlags(cmd, &cliVals, false)
+	common.DefineCreateFlags(cmd, &cliVals, false, false)
 	common.DefineNetFlags(cmd)
 
 	flags.SetNormalizeFunc(utils.AliasFlags)

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -61,7 +61,7 @@ func runFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
 	flags.SetInterspersed(false)
-	common.DefineCreateFlags(cmd, &cliVals, false)
+	common.DefineCreateFlags(cmd, &cliVals, false, false)
 	common.DefineNetFlags(cmd)
 
 	flags.SetNormalizeFunc(utils.AliasFlags)

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -63,7 +63,7 @@ func init() {
 	})
 	flags := createCommand.Flags()
 	flags.SetInterspersed(false)
-	common.DefineCreateFlags(createCommand, &infraOptions, true)
+	common.DefineCreateFlags(createCommand, &infraOptions, true, false)
 	common.DefineNetFlags(createCommand)
 
 	flags.BoolVar(&createOptions.Infra, "infra", true, "Create an infra container associated with the pod to share namespaces with")

--- a/docs/source/markdown/podman-container-clone.1.md
+++ b/docs/source/markdown/podman-container-clone.1.md
@@ -1,0 +1,180 @@
+% podman-container-clone(1)
+
+## NAME
+podman\-container\-clone - Creates a copy of an existing container
+
+## SYNOPSIS
+**podman container clone** [*options*] *container* *name* *image*
+
+## DESCRIPTION
+**podman container clone** creates a copy of a container, recreating the original with an identical configuration. This command takes three arguments: the first being the container id or name ot clone, the second argument in this command can change the name of the clone from the default of $ORIGINAL_NAME-clone, and the third is a new image to use in the cloned container.
+
+## OPTIONS
+
+#### **--name**
+
+Set a custom name for the cloned container. The default if not specified is of the syntax: **<ORIGINAL_NAME>-clone**
+
+#### **--destroy**
+
+Remove the original container that we are cloning once used to mimic the configuration.
+
+#### **--cpus**
+
+Set a number of CPUs for the container that overrides the original containers CPU limits. If none are specified, the original container's Nano CPUs are used.
+
+This is shorthand
+for **--cpu-period** and **--cpu-quota**, so only **--cpus** or either both the **--cpu-period** and **--cpu-quota** options can be set.
+
+#### **--cpuset-cpus**
+
+CPUs in which to allow execution (0-3, 0,1). If none are specified, the original container's CPUset is used.
+
+#### **--cpu-period**=*limit*
+
+Set the CPU period for the Completely Fair Scheduler (CFS), which is a
+duration in microseconds. Once the container's CPU quota is used up, it will
+not be scheduled to run until the current period ends. Defaults to 100000
+microseconds.
+
+On some systems, changing the CPU limits may not be allowed for non-root
+users. For more details, see
+https://github.com/containers/podman/blob/master/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
+
+If none is specified, the original container's cpu period is used
+
+#### **--cpu-shares**=*shares*
+
+CPU shares (relative weight)
+
+By default, all containers get the same proportion of CPU cycles. This proportion
+can be modified by changing the container's CPU share weighting relative
+to the weighting of all other running containers.
+
+To modify the proportion from the default of 1024, use the **--cpu-shares**
+option to set the weighting to 2 or higher.
+
+The proportion will only apply when CPU-intensive processes are running.
+When tasks in one container are idle, other containers can use the
+left-over CPU time. The actual amount of CPU time will vary depending on
+the number of containers running on the system.
+
+For example, consider three containers, one has a cpu-share of 1024 and
+two others have a cpu-share setting of 512. When processes in all three
+containers attempt to use 100% of CPU, the first container would receive
+50% of the total CPU time. If a fourth container is added with a cpu-share
+of 1024, the first container only gets 33% of the CPU. The remaining containers
+receive 16.5%, 16.5% and 33% of the CPU.
+
+On a multi-core system, the shares of CPU time are distributed over all CPU
+cores. Even if a container is limited to less than 100% of CPU time, it can
+use 100% of each individual CPU core.
+
+For example, consider a system with more than three cores.
+container **{C0}** is started with **-c=512** running one process, and another container
+**{C1}** with **-c=1024** running two processes, this can result in the following
+division of CPU shares:
+
+PID    container	CPU	CPU share
+100    {C0}		0	100% of CPU0
+101    {C1}		1	100% of CPU1
+102    {C1}		2	100% of CPU2
+
+If none are specified, the original container's CPU shares are used.
+
+#### **--cpuset-mems**=*nodes*
+
+Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
+
+If there are four memory nodes on the system (0-3), use `--cpuset-mems=0,1`
+then processes in the container will only use memory from the first
+two memory nodes.
+
+If none are specified, the original container's CPU memory nodes are used.
+
+#### **--cpu-quota**=*limit*
+
+Limit the CPU Completely Fair Scheduler (CFS) quota.
+
+Limit the container's CPU usage. By default, containers run with the full
+CPU resource. The limit is a number in microseconds. If a number is provided,
+the container will be allowed to use that much CPU time until the CPU period
+ends (controllable via **--cpu-period**).
+
+On some systems, changing the CPU limits may not be allowed for non-root
+users. For more details, see
+https://github.com/containers/podman/blob/master/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
+
+If none is specified, the original container's CPU quota are used.
+
+#### **--cpu-rt-period**=*microseconds*
+
+Limit the CPU real-time period in microseconds
+
+Limit the container's Real Time CPU usage. This option tells the kernel to restrict the container's Real Time CPU usage to the period specified.
+
+This option is not supported on cgroups V2 systems.
+
+If none is specified, the original container's CPU runtime period is used.
+
+
+#### **--cpu-rt-runtime**=*microseconds*
+
+Limit the CPU real-time runtime in microseconds.
+
+Limit the containers Real Time CPU usage. This option tells the kernel to limit the amount of time in a given CPU period Real Time tasks may consume. Ex:
+Period of 1,000,000us and Runtime of 950,000us means that this container could consume 95% of available CPU and leave the remaining 5% to normal priority tasks.
+
+The sum of all runtimes across containers cannot exceed the amount allotted to the parent cgroup.
+
+This option is not supported on cgroup V2 systems.
+
+#### **--memory**, **-m**=*limit*
+
+Memory limit (format: `<number>[<unit>]`, where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
+
+Allows the memory available to a container to be constrained. If the host
+supports swap memory, then the **-m** memory setting can be larger than physical
+RAM. If a limit of 0 is specified (not using **-m**), the container's memory is
+not limited. The actual limit may be rounded up to a multiple of the operating
+system's page size (the value would be very large, that's millions of trillions).
+
+If no memory limits are specified, the original container's will be used.
+
+#### **--run**
+
+When set to true, this flag runs the newly created container after the
+clone process has completed, this specifies a detached running mode.
+
+## EXAMPLES
+```
+# podman container clone d0cf1f782e2ed67e8c0050ff92df865a039186237a4df24d7acba5b1fa8cc6e7
+6b2c73ff8a1982828c9ae2092954bcd59836a131960f7e05221af9df5939c584
+```
+
+```
+# podman container clone --name=clone d0cf1f782e2ed67e8c0050ff92df865a039186237a4df24d7acba5b1fa8cc6e7
+6b2c73ff8a1982828c9ae2092954bcd59836a131960f7e05221af9df5939c584
+```
+
+```
+# podman container clone --destroy --cpus=5 d0cf1f782e2ed67e8c0050ff92df865a039186237a4df24d7acba5b1fa8cc6e7
+6b2c73ff8a1982828c9ae2092954bcd59836a131960f7e05221af9df5939c584
+```
+
+```
+# podman container clone 2d4d4fca7219b4437e0d74fcdc272c4f031426a6eacd207372691207079551de new_name fedora
+Resolved "fedora" as an alias (/etc/containers/registries.conf.d/shortnames.conf)
+Trying to pull registry.fedoraproject.org/fedora:latest...
+Getting image source signatures
+Copying blob c6183d119aa8 done
+Copying config e417cd49a8 done
+Writing manifest to image destination
+Storing signatures
+5a9b7851013d326aa4ac4565726765901b3ecc01fcbc0f237bc7fd95588a24f9
+```
+## SEE ALSO
+**[podman-create(1)](podman-create.1.md)**, **[cgroups(7)](https://man7.org/linux/man-pages/man7/cgroups.7.html)**
+
+## HISTORY
+January 2022, Originally written by Charlie Doern <cdoern@redhat.com>

--- a/docs/source/markdown/podman-container.1.md
+++ b/docs/source/markdown/podman-container.1.md
@@ -16,6 +16,7 @@ The container command allows you to manage containers
 | attach     | [podman-attach(1)](podman-attach.1.md)              | Attach to a running container.                                               |
 | checkpoint | [podman-container-checkpoint(1)](podman-container-checkpoint.1.md)  | Checkpoints one or more running containers.                  |
 | cleanup    | [podman-container-cleanup(1)](podman-container-cleanup.1.md)    | Cleanup the container's network and mountpoints.                 |
+| clone      | [podman-container-clone(1)](podman-container-clone.1.md)      |  Creates a copy of an existing container.                          |
 | commit     | [podman-commit(1)](podman-commit.1.md)              | Create new image based on the changed container.                             |
 | cp         | [podman-cp(1)](podman-cp.1.md)                      | Copy files/folders between a container and the local filesystem.             |
 | create     | [podman-create(1)](podman-create.1.md)              | Create a new container.                                                      |

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -417,7 +417,10 @@ func (c *Container) MountLabel() string {
 
 // Systemd returns whether the container will be running in systemd mode
 func (c *Container) Systemd() bool {
-	return c.config.Systemd
+	if c.config.Systemd != nil {
+		return *c.config.Systemd
+	}
+	return false
 }
 
 // User returns the user who the container is run as

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -375,8 +375,8 @@ type ContainerMiscConfig struct {
 	IsInfra bool `json:"pause"`
 	// SdNotifyMode tells libpod what to do with a NOTIFY_SOCKET if passed
 	SdNotifyMode string `json:"sdnotifyMode,omitempty"`
-	// Systemd tells libpod to setup the container in systemd mode
-	Systemd bool `json:"systemd"`
+	// Systemd tells libpod to setup the container in systemd mode, a value of nil denotes false
+	Systemd *bool `json:"systemd,omitempty"`
 	// HealthCheckConfig has the health check command and related timings
 	HealthCheckConfig *manifest.Schema2HealthConfig `json:"healthcheck"`
 	// PreserveFDs is a number of additional file descriptors (in addition

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -346,7 +346,7 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 	ctrConfig.Timeout = c.config.Timeout
 	ctrConfig.OpenStdin = c.config.Stdin
 	ctrConfig.Image = c.config.RootfsImageName
-	ctrConfig.SystemdMode = c.config.Systemd
+	ctrConfig.SystemdMode = c.Systemd()
 
 	// Leave empty is not explicitly overwritten by user
 	if len(c.config.Command) != 0 {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -557,7 +557,7 @@ func (c *Container) setupStorage(ctx context.Context) error {
 }
 
 func (c *Container) processLabel(processLabel string) (string, error) {
-	if !c.config.Systemd && !c.ociRuntime.SupportsKVM() {
+	if !c.Systemd() && !c.ociRuntime.SupportsKVM() {
 		return processLabel, nil
 	}
 	ctrSpec, err := c.specFromState()
@@ -569,7 +569,7 @@ func (c *Container) processLabel(processLabel string) (string, error) {
 		switch {
 		case c.ociRuntime.SupportsKVM():
 			return selinux.KVMLabel(processLabel)
-		case c.config.Systemd:
+		case c.Systemd():
 			return selinux.InitLabel(processLabel)
 		}
 	}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -614,7 +614,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 		}
 	}
 
-	if c.config.Systemd {
+	if c.Systemd() {
 		if err := c.setupSystemd(g.Mounts(), g); err != nil {
 			return nil, errors.Wrapf(err, "error adding systemd-specific mounts")
 		}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -566,7 +566,8 @@ func WithSystemd() CtrCreateOption {
 			return define.ErrCtrFinalized
 		}
 
-		ctr.config.Systemd = true
+		t := true
+		ctr.config.Systemd = &t
 		return nil
 	}
 }

--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -33,7 +33,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
-	rtSpec, spec, opts, err := generate.MakeContainer(context.Background(), runtime, &sg)
+	rtSpec, spec, opts, err := generate.MakeContainer(context.Background(), runtime, &sg, false, nil)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -463,3 +463,13 @@ type ContainerRenameOptions struct {
 	// NewName is the new name that will be given to the container.
 	NewName string
 }
+
+// ContainerCloneOptions contains options for cloning an existing continer
+type ContainerCloneOptions struct {
+	ID           string
+	Destroy      bool
+	CreateOpts   ContainerCreateOptions
+	Image        string
+	RawImageName string
+	Run          bool
+}

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -19,6 +19,7 @@ type ContainerEngine interface {
 	ContainerAttach(ctx context.Context, nameOrID string, options AttachOptions) error
 	ContainerCheckpoint(ctx context.Context, namesOrIds []string, options CheckpointOptions) ([]*CheckpointReport, error)
 	ContainerCleanup(ctx context.Context, namesOrIds []string, options ContainerCleanupOptions) ([]*ContainerCleanupReport, error)
+	ContainerClone(ctx context.Context, ctrClone ContainerCloneOptions) (*ContainerCreateReport, error)
 	ContainerCommit(ctx context.Context, nameOrID string, options CommitOptions) (*CommitReport, error)
 	ContainerCopyFromArchive(ctx context.Context, nameOrID, path string, reader io.Reader, options CopyOptions) (ContainerCopyFunc, error)
 	ContainerCopyToArchive(ctx context.Context, nameOrID string, path string, writer io.Writer) (ContainerCopyFunc, error)

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -264,6 +264,7 @@ type ContainerCreateOptions struct {
 	SeccompPolicy     string
 	PidFile           string
 	IsInfra           bool
+	IsClone           bool
 
 	Net *NetOptions `json:"net,omitempty"`
 

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -392,7 +392,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		if err != nil {
 			return nil, err
 		}
-		rtSpec, spec, opts, err := generate.MakeContainer(ctx, ic.Libpod, specGen)
+		rtSpec, spec, opts, err := generate.MakeContainer(ctx, ic.Libpod, specGen, false, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -435,7 +435,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			if err != nil {
 				return nil, err
 			}
-			rtSpec, spec, opts, err := generate.MakeContainer(ctx, ic.Libpod, specGen)
+			rtSpec, spec, opts, err := generate.MakeContainer(ctx, ic.Libpod, specGen, false, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -958,3 +958,7 @@ func (ic *ContainerEngine) ShouldRestart(_ context.Context, id string) (bool, er
 func (ic *ContainerEngine) ContainerRename(ctx context.Context, nameOrID string, opts entities.ContainerRenameOptions) error {
 	return containers.Rename(ic.ClientCtx, nameOrID, new(containers.RenameOptions).WithName(opts.NewName))
 }
+
+func (ic *ContainerEngine) ContainerClone(ctx context.Context, ctrCloneOpts entities.ContainerCloneOptions) (*entities.ContainerCreateReport, error) {
+	return nil, errors.New("cloning a container is not supported on the remote client")
+}

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -301,7 +301,14 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 
 	if compatibleOptions.InfraResources == nil && s.ResourceLimits != nil {
-		g.Config.Linux.Resources = s.ResourceLimits
+		out, err := json.Marshal(s.ResourceLimits)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(out, g.Config.Linux.Resources)
+		if err != nil {
+			return nil, err
+		}
 	} else if s.ResourceLimits != nil { // if we have predefined resource limits we need to make sure we keep the infra and container limits
 		originalResources, err := json.Marshal(s.ResourceLimits)
 		if err != nil {

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -135,7 +135,7 @@ func MakePod(p *entities.PodSpec, rt *libpod.Runtime) (*libpod.Pod, error) {
 			return nil, err
 		}
 		p.PodSpecGen.InfraContainerSpec.User = "" // infraSpec user will get incorrectly assigned via the container creation process, overwrite here
-		rtSpec, spec, opts, err := MakeContainer(context.Background(), rt, p.PodSpecGen.InfraContainerSpec)
+		rtSpec, spec, opts, err := MakeContainer(context.Background(), rt, p.PodSpecGen.InfraContainerSpec, false, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/specgenutil/createparse.go
+++ b/pkg/specgenutil/createparse.go
@@ -26,6 +26,8 @@ func validate(c *entities.ContainerCreateOptions) error {
 	if _, ok := imageVolType[c.ImageVolume]; !ok {
 		if c.IsInfra {
 			c.ImageVolume = "bind"
+		} else if c.IsClone { // the image volume type will be deduced later from the container we are cloning
+			return nil
 		} else {
 			return errors.Errorf("invalid image-volume type %q. Pick one of bind, tmpfs, or ignore", c.ImageVolume)
 		}

--- a/test/e2e/container_clone_test.go
+++ b/test/e2e/container_clone_test.go
@@ -1,0 +1,187 @@
+package integration
+
+import (
+	"os"
+
+	. "github.com/containers/podman/v4/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Podman container clone", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest *PodmanTestIntegration
+	)
+
+	BeforeEach(func() {
+		SkipIfRemote("podman container clone is not supported in remote")
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanTestCreate(tempdir)
+		podmanTest.Setup()
+		podmanTest.SeedImages()
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+		f := CurrentGinkgoTestDescription()
+		processTestResult(f)
+
+	})
+
+	It("podman container clone basic test", func() {
+		SkipIfRootlessCgroupsV1("starting a container with the memory limits not supported")
+		create := podmanTest.Podman([]string{"create", ALPINE})
+		create.WaitWithDefaultTimeout()
+		Expect(create).To(Exit(0))
+		clone := podmanTest.Podman([]string{"container", "clone", create.OutputToString()})
+		clone.WaitWithDefaultTimeout()
+		Expect(clone).To(Exit(0))
+
+		clone = podmanTest.Podman([]string{"container", "clone", clone.OutputToString()})
+		clone.WaitWithDefaultTimeout()
+		Expect(clone).To(Exit(0))
+
+		ctrInspect := podmanTest.Podman([]string{"inspect", clone.OutputToString()})
+		ctrInspect.WaitWithDefaultTimeout()
+		Expect(ctrInspect).To(Exit(0))
+		Expect(ctrInspect.InspectContainerToJSON()[0].Name).To(ContainSubstring("-clone1"))
+
+		ctrStart := podmanTest.Podman([]string{"container", "start", clone.OutputToString()})
+		ctrStart.WaitWithDefaultTimeout()
+		Expect(ctrStart).To(Exit(0))
+	})
+
+	It("podman container clone image test", func() {
+		create := podmanTest.Podman([]string{"create", ALPINE})
+		create.WaitWithDefaultTimeout()
+		Expect(create).To(Exit(0))
+		clone := podmanTest.Podman([]string{"container", "clone", create.OutputToString(), "new_name", fedoraMinimal})
+		clone.WaitWithDefaultTimeout()
+		Expect(clone).To(Exit(0))
+
+		ctrInspect := podmanTest.Podman([]string{"inspect", clone.OutputToString()})
+		ctrInspect.WaitWithDefaultTimeout()
+		Expect(ctrInspect).To(Exit(0))
+		Expect(ctrInspect.InspectContainerToJSON()[0].ImageName).To(Equal(fedoraMinimal))
+		Expect(ctrInspect.InspectContainerToJSON()[0].Name).To(Equal("new_name"))
+	})
+
+	It("podman container clone name test", func() {
+		create := podmanTest.Podman([]string{"create", ALPINE})
+		create.WaitWithDefaultTimeout()
+		Expect(create).To(Exit(0))
+		clone := podmanTest.Podman([]string{"container", "clone", "--name", "testing123", create.OutputToString()})
+		clone.WaitWithDefaultTimeout()
+		Expect(clone).To(Exit(0))
+
+		cloneInspect := podmanTest.Podman([]string{"inspect", clone.OutputToString()})
+		cloneInspect.WaitWithDefaultTimeout()
+		Expect(cloneInspect).To(Exit(0))
+		cloneData := cloneInspect.InspectContainerToJSON()
+		Expect(cloneData[0].Name).To(Equal("testing123"))
+	})
+
+	It("podman container clone resource limits override", func() {
+		create := podmanTest.Podman([]string{"create", "--cpus=5", ALPINE})
+		create.WaitWithDefaultTimeout()
+		Expect(create).To(Exit(0))
+		clone := podmanTest.Podman([]string{"container", "clone", create.OutputToString()})
+		clone.WaitWithDefaultTimeout()
+		Expect(clone).To(Exit(0))
+
+		createInspect := podmanTest.Podman([]string{"inspect", create.OutputToString()})
+		createInspect.WaitWithDefaultTimeout()
+		Expect(createInspect).To(Exit(0))
+		createData := createInspect.InspectContainerToJSON()
+
+		cloneInspect := podmanTest.Podman([]string{"inspect", clone.OutputToString()})
+		cloneInspect.WaitWithDefaultTimeout()
+		Expect(cloneInspect).To(Exit(0))
+		cloneData := cloneInspect.InspectContainerToJSON()
+		Expect(createData[0].HostConfig.NanoCpus).To(Equal(cloneData[0].HostConfig.NanoCpus))
+
+		create = podmanTest.Podman([]string{"create", "--memory=5", ALPINE})
+		create.WaitWithDefaultTimeout()
+		Expect(create).To(Exit(0))
+		clone = podmanTest.Podman([]string{"container", "clone", "--cpus=6", create.OutputToString()})
+		clone.WaitWithDefaultTimeout()
+		Expect(clone).To(Exit(0))
+
+		createInspect = podmanTest.Podman([]string{"inspect", create.OutputToString()})
+		createInspect.WaitWithDefaultTimeout()
+		Expect(createInspect).To(Exit(0))
+		createData = createInspect.InspectContainerToJSON()
+
+		cloneInspect = podmanTest.Podman([]string{"inspect", clone.OutputToString()})
+		cloneInspect.WaitWithDefaultTimeout()
+		Expect(cloneInspect).To(Exit(0))
+		cloneData = cloneInspect.InspectContainerToJSON()
+		Expect(createData[0].HostConfig.MemorySwap).To(Equal(cloneData[0].HostConfig.MemorySwap))
+
+		create = podmanTest.Podman([]string{"create", "--cpus=5", ALPINE})
+		create.WaitWithDefaultTimeout()
+		Expect(create).To(Exit(0))
+		clone = podmanTest.Podman([]string{"container", "clone", "--cpus=4", create.OutputToString()})
+		clone.WaitWithDefaultTimeout()
+		Expect(clone).To(Exit(0))
+
+		var nanoCPUs int64
+		numCpus := 4
+		nanoCPUs = int64(numCpus * 1000000000)
+
+		createInspect = podmanTest.Podman([]string{"inspect", create.OutputToString()})
+		createInspect.WaitWithDefaultTimeout()
+		Expect(createInspect).To(Exit(0))
+		createData = createInspect.InspectContainerToJSON()
+
+		cloneInspect = podmanTest.Podman([]string{"inspect", clone.OutputToString()})
+		cloneInspect.WaitWithDefaultTimeout()
+		Expect(cloneInspect).To(Exit(0))
+		cloneData = cloneInspect.InspectContainerToJSON()
+		Expect(createData[0].HostConfig.NanoCpus).ToNot(Equal(cloneData[0].HostConfig.NanoCpus))
+		Expect(cloneData[0].HostConfig.NanoCpus).To(Equal(nanoCPUs))
+	})
+
+	It("podman container clone in a pod", func() {
+		SkipIfRootlessCgroupsV1("starting a container with the memory limits not supported")
+		run := podmanTest.Podman([]string{"run", "-dt", "--pod", "new:1234", ALPINE, "sleep", "20"})
+		run.WaitWithDefaultTimeout()
+		Expect(run).To(Exit(0))
+		clone := podmanTest.Podman([]string{"container", "clone", run.OutputToString()})
+		clone.WaitWithDefaultTimeout()
+		Expect(clone).To(Exit(0))
+		ctrStart := podmanTest.Podman([]string{"container", "start", clone.OutputToString()})
+		ctrStart.WaitWithDefaultTimeout()
+		Expect(ctrStart).To(Exit(0))
+
+		checkClone := podmanTest.Podman([]string{"ps", "-f", "id=" + clone.OutputToString(), "--ns", "--format", "{{.Namespaces.IPC}} {{.Namespaces.UTS}} {{.Namespaces.NET}}"})
+		checkClone.WaitWithDefaultTimeout()
+		Expect(checkClone).Should(Exit(0))
+		cloneArray := checkClone.OutputToStringArray()
+
+		checkCreate := podmanTest.Podman([]string{"ps", "-f", "id=" + run.OutputToString(), "--ns", "--format", "{{.Namespaces.IPC}} {{.Namespaces.UTS}} {{.Namespaces.NET}}"})
+		checkCreate.WaitWithDefaultTimeout()
+		Expect(checkCreate).Should(Exit(0))
+		createArray := checkCreate.OutputToStringArray()
+
+		Expect(cloneArray).To(ContainElements(createArray[:]))
+
+		ctrInspect := podmanTest.Podman([]string{"inspect", clone.OutputToString()})
+		ctrInspect.WaitWithDefaultTimeout()
+		Expect(ctrInspect).Should(Exit(0))
+
+		runInspect := podmanTest.Podman([]string{"inspect", run.OutputToString()})
+		runInspect.WaitWithDefaultTimeout()
+		Expect(runInspect).Should(Exit(0))
+
+		Expect(ctrInspect.InspectContainerToJSON()[0].Pod).Should(Equal(runInspect.InspectContainerToJSON()[0].Pod))
+		Expect(ctrInspect.InspectContainerToJSON()[0].HostConfig.NetworkMode).Should(Equal(runInspect.InspectContainerToJSON()[0].HostConfig.NetworkMode))
+	})
+
+})


### PR DESCRIPTION
podman container clone takes the id of an existing continer and creates a specgen from the given container's config
recreating all proper namespaces and overriding spec options like resource limits and the container name if given in the cli options

this command utilizes the common function DefineCreateFlags meaning that we can funnel as many create options as we want
into clone over time allowing the user to clone with as much or as little of the original config as they want.

the current supported flags are:

--id (ctr to clone)
--destroy (remove the original container)
--name (new ctr name)
--cpus (sets cpu period and quota)
--cpuset-cpus
--cpu-period
--cpu-rt-period
--cpu-rt-runtime
--cpu-shares
--cpuset-mems
--memory

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
