### PR TITLE
[CI:DOCS] Adapt podman images ls filters docs to be aligned with prune filters docs

### DIFF
--- a/docs/source/markdown/podman-images.1.md
+++ b/docs/source/markdown/podman-images.1.md
@@ -25,27 +25,32 @@ Show image digests
 
 #### **--filter**=*filter*, **-f**
 
-Filter output based on conditions provided
+Provide filter values.
 
-  Filters:
+The *filters* argument format is of `key=value`. If there is more than one *filter*, then pass multiple OPTIONS: **--filter** *foo=bar* **--filter** *bif=baz*.
 
-  **since=IMAGE**
-    Filter on images created after the given IMAGE (name or tag).
+Supported filters:
 
-  **before=IMAGE**
-    Filter on images created before the given IMAGE (name or tag).
+| Filter             | Description                                                                                   |
+| :----------------: | --------------------------------------------------------------------------------------------- |
+| *before*           | Filter by images created before the given IMAGE (name or tag).                                |
+| *dangling*         | Filter by dangling (unused) images.                                                           |
+| *label*            | Filter by images with (or without, in the case of label!=[...] is used) the specified labels. |
+| *readonly*         | Filter by read-only or read/write images.                                                     |
+| *reference*        | Filter by image name.                                                                         |
+| *since*            | Filter by images created after the given IMAGE (name or tag).                                 |
 
-  **dangling
-    Show dangling images. Dangling images are a file system layer that was used in a previous build of an image and is no longer referenced by any image. They are denoted with the `<none>` tag, consume disk space and serve no active purpose.
+The `before` *filter* accepts formats: `<image-name>[:<tag>]`, `<image id>` or `<image@digest>`.
 
-  **label**
-    Filter by images labels key and/or value.
+The `dangling` *filter* shows images that are taking up disk space and serve no purpose. Dangling image is a file system layer that was used in a previous build of an image and is no longer referenced by any image. They are denoted with the `<none>` tag, consume disk space and serve no active purpose.
 
-  **readonly
-     Show only read only images or Read/Write images. The default is to show both.  Read/Only images can be configured by modifying the  "additionalimagestores" in the /etc/containers/storage.conf file.
+The `label` *filter* accepts two formats. One is the `label`=*key* or `label`=*key*=*value*, which shows images with the specified labels. The other format is the `label!`=*key* or `label!`=*key*=*value*, which shows images without the specified labels.
 
-  **reference=**
-     Filter by image name, specified as regular expressions.
+The `readonly` *filter* shows, as a default, both read-only and read/write images. Read-only images can be configured by modifying the  `additionalimagestores` in the `/etc/containers/storage.conf` file.
+
+The `reference` *filter* accepts the pattern of an image reference `<image-name>[:<tag>]`.
+
+The `since` *filter* accepts formats: `<image-name>[:<tag>]`, `<image id>` or `<image@digest>`.
 
 #### **--format**=*format*
 


### PR DESCRIPTION
Follow up of #13009 and #12976

Please review if such formatting is acceptable for ls filters. If so, I'll open next PR with everything else aligned.



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
