### PR TITLE
play kube envVar.valueFrom.fieldRef

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -365,6 +365,11 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		if err != nil {
 			return nil, err
 		}
+
+		for k, v := range podSpec.PodSpecGen.Labels { // add podYAML labels
+			labels[k] = v
+		}
+
 		specgenOpts := kube.CtrSpecGenOptions{
 			Annotations:       annotations,
 			Container:         initCtr,
@@ -405,7 +410,12 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 				return nil, err
 			}
 
+			for k, v := range podSpec.PodSpecGen.Labels { // add podYAML labels
+				labels[k] = v
+			}
+
 			specgenOpts := kube.CtrSpecGenOptions{
+				Annotations:    annotations,
 				Container:      container,
 				Image:          pulledImage,
 				Volumes:        volumes,

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2984,7 +2984,7 @@ invalid kube kind
 		inspect = podmanTest.Podman([]string{"inspect", podName + "-" + ctr02Name, "--format", "'{{.Config.Labels}}'"})
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(Exit(0))
-		Expect(inspect.OutputToString()).To(ContainSubstring(`map[]`))
+		Expect(inspect.OutputToString()).NotTo(ContainSubstring(autoUpdateRegistry + ":" + autoUpdateRegistryValue))
 	})
 
 	It("podman play kube teardown", func() {


### PR DESCRIPTION
add support for env vars values from pod spec fields
see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core

relates to issue https://github.com/containers/podman/issues/12756

Signed-off-by: Yaron Dayagi <ydayagi@redhat.com>