### PR TITLE
[CI:DOCS] Add notes to "--oom-kill-disable" not supported on cgroups V2

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -739,6 +739,8 @@ This option conflicts with **--add-host**.
 
 Whether to disable OOM Killer for the container or not.
 
+This flag is not supported on cgroups V2 systems.
+
 #### **--oom-score-adj**=*num*
 
 Tune the host's OOM preferences for containers (accepts -1000 to 1000)

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -767,6 +767,8 @@ This option conflicts with **--add-host**.
 
 Whether to disable OOM Killer for the container or not.
 
+This flag is not supported on cgroups V2 systems.
+
 #### **--oom-score-adj**=*num*
 
 Tune the host's OOM preferences for containers (accepts values from **-1000** to **1000**).


### PR DESCRIPTION
Clarify "--oom-kill-disable" is not supported on cgroups V2 in documentation.

podman on crun and cgroups V2 gets the error as following when executing "podman run --oom-kill-disable=true".

```
# podman run --oom-kill-disable=true -d fedora sleep 300
Error: OCI runtime error: crun: cannot disable OOM killer with cgroupv2
```

podman version
```
# podman -v
podman version 4.0.0-dev
```

crun version
```
# podman info --format json | jq -r .host.ociRuntime.package
crun-1.4.1-1.fc34.x86_64
```

Signed-off-by: Tsubasa Watanabe <w.tsubasa@fujitsu.com>