### PR TITLE
libpod: report slirp4netns network stats

### DIFF
--- a/docs/source/markdown/podman-stats.1.md
+++ b/docs/source/markdown/podman-stats.1.md
@@ -98,6 +98,10 @@ ID             NAME           MEM USAGE / LIMIT
 6eae9e25a564   clever_bassi   3.031MB / 16.7GB
 ```
 
+Note: When using a slirp4netns network, the traffic send via the port forwarding will be accounted
+to the `lo` device.  Traffic accounted to `lo` is not accounted in the stats output.
+
+
 ## SEE ALSO
 **[podman(1)](podman.1.md)**
 

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -185,6 +185,19 @@ var _ = Describe("Podman stats", func() {
 		Expect(session).Should(Exit(0))
 	})
 
+	It("podman reads slirp4netns network stats", func() {
+		session := podmanTest.Podman([]string{"run", "-d", "--network", "slirp4netns", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		cid := session.OutputToString()
+
+		stats := podmanTest.Podman([]string{"stats", "--format", "'{{.NetIO}}'", "--no-stream", cid})
+		stats.WaitWithDefaultTimeout()
+		Expect(stats).Should(Exit(0))
+		Expect(stats.OutputToString()).To(Not(ContainSubstring("-- / --")))
+	})
+
 	// Regression test for #8265
 	It("podman stats with custom memory limits", func() {
 		// Run three containers. One with a memory limit.  Make sure


### PR DESCRIPTION
by default slirp4netns uses the tap0 device.  When slirp4netns is
used, use that device by default instead of eth0.

Closes: https://github.com/containers/podman/issues/11695

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
