### PR TITLE
COPR: fix dependencies

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -77,12 +77,15 @@ BuildRequires: ostree-devel
 BuildRequires: systemd
 BuildRequires: systemd-devel
 Requires: conmon >= 2:2.0.30-2
-Requires: containers-common >= 4:1-30
-Requires: containernetworking-plugins >= 1.0.0-15.1
+# containers-common pulled from podman-next copr for f34,
+# from the distro repos for f35+
+%if 0%{?fedora} <= 35
+Requires: containers-common >= 4:1-39
+%else
+Requires: containers-common >= 4:1-46
+%endif
 Requires: iptables
 Requires: nftables
-Requires: netavark
-Recommends: %{name}-plugins = %{epoch}:%{version}-%{release}
 Recommends: catatonit
 Suggests: qemu-user-static
 


### PR DESCRIPTION
containers-common rpm now `Recommends: netavark` and
`Provides: container-network-stack` which are
actually provided by both cni-plugins and netavark.

Netavark has a `Recommends: aardvark-dns` already.

So, we should only depend on the containers-common package and let it
handle everything.

Also, dnsname no longer needs to be recommended if we want new users to
use netavark / aardvark-dns.

[NO NEW TESTS NEEDED]

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


@cevich @rhatdan @mheon @baude @edsantiago PTAL

/cc @containers/podman-maintainers 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
