### PR TITLE
system prune: remove all networks

### DIFF
--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -21,7 +21,7 @@ import (
 var (
 	systemResetDescription = `Reset podman storage back to default state"
 
-  All containers will be stopped and removed, and all images, volumes and container content will be removed.
+  All containers will be stopped and removed, and all images, volumes, networks and container content will be removed.
 `
 	systemResetCommand = &cobra.Command{
 		Annotations:       map[string]string{registry.EngineMode: registry.ABIMode},
@@ -55,11 +55,11 @@ func reset(cmd *cobra.Command, args []string) {
 	// Prompt for confirmation if --force is not set
 	if !forceFlag {
 		reader := bufio.NewReader(os.Stdin)
-		fmt.Println(`
-WARNING! This will remove:
+		fmt.Println(`WARNING! This will remove:
         - all containers
         - all pods
         - all images
+        - all networks
         - all build cache`)
 		if len(listCtn) > 0 {
 			fmt.Println(`WARNING! The following external containers will be purged:`)

--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -7,7 +7,7 @@ podman\-system\-reset - Reset storage back to initial state
 **podman system reset** [*options*]
 
 ## DESCRIPTION
-**podman system reset** removes all pods, containers, images and volumes.
+**podman system reset** removes all pods, containers, images, networks and volumes.
 
 This command must be run **before** changing any of the following fields in the
 `containers.conf` or `storage.conf` files: `driver`, `static_dir`, `tmp_dir`
@@ -27,6 +27,17 @@ Do not prompt for confirmation
 Print usage statement
 
 ## EXAMPLES
+
+```
+$ podman system reset
+WARNING! This will remove:
+        - all containers
+        - all pods
+        - all images
+        - all networks
+        - all build cache
+Are you sure you want to continue? [y/N] y
+```
 
 ### Switching rootless user from VFS driver to overlay with fuse-overlayfs
 


### PR DESCRIPTION
podman system prune should also remove all networks. When we want to
users to migrate to the new network stack we recommend to run podman
system reset. However this did not remove networks and if there were
still networks around we would continue to use cni since this was
considered an old system.

There is one exception for the default network. It should not be removed
since this could cause other issues when it no longer exists. The
network backend detection logic ignores the default network so this is
fine.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
