### PR TITLE
Revert "Move each search dns to its own line"

### DIFF
--- a/pkg/resolvconf/resolvconf.go
+++ b/pkg/resolvconf/resolvconf.go
@@ -221,9 +221,11 @@ func GetOptions(resolvConf []byte) []string {
 // dnsSearch, and an "options" entry for every element in dnsOptions.
 func Build(path string, dns, dnsSearch, dnsOptions []string) (*File, error) {
 	content := bytes.NewBuffer(nil)
-	for _, search := range dnsSearch {
-		if _, err := content.WriteString("search " + search + "\n"); err != nil {
-			return nil, err
+	if len(dnsSearch) > 0 {
+		if searchString := strings.Join(dnsSearch, " "); strings.Trim(searchString, " ") != "." {
+			if _, err := content.WriteString("search " + searchString + "\n"); err != nil {
+				return nil, err
+			}
 		}
 	}
 	for _, dns := range dns {

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -597,7 +597,7 @@ load helpers
     searchIP="100.100.100.100"
     cat >$containersconf <<EOF
 [containers]
-  dns_searches  = [ "example.com", "test1.com"]
+  dns_searches  = [ "example.com"]
   dns_servers = [
     "1.1.1.1",
     "$searchIP",
@@ -605,14 +605,9 @@ load helpers
     "8.8.8.8",
 ]
 EOF
-export searchDNS="search example.com
-search test1.com
-search a.b"
     CONTAINERS_CONF=$containersconf run_podman run --rm $IMAGE grep "example.com" /etc/resolv.conf
     CONTAINERS_CONF=$containersconf run_podman run --rm $IMAGE grep $searchIP /etc/resolv.conf
     is "$output" "nameserver $searchIP" "Should only be one $searchIP not multiple"
-    CONTAINERS_CONF=$containersconf run_podman run --dns-search a.b --rm $IMAGE grep search /etc/resolv.conf
-    is "$output" "$searchDNS" "Searches should be on different lines"
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
This reverts commit a1bc8cb52cefd49e8cc54ae14d1864b8a1ec216e.
Please see resolv.conf(5) search domains must be on the same line. If
you use multiple seach key words only the last one is used. I tested this
with alpine and it works correctly when they are on the same line so I
am not sure what issues Dan had with it but this is not correct.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
