### PR TITLE
[v4.0] pkg/bindings/images.Build(): slashify "dockerfile" values, too

### DIFF
--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -332,7 +332,7 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 	}
 
 	tarContent := []string{options.ContextDirectory}
-	newContainerFiles := []string{}
+	newContainerFiles := []string{} // dockerfile paths, relative to context dir, ToSlash()ed
 
 	dontexcludes := []string{"!Dockerfile", "!Containerfile", "!.dockerignore", "!.containerignore"}
 	for _, c := range containerFiles {
@@ -380,7 +380,7 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 				tarContent = append(tarContent, containerfile)
 			}
 		}
-		newContainerFiles = append(newContainerFiles, containerfile)
+		newContainerFiles = append(newContainerFiles, filepath.ToSlash(containerfile))
 	}
 	if len(newContainerFiles) > 0 {
 		cFileJSON, err := json.Marshal(newContainerFiles)


### PR DESCRIPTION
When the Dockerfile isn't in the root directory of the build context, the client supplies its pathname to the server, but it needs to do so using "/" as the path separator, not the client OS's path separator.

Cherry-picked from #13120.