### PR TITLE
System tests: revert emergency skip of checkpoint tests

### DIFF
--- a/test/system/520-checkpoint.bats
+++ b/test/system/520-checkpoint.bats
@@ -15,10 +15,6 @@ function setup() {
         skip "FIXME: checkpointing broken in Ubuntu 2004, 2104, 2110, ..."
     fi
 
-    if [[ "$(uname -r)" =~ "5.17" ]]; then
-        skip "FIXME: checkpointing broken on kernel 5.17 (#12949)"
-    fi
-
     # None of these tests work rootless....
     if is_rootless; then
         # ...however, is that a genuine cast-in-stone limitation, or one


### PR DESCRIPTION
Revert #13049. criu-3.16.1-6.fc36 fixes the problem and is
now in fc36 stable:

   https://bodhi.fedoraproject.org/updates/FEDORA-2022-183b337712

(Yes, I confirmed that tests pass on a rawhide vm)

Signed-off-by: Ed Santiago <santiago@redhat.com>
