### PR TITLE
compat: endpoint `/build` must set header `content type` as `application/json` in response header.

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -605,8 +605,8 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Send headers and prime client for stream to come
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	flush()
 
 	body := w.(io.Writer)

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -190,6 +190,11 @@ t POST "libpod/build?dockerfile=containerfile" $CONTAINERFILE_TAR application/js
 t POST "build?dockerfile=containerfile" $CONTAINERFILE_TAR application/json 200 \
   .stream~"STEP 1/1: FROM $IMAGE"
 
+# Build api response header must contain Content-type: application/json
+t POST "build?dockerfile=containerfile" $CONTAINERFILE_TAR application/json 200
+response_headers=$(cat "$WORKDIR/curl.headers.out")
+like "$response_headers" ".*application/json.*" "header does not contains application/json"
+
 # PR #12091: output from compat API must now include {"aux":{"ID":"sha..."}}
 t POST "build?dockerfile=containerfile" $CONTAINERFILE_TAR 200 \
   '.aux|select(has("ID")).ID~^sha256:[0-9a-f]\{64\}$'


### PR DESCRIPTION
Lot of clients are expecting proper `Content-type: application/json`
configured in response headers of `/build` compat api. Following commit
fixes that.

Fixes issues where code is setting header field after writing header
which does not seems correct. We must set `content-type` before we write and flush
http header.

Closes: https://github.com/containers/podman/issues/13148