### PR TITLE
Cleanup: remove obsolete/misleading bug workaround

### DIFF
--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -15,9 +15,6 @@ function _check_health {
     run_podman inspect --format "{{json .State.Healthcheck}}" healthcheck_c
 
     parse_table "$tests" | while read field expect;do
-        # (kludge to deal with parse_table and empty strings)
-        if [ "$expect" = "''" ]; then expect=""; fi
-
         actual=$(jq ".$field" <<<"$output")
         is "$actual" "$expect" "$testname - .State.Healthcheck.$field"
     done


### PR DESCRIPTION
Followup to #13129: remove a no-longer-necessary workaround
for a healthcheck bug.

Signed-off-by: Ed Santiago <santiago@redhat.com>
