### PR TITLE
fix: Multiplication of durations

### DIFF
--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -257,7 +257,7 @@ func (r *ConmonOCIRuntime) ExecStopContainer(ctr *Container, sessionID string, t
 	}
 
 	// Wait for the PID to stop
-	if err := waitPidStop(pid, killContainerTimeout*time.Second); err != nil {
+	if err := waitPidStop(pid, killContainerTimeout); err != nil {
 		return errors.Wrapf(err, "timed out waiting for container %s exec session %s PID %d to stop after SIGKILL", ctr.ID(), sessionID, pid)
 	}
 


### PR DESCRIPTION
`killContainerTimeout` is already 5 second
```go
// Timeout before declaring that runtime has failed to kill a given
// container
const killContainerTimeout = 5 * time.Second
```
Multiply it by another time.Second when using
```go
if err := waitPidStop(pid, killContainerTimeout*time.Second); err != nil {
```

[NO NEW TESTS NEEDED]

Signed-off-by: myml <wurongjie1@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
