### PR TITLE
[4.0] idmap should be able to be specified along with other options

### DIFF
--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -25,7 +25,7 @@ type defaultMountOptions struct {
 // The sourcePath variable, if not empty, contains a bind mount source.
 func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string, error) {
 	var (
-		foundWrite, foundSize, foundProp, foundMode, foundExec, foundSuid, foundDev, foundCopyUp, foundBind, foundZ, foundU, foundOverlay bool
+		foundWrite, foundSize, foundProp, foundMode, foundExec, foundSuid, foundDev, foundCopyUp, foundBind, foundZ, foundU, foundOverlay, foundIdmap bool
 	)
 
 	newOptions := make([]string, 0, len(options))
@@ -49,9 +49,10 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 		case "O":
 			foundOverlay = true
 		case "idmap":
-			if len(options) > 1 {
-				return nil, errors.Wrapf(ErrDupeMntOption, "'O' option can not be used with other options")
+			if foundIdmap {
+				return nil, errors.Wrapf(ErrDupeMntOption, "the 'idmap' option can only be set once")
 			}
+			foundIdmap = true
 		case "exec", "noexec":
 			if foundExec {
 				return nil, errors.Wrapf(ErrDupeMntOption, "only one of 'noexec' and 'exec' can be used")


### PR DESCRIPTION
[NO NEW TESTS NEEDED] crun is not available everywhere to test idmap.
Kernel might not be recent enough and not all file systems support
idmap option.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
