### PR TITLE
[CI:DOCS] Show API doc for several versions

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -166,6 +166,8 @@ spelled with complete minutiae.
       `git log -1 $(git tag | sort -V | tail -1)`.
    1. Edit `version/version.go` and bump the `Version` value to the new
       release version.  If there were API changes, also bump `APIVersion` value.
+      Make sure to also bump the version in the swagger.yaml `pkg/api/server/docs.go`
+      and to add a new entry in `docs/source/Reference.rst` for major and minor releases.
    1. Commit this and sign the commit (`git commit -a -s -S`). The commit message
       should be `Bump to vX.Y.Z` (using the actual version numbers).
    1. Push this single change to your github fork, and make a new PR,

--- a/docs/source/Reference.rst
+++ b/docs/source/Reference.rst
@@ -3,8 +3,16 @@
 Reference
 =========
 
-To see full screen version please visit: `API documentation <https://docs.podman.io/en/latest/_static/api.html>`_
+Show the API documentation for version:
 
-.. raw:: html
+* `latest (main branch) <_static/api.html>`_
 
-    <iframe src="_static/api.html" allowfullscreen="true" height="600px" width="120%"></iframe>
+* `version 4.0 <_static/api.html?version=v4.0>`_
+
+* `version 3.4 <_static/api.html?version=v3.4>`_
+
+* `version 3.3 <_static/api.html?version=v3.3>`_
+
+* `version 3.2 <_static/api.html?version=v3.2>`_
+
+* `version 3.1 <_static/api.html?version=v3.1>`_

--- a/docs/source/_static/api.html
+++ b/docs/source/_static/api.html
@@ -18,7 +18,22 @@
     </style>
   </head>
   <body>
-    <redoc spec-url='https://storage.googleapis.com/libpod-master-releases/swagger-latest.yaml' sort-props-alphabetically sort-operations-alphabetically></redoc>
+    <script>
+      // get version from query (default to latest)
+      var queryString = window.location.search;
+      var query = new URLSearchParams(queryString);
+      var version = "latest";
+      if (query.has("version")) {
+        version = query.get("version");
+      }
+
+      var redoc = document.createElement("redoc");
+      redoc.setAttribute("sort-props-alphabetically","");
+      redoc.setAttribute("sort-operations-alphabetically","");
+      redoc.setAttribute("spec-url","https://storage.googleapis.com/libpod-master-releases/swagger-" + version + ".yaml");
+
+      document.body.appendChild(redoc);
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
Right now it is not possible to look at the API version for a specific
version. docs.podman.io always show the latest version from the main
branch. This is not want many users want so they now have the ability to
select a different version.

Fixes #12796

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
