### PR TITLE
Do not set the network config dir to cni plugin dir

### DIFF
--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -81,11 +81,6 @@ func newPodmanConfig() {
 		mode = entities.TunnelMode
 	}
 
-	cfg.Network.NetworkConfigDir = cfg.Network.CNIPluginDirs[0]
-	if rootless.IsRootless() {
-		cfg.Network.NetworkConfigDir = ""
-	}
-
 	podmanOptions = entities.PodmanConfig{Config: cfg, EngineMode: mode}
 }
 


### PR DESCRIPTION
I do not know why this code was added but it is wrong. We should never
use a plugin dir as config dir. Also this will fail for netavark. The
correct default will be set in c/common so podman should not touch it.

Ref #13183

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
