### PR TITLE
[4.0] Add version guard to libpod API endpoints

### DIFF
--- a/pkg/bindings/test/networks_test.go
+++ b/pkg/bindings/test/networks_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Podman networks", func() {
 
 		// Valid filter params => network should be pruned now.
 		filters = map[string][]string{
-			"until": {"5000000000"}, //June 11, 2128
+			"until": {"5000000000"}, // June 11, 2128
 		}
 		pruneResponse, err = network.Prune(connText, new(network.PruneOptions).WithFilters(filters))
 		Expect(err).To(BeNil())
@@ -105,7 +105,7 @@ var _ = Describe("Podman networks", func() {
 		_, err = network.Create(connText, &net)
 		Expect(err).ToNot(BeNil())
 		code, _ := bindings.CheckResponseCode(err)
-		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
+		Expect(code).To(BeNumerically("==", http.StatusConflict))
 	})
 
 	It("inspect network", func() {

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -8,7 +8,10 @@ t GET networks/non-existing-network 404 \
 
 t POST libpod/networks/create name='"network1"' 200 \
   .name=network1 \
-  .created~[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}.* \
+  .created~[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}.*
+
+t POST /v3.4.0/libpod/networks/create name='"bad_version"' 400 \
+    .cause='given version is not supported'
 
 # --data '{"name":"network2","subnets":[{"subnet":"10.10.254.0/24"}],"Labels":{"abc":"val"}}'
 t POST libpod/networks/create name='"network2"' \

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -256,11 +256,11 @@ function t() {
 
     # If given path begins with /, use it as-is; otherwise prepend /version/
     local url=http://$HOST:$PORT
-    if expr "$path" : "/" >/dev/null; then
-        url="$url$path"
-    else
-        url="$url/v1.40/$path"
-    fi
+    case "$path" in
+        /*) url="$url$path" ;;
+        libpod/*) url="$url/v4.0.0/$path" ;;
+        *)  url="$url/v1.41/$path" ;;
+    esac
 
     # Log every action we do
     echo "-------------------------------------------------------------" >>$LOG


### PR DESCRIPTION
* Ensure meaningful behaviour when called with /v3.x.x semantics
* Change return code to 409 from 500 when client attempts to use an
  existing network name
* Update API bats test runner to support /v4.0.0 endpoints by default

Signed-off-by: Jhon Honce <jhonce@redhat.com>

See also, https://github.com/containers/podman/pull/13189

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
