### PR TITLE
[DO NOT MERGE] Revert "utils: reintroduce moveToCgroup"

### DIFF
--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -44,15 +44,6 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 	ch := make(chan string)
 	_, err = conn.StartTransientUnit(unitName, "replace", properties, ch)
 	if err != nil {
-		// On errors check if the cgroup already exists, if it does move the process there
-		if props, err := conn.GetUnitTypeProperties(unitName, "Scope"); err == nil {
-			if cgroup, ok := props["ControlGroup"].(string); ok && cgroup != "" {
-				if err := moveUnderCgroup(cgroup, "", []uint32{uint32(pid)}); err == nil {
-					return nil
-				}
-				// On errors return the original error message we got from StartTransientUnit.
-			}
-		}
 		return err
 	}
 


### PR DESCRIPTION
It is just a test to verify: https://github.com/containers/podman/issues/12561

This reverts commit 0999245e40b0fd56e98ad7149556d5879646b3ac.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

