### PR TITLE
Fix checkpoint/restore pod tests

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -192,6 +192,11 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 		}
 		// Reset the log path to point to the default
 		ctr.config.LogPath = ""
+		// Later in validate() the check is for nil. JSONDeepCopy sets it to an empty
+		// object. Resetting it to nil if it was nil before.
+		if config.StaticMAC == nil {
+			ctr.config.StaticMAC = nil
+		}
 	}
 
 	ctr.config.Spec = rSpec

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -140,6 +140,13 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 				return nil, errors.Errorf("pod %s does not share the network namespace", ctrConfig.Pod)
 			}
 			ctrConfig.NetNsCtr = infraContainer.ID()
+			for net, opts := range ctrConfig.Networks {
+				opts.StaticIPs = nil
+				opts.StaticMAC = nil
+				ctrConfig.Networks[net] = opts
+			}
+			ctrConfig.StaticIP = nil
+			ctrConfig.StaticMAC = nil
 		}
 
 		if ctrConfig.PIDNsCtr != "" {

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -1081,10 +1081,6 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	namespaceCombination := []string{
-		"cgroup,ipc,net,uts,pid",
-		"cgroup,ipc,net,uts",
-		"cgroup,ipc,net",
-		"cgroup,ipc",
 		"ipc,net,uts,pid",
 		"ipc,net,uts",
 		"ipc,net",


### PR DESCRIPTION
Checkpoint/restore pod tests are not running with an older runc and now that runc 1.1.0 appears in the repositories it was detected that the tests were failing. This was not detected in CI as CI was not using runc 1.1.0 yet.

With CI moving to runc 1.1.0 in #13055 CI discovered that tests were broken since they originally were added to the repository.

This fixes podman to be ready for runc 1.1.0 based testing.