### PR TITLE
[4.0] Enable Netavark/Aardvark-DNS CI Testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -521,51 +521,6 @@ container_integration_test_task:
     always: *int_logs_artifacts
 
 
-# Run the integration tests using the latest upstream build of netavark.
-netavark_integration_test_task:
-    name: "Netavark integration"  # using *std_name_fmt here is unreadable
-    alias: netavark_integration_test
-    only_if: *not_build
-    skip: *branches_and_tags
-    depends_on:
-        - unit_test
-    gce_instance: *standardvm
-    env:
-        DISTRO_NV: ${FEDORA_NAME}
-        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-        TEST_FLAVOR: int
-        TEST_ENVIRON: host-netavark
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *int_logs_artifacts
-
-
-netavark_system_test_task:
-    name: "Netavark system"
-    alias: netavark_system_test
-    skip: *tags
-    only_if: *not_build
-    depends_on:
-      - netavark_integration_test
-    gce_instance: *standardvm
-    env:
-        DISTRO_NV: ${FEDORA_NAME}
-        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-        TEST_ENVIRON: host-netavark
-        TEST_FLAVOR: sys
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
-
-
 # Execute most integration tests as a regular (non-root) user.
 rootless_integration_test_task:
     name: *std_name_fmt
@@ -580,6 +535,41 @@ rootless_integration_test_task:
     env:
         TEST_FLAVOR: int
         PRIV_NAME: rootless
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: *int_logs_artifacts
+
+
+# Run various scenarios using upstream netavark/aardvark-dns binaries
+netavark_task:
+    name: "Netavark $TEST_FLAVOR $PODBIN_NAME $PRIV_NAME"
+    alias: netavark
+    only_if: *not_build
+    skip: *branches_and_tags
+    depends_on:
+        - unit_test
+    gce_instance: *standardvm
+    matrix:
+        - env: &nenv
+            DISTRO_NV: ${FEDORA_NAME}
+            _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+            VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
+            CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+            TEST_FLAVOR: int
+            TEST_ENVIRON: host-netavark
+        - env:
+            <<: *nenv
+            TEST_FLAVOR: int
+            PRIV_NAME: rootless
+        - env:
+            <<: *nenv
+            TEST_FLAVOR: sys
+        - env:
+            <<: *nenv
+            TEST_FLAVOR: sys
+            PRIV_NAME: rootless
     clone_script: *noop  # Comes from cache
     gopath_cache: *ro_gopath_cache
     setup_script: *setup
@@ -795,9 +785,8 @@ success_task:
         - local_integration_test
         - remote_integration_test
         - container_integration_test
-        - netavark_integration_test
-        - netavark_system_test
         - rootless_integration_test
+        - netavark
         - local_system_test
         - remote_system_test
         - rootless_system_test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,9 +8,9 @@ env:
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
     DEST_BRANCH: "v4.0"
     # Netavark branch to use when TEST_ENVIRON=host-netavark
-    NETAVARK_BRANCH: "main"
+    NETAVARK_BRANCH: "main"  # TODO: This should point to a release branch
     # Aardvark branch to use
-    AARDVARK_BRANCH: "main"
+    AARDVARK_BRANCH: "main"  # TODO: This should also be a release branch
     # Overrides default location (/tmp/cirrus) for repo clone
     GOPATH: &gopath "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,6 +9,8 @@ env:
     DEST_BRANCH: "v4.0"
     # Netavark branch to use when TEST_ENVIRON=host-netavark
     NETAVARK_BRANCH: "main"
+    # Aardvark branch to use
+    AARDVARK_BRANCH: "main"
     # Overrides default location (/tmp/cirrus) for repo clone
     GOPATH: &gopath "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"
@@ -528,6 +530,8 @@ netavark_integration_test_task:
         TEST_ENVIRON: host-netavark
         NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
         NETAVARK_DEBUG: 0  # set non-zero to use the debug-mode binary
+        AARDVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/aardvark-dns/success/binary.zip?branch=${AARDVARK_BRANCH}"
+        AARDVARK_DEBUG: 0  # set non-zero to use the debug-mode binary
     clone_script: *noop  # Comes from cache
     gopath_cache: *ro_gopath_cache
     setup_script: *setup
@@ -757,6 +761,7 @@ success_task:
         - compose_test
         - local_integration_test
         - remote_integration_test
+        - netavark_integration_test
         - rootless_integration_test
         - container_integration_test
         - netavark_integration_test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,6 +24,11 @@ env:
     # Runner statistics log file path/name
     STATS_LOGFILE_SFX: 'runner_stats.log'
     STATS_LOGFILE: '$GOSRC/${CIRRUS_TASK_NAME}-${STATS_LOGFILE_SFX}'
+    # Netavark/aardvark location/options when TEST_ENVIRON=host-netavark
+    NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
+    NETAVARK_DEBUG: 0  # set non-zero to use the debug-mode binary
+    AARDVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/aardvark-dns/success/binary.zip?branch=${AARDVARK_BRANCH}"
+    AARDVARK_DEBUG: 0  # set non-zero to use the debug-mode binary
 
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
@@ -512,6 +517,7 @@ container_integration_test_task:
     main_script: *main
     always: *int_logs_artifacts
 
+
 # Run the integration tests using the latest upstream build of netavark.
 netavark_integration_test_task:
     name: "Netavark integration"  # using *std_name_fmt here is unreadable
@@ -528,15 +534,33 @@ netavark_integration_test_task:
         CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
         TEST_FLAVOR: int
         TEST_ENVIRON: host-netavark
-        NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
-        NETAVARK_DEBUG: 0  # set non-zero to use the debug-mode binary
-        AARDVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/aardvark-dns/success/binary.zip?branch=${AARDVARK_BRANCH}"
-        AARDVARK_DEBUG: 0  # set non-zero to use the debug-mode binary
     clone_script: *noop  # Comes from cache
     gopath_cache: *ro_gopath_cache
     setup_script: *setup
     main_script: *main
     always: *int_logs_artifacts
+
+
+netavark_system_test_task:
+    name: "Netavark system"
+    alias: netavark_system_test
+    skip: *tags
+    only_if: *not_build
+    depends_on:
+      - netavark_integration_test
+    gce_instance: *standardvm
+    env:
+        DISTRO_NV: ${FEDORA_NAME}
+        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
+        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+        TEST_ENVIRON: host-netavark
+        TEST_FLAVOR: sys
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: *logs_artifacts
 
 
 # Execute most integration tests as a regular (non-root) user.
@@ -591,6 +615,7 @@ remote_system_test_task:
         TEST_FLAVOR: sys
         PODBIN_NAME: remote
 
+
 rootless_remote_system_test_task:
     <<: *local_system_test_task
     alias: rootless_remote_system_test
@@ -610,6 +635,7 @@ rootless_remote_system_test_task:
         TEST_FLAVOR: sys
         PODBIN_NAME: remote
         PRIV_NAME: rootless
+
 
 buildah_bud_test_task:
     name: *std_name_fmt
@@ -639,6 +665,7 @@ buildah_bud_test_task:
     main_script: *main
     always: *int_logs_artifacts
 
+
 rootless_system_test_task:
     name: *std_name_fmt
     alias: rootless_system_test
@@ -656,6 +683,7 @@ rootless_system_test_task:
     setup_script: *setup
     main_script: *main
     always: *logs_artifacts
+
 
 rootless_gitlab_test_task:
     name: *std_name_fmt
@@ -683,6 +711,7 @@ rootless_gitlab_test_task:
             path: gitlab-runner-podman.xml
             type: text/xml
             format: junit
+
 
 upgrade_test_task:
     name: "Upgrade test: from $PODMAN_UPGRADE_FROM"
@@ -712,6 +741,7 @@ upgrade_test_task:
     setup_script: *setup
     main_script: *main
     always: *logs_artifacts
+
 
 # This task is critical.  It updates the "last-used by" timestamp stored
 # in metadata for all VM images.  This mechanism functions in tandem with
@@ -761,10 +791,10 @@ success_task:
         - compose_test
         - local_integration_test
         - remote_integration_test
-        - netavark_integration_test
-        - rootless_integration_test
         - container_integration_test
         - netavark_integration_test
+        - netavark_system_test
+        - rootless_integration_test
         - local_system_test
         - remote_system_test
         - rootless_system_test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -227,7 +227,8 @@ validate_task:
 bindings_task:
     name: "Test Bindings"
     alias: bindings
-    only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
+    # Don't run for [CI:DOCS] or [CI:BUILD]
+    only_if: &not_build $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' && $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*'
     skip: *branches_and_tags
     depends_on:
         - build
@@ -307,7 +308,8 @@ consistency_task:
 alt_build_task:
     name: "$ALT_NAME"
     alias: alt_build
-    only_if: *not_docs
+    # Don't run for [CI:DOCS]; DO run for [CI:BUILD]
+    only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
     depends_on:
         - build
     env:
@@ -336,6 +338,7 @@ alt_build_task:
 osx_alt_build_task:
     name: "OSX Cross"
     alias: osx_alt_build
+    only_if: *not_docs
     depends_on:
         - build
     env:
@@ -361,7 +364,7 @@ docker-py_test_task:
     name: Docker-py Compat.
     alias: docker-py_test
     skip: *tags
-    only_if: *not_docs
+    only_if: *not_build
     depends_on:
         - build
     gce_instance: *standardvm
@@ -382,7 +385,7 @@ unit_test_task:
     name: "Unit tests on $DISTRO_NV"
     alias: unit_test
     skip: *tags
-    only_if: *not_docs
+    only_if: *not_build
     depends_on:
         - validate
     matrix:
@@ -407,7 +410,7 @@ unit_test_task:
 apiv2_test_task:
     name: "APIv2 test on $DISTRO_NV"
     alias: apiv2_test
-    only_if: *not_docs
+    only_if: *not_build
     skip: *tags
     depends_on:
         - validate
@@ -428,7 +431,7 @@ apiv2_test_task:
 compose_test_task:
     name: "compose test on $DISTRO_NV ($PRIV_NAME)"
     alias: compose_test
-    only_if: *not_docs
+    only_if: *not_build
     skip: *tags
     depends_on:
         - validate
@@ -455,7 +458,7 @@ local_integration_test_task: &local_integration_test_task
     # <int.|sys.> <podman|remote> <Distro NV> <root|rootless>
     name: &std_name_fmt "$TEST_FLAVOR $PODBIN_NAME $DISTRO_NV $PRIV_NAME $TEST_ENVIRON"
     alias: local_integration_test
-    only_if: *not_docs
+    only_if: *not_build
     skip: *branches_and_tags
     depends_on:
         - unit_test
@@ -491,7 +494,7 @@ remote_integration_test_task:
 container_integration_test_task:
     name: *std_name_fmt
     alias: container_integration_test
-    only_if: *not_docs
+    only_if: *not_build
     skip: *branches_and_tags
     depends_on:
         - unit_test
@@ -522,7 +525,7 @@ container_integration_test_task:
 netavark_integration_test_task:
     name: "Netavark integration"  # using *std_name_fmt here is unreadable
     alias: netavark_integration_test
-    only_if: *not_docs
+    only_if: *not_build
     skip: *branches_and_tags
     depends_on:
         - unit_test
@@ -567,7 +570,7 @@ netavark_system_test_task:
 rootless_integration_test_task:
     name: *std_name_fmt
     alias: rootless_integration_test
-    only_if: *not_docs
+    only_if: *not_build
     skip: *branches_and_tags
     depends_on:
         - unit_test
@@ -592,7 +595,7 @@ local_system_test_task: &local_system_test_task
     name: *std_name_fmt
     alias: local_system_test
     skip: *tags
-    only_if: *not_docs
+    only_if: *not_build
     depends_on:
       - local_integration_test
     matrix: *platform_axis
@@ -641,7 +644,7 @@ buildah_bud_test_task:
     name: *std_name_fmt
     alias: buildah_bud_test
     skip: *tags
-    only_if: *not_docs
+    only_if: *not_build
     depends_on:
       - local_integration_test
     env:
@@ -670,7 +673,7 @@ rootless_system_test_task:
     name: *std_name_fmt
     alias: rootless_system_test
     skip: *tags
-    only_if: *not_docs
+    only_if: *not_build
     depends_on:
       - rootless_integration_test
     matrix: *platform_axis
@@ -689,7 +692,7 @@ rootless_gitlab_test_task:
     name: *std_name_fmt
     alias: rootless_gitlab_test
     skip: *tags
-    only_if: *not_docs
+    only_if: *not_build
     # Community-maintained downstream test may fail unexpectedly.
     # Ref. repository: https://gitlab.com/gitlab-org/gitlab-runner
     # If necessary, uncomment the next line and file issue(s) with details.
@@ -717,7 +720,7 @@ upgrade_test_task:
     name: "Upgrade test: from $PODMAN_UPGRADE_FROM"
     alias: upgrade_test
     skip: *tags
-    only_if: $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' || $CIRRUS_CRON != ''
+    only_if: *not_build
     depends_on:
       - local_system_test
     matrix:
@@ -839,7 +842,10 @@ release_task:
 release_test_task:
     name: "Optional Release Test"
     alias: release_test
-    only_if: $CIRRUS_PR != ''
+    # Release-PRs are never ever marked with [CI:DOCS] or [CI:BUILD]
+    only_if: *not_build
+    # Allow running manually as part of release PR preperation
+    # see RELEASE_PROCESS.md
     trigger_type: manual
     depends_on:
         - success

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -842,9 +842,9 @@ release_task:
 release_test_task:
     name: "Optional Release Test"
     alias: release_test
-    # Release-PRs are never ever marked with [CI:DOCS] or [CI:BUILD]
-    only_if: *not_build
-    # Allow running manually as part of release PR preperation
+    # Release-PRs always include "release" or "Bump" in the title
+    only_if: $CIRRUS_CHANGE_TITLE =~ '.*((release)|(bump)).*'
+    # Allow running manually only as part of release-related builds
     # see RELEASE_PROCESS.md
     trigger_type: manual
     depends_on:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,8 @@ env:
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
     DEST_BRANCH: "v4.0"
+    # Netavark branch to use when TEST_ENVIRON=host-netavark
+    NETAVARK_BRANCH: "main"
     # Overrides default location (/tmp/cirrus) for repo clone
     GOPATH: &gopath "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"
@@ -44,7 +46,7 @@ env:
     #### N/B: Required ALL of these are set for every single task.
     ####
     TEST_FLAVOR:             # int, sys, ext_svc, validate, automation, etc.
-    TEST_ENVIRON: host       # 'host' or 'container'
+    TEST_ENVIRON: host       # 'host', 'host-netavark', or 'container'
     PODBIN_NAME: podman      # 'podman' or 'remote'
     PRIV_NAME: root          # 'root' or 'rootless'
     DISTRO_NV:               # any {PRIOR_,}{FEDORA,UBUNTU}_NAME value
@@ -508,6 +510,30 @@ container_integration_test_task:
     main_script: *main
     always: *int_logs_artifacts
 
+# Run the integration tests using the latest upstream build of netavark.
+netavark_integration_test_task:
+    name: "Netavark integration"  # using *std_name_fmt here is unreadable
+    alias: netavark_integration_test
+    only_if: *not_docs
+    skip: *branches_and_tags
+    depends_on:
+        - unit_test
+    gce_instance: *standardvm
+    env:
+        DISTRO_NV: ${FEDORA_NAME}
+        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
+        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+        TEST_FLAVOR: int
+        TEST_ENVIRON: host-netavark
+        NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
+        NETAVARK_DEBUG: 0  # set non-zero to use the debug-mode binary
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: *int_logs_artifacts
+
 
 # Execute most integration tests as a regular (non-root) user.
 rootless_integration_test_task:
@@ -733,6 +759,7 @@ success_task:
         - remote_integration_test
         - rootless_integration_test
         - container_integration_test
+        - netavark_integration_test
         - local_system_test
         - remote_system_test
         - rootless_system_test

--- a/Makefile
+++ b/Makefile
@@ -535,7 +535,7 @@ run-docker-py-tests:
 .PHONY: localunit
 localunit: test/goecho/goecho test/version/version
 	rm -rf ${COVERAGE_PATH} && mkdir -p ${COVERAGE_PATH}
-	$(GOBIN)/ginkgo \
+	UNIT=1 $(GOBIN)/ginkgo \
 		-r \
 		$(TESTFLAGS) \
 		--skipPackage test/e2e,pkg/apparmor,pkg/bindings,hack \

--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -71,7 +71,6 @@ func networkList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
 	// sort the networks to make sure the order is deterministic
 	sort.Slice(responses, func(i, j int) bool {
 		return responses[i].Name < responses[j].Name

--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -74,6 +74,19 @@ case $1 in
         echo "Cgroups: " $(stat -f -c %T /sys/fs/cgroup)
         # Any not-present packages will be listed as such
         $PKG_LST_CMD "${PKG_NAMES[@]}" | sort -u
+
+        # TODO: Remove this once netavark/aardvark-dns packages are used
+        if [[ "$TEST_ENVIRON" =~ netavark ]]; then
+            _npath=/usr/local/libexec/podman/
+            for name in netavark aardvark-dns; do
+                echo "$name binary details:"
+                if [[ -r "$_npath/${name}.info" ]]; then
+                    cat "$_npath/${name}.info"
+                else
+                    echo "WARNING: $_npath/${name}.info not found."
+                fi
+            done
+        fi
         ;;
     time)
         # Assumed to be empty/undefined outside of Cirrus-CI (.cirrus.yml)

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -12,7 +12,7 @@ set -eo pipefail
 # most notably:
 #
 #    PODBIN_NAME  : "podman" (i.e. local) or "remote"
-#    TEST_ENVIRON : 'host' or 'container'; desired environment in which to run
+#    TEST_ENVIRON : 'host', 'host-netavark', or 'container'; desired environment in which to run
 #    CONTAINER    : 1 if *currently* running inside a container, 0 if host
 #
 

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -173,6 +173,8 @@ case "$TEST_ENVIRON" in
             done
 
             restorecon -F -v $_pdir
+            # This is critical, it signals to all tests that netavark
+            # use is expected.
             msg "Forcing NETWORK_BACKEND=netavark in all subsequent environments."
             echo "NETWORK_BACKEND=netavark" >> /etc/ci_environment
         fi

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -289,11 +289,11 @@ case "$TEST_FLAVOR" in
                 die "Refusing to config. host-test in container";
             fi
             remove_packaged_podman_files
-            make install PREFIX=/usr ETCDIR=/etc
+            make && make install PREFIX=/usr ETCDIR=/etc
         elif [[ "$TEST_ENVIRON" == "container" ]]; then
             if ((CONTAINER)); then
                 remove_packaged_podman_files
-                make install PREFIX=/usr ETCDIR=/etc
+                make && make install PREFIX=/usr ETCDIR=/etc
             fi
         else
             die "Invalid value for \$TEST_ENVIRON=$TEST_ENVIRON"
@@ -310,7 +310,7 @@ case "$TEST_FLAVOR" in
         # Ref: https://gitlab.com/gitlab-org/gitlab-runner/-/issues/27270#note_499585550
 
         remove_packaged_podman_files
-        make install PREFIX=/usr ETCDIR=/etc
+        make && make install PREFIX=/usr ETCDIR=/etc
 
         msg "Installing docker and containerd"
         # N/B: Tests check/expect `docker info` output, and this `!= podman info`

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -142,31 +142,37 @@ case "$TEST_ENVIRON" in
             echo "CGROUP_MANAGER=cgroupfs" >> /etc/ci_environment
         fi
         # TODO: For the foreseeable future, need to support running tests
-        # with and without the latest netavark.  Once netavark is more
-        # stable and widely supported in Fedora, it can be pre-installed
+        # with and without the latest netavark/aardvark.  Once they're more
+        # stable and widely supported in Fedora, they can be pre-installed
         # from its RPM at VM image build-time.
         if [[ "$TEST_ENVIRON" =~ netavark ]]; then
-            req_env_vars NETAVARK_BRANCH NETAVARK_URL NETAVARK_DEBUG
-            msg "Downloading latest netavark from upstream branch '$NETAVARK_BRANCH'"
-            curl --fail --location -o /tmp/netavark.zip "${NETAVARK_URL}"
+            for info in "netavark $NETAVARK_BRANCH $NETAVARK_URL $NETAVARK_DEBUG" \
+                        "aardvark-dns $AARDVARK_BRANCH $AARDVARK_URL $AARDVARK_DEBUG"; do
 
-            # Needs to be in a specific location
-            # ref: https://github.com/containers/common/blob/main/pkg/config/config_linux.go#L39
-            _nvdir=/usr/local/libexec/podman
-            mkdir -p $_nvdir
-            cd $_nvdir
-            msg "$PWD"
-            unzip /tmp/netavark.zip
-            if ((NETAVARK_DEBUG)); then
-                warn "Using debug netavark binary"
-                mv netavark.debug netavark
-            else
-                rm netavark.debug
-            fi
-            cd -
+                read _name _branch _url _debug <<<"$info"
+                req_env_vars _name _branch _url _debug
+                msg "Downloading latest $_name from upstream branch '$_branch'"
+                # Use identifiable archive filename in of a get_ci_env.sh environment
+                curl --fail --location -o /tmp/$_name.zip "$_url"
 
-            chmod 0755 $_nvdir/netavark
-            restorecon -F -v $_nvdir
+                # Needs to be in a specific location
+                # ref: https://github.com/containers/common/blob/main/pkg/config/config_linux.go#L39
+                _pdir=/usr/local/libexec/podman
+                mkdir -p $_pdir
+                cd $_pdir
+                msg "$PWD"
+                unzip /tmp/$_name.zip
+                if ((_debug)); then
+                    warn "Using debug $_name binary"
+                    mv $_name.debug $_name
+                else
+                    rm $_name.debug
+                fi
+                chmod 0755 $_pdir/$_name
+                cd -
+            done
+
+            restorecon -F -v $_pdir
             msg "Forcing NETWORK_BACKEND=netavark in all subsequent environments."
             echo "NETWORK_BACKEND=netavark" >> /etc/ci_environment
         fi

--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -106,6 +106,10 @@ var _ = Describe("Podman create with --ip flag", func() {
 		result = podmanTest.Podman([]string{"start", "test2"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).To(ExitWithError())
-		Expect(result.ErrorToString()).To(ContainSubstring("requested IP address " + ip + " is not available"))
+		if podmanTest.NetworkBackend == CNI {
+			Expect(result.ErrorToString()).To(ContainSubstring("requested IP address " + ip + " is not available"))
+		} else if podmanTest.NetworkBackend == Netavark {
+			Expect(result.ErrorToString()).To(ContainSubstring("requested ip address %s is already allocated", ip))
+		}
 	})
 })

--- a/test/e2e/create_staticmac_test.go
+++ b/test/e2e/create_staticmac_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Podman run with --mac-address flag", func() {
 		net := "n1" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(session).Should(Exit(0))
 
 		result := podmanTest.Podman([]string{"run", "--network", net, "--mac-address", "92:d0:c6:00:29:34", ALPINE, "ip", "addr"})

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -598,7 +598,7 @@ var _ = Describe("Podman create", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		session = podmanTest.Podman([]string{"create", "--pod", name, "--network", netName, ALPINE, "top"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -153,8 +153,9 @@ func (p *PodmanTestIntegration) StopRemoteService() {
 
 // MakeOptions assembles all the podman main options
 func getRemoteOptions(p *PodmanTestIntegration, args []string) []string {
+	networkDir := p.NetworkConfigDir
 	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --network-config-dir %s --cgroup-manager %s",
-		p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, p.CNIConfigDir, p.CgroupManager), " ")
+		p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, networkDir, p.CgroupManager), " ")
 	if os.Getenv("HOOK_OPTION") != "" {
 		podmanOptions = append(podmanOptions, os.Getenv("HOOK_OPTION"))
 	}

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -11,7 +11,6 @@ import (
 
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 )
@@ -24,7 +23,6 @@ var _ = Describe("Podman login and logout", func() {
 		authPath                 string
 		certPath                 string
 		certDirPath              string
-		port                     int
 		server                   string
 		testImg                  string
 		registriesConfWithSearch []byte
@@ -62,7 +60,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		f.WriteString(session.OutputToString())
 		f.Sync()
-		port = 4999 + config.GinkgoConfig.ParallelNode
+		port := GetPort()
 		server = strings.Join([]string{"localhost", strconv.Itoa(port)}, ":")
 
 		registriesConfWithSearch = []byte(fmt.Sprintf("[registries.search]\nregistries = ['%s']", server))

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		dis := podmanTest.Podman([]string{"network", "disconnect", netName, "foobar"})
 		dis.WaitWithDefaultTimeout()
@@ -57,12 +57,12 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		session = podmanTest.Podman([]string{"create", "--name", "test", "--network", "slirp4netns", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		con := podmanTest.Podman([]string{"network", "disconnect", netName, "test"})
 		con.WaitWithDefaultTimeout()
@@ -75,7 +75,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		ctr := podmanTest.Podman([]string{"run", "-dt", "--name", "test", "--network", netName, ALPINE, "top"})
 		ctr.WaitWithDefaultTimeout()
@@ -111,7 +111,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		dis := podmanTest.Podman([]string{"network", "connect", netName, "foobar"})
 		dis.WaitWithDefaultTimeout()
@@ -123,12 +123,12 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		session = podmanTest.Podman([]string{"create", "--name", "test", "--network", "slirp4netns", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		con := podmanTest.Podman([]string{"network", "connect", netName, "test"})
 		con.WaitWithDefaultTimeout()
@@ -141,7 +141,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		ctr := podmanTest.Podman([]string{"create", "--name", "test", "--network", netName, ALPINE, "top"})
 		ctr.WaitWithDefaultTimeout()
@@ -164,7 +164,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		ctr := podmanTest.Podman([]string{"run", "-dt", "--name", "test", "--network", netName, ALPINE, "top"})
 		ctr.WaitWithDefaultTimeout()
@@ -180,7 +180,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session = podmanTest.Podman([]string{"network", "create", newNetName, "--subnet", "10.11.100.0/24"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(newNetName)
+		defer podmanTest.removeNetwork(newNetName)
 
 		ip := "10.11.100.99"
 		mac := "44:11:44:11:44:11"
@@ -218,13 +218,13 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName1)
+		defer podmanTest.removeNetwork(netName1)
 
 		netName2 := "connect2" + stringid.GenerateNonCryptoID()
 		session = podmanTest.Podman([]string{"network", "create", netName2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName2)
+		defer podmanTest.removeNetwork(netName2)
 
 		ctr := podmanTest.Podman([]string{"create", "--name", "test", "--network", netName1, ALPINE, "top"})
 		ctr.WaitWithDefaultTimeout()
@@ -257,7 +257,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		session = podmanTest.Podman([]string{"network", "ls", "--format", "{{.ID}}", "--filter", "name=" + netName})
 		session.WaitWithDefaultTimeout()
@@ -277,7 +277,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session = podmanTest.Podman([]string{"network", "create", newNetName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(newNetName)
+		defer podmanTest.removeNetwork(newNetName)
 
 		session = podmanTest.Podman([]string{"network", "ls", "--format", "{{.ID}}", "--filter", "name=" + newNetName})
 		session.WaitWithDefaultTimeout()
@@ -304,13 +304,13 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName1)
+		defer podmanTest.removeNetwork(netName1)
 
 		netName2 := "aliasTest" + stringid.GenerateNonCryptoID()
 		session2 := podmanTest.Podman([]string{"network", "create", netName2})
 		session2.WaitWithDefaultTimeout()
 		Expect(session2).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName2)
+		defer podmanTest.removeNetwork(netName2)
 
 		ctr := podmanTest.Podman([]string{"create", "--name", "test", "--network", netName1 + "," + netName2, ALPINE, "top"})
 		ctr.WaitWithDefaultTimeout()
@@ -349,7 +349,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 
 		session = podmanTest.Podman([]string{"network", "ls", "--format", "{{.ID}}", "--filter", "name=" + netName})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Podman network create", func() {
 		netName := "subnet-" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--ip-range", "10.11.12.0/26", netName})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 		Expect(nc).Should(Exit(0))
 
 		// Inspect the network configuration
@@ -88,7 +88,7 @@ var _ = Describe("Podman network create", func() {
 		netName := "ipv6-" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:1:2:3:4::/64", netName})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 		Expect(nc).Should(Exit(0))
 
 		// Inspect the network configuration
@@ -127,7 +127,7 @@ var _ = Describe("Podman network create", func() {
 		netName := "dual-" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:3:2::/64", "--ipv6", netName})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 		Expect(nc).Should(Exit(0))
 
 		// Inspect the network configuration
@@ -160,7 +160,7 @@ var _ = Describe("Podman network create", func() {
 		netName2 := "dual-" + stringid.GenerateNonCryptoID()
 		nc = podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:10:3:2::/64", "--ipv6", netName2})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName2)
+		defer podmanTest.removeNetwork(netName2)
 		Expect(nc).Should(Exit(0))
 
 		// Inspect the network configuration
@@ -215,7 +215,7 @@ var _ = Describe("Podman network create", func() {
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--ipv6", name})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(Exit(0))
-		defer podmanTest.removeCNINetwork(name)
+		defer podmanTest.removeNetwork(name)
 
 		nc = podmanTest.Podman([]string{"network", "inspect", name})
 		nc.WaitWithDefaultTimeout()
@@ -229,7 +229,7 @@ var _ = Describe("Podman network create", func() {
 		nc := podmanTest.Podman([]string{"network", "create", "--ipv6", name})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(Exit(0))
-		defer podmanTest.removeCNINetwork(name)
+		defer podmanTest.removeNetwork(name)
 
 		nc = podmanTest.Podman([]string{"network", "inspect", name})
 		nc.WaitWithDefaultTimeout()
@@ -254,7 +254,7 @@ var _ = Describe("Podman network create", func() {
 		netName := "same-" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", netName})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 		Expect(nc).Should(Exit(0))
 
 		ncFail := podmanTest.Podman([]string{"network", "create", netName})
@@ -266,13 +266,13 @@ var _ = Describe("Podman network create", func() {
 		netName1 := "sub1-" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.13.0/24", netName1})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName1)
+		defer podmanTest.removeNetwork(netName1)
 		Expect(nc).Should(Exit(0))
 
 		netName2 := "sub2-" + stringid.GenerateNonCryptoID()
 		ncFail := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.13.0/24", netName2})
 		ncFail.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName2)
+		defer podmanTest.removeNetwork(netName2)
 		Expect(ncFail).To(ExitWithError())
 	})
 
@@ -280,13 +280,13 @@ var _ = Describe("Podman network create", func() {
 		netName1 := "subipv61-" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:4:4:4::/64", "--ipv6", netName1})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName1)
+		defer podmanTest.removeNetwork(netName1)
 		Expect(nc).Should(Exit(0))
 
 		netName2 := "subipv62-" + stringid.GenerateNonCryptoID()
 		ncFail := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:4:4:4::/64", "--ipv6", netName2})
 		ncFail.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName2)
+		defer podmanTest.removeNetwork(netName2)
 		Expect(ncFail).To(ExitWithError())
 	})
 
@@ -300,7 +300,7 @@ var _ = Describe("Podman network create", func() {
 		net := "mtu-test" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "mtu=9000", net})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(nc).Should(Exit(0))
 
 		nc = podmanTest.Podman([]string{"network", "inspect", net})
@@ -313,7 +313,7 @@ var _ = Describe("Podman network create", func() {
 		net := "vlan-test" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "vlan=9", net})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(nc).Should(Exit(0))
 
 		nc = podmanTest.Podman([]string{"network", "inspect", net})
@@ -326,15 +326,16 @@ var _ = Describe("Podman network create", func() {
 		net := "invalid-test" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "foo=bar", net})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create with internal should not have dnsname", func() {
+		SkipUntilAardvark(podmanTest)
 		net := "internal-test" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "--internal", net})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(nc).Should(Exit(0))
 		// Not performing this check on remote tests because it is a logrus error which does
 		// not come back via stderr on the remote client.
@@ -362,7 +363,7 @@ var _ = Describe("Podman network create", func() {
 		subnet2 := "10.10.1.0/24"
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", subnet1, "--subnet", subnet2, name})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(name)
+		defer podmanTest.removeNetwork(name)
 		Expect(nc).To(Exit(0))
 		Expect(nc.OutputToString()).To(Equal(name))
 
@@ -380,7 +381,7 @@ var _ = Describe("Podman network create", func() {
 		subnet2 := "fd52:2a5a:747e:3acd::/64"
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", subnet1, "--subnet", subnet2, name})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(name)
+		defer podmanTest.removeNetwork(name)
 		Expect(nc).To(Exit(0))
 		Expect(nc.OutputToString()).To(Equal(name))
 
@@ -401,7 +402,7 @@ var _ = Describe("Podman network create", func() {
 		gw2 := "fd52:2a5a:747e:3acd::10"
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", subnet1, "--gateway", gw1, "--ip-range", range1, "--subnet", subnet2, "--gateway", gw2, name})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(name)
+		defer podmanTest.removeNetwork(name)
 		Expect(nc).To(Exit(0))
 		Expect(nc.OutputToString()).To(Equal(name))
 

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -118,13 +118,13 @@ var _ = Describe("Podman network", func() {
 		label2 := "abcdef"
 		session := podmanTest.Podman([]string{"network", "create", "--label", label1, net1})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net1)
+		defer podmanTest.removeNetwork(net1)
 		Expect(session).Should(Exit(0))
 
 		net2 := "labelnet" + stringid.GenerateNonCryptoID()
 		session = podmanTest.Podman([]string{"network", "create", "--label", label1, "--label", label2, net2})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net2)
+		defer podmanTest.removeNetwork(net2)
 		Expect(session).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"network", "ls", "--filter", "label=" + label1})
@@ -144,7 +144,7 @@ var _ = Describe("Podman network", func() {
 		net := "net" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(session).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"network", "ls", "--filter", "namr=ab"})
@@ -169,9 +169,16 @@ var _ = Describe("Podman network", func() {
 		netID := "6073aefe03cdf8f29be5b23ea9795c431868a3a22066a6290b187691614fee84"
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(session).Should(Exit(0))
 
+		if podmanTest.NetworkBackend == Netavark {
+			// netavark uses a different algo for determining the id and it is not repeatable
+			getid := podmanTest.Podman([]string{"network", "inspect", net, "--format", "{{.ID}}"})
+			getid.WaitWithDefaultTimeout()
+			Expect(getid).Should(Exit(0))
+			netID = getid.OutputToString()
+		}
 		// Tests Default Table Output
 		session = podmanTest.Podman([]string{"network", "ls", "--filter", "id=" + netID})
 		session.WaitWithDefaultTimeout()
@@ -270,7 +277,7 @@ var _ = Describe("Podman network", func() {
 		netName := "net-" + stringid.GenerateNonCryptoID()
 		network := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.50.0/24", netName})
 		network.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 		Expect(network).Should(Exit(0))
 
 		ctrName := "testCtr"
@@ -300,13 +307,13 @@ var _ = Describe("Podman network", func() {
 		netName1 := "net1-" + stringid.GenerateNonCryptoID()
 		network1 := podmanTest.Podman([]string{"network", "create", netName1})
 		network1.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName1)
+		defer podmanTest.removeNetwork(netName1)
 		Expect(network1).Should(Exit(0))
 
 		netName2 := "net2-" + stringid.GenerateNonCryptoID()
 		network2 := podmanTest.Podman([]string{"network", "create", netName2})
 		network2.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName2)
+		defer podmanTest.removeNetwork(netName2)
 		Expect(network2).Should(Exit(0))
 
 		ctrName := "testCtr"
@@ -337,13 +344,13 @@ var _ = Describe("Podman network", func() {
 		netName1 := "net1-" + stringid.GenerateNonCryptoID()
 		network1 := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.51.0/25", netName1})
 		network1.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName1)
+		defer podmanTest.removeNetwork(netName1)
 		Expect(network1).Should(Exit(0))
 
 		netName2 := "net2-" + stringid.GenerateNonCryptoID()
 		network2 := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.51.128/26", netName2})
 		network2.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName2)
+		defer podmanTest.removeNetwork(netName2)
 		Expect(network2).Should(Exit(0))
 
 		ctrName := "testCtr"
@@ -380,7 +387,7 @@ var _ = Describe("Podman network", func() {
 
 		session := podmanTest.Podman([]string{"network", "create", network})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(network)
+		defer podmanTest.removeNetwork(network)
 		Expect(session).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"run", "--name", container, "--network", network, "-d", ALPINE, "top"})
@@ -406,7 +413,7 @@ var _ = Describe("Podman network", func() {
 		netName := "net-" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 		Expect(session).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"pod", "create", "--network", netName})
@@ -442,13 +449,13 @@ var _ = Describe("Podman network", func() {
 		netName1 := "net1-" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName1)
+		defer podmanTest.removeNetwork(netName1)
 		Expect(session).Should(Exit(0))
 
 		netName2 := "net2-" + stringid.GenerateNonCryptoID()
 		session = podmanTest.Podman([]string{"network", "create", netName2})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName2)
+		defer podmanTest.removeNetwork(netName2)
 		Expect(session).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"network", "rm", netName1, netName2})
@@ -460,11 +467,12 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network with multiple aliases", func() {
+		SkipUntilAardvark(podmanTest)
 		var worked bool
 		netName := "aliasTest" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 		Expect(session).Should(Exit(0))
 
 		interval := time.Duration(250 * time.Millisecond)
@@ -510,10 +518,12 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network create/remove macvlan", func() {
+		// Netavark currently does not do dhcp so the this test fails
+		SkipIfNetavark(podmanTest)
 		net := "macvlan" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "--macvlan", "lo", net})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(nc).Should(Exit(0))
 
 		nc = podmanTest.Podman([]string{"network", "rm", net})
@@ -522,10 +532,12 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network create/remove macvlan as driver (-d) no device name", func() {
+		// Netavark currently does not do dhcp so the this test fails
+		SkipIfNetavark(podmanTest)
 		net := "macvlan" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", net})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(nc).Should(Exit(0))
 
 		inspect := podmanTest.Podman([]string{"network", "inspect", net})
@@ -547,10 +559,12 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network create/remove macvlan as driver (-d) with device name", func() {
+		// Netavark currently does not do dhcp so the this test fails
+		SkipIfNetavark(podmanTest)
 		net := "macvlan" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", "parent=lo", net})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(nc).Should(Exit(0))
 
 		inspect := podmanTest.Podman([]string{"network", "inspect", net})
@@ -577,7 +591,7 @@ var _ = Describe("Podman network", func() {
 		net := "net" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(session).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"network", "exists", net})
@@ -593,7 +607,7 @@ var _ = Describe("Podman network", func() {
 		net := "macvlan" + stringid.GenerateNonCryptoID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", "parent=lo", "-o", "mtu=1500", "--gateway", "192.168.1.254", "--subnet", "192.168.1.0/24", net})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(nc).Should(Exit(0))
 
 		inspect := podmanTest.Podman([]string{"network", "inspect", net})
@@ -622,7 +636,7 @@ var _ = Describe("Podman network", func() {
 
 	It("podman network prune --filter", func() {
 		// set custom cni directory to prevent flakes
-		podmanTest.CNIConfigDir = tempdir
+		podmanTest.NetworkConfigDir = tempdir
 		if IsRemote() {
 			podmanTest.RestartRemoteService()
 		}
@@ -630,7 +644,7 @@ var _ = Describe("Podman network", func() {
 
 		nc := podmanTest.Podman([]string{"network", "create", net1})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net1)
+		defer podmanTest.removeNetwork(net1)
 		Expect(nc).Should(Exit(0))
 
 		list := podmanTest.Podman([]string{"network", "ls", "--format", "{{.Name}}"})
@@ -670,7 +684,7 @@ var _ = Describe("Podman network", func() {
 
 	It("podman network prune", func() {
 		// set custom cni directory to prevent flakes
-		podmanTest.CNIConfigDir = tempdir
+		podmanTest.NetworkConfigDir = tempdir
 		if IsRemote() {
 			podmanTest.RestartRemoteService()
 		}
@@ -684,12 +698,12 @@ var _ = Describe("Podman network", func() {
 		net2 := net + "2"
 		nc := podmanTest.Podman([]string{"network", "create", net1})
 		nc.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net1)
+		defer podmanTest.removeNetwork(net1)
 		Expect(nc).Should(Exit(0))
 
 		nc2 := podmanTest.Podman([]string{"network", "create", net2})
 		nc2.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net2)
+		defer podmanTest.removeNetwork(net2)
 		Expect(nc2).Should(Exit(0))
 
 		list := podmanTest.Podman([]string{"network", "ls", "--format", "{{.Name}}"})

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2190,7 +2190,7 @@ spec:
 		net := "playkube" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.31.0/24", net})
 		session.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 		Expect(session).Should(Exit(0))
 
 		ips := []string{"10.25.31.5", "10.25.31.10", "10.25.31.15"}
@@ -2234,12 +2234,12 @@ spec:
 
 		net := podmanTest.Podman([]string{"network", "create", "--subnet", "10.0.11.0/24", net1})
 		net.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net1)
+		defer podmanTest.removeNetwork(net1)
 		Expect(net).Should(Exit(0))
 
 		net = podmanTest.Podman([]string{"network", "create", "--subnet", "10.0.12.0/24", net2})
 		net.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(net2)
+		defer podmanTest.removeNetwork(net2)
 		Expect(net).Should(Exit(0))
 
 		ip1 := "10.0.11.5"

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -109,7 +109,8 @@ var _ = Describe("Podman pod create", func() {
 
 	It("podman create pod with network portbindings", func() {
 		name := "test"
-		session := podmanTest.Podman([]string{"pod", "create", "--name", name, "-p", "8081:80"})
+		port := GetPort()
+		session := podmanTest.Podman([]string{"pod", "create", "--name", name, "-p", fmt.Sprintf("%d:80", port)})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		pod := session.OutputToString()
@@ -117,24 +118,21 @@ var _ = Describe("Podman pod create", func() {
 		webserver := podmanTest.Podman([]string{"run", "--pod", pod, "-dt", nginx})
 		webserver.WaitWithDefaultTimeout()
 		Expect(webserver).Should(Exit(0))
-
-		check := SystemExec("nc", []string{"-z", "localhost", "8081"})
-		Expect(check).Should(Exit(0))
+		Expect(ncz(port)).To(BeTrue())
 	})
 
 	It("podman create pod with id file with network portbindings", func() {
 		file := filepath.Join(podmanTest.TempDir, "pod.id")
 		name := "test"
-		session := podmanTest.Podman([]string{"pod", "create", "--name", name, "--pod-id-file", file, "-p", "8082:80"})
+		port := GetPort()
+		session := podmanTest.Podman([]string{"pod", "create", "--name", name, "--pod-id-file", file, "-p", fmt.Sprintf("%d:80", port)})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
 		webserver := podmanTest.Podman([]string{"run", "--pod-id-file", file, "-dt", nginx})
 		webserver.WaitWithDefaultTimeout()
 		Expect(webserver).Should(Exit(0))
-
-		check := SystemExec("nc", []string{"-z", "localhost", "8082"})
-		Expect(check).Should(Exit(0))
+		Expect(ncz(port)).To(BeTrue())
 	})
 
 	It("podman create pod with no infra but portbindings should fail", func() {

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -299,7 +299,7 @@ var _ = Describe("Podman ps", func() {
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 
 		session = podmanTest.Podman([]string{"pod", "create", "--network", net})
 		session.WaitWithDefaultTimeout()
@@ -338,12 +338,12 @@ var _ = Describe("Podman ps", func() {
 		session = podmanTest.Podman([]string{"network", "create", net1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(net1)
+		defer podmanTest.removeNetwork(net1)
 		net2 := stringid.GenerateNonCryptoID()
 		session = podmanTest.Podman([]string{"network", "create", net2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(net2)
+		defer podmanTest.removeNetwork(net2)
 
 		session = podmanTest.Podman([]string{"pod", "create", "--network", net1 + "," + net2})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -822,7 +822,7 @@ var _ = Describe("Podman ps", func() {
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(net)
+		defer podmanTest.removeNetwork(net)
 
 		session = podmanTest.Podman([]string{"create", "--network", net, ALPINE})
 		session.WaitWithDefaultTimeout()
@@ -865,12 +865,12 @@ var _ = Describe("Podman ps", func() {
 		session = podmanTest.Podman([]string{"network", "create", net1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(net1)
+		defer podmanTest.removeNetwork(net1)
 		net2 := stringid.GenerateNonCryptoID()
 		session = podmanTest.Podman([]string{"network", "create", net2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		defer podmanTest.removeCNINetwork(net2)
+		defer podmanTest.removeNetwork(net2)
 
 		session = podmanTest.Podman([]string{"create", "--network", net1 + "," + net2, ALPINE})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 		ipv6 := "fd46:db93:aa76:ac37::10"
 		net := podmanTest.Podman([]string{"network", "create", "--subnet", "fd46:db93:aa76:ac37::/64", netName})
 		net.WaitWithDefaultTimeout()
-		defer podmanTest.removeCNINetwork(netName)
+		defer podmanTest.removeNetwork(netName)
 		Expect(net).To(Exit(0))
 
 		result := podmanTest.Podman([]string{"run", "-ti", "--network", netName, "--ip6", ipv6, ALPINE, "ip", "addr"})

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -88,6 +88,18 @@ host.slirp4netns.executable | $expr_path
     is "$output" ".*graphOptions: {}" "output includes graphOptions: {}"
 }
 
+@test "podman info netavark " {
+    # Confirm netavark in use when explicitely required by execution environment.
+    if [[ "$NETWORK_BACKEND" == "netavark" ]]; then
+        if ! is_netavark; then
+            # Assume is_netavark() will provide debugging feedback.
+            die "Netavark driver testing required, but not in use by podman."
+        fi
+    else
+        skip "Netavark testing not requested (\$NETWORK_BACKEND='$NETWORK_BACKEND')"
+    fi
+}
+
 @test "podman --root PATH info - basic output" {
     if ! is_remote; then
         run_podman --storage-driver=vfs --root ${PODMAN_TMPDIR}/nothing-here-move-along info --format '{{ .Store.GraphOptions }}'

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -256,13 +256,17 @@ load helpers
 
     # rootless cannot modify iptables
     if ! is_rootless; then
-        # flush the CNI iptables here
-        run iptables -t nat -F CNI-HOSTPORT-DNAT
+        # flush the port forwarding iptable rule here
+        chain="CNI-HOSTPORT-DNAT"
+        if is_netavark; then
+            chain="NETAVARK-HOSTPORT-DNAT"
+        fi
+        run iptables -t nat -F "$chain"
 
         # check that we cannot curl (timeout after 5 sec)
         run timeout 5 curl -s $SERVER/index.txt
         if [ "$status" -ne 124 ]; then
-	        die "curl did not timeout, status code: $status"
+            die "curl did not timeout, status code: $status"
         fi
     fi
 

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -49,6 +49,7 @@ Running tests
 To run the tests locally in your sandbox, you can use one of these methods:
 * make;PODMAN=./bin/podman bats ./test/system/070-build.bats # runs just the specified test
 * make;PODMAN=./bin/podman bats ./test/system                # runs all
+* make;PODMAN=./bin/podman NETWORK_BACKEND=netavark bats ./test/system  # Assert & enable netavark testing
 
 To test as root:
 *  $ PODMAN=./bin/podman sudo --preserve-env=PODMAN bats test/system

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -341,6 +341,15 @@ function is_cgroupsv2() {
     test "$cgroup_type" = "cgroup2fs"
 }
 
+# True if podman is using netavark
+function is_netavark() {
+    run_podman info --format '{{.Host.NetworkBackend}}'
+    if [[ "$output" =~ netavark ]]; then
+        return 0
+    fi
+    return 1
+}
+
 # Returns the OCI runtime *basename* (typically crun or runc). Much as we'd
 # love to cache this result, we probably shouldn't.
 function podman_runtime() {


### PR DESCRIPTION
Backport of necessary commits from `main`.

***Note***:  We need fix in this PR, or item on @baude release punch-list to do release branches of netavark/aardvark in order to resolve:

```
    # Netavark branch to use when TEST_ENVIRON=host-netavark
    NETAVARK_BRANCH: "main"  # TODO: This should point to a release branch
    # Aardvark branch to use
    AARDVARK_BRANCH: "main"  # TODO: This should also be a release branch
```