### PR TITLE
Set $container_uuid and mount basic /run/host

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/godbus/dbus/v5 v5.0.6
+	github.com/google/go-cmp v0.5.7
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.5.1

--- a/libpod/container_internal_linux_test.go
+++ b/libpod/container_internal_linux_test.go
@@ -4,11 +4,18 @@
 package libpod
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/namespaces"
+	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/stringid"
+	"github.com/google/go-cmp/cmp"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -96,4 +103,97 @@ func TestAppendLocalhost(t *testing.T) {
 		assert.Equal(t, "", c.appendLocalhost(""))
 		assert.Equal(t, "127.0.0.1\tlocalhost", c.appendLocalhost("127.0.0.1\tlocalhost"))
 	}
+}
+
+func TestContainerUUIDEnv(t *testing.T) {
+	ctx := context.Background()
+	c := makeTestContainer(t)
+
+	s, err := c.generateSpec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, hasProcessEnv(t, s, "container_uuid="+c.config.ID[:32]))
+
+	c.config.Spec.Process.Env = append(c.config.Spec.Process.Env, "container_uuid=test")
+	s, err = c.generateSpec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, hasProcessEnv(t, s, "container_uuid=test"))
+}
+
+func TestContainerRunHost(t *testing.T) {
+	ctx := context.Background()
+	c := makeTestContainer(t)
+
+	s, err := c.generateSpec(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, hasMount(t, s, spec.Mount{
+		Destination: "/run/host",
+		Source:      c.runHostDir(),
+		Type:        "bind",
+		Options:     []string{"bind", "rprivate", "ro", "nosuid", "noexec", "nodev"}},
+	), "run-host mount not found: %+v", s.Mounts)
+	b, err := os.ReadFile(filepath.Join(c.runHostDir(), "container-manager"))
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	assert.Equal(t, string(b), "podman\n")
+	b, err = os.ReadFile(filepath.Join(c.runHostDir(), "container-uuid"))
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	assert.Equal(t, string(b), c.config.ID[:32]+"\n")
+}
+
+func makeTestContainer(t *testing.T) Container {
+	t.Helper()
+	return Container{
+		config: &ContainerConfig{
+			Spec: &spec.Spec{
+				Process: &spec.Process{},
+				Root:    &spec.Root{},
+				Linux: &spec.Linux{
+					Namespaces: []spec.LinuxNamespace{{Type: spec.NetworkNamespace, Path: ""}},
+				},
+			},
+			ID: stringid.GenerateNonCryptoID(),
+			IDMappings: storage.IDMappingOptions{
+				UIDMap: []idtools.IDMap{{ContainerID: 0, HostID: os.Geteuid(), Size: 1}},
+				GIDMap: []idtools.IDMap{{ContainerID: 0, HostID: os.Getegid(), Size: 1}},
+			},
+			ContainerNetworkConfig: ContainerNetworkConfig{UseImageHosts: true},
+			ContainerMiscConfig:    ContainerMiscConfig{CgroupManager: config.SystemdCgroupsManager},
+		},
+		state: &ContainerState{
+			BindMounts: map[string]string{"/run/.containerenv": ""},
+			RunDir:     t.TempDir(),
+		},
+		runtime: &Runtime{
+			config: &config.Config{Containers: config.ContainersConfig{}},
+		},
+	}
+}
+
+func hasProcessEnv(t *testing.T, s *spec.Spec, want string) bool {
+	t.Helper()
+	for _, checkEnv := range s.Process.Env {
+		if checkEnv == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMount(t *testing.T, s *spec.Spec, want spec.Mount) bool {
+	t.Helper()
+	for _, m := range s.Mounts {
+		if cmp.Equal(want, m) {
+			return true
+		}
+	}
+	return false
 }

--- a/libpod/diff.go
+++ b/libpod/diff.go
@@ -14,6 +14,7 @@ var initInodes = map[string]bool{
 	"/etc/resolv.conf":   true,
 	"/proc":              true,
 	"/run":               true,
+	"/run/host":          true,
 	"/run/notify":        true,
 	"/run/.containerenv": true,
 	"/run/secrets":       true,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -413,6 +413,7 @@ github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/go-cmp v0.5.7
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags


### PR DESCRIPTION
The `container_uuid` environment variable is read by systemd to set the machine ID, per https://systemd.io/CONTAINER_INTERFACE/#environment-variables. This patch modifies `generateSpec` to apply this environment variable. The "UUID" is the container ID's first 32 characters.

Fixed #13187