### PR TITLE
[WIP] Return slirp ip information from getHosts()

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2377,7 +2377,17 @@ func (c *Container) getHosts() string {
 
 		if depCtr != nil {
 			host := ""
+			if depCtr.config.NetMode.IsSlirp4netns() {
+				// When using slirp4netns, the interface gets a static IP
+				if slirp4netnsIP, err := GetSlirp4netnsIP(depCtr.slirp4netnsSubnet); err != nil {
+					logrus.Warnf("Failed to determine slirp4netnsIP: %v", err.Error())
+				} else {
+					return fmt.Sprintf("%s\t%s %s\n", slirp4netnsIP.String(), c.Hostname(), c.config.Name)
+				}
+			}
 		outer:
+			// Paul this is returning nothing, even though I know depctr is up and
+			// running with an IP Address in rootfull mode?
 			for net, status := range depCtr.getNetworkStatus() {
 				network, err := c.runtime.network.NetworkInspect(net)
 				// only add the host entry for bridge networks

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -633,6 +633,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		exec4.WaitWithDefaultTimeout()
 		Expect(exec4).Should(Exit(0))
 		Expect(exec4.OutputToString()).To(ContainSubstring("192.0.2.2 test1"))
+		Expect(exec4.OutputToString()).To(ContainSubstring(ctrName2))
 	})
 
 	It("podman run /etc/hosts contains --hostname", func() {


### PR DESCRIPTION
When one container shares the network namespace with another container
or with a Pod, there should be an entry added to the /etc/hosts file
for the second container.

Fixes: https://github.com/containers/podman/issues/12003

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
