### PR TITLE
Add support for --chrootdirs

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -631,6 +631,14 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			"Write the container process ID to the file")
 		_ = cmd.RegisterFlagCompletionFunc(pidFileFlagName, completion.AutocompleteDefault)
 
+		chrootDirsFlagName := "chrootdirs"
+		createFlags.StringSliceVar(
+			&cf.ChrootDirs,
+			chrootDirsFlagName, []string{},
+			"Chroot directories inside the container",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(chrootDirsFlagName, completion.AutocompleteDefault)
+
 		if registry.IsRemote() {
 			_ = createFlags.MarkHidden("env-host")
 			_ = createFlags.MarkHidden("http-proxy")

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1453,6 +1453,11 @@ After the container is started, the location for the pidfile can be discovered w
     $ podman inspect --format '{{ .PidFile }}' $CID
     /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile
 
+#### **--chrootdirs**=*path*
+
+Path to a directory inside the container that should be treated as a `chroot` directory.
+Any Podman managed file (e.g., /etc/resolv.conf, /etc/hosts, etc/hostname) that is mounted into the root directory will be mounted into that location as well.
+Multiple directories should be separated with a comma.
 
 ## EXAMPLES
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1529,6 +1529,12 @@ After the container is started, the location for the pidfile can be discovered w
     $ podman inspect --format '{{ .PidFile }}' $CID
     /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile
 
+#### **--chrootdirs**=*path*
+
+Path to a directory inside the container that should be treated as a `chroot` directory.
+Any Podman managed file (e.g., /etc/resolv.conf, /etc/hosts, etc/hostname) that is mounted into the root directory will be mounted into that location as well.
+Multiple directories should be separated with a comma.
+
 ## Exit Status
 
 The exit code from **podman run** gives information about why the container

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -165,6 +165,10 @@ type ContainerRootFSConfig struct {
 	Volatile bool `json:"volatile,omitempty"`
 	// Passwd allows to user to override podman's passwd/group file setup
 	Passwd *bool `json:"passwd,omitempty"`
+	// ChrootDirs is an additional set of directories that need to be
+	// treated as root directories. Standard bind mounts will be mounted
+	// into paths relative to these directories.
+	ChrootDirs []string `json:"chroot_directories,omitempty"`
 }
 
 // ContainerSecurityConfig is an embedded sub-config providing security configuration

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -411,6 +411,7 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 	}
 
 	ctrConfig.Passwd = c.config.Passwd
+	ctrConfig.ChrootDirs = append(ctrConfig.ChrootDirs, c.config.ChrootDirs...)
 
 	return ctrConfig
 }

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -75,6 +75,10 @@ type InspectContainerConfig struct {
 	StopTimeout uint `json:"StopTimeout"`
 	// Passwd determines whether or not podman can add entries to /etc/passwd and /etc/group
 	Passwd *bool `json:"Passwd,omitempty"`
+	// ChrootDirs is an additional set of directories that need to be
+	// treated as root directories. Standard bind mounts will be mounted
+	// into paths relative to these directories.
+	ChrootDirs []string `json:"ChrootDirs,omitempty"`
 }
 
 // InspectRestartPolicy holds information about the container's restart policy.

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -2036,3 +2036,18 @@ func WithVolatile() CtrCreateOption {
 		return nil
 	}
 }
+
+// WithChrootDirs is an additional set of directories that need to be
+// treated as root directories. Standard bind mounts will be mounted
+// into paths relative to these directories.
+func WithChrootDirs(dirs []string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.ChrootDirs = dirs
+
+		return nil
+	}
+}

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -263,6 +263,7 @@ type ContainerCreateOptions struct {
 	Workdir           string
 	SeccompPolicy     string
 	PidFile           string
+	ChrootDirs        []string
 	IsInfra           bool
 	IsClone           bool
 

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -526,6 +526,10 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 		options = append(options, libpod.WithPidFile(s.PidFile))
 	}
 
+	if len(s.ChrootDirs) != 0 {
+		options = append(options, libpod.WithChrootDirs(s.ChrootDirs))
+	}
+
 	options = append(options, libpod.WithSelectedPasswordManagement(s.Passwd))
 
 	return options, nil

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -301,6 +301,10 @@ type ContainerStorageConfig struct {
 	// Volatile specifies whether the container storage can be optimized
 	// at the cost of not syncing all the dirty files in memory.
 	Volatile bool `json:"volatile,omitempty"`
+	// ChrootDirs is an additional set of directories that need to be
+	// treated as root directories. Standard bind mounts will be mounted
+	// into paths relative to these directories.
+	ChrootDirs []string `json:"chroot_directories,omitempty"`
 }
 
 // ContainerSecurityConfig is a container's security features, including

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -819,6 +819,9 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	if !s.UnsetEnvAll {
 		s.UnsetEnvAll = c.UnsetEnvAll
 	}
+	if len(s.ChrootDirs) == 0 || len(c.ChrootDirs) != 0 {
+		s.ChrootDirs = c.ChrootDirs
+	}
 
 	// Initcontainers
 	if len(s.InitContainerType) == 0 || len(c.InitContainerType) != 0 {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
Adds support for optional --chrootdirs=x to specify chroot dirs. Special files such as /etc/hosts will be automatically mounted into x/etc/hosts and so on.

Closes #12691