### PR TITLE
Don't log errors on removing volumes inuse, if container --volumes-from

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -51,6 +51,17 @@ func (c *Container) Inspect(size bool) (*define.InspectContainerData, error) {
 	return c.inspectLocked(size)
 }
 
+func (c *Container) volumesFrom() ([]string, error) {
+	ctrSpec, err := c.specFromState()
+	if err != nil {
+		return nil, err
+	}
+	if ctrs, ok := ctrSpec.Annotations[define.InspectAnnotationVolumesFrom]; ok {
+		return strings.Split(ctrs, ","), nil
+	}
+	return nil, nil
+}
+
 func (c *Container) getContainerInspectData(size bool, driverData *define.DriverData) (*define.InspectContainerData, error) {
 	config := c.config
 	runtimeInfo := c.state

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -768,6 +768,14 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 				continue
 			}
 			if err := runtime.removeVolume(ctx, volume, false, timeout); err != nil && errors.Cause(err) != define.ErrNoSuchVolume {
+				if errors.Cause(err) == define.ErrVolumeBeingUsed {
+					// Ignore error, since podman will report original error
+					volumesFrom, _ := c.volumesFrom()
+					if len(volumesFrom) > 0 {
+						logrus.Debugf("Cleanup volume not possible since volume is in use (%s)", v)
+						continue
+					}
+				}
 				logrus.Errorf("Cleanup volume (%s): %v", v, err)
 			}
 		}


### PR DESCRIPTION
When removing a container created with a --volumes-from a container
created with a built in volume, we complain if the original container
still exists.  Since this is an expected state, we should not complain
about it.

Fixes: https://github.com/containers/podman/issues/12808

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
