### PR TITLE
[CI:DOCS] podman network: add documentation for netavark

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -1,7 +1,7 @@
 % podman-network-create(1)
 
 ## NAME
-podman\-network-create - Create a Podman CNI network
+podman\-network-create - Create a Podman network
 
 ## SYNOPSIS
 **podman network create**  [*options*] name

--- a/docs/source/markdown/podman-network-inspect.1.md
+++ b/docs/source/markdown/podman-network-inspect.1.md
@@ -1,7 +1,7 @@
 % podman-network-inspect(1)
 
 ## NAME
-podman\-network\-inspect - Displays the raw CNI network configuration for one or more networks
+podman\-network\-inspect - Displays the raw network configuration for one or more networks
 
 ## SYNOPSIS
 **podman network inspect** [*options*] *network* [*network* ...]

--- a/docs/source/markdown/podman-network-ls.1.md
+++ b/docs/source/markdown/podman-network-ls.1.md
@@ -1,7 +1,7 @@
 % podman-network-ls(1)
 
 ## NAME
-podman\-network\-ls - Display a summary of CNI networks
+podman\-network\-ls - Display a summary of networks
 
 ## SYNOPSIS
 **podman network ls**  [*options*]

--- a/docs/source/markdown/podman-network-rm.1.md
+++ b/docs/source/markdown/podman-network-rm.1.md
@@ -1,7 +1,7 @@
 % podman-network-rm(1)
 
 ## NAME
-podman\-network\-rm - Remove one or more CNI networks
+podman\-network\-rm - Remove one or more networks
 
 ## SYNOPSIS
 **podman network rm** [*options*] [*network...*]

--- a/docs/source/markdown/podman-network.1.md
+++ b/docs/source/markdown/podman-network.1.md
@@ -1,27 +1,37 @@
 % podman-network(1)
 
 ## NAME
-podman\-network - Manage Podman CNI networks
+podman\-network - Manage Podman networks
 
 ## SYNOPSIS
 **podman network** *subcommand*
 
 ## DESCRIPTION
-The network command manages CNI networks for Podman.
+The network command manages networks for Podman.
+
+Podman supports two network backends [Netavark](https://github.com/containers/netavark)
+and [CNI](https://www.cni.dev/). Support for netavark was added in Podman v4.0. To configure
+the network backend use the `network_backend`key under the `[Network]` in
+**[containers.conf(5)](https://github.com/containers/common/blob/master/docs/containers.conf.5.md)**.
+New systems should use netavark by default, to check what backed is used run
+`podman info --format {{.Host.NetworkBackend}}`.
+
+All network commands work for both backends but CNI and Netavark use different config files
+so networks have to be created again after a backend change.
 
 ## COMMANDS
 
-| Command    | Man Page                                                       | Description                                                         |
-| ---------- | -------------------------------------------------------------- | ------------------------------------------------------------------- |
-| connect    | [podman-network-connect(1)](podman-network-connect.1.md)       | Connect a container to a network                                    |
-| create     | [podman-network-create(1)](podman-network-create.1.md)         | Create a Podman CNI network                                         |
-| disconnect | [podman-network-disconnect(1)](podman-network-disconnect.1.md) | Disconnect a container from a network                               |
-| exists     | [podman-network-exists(1)](podman-network-exists.1.md)         | Check if the given network exists                                   |
-| inspect    | [podman-network-inspect(1)](podman-network-inspect.1.md)       | Displays the raw CNI network configuration for one or more networks |
-| ls         | [podman-network-ls(1)](podman-network-ls.1.md)                 | Display a summary of CNI networks                                   |
-| prune      | [podman-network-prune(1)](podman-network-prune.1.md)           | Remove all unused networks |
-| reload     | [podman-network-reload(1)](podman-network-reload.1.md)         | Reload network configuration for containers                         |
-| rm         | [podman-network-rm(1)](podman-network-rm.1.md)                 | Remove one or more CNI networks                                     |
+| Command    | Man Page                                                       | Description                                                     |
+| ---------- | -------------------------------------------------------------- | --------------------------------------------------------------- |
+| connect    | [podman-network-connect(1)](podman-network-connect.1.md)       | Connect a container to a network                                |
+| create     | [podman-network-create(1)](podman-network-create.1.md)         | Create a Podman network                                         |
+| disconnect | [podman-network-disconnect(1)](podman-network-disconnect.1.md) | Disconnect a container from a network                           |
+| exists     | [podman-network-exists(1)](podman-network-exists.1.md)         | Check if the given network exists                               |
+| inspect    | [podman-network-inspect(1)](podman-network-inspect.1.md)       | Displays the raw network configuration for one or more networks |
+| ls         | [podman-network-ls(1)](podman-network-ls.1.md)                 | Display a summary of networks                                   |
+| prune      | [podman-network-prune(1)](podman-network-prune.1.md)           | Remove all unused networks                                      |
+| reload     | [podman-network-reload(1)](podman-network-reload.1.md)         | Reload network configuration for containers                     |
+| rm         | [podman-network-rm(1)](podman-network-rm.1.md)                 | Remove one or more networks                                     |
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**
+**[podman(1)](podman.1.md)**, **[containers.conf(5)](https://github.com/containers/common/blob/main/docs/containers.conf.5.md)**

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -300,7 +300,7 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-events(1)](podman-events.1.md)           | Monitor Podman events                                                       |
 | [podman-exec(1)](podman-exec.1.md)               | Execute a command in a running container.                                   |
 | [podman-export(1)](podman-export.1.md)           | Export a container's filesystem contents as a tar archive.                  |
-| [podman-generate(1)](podman-generate.1.md)       | Generate structured data based on containers, pods or volumes.                   |
+| [podman-generate(1)](podman-generate.1.md)       | Generate structured data based on containers, pods or volumes.              |
 | [podman-healthcheck(1)](podman-healthcheck.1.md) | Manage healthchecks for containers                                          |
 | [podman-history(1)](podman-history.1.md)         | Show the history of an image.                                               |
 | [podman-image(1)](podman-image.1.md)             | Manage images.                                                              |
@@ -317,9 +317,9 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-machine(1)](podman-machine.1.md)         | Manage Podman's virtual machine                                             |
 | [podman-manifest(1)](podman-manifest.1.md)       | Create and manipulate manifest lists and image indexes.                     |
 | [podman-mount(1)](podman-mount.1.md)             | Mount a working container's root filesystem.                                |
-| [podman-network(1)](podman-network.1.md)         | Manage Podman CNI networks.                                                 |
+| [podman-network(1)](podman-network.1.md)         | Manage Podman networks.                                                     |
 | [podman-pause(1)](podman-pause.1.md)             | Pause one or more containers.                                               |
-| [podman-play(1)](podman-play.1.md)               | Play containers, pods or volumes based on a structured input file.                  |
+| [podman-play(1)](podman-play.1.md)               | Play containers, pods or volumes based on a structured input file.          |
 | [podman-pod(1)](podman-pod.1.md)                 | Management tool for groups of containers, called pods.                      |
 | [podman-port(1)](podman-port.1.md)               | List port mappings for a container.                                         |
 | [podman-ps(1)](podman-ps.1.md)                   | Prints out information about containers.                                    |


### PR DESCRIPTION
Add some docs about the different network backends. Also remove the CNI
word from network since we refer to either a netavark or CNI config.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
