### PR TITLE
[BACKPORT] Backporte2efixes

### DIFF
--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -187,23 +187,27 @@ WORKDIR /test
 	})
 
 	It("podman images filter since image", func() {
-		dockerfile := `FROM quay.io/libpod/alpine:latest
+		dockerfile := `FROM scratch
 `
-		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
-		result := podmanTest.Podman([]string{"images", "-q", "-f", "since=quay.io/libpod/alpine:latest"})
+		podmanTest.BuildImage(dockerfile, "foobar.com/one:latest", "false")
+		podmanTest.BuildImage(dockerfile, "foobar.com/two:latest", "false")
+		podmanTest.BuildImage(dockerfile, "foobar.com/three:latest", "false")
+		result := podmanTest.PodmanNoCache([]string{"images", "-q", "-f", "since=foobar.com/one:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(result.OutputToStringArray()).To(HaveLen(9))
+		Expect(result.OutputToStringArray()).To(HaveLen(2))
 	})
 
 	It("podman image list filter after image", func() {
-		dockerfile := `FROM quay.io/libpod/alpine:latest
+		dockerfile := `FROM scratch
 `
-		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
-		result := podmanTest.Podman([]string{"image", "list", "-q", "-f", "after=quay.io/libpod/alpine:latest"})
+		podmanTest.BuildImage(dockerfile, "foobar.com/one:latest", "false")
+		podmanTest.BuildImage(dockerfile, "foobar.com/two:latest", "false")
+		podmanTest.BuildImage(dockerfile, "foobar.com/three:latest", "false")
+		result := podmanTest.Podman([]string{"image", "list", "-q", "-f", "after=foobar.com/one:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(result.OutputToStringArray()).Should(HaveLen(9), "list filter output: %q", result.OutputToString())
+		Expect(result.OutputToStringArray()).Should(HaveLen(2), "list filter output: %q", result.OutputToString())
 	})
 
 	It("podman images filter dangling", func() {

--- a/test/python/docker/compat/test_images.py
+++ b/test/python/docker/compat/test_images.py
@@ -87,7 +87,8 @@ class TestImages(unittest.TestCase):
     def test_search_image(self):
         """Search for image"""
         for r in self.client.images.search("alpine"):
-            self.assertIn("alpine", r["Name"])
+            # registry matches if string is in either one
+            self.assertIn("alpine", r["Name"]+" "+r["Description"].lower())
 
     def test_search_bogus_image(self):
         """Search for bogus image should throw exception"""


### PR DESCRIPTION
It looks like some descriptions have changed on the docker registry
where we had been searching for images that include 'alpine'.  We are
now seeing an image in the initial list that has 'alpine' in its
description.

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
