### PR TITLE
generate: ignore net sysctls with --net=none

### DIFF
--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -208,7 +208,7 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 	g.SetRootReadonly(s.ReadOnlyFilesystem)
 
 	noUseIPC := s.IpcNS.NSMode == specgen.FromContainer || s.IpcNS.NSMode == specgen.FromPod || s.IpcNS.NSMode == specgen.Host
-	noUseNet := s.NetNS.NSMode == specgen.FromContainer || s.NetNS.NSMode == specgen.FromPod || s.NetNS.NSMode == specgen.Host
+	noUseNet := s.NetNS.NSMode == specgen.FromContainer || s.NetNS.NSMode == specgen.FromPod || s.NetNS.NSMode == specgen.Host || s.NetNS.NSMode == specgen.NoNetwork
 	noUseUTS := s.UtsNS.NSMode == specgen.FromContainer || s.UtsNS.NSMode == specgen.FromPod || s.UtsNS.NSMode == specgen.Host
 
 	// Add default sysctls
@@ -224,7 +224,7 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 			continue
 		}
 
-		// Ignore net sysctls if --net=host
+		// Ignore net sysctls if --net=host or --net=none
 		if noUseNet && strings.HasPrefix(sysctlKey, "net.") {
 			logrus.Infof("Sysctl %s=%s ignored in containers.conf, since Network Namespace set to host", sysctlKey, sysctlVal)
 			continue

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -649,6 +649,11 @@ USER bin`, BB)
 		session = podmanTest.Podman([]string{"run", "--net", "host", "--rm", "--sysctl", "net.core.somaxconn=65535", ALPINE, "sysctl", "net.core.somaxconn"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(125))
+
+		// network sysctls should fail if --net=none is set
+		session = podmanTest.Podman([]string{"run", "--net", "none", "--rm", "--sysctl", "net.core.somaxconn=65535", ALPINE, "sysctl", "net.core.somaxconn"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(125))
 	})
 
 	It("podman run blkio-weight test", func() {


### PR DESCRIPTION
ignore the network sysctls when --net=none is specified.

Closes: https://github.com/containers/podman/issues/13194

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
