### PR TITLE
Calculate device major/minor using bitshift

### DIFF
--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -39,8 +39,10 @@ func FindDeviceNodes() (map[string]string, error) {
 		if !ok {
 			return errors.Errorf("Could not convert stat output for use")
 		}
-		major := sysstat.Rdev / 256
-		minor := sysstat.Rdev % 256
+		// We must typeconvert sysstat.Rdev from uint64->int to avoid constant overflow
+		rdev := int(sysstat.Rdev)
+		major := ((rdev >> 8) & 0xfff) | ((rdev >> 32) & ^0xfff)
+		minor := (rdev & 0xff) | ((rdev >> 12) & ^0xff)
 
 		nodes[fmt.Sprintf("%d:%d", major, minor)] = path
 


### PR DESCRIPTION
Previously, devices with a major/minor number >256 would fail to be
detected.  Switch to using bitwise conversion (similar to
sys/sysmacros in C).

Currently, minor numbers for attached devices cannot exceed 256 as we use a modulo to determine the device's minor number.

In the current Linux kernel, it is currently possible to have much larger ID's than this, and if this happens podman will error as the modulo will produce an incorrect result.  Consider the following where I created a large minor-numbered device via a custom driver:
```bash
# podman create --device /dev/bigdummy-0:/dev/bigdummy-0 --name tester registry.redhat.io/ubi8 ls -l /dev/bigdummy-0

# podman start tester

# podman inspect tester --format {{.HostConfig.Devices}}
WARN[0000] Could not locate device 242:65536 on host    
[]
```

This patch uses bitwise maths to determine the ID's from the `stat` syscall, and should future-proof both the minor and major device numbers, at least for a little while.  Check the `gnu_dev_major` and `gnu_dev_minor` in `<sys/sysmacros.h>` for similar operations.

For those interested/seeking to reproduce, here is the kernel module that produces a large minor device number I authored to test this:

https://gist.github.com/robbmanes/0f691939333a2cba48c3e634bd1ca1f4

Testing with this module and this PR, the issue appears to be resolved:
```bash
# ./bin/podman create --device /dev/bigdummy-0:/dev/bigdummy-0 --name tester registry.redhat.io/ubi8 ls -l /dev/bigdummy-0

# ./bin/podman start tester

# ./bin/podman inspect tester --format {{.HostConfig.Devices}}
[{/dev/bigdummy-0 /dev/bigdummy-0 }]
```