### PR TITLE
[CI:DOCS] Update release notes with v4.0.0 additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Podman (the POD MANager) is a tool for managing containers and images, volumes mounted into those containers, and pods made from groups of containers.
 Podman is based on libpod, a library for container lifecycle management that is also contained in this repository. The libpod library provides APIs for managing containers, pods, container images, and volumes.
 
-* [Latest Version: 3.4.0](https://github.com/containers/podman/releases/latest)
+* [Latest Version: 4.0.0](https://github.com/containers/podman/releases/latest)
   * Latest Remote client for Windows
   * Latest Remote client for macOS
   * Latest Static Remote client for Linux
@@ -20,21 +20,21 @@ At a high level, the scope of Podman and libpod is the following:
 * Support for multiple container image formats, including OCI and Docker images.
 * Full management of those images, including pulling from various sources (including trust and verification), creating (built via Containerfile or Dockerfile or committed from a container), and pushing to registries and other storage backends.
 * Full management of container lifecycle, including creation (both from an image and from an exploded root filesystem), running, checkpointing and restoring (via CRIU), and removal.
+* Full management of container networking, using CNI, Netavark, and slirp4netns
 * Support for pods, groups of containers that share resources and are managed together.
 * Support for running containers and pods without root or other elevated privileges.
 * Resource isolation of containers and pods.
 * Support for a Docker-compatible CLI interface.
 * No manager daemon, for improved security and lower resource utilization at idle.
 * Support for a REST API providing both a Docker-compatible interface and an improved interface exposing advanced Podman functionality.
-* In the future, integration with [CRI-O](https://github.com/cri-o/cri-o) to share containers and backend code.
 
 Podman presently only supports running containers on Linux. However, we are building a remote client which can run on Windows and macOS and manage Podman containers on a Linux system via the REST API using SSH tunneling.
 
 ## Roadmap
 
 1. Further improvements to the REST API, with a focus on bugfixes and implementing missing functionality
-1. Integrate libpod into [CRI-O](https://github.com/cri-o/cri-o) to replace its existing container management backend
 1. Improvements on rootless containers, with a focus on improving the user experience and exposing presently-unavailable features when possible
+1. Improvements to Pods, including the addition of pod-level resource limits
 
 ## Communications
 
@@ -74,14 +74,14 @@ A little configuration by an administrator is required before rootless Podman ca
 
 ## OCI Projects Plans
 
-The plan is to use OCI projects and best of breed libraries for different aspects:
+Podman uses OCI projects and best of breed libraries for different aspects:
 - Runtime: We use the [OCI runtime tools](https://github.com/opencontainers/runtime-tools) to generate OCI runtime configurations that can be used with any OCI-compliant runtime, like [crun](https://github.com/containers/crun/) and [runc](https://github.com/opencontainers/runc/).
 - Images: Image management uses the [containers/image](https://github.com/containers/image) library.
 - Storage: Container and image storage is managed by [containers/storage](https://github.com/containers/storage).
-- Networking: Networking support through use of [CNI](https://github.com/containernetworking/cni).
+- Networking: Networking support through use of [Netavark](https://github.com/containers/netavark) and [Aardvark](https://github.com/containers/aardvark-dns). Support for [CNI](https://github.com/containernetworking/cni) is also available. Rootless networking is handled via [slirp4netns](https://github.com/rootless-containers/slirp4netns).
 - Builds: Builds are supported via [Buildah](https://github.com/containers/buildah).
 - Conmon: [Conmon](https://github.com/containers/conmon) is a tool for monitoring OCI runtimes, used by both Podman and CRI-O.
-- Seccomp: A unified [Seccomp](https://github.com/seccomp/containers-golang) policy for Podman, Buildah, and CRI-O.
+- Seccomp: A unified [Seccomp](https://github.com/containers/common/blob/main/pkg/seccomp/seccomp.json) policy for Podman, Buildah, and CRI-O.
 
 ## Podman Information for Developers
 


### PR DESCRIPTION
Copy release notes from the v4.0 branch to main, and bump current version in README.