### PR TITLE
[CI:DOCS] troubleshooting: mention overlay option for --rootfs

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -645,16 +645,26 @@ to mount volumes on them.
 Run the container once in read/write mode, Podman will generate all of the FDs on the rootfs, and
 from that point forward you can run with a read-only rootfs.
 
+```
 $ podman run --rm --rootfs /path/to/rootfs true
+```
 
 The command above will create all the missing directories needed to run the container.
 
 After that, it can be used in read only mode, by multiple containers at the same time:
 
+```
 $ podman run --read-only --rootfs /path/to/rootfs ....
+```
 
-Another option would be to create an overlay file system on the directory as a lower and then
-then allow podman to create the files on the upper.
+Another option is to use an Overlay Rootfs Mount:
+
+```
+$ podman run --rootfs /path/to/rootfs:O ....
+```
+
+Modifications to the mount point are destroyed when the container
+finishes executing, similar to a tmpfs mount point being unmounted.
 
 ### 26) Running containers with CPU limits fails with a permissions error
 


### PR DESCRIPTION
* Mention overlay option for --rootfs. Overlay description text
  is from commit 020d81f113ea1e11398ea77495cc4b8e05a91d38
  by Qi Wang

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
