### PR TITLE
kube: honor `--build=false` if specified.

### DIFF
--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -27,6 +27,7 @@ type playKubeOptionsWrapper struct {
 	TLSVerifyCLI   bool
 	CredentialsCLI string
 	StartCLI       bool
+	BuildCLI       bool
 }
 
 var (
@@ -117,7 +118,7 @@ func init() {
 		_ = kubeCmd.RegisterFlagCompletionFunc(configmapFlagName, completion.AutocompleteDefault)
 
 		buildFlagName := "build"
-		flags.BoolVar(&kubeOptions.Build, buildFlagName, false, "Build all images in a YAML (given Containerfiles exist)")
+		flags.BoolVar(&kubeOptions.BuildCLI, buildFlagName, false, "Build all images in a YAML (given Containerfiles exist)")
 	}
 
 	if !registry.IsRemote() {
@@ -137,6 +138,9 @@ func kube(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flags().Changed("start") {
 		kubeOptions.Start = types.NewOptionalBool(kubeOptions.StartCLI)
+	}
+	if cmd.Flags().Changed("build") {
+		kubeOptions.Build = types.NewOptionalBool(kubeOptions.BuildCLI)
 	}
 	if kubeOptions.Authfile != "" {
 		if _, err := os.Stat(kubeOptions.Authfile); err != nil {

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -67,7 +67,8 @@ like:
 ```
 
 The build will consider `foobar` to be the context directory for the build. If there is an image in local storage
-called `foobar`, the image will not be built unless the `--build` flag is used.
+called `foobar`, the image will not be built unless the `--build` flag is used. Use `--build=false` to completely
+disable builds.
 
 `Kubernetes ConfigMap`
 
@@ -115,7 +116,7 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 
 #### **--build**
 
-Build images even if they are found in the local storage.
+Build images even if they are found in the local storage. Use `--build=false` to completely disable builds.
 
 #### **--cert-dir**=*path*
 

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -11,7 +11,7 @@ type PlayKubeOptions struct {
 	// Authfile - path to an authentication file.
 	Authfile string
 	// Indicator to build all images with Containerfile or Dockerfile
-	Build bool
+	Build types.OptionalBool
 	// CertDir - to a directory containing TLS certifications and keys.
 	CertDir string
 	// Down indicates whether to bring contents of a yaml file "down"

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -486,7 +486,7 @@ func (ic *ContainerEngine) getImageAndLabelInfo(ctx context.Context, cwd string,
 	if err != nil {
 		return nil, nil, err
 	}
-	if (len(buildFile) > 0 && !existsLocally) || (len(buildFile) > 0 && options.Build) {
+	if (len(buildFile) > 0) && ((!existsLocally && options.Build != types.OptionalBoolFalse) || (options.Build == types.OptionalBoolTrue)) {
 		buildOpts := new(buildahDefine.BuildOptions)
 		commonOpts := new(buildahDefine.CommonBuildOptions)
 		buildOpts.ConfigureNetwork = buildahDefine.NetworkDefault


### PR DESCRIPTION
`podman play kube` tries to build images even if `--build` is set to
false so lets honor that and make `--build` , `true` by default so it
matches the original behavior.

Closes: https://github.com/containers/podman/issues/13285