### PR TITLE
Implement podman down command

### DIFF
--- a/cmd/podman/common/play_teardown.go
+++ b/cmd/podman/common/play_teardown.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/utils"
+	"github.com/containers/podman/v4/pkg/domain/entities"
+)
+
+// TeardownPlayKube tears down a Kubernetes Play based on its YAML
+// configuration. It is in the common package because it is shared
+// by "podman play kube --down" and "podman down kube"
+func TeardownPlayKube(yamlfile string, opts entities.PlayKubeDownOptions) error {
+	var (
+		podStopErrors utils.OutputErrors
+		podRmErrors   utils.OutputErrors
+	)
+
+	reports, err := registry.ContainerEngine().PlayKubeDown(registry.GetContext(), yamlfile, opts)
+	if err != nil {
+		return err
+	}
+
+	// Output stopped pods
+	fmt.Println("Pods stopped:")
+	for _, stopped := range reports.StopReport {
+		if len(stopped.Errs) == 0 {
+			fmt.Println(stopped.Id)
+		} else {
+			podStopErrors = append(podStopErrors, stopped.Errs...)
+		}
+	}
+	// Dump any stop errors
+	lastStopError := podStopErrors.PrintErrors()
+	if lastStopError != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", lastStopError)
+	}
+
+	// Output rm'd pods
+	fmt.Println("Pods removed:")
+	for _, removed := range reports.RmReport {
+		if removed.Err == nil {
+			fmt.Println(removed.Id)
+		} else {
+			podRmErrors = append(podRmErrors, removed.Err)
+		}
+	}
+	return podRmErrors.PrintErrors()
+}

--- a/cmd/podman/down/down.go
+++ b/cmd/podman/down/down.go
@@ -1,0 +1,23 @@
+package down
+
+import (
+	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/validate"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Command: podman _down_
+	downCmd = &cobra.Command{
+		Use:   "down",
+		Short: "Stop containers, pods or volumes from a structured file",
+		Long:  "Stop containers, pods or volumes created from a structured file (e.g., Kubernetes YAML).",
+		RunE:  validate.SubCommandExists,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: downCmd,
+	})
+}

--- a/cmd/podman/down/kube.go
+++ b/cmd/podman/down/kube.go
@@ -1,0 +1,53 @@
+package down
+
+import (
+	"github.com/containers/podman/v4/cmd/podman/common"
+	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/utils"
+	"github.com/containers/podman/v4/pkg/domain/entities"
+	"github.com/spf13/cobra"
+)
+
+// playKubeOptionsWrapper allows for separating CLI-only fields from API-only
+// fields.
+type playKubeOptionsWrapper struct {
+	entities.PlayKubeDownOptions
+}
+
+var (
+	kubeOptions     = playKubeOptionsWrapper{}
+	kubeDescription = `Command stops pods or volumes defined in Kubernetes YAML.
+
+  It stops pods or volumes created from a Kubernetes YAML. Supported kinds are Pods, Deployments and PersistentVolumeClaims.`
+
+	kubeCmd = &cobra.Command{
+		Use:               "kube [options] KUBEFILE|-",
+		Short:             "Stop a pod or volume based on Kubernetes YAML.",
+		Long:              kubeDescription,
+		RunE:              kube,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: common.AutocompleteDefaultOneArg,
+		Example: `podman down kube nginx.yml
+  cat nginx.yml | podman down kube -
+  podman down kube apache.yml`,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: kubeCmd,
+		Parent:  downCmd,
+	})
+
+	flags := kubeCmd.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
+}
+
+func kube(cmd *cobra.Command, args []string) error {
+	yamlfile := args[0]
+	if yamlfile == "-" {
+		yamlfile = "/dev/stdin"
+	}
+
+	return common.TeardownPlayKube(yamlfile, kubeOptions.PlayKubeDownOptions)
+}

--- a/cmd/podman/generate/kube.go
+++ b/cmd/podman/generate/kube.go
@@ -3,7 +3,6 @@ package pods
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/containers/common/pkg/completion"
@@ -53,12 +52,14 @@ func init() {
 }
 
 func kube(cmd *cobra.Command, args []string) error {
+	cmd.OutOrStdout()
+	cmd.Context()
 	report, err := registry.ContainerEngine().GenerateKube(registry.GetContext(), args, kubeOptions)
 	if err != nil {
 		return err
 	}
 
-	content, err := ioutil.ReadAll(report.Reader)
+	content, err := io.ReadAll(report.Reader)
 	if err != nil {
 		return err
 	}
@@ -70,7 +71,7 @@ func kube(cmd *cobra.Command, args []string) error {
 		if _, err := os.Stat(kubeFile); err == nil {
 			return errors.Errorf("cannot write to %q; file exists", kubeFile)
 		}
-		if err := ioutil.WriteFile(kubeFile, content, 0644); err != nil {
+		if err := os.WriteFile(kubeFile, content, 0644); err != nil {
 			return errors.Wrapf(err, "cannot write to %q", kubeFile)
 		}
 		return nil

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -7,6 +7,7 @@ import (
 
 	_ "github.com/containers/podman/v4/cmd/podman/completion"
 	_ "github.com/containers/podman/v4/cmd/podman/containers"
+	_ "github.com/containers/podman/v4/cmd/podman/down"
 	_ "github.com/containers/podman/v4/cmd/podman/generate"
 	_ "github.com/containers/podman/v4/cmd/podman/healthcheck"
 	_ "github.com/containers/podman/v4/cmd/podman/images"

--- a/docs/source/markdown/podman-down-kube.1.md
+++ b/docs/source/markdown/podman-down-kube.1.md
@@ -1,0 +1,14 @@
+% podman-down-kube(1)
+
+## NAME
+podman-down-kube - Stop containers, pods or volumes based on Kubernetes YAML
+
+## SYNOPSIS
+**podman down kube** [*options*] *file.yml|-*
+
+## DESCRIPTION
+**podman down kube** will tear down the pods created by a previous run of `podman play kube`. It reads in a structured file of Kubernetes YAML.  It will then stop the containers, pods or volumes described in the YAML. If the yaml file is specified as "-" then `podman down kube` will read the YAML file from stdin.
+Ideally the input file would be one created by Podman (see podman-generate-kube(1)).  This would guarantee a smooth import and expected results.
+
+## SEE ALSO
+**[podman(1)](podman.1.md)**, **[podman-play(1)](podman-play.1.md)**, **[podman-play-kube(1)](podman-play-kube.1.md)**, **[podman-network-create(1)](podman-network-create.1.md)**, **[podman-generate-kube(1)](podman-generate-kube.1.md)**, **[podman-down(1)](podman-down.1.md)**

--- a/docs/source/markdown/podman-down.1.md
+++ b/docs/source/markdown/podman-down.1.md
@@ -1,0 +1,20 @@
+% podman-down(1)
+
+## NAME
+podman\-down - Stop containers, pods or volumes based on a structured input file
+
+## SYNOPSIS
+**podman down** *subcommand*
+
+## DESCRIPTION
+The down command will stop containers, pods or volumes based on the input from a structured (like YAML)
+file input.
+
+## COMMANDS
+
+| Command  | Man Page                                            | Description                                                                  |
+| -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
+| kube     | [podman-down-kube(1)](podman-down-kube.1.md)        | Stop containers, pods or volumes based on Kubernetes YAML.                   |
+
+## SEE ALSO
+**[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-container(1)](podman-container.1.md)**, **[podman-generate(1)](podman-generate.1.md)**, **[podman-play-kube(1)](podman-play-kube.1.md)**, **[podman-down-kube(1)](podman-down-kube.1.md)**

--- a/pkg/api/handlers/libpod/down.go
+++ b/pkg/api/handlers/libpod/down.go
@@ -1,0 +1,52 @@
+package libpod
+
+import (
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/containers/podman/v4/libpod"
+	"github.com/containers/podman/v4/pkg/api/handlers/utils"
+	api "github.com/containers/podman/v4/pkg/api/types"
+	"github.com/containers/podman/v4/pkg/domain/entities"
+	"github.com/containers/podman/v4/pkg/domain/infra/abi"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func DownKube(w http.ResponseWriter, r *http.Request) {
+	PlayKubeDown(w, r)
+}
+
+func PlayKubeDown(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+	tmpfile, err := os.CreateTemp("", "libpod-play-kube.yml")
+	if err != nil {
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+		return
+	}
+	defer func() {
+		if err := os.Remove(tmpfile.Name()); err != nil {
+			logrus.Warn(err)
+		}
+	}()
+	if _, err := io.Copy(tmpfile, r.Body); err != nil && err != io.EOF {
+		if err := tmpfile.Close(); err != nil {
+			logrus.Warn(err)
+		}
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to write archive to temporary file"))
+		return
+	}
+	if err := tmpfile.Close(); err != nil {
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error closing temporary file"))
+		return
+	}
+	containerEngine := abi.ContainerEngine{Libpod: runtime}
+	options := new(entities.PlayKubeDownOptions)
+	report, err := containerEngine.PlayKubeDown(r.Context(), tmpfile.Name(), *options)
+	if err != nil {
+		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error tearing down YAML file"))
+		return
+	}
+	utils.WriteResponse(w, http.StatusOK, report)
+}

--- a/pkg/bindings/down/play.go
+++ b/pkg/bindings/down/play.go
@@ -1,0 +1,39 @@
+package down
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	"github.com/containers/podman/v4/pkg/bindings"
+	"github.com/containers/podman/v4/pkg/domain/entities"
+	"github.com/sirupsen/logrus"
+)
+
+func KubeDown(ctx context.Context, path string) (*entities.PlayKubeReport, error) {
+	// TODO: should this be entities.PlayKubeTeardown?
+	var report entities.PlayKubeReport
+	conn, err := bindings.GetClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			logrus.Warn(err)
+		}
+	}()
+	response, err := conn.DoRequest(ctx, f, http.MethodDelete, "/play/kube", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := response.Process(&report); err != nil {
+		return nil, err
+	}
+
+	return &report, nil
+}

--- a/pkg/bindings/play/play.go
+++ b/pkg/bindings/play/play.go
@@ -9,8 +9,8 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v4/pkg/auth"
 	"github.com/containers/podman/v4/pkg/bindings"
+	"github.com/containers/podman/v4/pkg/bindings/down"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/sirupsen/logrus"
 )
 
 func Kube(ctx context.Context, path string, options *KubeOptions) (*entities.PlayKubeReport, error) {
@@ -60,28 +60,5 @@ func Kube(ctx context.Context, path string, options *KubeOptions) (*entities.Pla
 }
 
 func KubeDown(ctx context.Context, path string) (*entities.PlayKubeReport, error) {
-	var report entities.PlayKubeReport
-	conn, err := bindings.GetClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := f.Close(); err != nil {
-			logrus.Warn(err)
-		}
-	}()
-	response, err := conn.DoRequest(ctx, f, http.MethodDelete, "/play/kube", nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	if err := response.Process(&report); err != nil {
-		return nil, err
-	}
-
-	return &report, nil
+	return down.KubeDown(ctx, path)
 }

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -85,7 +85,7 @@ type PlayKubeReport struct {
 // PlayKubeDownOptions are options for tearing down pods
 type PlayKubeDownOptions struct{}
 
-// PlayKubeDownReport contains the results of tearing down play kube
+// PlayKubeTeardown contains the results of tearing down play kube
 type PlayKubeTeardown struct {
 	StopReport []*PodStopReport
 	RmReport   []*PodRmReport


### PR DESCRIPTION
Add a "podman down kube" command analogous to "podman play kube".

Closes: #12475

Signed-off-by: Jonathan Yu <jawnsy@cpan.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
