### PR TITLE
provide better error on invalid flag

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -72,6 +72,8 @@ func parseCommands() *cobra.Command {
 		}
 		parent.AddCommand(c.Command)
 
+		c.Command.SetFlagErrorFunc(flagErrorFuncfunc)
+
 		// - templates need to be set here, as PersistentPreRunE() is
 		// not called when --help is used.
 		// - rootCmd uses cobra default template not ours
@@ -84,5 +86,11 @@ func parseCommands() *cobra.Command {
 		os.Exit(1)
 	}
 
+	rootCmd.SetFlagErrorFunc(flagErrorFuncfunc)
 	return rootCmd
+}
+
+func flagErrorFuncfunc(c *cobra.Command, e error) error {
+	e = fmt.Errorf("%w\nSee '%s --help'", e, c.CommandPath())
+	return e
 }

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -88,7 +88,8 @@ function setup() {
 
     # ...but no matter what, --remote is never allowed after subcommand
     PODMAN="${podman_non_remote} ${podman_args[@]}" run_podman 125 version --remote
-    is "$output" "Error: unknown flag: --remote" "podman version --remote"
+    is "$output" "Error: unknown flag: --remote
+See 'podman version --help'" "podman version --remote"
 }
 
 @test "podman-remote: defaults" {

--- a/test/system/300-cli-parsing.bats
+++ b/test/system/300-cli-parsing.bats
@@ -12,4 +12,18 @@ load helpers
     run_podman run --rm --label 'true="false"' $IMAGE true
 }
 
+@test "podman flag error" {
+    local name="podman"
+    if is_remote; then
+        name="podman-remote"
+    fi
+    run_podman 125 run -h
+    is "$output" "Error: flag needs an argument: 'h' in -h
+See '$name run --help'" "expected error output"
+
+    run_podman 125 bad --invalid
+    is "$output" "Error: unknown flag: --invalid
+See '$name --help'" "expected error output"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Add a extra `See 'podman command --help'` to the error output.
With this patch you now get:
```
$ podman run -h
Error: flag needs an argument: 'h' in -h
See 'podman run --help'
```

Fixes #13082
Fixes #13002

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
