### PR TITLE
System tests: show one-line config overview

### DIFF
--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -33,6 +33,23 @@ function setup() {
     fi
 }
 
+@test "podman info" {
+    # These will be displayed on the test output stream, offering an
+    # at-a-glance overview of important system configuration details
+    local -a want=(
+        'Arch:{{.Host.Arch}}'
+        'OS:{{.Host.Distribution.Distribution}}{{.Host.Distribution.Version}}'
+        'Runtime:{{.Host.OCIRuntime.Name}}'
+        'Rootless:{{.Host.Security.Rootless}}'
+        'Events:{{.Host.EventLogger}}'
+        'Logdriver:{{.Host.LogDriver}}'
+        'Cgroups:{{.Host.CgroupsVersion}}+{{.Host.CgroupManager}}'
+        'Net:{{.Host.NetworkBackend}}'
+    )
+    run_podman info --format "$(IFS='/' echo ${want[@]})"
+    echo "# $output" >&3
+}
+
 
 @test "podman --context emits reasonable output" {
     # All we care about here is that the command passes


### PR DESCRIPTION
We're running into problems that are impossible to diagnose
because we have no idea if the SUT is using netavark or CNI.
We've previously run into similar problems with runc/crun,
or cgroups 1/2.

This adds a one-line 'echo' with important system info. Now,
when viewing a full test log, it will be possible to view
system settings in one glance.

Signed-off-by: Ed Santiago <santiago@redhat.com>
