### PR TITLE
system tests: cleanup networks on teardown

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -108,6 +108,7 @@ function basic_teardown() {
     echo "# [teardown]" >&2
     run_podman '?' pod rm -t 0 --all --force --ignore
     run_podman '?'     rm -t 0 --all --force --ignore
+    run_podman '?' network prune --force
 
     command rm -rf $PODMAN_TMPDIR
 }


### PR DESCRIPTION
When a test which creates a network fail it will not remove the network.
The teardown logic should remove the networks. Since there is no --all
option for network rm we use network prune --force.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
