### PR TITLE
container-commit: support `--squash` to squash layers into one if users want.

### DIFF
--- a/cmd/podman/containers/commit.go
+++ b/cmd/podman/containers/commit.go
@@ -77,6 +77,7 @@ func commitFlags(cmd *cobra.Command) {
 
 	flags.BoolVarP(&commitOptions.Pause, "pause", "p", false, "Pause container during commit")
 	flags.BoolVarP(&commitOptions.Quiet, "quiet", "q", false, "Suppress output")
+	flags.BoolVarP(&commitOptions.Squash, "squash", "s", false, "squash newly built layers into a single new layer")
 	flags.BoolVar(&commitOptions.IncludeVolumes, "include-volumes", false, "Include container volumes as image volumes")
 }
 

--- a/docs/source/markdown/podman-commit.1.md
+++ b/docs/source/markdown/podman-commit.1.md
@@ -60,6 +60,11 @@ Set commit message for committed image.\
 Pause the container when creating an image.\
 The default is **false**.
 
+#### **--squash**, **-s**
+
+Squash newly built layers into a single new layer.\
+The default is **false**.
+
 #### **--quiet**, **-q**
 
 Suppresses output.\

--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -27,6 +27,7 @@ type ContainerCommitOptions struct {
 	Author         string
 	Message        string
 	Changes        []string
+	Squash         bool
 }
 
 // Commit commits the changes between a container and its image, creating a new
@@ -63,6 +64,7 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 	commitOptions := buildah.CommitOptions{
 		SignaturePolicyPath:   options.SignaturePolicyPath,
 		ReportWriter:          options.ReportWriter,
+		Squash:                options.Squash,
 		SystemContext:         c.runtime.imageContext,
 		PreferredManifestType: options.PreferredManifestType,
 	}

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -102,6 +102,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 		Comment   string   `schema:"comment"`
 		Container string   `schema:"container"`
 		Pause     bool     `schema:"pause"`
+		Squash    bool     `schema:"squash"`
 		Repo      string   `schema:"repo"`
 		Tag       string   `schema:"tag"`
 		// fromSrc   string  # fromSrc is currently unused
@@ -138,6 +139,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	options.Message = query.Comment
 	options.Author = query.Author
 	options.Pause = query.Pause
+	options.Squash = query.Squash
 	for _, change := range query.Changes {
 		options.Changes = append(options.Changes, strings.Split(change, "\n")...)
 	}

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -497,6 +497,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 		Container string   `schema:"container"`
 		Format    string   `schema:"format"`
 		Pause     bool     `schema:"pause"`
+		Squash    bool     `schema:"squash"`
 		Repo      string   `schema:"repo"`
 		Tag       string   `schema:"tag"`
 	}{
@@ -543,6 +544,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	options.Message = query.Comment
 	options.Author = query.Author
 	options.Pause = query.Pause
+	options.Squash = query.Squash
 	options.Changes = query.Changes
 	ctr, err := runtime.LookupContainer(query.Container)
 	if err != nil {

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -460,6 +460,10 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    name: changes
 	//    type: string
 	//    description: instructions to apply while committing in Dockerfile format
+	//  - in: query
+	//    name: squash
+	//    type: boolean
+	//    description: squash newly built layers into a single new layer
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -30,6 +30,7 @@ type CommitOptions struct {
 	Comment *string
 	Format  *string
 	Pause   *bool
+	Squash  *bool
 	Repo    *string
 	Tag     *string
 }

--- a/pkg/bindings/containers/types_commit_options.go
+++ b/pkg/bindings/containers/types_commit_options.go
@@ -92,6 +92,21 @@ func (o *CommitOptions) GetPause() bool {
 	return *o.Pause
 }
 
+// WithSquash set field Squash to given value
+func (o *CommitOptions) WithSquash(value bool) *CommitOptions {
+	o.Squash = &value
+	return o
+}
+
+// GetSquash returns value of field Squash
+func (o *CommitOptions) GetSquash() bool {
+	if o.Squash == nil {
+		var z bool
+		return z
+	}
+	return *o.Squash
+}
+
 // WithRepo set field Repo to given value
 func (o *CommitOptions) WithRepo(value string) *CommitOptions {
 	o.Repo = &value

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -154,6 +154,7 @@ type CommitOptions struct {
 	Message        string
 	Pause          bool
 	Quiet          bool
+	Squash         bool
 	Writer         io.Writer
 }
 

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -528,6 +528,7 @@ func (ic *ContainerEngine) ContainerCommit(ctx context.Context, nameOrID string,
 		Message:        options.Message,
 		Changes:        options.Changes,
 		Author:         options.Author,
+		Squash:         options.Squash,
 	}
 	newImage, err := ctr.Commit(ctx, options.ImageName, opts)
 	if err != nil {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -302,7 +302,7 @@ func (ic *ContainerEngine) ContainerCommit(ctx context.Context, nameOrID string,
 			return nil, errors.Errorf("invalid image name %q", opts.ImageName)
 		}
 	}
-	options := new(containers.CommitOptions).WithAuthor(opts.Author).WithChanges(opts.Changes).WithComment(opts.Message)
+	options := new(containers.CommitOptions).WithAuthor(opts.Author).WithChanges(opts.Changes).WithComment(opts.Message).WithSquash(opts.Squash)
 	options.WithFormat(opts.Format).WithPause(opts.Pause).WithRepo(repo).WithTag(tag)
 	response, err := containers.Commit(ic.ClientCtx, nameOrID, options)
 	if err != nil {


### PR DESCRIPTION
Allow users to commit containers into a single layer.

Usage
```bash
podman container commit --squash <name>
```

Closes: https://github.com/containers/podman/issues/12889