### PR TITLE
kube: honor mount propagation mode

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -322,7 +322,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 			continue
 		}
 
-		dest, options, err := parseMountPath(volume.MountPath, volume.ReadOnly)
+		dest, options, err := parseMountPath(volume.MountPath, volume.ReadOnly, volume.MountPropagation)
 		if err != nil {
 			return nil, err
 		}
@@ -388,7 +388,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	return s, nil
 }
 
-func parseMountPath(mountPath string, readOnly bool) (string, []string, error) {
+func parseMountPath(mountPath string, readOnly bool, propagationMode *v1.MountPropagationMode) (string, []string, error) {
 	options := []string{}
 	splitVol := strings.Split(mountPath, ":")
 	if len(splitVol) > 2 {
@@ -407,6 +407,18 @@ func parseMountPath(mountPath string, readOnly bool) (string, []string, error) {
 	opts, err := parse.ValidateVolumeOpts(options)
 	if err != nil {
 		return "", opts, errors.Wrapf(err, "parsing MountOptions")
+	}
+	if propagationMode != nil {
+		switch *propagationMode {
+		case v1.MountPropagationNone:
+			opts = append(opts, "private")
+		case v1.MountPropagationHostToContainer:
+			opts = append(opts, "rslave")
+		case v1.MountPropagationBidirectional:
+			opts = append(opts, "rshared")
+		default:
+			return "", opts, errors.Errorf("unknown propagation mode %q", *propagationMode)
+		}
 	}
 	return dest, opts, nil
 }

--- a/pkg/specgen/generate/kube/kube_test.go
+++ b/pkg/specgen/generate/kube/kube_test.go
@@ -1,0 +1,42 @@
+package kube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	//"github.com/stretchr/testify/require"
+)
+
+func testPropagation(t *testing.T, propagation v1.MountPropagationMode, expected string) {
+	dest, options, err := parseMountPath("/to", false, &propagation)
+	assert.NoError(t, err)
+	assert.Equal(t, dest, "/to")
+	assert.Contains(t, options, expected)
+}
+
+func TestParseMountPathPropagation(t *testing.T) {
+	testPropagation(t, v1.MountPropagationNone, "private")
+	testPropagation(t, v1.MountPropagationHostToContainer, "rslave")
+	testPropagation(t, v1.MountPropagationBidirectional, "rshared")
+
+	prop := v1.MountPropagationMode("SpaceWave")
+	_, _, err := parseMountPath("/to", false, &prop)
+	assert.Error(t, err)
+
+	_, options, err := parseMountPath("/to", false, nil)
+	assert.NoError(t, err)
+	assert.NotContains(t, options, "private")
+	assert.NotContains(t, options, "rslave")
+	assert.NotContains(t, options, "rshared")
+}
+
+func TestParseMountPathRO(t *testing.T) {
+	_, options, err := parseMountPath("/to", true, nil)
+	assert.NoError(t, err)
+	assert.Contains(t, options, "ro")
+
+	_, options, err = parseMountPath("/to", false, nil)
+	assert.NoError(t, err)
+	assert.NotContains(t, options, "ro")
+}


### PR DESCRIPTION
convert the propagation mode specified for the mount to the expected
Linux mount option.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
