### PR TITLE
Improve the error message for usused configMaps

### DIFF
--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -72,9 +72,11 @@ disable builds.
 
 `Kubernetes ConfigMap`
 
-Kubernetes ConfigMap can be referred as a source of environment variables in Pods or Deployments.
+Kubernetes ConfigMap can be referred as a source of environment variables or volumes in Pods or Deployments.
+ConfigMaps aren't a standalone object in Podman; instead, when a container uses a ConfigMap, Podman will create environment variables or volumes as needed.
 
-For example ConfigMap defined in following YAML:
+For example, the following YAML document defines a ConfigMap and then uses it in a Pod:
+
 ```
 apiVersion: v1
 kind: ConfigMap
@@ -82,14 +84,11 @@ metadata:
   name: foo
 data:
     FOO: bar
-```
-
-can be referred in a Pod in following way:
-```
+---
 apiVersion: v1
 kind: Pod
 metadata:
-...
+  name: foobar
 spec:
   containers:
   - command:

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -128,6 +128,9 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, path string, options en
 	}
 
 	if validKinds == 0 {
+		if len(configMaps) > 0 {
+			return nil, fmt.Errorf("ConfigMaps in podman are not a standalone object and must be used in a container")
+		}
 		return nil, fmt.Errorf("YAML document does not contain any supported kube kind")
 	}
 


### PR DESCRIPTION
If you run `podman play kube` on a yaml file that only contains
configMaps, podman will fail with the error:

	Error: YAML document does not contain any supported kube kind

This is not strictly true; configMaps are a supported kube kind. The
problem is that configMaps aren't a standalone entity. They have to be
used in a container somewhere, otherwise they don't do anything.

This change adds a new message in the case when there only configMaps
resources. It would be helpful if podman reported which configMaps are
unused on every invocation of kube play. However, even if that feedback
were added, this new error messages still helpfully explains the reason
that podman is not creating any resources.

[NO TESTS NEEDED]

Signed-off-by: Jordan Christiansen <xordspar0@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
