### PR TITLE
[CI:DOCS] generate-systemd: pod requires an infra container

### DIFF
--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -10,6 +10,8 @@ podman\-generate\-systemd - Generate systemd unit file(s) for a container or pod
 **podman generate systemd** will create a systemd unit file that can be used to control a container or pod.
 By default, the command will print the content of the unit files to stdout.
 
+Generating unit files for a pod requires the pod to be created with an infra container (see `--infra=true`).  An infra container runs across the entire lifespan of a pod and is hence required for systemd to manage the life cycle of the pod's main unit.
+
 _Note: If you use this command with the remote client, including Mac and Windows (excluding WSL2) machines, you would still have to place the generated units on the remote system.  Moreover, please make sure that the XDG_RUNTIME_DIR environment variable is set.  If unset, you may set it via `export XDG_RUNTIME_DIR=/run/user/$(id -u)`._
 
 ## OPTIONS


### PR DESCRIPTION
Generating unit files for a pod requires the pod to be created with an
infra container (see `--infra=true`).  An infra container runs across
the entire lifespan of a pod and is hence required for systemd to manage
the life cycle of the pod's main unit.

This issue came up on the mailing list.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>