### PR TITLE
Show version of the deb package in info output

### DIFF
--- a/libpod/util.go
+++ b/libpod/util.go
@@ -149,6 +149,14 @@ func queryPackageVersion(cmdArg ...string) string {
 		cmd := exec.Command(cmdArg[0], cmdArg[1:]...)
 		if outp, err := cmd.Output(); err == nil {
 			output = string(outp)
+			if cmdArg[0] == "/usr/bin/dpkg" {
+				r := strings.Split(output, ": ")
+				queryFormat := `${Package}_${Version}_${Architecture}`
+				cmd = exec.Command("/usr/bin/dpkg-query", "-f", queryFormat, "-W", r[0])
+				if outp, err := cmd.Output(); err == nil {
+					output = string(outp)
+				}
+			}
 		}
 		if cmdArg[0] == "/sbin/apk" {
 			prefix := cmdArg[len(cmdArg)-1] + " is owned by "


### PR DESCRIPTION
Previously just showing name of the package, followed by
the path repeated again (already stated on the line above)


BEFORE:

```
  conmon:
    package: 'conmon: /usr/libexec/podman/conmon'
    path: /usr/libexec/podman/conmon
```

```
    name: crun
    package: 'crun: /usr/bin/crun'
    path: /usr/bin/crun
```

```
  slirp4netns:
    executable: /usr/bin/slirp4netns
    package: 'slirp4netns: /usr/bin/slirp4netns'
```


AFTER

```
  conmon:
    package: conmon_100:2.0.30-2_amd64
    path: /usr/libexec/podman/conmon
```

```
    name: crun
    package: crun_100:1.2-2_amd64
    path: /usr/bin/crun
```

```
  slirp4netns:
    executable: /usr/bin/slirp4netns
    package: slirp4netns_100:1.1.8-3_amd64
```
