### PR TITLE
[CI:BUILD] Cirrus: Collect test-RPM artifacts

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -234,6 +234,8 @@ function _run_altbuild() {
             ;;
         *RPM*)
             make package
+            find /tmp/rpkg/podman* -type f -name '*.rpm' -exec \
+                cp --target-directory=$GOSRC '{}' +
             ;;
         Alt*Cross)
             arches=(\


### PR DESCRIPTION
When this jobs runs on a branch, the latest successful copies of these
files will be available via a consistent URL as described at:
https://cirrus-ci.org/guide/writing-tasks/#latest-build-artifacts

/cc @jwhonce 