### PR TITLE
copr packaging: use generic macros for tmpfiles and modules load dirs

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -244,9 +244,9 @@ done
 %{_userunitdir}/%{name}.service
 %{_userunitdir}/%{name}.socket
 %{_userunitdir}/%{name}-restart.service
-%{_usr}/lib/tmpfiles.d/%{name}.conf
+%{_tmpfilesdir}/%{name}.conf
 %if 0%{?fedora} >= 36
-    %{_usr}/lib/modules-load.d/%{name}-iptables.conf
+%{_modulesloaddir}/%{name}-iptables.conf
 %endif
 
 %files docker


### PR DESCRIPTION
[NO NEW TESTS NEEDED]

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@baude @mheon @Luap99 @rhatdan PTAL

/cc @containers/podman-maintainers 