### PR TITLE
Option --url and --connection should imply --remote.

### DIFF
--- a/cmd/podman/registry/remote.go
+++ b/cmd/podman/registry/remote.go
@@ -30,6 +30,12 @@ func IsRemote() bool {
 		fs.Usage = func() {}
 		fs.SetInterspersed(false)
 		fs.BoolVarP(&remoteFromCLI.Value, "remote", "r", remote, "")
+		connectionFlagName := "connection"
+		ignoredConnection := ""
+		fs.StringVarP(&ignoredConnection, connectionFlagName, "c", "", "")
+		urlFlagName := "url"
+		ignoredURL := ""
+		fs.StringVar(&ignoredURL, urlFlagName, "", "")
 
 		// The shell completion logic will call a command called "__complete" or "__completeNoDesc"
 		// This command will always be the second argument
@@ -39,6 +45,8 @@ func IsRemote() bool {
 			start = 2
 		}
 		_ = fs.Parse(os.Args[start:])
+		// --connection or --url implies --remote
+		remoteFromCLI.Value = remoteFromCLI.Value || fs.Changed(connectionFlagName) || fs.Changed(urlFlagName)
 	})
 	return podmanOptions.EngineMode == entities.TunnelMode || remoteFromCLI.Value
 }

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -42,6 +42,7 @@ and "$graphroot/networks" as rootless.
 
 #### **--connection**, **-c**
 Connection to use for remote podman, including Mac and Windows (excluding WSL2) machines, (Default connection is configured in `containers.conf`)
+Setting this option will switch the **--remote** option to true.
 Remote connections use local containers.conf for default.
 
 #### **--conmon**
@@ -108,6 +109,7 @@ environment variable is set, the **--remote** option defaults to true.
 
 #### **--url**=*value*
 URL to access Podman service (default from `containers.conf`, rootless `unix://run/user/$UID/podman/podman.sock` or as root `unix://run/podman/podman.sock`).
+Setting this option will switch the **--remote** option to true.
 
  - `CONTAINER_HOST` is of the format `<schema>://[<user[:<password>]@]<host>[:<port>][<path>]`
 

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -126,6 +126,17 @@ See 'podman version --help'" "podman version --remote"
     if grep -- " --remote " <<<"$output"; then
         die "podman --help, with CONTAINER_CONNECTION set, is showing --remote"
     fi
+
+    # When it detects --url or --connection, --remote is not an option
+    run_podman --url foobar --help
+    if grep -- " --remote " <<<"$output"; then
+        die "podman --help, with --url set, is showing --remote"
+    fi
+
+    run_podman --connection foobar --help
+    if grep -- " --remote " <<<"$output"; then
+        die "podman --help, with --connection set, is showing --remote"
+    fi
 }
 
 # Check that just calling "podman-remote" prints the usage message even


### PR DESCRIPTION
Closes #13242

This is a backport of #13296 in branch "v4.0". I have read in another issue that Red Hat plans on shipping podman 4 in RHEL 8.6 in couple of months, I am a RHEL user and I expect to see this commit part of the next RHEL 8.6 release ;)

I am not sure what is your policy for backport though, nor if I shall go though the paying Red Hat customer portal for these requests, so feel free to decline if I have done it the wrong way.