### PR TITLE
Inspect network info of a joined network namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/vbauerster/mpb/v6 v6.0.4
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
+	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
 	go.etcd.io/bbolt v1.3.6
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c


### PR DESCRIPTION
- Display network info of a joined network namespace upon inspect
  Join network namespace and query interfaces/IPs/gateway
- Due to discrepancy between libpod API and Docker API secondaryIPAddresses are
left out intentionally but included in main branch PR https://github.com/containers/podman/pull/13366

Signed-off-by: Mostafa Emami <mustafaemami@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
