### PR TITLE
bindings: manifest should follow `es_model` naming convention while marshalling `OSVersion` and `OSFeatures`

### DIFF
--- a/pkg/bindings/manifests/types.go
+++ b/pkg/bindings/manifests/types.go
@@ -44,16 +44,18 @@ type RemoveOptions struct {
 type ModifyOptions struct {
 	// Operation values are "update", "remove" and "annotate". This allows the service to
 	//   efficiently perform each update on a manifest list.
-	Operation     *string
-	All           *bool             // All when true, operate on all images in a manifest list that may be included in Images
-	Annotations   map[string]string // Annotations to add to manifest list
-	Arch          *string           // Arch overrides the architecture for the image
-	Features      []string          // Feature list for the image
-	Images        []string          // Images is an optional list of images to add/remove to/from manifest list depending on operation
-	OS            *string           // OS overrides the operating system for the image
-	OSFeatures    []string          // OS features for the image
-	OSVersion     *string           // OSVersion overrides the operating system for the image
-	Variant       *string           // Variant overrides the operating system variant for the image
+	Operation   *string
+	All         *bool             // All when true, operate on all images in a manifest list that may be included in Images
+	Annotations map[string]string // Annotations to add to manifest list
+	Arch        *string           // Arch overrides the architecture for the image
+	Features    []string          // Feature list for the image
+	Images      []string          // Images is an optional list of images to add/remove to/from manifest list depending on operation
+	OS          *string           // OS overrides the operating system for the image
+	// OS features for the image
+	OSFeatures []string `json:"os_features" schema:"os_features"`
+	// OSVersion overrides the operating system for the image
+	OSVersion     *string `json:"os_version" schema:"os_version"`
+	Variant       *string // Variant overrides the operating system variant for the image
 	Authfile      *string
 	Password      *string
 	Username      *string

--- a/pkg/bindings/manifests/types_modify_options.go
+++ b/pkg/bindings/manifests/types_modify_options.go
@@ -122,13 +122,13 @@ func (o *ModifyOptions) GetOS() string {
 	return *o.OS
 }
 
-// WithOSFeatures set oS features for the image
+// WithOSFeatures set field OSFeatures to given value
 func (o *ModifyOptions) WithOSFeatures(value []string) *ModifyOptions {
 	o.OSFeatures = value
 	return o
 }
 
-// GetOSFeatures returns value of oS features for the image
+// GetOSFeatures returns value of field OSFeatures
 func (o *ModifyOptions) GetOSFeatures() []string {
 	if o.OSFeatures == nil {
 		var z []string
@@ -137,13 +137,13 @@ func (o *ModifyOptions) GetOSFeatures() []string {
 	return o.OSFeatures
 }
 
-// WithOSVersion set oSVersion overrides the operating system for the image
+// WithOSVersion set field OSVersion to given value
 func (o *ModifyOptions) WithOSVersion(value string) *ModifyOptions {
 	o.OSVersion = &value
 	return o
 }
 
-// GetOSVersion returns value of oSVersion overrides the operating system for the image
+// GetOSVersion returns value of field OSVersion
 func (o *ModifyOptions) GetOSVersion() string {
 	if o.OSVersion == nil {
 		var z string

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -91,6 +91,27 @@ var _ = Describe("Podman manifest", func() {
 		Expect(session.OutputToString()).To(ContainSubstring(imageListARM64InstanceDigest))
 	})
 
+	It("add with new version", func() {
+		// Following test must pass for both podman and podman-remote
+		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		id := strings.TrimSpace(string(session.Out.Contents()))
+
+		session = podmanTest.Podman([]string{"manifest", "inspect", id})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"manifest", "add", "--os-version", "7.7.7", "foo", imageListInstance})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"manifest", "inspect", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("7.7.7"))
+	})
+
 	It("tag", func() {
 		session := podmanTest.Podman([]string{"manifest", "create", "foobar"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
It seems API needs json names for `OSVersion` and `OSFeatures` in `es_model`
ref: https://github.com/containers/podman/blob/main/pkg/domain/entities/manifest.go#L42

So at bindings end ensure that we honor `es_model` naming convention when
we perform marshaling otherwise API will ignore these fields

Closes: https://github.com/containers/podman/issues/12774