### PR TITLE
libpod: drop warning if cgroup doesn't exist

### DIFF
--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod
@@ -5,6 +6,7 @@ package libpod
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -236,7 +238,7 @@ func (r *Runtime) removePod(ctx context.Context, p *Pod, removeCtrs, force bool,
 
 		// Don't try if we failed to retrieve the cgroup
 		if err == nil {
-			if err := conmonCgroup.Update(resLimits); err != nil {
+			if err := conmonCgroup.Update(resLimits); err != nil && !os.IsNotExist(err) {
 				logrus.Warnf("Error updating pod %s conmon cgroup PID limit: %v", p.ID(), err)
 			}
 		}


### PR DESCRIPTION
do not print a warning on cgroup removal if it doesn't exist.

Closes: https://github.com/containers/podman/issues/13382

[NO NEW TESTS NEEDED]

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
