### PR TITLE
[v1.6.4-rhel] stats: report correctly CPU usage

### DIFF
--- a/pkg/cgroups/cpu.go
+++ b/pkg/cgroups/cpu.go
@@ -81,14 +81,14 @@ func (c *cpuHandler) Stat(ctr *CgroupControl, m *Metrics) error {
 			return err
 		}
 		if val, found := values["usage_usec"]; found {
-			usage.Kernel, err = strconv.ParseUint(cleanString(val[0]), 10, 0)
+			usage.Total, err = strconv.ParseUint(cleanString(val[0]), 10, 0)
 			if err != nil {
 				return err
 			}
 			usage.Kernel *= 1000
 		}
 		if val, found := values["system_usec"]; found {
-			usage.Total, err = strconv.ParseUint(cleanString(val[0]), 10, 0)
+			usage.Kernel, err = strconv.ParseUint(cleanString(val[0]), 10, 0)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
[NO NEW TESTS NEEDED}

Backport of #4423 to the v1.6.4-rhel branch so that it
can be included into RHEL 8.2

This fixes the was that CPU is reported from the
`podman stats` command.  This fix was first put into
 podman v1.7.0

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=2060095

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
