### PR TITLE
MacOS improvements

### DIFF
--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine
@@ -28,6 +29,8 @@ type InitOptions struct {
 	Username     string
 	ReExec       bool
 	Rootful      bool
+	// The numberical userid of the user that called machine
+	UID string
 }
 
 type QemuMachineStatus = string

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -1,8 +1,11 @@
+//go:build (amd64 && !windows) || (arm64 && !windows)
 // +build amd64,!windows arm64,!windows
 
 package qemu
 
-import "time"
+import (
+	"time"
+)
 
 type Provider struct{}
 
@@ -35,6 +38,8 @@ type MachineVM struct {
 	RemoteUsername string
 	// Whether this machine should run in a rootful or rootless manner
 	Rootful bool
+	// UID is the numerical id of the user that called machine
+	UID int
 }
 
 type Mount struct {

--- a/pkg/machine/qemu/options_darwin_arm64.go
+++ b/pkg/machine/qemu/options_darwin_arm64.go
@@ -45,6 +45,7 @@ func getOvmfDir(imagePath, vmName string) string {
  */
 func getEdk2CodeFd(name string) string {
 	dirs := []string{
+		"/opt/homebrew/opt/podman/libexec/share/qemu",
 		"/usr/local/share/qemu",
 		"/opt/homebrew/share/qemu",
 	}


### PR DESCRIPTION
* Enable support of virtfs in Podman and darwin.  At the time of this writing, it requires a special patch not yet included in upstream qemu.
* Prefer to use a specially built qemu to support virtfs.  The qemu is installed under libexec/podman.

Signed-off-by: brent baude <brentbaude@brents-Mac-mini.localdomain>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
