### PR TITLE
libpod: pods do not use cgroups if --cgroups=disabled

### DIFF
--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -562,6 +562,11 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		inspect = podmanTest.Podman([]string{"inspect", "--format", "{{ .HostConfig.Cgroups }}", result.OutputToString()})
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect.OutputToString()).To(Equal("disabled"))
+
+		// Check we can also create a pod when cgroups=disabled
+		result = podmanTest.Podman([]string{"pod", "create"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
 	})
 
 	It("podman containers.conf runtime", func() {


### PR DESCRIPTION
do not attempt to use cgroups with pods if the cgroups are disabled.
A similar check is already in place for containers.

Closes: https://github.com/containers/podman/issues/13411

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
