### PR TITLE
Add ExitCommandDelay configuration use in API exec handler

### DIFF
--- a/pkg/api/handlers/compat/exec.go
+++ b/pkg/api/handlers/compat/exec.go
@@ -73,7 +73,7 @@ func ExecCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Run the exit command after 5 minutes, to mimic Docker's exec cleanup
 	// behavior.
-	libpodConfig.ExitCommandDelay = 5 * 60
+	libpodConfig.ExitCommandDelay = runtimeConfig.Engine.ExitCommandDelay
 
 	sessID, err := ctr.ExecCreate(libpodConfig)
 	if err != nil {


### PR DESCRIPTION
This PR closes #13222 and continues from [PR941](https://github.com/containers/common/pull/941). 

It uses the `ExitCommandDelay` configuration value in order to reduce the clutter of many exec process idling in the background. This now allows you to configure this. I currently tested it for the default value and a smaller value by checking the processes and how much time they take to exit and debugged the int value, which was correctly set by changing it in `containers.conf`. In case we need a unit test or any documentation for this, please let me know!

Signed-off-by: Rover van der Noort <s.r.vandernoort@student.tudelft.nl>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
