### PR TITLE
RELEASE_PROCESS.md: build artifacts locally

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -236,18 +236,18 @@ spelled with complete minutiae.
 
    1. Return to the Cirrus-CI Build page for the new release tag, confirm
       (or wait for) it to complete, re-running any failed tasks as appropriate.
-   1. For anything other than an RC, download the new release artifacts from CI
-      (the binaries which were actually tested).  The items are
-      located under the *checks* tab in github for:
+   1. For anything other than an RC, the release artifacts need to be published along
+      with the release. These can be built locally using:
 
-      * `Cirrus CI / Alt Arch. Cross` - tarball for each architecture
-      * `Cirrus CI / OSX Cross` - two zip files (amd64 and arm64)
-      * `Cirrus CI / Windows Cross` - an `msi` file
+      ```shell
+      $ git checkout vX.Y.Z
+      $ make podman-remote-release-darwin_amd64.zip podman-remote-release-darwin_arm64.zip podman-remote-release-windows_amd64.zip podman.msi podman-remote-static
+      $ mv podman-* bin/
+      $ cd bin/
+      $ tar -cvzf podman-remote-static.tar.gz podman-remote-static
+      $ sha256sum *.zip *.msi *.tar.gz > shasums
+      ```
 
-      Under the "Artifacts" section of each task, click the "gosrc" link,
-      find and download the release archive (`zip`, `tar.gz` or `.msi`).
-      Save the the archive with a meaningful name, for example
-      `podman-v3.0.0.msi`.
    1. The `podman-vX.Y.Z.dmg` file is produced manually by someone in
       possession of a developer signing key.
    1. In the directory where you downloaded the archives, run
@@ -263,8 +263,10 @@ spelled with complete minutiae.
       that to upload the artifacts you previously downloaded, including
       the `shasums` file.
 
-      * podman-remote-release-darwin.zip
-      * podman-remote-release-windows.zip
+      * podman-remote-release-darwin_amd64.zip
+      * podman-remote-release-darwin_arm64.zip
+      * podman-remote-release-windows_amd64.zip
       * podman-vX.Y.Z.msi
+      * podman-remote-static.tar.gz
       * shasums
    1. Save the release.


### PR DESCRIPTION
The current PR process for release bump has the HEAD commit which bumps
version/version.go to the form `release+1-dev`. This makes Cirrus
publish release artifacts with `release+1-dev` and not `release`.

For example, the msi generated at https://cirrus-ci.com/task/5403901196238848
says podman-v4.0.3-dev.msi .

Building locally by checking out the released tag would generate the
correct artifacts and would also be faster and more convenient.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


@mheon @ashley-cui @TomSweeneyRedHat @rhatdan @baude PTAL

/cc @containers/podman-maintainers 

DO NOT MERGE without LGTMs from @mheon and @ashley-cui 