### PR TITLE
[CI:DOCS] Remove "(1)" from web tab text

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,8 +72,13 @@ def convert_markdown_title(app, docname, source):
     docpath = app.env.doc2path(docname)
     if docpath.endswith(".md"):
         # Convert pandoc title line into eval_rst block for myst_parser
-        source[0] = re.sub(r"^% (.*)", r"```{title} \g<1>\n```", source[0])
-
+        #
+        # Remove the ending "(1)" to avoid it from being displayed
+        # in the web tab. Often such a text indicates that
+        # a web page got an update. For instance GitHub issues
+        # shows the number of new comments that have been written
+        # after the user's last visit.
+        source[0] = re.sub(r"^% (.*)(\(\d\))", r"```{title} \g<1>\n```", source[0])
 
 def setup(app):
     app.connect("source-read", convert_markdown_title)


### PR DESCRIPTION
* Remove the ending text "(1)" to avoid it from being
  displayed in the web tab title for a command man page
  on the web. Often such a text indicates that a web
  page got an update. For instance GitHub issues shows
  the number of new comments that have been written
  after the user's last visit.
  Fixes #13438

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
