### PR TITLE
[CI:DOCS] troubleshooting.md: mention "podman unshare chown 0:0 path"

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -991,12 +991,15 @@ less: dir1/a: Permission denied
 
 #### Solution
 
-If you want to read or remove such a file, you can do so by entering a user namespace.
-Instead of running commands such as `less dir1/a` or `rm dir1/a`, you would need to
-prepend the command-line with `podman unshare`, i.e.,
-`podman unshare less dir1/a` or `podman unshare rm dir1/a`. To be able to use Bash
-features, such as variable expansion and globbing, you need to wrap the command with
-`bash -c`, e.g. `podman unshare bash -c 'ls $HOME/dir1/a*'`.
+If you want to read, chown, or remove such a file, enter a user
+namespace. Instead of running commands such as `less dir1/a` or `rm dir1/a`, you
+need to prepend the command-line with `podman unshare`, i.e.,
+`podman unshare less dir1/a` or `podman unshare rm dir1/a`. To change the ownership
+of the file _dir1/a_ to your regular user's UID and GID, run `podman unshare chown 0:0 dir1/a`.
+A file having the ownership _0:0_ in the user namespace is owned by the regular
+user on the host. To use Bash features, such as variable expansion and
+globbing, you need to wrap the command with `bash -c`, e.g.
+`podman unshare bash -c 'ls $HOME/dir1/a*'`.
 
 Would it have been possible to run Podman in another way so that your regular
 user would have become the owner of the file? Yes, you can use the options


### PR DESCRIPTION
* Mention the command "podman unshare chown 0:0 dir1/a"
  that changes file ownership to the regular user's UID and GID on
  the host.

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
