### PR TITLE
[WIP] Volume mount paths compatibility on darwin

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -42,6 +42,10 @@ func GetQemuProvider() machine.Provider {
 	return qemuProvider
 }
 
+func getCoreOSTargetMountPath(targetMountPath string) string {
+	return "/mnt" + targetMountPath
+}
+
 const (
 	VolumeTypeVirtfs     = "virtfs"
 	MountType9p          = "9p"
@@ -246,7 +250,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 				virtfsOptions += ",readonly"
 			}
 			v.CmdLine = append(v.CmdLine, []string{"-virtfs", virtfsOptions}...)
-			mounts = append(mounts, Mount{Type: MountType9p, Tag: tag, Source: source, Target: target, ReadOnly: readonly})
+			mounts = append(mounts, Mount{Type: MountType9p, Tag: tag, Source: source, Target: getCoreOSTargetMountPath(target), ReadOnly: readonly})
 		}
 	}
 	v.Mounts = mounts

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -479,17 +479,7 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 	for _, mount := range v.Mounts {
 		fmt.Printf("Mounting volume... %s:%s\n", mount.Source, mount.Target)
 		// create mountpoint directory if it doesn't exist
-		// because / is immutable, we have to monkey around with permissions
-		// if we dont mount in /home or /mnt
-		args := []string{"-q", "--"}
-		if !strings.HasPrefix(mount.Target, "/home") || !strings.HasPrefix(mount.Target, "/mnt") {
-			args = append(args, "sudo", "chattr", "-i", "/", ";")
-		}
-		args = append(args, "sudo", "mkdir", "-p", mount.Target)
-		if !strings.HasPrefix(mount.Target, "/home") || !strings.HasPrefix(mount.Target, "/mnt") {
-			args = append(args, ";", "sudo", "chattr", "+i", "/", ";")
-		}
-		err = v.SSH(name, machine.SSHOptions{Args: args})
+		err = v.SSH(name, machine.SSHOptions{Args: []string{"-q", "--", "sudo", "mkdir", "-p", mount.Target}})
 		if err != nil {
 			return err
 		}

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -126,7 +126,7 @@ func parseVolumes(volumeFlag, mountFlag, tmpfsFlag []string, addReadOnlyTmpfs bo
 			if err != nil {
 				return nil, nil, nil, nil, errors.Wrapf(err, "error getting absolute path of %s", mount.Source)
 			}
-			mount.Source = absSrc
+			mount.Source = util.GetSrcMountPath(absSrc)
 		}
 		finalMounts = append(finalMounts, mount)
 	}

--- a/pkg/util/utils_darwin.go
+++ b/pkg/util/utils_darwin.go
@@ -10,3 +10,7 @@ import (
 func GetContainerPidInformationDescriptors() ([]string, error) {
 	return []string{}, errors.New("this function is not supported on darwin")
 }
+
+func GetSrcMountPath(absolutePath string) string {
+	return "/mnt" + absolutePath
+}

--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -17,6 +17,10 @@ func GetContainerPidInformationDescriptors() ([]string, error) {
 	return psgo.ListDescriptors(), nil
 }
 
+func GetSrcMountPath(absolutePath string) string {
+	return absolutePath
+}
+
 // FindDeviceNodes parses /dev/ into a set of major:minor -> path, where
 // [major:minor] is the device's major and minor numbers formatted as, for
 // example, 2:0 and path is the path to the device node.

--- a/pkg/util/utils_windows.go
+++ b/pkg/util/utils_windows.go
@@ -41,3 +41,7 @@ func GetRuntimeDir() (string, error) {
 func GetRootlessConfigHomeDir() (string, error) {
 	return "", errors.New("this function is not implemented for windows")
 }
+
+func GetSrcMountPath(absolutePath string) string {
+	return "/mnt" + absolutePath
+}


### PR DESCRIPTION
CoreOS disallows mounting at `/`root because it is [immutable](https://docs.fedoraproject.org/en-US/fedora-coreos/storage/#_immutable_read_only_usr).

As an alternative, it is recommended to mount at `/mnt`, e.g: `podman machine init -v /Users:/mnt/Users` on darwin. This, however, breaks compatibility with other tools, e.g. docker desktop, colima when specifying mounts:
```config
\# docker-compose.yml
...
volumes:
    - ./app:/app
```
- Works in colima and docker desktop.
- Fails with `podman run` because it is missing the `/mnt` prefix.

As a result, I can't use podman and docker desktop interchangeably
with one single `docker-compose.yml` file.

This WIP tries to solve that with the following convention:
- `podman machine:` every target mount path into coreOS is internally prefixed with
`/mnt` so that it can be mounted.
- `podman run`: every source mount path is internally prefixed with `/mnt` if you
are on darwin.

Now the last sentence _if youare on darwin_ may break a lot stuff, e.g what happens when using the podman remote client on linux with server vs. when using it with a linux vm. Since I am brand new to this project, it may very well be that this approach is heading into the wrong direction. But it at least works on my m1 Mac and may serve as a good starting point for a discussion for v4.1.

There are multiple approaches to solving this issue. I can currently think of 4:
- Removing the immutability of / in the coreOS image. This allows mounting on root. https://github.com/coreos/fedora-coreos-tracker/issues/270
- Workaround the immutability by first disabling it, mounting the volume and then enabling it again. Currently in master:
https://github.com/containers/podman/blob/4a242b1327fb34e6cac6c1686afb3370901180d3/pkg/machine/qemu/machine.go#L477-L488
- Mounting under `/mnt`, then disabling the immutability using the above trick by @baude, then creating a symlink in root, then enabling immutability again.
- This pr: using a convention.
- ...

