### PR TITLE
machine rm -f stops and removes machine

### DIFF
--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -37,7 +37,7 @@ func init() {
 
 	flags := rmCmd.Flags()
 	formatFlagName := "force"
-	flags.BoolVar(&destoryOptions.Force, formatFlagName, false, "Do not prompt before rming")
+	flags.BoolVarP(&destoryOptions.Force, formatFlagName, "f", false, "Stop and do not prompt before rming")
 
 	keysFlagName := "save-keys"
 	flags.BoolVar(&destoryOptions.SaveKeys, keysFlagName, false, "Do not delete SSH keys")
@@ -64,7 +64,7 @@ func rm(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	confirmationMessage, remove, err := vm.Remove(vmName, machine.RemoveOptions{})
+	confirmationMessage, remove, err := vm.Remove(vmName, destoryOptions)
 	if err != nil {
 		return err
 	}

--- a/docs/source/markdown/podman-machine-rm.1.md
+++ b/docs/source/markdown/podman-machine-rm.1.md
@@ -23,9 +23,9 @@ is used.
 
 Print usage statement.
 
-#### **--force**
+#### **--force**, **-f**
 
-Delete without confirmation
+Stop and delete without confirmation
 
 #### **--save-ignition**
 
@@ -58,6 +58,10 @@ The following files will be deleted:
 Are you sure you want to continue? [y/N] y
 ```
 
+```
+$ podman machine rm -f test1
+$
+```
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-machine(1)](podman-machine.1.md)**
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -679,7 +679,7 @@ func (v *MachineVM) Remove(name string, opts machine.RemoveOptions) (string, fun
 	if err != nil {
 		return "", nil, err
 	}
-	if running {
+	if running && !opts.Force {
 		return "", nil, errors.Errorf("running vm %q cannot be destroyed", v.Name)
 	}
 


### PR DESCRIPTION
If you want to remove a running machine, you can now pass the --force/-f
to podman machine rm and the machine will be stopped and removed without
confirmations.

Fixes: #13448

[NO NEW TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
