### PR TITLE
[v4.0] Backport Set default rule at the head of dev config

### DIFF
--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -325,6 +325,11 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 	// Devices
 
+	// set the default rule at the beginning of device configuration
+	if !inUserNS && !s.Privileged {
+		g.AddLinuxResourcesDevice(false, "", nil, nil, "rwm")
+	}
+
 	var userDevices []spec.LinuxDevice
 	if s.Privileged {
 		// If privileged, we need to add all the host devices to the
@@ -356,7 +361,6 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 
 	// set the devices cgroup when not running in a user namespace
 	if !inUserNS && !s.Privileged {
-		g.AddLinuxResourcesDevice(false, "", nil, nil, "rwm")
 		for _, dev := range s.DeviceCgroupRule {
 			g.AddLinuxResourcesDevice(true, dev.Type, dev.Major, dev.Minor, dev.Access)
 		}

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -44,6 +44,11 @@ var _ = Describe("Podman run device", func() {
 		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg", ALPINE, "test", "-c", "/dev/kmsg"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
+		if !isRootless() {
+			session = podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg", "--cap-add", "SYS_ADMIN", ALPINE, "head", "-n", "1", "/dev/kmsg"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(0))
+		}
 	})
 
 	It("podman run device rename test", func() {


### PR DESCRIPTION
Backports: #13421 Set default rule at the head of device configuration
by @hshiina

The default rule should be set at the head of device configuration.
Otherwise, rules for user devices are overridden by the default rule so
that any access to the user devices are denied.

This has been requested to backport and to include in RHEL 8.6 and 9.0.
The exception process is underway.

Addresses these BZs for the backport:

https://bugzilla.redhat.com/show_bug.cgi?id=2059296
https://bugzilla.redhat.com/show_bug.cgi?id=2062835

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
