### PR TITLE
pod logs enhancements: option to color logs

### DIFF
--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -64,6 +64,7 @@ var (
 		ValidArgsFunction: logsCommand.ValidArgsFunction,
 		Example: `podman container logs ctrID
 		podman container logs --names ctrID1 ctrID2
+		podman container logs --color --names ctrID1 ctrID2
 		podman container logs --tail 2 mywebserver
 		podman container logs --follow=true --since 10m ctrID
 		podman container logs mywebserver mydbserver`,
@@ -112,7 +113,9 @@ func logsFlags(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(tailFlagName, completion.AutocompleteNone)
 
 	flags.BoolVarP(&logsOptions.Timestamps, "timestamps", "t", false, "Output the timestamps in the log")
+	flags.BoolVarP(&logsOptions.Colors, "color", "", false, "Output the containers with different colors in the log.")
 	flags.BoolVarP(&logsOptions.Names, "names", "n", false, "Output the container name in the log")
+
 	flags.SetInterspersed(false)
 	_ = flags.MarkHidden("details")
 }

--- a/cmd/podman/pods/logs.go
+++ b/cmd/podman/pods/logs.go
@@ -89,6 +89,8 @@ func logsFlags(cmd *cobra.Command) {
 
 	flags.BoolVarP(&logsPodOptions.Names, "names", "n", false, "Output container names instead of container IDs in the log")
 	flags.BoolVarP(&logsPodOptions.Timestamps, "timestamps", "t", false, "Output the timestamps in the log")
+	flags.BoolVarP(&logsPodOptions.Colors, "color", "", false, "Output the containers within a pod with different colors in the log")
+
 	flags.SetInterspersed(false)
 	_ = flags.MarkHidden("details")
 }

--- a/docs/source/markdown/podman-logs.1.md
+++ b/docs/source/markdown/podman-logs.1.md
@@ -15,6 +15,10 @@ any logs at the time you execute podman logs).
 
 ## OPTIONS
 
+#### **--color**
+
+Output the containers with different colors in the log.
+
 #### **--follow**, **-f**
 
 Follow log output.  Default is false.

--- a/docs/source/markdown/podman-pod-logs.1.md
+++ b/docs/source/markdown/podman-pod-logs.1.md
@@ -13,6 +13,10 @@ Note: Long running command of `podman pod log` with a `-f` or `--follow` needs t
 
 ## OPTIONS
 
+#### **--color**
+
+Output the containers with different colors in the log.
+
 #### **--container**, **-c**
 
 By default `podman pod logs` retrieves logs for all the containers available within the pod differentiate by field `container`. However there are use-cases where user would want to limit the log stream only to a particular container of a pod for such cases `-c` can be used like `podman pod logs -c ctrNameorID podname`.

--- a/libpod/container_log_linux.go
+++ b/libpod/container_log_linux.go
@@ -45,7 +45,7 @@ func (c *Container) initializeJournal(ctx context.Context) error {
 	return journal.Send("", journal.PriInfo, m)
 }
 
-func (c *Container) readFromJournal(ctx context.Context, options *logs.LogOptions, logChannel chan *logs.LogLine) error {
+func (c *Container) readFromJournal(ctx context.Context, options *logs.LogOptions, logChannel chan *logs.LogLine, colorID int64) error {
 	// We need the container's events in the same journal to guarantee
 	// consistency, see #10323.
 	if options.Follow && c.runtime.config.Engine.EventsLogger != "journald" {
@@ -231,6 +231,7 @@ func (c *Container) readFromJournal(ctx context.Context, options *logs.LogOption
 			}
 
 			logLine, err := logs.NewJournaldLogLine(message, options.Multi)
+			logLine.ColorID = colorID
 			if err != nil {
 				logrus.Errorf("Failed parse log line: %v", err)
 				return

--- a/libpod/container_log_unsupported.go
+++ b/libpod/container_log_unsupported.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (c *Container) readFromJournal(_ context.Context, _ *logs.LogOptions, _ chan *logs.LogLine) error {
+func (c *Container) readFromJournal(_ context.Context, _ *logs.LogOptions, _ chan *logs.LogLine, colorID int64) error {
 	return errors.Wrapf(define.ErrOSNotSupported, "Journald logging only enabled with systemd on linux")
 }
 

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -661,7 +661,7 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 			}
 			errChan <- err
 		}()
-		if err := ctr.ReadLog(context.Background(), logOpts, logChan); err != nil {
+		if err := ctr.ReadLog(context.Background(), logOpts, logChan, 0); err != nil {
 			return err
 		}
 		go func() {

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -257,6 +257,8 @@ type ContainerLogsOptions struct {
 	Tail int64
 	// Show timestamps in the logs.
 	Timestamps bool
+	// Show different colors in the logs.
+	Colors bool
 	// Write the stdout to this Writer.
 	StdoutWriter io.Writer
 	// Write the stderr to this Writer.

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -149,6 +149,8 @@ type PodLogsOptions struct {
 	ContainerLogsOptions
 	// If specified will only fetch the logs of specified container
 	ContainerName string
+	// Show different colors in the logs.
+	Color bool
 }
 
 type ContainerCreateOptions struct {
@@ -482,6 +484,7 @@ func PodLogsOptionsToContainerLogsOptions(options PodLogsOptions) ContainerLogsO
 		Until:        options.Until,
 		Tail:         options.Tail,
 		Timestamps:   options.Timestamps,
+		Colors:       options.Colors,
 		StdoutWriter: options.StdoutWriter,
 		StderrWriter: options.StderrWriter,
 	}

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1088,6 +1088,7 @@ func (ic *ContainerEngine) ContainerLogs(ctx context.Context, containers []strin
 		Until:      options.Until,
 		Tail:       options.Tail,
 		Timestamps: options.Timestamps,
+		Colors:     options.Colors,
 		UseName:    options.Names,
 		WaitGroup:  &wg,
 	}


### PR DESCRIPTION
Created an option to colourise ```pod logs``` with an option ```--color```.  You can recreate with the following steps:

1. Create a pod with containers
```bash
bin/podman pod create --name=pod_testlogs; bin/podman run --name=testlogs_loop1_1 -d --pod=pod_testlogs busybox /bin/sh -c 'for i in `seq 1 10000`; do echo "loop1: $i"; sleep 1; done'; bin/podman run --name=testlogs_loop2_1 -d --pod=pod_testlogs busybox /bin/sh -c 'for i in `seq 1 10000`; do echo "loop2: $i"; sleep 3; done';
```

2. Logs with colour:

```bash
bin/podman pod logs --tail=10 -f --color pod_testlogs
```

3. Kill all pods and remove containers:

```bash
bin/podman kill --all; bin/podman rm --all; bin/podman pod rm --all
```

Closes #13266 