### PR TITLE
Fixes TTY & resizing on Mac and Windows

### DIFF
--- a/pkg/bindings/containers/term_unix.go
+++ b/pkg/bindings/containers/term_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+// +build !windows
+
+package containers
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	sig "github.com/containers/podman/v4/pkg/signal"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func makeRawTerm(stdin *os.File) (*terminal.State, error) {
+	return terminal.MakeRaw(int(stdin.Fd()))
+}
+
+func notifyWinChange(ctx context.Context, winChange chan os.Signal, stdin *os.File, stdout *os.File) {
+	signal.Notify(winChange, sig.SIGWINCH)
+}
+
+func getTermSize(stdin *os.File, stdout *os.File) (width, height int, err error) {
+	return terminal.GetSize(int(stdin.Fd()))
+}

--- a/pkg/bindings/containers/term_windows.go
+++ b/pkg/bindings/containers/term_windows.go
@@ -1,0 +1,69 @@
+package containers
+
+import (
+	"context"
+	"os"
+	"time"
+
+	sig "github.com/containers/podman/v4/pkg/signal"
+	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/sys/windows"
+)
+
+func makeRawTerm(stdin *os.File) (*terminal.State, error) {
+	state, err := terminal.MakeRaw(int(stdin.Fd()))
+	if err != nil {
+		return nil, err
+	}
+
+	// Attempt VT if supported (recent versions of Windows 10+)
+	var raw uint32
+	handle := windows.Handle(stdin.Fd())
+	if err := windows.GetConsoleMode(handle, &raw); err != nil {
+		return nil, err
+	}
+
+	tryVT := raw | windows.ENABLE_VIRTUAL_TERMINAL_INPUT
+
+	if err := windows.SetConsoleMode(handle, tryVT); err != nil {
+		if err := windows.SetConsoleMode(handle, raw); err != nil {
+			return nil, err
+		}
+	}
+
+	return state, nil
+}
+
+func notifyWinChange(ctx context.Context, winChange chan os.Signal, stdin *os.File, stdout *os.File) {
+	// Simulate WINCH with polling
+	go func() {
+		var lastW int
+		var lastH int
+
+		d := time.Millisecond * 250
+		timer := time.NewTimer(d)
+		defer timer.Stop()
+		for ; ; timer.Reset(d) {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				break
+			}
+
+			w, h, err := terminal.GetSize(int(stdout.Fd()))
+			if err != nil {
+				continue
+			}
+			if w != lastW || h != lastH {
+				winChange <- sig.SIGWINCH
+				lastW, lastH = w, h
+			}
+		}
+	}()
+
+}
+
+func getTermSize(stdin *os.File, stdout *os.File) (width, height int, err error) {
+	return terminal.GetSize(int(stdout.Fd()))
+}

--- a/pkg/signal/signal_unix.go
+++ b/pkg/signal/signal_unix.go
@@ -1,4 +1,4 @@
-// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris,!zos
+// +build aix darwin dragonfly freebsd netbsd openbsd solaris zos
 
 // Signal handling for Linux only.
 package signal
@@ -12,7 +12,7 @@ const (
 	sigrtmin = 34
 	sigrtmax = 64
 
-	SIGWINCH = syscall.Signal(0xff)
+	SIGWINCH = syscall.SIGWINCH
 )
 
 // signalMap is a map of Linux signals.


### PR DESCRIPTION
On Windows:

- Fixes "Failed to obtain TTY size" (the size call needs to be against stdout, the rest stdin)
- Adds support for vt100+ input so that cursor keys + escape work
- Implements window resizing via a polling methodology (only reliable solution on windows)

On Mac and other Unixes

- Added SIGWINCH support for all OSs that have it 

Signed-off-by: Jason T. Greene <jason.greene@redhat.com>

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
