### PR TITLE
Add support for checkpoint image

### DIFF
--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -68,6 +68,10 @@ func init() {
 	flags.BoolVarP(&checkpointOptions.PreCheckPoint, "pre-checkpoint", "P", false, "Dump container's memory information only, leave the container running")
 	flags.BoolVar(&checkpointOptions.WithPrevious, "with-previous", false, "Checkpoint container with pre-checkpoint images")
 
+	createImageFlagName := "create-image"
+	flags.StringVarP(&checkpointOptions.CreateImage, createImageFlagName, "", "", "Create checkpoint image with specified name")
+	_ = checkpointCommand.RegisterFlagCompletionFunc(createImageFlagName, completion.AutocompleteNone)
+
 	flags.StringP("compress", "c", "zstd", "Select compression algorithm (gzip, none, zstd) for checkpoint archive.")
 	_ = checkpointCommand.RegisterFlagCompletionFunc("compress", common.AutocompleteCheckpointCompressType)
 

--- a/docs/source/markdown/podman-container-checkpoint.1.md
+++ b/docs/source/markdown/podman-container-checkpoint.1.md
@@ -28,6 +28,60 @@ archives. Not compressing the checkpoint archive can result in faster checkpoint
 archive creation.\
 The default is **zstd**.
 
+#### **--create-image**=*image*
+
+Create a checkpoint image from a running container. This is a standard OCI image
+created in the local image store. It consists of a single layer that contains
+all of the checkpoint files. The content of this image layer is in the same format as a
+checkpoint created with **--export**. A checkpoint image can be pushed to a
+standard container registry and pulled on a different system to enable container
+migration. In addition, the image can be exported with **podman image save** and
+inspected with **podman inspect**. Inspecting a checkpoint image would display
+additional information, stored as annotations, about the host environment used
+to do the checkpoint:
+
+- **io.podman.annotations.checkpoint.name**: Human-readable name of the original
+  container.
+
+- **io.podman.annotations.checkpoint.rawImageName**: Unprocessed name of the
+  image used to create the original container (as specified by the user).
+
+- **io.podman.annotations.checkpoint.rootfsImageID**: ID of the image used to
+  create the original container.
+
+- **io.podman.annotations.checkpoint.rootfsImageName**: Image name used to
+  create the original container.
+
+- **io.podman.annotations.checkpoint.podman.version**: Version of Podman used to
+  create the checkpoint.
+
+- **io.podman.annotations.checkpoint.criu.version**: Version of CRIU used to
+  create the checkpoint.
+
+- **io.podman.annotations.checkpoint.runtime.name**: Container runtime (e.g.,
+  runc, crun) used to create the checkpoint.
+
+- **io.podman.annotations.checkpoint.runtime.version**: Version of the container
+  runtime used to create the checkpoint.
+
+- **io.podman.annotations.checkpoint.conmon.version**: Version of conmon used
+  with the original container.
+
+- **io.podman.annotations.checkpoint.host.arch**: CPU architecture of the host
+  on which the checkpoint was created.
+
+- **io.podman.annotations.checkpoint.host.kernel**: Version of Linux kernel
+  of the host where the checkpoint was created.
+
+- **io.podman.annotations.checkpoint.cgroups.version**: cgroup version used by
+  the host where the checkpoint was created.
+
+- **io.podman.annotations.checkpoint.distribution.version**: Version of host
+  distribution on which the checkpoint was created.
+
+- **io.podman.annotations.checkpoint.distribution.name**: Name of host
+  distribution on which the checkpoint was created.
+
 #### **--export**, **-e**=*archive*
 
 Export the checkpoint to a tar.gz file. The exported checkpoint can be used
@@ -143,6 +197,11 @@ availability on different systems.
 Make a checkpoint for the container "mywebserver".
 ```
 # podman container checkpoint mywebserver
+```
+
+Create a checkpoint image for the container "mywebserver".
+```
+# podman container checkpoint --create-image mywebserver-checkpoint-1 mywebserver
 ```
 
 Dumps the container's memory information of the latest container into an archive.

--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -4,10 +4,11 @@
 podman\-container\-restore - Restores one or more containers from a checkpoint
 
 ## SYNOPSIS
-**podman container restore** [*options*] *container* [*container* ...]
+**podman container restore** [*options*] *name* [...]
 
 ## DESCRIPTION
-**podman container restore** restores a container from a checkpoint. The *container IDs* or *names* are used as input.
+**podman container restore** restores a container from a container checkpoint or
+checkpoint image. The *container IDs*, *image IDs* or *names* are used as input.
 
 ## OPTIONS
 #### **--all**, **-a**
@@ -106,14 +107,16 @@ If the **--name, -n** option is used, Podman will not attempt to assign the same
 address to the *container* it was using before checkpointing as each IP address can only
 be used once and the restored *container* will have another IP address. This also means
 that **--name, -n** cannot be used in combination with **--tcp-established**.\
-*IMPORTANT: This OPTION is only available in combination with __--import, -i__.*
+*IMPORTANT: This OPTION is only available for a checkpoint image or in combination
+with __--import, -i__.*
 
 #### **--pod**=*name*
 
 Restore a container into the pod *name*. The destination pod for this restore
 has to have the same namespaces shared as the pod this container was checkpointed
 from (see **[podman pod create --share](podman-pod-create.1.md#--share)**).\
-*IMPORTANT: This OPTION is only available in combination with __--import, -i__.*
+*IMPORTANT: This OPTION is only available for a checkpoint image or in combination
+with __--import, -i__.*
 
 This option requires at least CRIU 3.16.
 
@@ -173,6 +176,15 @@ Start the container "mywebserver". Make a checkpoint of the container and export
 $ podman run --rm -p 2345:80 -d webserver
 # podman container checkpoint -l --export=dump.tar
 # podman container restore -p 5432:8080 --import=dump.tar
+```
+
+Start a container with the name "foobar-1". Create a checkpoint image "foobar-checkpoint". Restore the container from the checkpoint image with a different name.
+```
+# podman run --name foobar-1 -d webserver
+# podman container checkpoint --create-image foobar-checkpoint foobar-1
+# podman inspect foobar-checkpoint
+# podman container restore --name foobar-2 foobar-checkpoint
+# podman container restore --name foobar-3 foobar-checkpoint
 ```
 
 ## SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.1.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/buger/goterm v1.0.4
-	github.com/checkpoint-restore/checkpointctl v0.0.0-20211204171957-54b4ebfdb681
+	github.com/checkpoint-restore/checkpointctl v0.0.0-20220321135231-33f4a66335f0
 	github.com/checkpoint-restore/go-criu/v5 v5.3.0
 	github.com/container-orchestrated-devices/container-device-interface v0.3.2
 	github.com/containernetworking/cni v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cb
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charithe/durationcheck v0.0.9/go.mod h1:SSbRIBVfMjCi/kEB6K65XEA83D6prSM8ap1UCpNKtgg=
 github.com/chavacava/garif v0.0.0-20210405164556-e8a0a408d6af/go.mod h1:Qjyv4H3//PWVzTeCezG2b9IRn6myJxJSr4TD/xo6ojU=
-github.com/checkpoint-restore/checkpointctl v0.0.0-20211204171957-54b4ebfdb681 h1:Jj8mYL2K6peLJdvT10oGTyYyBPqOynmly37D+iL3xNw=
-github.com/checkpoint-restore/checkpointctl v0.0.0-20211204171957-54b4ebfdb681/go.mod h1:67kWC1PXQLR3lM/mmNnu3Kzn7K4TSWZAGUuQP1JSngk=
+github.com/checkpoint-restore/checkpointctl v0.0.0-20220321135231-33f4a66335f0 h1:txB5jvhzUCSiiQmqmMWpo5CEB7Gj/Hq5Xqi7eaPl8ko=
+github.com/checkpoint-restore/checkpointctl v0.0.0-20220321135231-33f4a66335f0/go.mod h1:67kWC1PXQLR3lM/mmNnu3Kzn7K4TSWZAGUuQP1JSngk=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.2.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -754,6 +754,9 @@ type ContainerCheckpointOptions struct {
 	// TargetFile tells the API to read (or write) the checkpoint image
 	// from (or to) the filename set in TargetFile
 	TargetFile string
+	// CheckpointImageID tells the API to restore the container from
+	// checkpoint image with ID set in CheckpointImageID
+	CheckpointImageID string
 	// Name tells the API that during restore from an exported
 	// checkpoint archive a new name should be used for the
 	// restored container
@@ -781,6 +784,9 @@ type ContainerCheckpointOptions struct {
 	// ImportPrevious tells the API to restore container with two
 	// images. One is TargetFile, the other is ImportPrevious.
 	ImportPrevious string
+	// CreateImage tells Podman to create an OCI image from container
+	// checkpoint in the local image store.
+	CreateImage string
 	// Compression tells the API which compression to use for
 	// the exported checkpoint archive.
 	Compression archive.Compression

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -132,6 +132,11 @@ func (c *Container) ControlSocketPath() string {
 	return filepath.Join(c.bundlePath(), "ctl")
 }
 
+// CheckpointVolumesPath returns the path to the directory containing the checkpointed volumes
+func (c *Container) CheckpointVolumesPath() string {
+	return filepath.Join(c.bundlePath(), metadata.CheckpointVolumesDirectory)
+}
+
 // CheckpointPath returns the path to the directory containing the checkpoint
 func (c *Container) CheckpointPath() string {
 	return filepath.Join(c.bundlePath(), metadata.CheckpointDirectory)

--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -65,6 +65,76 @@ const (
 	// InspectResponseFalse is a boolean False response for an inspect
 	// annotation.
 	InspectResponseFalse = "FALSE"
+
+	// CheckpointAnnotationName is used by Container Checkpoint when creating a
+	// checkpoint image to specify the original human-readable name for the
+	// container.
+	CheckpointAnnotationName = "io.podman.annotations.checkpoint.name"
+
+	// CheckpointAnnotationRawImageName is used by Container Checkpoint when
+	// creating a checkpoint image to specify the original unprocessed name of
+	// the image used to create the container (as specified by the user).
+	CheckpointAnnotationRawImageName = "io.podman.annotations.checkpoint.rawImageName"
+
+	// CheckpointAnnotationRootfsImageID is used by Container Checkpoint when
+	// creating a checkpoint image to specify the original ID of the image used
+	// to create the container.
+	CheckpointAnnotationRootfsImageID = "io.podman.annotations.checkpoint.rootfsImageID"
+
+	// CheckpointAnnotationRootfsImageName is used by Container Checkpoint when
+	// creating a checkpoint image to specify the original image name used to
+	// create the container.
+	CheckpointAnnotationRootfsImageName = "io.podman.annotations.checkpoint.rootfsImageName"
+
+	// CheckpointAnnotationPodmanVersion is used by Container Checkpoint when
+	// creating a checkpoint image to specify the version of Podman used on the
+	// host where the checkpoint was created.
+	CheckpointAnnotationPodmanVersion = "io.podman.annotations.checkpoint.podman.version"
+
+	// CheckpointAnnotationCriuVersion is used by Container Checkpoint when
+	// creating a checkpoint image to specify the version of CRIU used on the
+	// host where the checkpoint was created.
+	CheckpointAnnotationCriuVersion = "io.podman.annotations.checkpoint.criu.version"
+
+	// CheckpointAnnotationRuntimeName is used by Container Checkpoint when
+	// creating a checkpoint image to specify the runtime used on the host where
+	// the checkpoint was created.
+	CheckpointAnnotationRuntimeName = "io.podman.annotations.checkpoint.runtime.name"
+
+	// CheckpointAnnotationRuntimeVersion is used by Container Checkpoint when
+	// creating a checkpoint image to specify the version of runtime used on the
+	// host where the checkpoint was created.
+	CheckpointAnnotationRuntimeVersion = "io.podman.annotations.checkpoint.runtime.version"
+
+	// CheckpointAnnotationConmonVersion is used by Container Checkpoint when
+	// creating a checkpoint image to specify the version of conmon used on
+	// the host where the checkpoint was created.
+	CheckpointAnnotationConmonVersion = "io.podman.annotations.checkpoint.conmon.version"
+
+	// CheckpointAnnotationHostArch is used by Container Checkpoint when
+	// creating a checkpoint image to specify the CPU architecture of the host
+	// on which the checkpoint was created.
+	CheckpointAnnotationHostArch = "io.podman.annotations.checkpoint.host.arch"
+
+	// CheckpointAnnotationHostKernel is used by Container Checkpoint when
+	// creating a checkpoint image to specify the kernel version used by the
+	// host where the checkpoint was created.
+	CheckpointAnnotationHostKernel = "io.podman.annotations.checkpoint.host.kernel"
+
+	// CheckpointAnnotationCgroupVersion is used by Container Checkpoint when
+	// creating a checkpoint image to specify the cgroup version used by the
+	// host where the checkpoint was created.
+	CheckpointAnnotationCgroupVersion = "io.podman.annotations.checkpoint.cgroups.version"
+
+	// CheckpointAnnotationDistributionVersion is used by Container Checkpoint
+	// when creating a checkpoint image to specify the version of host
+	// distribution on which the checkpoint was created.
+	CheckpointAnnotationDistributionVersion = "io.podman.annotations.checkpoint.distribution.version"
+
+	// CheckpointAnnotationDistributionName is used by Container Checkpoint when
+	// creating a checkpoint image to specify the name of host distribution on
+	// which the checkpoint was created.
+	CheckpointAnnotationDistributionName = "io.podman.annotations.checkpoint.distribution.name"
 )
 
 // IsReservedAnnotation returns true if the specified value corresponds to an

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -47,6 +47,7 @@ type AttachOptions struct {
 // CheckpointOptions are optional options for checkpointing containers
 type CheckpointOptions struct {
 	Export         *string
+	CreateImage    *string
 	IgnoreRootfs   *bool
 	Keep           *bool
 	LeaveRunning   *bool

--- a/pkg/bindings/containers/types_checkpoint_options.go
+++ b/pkg/bindings/containers/types_checkpoint_options.go
@@ -32,6 +32,21 @@ func (o *CheckpointOptions) GetExport() string {
 	return *o.Export
 }
 
+// WithCreateImage set field CreateImage to given value
+func (o *CheckpointOptions) WithCreateImage(value string) *CheckpointOptions {
+	o.CreateImage = &value
+	return o
+}
+
+// GetCreateImage returns value of field CreateImage
+func (o *CheckpointOptions) GetCreateImage() string {
+	if o.CreateImage == nil {
+		var z string
+		return z
+	}
+	return *o.CreateImage
+}
+
 // WithIgnoreRootfs set field IgnoreRootfs to given value
 func (o *CheckpointOptions) WithIgnoreRootfs(value bool) *CheckpointOptions {
 	o.IgnoreRootfs = &value

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -22,9 +22,7 @@ import (
 
 // Prefixing the checkpoint/restore related functions with 'cr'
 
-// CRImportCheckpoint it the function which imports the information
-// from checkpoint tarball and re-creates the container from that information
-func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOptions entities.RestoreOptions) ([]*libpod.Container, error) {
+func CRImportCheckpointTar(ctx context.Context, runtime *libpod.Runtime, restoreOptions entities.RestoreOptions) ([]*libpod.Container, error) {
 	// First get the container definition from the
 	// tarball to a temporary directory
 	dir, err := ioutil.TempDir("", "checkpoint")
@@ -39,7 +37,12 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 	if err := crutils.CRImportCheckpointConfigOnly(dir, restoreOptions.Import); err != nil {
 		return nil, err
 	}
+	return CRImportCheckpoint(ctx, runtime, restoreOptions, dir)
+}
 
+// CRImportCheckpoint it the function which imports the information
+// from checkpoint tarball and re-creates the container from that information
+func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOptions entities.RestoreOptions, dir string) ([]*libpod.Container, error) {
 	// Load spec.dump from temporary directory
 	dumpSpec := new(spec.Spec)
 	if _, err := metadata.ReadJSONFile(dumpSpec, dir, metadata.SpecDumpFile); err != nil {
@@ -48,7 +51,7 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 
 	// Load config.dump from temporary directory
 	ctrConfig := new(libpod.ContainerConfig)
-	if _, err = metadata.ReadJSONFile(ctrConfig, dir, metadata.ConfigDumpFile); err != nil {
+	if _, err := metadata.ReadJSONFile(ctrConfig, dir, metadata.ConfigDumpFile); err != nil {
 		return nil, err
 	}
 

--- a/pkg/checkpoint/crutils/checkpoint_restore_utils.go
+++ b/pkg/checkpoint/crutils/checkpoint_restore_utils.go
@@ -54,7 +54,6 @@ func CRImportCheckpointConfigOnly(destination, input string) error {
 	options := &archive.TarOptions{
 		// Here we only need the files config.dump and spec.dump
 		ExcludePatterns: []string{
-			"volumes",
 			"ctr.log",
 			"artifacts",
 			stats.StatsDump,
@@ -62,6 +61,7 @@ func CRImportCheckpointConfigOnly(destination, input string) error {
 			metadata.DeletedFilesFile,
 			metadata.NetworkStatusFile,
 			metadata.CheckpointDirectory,
+			metadata.CheckpointVolumesDirectory,
 		},
 	}
 	if err = archive.Untar(archiveFile, destination, options); err != nil {

--- a/pkg/criu/criu.go
+++ b/pkg/criu/criu.go
@@ -28,6 +28,11 @@ func CheckForCriu(version int) bool {
 	return result
 }
 
+func GetCriuVestion() (int, error) {
+	c := criu.MakeCriu()
+	return c.GetCriuVersion()
+}
+
 func MemTrack() bool {
 	features, err := criu.MakeCriu().FeatureCheck(
 		&rpc.CriuFeatures{

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -178,6 +178,7 @@ type ContainerExportOptions struct {
 type CheckpointOptions struct {
 	All            bool
 	Export         string
+	CreateImage    string
 	IgnoreRootFS   bool
 	IgnoreVolumes  bool
 	Keep           bool
@@ -205,6 +206,7 @@ type RestoreOptions struct {
 	IgnoreStaticIP  bool
 	IgnoreStaticMAC bool
 	Import          string
+	CheckpointImage bool
 	Keep            bool
 	Latest          bool
 	Name            string

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/api/handlers"
 	"github.com/containers/podman/v4/pkg/bindings/containers"
+	"github.com/containers/podman/v4/pkg/bindings/images"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
 	"github.com/containers/podman/v4/pkg/errorhandling"
@@ -331,6 +332,7 @@ func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds [
 	options.WithIgnoreRootfs(opts.IgnoreRootFS)
 	options.WithKeep(opts.Keep)
 	options.WithExport(opts.Export)
+	options.WithCreateImage(opts.CreateImage)
 	options.WithTCPEstablished(opts.TCPEstablished)
 	options.WithPrintStats(opts.PrintStats)
 	options.WithPreCheckpoint(opts.PreCheckPoint)
@@ -396,8 +398,7 @@ func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []st
 	}
 
 	var (
-		err  error
-		ctrs = []entities.ListContainer{}
+		ids = []string{}
 	)
 	if opts.All {
 		allCtrs, err := getContainersByContext(ic.ClientCtx, true, false, []string{})
@@ -407,20 +408,42 @@ func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []st
 		// narrow the list to exited only
 		for _, c := range allCtrs {
 			if c.State == define.ContainerStateExited.String() {
-				ctrs = append(ctrs, c)
+				ids = append(ids, c.ID)
 			}
 		}
 	} else {
-		ctrs, err = getContainersByContext(ic.ClientCtx, false, false, namesOrIds)
+		getImageOptions := new(images.GetOptions).WithSize(false)
+		hostInfo, err := ic.Info(context.Background())
 		if err != nil {
 			return nil, err
 		}
+
+		for _, nameOrID := range namesOrIds {
+			ctrData, _, err := ic.ContainerInspect(ic.ClientCtx, []string{nameOrID}, entities.InspectOptions{})
+			if err == nil && len(ctrData) > 0 {
+				ids = append(ids, ctrData[0].ID)
+			} else {
+				// If container was not found, check if this is a checkpoint image
+				inspectReport, err := images.GetImage(ic.ClientCtx, nameOrID, getImageOptions)
+				if err != nil {
+					return nil, fmt.Errorf("no such container or image: %s", nameOrID)
+				}
+				checkpointRuntimeName, found := inspectReport.Annotations[define.CheckpointAnnotationRuntimeName]
+				if !found {
+					return nil, fmt.Errorf("image is not a checkpoint: %s", nameOrID)
+				}
+				if hostInfo.Host.OCIRuntime.Name != checkpointRuntimeName {
+					return nil, fmt.Errorf("container image \"%s\" requires runtime: \"%s\"", nameOrID, checkpointRuntimeName)
+				}
+				ids = append(ids, inspectReport.ID)
+			}
+		}
 	}
-	reports := make([]*entities.RestoreReport, 0, len(ctrs))
-	for _, c := range ctrs {
-		report, err := containers.Restore(ic.ClientCtx, c.ID, options)
+	reports := make([]*entities.RestoreReport, 0, len(ids))
+	for _, id := range ids {
+		report, err := containers.Restore(ic.ClientCtx, id, options)
 		if err != nil {
-			reports = append(reports, &entities.RestoreReport{Id: c.ID, Err: err})
+			reports = append(reports, &entities.RestoreReport{Id: id, Err: err})
 		}
 		reports = append(reports, report)
 	}

--- a/test/e2e/checkpoint_image_test.go
+++ b/test/e2e/checkpoint_image_test.go
@@ -1,0 +1,296 @@
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/containers/podman/v4/pkg/criu"
+	. "github.com/containers/podman/v4/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Podman checkpoint", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest *PodmanTestIntegration
+	)
+
+	BeforeEach(func() {
+		SkipIfRootless("checkpoint not supported in rootless mode")
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanTestCreate(tempdir)
+		podmanTest.Setup()
+		podmanTest.SeedImages()
+		// Check if the runtime implements checkpointing. Currently only
+		// runc's checkpoint/restore implementation is supported.
+		cmd := exec.Command(podmanTest.OCIRuntime, "checkpoint", "--help")
+		if err := cmd.Start(); err != nil {
+			Skip("OCI runtime does not support checkpoint/restore")
+		}
+		if err := cmd.Wait(); err != nil {
+			Skip("OCI runtime does not support checkpoint/restore")
+		}
+
+		if !criu.CheckForCriu(criu.MinCriuVersion) {
+			Skip("CRIU is missing or too old.")
+		}
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+		f := CurrentGinkgoTestDescription()
+		processTestResult(f)
+	})
+
+	It("podman checkpoint --create-image with bogus container", func() {
+		checkpointImage := "foobar-checkpoint"
+		session := podmanTest.Podman([]string{"container", "checkpoint", "--create-image", checkpointImage, "foobar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitWithError())
+		Expect(session.ErrorToString()).To(ContainSubstring("no container with name or ID \"foobar\" found"))
+	})
+
+	It("podman checkpoint --create-image with running container", func() {
+		// Container image must be lowercase
+		checkpointImage := "alpine-checkpoint-" + strings.ToLower(RandomString(6))
+		containerName := "alpine-container-" + RandomString(6)
+
+		localRunString := []string{
+			"run",
+			"-it",
+			"-d",
+			"--ip", GetRandomIPAddress(),
+			"--name", containerName,
+			ALPINE,
+			"top",
+		}
+		session := podmanTest.Podman(localRunString)
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		containerID := session.OutputToString()
+
+		// Checkpoint image should not exist
+		session = podmanTest.Podman([]string{"images"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.LineInOutputContainsTag("localhost/"+checkpointImage, "latest")).To(BeFalse())
+
+		// Check if none of the checkpoint/restore specific information is displayed
+		// for newly started containers.
+		inspect := podmanTest.Podman([]string{"inspect", containerID})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		inspectOut := inspect.InspectContainerToJSON()
+		Expect(inspectOut[0].State.Checkpointed).To(BeFalse(), ".State.Checkpointed")
+		Expect(inspectOut[0].State.Restored).To(BeFalse(), ".State.Restored")
+		Expect(inspectOut[0].State.CheckpointPath).To(Equal(""))
+		Expect(inspectOut[0].State.CheckpointLog).To(Equal(""))
+		Expect(inspectOut[0].State.RestoreLog).To(Equal(""))
+
+		result := podmanTest.Podman([]string{"container", "checkpoint", "--create-image", checkpointImage, "--keep", containerID})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
+
+		inspect = podmanTest.Podman([]string{"inspect", containerID})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		inspectOut = inspect.InspectContainerToJSON()
+		Expect(inspectOut[0].State.Checkpointed).To(BeTrue(), ".State.Checkpointed")
+		Expect(inspectOut[0].State.CheckpointPath).To(ContainSubstring("userdata/checkpoint"))
+		Expect(inspectOut[0].State.CheckpointLog).To(ContainSubstring("userdata/dump.log"))
+
+		// Check if checkpoint image has been created
+		session = podmanTest.Podman([]string{"images"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.LineInOutputContainsTag("localhost/"+checkpointImage, "latest")).To(BeTrue())
+
+		// Check if the checkpoint image contains annotations
+		inspect = podmanTest.Podman([]string{"inspect", checkpointImage})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		inspectImageOut := inspect.InspectImageJSON()
+		Expect(inspectImageOut[0].Annotations["io.podman.annotations.checkpoint.name"]).To(
+			BeEquivalentTo(containerName),
+			"io.podman.annotations.checkpoint.name",
+		)
+
+		ociRuntimeName := ""
+		if strings.Contains(podmanTest.OCIRuntime, "runc") {
+			ociRuntimeName = "runc"
+		} else if strings.Contains(podmanTest.OCIRuntime, "crun") {
+			ociRuntimeName = "crun"
+		}
+		if ociRuntimeName != "" {
+			Expect(inspectImageOut[0].Annotations["io.podman.annotations.checkpoint.runtime.name"]).To(
+				BeEquivalentTo(ociRuntimeName),
+				"io.podman.annotations.checkpoint.runtime.name",
+			)
+		}
+
+		// Remove existing container
+		result = podmanTest.Podman([]string{"rm", "-t", "1", "-f", containerID})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+
+		// Restore container from checkpoint image
+		result = podmanTest.Podman([]string{"container", "restore", checkpointImage})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
+
+		// Clean-up
+		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+
+		result = podmanTest.Podman([]string{"rmi", checkpointImage})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+	})
+
+	It("podman restore multiple containers from single checkpint image", func() {
+		// Container image must be lowercase
+		checkpointImage := "alpine-checkpoint-" + strings.ToLower(RandomString(6))
+		containerName := "alpine-container-" + RandomString(6)
+
+		localRunString := []string{"run", "-d", "--name", containerName, ALPINE, "top"}
+		session := podmanTest.Podman(localRunString)
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		containerID := session.OutputToString()
+
+		// Checkpoint image should not exist
+		session = podmanTest.Podman([]string{"images"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.LineInOutputContainsTag("localhost/"+checkpointImage, "latest")).To(BeFalse())
+
+		result := podmanTest.Podman([]string{"container", "checkpoint", "--create-image", checkpointImage, "--keep", containerID})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
+
+		// Check if checkpoint image has been created
+		session = podmanTest.Podman([]string{"images"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.LineInOutputContainsTag("localhost/"+checkpointImage, "latest")).To(BeTrue())
+
+		// Remove existing container
+		result = podmanTest.Podman([]string{"rm", "-t", "1", "-f", containerID})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+
+		for i := 1; i < 5; i++ {
+			// Restore container from checkpoint image
+			name := containerName + strconv.Itoa(i)
+			result = podmanTest.Podman([]string{"container", "restore", "--name", name, checkpointImage})
+			result.WaitWithDefaultTimeout()
+			Expect(result).Should(Exit(0))
+			Expect(podmanTest.NumberOfContainersRunning()).To(Equal(i))
+
+			// Check that the container is running
+			status := podmanTest.Podman([]string{"inspect", name, "--format={{.State.Status}}"})
+			status.WaitWithDefaultTimeout()
+			Expect(status).Should(Exit(0))
+			Expect(status.OutputToString()).To(Equal("running"))
+		}
+
+		// Clean-up
+		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+
+		result = podmanTest.Podman([]string{"rmi", checkpointImage})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+	})
+
+	It("podman restore multiple containers from multiple checkpint images", func() {
+		// Container image must be lowercase
+		checkpointImage1 := "alpine-checkpoint-" + strings.ToLower(RandomString(6))
+		checkpointImage2 := "alpine-checkpoint-" + strings.ToLower(RandomString(6))
+		containerName1 := "alpine-container-" + RandomString(6)
+		containerName2 := "alpine-container-" + RandomString(6)
+
+		// Create first container
+		localRunString := []string{"run", "-d", "--name", containerName1, ALPINE, "top"}
+		session := podmanTest.Podman(localRunString)
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		containerID1 := session.OutputToString()
+
+		// Create second container
+		localRunString = []string{"run", "-d", "--name", containerName2, ALPINE, "top"}
+		session = podmanTest.Podman(localRunString)
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		containerID2 := session.OutputToString()
+
+		// Checkpoint first container
+		result := podmanTest.Podman([]string{"container", "checkpoint", "--create-image", checkpointImage1, "--keep", containerID1})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+
+		// Checkpoint second container
+		result = podmanTest.Podman([]string{"container", "checkpoint", "--create-image", checkpointImage2, "--keep", containerID2})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+
+		// Remove existing containers
+		result = podmanTest.Podman([]string{"rm", "-t", "1", "-f", containerName1, containerName2})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+
+		// Restore both containers from images
+		result = podmanTest.Podman([]string{"container", "restore", checkpointImage1, checkpointImage2})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
+
+		// Check if first container is running
+		status := podmanTest.Podman([]string{"inspect", containerName1, "--format={{.State.Status}}"})
+		status.WaitWithDefaultTimeout()
+		Expect(status).Should(Exit(0))
+		Expect(status.OutputToString()).To(Equal("running"))
+
+		// Check if second container is running
+		status = podmanTest.Podman([]string{"inspect", containerName2, "--format={{.State.Status}}"})
+		status.WaitWithDefaultTimeout()
+		Expect(status).Should(Exit(0))
+		Expect(status.OutputToString()).To(Equal("running"))
+
+		// Clean-up
+		result = podmanTest.Podman([]string{"rm", "-t", "0", "-fa"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+
+		result = podmanTest.Podman([]string{"rmi", checkpointImage1, checkpointImage2})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+	})
+})

--- a/vendor/github.com/checkpoint-restore/checkpointctl/lib/metadata.go
+++ b/vendor/github.com/checkpoint-restore/checkpointctl/lib/metadata.go
@@ -48,13 +48,16 @@ const (
 	// kubelet archive
 	CheckpointedPodsFile = "checkpointed.pods"
 	// container archive
-	ConfigDumpFile      = "config.dump"
-	SpecDumpFile        = "spec.dump"
-	NetworkStatusFile   = "network.status"
-	CheckpointDirectory = "checkpoint"
-	DevShmCheckpointTar = "devshm-checkpoint.tar"
-	RootFsDiffTar       = "rootfs-diff.tar"
-	DeletedFilesFile    = "deleted.files"
+	ConfigDumpFile             = "config.dump"
+	SpecDumpFile               = "spec.dump"
+	NetworkStatusFile          = "network.status"
+	CheckpointDirectory        = "checkpoint"
+	CheckpointVolumesDirectory = "volumes"
+	DevShmCheckpointTar        = "devshm-checkpoint.tar"
+	RootFsDiffTar              = "rootfs-diff.tar"
+	DeletedFilesFile           = "deleted.files"
+	DumpLogFile                = "dump.log"
+	RestoreLogFile             = "restore.log"
 	// pod archive
 	PodOptionsFile = "pod.options"
 	PodDumpFile    = "pod.dump"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -46,7 +46,7 @@ github.com/blang/semver
 github.com/buger/goterm
 # github.com/cespare/xxhash/v2 v2.1.2
 github.com/cespare/xxhash/v2
-# github.com/checkpoint-restore/checkpointctl v0.0.0-20211204171957-54b4ebfdb681
+# github.com/checkpoint-restore/checkpointctl v0.0.0-20220321135231-33f4a66335f0
 ## explicit
 github.com/checkpoint-restore/checkpointctl/lib
 # github.com/checkpoint-restore/go-criu/v5 v5.3.0


### PR DESCRIPTION
This is an enhancement proposal for the checkpoint / restore feature of Podman that enables container migration across multiple systems with standard image distribution infrastructure.

A new option `--create-image <image>` has been added to the `podman container checkpoint` command. This option tells Podman to create a container image.  This is a standard image with a single layer, tar archive, that that contains all checkpoint files. This is similar to the current approach for container migration using `--export` / `--import`.

The checkpoint image can be pushed to a container registry and pulled on a different system.  It can also be exported locally with `podman image save` and inspected with `podman inspect`. Inspecting the image would display additional information (stored as annotations) about the host and the versions of Podman, criu, crun/runc, kernel, etc.

`podman container restore` has also been extended to support checkpoint image provided as input.

Simple example:
```
podman run -d --name looper busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
podman container checkpoint --create-image checkpoint-image-test looper
podman rm looper
podman container restore checkpoint-image-test
```
Example with multiple containers:
```
podman run -d --name looper-1 busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
podman run -d --name looper-2 busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
podman container checkpoint --create-image checkpoint-1 looper-1
podman container checkpoint --create-image checkpoint-2 looper-2
podman rm looper-1 looper-2
podman container restore checkpoint-1 checkpoint-2
```
Example using container registry:
```
podman run -d --name looper busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
podman container checkpoint --create-image quay.io/rst0git/checkpoint-image-test-1 looper
podman push quay.io/rst0git/checkpoint-image-test-1
podman rm -a
podman rmi -a
podman pull quay.io/rst0git/checkpoint-image-test-1
podman inspect quay.io/rst0git/checkpoint-image-test-1
podman container restore quay.io/rst0git/checkpoint-image-test-1
```