### PR TITLE
use 4.0.2 as version - this is a maintenance branch

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ const (
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-var Version = semver.MustParse("4.0.3-dev")
+var Version = semver.MustParse("4.0.2")
 
 // See https://docs.docker.com/engine/api/v1.40/
 // libpod compat handlers are expected to honor docker API versions


### PR DESCRIPTION
[NO NEW TESTS NEEDED]

Signed-off-by: Jindrich Novy <jnovy@redhat.com>