### PR TITLE
fix breaking change in pkg/bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ endif
 # dependencies. This is only used for the Windows installer task (podman.msi), which must
 # include this lightweight helper binary.
 #
-GV_GITURL=git://github.com/containers/gvisor-tap-vsock.git
+GV_GITURL=https://github.com/containers/gvisor-tap-vsock.git
 GV_SHA=e943b1806d94d387c4c38d96719432d50a84bbd0
 
 ###

--- a/pkg/bindings/containers/checkpoint.go
+++ b/pkg/bindings/containers/checkpoint.go
@@ -79,7 +79,14 @@ func Restore(ctx context.Context, nameOrID string, options *RestoreOptions) (*en
 
 	// Open the to-be-imported archive if needed.
 	var r io.Reader
-	if i := options.GetImportArchive(); i != "" {
+	i := options.GetImportArchive()
+	if i == "" {
+		// backwards compat, ImportAchive is a typo but we still have to
+		// support this to avoid breaking users
+		// TODO: remove ImportAchive with 5.0
+		i = options.GetImportAchive()
+	}
+	if i != "" {
 		params.Set("import", "true")
 		r, err = os.Open(i)
 		if err != nil {

--- a/pkg/bindings/containers/types.go
+++ b/pkg/bindings/containers/types.go
@@ -64,14 +64,21 @@ type RestoreOptions struct {
 	IgnoreVolumes   *bool
 	IgnoreStaticIP  *bool
 	IgnoreStaticMAC *bool
-	ImportArchive   *string
-	Keep            *bool
-	Name            *string
-	TCPEstablished  *bool
-	Pod             *string
-	PrintStats      *bool
-	PublishPorts    []string
-	FileLocks       *bool
+	// ImportAchive is the path to an archive which contains the checkpoint data.
+	//
+	// Deprecated: Use ImportArchive instead. This field name is a typo and
+	// will be removed in a future major release.
+	ImportAchive *string
+	// ImportArchive is the path to an archive which contains the checkpoint data.
+	// ImportArchive is preferred over ImportAchive when both are set.
+	ImportArchive  *string
+	Keep           *bool
+	Name           *string
+	TCPEstablished *bool
+	Pod            *string
+	PrintStats     *bool
+	PublishPorts   []string
+	FileLocks      *bool
 }
 
 //go:generate go run ../generator/generator.go CreateOptions

--- a/pkg/bindings/containers/types_restore_options.go
+++ b/pkg/bindings/containers/types_restore_options.go
@@ -77,6 +77,21 @@ func (o *RestoreOptions) GetIgnoreStaticMAC() bool {
 	return *o.IgnoreStaticMAC
 }
 
+// WithImportAchive set field ImportAchive to given value
+func (o *RestoreOptions) WithImportAchive(value string) *RestoreOptions {
+	o.ImportAchive = &value
+	return o
+}
+
+// GetImportAchive returns value of field ImportAchive
+func (o *RestoreOptions) GetImportAchive() string {
+	if o.ImportAchive == nil {
+		var z string
+		return z
+	}
+	return *o.ImportAchive
+}
+
 // WithImportArchive set field ImportArchive to given value
 func (o *RestoreOptions) WithImportArchive(value string) *RestoreOptions {
 	o.ImportArchive = &value


### PR DESCRIPTION
pkg/bindings is considered stable. We cannot make changes that would
break any users. If someone uses this field their code would fail to
compile. Since the fix is obviously correct we will keep it but also
add the old field back in to keep compatibility with old code.

When both fields are set ImportArchive is preferred over ImportAchive.

Fixes changes from commit 217197340c8f


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
