### PR TITLE
fix empty newline in version output

### DIFF
--- a/cmd/podman/system/version.go
+++ b/cmd/podman/system/version.go
@@ -89,9 +89,7 @@ Client:\tPodman Engine
 Version:\t{{.Version}}
 API Version:\t{{.APIVersion}}
 Go Version:\t{{.GoVersion}}
-{{if .GitCommit -}}
-  Git Commit:\t{{.GitCommit}}
-{{- end}}
+{{if .GitCommit -}}Git Commit:\t{{.GitCommit}}\n{{end -}}
 Built:\t{{.BuiltTime}}
 OS/Arch:\t{{.OsArch}}
 {{- end}}
@@ -102,9 +100,7 @@ Server:\tPodman Engine
 Version:\t{{.Version}}
 API Version:\t{{.APIVersion}}
 Go Version:\t{{.GoVersion}}
-{{if .GitCommit -}}
-  Git Commit:\t{{.GitCommit}}
-{{- end}}
+{{if .GitCommit -}}Git Commit:\t{{.GitCommit}}\n{{end -}}
 Built:\t{{.BuiltTime}}
 OS/Arch:\t{{.OsArch}}
 {{- end}}{{- end}}


### PR DESCRIPTION
When podman is build without git commit information it will print a
empty newline instead. This is undesirable and a regression introduced
in commit 7d22cc88ef38.

To test build podman with `go build -mod=vendor -o bin/podman ./cmd/podman`
and check the output of bin/podman version with and without this commit.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
