### PR TITLE
Set rawimage for containers created via play kube

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -462,6 +462,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 			if err != nil {
 				return nil, err
 			}
+			specGen.RawImageName = container.Image
 			rtSpec, spec, opts, err := generate.MakeContainer(ctx, ic.Libpod, specGen, false, nil)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This commit set the containers RawImageName to default image name
specified in Pod YAML, so the containers could be used via autoupdate
feature, which needs the RawImageName to be set.

Currently RawImageName is set only for the create/run/clone podman
commands.

Previously if `auto-update` command was executed on containers created by `podman play kube` we got ouput:

```yaml
$ podman auto-update --dry-run
UNIT                     CONTAINER                       IMAGE                                 POLICY      UPDATED
Error: registry auto-updating container "7f519304b0081d142b8f1802a50ed0ce7832bcc6862b44e12bd9510120b93c41": raw-image name is empty
```

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
