### PR TITLE
podman create: building local pause image: do not read ignore files

### DIFF
--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -56,6 +56,7 @@ ENTRYPOINT ["/catatonit", "-P"]`, catatonitPath)
 		CommonBuildOpts: &buildahDefine.CommonBuildOptions{},
 		Output:          imageName,
 		Quiet:           true,
+		IgnoreFile:      "/dev/null", // makes sure to not read a local .ignorefile (see #13529)
 		IIDFile:         "/dev/null", // prevents Buildah from writing the ID on stdout
 	}
 	if _, _, err := rt.Build(context.Background(), buildOptions, tmpF.Name()); err != nil {

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -248,8 +248,7 @@ Labels.created_at | 20[0-9-]\\\+T[0-9:]\\\+Z
     run_podman inspect --format '{{.ID}}' $IMAGE
     imageID=$output
 
-    run_podman version --format "{{.Server.Version}}-{{.Server.Built}}"
-    pauseImage=localhost/podman-pause:$output
+    pauseImage=$(pause_image)
     run_podman inspect --format '{{.ID}}' $pauseImage
     pauseID=$output
 

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -605,7 +605,7 @@ EOF
     done
 }
 
-# Regression test for #9867
+# Regression test for #9867 and #13529
 # Make sure that if you exclude everything in context dir, that
 # the Containerfile/Dockerfile in the context dir are used
 @test "podman build with ignore '*'" {
@@ -619,6 +619,15 @@ EOF
 cat >$tmpdir/.dockerignore <<EOF
 *
 EOF
+
+    # Prior to the fix for #13529, pod-create would fail with 'error building
+    # at STEP COPY .../catatonit' because of the local .dockerignore file was
+    # used.
+    pushd "${tmpdir}"
+    run_podman pod create
+    run_podman pod rm $output
+    run_podman rmi $(pause_image)
+    popd
 
     run_podman build -t build_test $tmpdir
 

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -6,13 +6,7 @@ load helpers
 function teardown() {
     run_podman pod rm -f -t 0 -a
     run_podman rm -f -t 0 -a
-    run_podman image list --format '{{.ID}} {{.Repository}}'
-    while read id name; do
-        if [[ "$name" =~ /podman-pause ]]; then
-            run_podman rmi $id
-        fi
-    done <<<"$output"
-
+    run_podman ? rmi $(pause_image)
     basic_teardown
 }
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -383,6 +383,15 @@ function journald_unavailable() {
     return 1
 }
 
+# Returns the name of the local pause image.
+function pause_image() {
+    # This function is intended to be used as '$(pause_image)', i.e.
+    # our caller wants our output. run_podman() messes with output because
+    # it emits the command invocation to stdout, hence the redirection.
+    run_podman version --format "{{.Server.Version}}-{{.Server.Built}}" >/dev/null
+    echo "localhost/podman-pause:$output"
+}
+
 ###########################
 #  _add_label_if_missing  #  make sure skip messages include rootless/remote
 ###########################


### PR DESCRIPTION
Make sure to ignore local {container,docker}ignore files when building a
local pause image.  Otherwise, we may mistakenly not be able to copy
catatonit into the build container.

Fixes: #13529
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>
