### PR TITLE
[v4.0] Backport: Fix windows win-sshproxy build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ endif
 # dependencies. This is only used for the Windows installer task (podman.msi), which must
 # include this lightweight helper binary.
 #
-GV_GITURL=git://github.com/containers/gvisor-tap-vsock.git
+GV_GITURL=https://github.com/containers/gvisor-tap-vsock.git
 GV_SHA=e943b1806d94d387c4c38d96719432d50a84bbd0
 
 ###


### PR DESCRIPTION
Github no longer supports the unauthenticated git protocol, so switch
to using https instead.

https://github.blog/2021-09-01-improving-git-protocol-security-github/

Signed-off-by: Paul Holzinger <pholzing@redhat.com>