### PR TITLE
[v4.0-rhel] Backport: Fix windows win-sshproxy build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
     #### Global variables used for all tasks
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
-    DEST_BRANCH: "v4.0"
+    DEST_BRANCH: "v4.0-rhel"
     # Netavark branch to use when TEST_ENVIRON=host-netavark
     NETAVARK_BRANCH: "main"  # TODO: This should point to a release branch
     # Aardvark branch to use

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ endif
 # dependencies. This is only used for the Windows installer task (podman.msi), which must
 # include this lightweight helper binary.
 #
-GV_GITURL=git://github.com/containers/gvisor-tap-vsock.git
+GV_GITURL=https://github.com/containers/gvisor-tap-vsock.git
 GV_SHA=e943b1806d94d387c4c38d96719432d50a84bbd0
 
 ###


### PR DESCRIPTION
Github no longer supports the unauthenticated git protocol, so switch
to using https instead.

https://github.blog/2021-09-01-improving-git-protocol-security-github/

Signed-off-by: Paul Holzinger <pholzing@redhat.com>