### PR TITLE
go fmt: use go 1.18 conditional-build syntax

### DIFF
--- a/cmd/podman/early_init_unsupported.go
+++ b/cmd/podman/early_init_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package main

--- a/cmd/podman/images/utils_unsupported.go
+++ b/cmd/podman/images/utils_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package images

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine

--- a/cmd/podman/machine/machine_unsupported.go
+++ b/cmd/podman/machine/machine_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !amd64 && !arm64
 // +build !amd64,!arm64
 
 package machine

--- a/cmd/podman/machine/platform.go
+++ b/cmd/podman/machine/platform.go
@@ -1,3 +1,4 @@
+//go:build (amd64 && !windows) || (arm64 && !windows)
 // +build amd64,!windows arm64,!windows
 
 package machine

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine

--- a/cmd/podman/registry/config_abi.go
+++ b/cmd/podman/registry/config_abi.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package registry

--- a/cmd/podman/registry/config_tunnel.go
+++ b/cmd/podman/registry/config_tunnel.go
@@ -1,3 +1,4 @@
+//go:build remote
 // +build remote
 
 package registry

--- a/cmd/podman/syslog_unsupported.go
+++ b/cmd/podman/syslog_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package main

--- a/cmd/podman/system/migrate.go
+++ b/cmd/podman/system/migrate.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package system

--- a/cmd/podman/system/renumber.go
+++ b/cmd/podman/system/renumber.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package system

--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package system

--- a/cmd/podman/system/service.go
+++ b/cmd/podman/system/service.go
@@ -1,3 +1,4 @@
+//go:build linux && !remote
 // +build linux,!remote
 
 package system

--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -1,3 +1,4 @@
+//go:build linux && !remote
 // +build linux,!remote
 
 package system

--- a/cmd/podman/utils/signals_linux.go
+++ b/cmd/podman/utils/signals_linux.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package utils

--- a/cmd/podman/utils/signals_windows.go
+++ b/cmd/podman/utils/signals_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package utils

--- a/dependencies/dependencies.go
+++ b/dependencies/dependencies.go
@@ -1,3 +1,4 @@
+//go:build !linter
 // +build !linter
 
 package dependencies

--- a/libpod/boltdb_state_linux.go
+++ b/libpod/boltdb_state_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/container_copy_linux.go
+++ b/libpod/container_copy_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/container_linux.go
+++ b/libpod/container_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/container_log_unsupported.go
+++ b/libpod/container_log_unsupported.go
@@ -1,4 +1,5 @@
-//+build !linux !systemd
+//go:build !linux || !systemd
+// +build !linux !systemd
 
 package libpod
 

--- a/libpod/container_stat_linux.go
+++ b/libpod/container_stat_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/container_top_linux.go
+++ b/libpod/container_top_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/events/events_unsupported.go
+++ b/libpod/events/events_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package events

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -1,3 +1,4 @@
+//go:build systemd
 // +build systemd
 
 package events

--- a/libpod/events/journal_unsupported.go
+++ b/libpod/events/journal_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !systemd
 // +build !systemd
 
 package events

--- a/libpod/linkmode/linkmode_dynamic.go
+++ b/libpod/linkmode/linkmode_dynamic.go
@@ -1,3 +1,4 @@
+//go:build !static
 // +build !static
 
 package linkmode

--- a/libpod/linkmode/linkmode_static.go
+++ b/libpod/linkmode/linkmode_static.go
@@ -1,3 +1,4 @@
+//go:build static
 // +build static
 
 package linkmode

--- a/libpod/lock/shm/shm_lock.go
+++ b/libpod/lock/shm/shm_lock.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package shm

--- a/libpod/lock/shm/shm_lock_nocgo.go
+++ b/libpod/lock/shm/shm_lock_nocgo.go
@@ -1,3 +1,4 @@
+//go:build linux && !cgo
 // +build linux,!cgo
 
 package shm

--- a/libpod/lock/shm/shm_lock_test.go
+++ b/libpod/lock/shm/shm_lock_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package shm

--- a/libpod/lock/shm_lock_manager_linux.go
+++ b/libpod/lock/shm_lock_manager_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package lock

--- a/libpod/lock/shm_lock_manager_unsupported.go
+++ b/libpod/lock/shm_lock_manager_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package lock

--- a/libpod/mounts_linux.go
+++ b/libpod/mounts_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/oci_attach_linux.go
+++ b/libpod/oci_attach_linux.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package libpod
 

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/pod_top_linux.go
+++ b/libpod/pod_top_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/runtime_migrate.go
+++ b/libpod/runtime_migrate.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/libpod/util_linux.go
+++ b/libpod/util_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package libpod

--- a/pkg/bindings/generator/generator.go
+++ b/pkg/bindings/generator/generator.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/pkg/bindings/images/build_unix.go
+++ b/pkg/bindings/images/build_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package images

--- a/pkg/criu/criu.go
+++ b/pkg/criu/criu.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package criu

--- a/pkg/criu/criu_unsupported.go
+++ b/pkg/criu/criu_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package criu

--- a/pkg/ctime/ctime_linux.go
+++ b/pkg/ctime/ctime_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package ctime

--- a/pkg/ctime/ctime_unsupported.go
+++ b/pkg/ctime/ctime_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package ctime

--- a/pkg/domain/infra/runtime_abi.go
+++ b/pkg/domain/infra/runtime_abi.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package infra

--- a/pkg/domain/infra/runtime_abi_unsupported.go
+++ b/pkg/domain/infra/runtime_abi_unsupported.go
@@ -1,3 +1,4 @@
+//go:build remote
 // +build remote
 
 package infra

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package infra

--- a/pkg/domain/infra/runtime_proxy.go
+++ b/pkg/domain/infra/runtime_proxy.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package infra

--- a/pkg/domain/infra/runtime_tunnel.go
+++ b/pkg/domain/infra/runtime_tunnel.go
@@ -1,3 +1,4 @@
+//go:build remote
 // +build remote
 
 package infra

--- a/pkg/env/env_unix.go
+++ b/pkg/env/env_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package env

--- a/pkg/k8s.io/apimachinery/pkg/util/intstr/instr_fuzz.go
+++ b/pkg/k8s.io/apimachinery/pkg/util/intstr/instr_fuzz.go
@@ -1,3 +1,4 @@
+//go:build !notest
 // +build !notest
 
 /*

--- a/pkg/machine/fcos.go
+++ b/pkg/machine/fcos.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine

--- a/pkg/machine/fedora.go
+++ b/pkg/machine/fedora.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine

--- a/pkg/machine/ignition_darwin.go
+++ b/pkg/machine/ignition_darwin.go
@@ -1,4 +1,5 @@
-//+build darwin
+//go:build darwin
+// +build darwin
 
 package machine
 

--- a/pkg/machine/ignition_schema.go
+++ b/pkg/machine/ignition_schema.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine

--- a/pkg/machine/ignition_windows.go
+++ b/pkg/machine/ignition_windows.go
@@ -1,4 +1,5 @@
-//+build windows
+//go:build windows
+// +build windows
 
 package machine
 

--- a/pkg/machine/keys.go
+++ b/pkg/machine/keys.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine

--- a/pkg/machine/machine_unsupported.go
+++ b/pkg/machine/machine_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !amd64 && !arm64
 // +build !amd64,!arm64
 
 package machine

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -1,3 +1,4 @@
+//go:build amd64 || arm64
 // +build amd64 arm64
 
 package machine

--- a/pkg/machine/qemu/machine_unsupported.go
+++ b/pkg/machine/qemu/machine_unsupported.go
@@ -1,3 +1,4 @@
+//go:build (!amd64 && !arm64) || windows
 // +build !amd64,!arm64 windows
 
 package qemu

--- a/pkg/machine/wsl/machine_unsupported.go
+++ b/pkg/machine/wsl/machine_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wsl

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package rootless

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux || !cgo
 // +build !linux !cgo
 
 package rootless

--- a/pkg/rootlessport/rootlessport_linux.go
+++ b/pkg/rootlessport/rootlessport_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 // Package rootlessport provides reexec for RootlessKit-based port forwarder.

--- a/pkg/servicereaper/service.go
+++ b/pkg/servicereaper/service.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package servicereaper
 

--- a/pkg/signal/signal_linux.go
+++ b/pkg/signal/signal_linux.go
@@ -1,5 +1,5 @@
-// +build linux
-// +build !mips,!mipsle,!mips64,!mips64le
+//go:build linux && !mips && !mipsle && !mips64 && !mips64le
+// +build linux,!mips,!mipsle,!mips64,!mips64le
 
 // Signal handling for Linux only.
 package signal

--- a/pkg/signal/signal_linux_mipsx.go
+++ b/pkg/signal/signal_linux_mipsx.go
@@ -1,3 +1,4 @@
+//go:build linux && (mips || mipsle || mips64 || mips64le)
 // +build linux
 // +build mips mipsle mips64 mips64le
 

--- a/pkg/signal/signal_unix.go
+++ b/pkg/signal/signal_unix.go
@@ -1,3 +1,4 @@
+//go:build aix || darwin || dragonfly || freebsd || netbsd || openbsd || solaris || zos
 // +build aix darwin dragonfly freebsd netbsd openbsd solaris zos
 
 // Signal handling for Linux only.

--- a/pkg/signal/signal_unsupported.go
+++ b/pkg/signal/signal_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !zos
 // +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris,!zos
 
 // Signal handling for Linux only.

--- a/pkg/specgen/config_unsupported.go
+++ b/pkg/specgen/config_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package specgen

--- a/pkg/specgen/generate/config_linux_cgo.go
+++ b/pkg/specgen/generate/config_linux_cgo.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package generate

--- a/pkg/specgen/generate/config_linux_nocgo.go
+++ b/pkg/specgen/generate/config_linux_nocgo.go
@@ -1,3 +1,4 @@
+//go:build linux && !cgo
 // +build linux,!cgo
 
 package generate

--- a/pkg/terminal/console_unix.go
+++ b/pkg/terminal/console_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package terminal

--- a/pkg/terminal/console_windows.go
+++ b/pkg/terminal/console_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package terminal

--- a/pkg/util/mountOpts_other.go
+++ b/pkg/util/mountOpts_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package util

--- a/pkg/util/utils_darwin.go
+++ b/pkg/util/utils_darwin.go
@@ -1,4 +1,5 @@
-//+build darwin
+//go:build darwin
+// +build darwin
 
 package util
 

--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package util

--- a/pkg/util/utils_unsupported.go
+++ b/pkg/util/utils_unsupported.go
@@ -1,3 +1,4 @@
+//go:build darwin || windows
 // +build darwin windows
 
 package util

--- a/pkg/util/utils_windows.go
+++ b/pkg/util/utils_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package util

--- a/test/checkseccomp/checkseccomp.go
+++ b/test/checkseccomp/checkseccomp.go
@@ -1,3 +1,4 @@
+//go:build seccomp
 // +build seccomp
 
 package main

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package integration

--- a/test/e2e/play_build_test.go
+++ b/test/e2e/play_build_test.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 // build for play kube is not supported on remote yet.

--- a/test/e2e/run_apparmor_test.go
+++ b/test/e2e/run_apparmor_test.go
@@ -1,3 +1,4 @@
+//go:build !remote
 // +build !remote
 
 package integration

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package utils

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package utils


### PR DESCRIPTION
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

@containers/podman-maintainers PTAL

Without it, `make validate` will always bark on go 1.18 (F36).
