### PR TITLE
fix compose test flake

### DIFF
--- a/test/compose/slirp4netns_opts/tests.sh
+++ b/test/compose/slirp4netns_opts/tests.sh
@@ -3,4 +3,18 @@
 output="$(cat $OUTFILE)"
 expected="teststring"
 
+# Reading from the nc socket is flaky because docker-compose only starts
+# the containers. We cannot know at this point if the container did already
+# send the message. Give the container 5 seconds time to send the message
+# to prevent flakes.
+local _timeout=5
+while [ $_timeout -gt 0 ]; do
+    if [ -n "$output" ]; then
+        break
+    fi
+    sleep 1
+    _timeout=$(($_timeout - 1))
+    output="$(cat $OUTFILE)"
+done
+
 is "$output" "$expected" "$testname : nc received teststring"


### PR DESCRIPTION
Reading from the nc socket is flaky because docker-compose only starts
the containers. We cannot know at this point if the container did already
send the message. Give the container 5 seconds time to send the message
to prevent flakes.

This happened rarely with compose v1 but it looks like it will happen a
lot more with compose v2.

Example failure log:
https://storage.googleapis.com/cirrus-ci-6707778565701632-fcae48/artifacts/containers/podman/6567556239589376/html/compose_v2-podman-fedora-35-rootless-host.log.html

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
