### PR TITLE
Fix type-o and cleanup doc punctuation

### DIFF
--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -27,7 +27,7 @@ var (
 )
 
 var (
-	destoryOptions machine.RemoveOptions
+	destroyOptions machine.RemoveOptions
 )
 
 func init() {
@@ -38,16 +38,16 @@ func init() {
 
 	flags := rmCmd.Flags()
 	formatFlagName := "force"
-	flags.BoolVarP(&destoryOptions.Force, formatFlagName, "f", false, "Stop and do not prompt before rming")
+	flags.BoolVarP(&destroyOptions.Force, formatFlagName, "f", false, "Stop and do not prompt before rming")
 
 	keysFlagName := "save-keys"
-	flags.BoolVar(&destoryOptions.SaveKeys, keysFlagName, false, "Do not delete SSH keys")
+	flags.BoolVar(&destroyOptions.SaveKeys, keysFlagName, false, "Do not delete SSH keys")
 
 	ignitionFlagName := "save-ignition"
-	flags.BoolVar(&destoryOptions.SaveIgnition, ignitionFlagName, false, "Do not delete ignition file")
+	flags.BoolVar(&destroyOptions.SaveIgnition, ignitionFlagName, false, "Do not delete ignition file")
 
 	imageFlagName := "save-image"
-	flags.BoolVar(&destoryOptions.SaveImage, imageFlagName, false, "Do not delete the image file")
+	flags.BoolVar(&destroyOptions.SaveImage, imageFlagName, false, "Do not delete the image file")
 }
 
 func rm(cmd *cobra.Command, args []string) error {
@@ -65,12 +65,12 @@ func rm(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	confirmationMessage, remove, err := vm.Remove(vmName, destoryOptions)
+	confirmationMessage, remove, err := vm.Remove(vmName, destroyOptions)
 	if err != nil {
 		return err
 	}
 
-	if !destoryOptions.Force {
+	if !destroyOptions.Force {
 		// Warn user
 		fmt.Println(confirmationMessage)
 		reader := bufio.NewReader(os.Stdin)

--- a/docs/source/markdown/podman-machine-rm.1.md
+++ b/docs/source/markdown/podman-machine-rm.1.md
@@ -25,15 +25,15 @@ Print usage statement.
 
 #### **--force**, **-f**
 
-Stop and delete without confirmation
+Stop and delete without confirmation.
 
 #### **--save-ignition**
 
-Do not delete the generated ignition file
+Do not delete the generated ignition file.
 
 #### **--save-image**
 
-Do not delete the VM image
+Do not delete the VM image.
 
 #### **--save-keys**
 
@@ -42,7 +42,7 @@ deleted.
 
 ## EXAMPLES
 
-Remove a VM named "test1"
+Remove a VM named "test1":
 
 ```
 $ podman machine rm test1


### PR DESCRIPTION
Minor cleanup that came out of a backport review:  
https://github.com/containers/podman/pull/13560#discussion_r830373870

[NO NEW TESTS NEEDED]
