### PR TITLE
[CI:DOCS] Fix inconsistency in documentation

### DIFF
--- a/docs/source/markdown/podman-system-service.1.md
+++ b/docs/source/markdown/podman-system-service.1.md
@@ -15,7 +15,7 @@ example *unix:///run/user/1000/podman/podman.sock*)
 
 To access the API service inside a container:
 - mount the socket as a volume
-- run the container with `--security-opt label:disable`
+- run the container with `--security-opt label=disable`
 
 The REST API provided by **podman system service** is split into two parts: a compatibility layer offering support for the Docker v1.40 API, and a Podman-native Libpod layer.
 Documentation for the latter is available at *https://docs.podman.io/en/latest/_static/api.html*.


### PR DESCRIPTION
There was a small typo in documentation, `--security-opt label=disable` was written as `--security-opt label:disable` instead.


Fixes https://github.com/containers/podman/issues/13526

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
