### PR TITLE
bump golangci-lint to v1.45.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,23 @@ linters:
     - gocritic
     - gosec
     - maligned
+    - gomoddirectives
+    - revive
+    - containedctx
+    - contextcheck
+    - cyclop
+    - errname
+    - forcetypeassert
+    - ineffassign
+    - ireturn
+    - tagliatelle
+    - varnamelen
+    - errchkjson
+    - maintidx
+    - nilerr
+    - wastedassign
+    - nilnil
+    - interfacer
 linters-settings:
   errcheck:
     check-blank: false

--- a/Makefile
+++ b/Makefile
@@ -882,7 +882,7 @@ install.tools: .install.goimports .install.gitvalidation .install.md2man .instal
 
 .PHONY: .install.golangci-lint
 .install.golangci-lint: .gopathok
-	VERSION=1.36.0 GOBIN=$(GOBIN) ./hack/install_golangci.sh
+	VERSION=1.45.0 GOBIN=$(GOBIN) ./hack/install_golangci.sh
 
 .PHONY: .install.bats
 .install.bats: .gopathok

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -122,7 +122,7 @@ func start(cmd *cobra.Command, args []string) error {
 		startOptions.Stdout = os.Stdout
 	}
 
-	var containers []string = args
+	containers := args
 	if len(filters) > 0 {
 		for _, f := range filters {
 			split := strings.SplitN(f, "=", 2)

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1371,7 +1371,7 @@ func (r *ConmonOCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, p
 	case define.JSONLogging:
 		fallthrough
 	//lint:ignore ST1015 the default case has to be here
-	default: //nolint-stylecheck
+	default: //nolint:stylecheck
 		// No case here should happen except JSONLogging, but keep this here in case the options are extended
 		logrus.Errorf("%s logging specified but not supported. Choosing k8s-file logging instead", ctr.LogDriver())
 		fallthrough

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -370,7 +370,7 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		conn           net.Conn
 		err            error
 		qemuSocketConn net.Conn
-		wait           time.Duration = time.Millisecond * 500
+		wait           = time.Millisecond * 500
 	)
 
 	if v.isIncompatible() {


### PR DESCRIPTION
* supports Go 1.18
* disable a number of new linters
* fix minor stylecheck issues

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

@containers/podman-maintainers @cevich 
