### PR TITLE
pod system tests: clean up stray image

### DIFF
--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -6,7 +6,7 @@ load helpers
 function teardown() {
     run_podman pod rm -f -t 0 -a
     run_podman rm -f -t 0 -a
-    run_podman ? rmi $(pause_image)
+    run_podman rmi --ignore $(pause_image)
     basic_teardown
 }
 
@@ -317,16 +317,17 @@ EOF
 
 @test "podman pod create should fail when infra-name is already in use" {
     local infra_name="infra_container_$(random_string 10 | tr A-Z a-z)"
+    local infra_image="k8s.gcr.io/pause:3.5"
     local pod_name="$(random_string 10 | tr A-Z a-z)"
 
-    run_podman --noout pod create --name $pod_name --infra-name "$infra_name" --infra-image "k8s.gcr.io/pause:3.5"
-    is "$output" "" "output should be empty"
+    run_podman --noout pod create --name $pod_name --infra-name "$infra_name" --infra-image "$infra_image"
+    is "$output" "" "output from pod create should be empty"
     run_podman '?' pod create --infra-name "$infra_name"
     if [ $status -eq 0 ]; then
         die "Podman should fail when user try to create two pods with the same infra-name value"
     fi
     run_podman pod rm -f $pod_name
-    run_podman images -a
+    run_podman rmi $infra_image
 }
 
 @test "podman pod create --share" {


### PR DESCRIPTION
One of the pod tests was leaving a stray image behind,
causing scary red warnings in CI logs. Clean that up.

Also, now that #13541 has merged, use 'rmi --ignore' instead of
ignoring exit status from rmi

Signed-off-by: Ed Santiago <santiago@redhat.com>