### PR TITLE
podman system df: fix percent calculation

### DIFF
--- a/cmd/podman/system/df.go
+++ b/cmd/podman/system/df.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"time"
@@ -288,6 +289,10 @@ func (d *dfSummary) Size() string {
 }
 
 func (d *dfSummary) Reclaimable() string {
-	percent := int(float64(d.reclaimable)/float64(d.size)) * 100
+	percent := 0
+	// make sure to check this to prevent div by zero problems
+	if d.size > 0 {
+		percent = int(math.Round(float64(d.reclaimable) / float64(d.size) * float64(100)))
+	}
 	return fmt.Sprintf("%s (%d%%)", units.HumanSize(float64(d.reclaimable)), percent)
 }

--- a/test/e2e/system_df_test.go
+++ b/test/e2e/system_df_test.go
@@ -41,11 +41,17 @@ var _ = Describe("podman system df", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"volume", "create", "data"})
+		// run two containers with volumes to create something in the volume
+		session = podmanTest.Podman([]string{"run", "-v", "data1:/data", "--name", "container1", BB, "sh", "-c", "echo test > /data/1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"create", "-v", "data:/data", "--name", "container1", BB})
+		session = podmanTest.Podman([]string{"run", "-v", "data2:/data", "--name", "container2", BB, "sh", "-c", "echo test > /data/1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		// remove one container, we keep the volume
+		session = podmanTest.Podman([]string{"rm", "container2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -61,9 +67,10 @@ var _ = Describe("podman system df", func() {
 		images := strings.Fields(session.OutputToStringArray()[1])
 		containers := strings.Fields(session.OutputToStringArray()[2])
 		volumes := strings.Fields(session.OutputToStringArray()[3])
-		Expect(images[1]).To(Equal(string(totImages)))
-		Expect(containers[1]).To(Equal("2"))
-		Expect(volumes[2]).To(Equal("1"))
+		Expect(images[1]).To(Equal(string(totImages)), "total images expected")
+		Expect(containers[1]).To(Equal("2"), "total containers expected")
+		Expect(volumes[2]).To(Equal("2"), "total volumes expected")
+		Expect(volumes[6]).To(Equal("(50%)"), "percentage usage expected")
 	})
 
 	It("podman system df image with no tag", func() {


### PR DESCRIPTION
The calculate the percentage we need floating point numbers. The current
code however casted the result of reclaimable/size to an int first.
Casting to an int in go will just discard the decimal points, thus the
result was either 0 or 1 so if multiplied by 100 it would show up as 0%
or 100%.

To fix this we have to multiply by 100 first before casting the result
to an int. Also add a check for div by zero which results in NaN and use
math.Round() to correctly round a number.

Ref #13516

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
