### PR TITLE
libpod: drop warning for Fedora 31

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1087,13 +1087,6 @@ func (c *Container) init(ctx context.Context, retainRetries bool) error {
 
 	// With the spec complete, do an OCI create
 	if _, err = c.ociRuntime.CreateContainer(c, nil); err != nil {
-		// Fedora 31 is carrying a patch to display improved error
-		// messages to better handle the V2 transition. This is NOT
-		// upstream in any OCI runtime.
-		// TODO: Remove once runc supports cgroupsv2
-		if strings.Contains(err.Error(), "this version of runc doesn't work on cgroups v2") {
-			logrus.Errorf("Oci runtime %q does not support Cgroups V2: use system migrate to mitigate", c.ociRuntime.Name())
-		}
 		return err
 	}
 


### PR DESCRIPTION
drop a warning for runc not supporting cgroup v2 on Fedora 31.

[NO NEW TESTS NEEDED]

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
