### PR TITLE
healthcheck: stop showing wrong status when `--no-healthcheck` is set

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1268,7 +1268,10 @@ func (c *Container) start() error {
 		}
 	}
 
-	if c.config.HealthCheckConfig != nil {
+	// Check if healthcheck is not nil and --no-healthcheck option is not set.
+	// If --no-healthcheck is set Test will be always set to `[NONE]` so no need
+	// to update status in such case.
+	if c.config.HealthCheckConfig != nil && !(len(c.config.HealthCheckConfig.Test) == 1 && c.config.HealthCheckConfig.Test[0] == "NONE") {
 		if err := c.updateHealthStatus(define.HealthCheckStarting); err != nil {
 			logrus.Error(err)
 		}

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -54,6 +54,16 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(hc).Should(Exit(125))
 	})
 
+	It("podman disable healthcheck with --no-healthcheck must not show starting on status", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", "--no-healthcheck", "--name", "hc", healthcheck})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		hc := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.State.Health.Status}}", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc).Should(Exit(0))
+		Expect(hc.OutputToString()).To(Not(ContainSubstring("starting")))
+	})
+
 	It("podman run healthcheck and logs should contain healthcheck output", func() {
 		session := podmanTest.Podman([]string{"run", "--name", "test-logs", "-dt", "--health-interval", "1s", "--health-cmd", "echo working", "busybox", "sleep", "3600"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Containers started with `--no-healthcheck` are configured to contain no
health-check and test configured as `NONE`. Podman shows wrong status as
such use cases.

Following commit fixes the faulty behavior of stauts field for
containers started with `--no-healthcheck`

Closes: https://github.com/containers/podman/issues/13578