### PR TITLE
fix compose test error in retry logic

### DIFF
--- a/test/compose/slirp4netns_opts/tests.sh
+++ b/test/compose/slirp4netns_opts/tests.sh
@@ -1,20 +1,19 @@
 # -*- bash -*-
 
-output="$(cat $OUTFILE)"
 expected="teststring"
 
 # Reading from the nc socket is flaky because docker-compose only starts
 # the containers. We cannot know at this point if the container did already
 # send the message. Give the container 5 seconds time to send the message
 # to prevent flakes.
-local _timeout=5
-while [ $_timeout -gt 0 ]; do
+container_timeout=5
+while [ $container_timeout -gt 0 ]; do
+    output="$(< $OUTFILE)"
     if [ -n "$output" ]; then
         break
     fi
     sleep 1
-    _timeout=$(($_timeout - 1))
-    output="$(cat $OUTFILE)"
+    container_timeout=$(($container_timeout - 1))
 done
 
 is "$output" "$expected" "$testname : nc received teststring"


### PR DESCRIPTION
We cannot use local var outside of a function. We have to use a global
one.

Log: https://storage.googleapis.com/cirrus-ci-6707778565701632-fcae48/artifacts/containers/podman/5970023511490560/html/compose_v2-podman-fedora-35-root-host.log.html


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
