### PR TITLE
fix pod volume passing and alter infra inheritance

### DIFF
--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/common/pkg/secrets"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/podman/v4/pkg/namespaces"
+	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/storage"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -405,13 +406,19 @@ type ContainerMiscConfig struct {
 	InitContainerType string `json:"init_container_type,omitempty"`
 }
 
+// InfraInherit contains the compatible options inheritable from the infra container
 type InfraInherit struct {
-	InfraSecurity     ContainerSecurityConfig
-	InfraLabels       []string                  `json:"labelopts,omitempty"`
-	InfraVolumes      []*ContainerNamedVolume   `json:"namedVolumes,omitempty"`
-	InfraOverlay      []*ContainerOverlayVolume `json:"overlayVolumes,omitempty"`
-	InfraImageVolumes []*ContainerImageVolume   `json:"ctrImageVolumes,omitempty"`
-	InfraUserVolumes  []string                  `json:"userVolumes,omitempty"`
-	InfraResources    *spec.LinuxResources      `json:"resources,omitempty"`
-	InfraDevices      []spec.LinuxDevice        `json:"device_host_src,omitempty"`
+	ApparmorProfile    string                   `json:"apparmor_profile,omitempty"`
+	CapAdd             []string                 `json:"cap_add,omitempty"`
+	CapDrop            []string                 `json:"cap_drop,omitempty"`
+	HostDeviceList     []spec.LinuxDevice       `json:"host_device_list,omitempty"`
+	ImageVolumes       []*specgen.ImageVolume   `json:"image_volumes,omitempty"`
+	InfraResources     *spec.LinuxResources     `json:"resource_limits,omitempty"`
+	Mounts             []spec.Mount             `json:"mounts,omitempty"`
+	NoNewPrivileges    bool                     `json:"no_new_privileges,omitempty"`
+	OverlayVolumes     []*specgen.OverlayVolume `json:"overlay_volumes,omitempty"`
+	SeccompPolicy      string                   `json:"seccomp_policy,omitempty"`
+	SeccompProfilePath string                   `json:"seccomp_profile_path,omitempty"`
+	SelinuxOpts        []string                 `json:"selinux_opts,omitempty"`
+	Volumes            []*specgen.NamedVolume   `json:"volumes,omitempty"`
 }

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -103,8 +103,8 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 		}
 	}
 
-	namedVolumes, mounts := c.sortUserVolumes(ctrSpec)
-	inspectMounts, err := c.GetInspectMounts(namedVolumes, c.config.ImageVolumes, mounts)
+	namedVolumes, mounts := c.SortUserVolumes(ctrSpec)
+	inspectMounts, err := c.GetMounts(namedVolumes, c.config.ImageVolumes, mounts)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 // Get inspect-formatted mounts list.
 // Only includes user-specified mounts. Only includes bind mounts and named
 // volumes, not tmpfs volumes.
-func (c *Container) GetInspectMounts(namedVolumes []*ContainerNamedVolume, imageVolumes []*ContainerImageVolume, mounts []spec.Mount) ([]define.InspectMount, error) {
+func (c *Container) GetMounts(namedVolumes []*ContainerNamedVolume, imageVolumes []*ContainerImageVolume, mounts []spec.Mount) ([]define.InspectMount, error) {
 	inspectMounts := []define.InspectMount{}
 
 	// No mounts, return early

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -2235,9 +2235,9 @@ func (c *Container) prepareCheckpointExport() error {
 	return nil
 }
 
-// sortUserVolumes sorts the volumes specified for a container
+// SortUserVolumes sorts the volumes specified for a container
 // between named and normal volumes
-func (c *Container) sortUserVolumes(ctrSpec *spec.Spec) ([]*ContainerNamedVolume, []spec.Mount) {
+func (c *Container) SortUserVolumes(ctrSpec *spec.Spec) ([]*ContainerNamedVolume, []spec.Mount) {
 	namedUserVolumes := []*ContainerNamedVolume{}
 	userMounts := []spec.Mount{}
 

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -773,7 +773,7 @@ func libpodEnvVarsToKubeEnvVars(envs []string, imageEnvs []string) ([]v1.EnvVar,
 
 // libpodMountsToKubeVolumeMounts converts the containers mounts to a struct kube understands
 func libpodMountsToKubeVolumeMounts(c *Container) ([]v1.VolumeMount, []v1.Volume, map[string]string, error) {
-	namedVolumes, mounts := c.sortUserVolumes(c.config.Spec)
+	namedVolumes, mounts := c.SortUserVolumes(c.config.Spec)
 	vms := make([]v1.VolumeMount, 0, len(mounts))
 	vos := make([]v1.Volume, 0, len(mounts))
 	annotations := make(map[string]string)

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -602,8 +602,8 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		infraConfig.CPUSetCPUs = p.ResourceLim().CPU.Cpus
 		infraConfig.PidNS = p.PidMode()
 		infraConfig.UserNS = p.UserNSMode()
-		namedVolumes, mounts := infra.sortUserVolumes(infra.config.Spec)
-		inspectMounts, err = infra.GetInspectMounts(namedVolumes, infra.config.ImageVolumes, mounts)
+		namedVolumes, mounts := infra.SortUserVolumes(infra.config.Spec)
+		inspectMounts, err = infra.GetMounts(namedVolumes, infra.config.ImageVolumes, mounts)
 		infraSecurity = infra.GetSecurityOptions()
 		if err != nil {
 			return nil, err

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1491,7 +1491,7 @@ func (ic *ContainerEngine) ContainerRename(ctx context.Context, nameOrID string,
 func (ic *ContainerEngine) ContainerClone(ctx context.Context, ctrCloneOpts entities.ContainerCloneOptions) (*entities.ContainerCreateReport, error) {
 	spec := specgen.NewSpecGenerator(ctrCloneOpts.Image, ctrCloneOpts.CreateOpts.RootFS)
 	var c *libpod.Container
-	c, err := generate.ConfigToSpec(ic.Libpod, spec, ctrCloneOpts.ID)
+	c, _, err := generate.ConfigToSpec(ic.Libpod, spec, ctrCloneOpts.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -352,8 +352,8 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 				return nil, err
 			}
 		}
-		if len(compatibleOptions.InfraDevices) > 0 && len(s.Devices) == 0 {
-			userDevices = compatibleOptions.InfraDevices
+		if len(compatibleOptions.HostDeviceList) > 0 && len(s.Devices) == 0 {
+			userDevices = compatibleOptions.HostDeviceList
 		} else {
 			userDevices = s.Devices
 		}

--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -28,7 +28,7 @@ var (
 // TODO: handle options parsing/processing via containers/storage/pkg/mount
 func parseVolumes(volumeFlag, mountFlag, tmpfsFlag []string, addReadOnlyTmpfs bool) ([]spec.Mount, []*specgen.NamedVolume, []*specgen.OverlayVolume, []*specgen.ImageVolume, error) {
 	// Get mounts from the --mounts flag.
-	unifiedMounts, unifiedVolumes, unifiedImageVolumes, err := getMounts(mountFlag)
+	unifiedMounts, unifiedVolumes, unifiedImageVolumes, err := Mounts(mountFlag)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -167,12 +167,12 @@ func findMountType(input string) (mountType string, tokens []string, err error) 
 	return
 }
 
-// getMounts takes user-provided input from the --mount flag and creates OCI
+// Mounts takes user-provided input from the --mount flag and creates OCI
 // spec mounts and Libpod named volumes.
 // podman run --mount type=bind,src=/etc/resolv.conf,target=/etc/resolv.conf ...
 // podman run --mount type=tmpfs,target=/dev/shm ...
 // podman run --mount type=volume,source=test-volume, ...
-func getMounts(mountFlag []string) (map[string]spec.Mount, map[string]*specgen.NamedVolume, map[string]*specgen.ImageVolume, error) {
+func Mounts(mountFlag []string) (map[string]spec.Mount, map[string]*specgen.NamedVolume, map[string]*specgen.ImageVolume, error) {
 	finalMounts := make(map[string]spec.Mount)
 	finalNamedVolumes := make(map[string]*specgen.NamedVolume)
 	finalImageVolumes := make(map[string]*specgen.ImageVolume)

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -874,6 +874,10 @@ ENTRYPOINT ["sleep","99999"]
 		ctr3 := podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "cat", "/tmp1/test"})
 		ctr3.WaitWithDefaultTimeout()
 		Expect(ctr3.OutputToString()).To(ContainSubstring("hello"))
+
+		ctr4 := podmanTest.Podman([]string{"run", "--pod", podName, ALPINE, "touch", "/tmp1/testing.txt"})
+		ctr4.WaitWithDefaultTimeout()
+		Expect(ctr4).Should(Exit(0))
 	})
 
 	It("podman pod create --device", func() {


### PR DESCRIPTION
the infra Inherit function was not properly passing pod volume information to new containers. alter the inherit function and struct to use the new `ConfigToSpec` function used in clone pick and choose the proper entities from a temp spec and validate them on the spegen side rather than passing directly to a config

resolves #13548

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
