### PR TITLE
podman stats: calc CPU percentage correctly

### DIFF
--- a/libpod/define/containerstate.go
+++ b/libpod/define/containerstate.go
@@ -138,7 +138,6 @@ type ContainerStats struct {
 	CPU           float64
 	CPUNano       uint64
 	CPUSystemNano uint64
-	DataPoints    int64
 	SystemNano    uint64
 	MemUsage      uint64
 	MemLimit      uint64

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -422,10 +422,6 @@ type PodContainerStats struct {
 
 // GetPodStats returns the stats for each of its containers
 func (p *Pod) GetPodStats(previousContainerStats map[string]*define.ContainerStats) (map[string]*define.ContainerStats, error) {
-	var (
-		ok       bool
-		prevStat *define.ContainerStats
-	)
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -438,10 +434,7 @@ func (p *Pod) GetPodStats(previousContainerStats map[string]*define.ContainerSta
 	}
 	newContainerStats := make(map[string]*define.ContainerStats)
 	for _, c := range containers {
-		if prevStat, ok = previousContainerStats[c.ID()]; !ok {
-			prevStat = &define.ContainerStats{}
-		}
-		newStats, err := c.GetContainerStats(prevStat)
+		newStats, err := c.GetContainerStats(previousContainerStats[c.ID()])
 		// If the container wasn't running, don't include it
 		// but also suppress the error
 		if err != nil && errors.Cause(err) != define.ErrCtrStateInvalid {

--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -77,8 +77,8 @@ func (c *Container) GetContainerStats(previousStats *define.ContainerStats) (*de
 	stats.Duration = cgroupStats.CPU.Usage.Total
 	stats.UpTime = time.Duration(stats.Duration)
 	stats.CPU = calculateCPUPercent(cgroupStats, previousCPU, now, previousStats.SystemNano)
-	stats.AvgCPU = calculateAvgCPU(stats.CPU, previousStats.AvgCPU, previousStats.DataPoints)
-	stats.DataPoints = previousStats.DataPoints + 1
+	// calc the average cpu usage for the time the container is running
+	stats.AvgCPU = calculateCPUPercent(cgroupStats, 0, now, uint64(c.state.StartedTime.UnixNano()))
 	stats.MemUsage = cgroupStats.Memory.Usage.Usage
 	stats.MemLimit = c.getMemLimit()
 	stats.MemPerc = (float64(stats.MemUsage) / float64(stats.MemLimit)) * 100
@@ -155,10 +155,4 @@ func calculateBlockIO(stats *cgroups.Metrics) (read uint64, write uint64) {
 		}
 	}
 	return
-}
-
-// calculateAvgCPU calculates the avg CPU percentage given the previous average and the number of data points.
-func calculateAvgCPU(statsCPU float64, prevAvg float64, prevData int64) float64 {
-	avgPer := ((prevAvg * float64(prevData)) + statsCPU) / (float64(prevData) + 1)
-	return avgPer
 }

--- a/pkg/api/handlers/compat/containers_stats.go
+++ b/pkg/api/handlers/compat/containers_stats.go
@@ -56,7 +56,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stats, err := ctnr.GetContainerStats(&define.ContainerStats{})
+	stats, err := ctnr.GetContainerStats(nil)
 	if err != nil {
 		utils.InternalServerError(w, errors.Wrapf(err, "failed to obtain Container %s stats", name))
 		return

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1431,12 +1431,7 @@ func (ic *ContainerEngine) ContainerStats(ctx context.Context, namesOrIds []stri
 
 			reportStats := []define.ContainerStats{}
 			for _, ctr := range containers {
-				prev, ok := containerStats[ctr.ID()]
-				if !ok {
-					prev = &define.ContainerStats{}
-				}
-
-				stats, err := ctr.GetContainerStats(prev)
+				stats, err := ctr.GetContainerStats(containerStats[ctr.ID()])
 				if err != nil {
 					cause := errors.Cause(err)
 					if queryAll && (cause == define.ErrCtrRemoved || cause == define.ErrNoSuchCtr || cause == define.ErrCtrStateInvalid) {


### PR DESCRIPTION
When you run podman stats, the first interval always shows the wrong cpu
usage. To calculate cpu percentage we get the cpu time from the cgroup
and compare this against the system time between two stats. Since the
first time we do not have a previous stats an empty struct is used
instead. Thus we do not use the actual running time of the container but
the current unix timestamp (time since Jan 1 1970).

To fix this we make sure that the previous stats time is set to the
container start time, when it is empty.

[NO NEW TESTS NEEDED] No idea how I could create a test which would have
a predictable cpu usage.

See the linked bugzilla for a reproducer.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2066145
