### PR TITLE
Binary growth check, part 2 of 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ validate: gofmt lint .gitvalidation validate.completions man-page-check swagger-
 .PHONY: build-all-new-commits
 build-all-new-commits:
 	# Validate that all the commits build on top of $(GIT_BASE_BRANCH)
-	git rebase $(GIT_BASE_BRANCH) -x make
+	git rebase $(GIT_BASE_BRANCH) -x "$(MAKE)"
 
 .PHONY: vendor
 vendor:

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -228,7 +228,17 @@ function _run_altbuild() {
     case "$ALT_NAME" in
         *Each*)
             git fetch origin
-            make build-all-new-commits GIT_BASE_BRANCH=origin/$DEST_BRANCH
+            # The check-size script, introduced 2022-03-22 in #13518,
+            # runs 'make' (the original purpose of this check) against
+            # each commit, then checks image sizes to make sure that
+            # none have grown beyond a given limit. That of course
+            # requires a baseline, which is why we use '^' to start
+            # with the *parent* commit of this PR, not the first commit.
+            context_dir=$(mktemp -d --tmpdir make-size-check.XXXXXXX)
+            make build-all-new-commits \
+                 GIT_BASE_BRANCH=origin/"${DEST_BRANCH}^" \
+                 MAKE="hack/make-and-check-size $context_dir"
+            rm -rf $context_dir
             ;;
         *Windows*)
             make podman-remote-release-windows_amd64.zip

--- a/hack/make-and-check-size
+++ b/hack/make-and-check-size
@@ -2,28 +2,30 @@
 #
 # make-and-check-size - wrapper around 'make' that also checks binary growth
 #
-# This script is intended to be run via 'git rebase -x', in a Makefile rule
-# such as:
+# This script is intended to be run via 'git rebase -x', in a form such as:
 #
-#    build-all-new-commits:
-#       CONTEXT_DIR=$(shell mktemp -d --tmpdir make-size-check.XXXXXXX); \
-#       git rebase $(GIT_BASE_BRANCH)^ -x "hack/make-and-check-size $$CONTEXT_DIR"; \
-#       $(RM) -rf $$CONTEXT_DIR
+#     context_dir=$(mktemp -d --tmpdir make-size-check.XXXXXXX)
+#     git rebase ${GIT_BASE_BRANCH}^ -x "hack/make-and-check-size $context_dir"
+#     rm -rf $context_dir
 #
-# ...which has long been a part of our usual CI, one that makes sure that
-# each commit (in a multi-commit PR) can be compiled individually. By
-# adding the '^' to GIT_BASE_BRANCH we establish a baseline and store
+# (Carefully note the '^' next to GIT_BASE_BRANCH!)
+#
+# A 'git rebase -x' has long been a part of our usual CI; it guarantees
+# that each commit (whether in a single- or multi-commit PR) can be
+# compiled individually.
+#
+# By adding the '^' to GIT_BASE_BRANCH we establish a baseline and store
 # the binary sizes of each file (podman, podman-remote) prior to our PR.
 #
-# CONTEXT_DIR is a temporary directory used to store the original sizes
+# context_dir is a temporary directory used to store the original sizes
 # of each binary file under bin/
 #
 # *IMPORTANT NOTE*: this script will leave the git checkout in a funky state!
 # (because we rebase onto a nonterminal commit). I believe this is OK, since
-# this makefile target is used only in CI and only in a scratch VM. Running
-# this in a development environment would yield unpredictable results anyway,
-# by rebasing onto origin/main by default and by leaving an aborted rebase
-# on failure.
+# this script is only invoked in CI from runner.sh and only in a scratch VM.
+# Running this in a development environment would yield unpredictable results
+# anyway, by rebasing onto origin/main by default and by leaving an aborted
+# rebase on failure.
 #
 ME=$(basename $0)
 


### PR DESCRIPTION
Add a CI check to prevent unwanted bloat in binary images,
by building a baseline (pre-PR) binary then comparing file
sizes post-PR.

Part 1 (#13518) added a new script that runs multiple 'make's,
comparing image sizes against an original, and failing loudly
if growth is too big. An override mechanism is defined.

This is part 2 of 2: adding the CI rule. We couldn't do that
in part 1, because the rule would call a script that didn't
exist in the pre-PR commit.

Signed-off-by: Ed Santiago <santiago@redhat.com>
