### PR TITLE
[v4.0-rhel] vendor c/common@v0.47.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.0.1
 	github.com/containernetworking/plugins v1.0.1
 	github.com/containers/buildah v1.24.1
-	github.com/containers/common v0.47.4
+	github.com/containers/common v0.47.5
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.19.1
 	github.com/containers/ocicrypt v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/containernetworking/plugins v1.0.1/go.mod h1:QHCfGpaTwYTbbH+nZXKVTxNB
 github.com/containers/buildah v1.24.1 h1:PlvU0hbUsm1x4H9kPcsmqjViqDGnBpSZT3QtZ00RtgI=
 github.com/containers/buildah v1.24.1/go.mod h1:sE7AaoPQYwAB7dleOOKOpzOO3bA8lRUvZRiZcn/RYi0=
 github.com/containers/common v0.47.3/go.mod h1:/VAV4ibC27Lfyb9cxXM4uTYrJFa/7s+utNB052MJdzY=
-github.com/containers/common v0.47.4 h1:kS202Z/bTQIM/pwyuJ+lF8143Uli6AB9Q9OVR0xa9CM=
-github.com/containers/common v0.47.4/go.mod h1:HgX0mFXyB0Tbe2REEIp9x9CxET6iSzmHfwR6S/t2LZc=
+github.com/containers/common v0.47.5 h1:Qm9o+wVPO9sbggTKubN3xYMtPRaPv7dmcrJQgongHHw=
+github.com/containers/common v0.47.5/go.mod h1:HgX0mFXyB0Tbe2REEIp9x9CxET6iSzmHfwR6S/t2LZc=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.19.1 h1:g4/+XIuh1kRoRn2MfLDhfHhkNOIO9JtqhSyo55tjpfE=

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -417,12 +417,12 @@ var _ = Describe("Podman login and logout", func() {
 		Expect(authInfo).NotTo(HaveKey(testRepos[1]))
 	})
 
-	It("podman login with repository invalid arguments", func() {
+	It("podman login with http{s} prefix", func() {
 		authFile := filepath.Join(podmanTest.TempDir, "auth.json")
 
 		for _, invalidArg := range []string{
 			"https://" + server + "/podmantest",
-			server + "/podmantest/image:latest",
+			"http://" + server + "/podmantest/image:latest",
 		} {
 			session := podmanTest.Podman([]string{
 				"login",
@@ -432,7 +432,7 @@ var _ = Describe("Podman login and logout", func() {
 				invalidArg,
 			})
 			session.WaitWithDefaultTimeout()
-			Expect(session).Should(ExitWithError())
+			Expect(session).To(Exit(0))
 		}
 	})
 

--- a/vendor/github.com/containers/common/version/version.go
+++ b/vendor/github.com/containers/common/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.47.4"
+const Version = "0.47.5"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -109,7 +109,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.47.4
+# github.com/containers/common v0.47.5
 ## explicit
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests


### PR DESCRIPTION
Update the login tests to reflect the latest changes to allow http{s}
prefixes (again) to address bugzilla.redhat.com/show_bug.cgi?id=2062072.

Backport of commit 57cdc21b0057.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>
