### PR TITLE
run, create: add --passwd-entry

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -630,6 +630,10 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(chrootDirsFlagName, completion.AutocompleteDefault)
 
+		passwdEntryName := "passwd-entry"
+		createFlags.StringVar(&cf.PasswdEntry, passwdEntryName, "", "Entry to write to /etc/passwd")
+		_ = cmd.RegisterFlagCompletionFunc(passwdEntryName, completion.AutocompleteNone)
+
 		if registry.IsRemote() {
 			_ = createFlags.MarkHidden("env-host")
 			_ = createFlags.MarkHidden("http-proxy")

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -755,6 +755,12 @@ Tune the host's OOM preferences for containers (accepts -1000 to 1000)
 #### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
 
+#### **--passwd-entry**=*ENTRY*
+
+Customize the entry that is written to the `/etc/passwd` file within the container when `--passwd` is used.
+
+The variables $USERNAME, $UID, $GID, $NAME, $HOME are automatically replaced with their value at runtime.
+
 #### **--personality**=*persona*
 
 Personality sets the execution domain via Linux personality(2).

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -787,6 +787,12 @@ Override the OS, defaults to hosts, of the image to be pulled. For example, `win
 Allow Podman to add entries to /etc/passwd and /etc/group when used in conjunction with the --user option.
 This is used to override the Podman provided user setup in favor of entrypoint configurations such as libnss-extrausers.
 
+#### **--passwd-entry**=*ENTRY*
+
+Customize the entry that is written to the `/etc/passwd` file within the container when `--passwd` is used.
+
+The variables $USERNAME, $UID, $GID, $NAME, $HOME are automatically replaced with their value at runtime.
+
 #### **--personality**=*persona*
 
 Personality sets the execution domain via Linux personality(2).

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -404,6 +404,8 @@ type ContainerMiscConfig struct {
 	// InitContainerType specifies if the container is an initcontainer
 	// and if so, what type: always or once are possible non-nil entries
 	InitContainerType string `json:"init_container_type,omitempty"`
+	// PasswdEntry specifies arbitrary data to append to a file.
+	PasswdEntry string `json:"passwd_entry,omitempty"`
 }
 
 // InfraInherit contains the compatible options inheritable from the infra container

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -2051,3 +2051,16 @@ func WithChrootDirs(dirs []string) CtrCreateOption {
 		return nil
 	}
 }
+
+// WithPasswdEntry sets the entry to write to the /etc/passwd file.
+func WithPasswdEntry(passwdEntry string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.PasswdEntry = passwdEntry
+
+		return nil
+	}
+}

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -272,6 +272,8 @@ type ContainerCreateOptions struct {
 	Net *NetOptions `json:"net,omitempty"`
 
 	CgroupConf []string
+
+	PasswdEntry string
 }
 
 func NewInfraContainerCreateOptions() ContainerCreateOptions {

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -286,6 +286,9 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 	if s.Volatile {
 		options = append(options, libpod.WithVolatile())
 	}
+	if s.PasswdEntry != "" {
+		options = append(options, libpod.WithPasswdEntry(s.PasswdEntry))
+	}
 
 	useSystemd := false
 	switch s.Systemd {

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -206,6 +206,8 @@ type ContainerBasicConfig struct {
 	UnsetEnvAll bool `json:"unsetenvall,omitempty"`
 	// Passwd is a container run option that determines if we are validating users/groups before running the container
 	Passwd *bool `json:"manage_password,omitempty"`
+	// PasswdEntry specifies arbitrary data to append to a file.
+	PasswdEntry string `json:"passwd_entry,omitempty"`
 }
 
 // ContainerStorageConfig contains information on the storage configuration of a

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -832,6 +832,11 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	if s.Passwd == nil {
 		s.Passwd = &t
 	}
+
+	if len(s.PasswdEntry) == 0 || len(c.PasswdEntry) != 0 {
+		s.PasswdEntry = c.PasswdEntry
+	}
+
 	return nil
 }
 

--- a/test/e2e/run_passwd_test.go
+++ b/test/e2e/run_passwd_test.go
@@ -137,4 +137,16 @@ USER 1000`, ALPINE)
 		Expect(run).Should(Exit(0))
 		Expect(run.OutputToString()).NotTo((ContainSubstring("1234:1234")))
 	})
+
+	It("podman run --passwd-entry flag", func() {
+		// Test that the line we add doesn't contain anything else than what is specified
+		run := podmanTest.Podman([]string{"run", "--user", "1234:1234", "--passwd-entry=FOO", ALPINE, "grep", "^FOO$", "/etc/passwd"})
+		run.WaitWithDefaultTimeout()
+		Expect(run).Should(Exit(0))
+
+		run = podmanTest.Podman([]string{"run", "--user", "12345:12346", "-w", "/etc", "--passwd-entry=$UID-$GID-$NAME-$HOME-$USERNAME", ALPINE, "cat", "/etc/passwd"})
+		run.WaitWithDefaultTimeout()
+		Expect(run).Should(Exit(0))
+		Expect(run.OutputToString()).To(ContainSubstring("12345-12346-container user-/etc-12345"))
+	})
 })


### PR DESCRIPTION
It allows to customize the entry that is written to the `/etc/passwd`
file when --passwd is used.

Closes: https://github.com/containers/podman/issues/13185

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
