### PR TITLE
Explicitly use IPv4 to check if podman-machine VM is listening

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -782,7 +782,7 @@ func (v *MachineVM) isRunning() (bool, error) {
 
 func (v *MachineVM) isListening() bool {
 	// Check if we can dial it
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", "localhost", v.Port), 10*time.Millisecond)
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", "127.0.0.1", v.Port), 10*time.Millisecond)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
When starting a VM that has been configured with volume mounts, the podman client attempts to connect via
TCP to localhost, which runs gvproxy to proxy an ephemeral port to the VM's ssh port.  Previously, gvproxy
was listening on all interfaces and IP addresses, but this behavior has changed to listening only on the
IPv4 loopback address.

Without this change, if a newer build of gvproxy is used, a podman machine configured with volume mounts
will hang forever after "podman machine start" with "Waiting for VM ...".

Signed-off-by: Burt Holzman <burt@fnal.gov>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
