### PR TITLE
podman machine start: lookup qemu path again if not found

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -98,7 +98,7 @@ func (p *Provider) NewMachine(opts machine.InitOptions) (machine.VM, error) {
 		return nil, err
 	}
 
-	cmd := append([]string{execPath})
+	cmd := []string{execPath}
 	// Add memory
 	cmd = append(cmd, []string{"-m", strconv.Itoa(int(vm.Memory))}...)
 	// Add cpus
@@ -436,7 +436,23 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 
 	_, err = os.StartProcess(v.CmdLine[0], cmd, attr)
 	if err != nil {
-		return err
+		// check if qemu was not found
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		// lookup qemu again maybe the path was changed, https://github.com/containers/podman/issues/13394
+		cfg, err := config.Default()
+		if err != nil {
+			return err
+		}
+		cmd[0], err = cfg.FindHelperBinary(QemuCommand, true)
+		if err != nil {
+			return err
+		}
+		_, err = os.StartProcess(cmd[0], cmd, attr)
+		if err != nil {
+			return err
+		}
 	}
 	fmt.Println("Waiting for VM ...")
 	socketPath, err := getRuntimeDir()

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -430,7 +430,7 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 
 	// Disable graphic window when not in debug mode
 	// Done in start, so we're not suck with the debug level we used on init
-	if logrus.GetLevel() != logrus.DebugLevel {
+	if !logrus.IsLevelEnabled(logrus.DebugLevel) {
 		cmd = append(cmd, "-display", "none")
 	}
 


### PR DESCRIPTION
We store the full path to qemu in the machine config. When the path
changes on the host the machine can longer be started. To fix it we get
the path again when we fail to start the machine due the missing binary.

We want to store and use the full path first because otherwise existing
machines can break when the qemu version changed.

[NO TESTS NEEDED] We still have no machine tests.

Fixes https://github.com/containers/podman/issues/13394
