### PR TITLE
[CI:DOCS] document that using libpod package directly is not supported

### DIFF
--- a/libpod/container_path_resolution.go
+++ b/libpod/container_path_resolution.go
@@ -1,4 +1,3 @@
-// +linux
 package libpod
 
 import (

--- a/libpod/doc.go
+++ b/libpod/doc.go
@@ -1,0 +1,11 @@
+// The libpod library is not stable and we do not support use cases outside of
+// this repository. The API can change at any time even with patch releases.
+//
+// If you need a stable interface Podman provides a HTTP API which follows semver,
+// please see https://docs.podman.io/en/latest/markdown/podman-system-service.1.html
+// to start the api service and https://docs.podman.io/en/latest/_static/api.html
+// for the API reference.
+//
+// We also provide stable go bindings to talk to the api service from another go
+// program, see the pkg/bindings directory.
+package libpod


### PR DESCRIPTION
We do not support using the libpod package outside of podman. There is
no stable interface which can be used. Instead point users to the API
and go bindings.

Fixes #13086

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
