### PR TITLE
When running systemd in a container set container_uuid

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1020,15 +1020,20 @@ Run container in systemd mode. The default is *true*.
 
 The value *always* enforces the systemd mode is enforced without
 looking at the executable name. Otherwise, if set to true and the
-command you are running inside the container is systemd, /usr/sbin/init,
-/sbin/init or /usr/local/sbin/init.
+command you are running inside the container is **systemd**, **/usr/sbin/init**,
+**/sbin/init** or **/usr/local/sbin/init**.
 
-If the command you are running inside of the container is systemd,
-Podman will setup tmpfs mount points in the following directories:
+Running the container in systemd mode causes the following changes:
 
-/run, /run/lock, /tmp, /sys/fs/cgroup/systemd, /var/lib/journal
-
-It will also set the default stop signal to SIGRTMIN+3.
+* Podman mounts tmpfs file systems on the following directories
+  * _/run_
+  * _/run/lock_
+  * _/tmp_
+  * _/sys/fs/cgroup/systemd_
+  * _/var/lib/journal_
+* Podman sets the default stop signal to **SIGRTMIN+3**.
+* Podman sets **container_uuid** environment variable in the container to the
+first 32 characters of the container id.
 
 This allows systemd to run in a confined container without any modifications.
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1082,20 +1082,21 @@ Note: if you use the **--network=host** option, these sysctls will not be allowe
 Run container in systemd mode. The default is **true**.
 
 The value *always* enforces the systemd mode is enforced without
-looking at the executable name. Otherwise, if set to **true** and the
-command you are running inside the container is systemd, _/usr/sbin/init_,
-_/sbin/init_ or _/usr/local/sbin/init_.
+looking at the executable name. Otherwise, if set to true and the
+command you are running inside the container is **systemd**, **/usr/sbin/init**,
+**/sbin/init** or **/usr/local/sbin/init**.
 
-If the command you are running inside of the container is systemd
-Podman will setup tmpfs mount points in the following directories:
+Running the container in systemd mode causes the following changes:
 
-- _/run_
-- _/run/lock_
-- _/tmp_
-- _/sys/fs/cgroup/systemd_
-- _/var/lib/journal_
-
-It will also set the default stop signal to **SIGRTMIN+3**.
+* Podman mounts tmpfs file systems on the following directories
+  * _/run_
+  * _/run/lock_
+  * _/tmp_
+  * _/sys/fs/cgroup/systemd_
+  * _/var/lib/journal_
+* Podman sets the default stop signal to **SIGRTMIN+3**.
+* Podman sets **container_uuid** environment variable in the container to the
+first 32 characters of the container id.
 
 This allows systemd to run in a confined container without any modifications.
 

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -968,6 +968,16 @@ func (c *Container) mountNotifySocket(g generate.Generator) error {
 // systemd expects to have /run, /run/lock and /tmp on tmpfs
 // It also expects to be able to write to /sys/fs/cgroup/systemd and /var/log/journal
 func (c *Container) setupSystemd(mounts []spec.Mount, g generate.Generator) error {
+	var containerUUIDSet bool
+	for _, s := range c.config.Spec.Process.Env {
+		if strings.HasPrefix(s, "container_uuid=") {
+			containerUUIDSet = true
+			break
+		}
+	}
+	if !containerUUIDSet {
+		g.AddProcessEnv("container_uuid", c.ID()[:32])
+	}
 	options := []string{"rw", "rprivate", "nosuid", "nodev"}
 	for _, dest := range []string{"/run", "/run/lock"} {
 		if MountExists(mounts, dest) {

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -281,6 +281,13 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
     is "$output" "" "output should be empty"
 }
 
+@test "podman --systemd sets container_uuid" {
+    run_podman run --systemd=always --name test $IMAGE printenv container_uuid
+    container_uuid=$output
+    run_podman inspect test --format '{{ .ID }}'
+    is "${container_uuid}" "${output:0:32}" "UUID should be first 32 chars of Container id"
+}
+
 # https://github.com/containers/podman/issues/13153
 @test "podman rootless-netns slirp4netns process should be in different cgroup" {
     is_rootless || skip "only meaningful for rootless"


### PR DESCRIPTION
systemd expects the container_uuid environment variable be set
when it is running in a container.

Fixes: https://github.com/containers/podman/issues/13187

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
