### PR TITLE
machine-set: fix example for setting `rootful` flag

### DIFF
--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -17,7 +17,7 @@ var (
 		Long:              "Sets an updatable virtual machine setting",
 		RunE:              setMachine,
 		Args:              cobra.MaximumNArgs(1),
-		Example:           `podman machine set --root=false`,
+		Example:           `podman machine set --rootful=false`,
 		ValidArgsFunction: completion.AutocompleteNone,
 	}
 )


### PR DESCRIPTION
Flag is actually named `rootful` however documented as `root`, fix the
documented example as actual flag.

Both `podman machine init` and `podman machine set` uses flag `rootfull`

[NO TESTS NEEDED]
[NO NEW TESTS NEEDED]

Closes: https://github.com/containers/podman/issues/13632