### PR TITLE
[CI:DOCS] Remove experimental warning from podman-remote rpm

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -144,10 +144,7 @@ Summary: (Experimental) Remote client for managing %{name} containers
 %description remote
 Remote client for managing %{name} containers.
 
-This experimental remote client is under heavy development. Please do not
-run %{name}-remote in production.
-
-%{name}-remote uses the version 2 API to connect to a %{name} client to
+%{name}-remote uses the libpod REST API to connect to a %{name} client to
 manage pods, containers and container images. %{name}-remote supports ssh
 connections as well.
 


### PR DESCRIPTION
podman-remote is considered stable and follows the same semver as
podman.

Fixes a question on the podman mailing list.
https://lists.podman.io/archives/list/podman@lists.podman.io/thread/2DVCU5Z54U4PI5ROTBQXHDBLQSAXAHFU/

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
