### PR TITLE
readConmonPipeData: try to improve error

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1587,11 +1587,13 @@ func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, 
 		var si *syncInfo
 		rdr := bufio.NewReader(pipe)
 		b, err := rdr.ReadBytes('\n')
-		if err != nil {
+		// ignore EOF here, error is returned even when data was read
+		// if it is no valid json unmarshal will fail below
+		if err != nil && !errors.Is(err, io.EOF) {
 			ch <- syncStruct{err: err}
 		}
 		if err := json.Unmarshal(b, &si); err != nil {
-			ch <- syncStruct{err: err}
+			ch <- syncStruct{err: fmt.Errorf("conmon bytes %q: %w", string(b), err)}
 			return
 		}
 		ch <- syncStruct{si: si}


### PR DESCRIPTION
Issue #10927 reports `container create failed (no logs from conmon): EOF`
errors. Since we do not know the root cause it would be helpful to try
to get as much info as possible out of the error.
(buffer).ReadBytes() will return the bytes read even when an error
occurs. So when we get an EOF we could still have some valuable
information in the buffer. Lets try to unmarshal them and if this fails
we add the bytes to the error message.

This does not fix the issue but it might help us getting a better error.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
