### PR TITLE
[CI:DOCS] podman machine set: clarify --rootful option

### DIFF
--- a/docs/source/markdown/podman-machine-set.1.md
+++ b/docs/source/markdown/podman-machine-set.1.md
@@ -26,7 +26,9 @@ container execution. This option will also update the current podman
 remote connection default if it is currently pointing at the specified
 machine name (or `podman-machine-default` if no name is specified).
 
-API forwarding, if available, will follow this setting.
+Unlike [**podman system connection default**](podman-system-connection-default.1.md)
+this option will also make the API socket, if available, forward to the rootful/rootless
+socket in the VM.
 
 ## EXAMPLES
 


### PR DESCRIPTION
It is not quite clear what the difference between `podman machine set
--rootful` and `podman system connection default` is.
Add a small note with the difference, the --rootful option will also
affect the socket forwarding.

Fixes #13515

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
