### PR TITLE
[CI:DOCS] clarifying "loginctl enable-linger" section in doc

### DIFF
--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -224,7 +224,7 @@ To run the user services placed in `$HOME/.config/systemd/user` on first login o
 ```
 $ systemctl --user enable <.service>
 ```
-The systemd user instance is killed after the last session for the user is closed. The systemd user instance can be kept running ever after the user logs out by enabling `lingering` using
+The systemd user instance is killed after the last session for the user is closed. The systemd user instance can be started at boot and kept running even after the user logs out by enabling `lingering` using
 
 ```
 $ loginctl enable-linger <username>


### PR DESCRIPTION
As currently written, it isn't clear that loginctl enable-linger <username> also starts user services at boot.
here is a quote from the enable-linger command in the systemd docs:
"If enabled for a specific user, a user manager is spawned for the user at boot and kept around after logouts."
https://www.freedesktop.org/software/systemd/man/loginctl.html

Signed-off-by: Adam Maryniuk <adamaze@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
