### PR TITLE
[WIP]change macos directory for machine sockets

### DIFF
--- a/cmd/podman-mac-helper/install.go
+++ b/cmd/podman-mac-helper/install.go
@@ -101,7 +101,7 @@ func install(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	target := filepath.Join(homeDir, ".local", "share", "containers", "podman", "machine", "podman.sock")
+	target := filepath.Join(homeDir, ".podman", "podman.sock")
 	var buf bytes.Buffer
 	t := template.Must(template.New("launchdConfig").Parse(launchConfig))
 	err = t.Execute(&buf, launchParams{prog, userName, uid, target})

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1060,26 +1060,12 @@ func (v *MachineVM) isIncompatible() bool {
 }
 
 func (v *MachineVM) getForwardSocketPath() (string, error) {
-	path, err := machine.GetDataDir(v.Name)
+	qemuSocketDir, _, err := v.getSocketandPid()
 	if err != nil {
-		logrus.Errorf("Error resolving data dir: %s", err.Error())
+		logrus.Errorf("Error resolving socket dir: %s", err.Error())
 		return "", nil
 	}
-	return filepath.Join(path, "podman.sock"), nil
-}
-
-func (v *MachineVM) getSocketandPid() (string, string, error) {
-	rtPath, err := getRuntimeDir()
-	if err != nil {
-		return "", "", err
-	}
-	if !rootless.IsRootless() {
-		rtPath = "/run"
-	}
-	socketDir := filepath.Join(rtPath, "podman")
-	pidFile := filepath.Join(socketDir, fmt.Sprintf("%s.pid", v.Name))
-	qemuSocket := filepath.Join(socketDir, fmt.Sprintf("qemu_%s.sock", v.Name))
-	return qemuSocket, pidFile, nil
+	return filepath.Join(filepath.Dir(qemuSocketDir), "podman.sock"), nil
 }
 
 func checkSockInUse(sock string) bool {

--- a/pkg/machine/qemu/options_linux.go
+++ b/pkg/machine/qemu/options_linux.go
@@ -11,3 +11,17 @@ func getRuntimeDir() (string, error) {
 	}
 	return util.GetRuntimeDir()
 }
+
+func (v *MachineVM) getSocketandPid() (string, string, error) {
+	rtPath, err := getRuntimeDir()
+	if err != nil {
+		return "", "", err
+	}
+	if !rootless.IsRootless() {
+		rtPath = "/run"
+	}
+	socketDir := filepath.Join(rtPath, "podman")
+	pidFile := filepath.Join(socketDir, fmt.Sprintf("%s.pid", v.Name))
+	qemuSocket := filepath.Join(socketDir, fmt.Sprintf("qemu_%s.sock", v.Name))
+	return qemuSocket, pidFile, nil
+}

--- a/pkg/machine/qemu/options_linux.go
+++ b/pkg/machine/qemu/options_linux.go
@@ -1,6 +1,9 @@
 package qemu
 
 import (
+	"fmt"
+	"path/filepath"
+
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/util"
 )
@@ -24,4 +27,9 @@ func (v *MachineVM) getSocketandPid() (string, string, error) {
 	pidFile := filepath.Join(socketDir, fmt.Sprintf("%s.pid", v.Name))
 	qemuSocket := filepath.Join(socketDir, fmt.Sprintf("qemu_%s.sock", v.Name))
 	return qemuSocket, pidFile, nil
+}
+
+func createCompatTmpLink() error {
+	// Only necessary on Mac
+	return nil
 }


### PR DESCRIPTION
if the machine name is long and/or the username is long, it is possible to exceed the 104byte limit for filenames in MacOS.  This PR shortcuts things to $HOME/.podman instead.

Fixes: #13609

[NO NEW TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
