### PR TITLE
Remove error stutter

### DIFF
--- a/cmd/podman/images/import.go
+++ b/cmd/podman/images/import.go
@@ -118,14 +118,14 @@ func importCon(cmd *cobra.Command, args []string) error {
 	if source == "-" {
 		outFile, err := ioutil.TempFile("", "podman")
 		if err != nil {
-			return errors.Errorf("error creating file %v", err)
+			return errors.Errorf("creating file %v", err)
 		}
 		defer os.Remove(outFile.Name())
 		defer outFile.Close()
 
 		_, err = io.Copy(outFile, os.Stdin)
 		if err != nil {
-			return errors.Errorf("error copying file %v", err)
+			return errors.Errorf("copying file %v", err)
 		}
 		source = outFile.Name()
 	}

--- a/cmd/podman/images/load.go
+++ b/cmd/podman/images/load.go
@@ -95,14 +95,14 @@ func load(cmd *cobra.Command, args []string) error {
 		}
 		outFile, err := ioutil.TempFile(util.Tmpdir(), "podman")
 		if err != nil {
-			return errors.Errorf("error creating file %v", err)
+			return errors.Errorf("creating file %v", err)
 		}
 		defer os.Remove(outFile.Name())
 		defer outFile.Close()
 
 		_, err = io.Copy(outFile, os.Stdin)
 		if err != nil {
-			return errors.Errorf("error copying file %v", err)
+			return errors.Errorf("copying file %v", err)
 		}
 		loadOpts.Input = outFile.Name()
 	}

--- a/cmd/podman/images/scp.go
+++ b/cmd/podman/images/scp.go
@@ -268,7 +268,7 @@ func saveToRemote(image, localFile string, tag string, uri *urlP.URL, iden strin
 	}
 	n, err := scpD.CopyFrom(dial, remoteFile, localFile)
 	if _, conErr := connection.ExecRemoteCommand(dial, "rm "+remoteFile); conErr != nil {
-		logrus.Errorf("Error removing file on endpoint: %v", conErr)
+		logrus.Errorf("Removing file on endpoint: %v", conErr)
 	}
 	if err != nil {
 		errOut := strconv.Itoa(int(n)) + " Bytes copied before error"

--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -231,7 +231,7 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 				fmt.Fprintf(os.Stderr, "error inspecting object: %v\n", err)
 			}
 		}
-		return errors.Errorf("error inspecting object: %v", errs[0])
+		return errors.Errorf("inspecting object: %v", errs[0])
 	}
 	return nil
 }

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -179,7 +179,7 @@ func create(cmd *cobra.Command, args []string) error {
 			return errors.Errorf("pod id file exists. Ensure another pod is not using it or delete %s", podIDFile)
 		}
 		if err != nil {
-			return errors.Errorf("error opening pod-id-file %s", podIDFile)
+			return errors.Errorf("opening pod-id-file %s", podIDFile)
 		}
 		defer errorhandling.CloseQuiet(podIDFD)
 		defer errorhandling.SyncQuiet(podIDFD)

--- a/cmd/podman/secrets/inspect.go
+++ b/cmd/podman/secrets/inspect.go
@@ -76,7 +76,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 				fmt.Fprintf(os.Stderr, "error inspecting secret: %v\n", err)
 			}
 		}
-		return errors.Errorf("error inspecting secret: %v", errs[0])
+		return errors.Errorf("inspecting secret: %v", errs[0])
 	}
 	return nil
 }

--- a/cmd/podman/system/dial_stdio.go
+++ b/cmd/podman/system/dial_stdio.go
@@ -88,10 +88,10 @@ func runDialStdio() error {
 func copier(to halfWriteCloser, from halfReadCloser, debugDescription string) error {
 	defer func() {
 		if err := from.CloseRead(); err != nil {
-			logrus.Errorf("error while CloseRead (%s): %v", debugDescription, err)
+			logrus.Errorf("while CloseRead (%s): %v", debugDescription, err)
 		}
 		if err := to.CloseWrite(); err != nil {
-			logrus.Errorf("error while CloseWrite (%s): %v", debugDescription, err)
+			logrus.Errorf("while CloseWrite (%s): %v", debugDescription, err)
 		}
 	}()
 	if _, err := io.Copy(to, from); err != nil {

--- a/cmd/podman/utils/error.go
+++ b/cmd/podman/utils/error.go
@@ -41,5 +41,5 @@ func ExitCodeFromBuildError(errorMsg string) (int, error) {
 			return buildahCLI.ExecErrorCodeGeneric, err
 		}
 	}
-	return buildahCLI.ExecErrorCodeGeneric, errors.New("error message does not contains a valid exit code")
+	return buildahCLI.ExecErrorCodeGeneric, errors.New("message does not contains a valid exit code")
 }

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1002,7 +1002,7 @@ func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, e
 				}
 			}
 			// do not propagate error inspecting a joined network ns
-			logrus.Errorf("Error inspecting network namespace: %s of container %s: %v", networkNSPath, c.ID(), err)
+			logrus.Errorf("Inspecting network namespace: %s of container %s: %v", networkNSPath, c.ID(), err)
 		}
 		// We can't do more if the network is down.
 

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -662,7 +662,7 @@ func (r *Runtime) setupRootlessPortMappingViaSlirp(ctr *Container, cmd *exec.Cmd
 			return errors.Wrapf(err, "error parsing error status from slirp4netns")
 		}
 		if e, found := y["error"]; found {
-			return errors.Errorf("error from slirp4netns while setting up port redirection: %v", e)
+			return errors.Errorf("from slirp4netns while setting up port redirection: %v", e)
 		}
 	}
 	logrus.Debug("slirp4netns port-forwarding setup via add_hostfwd is ready")

--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -242,7 +242,7 @@ func Attach(ctx context.Context, nameOrID string, stdin io.Reader, stdout io.Wri
 					}
 				}
 			case fd == 3:
-				return fmt.Errorf("error from service from stream: %s", frame)
+				return fmt.Errorf("from service from stream: %s", frame)
 			default:
 				return fmt.Errorf("unrecognized channel '%d' in header, 0-3 supported", fd)
 			}
@@ -562,7 +562,7 @@ func ExecStartAndAttach(ctx context.Context, sessionID string, options *ExecStar
 					}
 				}
 			case fd == 3:
-				return fmt.Errorf("error from service from stream: %s", frame)
+				return fmt.Errorf("from service from stream: %s", frame)
 			default:
 				return fmt.Errorf("unrecognized channel '%d' in header, 0-3 supported", fd)
 			}

--- a/pkg/bindings/containers/logs.go
+++ b/pkg/bindings/containers/logs.go
@@ -57,7 +57,7 @@ func Logs(ctx context.Context, nameOrID string, options *LogOptions, stdoutChan,
 		case 2:
 			stderrChan <- string(frame)
 		case 3:
-			return errors.New("error from service in stream: " + string(frame))
+			return errors.New("from service in stream: " + string(frame))
 		default:
 			return fmt.Errorf("unrecognized input header: %d", fd)
 		}

--- a/pkg/bindings/errors.go
+++ b/pkg/bindings/errors.go
@@ -54,6 +54,6 @@ func CheckResponseCode(inError error) (int, error) {
 	case *errorhandling.PodConflictErrorModel:
 		return e.Code(), nil
 	default:
-		return -1, errors.New("error is not type ErrorModel")
+		return -1, errors.New("is not type ErrorModel")
 	}
 }

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -575,7 +575,7 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 					if err != io.EOF {
 						return nil // non empty root dir, need to return
 					} else if err != nil {
-						logrus.Errorf("Error while reading directory %v: %v", path, err)
+						logrus.Errorf("While reading directory %v: %v", path, err)
 					}
 				}
 				name := filepath.ToSlash(strings.TrimPrefix(path, s+string(filepath.Separator)))

--- a/pkg/domain/infra/abi/images_test.go
+++ b/pkg/domain/infra/abi/images_test.go
@@ -48,7 +48,7 @@ func TestToDomainHistoryLayer(t *testing.T) {
 // 	r := DirectImageRuntime{m}
 // 	err := r.Delete(context.TODO(), actual, "fedora")
 // 	if err != nil {
-// 		t.Errorf("error should be nil, got: %v", err)
+// 		t.Errorf("should be nil, got: %v", err)
 // 	}
 // 	m.AssertExpectations(t)
 // }

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -129,7 +129,7 @@ func DownloadVMImage(downloadURL *url2.URL, localImagePath string) error {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("error downloading VM image %s: %s", downloadURL, resp.Status)
+		return fmt.Errorf("downloading VM image %s: %s", downloadURL, resp.Status)
 	}
 	size := resp.ContentLength
 	urlSplit := strings.Split(downloadURL.Path, "/")

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -317,7 +317,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 		resize.Stdout = os.Stdout
 		resize.Stderr = os.Stderr
 		if err := resize.Run(); err != nil {
-			return false, errors.Errorf("error resizing image: %q", err)
+			return false, errors.Errorf("resizing image: %q", err)
 		}
 	}
 	// If the user provides an ignition file, we need to
@@ -1078,7 +1078,7 @@ func (v *MachineVM) isIncompatible() bool {
 func (v *MachineVM) getForwardSocketPath() (string, error) {
 	path, err := machine.GetDataDir(v.Name)
 	if err != nil {
-		logrus.Errorf("Error resolving data dir: %s", err.Error())
+		logrus.Errorf("Resolving data dir: %s", err.Error())
 		return "", nil
 	}
 	return filepath.Join(path, "podman.sock"), nil

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -35,7 +35,7 @@ func TryJoinPauseProcess(pausePidPath string) (bool, int, error) {
 		if os.IsNotExist(err) {
 			return false, -1, nil
 		}
-		return false, -1, fmt.Errorf("error acquiring lock on %s: %w", pausePidPath, err)
+		return false, -1, fmt.Errorf("acquiring lock on %s: %w", pausePidPath, err)
 	}
 
 	pidFileLock.Lock()

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -146,7 +146,7 @@ func tryMappingTool(uid bool, pid int, hostID int, mappings []idtools.IDMap) err
 	}
 
 	if output, err := cmd.CombinedOutput(); err != nil {
-		logrus.Errorf("error running `%s`: %s", strings.Join(args, " "), output)
+		logrus.Errorf("running `%s`: %s", strings.Join(args, " "), output)
 		return errors.Wrapf(err, "cannot setup namespace using %q", path)
 	}
 	return nil
@@ -174,7 +174,7 @@ func joinUserAndMountNS(pid uint, pausePid string) (bool, int, error) {
 
 	ret := C.reexec_in_user_namespace_wait(pidC, 0)
 	if ret < 0 {
-		return false, -1, errors.New("error waiting for the re-exec process")
+		return false, -1, errors.New("waiting for the re-exec process")
 	}
 
 	return true, int(ret), nil
@@ -374,7 +374,7 @@ func becomeRootInUserNS(pausePid, fileToRead string, fileOutput *os.File) (_ boo
 	if fileOutput != nil {
 		ret := C.reexec_in_user_namespace_wait(pidC, 0)
 		if ret < 0 {
-			return false, -1, errors.New("error waiting for the re-exec process")
+			return false, -1, errors.New("waiting for the re-exec process")
 		}
 
 		return true, 0, nil
@@ -391,11 +391,11 @@ func becomeRootInUserNS(pausePid, fileToRead string, fileOutput *os.File) (_ boo
 				return joinUserAndMountNS(uint(pid), "")
 			}
 		}
-		return false, -1, errors.New("error setting up the process")
+		return false, -1, errors.New("setting up the process")
 	}
 
 	if b[0] != '0' {
-		return false, -1, errors.New("error setting up the process")
+		return false, -1, errors.New("setting up the process")
 	}
 
 	signals := []os.Signal{}
@@ -425,7 +425,7 @@ func becomeRootInUserNS(pausePid, fileToRead string, fileOutput *os.File) (_ boo
 
 	ret := C.reexec_in_user_namespace_wait(pidC, 0)
 	if ret < 0 {
-		return false, -1, errors.New("error waiting for the re-exec process")
+		return false, -1, errors.New("waiting for the re-exec process")
 	}
 
 	return true, int(ret), nil

--- a/pkg/specgen/generate/kube/volume.go
+++ b/pkg/specgen/generate/kube/volume.go
@@ -76,7 +76,7 @@ func VolumeFromHostPath(hostPath *v1.HostPathVolumeSource) (*KubeVolume, error) 
 				return nil, errors.Wrap(err, "error checking HostPathSocket")
 			}
 			if st.Mode()&os.ModeSocket != os.ModeSocket {
-				return nil, errors.Errorf("error checking HostPathSocket: path %s is not a socket", hostPath.Path)
+				return nil, errors.Errorf("checking HostPathSocket: path %s is not a socket", hostPath.Path)
 			}
 
 		case v1.HostPathDirectory:

--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -292,7 +292,7 @@ func getVolumesFrom(volumesFrom []string, runtime *libpod.Runtime) (map[string]s
 		// and append them in if we can find them.
 		spec := ctr.Spec()
 		if spec == nil {
-			return nil, nil, errors.Errorf("error retrieving container %s spec for volumes-from", ctr.ID())
+			return nil, nil, errors.Errorf("retrieving container %s spec for volumes-from", ctr.ID())
 		}
 		for _, mnt := range spec.Mounts {
 			if mnt.Type != define.TypeBind {

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -976,7 +976,7 @@ func parseThrottleIOPsDevices(iopsDevices []string) (map[string]specs.LinuxThrot
 }
 
 func parseSecrets(secrets []string) ([]specgen.Secret, map[string]string, error) {
-	secretParseError := errors.New("error parsing secret")
+	secretParseError := errors.New("parsing secret")
 	var mount []specgen.Secret
 	envs := make(map[string]string)
 	for _, val := range secrets {

--- a/pkg/systemd/generate/pods.go
+++ b/pkg/systemd/generate/pods.go
@@ -141,7 +141,7 @@ func PodUnits(pod *libpod.Pod, options entities.GenerateSystemdOptions) (map[str
 	// Error out if the pod has no infra container, which we require to be the
 	// main service.
 	if !pod.HasInfraContainer() {
-		return nil, errors.Errorf("error generating systemd unit files: Pod %q has no infra container", pod.Name())
+		return nil, errors.Errorf("generating systemd unit files: Pod %q has no infra container", pod.Name())
 	}
 
 	podInfo, err := generatePodInfo(pod, options)
@@ -160,7 +160,7 @@ func PodUnits(pod *libpod.Pod, options entities.GenerateSystemdOptions) (map[str
 		return nil, err
 	}
 	if len(containers) == 0 {
-		return nil, errors.Errorf("error generating systemd unit files: Pod %q has no containers", pod.Name())
+		return nil, errors.Errorf("generating systemd unit files: Pod %q has no containers", pod.Name())
 	}
 	graph, err := libpod.BuildContainerGraph(containers)
 	if err != nil {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -656,7 +656,7 @@ func CreateCidFile(cidfile string, id string) error {
 		if os.IsExist(err) {
 			return errors.Errorf("container id file exists. Ensure another container is not using it or delete %s", cidfile)
 		}
-		return errors.Errorf("error opening cidfile %s", cidfile)
+		return errors.Errorf("opening cidfile %s", cidfile)
 	}
 	if _, err = cidFile.WriteString(id); err != nil {
 		logrus.Error(err)

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1537,7 +1537,7 @@ USER mail`, BB)
 		session := podmanTest.Podman([]string{"run", "--tz", badTZFile, "--rm", ALPINE, "date"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(ContainSubstring("error finding timezone for container"))
+		Expect(session.ErrorToString()).To(ContainSubstring("finding timezone for container"))
 
 		err = os.Remove(tzFile)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
When podman gets an error it prints out "Error: " before
printing the error string.  If the error message starts with
error, we end up with

Error: error ...

This PR Removes all of these stutters.

logrus.Error() also prints out that this is an error, so no need for the
error stutter.

[NO NEW TESTS NEEDED]

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
