### PR TITLE
podman machine init: add a --with-foreign-arch flag

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -103,6 +103,11 @@ func init() {
 
 	rootfulFlagName := "rootful"
 	flags.BoolVar(&initOpts.Rootful, rootfulFlagName, false, "Whether this machine should prefer rootful container exectution")
+
+	flags.BoolVar(
+		&initOpts.QemuStatic,
+		"with-foreign-arch", false,
+		"Whether to enable running binaries from \"foreign\" CPUs (e.g., run amd64 on Apple M1 silicon). Only for Qemu machines.  Works by installing qemu-static and qemu-binfmt on the machine.  Will probably make the initialization process take longer.")
 }
 
 // TODO should we allow for a users to append to the qemu cmdline?

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -29,6 +29,7 @@ type InitOptions struct {
 	Username     string
 	ReExec       bool
 	Rootful      bool
+	QemuStatic   bool
 	// The numberical userid of the user that called machine
 	UID string
 }

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -331,12 +331,13 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	}
 	// Write the ignition file
 	ign := machine.DynamicIgnition{
-		Name:      opts.Username,
-		Key:       key,
-		VMName:    v.Name,
-		TimeZone:  opts.TimeZone,
-		WritePath: v.IgnitionFilePath,
-		UID:       v.UID,
+		Name:       opts.Username,
+		Key:        key,
+		VMName:     v.Name,
+		TimeZone:   opts.TimeZone,
+		WritePath:  v.IgnitionFilePath,
+		UID:        v.UID,
+		QemuStatic: opts.QemuStatic,
 	}
 	err = machine.NewIgnitionFile(ign)
 	return err == nil, err


### PR DESCRIPTION
The flag is qemu-specific.  It causes `qemu-static` & friends to be installed on the machine so that, e.g., amd64 binaries can be run on aarch64 (aka "arm64"). This "scratches an itch" for me because I am on Mac M1, but I would like to be able to build Docker images whose Dockerfiles contain RUN command(s) for amd64.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
