### PR TITLE
podman machine init: add a --with-foreign-arch flag

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -107,6 +107,11 @@ func init() {
 
 	rootfulFlagName := "rootful"
 	flags.BoolVar(&initOpts.Rootful, rootfulFlagName, false, "Whether this machine should prefer rootful container execution")
+
+	flags.BoolVar(
+		&initOpts.QemuStatic,
+		"with-foreign-arch", false,
+		"Enable running binaries from \"foreign\" CPUs (e.g., run x86_64 on Apple M1 silicon).")
 }
 
 // TODO should we allow for a users to append to the qemu cmdline?

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -87,6 +87,13 @@ so mounts must be created under the /mnt directory.
 
 Driver to use for mounting volumes from the host, such as `virtfs`.
 
+#### **--with-foreign-arch**
+
+Enable running binaries compiled for "foreign" CPUs (e.g., run x86_64 binaries on
+Apple M1 silicon).  This option only works for Qemu machines.  It works by installing
+qemu-static and qemu-binfmt packages on the machine.  The initialization process will
+likely take longer if this option is enabled.
+
 ## EXAMPLES
 
 ```

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -30,7 +30,8 @@ type InitOptions struct {
 	ReExec       bool
 	Rootful      bool
 	// The numerical userid of the user that called machine
-	UID string
+	UID        string
+	QemuStatic bool
 }
 
 type QemuMachineStatus = string

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -194,8 +194,7 @@ After=remove-moby.service
 # We run before 'zincati.service' to avoid conflicting with rpm-ostree
 # transactions.
 Before=zincati.service
-ConditionPathIsDirectory=|!/lib/binfmt.d
-ConditionDirectoryNotEmpty=|!/lib/binfmt.d
+ConditionPathExists=!/var/lib/%N.stamp
 
 [Service]
 Type=oneshot
@@ -208,6 +207,7 @@ ExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive qemu qemu-us
 # The 'systetmd-binfmt.service' unit _will_ do this, but it has long completed by the time this service is starting
 # So just run the command to enable the extra formats right away.
 ExecStart=/usr/lib/systemd/systemd-binfmt
+ExecStartPost=/bin/touch /var/lib/%N.stamp
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -214,6 +214,7 @@ WantedBy=multi-user.target
 `
 
 	if ign.QemuStatic {
+		// Make the `ready` service wait until `install-qemu-static` has run to completion.
 		pat := regexp.MustCompile(`(?m)^(After=.*sshd\.service)$`)
 		r := pat.ReplaceAllString(ready, `$1 install-qemu-static.service`)
 		ready = r

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -408,12 +408,13 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	}
 	// Write the ignition file
 	ign := machine.DynamicIgnition{
-		Name:      opts.Username,
-		Key:       key,
-		VMName:    v.Name,
-		TimeZone:  opts.TimeZone,
-		WritePath: v.IgnitionFilePath,
-		UID:       v.UID,
+		Name:       opts.Username,
+		Key:        key,
+		VMName:     v.Name,
+		TimeZone:   opts.TimeZone,
+		WritePath:  v.IgnitionFilePath,
+		UID:        v.UID,
+		QemuStatic: opts.QemuStatic,
 	}
 	err = machine.NewIgnitionFile(ign)
 	return err == nil, err


### PR DESCRIPTION
The flag is qemu-specific.  It causes `qemu-static` & friends to be installed on the machine so that, e.g., x86_64 binaries can be run on aarch64 (aka "arm64").  This is "scratching an itch" for me because I am on Mac M1, but I want to build Docker images whose Dockerfiles contain RUN instruction(s) for x86_64.

I did manual testing as follows, so (I believe it is the case that) [NO TESTS NEEDED].

- Preparation:
  - built `podman` per instructions in `build_osx.md`
  - establish a clean starting state: `./bin/podman machine stop && ./bin/podman machine rm -f`
   
- Run without the new option:
    - `./bin/podman machine init --now`
    - `./bin/podman machine ssh`
       - `sudo systemctl status install-qemu-static.service`:  shows up as `disabled` and `inactive`
       - `sudo systemctl edit ready.service`: the `After` line looks like this: 
           `# After=remove-moby.service sshd.socket sshd.service`
       - <log out from the SSH session>
    - `./bin/podman machine run --arch amd64 fedora:35 uname -a`: fails with `{"msg":"exec container process `/usr/bin/uname`: Exec format error","level":"error","time":"2022-03-26T08:07:03.000635889Z"}` (as expected)
    
- Clean up: `./bin/podman machine stop && ./bin/podman machine rm -f`

- Run with the new option:
    - `./bin/podman machine init --with-foreign-arch --now` (unfortunately it's now perceptably slower)
    - `./bin/podman machine ssh`
       - `sudo systemctl status install-qemu-static.service`:  shows up as `enabled` and having run successfully
       - `sudo systemctl edit ready.service`: the `After` line looks like this: 
           `# After=remove-moby.service sshd.socket sshd.service install-qemu-static.service`
       - <log out from the SSH session>
    - `./bin/podman machine run --arch amd64 fedora:35 uname -a`: prints `Linux 81c4b2d16270 5.15.18-200.fc35.aarch64 #1 SMP Sat Jan 29 12:44:33 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
