### PR TITLE
libpod, event: generate a valid event on container `rename` operation

### DIFF
--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -162,6 +162,8 @@ const (
 	Refresh Status = "refresh"
 	// Remove ...
 	Remove Status = "remove"
+	// Rename indicates that a container was renamed
+	Rename Status = "rename"
 	// Renumber indicates that lock numbers were reallocated at user
 	// request.
 	Renumber Status = "renumber"

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -188,6 +188,8 @@ func StringToStatus(name string) (Status, error) {
 		return Refresh, nil
 	case Remove.String():
 		return Remove, nil
+	case Rename.String():
+		return Rename, nil
 	case Renumber.String():
 		return Renumber, nil
 	case Restart.String():

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -155,6 +155,7 @@ func (r *Runtime) RenameContainer(ctx context.Context, ctr *Container, newName s
 		return nil, err
 	}
 
+	ctr.newContainerEvent(events.Rename)
 	return ctr, nil
 }
 

--- a/test/e2e/rename_test.go
+++ b/test/e2e/rename_test.go
@@ -74,6 +74,23 @@ var _ = Describe("podman rename", func() {
 		Expect(ps.OutputToString()).To(ContainSubstring(newName))
 	})
 
+	It("Successfully rename a created container and test event generated", func() {
+		ctrName := "testCtr"
+		ctr := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "top"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr).Should(Exit(0))
+
+		newName := "aNewName"
+		rename := podmanTest.Podman([]string{"rename", ctrName, newName})
+		rename.WaitWithDefaultTimeout()
+		Expect(rename).Should(Exit(0))
+
+		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "container=aNewName"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(result.OutputToString()).To(ContainSubstring("rename"))
+	})
+
 	It("Successfully rename a running container", func() {
 		ctrName := "testCtr"
 		ctr := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, ALPINE, "top"})


### PR DESCRIPTION
Following PR ensures that podman generates a valid event on `podman
container rename` where event specifies that it is a rename event and
container name switched to the latest name.

Closes: https://github.com/containers/podman/issues/13670