### PR TITLE
[CI:DOCS]  Unify examples section across several man pages

### DIFF
--- a/docs/source/markdown/podman-image-unmount.1.md
+++ b/docs/source/markdown/podman-image-unmount.1.md
@@ -33,11 +33,19 @@ as the mount point could be removed without their knowledge.
 
 ## EXAMPLE
 
+Unmount image with a given ID
+```
 podman image unmount imageID
+```
 
+Unmount multiple images wit given IDs
+```
 podman image unmount imageID1 imageID2 imageID3
+```
 
+Unmount all images
+```
 podman image unmount --all
-
+```
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-image-mount(1)](podman-image-mount.1.md)**, **[podman-container-mount(1)](podman-container-mount.1.md)**

--- a/docs/source/markdown/podman-network-prune.1.md
+++ b/docs/source/markdown/podman-network-prune.1.md
@@ -36,11 +36,14 @@ Do not prompt for confirmation
 
 ## EXAMPLE
 Prune networks
-
 ```
 podman network prune
 ```
 
+Prune all networks created before 2h
+```
+podman network prune --filter until=2h
+```
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-network(1)](podman-network.1.md)**, **[podman-network-rm(1)](podman-network-rm.1.md)**

--- a/docs/source/markdown/podman-pod-pause.1.md
+++ b/docs/source/markdown/podman-pod-pause.1.md
@@ -21,9 +21,15 @@ Instead of providing the pod name or ID, pause the last created pod. (This optio
 
 ## EXAMPLE
 
+Pause a pod with a given name
+```
 podman pod pause mywebserverpod
+```
 
+Pause a pod with a given ID
+```
 podman pod pause 860a4b23
+```
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-pod-unpause(1)](podman-pod-unpause.1.md)**, **[podman-pause(1)](podman-pause.1.md)**

--- a/docs/source/markdown/podman-unmount.1.md
+++ b/docs/source/markdown/podman-unmount.1.md
@@ -47,11 +47,20 @@ started container could be from either of those methods. (This option is not ava
 
 ## EXAMPLE
 
+Unmount container with a given ID
+```
 podman container unmount containerID
+```
 
+Unmount multiple containers with given IDs
+```
 podman unmount containerID1 containerID2 containerID3
+```
 
+Unmount all containers
+```
 podman unmount --all
+```
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-container-mount(1)](podman-container-mount.1.md)**, **[podman-image-mount(1)](podman-image-mount.1.md)**

--- a/docs/source/markdown/podman-unpause.1.md
+++ b/docs/source/markdown/podman-unpause.1.md
@@ -25,7 +25,6 @@ podman unpause mywebserver
 ```
 
 Unpause a container by a partial container ID.
-
 ```
 podman unpause 860a4b23
 ```

--- a/docs/source/markdown/podman-volume-ls.1.md
+++ b/docs/source/markdown/podman-volume-ls.1.md
@@ -26,7 +26,7 @@ Volumes can be filtered by the following attributes:
 | name       | [Name] Volume name (accepts regex)                                                    |
 | opt        | Matches a storage driver options                                                      |
 | scope      | Filters volume by scope                                                               |
-| until      | Only remove volumes created before given timestamp                                   |
+| until      | Only remove volumes created before given timestamp                                    |
 
 #### **--format**=*format*
 

--- a/docs/source/markdown/podman-volume-unmount.1.md
+++ b/docs/source/markdown/podman-volume-unmount.1.md
@@ -19,9 +19,14 @@ counter reaches zero indicating no other processes are using the mount.
 
 ## EXAMPLE
 
+Unmount volume with a given ID
+```
 podman volume unmount volumeID
+```
 
+Unmount multiple volumes with given IDs
+```
 podman volume unmount volumeID1 volumeID2 volumeID3
-
+```
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-volume(1)](podman-volume.1.md)**, **[podman-volume-mount(1)](podman-volume-mount.1.md)**


### PR DESCRIPTION
This commit adjusts example sections across several man pages
to the format seen in other pages.

Signed-off-by: Patrycja Guzik <patrycja.k.guzik@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
