### PR TITLE
size-check: display binary size and growth

### DIFF
--- a/hack/make-and-check-size
+++ b/hack/make-and-check-size
@@ -109,6 +109,7 @@ for bin in bin/*;do
         size_orig=$(< $saved_size_file)
         delta_size=$(( size - size_orig ))
 
+        printf "%-20s size=%9d  delta=%6d\n" $bin $size $delta_size
         if [[ $delta_size -gt $MAX_BIN_GROWTH ]]; then
             separator=$(printf "%.0s*" {1..75})   # row of stars, for highlight
             echo "$separator"
@@ -129,5 +130,6 @@ for bin in bin/*;do
     else
         # First time through: preserve original file size
         echo $size >$saved_size_file
+        printf "%-20s size=%9d\n" $bin $size
     fi
 done


### PR DESCRIPTION
This won't actually be seen except by someone who takes the
time to clickety-click into Cirrus - but that's better than
not showing it at all.

Signed-off-by: Ed Santiago <santiago@redhat.com>
