### PR TITLE
[4.0-rhel] do not set the inheritable capabilities

### DIFF
--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -758,11 +758,14 @@ func prepareProcessExec(c *Container, options *ExecOptions, env []string, sessio
 	} else {
 		pspec.Capabilities.Bounding = ctrSpec.Process.Capabilities.Bounding
 	}
+
+	// Always unset the inheritable capabilities similarly to what the Linux kernel does
+	// They are used only when using capabilities with uid != 0.
+	pspec.Capabilities.Inheritable = []string{}
+
 	if execUser.Uid == 0 {
 		pspec.Capabilities.Effective = pspec.Capabilities.Bounding
-		pspec.Capabilities.Inheritable = pspec.Capabilities.Bounding
 		pspec.Capabilities.Permitted = pspec.Capabilities.Bounding
-		pspec.Capabilities.Ambient = pspec.Capabilities.Bounding
 	} else {
 		if user == c.config.User {
 			pspec.Capabilities.Effective = ctrSpec.Process.Capabilities.Effective

--- a/pkg/specgen/generate/security.go
+++ b/pkg/specgen/generate/security.go
@@ -146,6 +146,10 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 
 	configSpec := g.Config
 	configSpec.Process.Capabilities.Ambient = []string{}
+
+	// Always unset the inheritable capabilities similarly to what the Linux kernel does
+	// They are used only when using capabilities with uid != 0.
+	configSpec.Process.Capabilities.Inheritable = []string{}
 	configSpec.Process.Capabilities.Bounding = caplist
 
 	user := strings.Split(s.User, ":")[0]
@@ -153,7 +157,6 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 	if (user == "" && s.UserNS.NSMode != specgen.KeepID) || user == "root" || user == "0" {
 		configSpec.Process.Capabilities.Effective = caplist
 		configSpec.Process.Capabilities.Permitted = caplist
-		configSpec.Process.Capabilities.Inheritable = caplist
 	} else {
 		mergedCaps, err := capabilities.MergeCapabilities(nil, s.CapAdd, nil)
 		if err != nil {
@@ -175,12 +178,12 @@ func securityConfigureGenerator(s *specgen.SpecGenerator, g *generate.Generator,
 		}
 		configSpec.Process.Capabilities.Effective = userCaps
 		configSpec.Process.Capabilities.Permitted = userCaps
-		configSpec.Process.Capabilities.Inheritable = userCaps
 
 		// Ambient capabilities were added to Linux 4.3.  Set ambient
 		// capabilities only when the kernel supports them.
 		if supportAmbientCapabilities() {
 			configSpec.Process.Capabilities.Ambient = userCaps
+			configSpec.Process.Capabilities.Inheritable = userCaps
 		}
 	}
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -498,7 +498,7 @@ var _ = Describe("Podman run", func() {
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "root", ALPINE, "grep", "CapInh", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring("00000000a80425fb"))
+		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "grep", "CapBnd", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
@@ -533,7 +533,7 @@ var _ = Describe("Podman run", func() {
 		session = podmanTest.Podman([]string{"run", "--user=0:0", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring("00000000a80425fb"))
+		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 
 		if os.Geteuid() > 0 {
 			if os.Getenv("SKIP_USERNS") != "" {
@@ -550,7 +550,7 @@ var _ = Describe("Podman run", func() {
 			session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--privileged", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
-			Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
+			Expect(session.OutputToString()).To(ContainSubstring("0000000000000002"))
 
 			session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 			session.WaitWithDefaultTimeout()

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -550,7 +550,7 @@ var _ = Describe("Podman run", func() {
 			session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--privileged", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
-			Expect(session.OutputToString()).To(ContainSubstring("0000000000000002"))
+			Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 
 			session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 			session.WaitWithDefaultTimeout()


### PR DESCRIPTION
The kernel never sets the inheritable capabilities for a process, they
are only set by userspace. Emulate the same behavior.

Closes: CVE-2022-27649

Signed-off-by: Giuseppe Scrivano [gscrivan@redhat.com](mailto:gscrivan@redhat.com)
(cherry picked from commit https://github.com/containers/podman/commit/aafa80918a245edcbdaceb1191d749570f1872d0)