### PR TITLE
Upgrade tests: reexamine cross-testing matrix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -722,13 +722,11 @@ upgrade_test_task:
       - local_system_test
     matrix:
         - env:
-              PODMAN_UPGRADE_FROM: v1.9.0
-        - env:
-              PODMAN_UPGRADE_FROM: v2.0.6
-        - env:
               PODMAN_UPGRADE_FROM: v2.1.1
         - env:
               PODMAN_UPGRADE_FROM: v3.1.2
+        - env:
+              PODMAN_UPGRADE_FROM: v3.4.4
     gce_instance: *standardvm
     env:
         TEST_FLAVOR: upgrade_test

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -75,6 +75,16 @@ setup() {
     cat >| $pmscript <<EOF
 #!/bin/bash
 
+#
+# Argh! podman >= 3.4 something something namespace something, fails with
+#   Error: invalid config provided: cannot set hostname when running in the host UTS namespace: invalid configuration
+#
+# https://github.com/containers/podman/issues/11969#issuecomment-943386484
+#
+if grep -q utsns /etc/containers/containers.conf; then
+    sed -i -e '/^\utsns=/d' /etc/containers/containers.conf
+fi
+
 # events-backend=journald does not work inside a container
 opts="--events-backend=file $_PODMAN_TEST_OPTS"
 


### PR DESCRIPTION
 - removed: v1.9.0, v2.0.6
 + added:   v3.4.0

(Cannot add v4 because there's no such image on quay. As soon
as one appears, we should add it.)

Signed-off-by: Ed Santiago <santiago@redhat.com>
