### PR TITLE
network create: add support for ipam-driver none

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1115,6 +1115,13 @@ func AutocompleteNetworkDriver(cmd *cobra.Command, args []string, toComplete str
 	return drivers, cobra.ShellCompDirectiveNoFileComp
 }
 
+// AutocompleteNetworkIPAMDriver - Autocomplete network ipam driver option.
+// -> "bridge", "macvlan"
+func AutocompleteNetworkIPAMDriver(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	drivers := []string{types.HostLocalIPAMDriver, types.DHCPIPAMDriver, types.NoneIPAMDriver}
+	return drivers, cobra.ShellCompDirectiveNoFileComp
+}
+
 // AutocompletePodShareNamespace - Autocomplete pod create --share flag option.
 // -> "ipc", "net", "pid", "user", "uts", "cgroup", "none"
 func AutocompletePodShareNamespace(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -33,6 +33,8 @@ var (
 	networkCreateOptions entities.NetworkCreateOptions
 	labels               []string
 	opts                 []string
+	ipamDriverFlagName   = "ipam-driver"
+	ipamDriver           string
 )
 
 func networkCreateFlags(cmd *cobra.Command) {
@@ -66,8 +68,8 @@ func networkCreateFlags(cmd *cobra.Command) {
 	flags.StringArrayVar(&labels, labelFlagName, nil, "set metadata on a network")
 	_ = cmd.RegisterFlagCompletionFunc(labelFlagName, completion.AutocompleteNone)
 
-	// TODO not supported yet
-	// flags.StringVar(&networkCreateOptions.IPamDriver, "ipam-driver", "",  "IP Address Management Driver")
+	flags.StringVar(&ipamDriver, ipamDriverFlagName, "", "IP Address Management Driver")
+	_ = cmd.RegisterFlagCompletionFunc(ipamDriverFlagName, common.AutocompleteNetworkIPAMDriver)
 
 	flags.BoolVar(&networkCreateOptions.IPv6, "ipv6", false, "enable IPv6 networking")
 
@@ -110,6 +112,12 @@ func networkCreate(cmd *cobra.Command, args []string) error {
 		IPv6Enabled: networkCreateOptions.IPv6,
 		DNSEnabled:  !networkCreateOptions.DisableDNS,
 		Internal:    networkCreateOptions.Internal,
+	}
+
+	if cmd.Flags().Changed(ipamDriverFlagName) {
+		network.IPAMOptions = map[string]string{
+			types.Driver: ipamDriver,
+		}
 	}
 
 	// old --macvlan option

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -49,6 +49,16 @@ Allocate container IP from a range.  The range must be a complete subnet and in 
 must be used with a *subnet* option. Can be specified multiple times.
 The argument order of the **--subnet**, **--gateway** and **--ip-range** options must match.
 
+#### **--ipam-driver**=*driver*
+
+Set the ipam driver (IP Address Management Driver) for the network. When unset podman will choose an
+ipam driver automatically based on the network driver. Valid values are:
+ - `host-local`: IP addresses are assigned locally.
+ - `dhcp`: IP addresses are assigned from a dhcp server on your network. This driver is not yet supported with netavark.
+ - `none`: No ip addresses are assigned to the interfaces.
+
+You can see the driver in the **podman network inspect** output under the `ipam_options` field.
+
 #### **--ipv6**
 
 Enable IPv6 (Dual Stack) networking. If not subnets are given it will allocate a ipv4 and ipv6 subnet.

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -1119,4 +1119,17 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})
+
+	It("podman run with ipam none driver", func() {
+		net := "ipam" + stringid.GenerateNonCryptoID()
+		session := podmanTest.Podman([]string{"network", "create", "--ipam-driver=none", net})
+		session.WaitWithDefaultTimeout()
+		defer podmanTest.removeNetwork(net)
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"run", "--network", net, ALPINE, "ip", "addr", "show", "eth0"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToStringArray()).To(HaveLen(4), "output should only show link local address")
+	})
 })


### PR DESCRIPTION
Add a new flag to set the ipam-driver. Also adds a new ipam driver none
mode which only creates interfaces but does not assign addresses.

Fixes https://github.com/containers/podman/issues/13521