### PR TITLE
Add 'Os' to be queried via 'version' output

### DIFF
--- a/libpod/define/version.go
+++ b/libpod/define/version.go
@@ -27,6 +27,7 @@ type Version struct {
 	BuiltTime  string
 	Built      int64
 	OsArch     string
+	Os         string
 }
 
 // GetVersion returns a VersionOutput struct for API and podman
@@ -49,5 +50,6 @@ func GetVersion() (Version, error) {
 		BuiltTime:  time.Unix(buildTime, 0).Format(time.ANSIC),
 		Built:      buildTime,
 		OsArch:     runtime.GOOS + "/" + runtime.GOARCH,
+		Os:         runtime.GOOS,
 	}, nil
 }

--- a/pkg/bindings/system/system.go
+++ b/pkg/bindings/system/system.go
@@ -120,6 +120,7 @@ func Version(ctx context.Context, options *VersionOptions) (*entities.SystemVers
 		BuiltTime:  time.Unix(b.Unix(), 0).Format(time.ANSIC),
 		Built:      b.Unix(),
 		OsArch:     fmt.Sprintf("%s/%s", component.Os, component.Arch),
+		Os:         component.Os,
 	}
 
 	for _, c := range component.Components {

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -87,7 +87,15 @@ var _ = Describe("Podman version", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
+		session = podmanTest.Podman([]string{"version", "--format", "{{ .Client.Os }}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
 		session = podmanTest.Podman([]string{"version", "--format", "{{ .Server.Version }}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"version", "--format", "{{ .Server.Os }}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 


### PR DESCRIPTION
Signed-off-by: John Matthews <jwmatthews@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
Fixes #13690 

As requested in #13690 this exposes an 'Os' field in version output to aid existing scripts that rely on docker's behavior of `docker version -f {{.Server.Os}} `.   I added 'Os' to both the Client and Server output assuming it'd be desired, but #13690 only asked for 'Server'