### PR TITLE
Relax /sys/dev/block restrictions for volumes and devices

### DIFF
--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -174,6 +174,8 @@ type ContainerRootFSConfig struct {
 	// treated as root directories. Standard bind mounts will be mounted
 	// into paths relative to these directories.
 	ChrootDirs []string `json:"chroot_directories,omitempty"`
+	// Expose /sys/dev/block entries for mounts and devices in the container.
+	SysDevBlock bool `json:"sysdevblock,omitempty"`
 }
 
 // ContainerSecurityConfig is an embedded sub-config providing security configuration

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -303,6 +303,18 @@ func WithStorageOpts(storageOpts map[string]string) CtrCreateOption {
 	}
 }
 
+// WithSysDevBlock sets the options to create /sys/dev/block symlinks
+// across reboots will be stored.
+func WithSysDevBlock() CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+		ctr.config.SysDevBlock = true
+		return nil
+	}
+}
+
 // WithDefaultMountsFile sets the file to look at for default mounts (mainly
 // secrets).
 // Note we are not saving this in the database as it is for testing purposes

--- a/libpod/util_linux.go
+++ b/libpod/util_linux.go
@@ -146,10 +146,10 @@ func Unmount(mount string) {
 func createSysBlockSymlink(path string, dir string) error {
 	statT := unix.Stat_t{}
 	if err := unix.Stat(path, &statT); err == nil {
-		major, minor := unix.Major(uint64(statT.Dev)), unix.Minor(uint64(statT.Dev))
+		major, minor := unix.Major(statT.Dev), unix.Minor(statT.Dev)
 		if statT.Mode&unix.S_IFBLK == unix.S_IFBLK {
 			// For block, copy what the major/minor the device is, not what fs it is placed on.
-			major, minor = unix.Major(uint64(statT.Rdev)), unix.Minor(uint64(statT.Rdev))
+			major, minor = unix.Major(statT.Rdev), unix.Minor(statT.Rdev)
 		}
 		target, errlink := os.Readlink(fmt.Sprintf(sysDevBlock+"/%d:%d", major, minor))
 		if errlink == nil {

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -85,7 +85,6 @@ func BlockAccessToKernelFilesystems(privileged, pidModeIsHost bool, mask, unmask
 		"/proc/scsi",
 		"/sys/firmware",
 		"/sys/fs/selinux",
-		"/sys/dev/block",
 	}
 
 	if !privileged {

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -219,6 +219,10 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 			}
 		}
 	}
+	// If its masked, BlockAccessToKernelFilesystems would have done it, if Unmasked, we don't need to do anything.
+	if !s.Privileged && shouldMask(sysDevBlock, s.Mask) && shouldMask(sysDevBlock, s.Unmask) {
+		options = append(options, libpod.WithSysDevBlock())
+	}
 	if len(s.HostDeviceList) > 0 {
 		options = append(options, libpod.WithHostDevice(s.HostDeviceList))
 	}

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const sysDevBlock = "/sys/dev/block"
+
 func setProcOpts(s *specgen.SpecGenerator, g *generate.Generator) {
 	if s.ProcOpts == nil {
 		return


### PR DESCRIPTION
User space programs want to access information about the block
devices they are operating on. E.g. the block size is an important
aspect if doing O_DIRECT filesystem calls.

On the other hand, rhbz#1772993 wants to keep the host information
as hidden from the container running processes as possible.

We expose only the volumes and devices that are mounted into the
container by re-generating the symlinks in /sys/dev/block using
temporary volume.

Closes containers/common#2277

```
$  bin/podman run --rm --device=/dev/loop0:/dev/loop0:rwm   -v .:/vol --security-opt=unmask=ALL debian:latest ls -la /sys/dev/block /dev/loop0
ls: cannot access '/dev/loop0': Permission denied
/sys/dev/block:
total 0
drwxr-xr-x. 2 nobody nogroup 0 Mar 30 04:32 .
drwxr-xr-x. 4 nobody nogroup 0 Mar 30 04:32 ..
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 252:0 -> ../../devices/virtual/block/zram0
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 253:0 -> ../../devices/virtual/block/dm-0
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 253:1 -> ../../devices/virtual/block/dm-1
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 253:2 -> ../../devices/virtual/block/dm-2
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 253:3 -> ../../devices/virtual/block/dm-3
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 259:0 -> ../../devices/pci0000:00/0000:00:1d.4/0000:07:00.0/nvme/nvme0/nvme0n1
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 259:1 -> ../../devices/pci0000:00/0000:00:1d.4/0000:07:00.0/nvme/nvme0/nvme0n1/nvme0n1p1
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 259:2 -> ../../devices/pci0000:00/0000:00:1d.4/0000:07:00.0/nvme/nvme0/nvme0n1/nvme0n1p2
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 259:3 -> ../../devices/pci0000:00/0000:00:1d.4/0000:07:00.0/nvme/nvme0/nvme0n1/nvme0n1p3
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 7:0 -> ../../devices/virtual/block/loop0
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 7:1 -> ../../devices/virtual/block/loop1
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 7:2 -> ../../devices/virtual/block/loop2
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 7:3 -> ../../devices/virtual/block/loop3
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 7:4 -> ../../devices/virtual/block/loop4
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 7:5 -> ../../devices/virtual/block/loop5
lrwxrwxrwx. 1 nobody nogroup 0 Mar 30 04:32 7:6 -> ../../devices/virtual/block/loop6

$  bin/podman run --rm --device=/dev/loop0:/dev/loop0:rwm   -v .:/vol --security-opt=mask=/sys/dev/block debian:latest ls -la /sys/dev/block /dev/loop0
ls: cannot access '/dev/loop0': Permission denied
/sys/dev/block:
total 0
drwxrwxrwt. 2 root   root    40 Mar 30 04:33 .
drwxr-xr-x. 4 nobody nogroup  0 Mar 30 04:33 ..

$  bin/podman run --rm --device=/dev/loop0:/dev/loop0:rwm   -v .:/vol  debian:latest ls -la /sys/dev/block /dev/loop0
ls: cannot access '/dev/loop0': Permission denied
/sys/dev/block:
total 4
drwxr-xr-x. 2 root   root    4096 Mar 30 04:33 .
drwxr-xr-x. 4 nobody nogroup    0 Mar 30 04:33 ..
lrwxrwxrwx. 1 root   root      32 Mar 30 04:33 253:3 -> ../../devices/virtual/block/dm-3
```

First POC for review. Excuse any poor golang style, its been years since I touched it.

TODO:
* tests
* docs
* remove volume, especially if we didn't put anything on it.