### PR TITLE
rootless netns: move process to scope only with systemd

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -498,10 +498,13 @@ func (r *Runtime) GetRootlessNetNs(new bool) (*RootlessNetNS, error) {
 			return nil, err
 		}
 
-		// move to systemd scope to prevent systemd from killing it
-		err = utils.MoveRootlessNetnsSlirpProcessToUserSlice(cmd.Process.Pid)
-		if err != nil {
-			logrus.Errorf("failed to move the rootless netns slirp4netns process to the systemd user.slice: %v", err)
+		if utils.RunsOnSystemd() {
+			// move to systemd scope to prevent systemd from killing it
+			err = utils.MoveRootlessNetnsSlirpProcessToUserSlice(cmd.Process.Pid)
+			if err != nil {
+				// only log this, it is not fatal but can lead to issues when running podman inside systemd units
+				logrus.Errorf("failed to move the rootless netns slirp4netns process to the systemd user.slice: %v", err)
+			}
 		}
 
 		// build a new resolv.conf file which uses the slirp4netns dns server address


### PR DESCRIPTION
When you run podman on a non systemd system we should not try to move the
process under a new systemd scope.

Ref #13703


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
