### PR TITLE
systemd: enable all cgroups when running as a service

### DIFF
--- a/contrib/systemd/system/podman.service.in
+++ b/contrib/systemd/system/podman.service.in
@@ -6,6 +6,7 @@ Documentation=man:podman-system-service(1)
 StartLimitIntervalSec=0
 
 [Service]
+Delegate=true
 Type=exec
 KillMode=process
 Environment=LOGGING="--log-level=info"


### PR DESCRIPTION
enable cgroup delegation when running as a systemd service so all the
available controllers are correctly detected.

Closes: https://github.com/containers/podman/issues/13710

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
