### PR TITLE
[CI:DOCS] Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -25,6 +25,9 @@ env:
     # (must be in $GITHUB_WORKSPACE/artifacts/)
     NAME_ID_FILEPATH: './artifacts/name_id.txt'
 
+permissions:
+  contents: read
+
 jobs:
     cron_failures:
         runs-on: ubuntu-latest

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -3,8 +3,14 @@ on:
   issues:
     types: [opened, edited]
 
+permissions:
+  contents: read
+
 jobs:
   triage:
+    permissions:
+      contents: read  # for github/issue-labeler to get repo contents
+      issues: write  # for github/issue-labeler to create or remove labels
     runs-on: ubuntu-latest
     steps:
     - uses: github/issue-labeler@3ae0e4623c1fda729347ae0d8f1c2e52302ef4c6 # v2.0

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -7,8 +7,13 @@ on:
     branches:
       - "!master"   # causes errors; reason unknown
 
+permissions:
+  contents: read
+
 jobs:
   update_pr:
+    permissions:
+      pull-requests: write  # for tzkhan/pr-update-action to update PRs
     runs-on: ubuntu-latest
     steps:
     - uses: tzkhan/pr-update-action@bbd4c9395df8a9c4ef075b8b7fe29f2ca76cdca9 # v2


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

