### PR TITLE
specgen: permit --privileged and --cap-add

### DIFF
--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -83,10 +83,6 @@ func (s *SpecGenerator) Validate() error {
 	//
 	// ContainerSecurityConfig
 	//
-	// capadd and privileged are exclusive
-	if len(s.CapAdd) > 0 && s.Privileged {
-		return exclusiveOptions("CapAdd", "privileged")
-	}
 	// userns and idmappings conflict
 	if s.UserNS.IsPrivate() && s.IDMappings == nil {
 		return errors.Wrap(ErrInvalidSpecConfig, "IDMappings are required when not creating a User namespace")

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -535,6 +535,11 @@ var _ = Describe("Podman run", func() {
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 
+		session = podmanTest.Podman([]string{"run", "--user=1:1", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapEff", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("0000000000000002"))
+
 		if os.Geteuid() > 0 {
 			if os.Getenv("SKIP_USERNS") != "" {
 				Skip("Skip userns tests.")


### PR DESCRIPTION
--cap-add is useful when running a privileged container with UID != 0,
so that individual capabilities can be added to the container process.

Closes: https://github.com/containers/podman/issues/13449

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
