### PR TITLE
[v3.0.1-rhel] do not set the inheritable capabilities

### DIFF
--- a/contrib/fedora-minimal/Dockerfile
+++ b/contrib/fedora-minimal/Dockerfile
@@ -1,1 +1,0 @@
-FROM registry.fedoraproject.org/fedora-minimal:latest

--- a/contrib/fedora-minimal/README.md
+++ b/contrib/fedora-minimal/README.md
@@ -1,4 +1,0 @@
-This dockerfile exists so that the container image can be "mirrored"
-onto quay.io automatically, so automated testing can be more resilient.
-
-https://quay.io/repository/libpod/fedora-minimal?tab=builds

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1281,11 +1281,11 @@ func prepareProcessExec(c *Container, options *ExecOptions, env []string, sessio
 	} else {
 		pspec.Capabilities.Bounding = ctrSpec.Process.Capabilities.Bounding
 	}
+	pspec.Capabilities.Inheritable = []string{}
+	pspec.Capabilities.Ambient = []string{}
 	if execUser.Uid == 0 {
 		pspec.Capabilities.Effective = pspec.Capabilities.Bounding
-		pspec.Capabilities.Inheritable = pspec.Capabilities.Bounding
 		pspec.Capabilities.Permitted = pspec.Capabilities.Bounding
-		pspec.Capabilities.Ambient = pspec.Capabilities.Bounding
 	} else {
 		if user == c.config.User {
 			pspec.Capabilities.Effective = ctrSpec.Process.Capabilities.Effective

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -2,7 +2,7 @@ package integration
 
 var (
 	redis             = "quay.io/libpod/redis:alpine"
-	fedoraMinimal     = "quay.io/libpod/fedora-minimal:latest"
+	fedoraMinimal     = "registry.fedoraproject.org/fedora-minimal:34"
 	ALPINE            = "quay.io/libpod/alpine:latest"
 	ALPINELISTTAG     = "quay.io/libpod/alpine:3.10.2"
 	ALPINELISTDIGEST  = "quay.io/libpod/alpine@sha256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -475,10 +475,10 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec preserves container groups with --user and --group-add", func() {
-		dockerfile := `FROM registry.fedoraproject.org/fedora-minimal
+		dockerfile := fmt.Sprintf(`FROM %s
 RUN groupadd -g 4000 first
 RUN groupadd -g 4001 second
-RUN useradd -u 1000 auser`
+RUN useradd -u 1000 auser`, fedoraMinimal)
 		imgName := "testimg"
 		podmanTest.BuildImage(dockerfile, imgName, "false")
 

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Podman images", func() {
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "reference=quay.io*"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(len(result.OutputToStringArray())).To(Equal(8))
+		Expect(len(result.OutputToStringArray())).To(Equal(7))
 
 		retalpine := podmanTest.Podman([]string{"images", "-f", "reference=a*pine"})
 		retalpine.WaitWithDefaultTimeout()

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -187,24 +187,24 @@ WORKDIR /test
 		Expect(result.OutputToString()).To(Equal("/test"))
 	})
 
-	It("podman images filter since image", func() {
-		dockerfile := `FROM quay.io/libpod/alpine:latest
+	It("podman images filter since/after image", func() {
+		dockerfile := `FROM scratch
 `
-		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
-		result := podmanTest.Podman([]string{"images", "-q", "-f", "since=quay.io/libpod/alpine:latest"})
-		result.WaitWithDefaultTimeout()
-		Expect(result).Should(Exit(0))
-		Expect(len(result.OutputToStringArray())).To(Equal(8))
-	})
+		podmanTest.BuildImage(dockerfile, "foobar.com/one:latest", "false")
+		podmanTest.BuildImage(dockerfile, "foobar.com/two:latest", "false")
+		podmanTest.BuildImage(dockerfile, "foobar.com/three:latest", "false")
 
-	It("podman image list filter after image", func() {
-		dockerfile := `FROM quay.io/libpod/alpine:latest
-`
-		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
-		result := podmanTest.Podman([]string{"image", "list", "-q", "-f", "after=quay.io/libpod/alpine:latest"})
+		// `since` filter
+		result := podmanTest.PodmanNoCache([]string{"images", "-q", "-f", "since=foobar.com/one:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(result.OutputToStringArray()).Should(HaveLen(8), "list filter output: %q", result.OutputToString())
+		Expect(result.OutputToStringArray()).To(HaveLen(2))
+
+		// `after` filter
+		result = podmanTest.Podman([]string{"image", "list", "-q", "-f", "after=foobar.com/one:latest"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(result.OutputToStringArray()).Should(HaveLen(2), "list filter output: %q", result.OutputToString())
 	})
 
 	It("podman images filter dangling", func() {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1361,7 +1361,7 @@ USER mail`
 	})
 
 	It("podman run --privileged and --group-add", func() {
-		groupName := "kvm"
+		groupName := "mail"
 		session := podmanTest.Podman([]string{"run", "-t", "-i", "--group-add", groupName, "--privileged", fedoraMinimal, "groups"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -435,7 +435,7 @@ var _ = Describe("Podman run", func() {
 			session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--privileged", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 			session.WaitWithDefaultTimeout()
 			Expect(session.ExitCode()).To(Equal(0))
-			Expect(session.OutputToString()).To(ContainSubstring("0000000000000002"))
+			Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 
 			session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 			session.WaitWithDefaultTimeout()

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -383,7 +383,7 @@ var _ = Describe("Podman run", func() {
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "root", ALPINE, "grep", "CapInh", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(ContainSubstring("00000000a80425fb"))
+		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "grep", "CapBnd", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
@@ -418,7 +418,7 @@ var _ = Describe("Podman run", func() {
 		session = podmanTest.Podman([]string{"run", "--user=0:0", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(ContainSubstring("00000000a80425fb"))
+		Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
 
 		if os.Geteuid() > 0 {
 			if os.Getenv("SKIP_USERNS") != "" {
@@ -435,7 +435,7 @@ var _ = Describe("Podman run", func() {
 			session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--privileged", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 			session.WaitWithDefaultTimeout()
 			Expect(session.ExitCode()).To(Equal(0))
-			Expect(session.OutputToString()).To(ContainSubstring("0000000000000000"))
+			Expect(session.OutputToString()).To(ContainSubstring("0000000000000002"))
 
 			session = podmanTest.Podman([]string{"run", "--userns=keep-id", "--cap-add=DAC_OVERRIDE", "--rm", ALPINE, "grep", "CapInh", "/proc/self/status"})
 			session.WaitWithDefaultTimeout()


### PR DESCRIPTION
The kernel never sets the inheritable capabilities for a process, they
are only set by userspace.  Emulate the same behavior.

Closes: CVE-2022-27649

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit aafa80918a245edcbdaceb1191d749570f1872d0)
