### PR TITLE
Allow creating anonymous volumes with --mount

### DIFF
--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -518,7 +518,7 @@ func getDevptsMount(args []string) (spec.Mount, error) {
 func getNamedVolume(args []string) (*specgen.NamedVolume, error) {
 	newVolume := new(specgen.NamedVolume)
 
-	var setSource, setDest, setRORW, setSuid, setDev, setExec, setOwnership bool
+	var setDest, setRORW, setSuid, setDev, setExec, setOwnership bool
 
 	for _, val := range args {
 		kv := strings.SplitN(val, "=", 2)
@@ -554,7 +554,6 @@ func getNamedVolume(args []string) (*specgen.NamedVolume, error) {
 				return nil, errors.Wrapf(optionArgError, kv[0])
 			}
 			newVolume.Name = kv[1]
-			setSource = true
 		case "target", "dst", "destination":
 			if len(kv) == 1 {
 				return nil, errors.Wrapf(optionArgError, kv[0])
@@ -585,9 +584,6 @@ func getNamedVolume(args []string) (*specgen.NamedVolume, error) {
 		}
 	}
 
-	if !setSource {
-		return nil, errors.Errorf("must set source volume")
-	}
 	if !setDest {
 		return nil, noDestError
 	}

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -778,6 +778,13 @@ VOLUME /test/`, ALPINE)
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).Should(Equal("888:888"))
 
+		// anonymous volume mount
+		vol = "type=volume," + "dst=" + dest
+		session = podmanTest.Podman([]string{"run", "--rm", "--user", "888:888", "--mount", vol, ALPINE, "stat", "-c", "%u:%g", dest})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).Should(Equal("888:888"))
+
 		// named volume mount
 		namedVolume := podmanTest.Podman([]string{"volume", "create", "foo"})
 		namedVolume.WaitWithDefaultTimeout()


### PR DESCRIPTION
This fixes #13756.

All the mechanics to create anonymous volumes is already present, but
there's still a validation preventing that path from being taken.  We
remove the validation, which allows the volume to be created
successfully.

Signed-off-by: Andrew Aylett <andrew@aylett.co.uk>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
