### PR TITLE
fix(libpod): runtime: check if store is nil

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1142,6 +1142,11 @@ func (r *Runtime) getVolumePlugin(name string) (*plugin.VolumePlugin, error) {
 
 // GetSecretsStoreageDir returns the directory that the secrets manager should take
 func (r *Runtime) GetSecretsStorageDir() string {
+	// prevent nil reference exception
+	if r.store == nil {
+		return ""
+	}
+
 	return filepath.Join(r.store.GraphRoot(), "secrets")
 }
 


### PR DESCRIPTION
Fixes a nil reference exception if libpod is started without storage (configureStorage is not called) and GetSecretsStorageDir is called.