### PR TITLE
specgen: do not set OOMScoreAdj by default

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -348,8 +348,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 
 		oomScoreAdjFlagName := "oom-score-adj"
-		createFlags.IntVar(
-			&cf.OOMScoreAdj,
+		createFlags.Int(
 			oomScoreAdjFlagName, 0,
 			"Tune the host's OOM preferences (-1000 to 1000)",
 		)

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -286,7 +286,7 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 		LogDriver:         cc.HostConfig.LogConfig.Type,
 		LogOptions:        stringMaptoArray(cc.HostConfig.LogConfig.Config),
 		Name:              cc.Name,
-		OOMScoreAdj:       cc.HostConfig.OomScoreAdj,
+		OOMScoreAdj:       &cc.HostConfig.OomScoreAdj,
 		Arch:              "",
 		OS:                "",
 		Variant:           "",

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -238,6 +238,13 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 			vals.GroupAdd = groups
 		}
 
+		if c.Flags().Changed("oom-score-adj") {
+			val, err := c.Flags().GetInt("oom-score-adj")
+			if err != nil {
+				return vals, err
+			}
+			vals.OOMScoreAdj = &val
+		}
 		if c.Flags().Changed("pids-limit") {
 			val := c.Flag("pids-limit").Value.String()
 			// Convert -1 to 0, so that -1 maps to unlimited pids limit

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -210,7 +210,7 @@ type ContainerCreateOptions struct {
 	Name              string `json:"container_name"`
 	NoHealthCheck     bool
 	OOMKillDisable    bool
-	OOMScoreAdj       int
+	OOMScoreAdj       *int
 	Arch              string
 	OS                string
 	Variant           string

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -753,8 +753,8 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.PreserveFDs = c.PreserveFDs
 	}
 
-	if s.OOMScoreAdj == nil || c.OOMScoreAdj != 0 {
-		s.OOMScoreAdj = &c.OOMScoreAdj
+	if s.OOMScoreAdj == nil || c.OOMScoreAdj != nil {
+		s.OOMScoreAdj = c.OOMScoreAdj
 	}
 	if c.Restart != "" {
 		splitRestart := strings.Split(c.Restart, ":")

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -609,6 +609,13 @@ USER bin`, BB)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(Equal("111"))
+
+		currentOOMScoreAdj, err := ioutil.ReadFile("/proc/self/oom_score_adj")
+		Expect(err).To(BeNil())
+		session = podmanTest.Podman([]string{"run", "--rm", fedoraMinimal, "cat", "/proc/self/oom_score_adj"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(Equal(strings.TrimRight(string(currentOOMScoreAdj), "\n")))
 	})
 
 	It("podman run limits host test", func() {

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -815,4 +815,10 @@ EOF
     run_podman run --uidmap 0:10001:10002 --rm --hostname ${HOST} $IMAGE grep ${HOST} /etc/hosts
     is "${lines[0]}" ".*${HOST}.*"
 }
+
+@test "podman run doesn't override oom-score-adj" {
+    current_oom_score_adj=$(cat /proc/self/oom_score_adj)
+    run_podman run --rm $IMAGE cat /proc/self/oom_score_adj
+    is "$output" "$current_oom_score_adj" "different oom_score_adj in the container"
+}
 # vim: filetype=sh


### PR DESCRIPTION
do not force a value of OOMScoreAdj=0 if it is wasn't specified by the
user.

Closes: https://github.com/containers/podman/issues/13731

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
