### PR TITLE
[CI:DOCS] Unify examples section across several man pages: init/kill

### DIFF
--- a/docs/source/markdown/podman-init.1.md
+++ b/docs/source/markdown/podman-init.1.md
@@ -29,12 +29,20 @@ to run containers such as CRI-O, the last started container could be from either
 
 ## EXAMPLE
 
+Initialize container with a given ID
+```
 podman init 35480fc9d568
+```
 
+Initialize container with a given name
+```
 podman init test1
+```
 
+Initialize the latest container created by Podman
+```
 podman init --latest
-
+```
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-start(1)](podman-start.1.md)**
 

--- a/docs/source/markdown/podman-kill.1.md
+++ b/docs/source/markdown/podman-kill.1.md
@@ -32,19 +32,36 @@ Signal to send to the container. For more information on Linux signals, refer to
 
 ## EXAMPLE
 
+Kill container with a given name
+```
 podman kill mywebserver
+```
 
+Kill container with a given ID
+```
 podman kill 860a4b23
+```
 
+Terminate container by sending `TERM` signal
+```
 podman kill --signal TERM 860a4b23
+```
 
+Kill the latest container created by Podman
+```
 podman kill --latest
+```
 
+Terminate all containers by sending `KILL` signal
+```
 podman kill --signal KILL -a
+```
 
+Kill container using ID specified in a given files
+```
 podman kill --cidfile /home/user/cidfile-1
-
 podman kill --cidfile /home/user/cidfile-1 --cidfile ./cidfile-2
+```
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-stop(1)](podman-stop.1.md)**

--- a/docs/source/markdown/podman-pod-kill.1.md
+++ b/docs/source/markdown/podman-pod-kill.1.md
@@ -26,15 +26,30 @@ Signal to send to the containers in the pod. For more information on Linux signa
 
 ## EXAMPLE
 
+Kill pod with a given name
+```
 podman pod kill mywebserver
+```
 
+Kill pod with a given ID
+```
 podman pod kill 860a4b23
+```
 
+Terminate pod by sending `TERM` signal
+```
 podman pod kill --signal TERM 860a4b23
+```
 
+Kill the latest pod created by Podman
+```
 podman pod kill --latest
+```
 
+Terminate all pods by sending `KILL` signal
+```
 podman pod kill --all
+```
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-pod-stop(1)](podman-pod-stop.1.md)**


### PR DESCRIPTION
This commit adjusts example sections across several man pages to the format seen in other pages.
Follow up PR #13682