### PR TITLE
[CI:DOCS] Unify examples section across several man pages: pod rm/start/unpause

### DIFF
--- a/docs/source/markdown/podman-pod-rm.1.md
+++ b/docs/source/markdown/podman-pod-rm.1.md
@@ -39,17 +39,31 @@ Seconds to wait before forcibly stopping running containers within the pod. The 
 
 ## EXAMPLE
 
+Remove pod with a given name
+```
 podman pod rm mywebserverpod
+```
 
+Remove multiple pods with given names and/or IDs
+```
 podman pod rm mywebserverpod myflaskserverpod 860a4b23
+```
 
+Forcefully remove pod with a given ID
+```
 podman pod rm -f 860a4b23
+```
 
+Forcefully remove all pods
+```
 podman pod rm -f -a
-
 podman pod rm -fa
+```
 
+Remove pod using ID specified in a given file
+```
 podman pod rm --pod-id-file /path/to/id/file
+```
 
 ## Exit Status
   **0**   All specified pods removed

--- a/docs/source/markdown/podman-pod-start.1.md
+++ b/docs/source/markdown/podman-pod-start.1.md
@@ -26,15 +26,30 @@ Read pod ID from the specified file and start the pod.  Can be specified multipl
 
 ## EXAMPLE
 
+Start pod with a given name
+```
 podman pod start mywebserverpod
+```
 
+Start pods with given IDs
+```
 podman pod start 860a4b23 5421ab4
+```
 
+Start the latest pod created by Podman
+```
 podman pod start --latest
+```
 
+Start all pods
+```
 podman pod start --all
+```
 
+Start pod using ID specified in a given file
+```
 podman pod start --pod-id-file /path/to/id/file
+```
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-pod-stop(1)](podman-pod-stop.1.md)**

--- a/docs/source/markdown/podman-pod-unpause.1.md
+++ b/docs/source/markdown/podman-pod-unpause.1.md
@@ -21,9 +21,15 @@ Instead of providing the pod name or ID, unpause the last created pod. (This opt
 
 ## EXAMPLE
 
+Unpause pod with a given name
+```
 podman pod unpause mywebserverpod
+```
 
+Unpause pod with a given ID
+```
 podman pod unpause 860a4b23
+```
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-pod-pause(1)](podman-pod-pause.1.md)**


### PR DESCRIPTION
This commit adjusts example sections across several man pages to the format seen in other pages.
Follow up PR #13682 and #13771