### PR TITLE
API: use no_hosts from containers.conf

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -181,6 +181,7 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 		Network:        nsmode,
 		PublishPorts:   specPorts,
 		NetworkOptions: netOpts,
+		NoHosts:        rtc.Containers.NoHosts,
 	}
 
 	// network names

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -467,7 +467,13 @@ type ContainerNetworkConfig struct {
 	// UseImageHosts indicates that /etc/hosts should not be managed by
 	// Podman, and instead sourced from the image.
 	// Conflicts with HostAdd.
-	UseImageHosts bool `json:"use_image_hosts,omitempty"`
+	// Do not set omitempty here, if this is false it should be set to not get
+	// the server default.
+	// Ideally this would be a pointer so we could differentiate between an
+	// explicitly false/true and unset (containers.conf default). However
+	// specgen is stable so we can not change this right now.
+	// TODO (5.0): change to pointer
+	UseImageHosts bool `json:"use_image_hosts"`
 	// HostAdd is a set of hosts which will be added to the container's
 	// /etc/hosts file.
 	// Conflicts with UseImageHosts.

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -447,3 +447,46 @@ t GET images/$iid/json 200 \
 
 t DELETE containers/$cid 204
 t DELETE images/docker.io/library/newrepo:v3?force=false 200
+
+# test create without default no_hosts
+t POST containers/create \
+  Image=$IMAGE \
+  201 \
+  .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+
+t POST libpod/containers/$cid/init 204
+
+t GET libpod/containers/$cid/json 200
+
+cpid_file=$(jq -r '.ConmonPidFile' <<<"$output")
+userdata_path=$(dirname $cpid_file)
+
+t GET libpod/containers/$cid/json 200 \
+  .HostsPath=$userdata_path/hosts
+
+t DELETE containers/$cid 204
+
+# test create with default no_hosts=true
+stop_service
+
+CONTAINERS_CONF=$TESTS_DIR/containers.no_hosts.conf start_service
+
+# check docker and libpod endpoint
+for endpoint in containers/create libpod/containers/create; do
+  t POST $endpoint \
+    Image=$IMAGE \
+    201 \
+    .Id~[0-9a-f]\\{64\\}
+  cid=$(jq -r '.Id' <<<"$output")
+
+  t POST libpod/containers/$cid/init 204
+
+  t GET libpod/containers/$cid/json 200 \
+    .HostsPath=""
+
+  t DELETE containers/$cid 204
+done
+
+stop_service
+start_service

--- a/test/apiv2/containers.no_hosts.conf
+++ b/test/apiv2/containers.no_hosts.conf
@@ -1,0 +1,2 @@
+[containers]
+no_hosts=true


### PR DESCRIPTION
The API endpoints should properly honour the `no_hosts=true` setting in
containers.conf.

Fixes #13719
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
