### PR TITLE
run, mount: allow setting driver specific option using `volume-opt=`

### DIFF
--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -523,6 +523,8 @@ func getNamedVolume(args []string) (*specgen.NamedVolume, error) {
 	for _, val := range args {
 		kv := strings.SplitN(val, "=", 2)
 		switch kv[0] {
+		case "volume-opt":
+			newVolume.Options = append(newVolume.Options, val)
 		case "ro", "rw":
 			if setRORW {
 				return nil, errors.Wrapf(optionArgError, "cannot pass 'ro' and 'rw' options more than once")

--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -57,6 +57,9 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 		switch splitOpt[0] {
 		case "O":
 			foundOverlay = true
+		case "volume-opt":
+			// Volume-opt should be relayed and processed by driver.
+			newOptions = append(newOptions, opt)
 		case "exec", "noexec":
 			if foundExec {
 				return nil, errors.Wrapf(ErrDupeMntOption, "only one of 'noexec' and 'exec' can be used")
@@ -174,4 +177,16 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 	}
 
 	return newOptions, nil
+}
+
+func ParseDriverOpts(option string) (string, string, error) {
+	token := strings.SplitN(option, "=", 2)
+	if len(token) != 2 {
+		return "", "", errors.Wrapf(ErrBadMntOption, "cannot parse driver opts")
+	}
+	opt := strings.SplitN(token[1], "=", 2)
+	if len(opt) != 2 {
+		return "", "", errors.Wrapf(ErrBadMntOption, "cannot parse driver opts")
+	}
+	return opt[0], opt[1], nil
 }

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -797,6 +797,19 @@ VOLUME /test/`, ALPINE)
 		Expect(session.OutputToString()).Should(Equal("888:888"))
 	})
 
+	It("podman run with --mount and named volume with driver-opts", func() {
+		// anonymous volume mount with driver opts
+		vol := "type=volume,source=test_vol,dst=/test,volume-opt=type=tmpfs,volume-opt=device=tmpfs,volume-opt=o=nodev"
+		session := podmanTest.Podman([]string{"run", "--rm", "--mount", vol, ALPINE, "echo", "hello"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		inspectVol := podmanTest.Podman([]string{"volume", "inspect", "test_vol"})
+		inspectVol.WaitWithDefaultTimeout()
+		Expect(inspectVol).Should(Exit(0))
+		Expect(inspectVol.OutputToString()).To(ContainSubstring("nodev"))
+	})
+
 	It("volume permissions after run", func() {
 		imgName := "testimg"
 		dockerfile := fmt.Sprintf(`FROM %s


### PR DESCRIPTION
`--mount` should allow setting driver specific options using
`volume-opt` when `type=volume` is set.

This ensures parity with docker.

Closes: https://github.com/containers/podman/issues/13387