### PR TITLE
images --size

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -87,6 +87,7 @@ func imageListFlagSet(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
 	flags.BoolVarP(&listOptions.All, "all", "a", false, "Show all images (default hides intermediate images)")
+	flags.BoolVarP(&listOptions.Size, "size", "", true, "Compute the size of each image")
 
 	filterFlagName := "filter"
 	flags.StringSliceVarP(&listOptions.Filter, filterFlagName, "f", []string{}, "Filter output based on conditions provided (default [])")
@@ -320,7 +321,10 @@ func lsFormatFromFlags(flags listFlagType) string {
 		row = append(row, "{{.Digest}}")
 	}
 
-	row = append(row, "{{.ID}}", "{{.Created}}", "{{.Size}}")
+	row = append(row, "{{.ID}}", "{{.Created}}")
+	if listOptions.Size {
+		row = append(row, "{{.Size}}")
+	}
 
 	if flags.history {
 		row = append(row, "{{if .History}}{{.History}}{{else}}<none>{{end}}")

--- a/docs/source/markdown/podman-images.1.md
+++ b/docs/source/markdown/podman-images.1.md
@@ -100,6 +100,10 @@ Omit the table headings from the listing of images.
 
 Lists only the image IDs.
 
+#### **--size**
+
+Compute and display the size of each image.  The default is true.  Computing the size of images can be costly.  If listing images is critical to performance, consider turning off size-computation via `--size=false`.
+
 #### **--sort**=*sort*=*created*
 
 Sort by created, id, repository, size or tag (default: created)

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -415,8 +415,9 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 		All     bool
 		Digests bool
 		Filter  string // Docker 1.24 compatibility
+		Size    bool
 	}{
-		// This is where you can override the golang default value for one of fields
+		Size: true,
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
@@ -443,7 +444,7 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 
-	listOptions := entities.ImageListOptions{All: query.All, Filter: filterList}
+	listOptions := entities.ImageListOptions{All: query.All, Filter: filterList, Size: query.Size}
 	summaries, err := imageEngine.List(r.Context(), listOptions)
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, err)

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -840,6 +840,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//        - `id`=(`<image-id>`)
 	//        - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
 	//     type: string
+	//   - name: size
+	//     in: query
+	//     description: Compute the size of each image
+	//     type: boolean
+	//     default: true
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -31,6 +31,8 @@ type ListOptions struct {
 	All *bool
 	// filters that can be used to get a more specific list of images
 	Filters map[string][]string
+	// Compute the size of each image
+	Size *bool
 }
 
 //go:generate go run ../generator/generator.go GetOptions

--- a/pkg/bindings/images/types_list_options.go
+++ b/pkg/bindings/images/types_list_options.go
@@ -46,3 +46,18 @@ func (o *ListOptions) GetFilters() map[string][]string {
 	}
 	return o.Filters
 }
+
+// WithSize set field Size to given value
+func (o *ListOptions) WithSize(value bool) *ListOptions {
+	o.Size = &value
+	return o
+}
+
+// GetSize returns value of field Size
+func (o *ListOptions) GetSize() bool {
+	if o.Size == nil {
+		var z bool
+		return z
+	}
+	return *o.Size
+}

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -251,6 +251,7 @@ type ImageSearchReport struct {
 type ImageListOptions struct {
 	All    bool     `json:"all" schema:"all"`
 	Filter []string `json:"Filter,omitempty"`
+	Size   bool     `json:"size" schema:"size"`
 }
 
 type ImagePruneOptions struct {

--- a/pkg/domain/infra/abi/images_list.go
+++ b/pkg/domain/infra/abi/images_list.go
@@ -60,14 +60,16 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 		}
 		e.Containers = len(ctnrs)
 
-		sz, err := img.Size()
-		if err != nil {
-			return nil, errors.Wrapf(err, "error retrieving size of image %q: you may need to remove the image to resolve the error", img.ID())
+		if opts.Size {
+			sz, err := img.Size()
+			if err != nil {
+				return nil, errors.Wrapf(err, "error retrieving size of image %q: you may need to remove the image to resolve the error", img.ID())
+			}
+			e.Size = sz
+			// This is good enough for now, but has to be
+			// replaced later with correct calculation logic
+			e.VirtualSize = sz
 		}
-		e.Size = sz
-		// This is good enough for now, but has to be
-		// replaced later with correct calculation logic
-		e.VirtualSize = sz
 
 		parent, err := img.Parent(ctx)
 		if err != nil {

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -38,7 +38,7 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 		f := strings.Split(filter, "=")
 		filters[f[0]] = f[1:]
 	}
-	options := new(images.ListOptions).WithAll(opts.All).WithFilters(filters)
+	options := new(images.ListOptions).WithAll(opts.All).WithFilters(filters).WithSize(opts.Size)
 	psImages, err := images.List(ir.ClientCtx, options)
 	if err != nil {
 		return nil, err

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -312,4 +312,15 @@ Deleted: $pauseID"
     is "$output" ""
 }
 
+@test "podman images --size" {
+    run_podman images
+    is "${lines[0]}" "REPOSITORY.*TAG.*IMAGE ID.*CREATED.*SIZE"
+    run_podman images --noheading --format "{{.Size}}"
+    is "$output" ".* MB"
+    run_podman images --size=false
+    is "${lines[0]}" "REPOSITORY.*TAG.*IMAGE ID.*CREATED"
+    run_podman images --noheading --format "{{.Size}}" --size=false
+    is "$output" "0 B"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Add a --size option to podman images to allow for disabling computing
the size of listed images.  If listing images is critical to
performance, user may chose to turn off size computation to speed things
up.

Context: #13755
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
