### PR TITLE
container,inspect: convert `Entrypoint` to an array instead of a string

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -367,7 +367,7 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) *define.Insp
 
 	// Leave empty if not explicitly overwritten by user
 	if len(c.config.Entrypoint) != 0 {
-		ctrConfig.Entrypoint = strings.Join(c.config.Entrypoint, " ")
+		ctrConfig.Entrypoint = c.config.Entrypoint
 	}
 
 	if len(c.config.Labels) != 0 {

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -44,7 +44,7 @@ type InspectContainerConfig struct {
 	// Container working directory
 	WorkingDir string `json:"WorkingDir"`
 	// Container entrypoint
-	Entrypoint string `json:"Entrypoint"`
+	Entrypoint []string `json:"Entrypoint"`
 	// On-build arguments - presently unused. More of Buildah's domain.
 	OnBuild *string `json:"OnBuild"`
 	// Container labels

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Podman create", func() {
 		result := podmanTest.Podman([]string{"inspect", "entrypoint_test", "--format", "{{.Config.Entrypoint}}"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(result.OutputToString()).To(Equal("/bin/foobar"))
+		Expect(result.OutputToString()).To(Equal("[/bin/foobar]"))
 	})
 
 	It("podman create --entrypoint \"\"", func() {
@@ -130,7 +130,7 @@ var _ = Describe("Podman create", func() {
 		result := podmanTest.Podman([]string{"inspect", session.OutputToString(), "--format", "{{.Config.Entrypoint}}"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(result.OutputToString()).To(Equal(""))
+		Expect(result.OutputToString()).To(Equal("[]"))
 	})
 
 	It("podman create --entrypoint json", func() {
@@ -143,7 +143,7 @@ var _ = Describe("Podman create", func() {
 		result := podmanTest.Podman([]string{"inspect", "entrypoint_json", "--format", "{{.Config.Entrypoint}}"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
-		Expect(result.OutputToString()).To(Equal("/bin/foo -c"))
+		Expect(result.OutputToString()).To(Equal("[/bin/foo -c]"))
 	})
 
 	It("podman create --mount flag with multiple mounts", func() {
@@ -281,7 +281,8 @@ var _ = Describe("Podman create", func() {
 		Expect(ctrJSON).To(HaveLen(1))
 		Expect(ctrJSON[0].Config.Cmd).To(HaveLen(1))
 		Expect(ctrJSON[0].Config.Cmd[0]).To(Equal("redis-server"))
-		Expect(ctrJSON[0].Config.Entrypoint).To(Equal("docker-entrypoint.sh"))
+		Expect(ctrJSON[0].Config.Entrypoint).To(HaveLen(1))
+		Expect(ctrJSON[0].Config.Entrypoint[0]).To(Equal("docker-entrypoint.sh"))
 	})
 
 	It("podman create --pull", func() {

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -368,7 +368,7 @@ var _ = Describe("Podman pod create", func() {
 		check1 := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Config.Entrypoint}}", data.Containers[0].ID})
 		check1.WaitWithDefaultTimeout()
 		Expect(check1).Should(Exit(0))
-		Expect(check1.OutputToString()).To(Equal("/catatonit -P"))
+		Expect(check1.OutputToString()).To(Equal("[/catatonit -P]"))
 
 		// check the Path and Args
 		check2 := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Path}}:{{.Args}}", data.Containers[0].ID})
@@ -391,7 +391,7 @@ var _ = Describe("Podman pod create", func() {
 		check1 := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Config.Entrypoint}}", data.Containers[0].ID})
 		check1.WaitWithDefaultTimeout()
 		Expect(check1).Should(Exit(0))
-		Expect(check1.OutputToString()).To(Equal("/pause1"))
+		Expect(check1.OutputToString()).To(Equal("[/pause1]"))
 
 		// check the Path and Args
 		check2 := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Path}}:{{.Args}}", data.Containers[0].ID})
@@ -418,7 +418,7 @@ entrypoint ["/fromimage"]
 		check1 := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Config.Entrypoint}}", data.Containers[0].ID})
 		check1.WaitWithDefaultTimeout()
 		Expect(check1).Should(Exit(0))
-		Expect(check1.OutputToString()).To(Equal("/fromimage"))
+		Expect(check1.OutputToString()).To(Equal("[/fromimage]"))
 
 		// check the Path and Args
 		check2 := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Path}}:{{.Args}}", data.Containers[0].ID})
@@ -445,7 +445,7 @@ entrypoint ["/fromimage"]
 		check1 := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Config.Entrypoint}}", data.Containers[0].ID})
 		check1.WaitWithDefaultTimeout()
 		Expect(check1).Should(Exit(0))
-		Expect(check1.OutputToString()).To(Equal("/fromcommand"))
+		Expect(check1.OutputToString()).To(Equal("[/fromcommand]"))
 
 		// check the Path and Args
 		check2 := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.Path}}:{{.Args}}", data.Containers[0].ID})

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -234,7 +234,7 @@ EOF
     local infra_cid="$output"
     # confirm that entrypoint is what we set
     run_podman container inspect --format '{{.Config.Entrypoint}}' $infra_cid
-    is "$output" "$infra_command" "infra-command took effect"
+    is "$output" "[$infra_command]" "infra-command took effect"
     # confirm that infra container name is set
     run_podman container inspect --format '{{.Name}}' $infra_cid
     is "$output" "$infra_name" "infra-name took effect"


### PR DESCRIPTION
Convert container entrypoint from string to an array inorder to make
sure there is parity between `podman inspect <ctr>` and `docker inspect <ctr>`

Closes: https://github.com/containers/podman/issues/13803

