### PR TITLE
[CI:BUILD] Cirrus: Fix unsupported cirrus-cron build status

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -776,8 +776,8 @@ image_build_task: &image-build
 
 test_image_build_task:
     <<: *image-build
-    # Allow this to run inside a PR
-    only_if: $CI == $CI
+    # Allow this to run inside a PR w/ [CI:BUILD]
+    only_if: $CIRRUS_PR != '' && $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
     # This takes a LONG time, only run when requested.  N/B: Any task
     # made to depend on this one will block FOREVER unless triggered.
     trigger_type: manual


### PR DESCRIPTION
Every weekday when the `check_cirrus_cron` github-actions
workflow runs. It checks the status of all cirrus-cron jobs.  If a build
is found with a 'FAILED' status, it triggers an alert e-mail to be sent.
However, the `test_image_build` is marked as a manually-triggered,
resulting in a perpetual status of 'EXECUTING', even if there were
failures.  Fix this by only allowing the problematic task to run in pull
requests without the `[CI:DOCS]` magic keyword.

Signed-off-by: Chris Evich <cevich@redhat.com>