### PR TITLE
machine,rm: Ignore `ENOENT` while cleaning machine paths

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -859,6 +859,9 @@ func (v *MachineVM) Remove(_ string, opts machine.RemoveOptions) (string, func()
 	return confirmationMessage, func() error {
 		for _, f := range files {
 			if err := os.Remove(f); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					continue
+				}
 				logrus.Error(err)
 			}
 		}


### PR DESCRIPTION
Certain paths like `../containers/podman/machine/my-test/podman.sock`
do not exist when machine is not started, so removing a machine before
starting it will result in ENOENT for such paths, so ignore `ENOENT` for such cases.

Reproducer:

```console
podman machine init
podman machine rm
```

Closes: https://github.com/containers/podman/issues/13834

[NO TESTS NEEDED]
[NO NEW TESTS NEEDED]
This does not adds a new feature.
