### PR TITLE
compat api: use network mode bridge as default

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -164,8 +164,13 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 		}
 	}
 
-	// netMode
-	nsmode, networks, netOpts, err := specgen.ParseNetworkFlag([]string{string(cc.HostConfig.NetworkMode)})
+	// special case for NetworkMode, the podman default is slirp4netns for
+	// rootless but for better docker compat we want bridge.
+	netmode := string(cc.HostConfig.NetworkMode)
+	if netmode == "" || netmode == "default" {
+		netmode = "bridge"
+	}
+	nsmode, networks, netOpts, err := specgen.ParseNetworkFlag([]string{netmode})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -239,16 +239,11 @@ t GET containers/$cid/json 200 \
 t POST containers/create Image=$IMAGE Entrypoint='["top"]' 201 \
   .Id~[0-9a-f]\\{64\\}
 cid_top=$(jq -r '.Id' <<<"$output")
-# .Network is N/A when rootless
-network_expect=
-if root; then
-    network_expect='.NetworkSettings.Networks.podman.NetworkID=podman'
-fi
 t GET containers/${cid_top}/json 200 \
   .Config.Entrypoint[0]="top" \
   .Config.Cmd='[]' \
   .Path="top" \
-  $network_expect
+  .NetworkSettings.Networks.podman.NetworkID=podman
 t POST  containers/${cid_top}/start 204
 # make sure the container is running
 t GET containers/${cid_top}/json 200 \
@@ -372,15 +367,11 @@ t GET containers/$cid/json 200 \
 t DELETE containers/$cid?v=true 204
 
 # Test Compat Create with default network mode (#10569)
-networkmode=slirp4netns
-if root; then
-    networkmode=bridge
-fi
 t POST containers/create Image=$IMAGE HostConfig='{"NetworkMode":"default"}' 201 \
   .Id~[0-9a-f]\\{64\\}
 cid=$(jq -r '.Id' <<<"$output")
 t GET containers/$cid/json 200 \
-  .HostConfig.NetworkMode="$networkmode"
+  .HostConfig.NetworkMode="bridge"
 
 t DELETE containers/$cid?v=true 204
 


### PR DESCRIPTION
For better docker compatibility we should use the bridge network mode as
default for rootless. This was already done previously but commit
535818414c2a introduced this regression in v4.0.

Since the apiv2 test are only run rootful we cannot catch this problem
in CI.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
