### PR TITLE
System tests: fix oops in start --filter tests

### DIFF
--- a/test/system/045-start.bats
+++ b/test/system/045-start.bats
@@ -41,18 +41,19 @@ load helpers
 @test "podman start --filter - start only containers that match the filter" {
     run_podman run -d $IMAGE /bin/true
     cid="$output"
-    run_podman start --filter restart-policy=always $cid "CID of restart-policy=always container"
-    is "$output" ""
+    run_podman start --filter restart-policy=always $cid
+    is "$output" "" "CID of restart-policy=always container"
 
-    run_podman start --filter restart-policy=none $cid "CID of restart-policy=none container"
-    is "$output" "$cid"
+    run_podman start --filter restart-policy=none $cid
+    is "$output" "$cid" "CID of restart-policy=none container"
 }
 
 @test "podman start --filter invalid-restart-policy - return error" {
     run_podman run -d $IMAGE /bin/true
     cid="$output"
-    run_podman 125 start --filter restart-policy=fakepolicy $cid "CID of restart-policy=<not-exists> container"
-    is "$output" "Error: fakepolicy invalid restart policy"
+    run_podman 125 start --filter restart-policy=fakepolicy $cid
+    is "$output" "Error: fakepolicy invalid restart policy" \
+       "CID of restart-policy=<not-exists> container"
 }
 
 @test "podman start --all --filter" {


### PR DESCRIPTION
Bad code got committed by accident: test description on run_podman
line, not test line.

Did not seem to affect tests, but fix it anyway.

Signed-off-by: Ed Santiago <santiago@redhat.com>
