### PR TITLE
Mount $HOME:$HOME by default in podman machine init

### DIFF
--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -83,6 +83,9 @@ Podman mounts _host-dir_ in the host to _machine-dir_ in the Podman machine.
 The root filesystem is mounted read-only in the default operating system,
 so mounts must be created under the /mnt directory.
 
+Default volume mounts are defined in *containers.conf*.  Unless changed, the default values
+is `$HOME:$HOME`.
+
 #### **--volume-driver**
 
 Driver to use for mounting volumes from the host, such as `virtfs`.


### PR DESCRIPTION
By default, mount the user's homedir into the vm at the same location.
any volumes defined on the cli will then override the default mount.
Also, added --no-volumes to disable volume mounts alltogether.

Signed-off-by: Brent Baude <bbaude@redhat.com>

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
