### PR TITLE
Fix --tail log on restart problem

### DIFF
--- a/libpod/container_log_linux.go
+++ b/libpod/container_log_linux.go
@@ -209,9 +209,6 @@ func (c *Container) readFromJournal(ctx context.Context, options *logs.LogOption
 					containerCouldBeLogging = true
 				case events.Exited:
 					containerCouldBeLogging = false
-					if doTail {
-						doTailFunc()
-					}
 				}
 				continue
 			}


### PR DESCRIPTION
--tail=1 is not working f you restart a container with journald logging.

We see the exit status and then call into the logging a second time
causing all of the logs to print.

Removing the tail log on exited seems to fix the problem.

Fixes: https://github.com/containers/podman/issues/13098

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
