### PR TITLE
[CI:DOCS] Bump to v3.4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Podman (the POD MANager) is a tool for managing containers and images, volumes mounted into those containers, and pods made from groups of containers.
 Podman is based on libpod, a library for container lifecycle management that is also contained in this repository. The libpod library provides APIs for managing containers, pods, container images, and volumes.
 
-* [Latest Version: 3.3.1](https://github.com/containers/podman/releases/latest)
+* [Latest Version: 3.4.6](https://github.com/containers/podman/releases/latest)
   * Latest Remote client for Windows
   * Latest Remote client for macOS
   * Latest Static Remote client for Linux

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 3.4.6
+### Security
+- This release addresses CVE-2022-27191, where an attacker could potentially cause crashes in remote Podman by using incorrect SSH ciphers.
+
 ## 3.4.5
 ### Security
 - This release addresses CVE-2022-27649, where Podman would set excess inheritable capabilities for processes in containers.

--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ const (
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-var Version = semver.MustParse("3.4.6")
+var Version = semver.MustParse("3.4.7-dev")
 
 // See https://docs.docker.com/engine/api/v1.40/
 // libpod compat handlers are expected to honor docker API versions

--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ const (
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-var Version = semver.MustParse("3.4.6-dev")
+var Version = semver.MustParse("3.4.6")
 
 // See https://docs.docker.com/engine/api/v1.40/
 // libpod compat handlers are expected to honor docker API versions


### PR DESCRIPTION
3.4.5 wasn't rebased fully so we missed a minor security patch. Cut another release to fix.