### PR TITLE
Allow HTTP attach to stopped containers

### DIFF
--- a/pkg/api/handlers/compat/containers_attach.go
+++ b/pkg/api/handlers/compat/containers_attach.go
@@ -83,7 +83,7 @@ func AttachContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// For Docker compatibility, we need to re-initialize containers in these states.
-	if state == define.ContainerStateConfigured || state == define.ContainerStateExited {
+	if state == define.ContainerStateConfigured || state == define.ContainerStateExited || state == define.ContainerStateStopped {
 		if err := ctr.Init(r.Context(), ctr.PodID() != ""); err != nil {
 			utils.Error(w, http.StatusConflict, errors.Wrapf(err, "error preparing container %s for attach", ctr.ID()))
 			return


### PR DESCRIPTION
There's a potential race condition where we attempt to attach to a container immediately after it's been stopped, but before the cleanup process has run on it. The existing code doesn't allow an attach to containers in the Stopped state (cleanup process has not run) but does allow an attach to containers in the Exited state (cleanup process has run). This doesn't make very much sense and there's no technical reason to restrict attach to only Exited containers, so allow attaching to Stopped containers.

[NO NEW TESTS NEEDED] Testing this is very racy - we need to get in before the cleanup process runs, which isn't really deterministic when we're invoked from a script - like the CI tests.
