### PR TITLE
System tests: Usage checks: better error messages

### DIFF
--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -68,9 +68,10 @@ function check_help() {
             if [ "$cmd" != "help" ]; then
                 dprint "$command_string invalid-arg"
                 run_podman '?' "$@" $cmd invalid-arg
-                is "$status" 125 "'$command_string invalid-arg' - exit status"
+                is "$status" 125 \
+                   "'$usage' indicates that the command takes no arguments. I invoked it with 'invalid-arg' and expected an error status"
                 is "$output" "Error: .* takes no arguments" \
-                   "'$command_string' with extra (invalid) arguments"
+                   "'$usage' indicates that the command takes no arguments. I invoked it with 'invalid-arg' and expected the following error message"
             fi
             found[takes_no_args]=1
         fi
@@ -115,9 +116,10 @@ function check_help() {
             # try to read username/password from stdin.
             dprint "$command_string (without required args)"
             run_podman '?' "$@" $cmd </dev/null
-            is "$status" 125 "'$command_string' with no arguments - exit status"
+            is "$status" 125 \
+               "'$usage' indicates at least one required arg. I invoked it with no args and expected an error exit code"
             is "$output" "Error:.* \(require\|specif\|must\|provide\|need\|choose\|accepts\)" \
-               "'$command_string' without required arg"
+               "'$usage' indicates at least one required arg. I invoked it with no args and expected one of these error messages"
 
             found[required_args]=1
         fi
@@ -138,9 +140,10 @@ function check_help() {
                 local n_args=$(wc -w <<<"$rhs")
 
                 run_podman '?' "$@" $cmd $(seq --format='x%g' 0 $n_args)
-                is "$status" 125 "'$command_string' with >$n_args arguments - exit status"
+                is "$status" 125 \
+                   "'$usage' indicates a maximum of $n_args args. I invoked it with more, and expected this exit status"
                 is "$output" "Error:.* \(takes no arguments\|requires exactly $n_args arg\|accepts at most\|too many arguments\|accepts $n_args arg(s), received\|accepts between .* and .* arg(s), received \)" \
-                   "'$command_string' with >$n_args arguments"
+                   "'$usage' indicates a maximum of $n_args args. I invoked it with more, and expected one of these error messages"
 
                 found[fixed_args]=1
             fi


### PR DESCRIPTION
Current error messages are really awful, and cause great
suffering every time someone adds a new subcommand. Let's
see if these are better.

Signed-off-by: Ed Santiago <santiago@redhat.com>
