### PR TITLE
Makefile: simplify for modern Go

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,9 @@ env:
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
     DEST_BRANCH: "main"
+    # Sane (default) value for GOPROXY and GOSUMDB.
+    GOPROXY: "https://proxy.golang.org,direct"
+    GOSUMDB: "sum.golang.org"
     # Overrides default location (/tmp/cirrus) for repo clone
     GOPATH: &gopath "/var/tmp/go"
     GOCACHE: "${GOPATH}/cache"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,6 @@ env:
     DEST_BRANCH: "main"
     # Overrides default location (/tmp/cirrus) for repo clone
     GOPATH: &gopath "/var/tmp/go"
-    GOBIN: "${GOPATH}/bin"
     GOCACHE: "${GOPATH}/cache"
     GOSRC: &gosrc "/var/tmp/go/src/github.com/containers/podman"
     CIRRUS_WORKING_DIR: *gosrc

--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,4 @@ tags
 result
 # Necessary to prevent hack/tree-status.sh false-positive
 /*runner_stats.log
-.install.goimports
 .generate-bindings

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,6 @@ PRE_COMMIT = $(shell command -v bin/venv/bin/pre-commit ~/.local/bin/pre-commit 
 # triggered.
 SOURCES = $(shell find . -path './.*' -prune -o \( \( -name '*.go' -o -name '*.c' \) -a ! -name '*_test.go' \) -print)
 
-BUILDFLAGS := -mod=vendor $(BUILDFLAGS)
-
 BUILDTAGS_CROSS ?= containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay
 CONTAINER_RUNTIME := $(shell command -v podman 2> /dev/null || echo docker)
 OCI_RUNTIME ?= ""

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ COVERAGE_PATH ?= .coverage
 DESTDIR ?=
 EPOCH_TEST_COMMIT ?= $(shell git merge-base $${DEST_BRANCH:-main} HEAD)
 HEAD ?= HEAD
-CHANGELOG_BASE ?= HEAD~
-CHANGELOG_TARGET ?= HEAD
 PROJECT := github.com/containers/podman
 GIT_BASE_BRANCH ?= origin/main
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
@@ -86,10 +84,8 @@ GIT_COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),${COMMIT
 DATE_FMT = %s
 ifdef SOURCE_DATE_EPOCH
 	BUILD_INFO ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
-	ISODATE ?= $(shell date -d "@$(SOURCE_DATE_EPOCH)" --iso-8601)
 else
 	BUILD_INFO ?= $(shell date "+$(DATE_FMT)")
-	ISODATE ?= $(shell date --iso-8601)
 endif
 LIBPOD := ${PROJECT}/v4/libpod
 GOFLAGS ?= -trimpath

--- a/Makefile
+++ b/Makefile
@@ -221,18 +221,6 @@ endif
 golangci-lint: .install.golangci-lint
 	hack/golangci-lint.sh run
 
-.PHONY: gofmt
-gofmt: ## Verify the source code gofmt
-	find . -name '*.go' -type f \
-		-not \( \
-			-name '.golangci.yml' -o \
-			-name 'Makefile' -o \
-			-path './vendor/*' -prune -o \
-			-path './test/tools/vendor/*' -prune -o \
-			-path './contrib/*' -prune \
-		\) -exec gofmt -d -e -s -w {} \+
-	git diff --exit-code
-
 .PHONY: test/checkseccomp/checkseccomp
 test/checkseccomp/checkseccomp: $(wildcard test/checkseccomp/*.go)
 	$(GOCMD) build $(BUILDFLAGS) $(GO_LDFLAGS) '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS)" -o $@ ./test/checkseccomp
@@ -257,7 +245,7 @@ codespell:
 	codespell -S bin,vendor,.git,go.sum,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.ps1,*.tar,swagger.yaml,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go" -L uint,iff,od,seeked,splitted,marge,ERRO,hist,ether -w
 
 .PHONY: validate
-validate: gofmt lint .gitvalidation validate.completions man-page-check swagger-check tests-included tests-expect-exit
+validate: lint .gitvalidation validate.completions man-page-check swagger-check tests-included tests-expect-exit
 
 .PHONY: build-all-new-commits
 build-all-new-commits:

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,6 @@
 ### Variables & Definitions
 ###
 
-export GOPROXY=https://proxy.golang.org
-
 GO ?= go
 GO_LDFLAGS:= $(shell if $(GO) version|grep -q gccgo ; then echo "-gccgoflags"; else echo "-ldflags"; fi)
 GOCMD = CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO)

--- a/Makefile
+++ b/Makefile
@@ -254,9 +254,9 @@ build-all-new-commits:
 
 .PHONY: vendor
 vendor:
-	GO111MODULE=on $(GO) mod tidy
-	GO111MODULE=on $(GO) mod vendor
-	GO111MODULE=on $(GO) mod verify
+	$(GO) mod tidy
+	$(GO) mod vendor
+	$(GO) mod verify
 
 .PHONY: vendor-in-container
 vendor-in-container:
@@ -372,7 +372,7 @@ rootlessport: bin/rootlessport
 .PHONY: generate-bindings
 generate-bindings:
 ifneq ($(GOOS),darwin)
-	GO111MODULE=off $(GOCMD) generate ./pkg/bindings/... ;
+	$(GOCMD) generate ./pkg/bindings/... ;
 endif
 
 # DO NOT USE: use local-cross instead

--- a/Makefile
+++ b/Makefile
@@ -923,7 +923,6 @@ clean: clean-binaries ## Clean all make artifacts
 		libpod/pod_ffjson.go \
 		libpod/container_easyjson.go \
 		libpod/pod_easyjson.go \
-		.install.goimports \
 		docs/build \
 		.venv
 	make -C docs clean

--- a/Makefile
+++ b/Makefile
@@ -887,13 +887,6 @@ install.tools: .install.ginkgo .install.golangci-lint .install.bats ## Install n
 		python3 -m pip install --user pre-commit; \
 	fi
 
-# $BUILD_TAGS variable is used in hack/golangci-lint.sh
-.PHONY: install.libseccomp.sudo
-install.libseccomp.sudo:
-	rm -rf ../../seccomp/libseccomp
-	git clone https://github.com/seccomp/libseccomp ../../seccomp/libseccomp
-	cd ../../seccomp/libseccomp && git checkout --detach $(LIBSECCOMP_COMMIT) && ./autogen.sh && ./configure --prefix=/usr && make all && make install
-
 .PHONY: uninstall
 uninstall:
 	for i in $(filter %.1,$(MANPAGES_DEST)); do \

--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -34,9 +34,11 @@ filtered_changes=$(git diff --name-only $base $head      |
                        fgrep -vx .cirrus.yml             |
                        fgrep -vx .pre-commit-config.yaml |
                        fgrep -vx .gitignore              |
-                       fgrep -vx Makefile                |
                        fgrep -vx go.mod                  |
                        fgrep -vx go.sum                  |
+                       fgrep -vx podman.spec.rpkg        |
+                       fgrep -vx .golangci.yml           |
+                       egrep -v  '/*Makefile$'           |
                        egrep -v  '^[^/]+\.md$'           |
                        egrep -v  '^.github'              |
                        egrep -v  '^contrib/'             |

--- a/pkg/api/Makefile
+++ b/pkg/api/Makefile
@@ -1,5 +1,3 @@
-export GO111MODULE=off
-
 SWAGGER_OUT ?= swagger.yaml
 
 validate: ${SWAGGER_OUT}

--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -13,16 +13,8 @@
 %endif
 
 %if ! 0%{?gobuild:1}
-%define gobuild(o:) GO111MODULE=off go build -buildmode pie -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld '" -a -v -x %{?**};
+%define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback ${BUILDTAGS:-}" -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '-Wl,-z,relro -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld '" -a -v -x %{?**};
 %endif
-
-%global provider github
-%global provider_tld com
-%global project containers
-%global repo %{name}
-# https://github.com/containers/%%{name}
-%global import_path %{provider}.%{provider_tld}/%{project}/%{repo}
-%global git0 https://%{import_path}
 
 # git_dir_name returns repository name derived from remote Git repository URL
 Name:       {{{ git_dir_name }}}
@@ -156,8 +148,7 @@ connections as well.
 # This will invoke `make` command in the directory with the extracted sources.
 %build
 %set_build_flags
-export GO111MODULE=off
-export GOPATH=$(pwd)/_build:$(pwd)
+%global gomodulesmode GO111MODULE=on
 export CGO_CFLAGS=$CFLAGS
 # These extra flags present in $CFLAGS have been skipped for now as they break the build
 CGO_CFLAGS=$(echo $CGO_CFLAGS | sed 's/-flto=auto//g')
@@ -168,33 +159,26 @@ CGO_CFLAGS=$(echo $CGO_CFLAGS | sed 's/-specs=\/usr\/lib\/rpm\/redhat\/redhat-an
 export CGO_CFLAGS+=" -m64 -mtune=generic -fcf-protection=full"
 %endif
 
-mkdir _build
-pushd _build
-mkdir -p src/%{provider}.%{provider_tld}/%{project}
-ln -s ../../../../ src/%{import_path}
-popd
-ln -s vendor src
-
 %if 0%{?rhel}
 rm -rf vendor/github.com/containers/storage/drivers/register/register_btrfs.go
 %endif
 
 # build date. FIXME: Makefile uses '/v2/libpod', that doesn't work here?
-LDFLAGS="-X %{import_path}/libpod/define.buildInfo=$(date +%s)"
+LDFLAGS="-X ./libpod/define.buildInfo=$(date +%s)"
 
 # build rootlessport first
-%gobuild -o bin/rootlessport %{import_path}/cmd/rootlessport
+%gobuild -o bin/rootlessport ./cmd/rootlessport
 
 # set base buildtags common to both %%{name} and %%{name}-remote
 export BASEBUILDTAGS="seccomp exclude_graphdriver_devicemapper $(hack/selinux_tag.sh) $(hack/systemd_tag.sh) $(hack/libsubid_tag.sh)"
 
 # build %%{name}
 export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh)"
-%gobuild -o bin/%{name} %{import_path}/cmd/%{name}
+%gobuild -o bin/%{name} ./cmd/%{name}
 
 # build %%{name}-remote
 export BUILDTAGS="$BASEBUILDTAGS exclude_graphdriver_btrfs btrfs_noversion remote"
-%gobuild -o bin/%{name}-remote %{import_path}/cmd/%{name}
+%gobuild -o bin/%{name}-remote ./cmd/%{name}
 
 make docs docker-docs
 


### PR DESCRIPTION
This removes about 100 lines from the top-level Makefile.

Please review commit by commit, and see commit messages for details.

Note some of these changes are standing on the assumption that Go >= 1.16 is used (which is true since we use things like filepath.WalkDir which require go 1.16).

