### PR TITLE
Add --quiet to machine ls

### DIFF
--- a/docs/source/markdown/podman-machine-list.1.md
+++ b/docs/source/markdown/podman-machine-list.1.md
@@ -47,7 +47,12 @@ Print usage statement.
 
 #### **--noheading**
 
-Omit the table headings from the listing of pods.
+Omit the table headings from the listing of machines
+
+#### **--quiet**, **-q**
+
+Only print the name of the machine. This also implies no table heading
+is printed.
 
 ## EXAMPLES
 


### PR DESCRIPTION
The podman machine ls command would benefit from a --quiet flag which
would only print the machine names without the extra information.  It
also implies --noheader as well.  This can be helpful for scripting with
the podman cli.

Signed-off-by: Brent Baude <bbaude@redhat.com>

[NO NEW TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
