### PR TITLE
Implement Windows volume/mount support

### DIFF
--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -347,7 +347,7 @@ func ContainerCreateToContainerCLIOpts(cc handlers.CreateContainerConfig, rtc *c
 		cliOpts.Volume = append(cliOpts.Volume, vol)
 		// Extract the destination so we don't add duplicate mounts in
 		// the volumes phase.
-		splitVol := strings.SplitN(vol, ":", 3)
+		splitVol := specgen.SplitVolumeString(vol)
 		switch len(splitVol) {
 		case 1:
 			volDestinations[vol] = true

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.0.1
 	github.com/containernetworking/plugins v1.1.1
 	github.com/containers/buildah v1.25.2-0.20220406205807-5b8e79118057
-	github.com/containers/common v0.47.5-0.20220421111103-112a47964ddb
+	github.com/containers/common v0.47.5-0.20220425182415-4081e6be9356
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.21.1-0.20220421124950-8527e238867c
 	github.com/containers/ocicrypt v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,8 @@ github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19
 github.com/containers/buildah v1.25.2-0.20220406205807-5b8e79118057 h1:lKSxhMBpcHyyQrj2QJYzcm56uiSeibRdSL2KoppF6rg=
 github.com/containers/buildah v1.25.2-0.20220406205807-5b8e79118057/go.mod h1:iSoopbYRb6K4b5c3hXgXNkGTI/T085t2+XiGjceud94=
 github.com/containers/common v0.47.5-0.20220331143923-5f14ec785c18/go.mod h1:Vr2Fn6EdzD6JNAbz8L8bTv3uWLv2p31Ih2O3EAK6Hyc=
-github.com/containers/common v0.47.5-0.20220421111103-112a47964ddb h1:TBrx1KcmWcesByqTb4Cq7F6bg7bDOjqCf6+6rbi8x4k=
-github.com/containers/common v0.47.5-0.20220421111103-112a47964ddb/go.mod h1:r80nWTmJrG9EoLkuI6WfbWQDUNQVqkVuB8Oaj1VVjOA=
+github.com/containers/common v0.47.5-0.20220425182415-4081e6be9356 h1:eJ1ghvyswTLRywF4YYEWrzZyOFEzlD1FUPLzJSz+wKo=
+github.com/containers/common v0.47.5-0.20220425182415-4081e6be9356/go.mod h1:r80nWTmJrG9EoLkuI6WfbWQDUNQVqkVuB8Oaj1VVjOA=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.19.2-0.20220224100137-1045fb70b094/go.mod h1:XoYK6kE0dpazFNcuS+a8lra+QfbC6s8tzv+cUuCrZpE=

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containers/common/libnetwork/etchosts"
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/config"
+	"github.com/containers/common/pkg/machine"
 	"github.com/containers/common/pkg/netns"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/libpod/events"
@@ -62,7 +63,7 @@ const (
 // This is need because a HostIP of 127.0.0.1 would now allow the gvproxy forwarder to reach to open ports.
 // For machine the HostIP must only be used by gvproxy and never in the VM.
 func (c *Container) convertPortMappings() []types.PortMapping {
-	if !c.runtime.config.Engine.MachineEnabled || len(c.config.PortMappings) == 0 {
+	if !machine.IsPodmanMachine() || len(c.config.PortMappings) == 0 {
 		return c.config.PortMappings
 	}
 	// if we run in a machine VM we have to ignore the host IP part

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -63,7 +63,7 @@ const (
 // This is need because a HostIP of 127.0.0.1 would now allow the gvproxy forwarder to reach to open ports.
 // For machine the HostIP must only be used by gvproxy and never in the VM.
 func (c *Container) convertPortMappings() []types.PortMapping {
-	if !machine.IsPodmanMachine() || len(c.config.PortMappings) == 0 {
+	if !machine.IsGvProxyBased() || len(c.config.PortMappings) == 0 {
 		return c.config.PortMappings
 	}
 	// if we run in a machine VM we have to ignore the host IP part

--- a/libpod/networking_machine.go
+++ b/libpod/networking_machine.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/common/pkg/machine"
 	"github.com/sirupsen/logrus"
 )
 
@@ -117,7 +118,7 @@ func annotateGvproxyResponseError(r io.Reader) error {
 
 // exposeMachinePorts exposes the ports for podman machine via gvproxy
 func (r *Runtime) exposeMachinePorts(ports []types.PortMapping) error {
-	if !r.config.Engine.MachineEnabled {
+	if !machine.IsGvProxyBased() {
 		return nil
 	}
 	return requestMachinePorts(true, ports)
@@ -125,7 +126,7 @@ func (r *Runtime) exposeMachinePorts(ports []types.PortMapping) error {
 
 // unexposeMachinePorts closes the ports for podman machine via gvproxy
 func (r *Runtime) unexposeMachinePorts(ports []types.PortMapping) error {
-	if !r.config.Engine.MachineEnabled {
+	if !machine.IsGvProxyBased() {
 		return nil
 	}
 	return requestMachinePorts(false, ports)

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -304,6 +304,8 @@ ExecStart=/usr/bin/sleep infinity
 	containers := `[containers]
 netns="bridge"
 `
+	// Set deprecated machine_enabled until podman package on fcos is
+	// current enough to no longer require it
 	rootContainers := `[engine]
 machine_enabled=true
 `
@@ -392,7 +394,7 @@ Delegate=memory pids cpu io
 		FileEmbedded1: FileEmbedded1{Mode: intToPtr(0644)},
 	})
 
-	// Set machine_enabled to true to indicate we're in a VM
+	// Set deprecated machine_enabled to true to indicate we're in a VM
 	files = append(files, File{
 		Node: Node{
 			Group: getNodeGrp("root"),
@@ -403,6 +405,22 @@ Delegate=memory pids cpu io
 			Append: nil,
 			Contents: Resource{
 				Source: encodeDataURLPtr(rootContainers),
+			},
+			Mode: intToPtr(0644),
+		},
+	})
+
+	// Set machine marker file to indicate podman is in a qemu based machine
+	files = append(files, File{
+		Node: Node{
+			Group: getNodeGrp("root"),
+			Path:  "/etc/containers/podman-machine",
+			User:  getNodeUsr("root"),
+		},
+		FileEmbedded1: FileEmbedded1{
+			Append: nil,
+			Contents: Resource{
+				Source: encodeDataURLPtr("qemu\n"),
 			},
 			Mode: intToPtr(0644),
 		},

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -448,6 +448,10 @@ func configureSystem(v *MachineVM, dist string) error {
 		return errors.Wrap(err, "could not create containers.conf for guest OS")
 	}
 
+	if err := runCmdPassThrough("wsl", "-d", dist, "sh", "-c", "echo wsl > /etc/containers/podman-machine"); err != nil {
+		return errors.Wrap(err, "could not create podman-machine file for guest OS")
+	}
+
 	return nil
 }
 

--- a/pkg/specgen/winpath.go
+++ b/pkg/specgen/winpath.go
@@ -1,0 +1,59 @@
+package specgen
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/pkg/errors"
+)
+
+func isHostWinPath(path string) bool {
+	return shouldResolveWinPaths() && strings.HasPrefix(path, `\\`) || hasWinDriveScheme(path, 0) || winPathExists(path)
+}
+
+func hasWinDriveScheme(path string, start int) bool {
+	if len(path) < start+2 || path[start+1] != ':' {
+		return false
+	}
+
+	drive := rune(path[start])
+	return drive < unicode.MaxASCII && unicode.IsLetter(drive)
+}
+
+// Converts a Windows path to a WSL guest path if local env is a WSL linux guest or this is a Windows client.
+func ConvertWinMountPath(path string) (string, error) {
+	if !shouldResolveWinPaths() {
+		return path, nil
+	}
+
+	if strings.HasPrefix(path, "/") {
+		// Handle /[driveletter]/windows/path form (e.g. c:\Users\bar == /c/Users/bar)
+		if len(path) > 2 && path[2] == '/' && shouldResolveUnixWinVariant(path) {
+			drive := unicode.ToLower(rune(path[1]))
+			if unicode.IsLetter(drive) && drive <= unicode.MaxASCII {
+				return fmt.Sprintf("/mnt/%c/%s", drive, path[3:]), nil
+			}
+		}
+
+		// unix path - pass through
+		return path, nil
+	}
+
+	// Convert remote win client relative paths to absolute
+	path = resolveRelativeOnWindows(path)
+
+	// Strip extended marker prefix if present
+	path = strings.TrimPrefix(path, `\\?\`)
+
+	// Drive installed via wsl --mount
+	if strings.HasPrefix(path, `\\.\`) {
+		path = "/mnt/wsl/" + path[4:]
+	} else if len(path) > 1 && path[1] == ':' {
+		path = "/mnt/" + strings.ToLower(path[0:1]) + path[2:]
+	} else {
+		return path, errors.New("unsupported UNC path")
+	}
+
+	return strings.ReplaceAll(path, `\`, "/"), nil
+}

--- a/pkg/specgen/winpath_linux.go
+++ b/pkg/specgen/winpath_linux.go
@@ -1,0 +1,24 @@
+package specgen
+
+import (
+	"os"
+
+	"github.com/containers/common/pkg/machine"
+)
+
+func shouldResolveWinPaths() bool {
+	return machine.MachineHostType() == "wsl"
+}
+
+func shouldResolveUnixWinVariant(path string) bool {
+	_, err := os.Stat(path)
+	return err != nil
+}
+
+func resolveRelativeOnWindows(path string) string {
+	return path
+}
+
+func winPathExists(path string) bool {
+	return false
+}

--- a/pkg/specgen/winpath_unsupported.go
+++ b/pkg/specgen/winpath_unsupported.go
@@ -1,0 +1,20 @@
+//go:build !linux && !windows
+// +build !linux,!windows
+
+package specgen
+
+func shouldResolveWinPaths() bool {
+	return false
+}
+
+func shouldResolveUnixWinVariant(path string) bool {
+	return false
+}
+
+func resolveRelativeOnWindows(path string) string {
+	return path
+}
+
+func winPathExists(path string) bool {
+	return false
+}

--- a/pkg/specgen/winpath_windows.go
+++ b/pkg/specgen/winpath_windows.go
@@ -1,0 +1,30 @@
+package specgen
+
+import (
+	"github.com/sirupsen/logrus"
+	"os"
+	"path/filepath"
+)
+
+func shouldResolveUnixWinVariant(path string) bool {
+	return true
+}
+
+func shouldResolveWinPaths() bool {
+	return true
+}
+
+func resolveRelativeOnWindows(path string) string {
+	ret, err := filepath.Abs(path)
+	if err != nil {
+		logrus.Debugf("problem resolving possible relative path %q: %s", path, err.Error())
+		return path
+	}
+
+	return ret
+}
+
+func winPathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/pkg/specgenutil/specgenutil_test.go
+++ b/pkg/specgenutil/specgenutil_test.go
@@ -1,0 +1,77 @@
+//go:build linux
+// +build linux
+
+package specgenutil
+
+import (
+	"testing"
+
+	"github.com/containers/common/pkg/machine"
+	"github.com/containers/podman/v4/pkg/domain/entities"
+	"github.com/containers/podman/v4/pkg/specgen"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWinPath(t *testing.T) {
+	const (
+		fail = false
+		pass = true
+	)
+	tests := []struct {
+		vol     string
+		source  string
+		dest    string
+		isN     bool
+		outcome bool
+		mach    string
+	}{
+		{`C:\Foo:/blah`, "/mnt/c/Foo", "/blah", false, pass, "wsl"},
+		{`C:\Foo:/blah`, "/mnt/c/Foo", "/blah", false, fail, ""},
+		{`\\?\C:\Foo:/blah`, "/mnt/c/Foo", "/blah", false, pass, "wsl"},
+		{`/c/bar:/blah`, "/mnt/c/bar", "/blah", false, pass, "wsl"},
+		{`/c/bar:/blah`, "/c/bar", "/blah", false, pass, ""},
+		{`/test/this:/blah`, "/test/this", "/blah", false, pass, "wsl"},
+		{`c:/bar/something:/other`, "/mnt/c/bar/something", "/other", false, pass, "wsl"},
+		{`c:/foo:ro`, "c", "/foo", true, pass, ""},
+		{`\\computer\loc:/dest`, "", "", false, fail, "wsl"},
+		{`\\.\drive\loc:/target`, "/mnt/wsl/drive/loc", "/target", false, pass, "wsl"},
+	}
+
+	f := func(vol string, mach string) (*specgen.SpecGenerator, error) {
+		machine := machine.GetMachineMarker()
+		oldEnable, oldType := machine.Enabled, machine.Type
+		machine.Enabled, machine.Type = len(mach) > 0, mach
+		sg := specgen.NewSpecGenerator("nothing", false)
+		err := FillOutSpecGen(sg, &entities.ContainerCreateOptions{
+			ImageVolume: "ignore",
+			Volume:      []string{vol}}, []string{},
+		)
+		machine.Enabled, machine.Type = oldEnable, oldType
+		return sg, err
+	}
+
+	for _, test := range tests {
+		msg := "Checking: " + test.vol
+		sg, err := f(test.vol, test.mach)
+		if test.outcome == fail {
+			assert.NotNil(t, err, msg)
+			continue
+		}
+		if !assert.Nil(t, err, msg) {
+			continue
+		}
+		if test.isN {
+			if !assert.Equal(t, 1, len(sg.Volumes), msg) {
+				continue
+			}
+			assert.Equal(t, test.source, sg.Volumes[0].Name, msg)
+			assert.Equal(t, test.dest, sg.Volumes[0].Dest, msg)
+		} else {
+			if !assert.Equal(t, 1, len(sg.Mounts), msg) {
+				continue
+			}
+			assert.Equal(t, test.source, sg.Mounts[0].Source, msg)
+			assert.Equal(t, test.dest, sg.Mounts[0].Destination, msg)
+		}
+	}
+}

--- a/vendor/github.com/containers/common/libnetwork/etchosts/ip.go
+++ b/vendor/github.com/containers/common/libnetwork/etchosts/ip.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/libnetwork/util"
 	"github.com/containers/common/pkg/config"
+	"github.com/containers/common/pkg/machine"
 	"github.com/containers/storage/pkg/unshare"
 )
 
@@ -15,8 +16,8 @@ func GetHostContainersInternalIP(conf *config.Config, netStatus map[string]types
 	switch conf.Containers.HostContainersInternalIP {
 	case "":
 		// if empty (default) we will automatically choose one below
-		// if machine we let the gvproxy dns server handle the dns name so do not add it
-		if conf.Engine.MachineEnabled {
+		// if machine using gvproxy we let the gvproxy dns server handle the dns name so do not add it
+		if machine.IsGvProxyBased() {
 			return ""
 		}
 	case "none":

--- a/vendor/github.com/containers/common/libnetwork/netavark/network.go
+++ b/vendor/github.com/containers/common/libnetwork/netavark/network.go
@@ -27,7 +27,7 @@ type netavarkNetwork struct {
 	// networkRunDir is where temporary files are stored, i.e.the ipam db, aardvark config etc
 	networkRunDir string
 
-	// tells netavark whether this is rootless mode or rootfull, "true" or "false"
+	// tells netavark whether this is rootless mode or rootful, "true" or "false"
 	networkRootless bool
 
 	// netavarkBinary is the path to the netavark binary.

--- a/vendor/github.com/containers/common/libnetwork/network/interface.go
+++ b/vendor/github.com/containers/common/libnetwork/network/interface.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/common/libnetwork/netavark"
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/config"
+	"github.com/containers/common/pkg/machine"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/containers/storage/pkg/ioutils"
@@ -173,7 +174,7 @@ func getCniInterface(conf *config.Config) (types.ContainerNetwork, error) {
 		DefaultNetwork:     conf.Network.DefaultNetwork,
 		DefaultSubnet:      conf.Network.DefaultSubnet,
 		DefaultsubnetPools: conf.Network.DefaultSubnetPools,
-		IsMachine:          conf.Engine.MachineEnabled,
+		IsMachine:          machine.IsGvProxyBased(),
 	})
 }
 

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -312,6 +312,8 @@ type EngineConfig struct {
 	LockType string `toml:"lock_type,omitempty"`
 
 	// MachineEnabled indicates if Podman is running in a podman-machine VM
+	//
+	// This method is soft deprecated, use machine.IsPodmanMachine instead
 	MachineEnabled bool `toml:"machine_enabled,omitempty"`
 
 	// MultiImageArchive - if true, the container engine allows for storing

--- a/vendor/github.com/containers/common/pkg/config/config_freebsd.go
+++ b/vendor/github.com/containers/common/pkg/config/config_freebsd.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"os"
+)
+
+// podman remote clients on freebsd cannot use unshare.isRootless() to determine the configuration file locations.
+func customConfigFile() (string, error) {
+	if path, found := os.LookupEnv("CONTAINERS_CONF"); found {
+		return path, nil
+	}
+	return rootlessConfigPath()
+}
+
+func ifRootlessConfigPath() (string, error) {
+	return rootlessConfigPath()
+}
+
+var defaultHelperBinariesDir = []string{
+	"/usr/local/bin",
+	"/usr/local/libexec/podman",
+	"/usr/local/lib/podman",
+	"/usr/local/libexec/podman",
+	"/usr/local/lib/podman",
+}

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -455,12 +455,6 @@ default_sysctls = [
 #
 #lock_type** = "shm"
 
-# Indicates if Podman is running inside a VM via Podman Machine.
-# Podman uses this value to do extra setup around networking from the
-# container inside the VM to to host.
-#
-#machine_enabled = false
-
 # MultiImageArchive - if true, the container engine allows for storing archives
 # (e.g., of the docker-archive transport) with multiple images.  By default,
 # Podman creates single-image archives.
@@ -572,9 +566,9 @@ default_sysctls = [
 #     URI to access the Podman service
 #     Examples:
 #       rootless "unix://run/user/$UID/podman/podman.sock" (Default)
-#       rootfull "unix://run/podman/podman.sock (Default)
+#       rootful "unix://run/podman/podman.sock (Default)
 #       remote rootless ssh://engineering.lab.company.com/run/user/1000/podman/podman.sock
-#       remote rootfull ssh://root@10.10.1.136:22/run/podman/podman.sock
+#       remote rootful ssh://root@10.10.1.136:22/run/podman/podman.sock
 #
 #    uri = "ssh://user@production.example.com/run/user/1001/podman/podman.sock"
 #    Path to file containing ssh identity key

--- a/vendor/github.com/containers/common/pkg/machine/machine.go
+++ b/vendor/github.com/containers/common/pkg/machine/machine.go
@@ -1,0 +1,70 @@
+package machine
+
+import (
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/containers/common/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+type MachineMarker struct {
+	Enabled bool
+	Type    string
+}
+
+const (
+	markerFile = "/etc/containers/podman-machine"
+	Wsl        = "wsl"
+	Qemu       = "qemu"
+)
+
+var (
+	markerSync    sync.Once
+	machineMarker *MachineMarker
+)
+
+func loadMachineMarker(file string) {
+	var kind string
+
+	// Support deprecated config value for compatibility
+	enabled := isLegacyConfigSet()
+
+	if content, err := os.ReadFile(file); err == nil {
+		enabled = true
+		kind = strings.TrimSpace(string(content))
+	}
+
+	machineMarker = &MachineMarker{enabled, kind}
+}
+
+func isLegacyConfigSet() bool {
+	config, err := config.Default()
+	if err != nil {
+		logrus.Warnf("could not obtain container configuration")
+		return false
+	}
+
+	//nolint:staticcheck //lint:ignore SA1019 deprecated call
+	return config.Engine.MachineEnabled
+}
+
+func IsPodmanMachine() bool {
+	return GetMachineMarker().Enabled
+}
+
+func MachineHostType() string {
+	return GetMachineMarker().Type
+}
+
+func IsGvProxyBased() bool {
+	return IsPodmanMachine() && MachineHostType() != Wsl
+}
+
+func GetMachineMarker() *MachineMarker {
+	markerSync.Do(func() {
+		loadMachineMarker(markerFile)
+	})
+	return machineMarker
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -109,7 +109,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.47.5-0.20220421111103-112a47964ddb
+# github.com/containers/common v0.47.5-0.20220425182415-4081e6be9356
 ## explicit
 github.com/containers/common/libimage
 github.com/containers/common/libimage/manifests
@@ -132,6 +132,7 @@ github.com/containers/common/pkg/config
 github.com/containers/common/pkg/download
 github.com/containers/common/pkg/filters
 github.com/containers/common/pkg/flag
+github.com/containers/common/pkg/machine
 github.com/containers/common/pkg/manifests
 github.com/containers/common/pkg/netns
 github.com/containers/common/pkg/parse


### PR DESCRIPTION
Based on WSL2 9p support: remaps windows paths to /mnt/<drive> locations for
both podman and Docker API clients.

For example:

` podman run -it -v C:\Users\Jason:/blah ubi8-micro sh`

Additionally unixified paths sometimes used by Docker clients are supported

` podman run -it -v /c/Users/Jason:/blah ubi8-micro sh`

This also works with mount paths:

` .\docker run -it --mount 'type=bind,source=C:\Users\Jason,destination=/blah' alpine sh`

Finally, windows paths can be used on Linux in the WSL session to enable workflows where users are running process under the native Linux prompt yet accessing data on their Win drives.

This code is only active if either the podman-remote client is windows (in which case there is client side path remapping), or if the podman backend is configured as a WSL machine. The latter is necessary since there are parsing ambiguities (see tests) when interpreting potential win paths. While in practice they are uncommon, ideally existing behavior is preserved and the new code paths are only active where needed. 

Resolves #13707

Depends on containers/common#1012

Signed-off-by: Jason T. Greene <jason.greene@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
