### PR TITLE
Add support for startup healthchecks

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -180,7 +180,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		createFlags.StringVar(
 			&cf.HealthInterval,
 			healthIntervalFlagName, define.DefaultHealthCheckInterval,
-			"set an interval for the healthchecks (a value of disable results in no automatic timer setup)",
+			"set an interval for the healthcheck (a value of disable results in no automatic timer setup)",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(healthIntervalFlagName, completion.AutocompleteNone)
 
@@ -427,6 +427,46 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			"Add secret to container",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(secretFlagName, AutocompleteSecrets)
+
+		startupHCCmdFlagName := "health-startup-cmd"
+		createFlags.StringVar(
+			&cf.StartupHCCmd,
+			startupHCCmdFlagName, "",
+			"Set a startup healthcheck command for the container",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(startupHCCmdFlagName, completion.AutocompleteNone)
+
+		startupHCIntervalFlagName := "health-startup-interval"
+		createFlags.StringVar(
+			&cf.StartupHCInterval,
+			startupHCIntervalFlagName, define.DefaultHealthCheckInterval,
+			"Set an interval for the startup healthcheck",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(startupHCIntervalFlagName, completion.AutocompleteNone)
+
+		startupHCRetriesFlagName := "health-startup-retries"
+		createFlags.UintVar(
+			&cf.StartupHCRetries,
+			startupHCRetriesFlagName, 0,
+			"Set the maximum number of retries before the startup healthcheck will restart the container",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(startupHCRetriesFlagName, completion.AutocompleteNone)
+
+		startupHCSuccessesFlagName := "health-startup-success"
+		createFlags.UintVar(
+			&cf.StartupHCSuccesses,
+			startupHCSuccessesFlagName, 0,
+			"Set the number of consecutive successes before the startup healthcheck is marked as successful and the normal healthcheck begins (0 indicates any success will start the regular healthcheck)",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(startupHCSuccessesFlagName, completion.AutocompleteNone)
+
+		startupHCTimeoutFlagName := "health-startup-timeout"
+		createFlags.StringVar(
+			&cf.StartupHCTimeout,
+			startupHCTimeoutFlagName, define.DefaultHealthCheckTimeout,
+			"Set the maximum amount of time that the startup healthcheck may take before it is considered failed",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(startupHCTimeoutFlagName, completion.AutocompleteNone)
 
 		stopSignalFlagName := "stop-signal"
 		createFlags.StringVar(

--- a/cmd/podman/healthcheck/run.go
+++ b/cmd/podman/healthcheck/run.go
@@ -35,7 +35,7 @@ func run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if response.Status == define.HealthCheckUnhealthy {
+	if response.Status == define.HealthCheckUnhealthy || response.Status == define.HealthCheckStarting {
 		registry.SetExitCode(1)
 		fmt.Println(response.Status)
 	}

--- a/docs/source/markdown/options/health-startup-cmd.md
+++ b/docs/source/markdown/options/health-startup-cmd.md
@@ -1,0 +1,11 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
+#### **--health-startup-cmd**=*"command"* | *'["command", "arg1", ...]'*
+
+Set a startup healthcheck command for a container. This command will be executed inside the container and is used to gate the regular
+healthcheck. When the startup command succeeds, the regular healthcheck will begin and the startup healthcheck will cease. Optionally,
+if the command fails for a set number of attempts, the container will be restarted. A startup healthcheck can be used to ensure that
+containers with an extended startup period are not marked as unhealthy until they are fully started. Startup healthchecks can only be
+used when a regular healthcheck (from the container's image or the **--health-cmd** option) is also set.

--- a/docs/source/markdown/options/health-startup-interval.md
+++ b/docs/source/markdown/options/health-startup-interval.md
@@ -1,0 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
+#### **--health-startup-interval**=*interval*
+
+Set an interval for the startup healthcheck. An _interval_ of **disable** results in no automatic timer setup. The default is **30s**.

--- a/docs/source/markdown/options/health-startup-retries.md
+++ b/docs/source/markdown/options/health-startup-retries.md
@@ -1,0 +1,8 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
+#### **--health-startup-retries**=*retries*
+
+The number of attempts allowed before the startup healthcheck restarts the container. If set to **0**, the container will never be
+restarted. The default is **0**.

--- a/docs/source/markdown/options/health-startup-success.md
+++ b/docs/source/markdown/options/health-startup-success.md
@@ -1,0 +1,8 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
+#### **--health-startup-success**=*retries*
+
+The number of successful runs required before the startup healthcheck will succeed and the regular healthcheck will begin. A value
+of **0** means that any success will begin the regular healthcheck. The default is **0**.

--- a/docs/source/markdown/options/health-startup-timeout.md
+++ b/docs/source/markdown/options/health-startup-timeout.md
@@ -1,0 +1,8 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
+#### **--health-startup-timeout**=*timeout*
+
+The maximum time a startup healthcheck command has to complete before it is marked as failed. The value can be expressed in a time
+format like **2m3s**. The default value is **30s**.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -172,6 +172,16 @@ See [**Environment**](#environment) note below for precedence and examples.
 
 @@option health-start-period
 
+@@option health-startup-cmd
+
+@@option health-startup-interval
+
+@@option health-startup-retries
+
+@@option health-startup-success
+
+@@option health-startup-timeout
+
 @@option health-timeout
 
 #### **--help**

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -204,6 +204,16 @@ See [**Environment**](#environment) note below for precedence and examples.
 
 @@option health-start-period
 
+@@option health-startup-cmd
+
+@@option health-startup-interval
+
+@@option health-startup-retries
+
+@@option health-startup-success
+
+@@option health-startup-timeout
+
 @@option health-timeout
 
 #### **--help**

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -200,6 +200,18 @@ type ContainerState struct {
 	// (only by restart policy).
 	RestartCount uint `json:"restartCount,omitempty"`
 
+	// StartupHCPassed indicates that the startup healthcheck has
+	// succeeded and the main healthcheck can begin.
+	StartupHCPassed bool `json:"startupHCPassed,omitempty"`
+	// StartupHCSuccessCount indicates the number of successes of the
+	// startup healthcheck. A startup HC can require more than one success
+	// to be marked as passed.
+	StartupHCSuccessCount int `json:"startupHCSuccessCount,omitempty"`
+	// StartupHCFailureCount indicates the number of failures of the startup
+	// healthcheck. The container will be restarted if this exceed a set
+	// number in the startup HC config.
+	StartupHCFailureCount int `json:"startupHCFailureCount,omitempty"`
+
 	// ExtensionStageHooks holds hooks which will be executed by libpod
 	// and not delegated to the OCI runtime.
 	ExtensionStageHooks map[string][]spec.Hook `json:"extensionStageHooks,omitempty"`
@@ -927,6 +939,20 @@ func (c *Container) StoppedByUser() (bool, error) {
 	}
 
 	return c.state.StoppedByUser, nil
+}
+
+// StartupHCPassed returns whether the container's startup healthcheck passed.
+func (c *Container) StartupHCPassed() (bool, error) {
+	if !c.batched {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+
+		if err := c.syncContainer(); err != nil {
+			return false, err
+		}
+	}
+
+	return c.state.StartupHCPassed, nil
 }
 
 // Misc Accessors

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -395,6 +395,10 @@ type ContainerMiscConfig struct {
 	HealthCheckConfig *manifest.Schema2HealthConfig `json:"healthcheck"`
 	// HealthCheckOnFailureAction defines an action to take once the container turns unhealthy.
 	HealthCheckOnFailureAction define.HealthCheckOnFailureAction `json:"healthcheck_on_failure_action"`
+	// StartupHealthCheckConfig is the configuration of the startup
+	// healthcheck for the container. This will run before the regular HC
+	// runs, and when it passes the regular HC will be activated.
+	StartupHealthCheckConfig *define.StartupHealthCheck `json:"startupHealthCheck,omitempty"`
 	// PreserveFDs is a number of additional file descriptors (in addition
 	// to 0, 1, 2) that will be passed to the executed process. The total FDs
 	// passed will be 3 + PreserveFDs.

--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -156,6 +156,11 @@ func (c *Container) validate() error {
 		}
 	}
 
+	// Cannot set startup HC without a healthcheck
+	if c.config.HealthCheckConfig == nil && c.config.StartupHealthCheckConfig != nil {
+		return fmt.Errorf("cannot set a startup healthcheck when there is no regular healthcheck: %w", define.ErrInvalidArg)
+	}
+
 	return nil
 }
 

--- a/libpod/define/healthchecks.go
+++ b/libpod/define/healthchecks.go
@@ -3,6 +3,8 @@ package define
 import (
 	"fmt"
 	"strings"
+
+	"github.com/containers/image/v5/manifest"
 )
 
 const (
@@ -38,6 +40,9 @@ const (
 	HealthCheckInternalError HealthCheckStatus = iota
 	// HealthCheckDefined means the healthcheck was found on the container
 	HealthCheckDefined HealthCheckStatus = iota
+	// HealthCheckStartup means the healthcheck was unhealthy, but is still
+	// either within the startup HC or the startup period of the healthcheck
+	HealthCheckStartup HealthCheckStatus = iota
 )
 
 // Healthcheck defaults.  These are used both in the cli as well in
@@ -130,4 +135,13 @@ func ParseHealthCheckOnFailureAction(s string) (HealthCheckOnFailureAction, erro
 		err := fmt.Errorf("invalid on-failure action %q for health check: supported actions are %s", s, strings.Join(SupportedHealthCheckOnFailureActions, ","))
 		return HealthCheckOnFailureActionInvalid, err
 	}
+}
+
+// StartupHealthCheck is the configuration of a startup healthcheck.
+type StartupHealthCheck struct {
+	manifest.Schema2HealthConfig
+	// Successes are the number of successes required to mark the startup HC
+	// as passed.
+	// If set to 0, a single success will mark the HC as passed.
+	Successes int `json:",omitempty"`
 }

--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -14,8 +14,8 @@ import (
 )
 
 // createTimer systemd timers for healthchecks of a container
-func (c *Container) createTimer() error {
-	if c.disableHealthCheckSystemd() {
+func (c *Container) createTimer(interval string, isStartup bool) error {
+	if c.disableHealthCheckSystemd(isStartup) {
 		return nil
 	}
 	podman, err := os.Executable()
@@ -31,7 +31,14 @@ func (c *Container) createTimer() error {
 	if path != "" {
 		cmd = append(cmd, "--setenv=PATH="+path)
 	}
-	cmd = append(cmd, "--unit", c.ID(), fmt.Sprintf("--on-unit-inactive=%s", c.HealthCheckConfig().Interval.String()), "--timer-property=AccuracySec=1s", podman, "healthcheck", "run", c.ID())
+
+	cmd = append(cmd, "--unit", c.hcUnitName(isStartup), fmt.Sprintf("--on-unit-inactive=%s", interval), "--timer-property=AccuracySec=1s", podman)
+
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		cmd = append(cmd, "--log-level=debug", "--syslog")
+	}
+
+	cmd = append(cmd, "healthcheck", "run", c.ID())
 
 	conn, err := systemd.ConnectToDBUS()
 	if err != nil {
@@ -58,8 +65,8 @@ func systemdOpSuccessful(c chan string) error {
 }
 
 // startTimer starts a systemd timer for the healthchecks
-func (c *Container) startTimer() error {
-	if c.disableHealthCheckSystemd() {
+func (c *Container) startTimer(isStartup bool) error {
+	if c.disableHealthCheckSystemd(isStartup) {
 		return nil
 	}
 	conn, err := systemd.ConnectToDBUS()
@@ -68,7 +75,7 @@ func (c *Container) startTimer() error {
 	}
 	defer conn.Close()
 
-	startFile := fmt.Sprintf("%s.service", c.ID())
+	startFile := fmt.Sprintf("%s.service", c.hcUnitName(isStartup))
 	startChan := make(chan string)
 	if _, err := conn.RestartUnitContext(context.Background(), startFile, "fail", startChan); err != nil {
 		return err
@@ -82,8 +89,8 @@ func (c *Container) startTimer() error {
 
 // removeTransientFiles removes the systemd timer and unit files
 // for the container
-func (c *Container) removeTransientFiles(ctx context.Context) error {
-	if c.disableHealthCheckSystemd() {
+func (c *Container) removeTransientFiles(ctx context.Context, isStartup bool) error {
+	if c.disableHealthCheckSystemd(isStartup) {
 		return nil
 	}
 	conn, err := systemd.ConnectToDBUS()
@@ -99,7 +106,7 @@ func (c *Container) removeTransientFiles(ctx context.Context) error {
 	// Stop the timer before the service to make sure the timer does not
 	// fire after the service is stopped.
 	timerChan := make(chan string)
-	timerFile := fmt.Sprintf("%s.timer", c.ID())
+	timerFile := fmt.Sprintf("%s.timer", c.hcUnitName(isStartup))
 	if _, err := conn.StopUnitContext(ctx, timerFile, "fail", timerChan); err != nil {
 		if !strings.HasSuffix(err.Error(), ".timer not loaded.") {
 			stopErrors = append(stopErrors, fmt.Errorf("removing health-check timer %q: %w", timerFile, err))
@@ -111,7 +118,7 @@ func (c *Container) removeTransientFiles(ctx context.Context) error {
 	// Reset the service before stopping it to make sure it's being removed
 	// on stop.
 	serviceChan := make(chan string)
-	serviceFile := fmt.Sprintf("%s.service", c.ID())
+	serviceFile := fmt.Sprintf("%s.service", c.hcUnitName(isStartup))
 	if err := conn.ResetFailedUnitContext(ctx, serviceFile); err != nil {
 		logrus.Debugf("Failed to reset unit file: %q", err)
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1898,6 +1898,21 @@ func WithInfraConfig(compatibleOptions InfraInherit) CtrCreateOption {
 	}
 }
 
+// WithStartupHealthcheck sets a startup healthcheck for the container.
+// Requires that a healthcheck must be set.
+func WithStartupHealthcheck(startupHC *define.StartupHealthCheck) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+		ctr.config.StartupHealthCheckConfig = new(define.StartupHealthCheck)
+		if err := JSONDeepCopy(startupHC, ctr.config.StartupHealthCheckConfig); err != nil {
+			return fmt.Errorf("error copying startup healthcheck into container: %w", err)
+		}
+		return nil
+	}
+}
+
 // Pod Creation Options
 
 // WithPodCreateCommand adds the full command plus arguments of the current

--- a/pkg/api/handlers/libpod/healthcheck.go
+++ b/pkg/api/handlers/libpod/healthcheck.go
@@ -12,7 +12,7 @@ import (
 func RunHealthCheck(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	name := utils.GetName(r)
-	status, err := runtime.HealthCheck(name)
+	status, err := runtime.HealthCheck(r.Context(), name)
 	if err != nil {
 		if status == define.HealthCheckContainerNotFound {
 			utils.ContainerNotFound(w, name, err)
@@ -32,6 +32,8 @@ func RunHealthCheck(w http.ResponseWriter, r *http.Request) {
 	hcStatus := define.HealthCheckUnhealthy
 	if status == define.HealthCheckSuccess {
 		hcStatus = define.HealthCheckHealthy
+	} else if status == define.HealthCheckStartup {
+		hcStatus = define.HealthCheckStarting
 	}
 	report := define.HealthCheckResults{
 		Status: hcStatus,

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -174,125 +174,129 @@ const (
 )
 
 type ContainerCreateOptions struct {
-	Annotation        []string
-	Attach            []string
-	Authfile          string
-	BlkIOWeight       string
-	BlkIOWeightDevice []string
-	CapAdd            []string
-	CapDrop           []string
-	CgroupNS          string
-	CgroupsMode       string
-	CgroupParent      string `json:"cgroup_parent,omitempty"`
-	CIDFile           string
-	ConmonPIDFile     string `json:"container_conmon_pidfile,omitempty"`
-	CPUPeriod         uint64
-	CPUQuota          int64
-	CPURTPeriod       uint64
-	CPURTRuntime      int64
-	CPUShares         uint64
-	CPUS              float64 `json:"cpus,omitempty"`
-	CPUSetCPUs        string  `json:"cpuset_cpus,omitempty"`
-	CPUSetMems        string
-	Devices           []string `json:"devices,omitempty"`
-	DeviceCgroupRule  []string
-	DeviceReadBPs     []string `json:"device_read_bps,omitempty"`
-	DeviceReadIOPs    []string
-	DeviceWriteBPs    []string
-	DeviceWriteIOPs   []string
-	Entrypoint        *string `json:"container_command,omitempty"`
-	Env               []string
-	EnvHost           bool
-	EnvFile           []string
-	Expose            []string
-	GIDMap            []string
-	GroupAdd          []string
-	HealthCmd         string
-	HealthInterval    string
-	HealthRetries     uint
-	HealthStartPeriod string
-	HealthTimeout     string
-	HealthOnFailure   string
-	Hostname          string `json:"hostname,omitempty"`
-	HTTPProxy         bool
-	HostUsers         []string
-	ImageVolume       string
-	Init              bool
-	InitContainerType string
-	InitPath          string
-	Interactive       bool
-	IPC               string
-	Label             []string
-	LabelFile         []string
-	LogDriver         string
-	LogOptions        []string
-	Memory            string
-	MemoryReservation string
-	MemorySwap        string
-	MemorySwappiness  int64
-	Name              string `json:"container_name"`
-	NoHealthCheck     bool
-	OOMKillDisable    bool
-	OOMScoreAdj       *int
-	Arch              string
-	OS                string
-	Variant           string
-	PID               string `json:"pid,omitempty"`
-	PIDsLimit         *int64
-	Platform          string
-	Pod               string
-	PodIDFile         string
-	Personality       string
-	PreserveFDs       uint
-	Privileged        bool
-	PublishAll        bool
-	Pull              string
-	Quiet             bool
-	ReadOnly          bool
-	ReadOnlyTmpFS     bool
-	Restart           string
-	Replace           bool
-	Requires          []string
-	Rm                bool
-	RootFS            bool
-	Secrets           []string
-	SecurityOpt       []string `json:"security_opt,omitempty"`
-	SdNotifyMode      string
-	ShmSize           string
-	SignaturePolicy   string
-	StopSignal        string
-	StopTimeout       uint
-	StorageOpts       []string
-	SubUIDName        string
-	SubGIDName        string
-	Sysctl            []string `json:"sysctl,omitempty"`
-	Systemd           string
-	Timeout           uint
-	TLSVerify         commonFlag.OptionalBool
-	TmpFS             []string
-	TTY               bool
-	Timezone          string
-	Umask             string
-	EnvMerge          []string
-	UnsetEnv          []string
-	UnsetEnvAll       bool
-	UIDMap            []string
-	Ulimit            []string
-	User              string
-	UserNS            string `json:"-"`
-	UTS               string
-	Mount             []string
-	Volume            []string `json:"volume,omitempty"`
-	VolumesFrom       []string `json:"volumes_from,omitempty"`
-	Workdir           string
-	SeccompPolicy     string
-	PidFile           string
-	ChrootDirs        []string
-	IsInfra           bool
-	IsClone           bool
-	DecryptionKeys    []string
-
-	Net *NetOptions `json:"net,omitempty"`
+	Annotation         []string
+	Attach             []string
+	Authfile           string
+	BlkIOWeight        string
+	BlkIOWeightDevice  []string
+	CapAdd             []string
+	CapDrop            []string
+	CgroupNS           string
+	CgroupsMode        string
+	CgroupParent       string `json:"cgroup_parent,omitempty"`
+	CIDFile            string
+	ConmonPIDFile      string `json:"container_conmon_pidfile,omitempty"`
+	CPUPeriod          uint64
+	CPUQuota           int64
+	CPURTPeriod        uint64
+	CPURTRuntime       int64
+	CPUShares          uint64
+	CPUS               float64 `json:"cpus,omitempty"`
+	CPUSetCPUs         string  `json:"cpuset_cpus,omitempty"`
+	CPUSetMems         string
+	Devices            []string `json:"devices,omitempty"`
+	DeviceCgroupRule   []string
+	DeviceReadBPs      []string `json:"device_read_bps,omitempty"`
+	DeviceReadIOPs     []string
+	DeviceWriteBPs     []string
+	DeviceWriteIOPs    []string
+	Entrypoint         *string `json:"container_command,omitempty"`
+	Env                []string
+	EnvHost            bool
+	EnvFile            []string
+	Expose             []string
+	GIDMap             []string
+	GroupAdd           []string
+	HealthCmd          string
+	HealthInterval     string
+	HealthRetries      uint
+	HealthStartPeriod  string
+	HealthTimeout      string
+	HealthOnFailure    string
+	Hostname           string `json:"hostname,omitempty"`
+	HTTPProxy          bool
+	HostUsers          []string
+	ImageVolume        string
+	Init               bool
+	InitContainerType  string
+	InitPath           string
+	Interactive        bool
+	IPC                string
+	Label              []string
+	LabelFile          []string
+	LogDriver          string
+	LogOptions         []string
+	Memory             string
+	MemoryReservation  string
+	MemorySwap         string
+	MemorySwappiness   int64
+	Name               string `json:"container_name"`
+	NoHealthCheck      bool
+	OOMKillDisable     bool
+	OOMScoreAdj        *int
+	Arch               string
+	OS                 string
+	Variant            string
+	PID                string `json:"pid,omitempty"`
+	PIDsLimit          *int64
+	Platform           string
+	Pod                string
+	PodIDFile          string
+	Personality        string
+	PreserveFDs        uint
+	Privileged         bool
+	PublishAll         bool
+	Pull               string
+	Quiet              bool
+	ReadOnly           bool
+	ReadOnlyTmpFS      bool
+	Restart            string
+	Replace            bool
+	Requires           []string
+	Rm                 bool
+	RootFS             bool
+	Secrets            []string
+	SecurityOpt        []string `json:"security_opt,omitempty"`
+	SdNotifyMode       string
+	ShmSize            string
+	SignaturePolicy    string
+	StartupHCCmd       string
+	StartupHCInterval  string
+	StartupHCRetries   uint
+	StartupHCSuccesses uint
+	StartupHCTimeout   string
+	StopSignal         string
+	StopTimeout        uint
+	StorageOpts        []string
+	SubUIDName         string
+	SubGIDName         string
+	Sysctl             []string `json:"sysctl,omitempty"`
+	Systemd            string
+	Timeout            uint
+	TLSVerify          commonFlag.OptionalBool
+	TmpFS              []string
+	TTY                bool
+	Timezone           string
+	Umask              string
+	EnvMerge           []string
+	UnsetEnv           []string
+	UnsetEnvAll        bool
+	UIDMap             []string
+	Ulimit             []string
+	User               string
+	UserNS             string `json:"-"`
+	UTS                string
+	Mount              []string
+	Volume             []string `json:"volume,omitempty"`
+	VolumesFrom        []string `json:"volumes_from,omitempty"`
+	Workdir            string
+	SeccompPolicy      string
+	PidFile            string
+	ChrootDirs         []string
+	IsInfra            bool
+	IsClone            bool
+	DecryptionKeys     []string
+	Net                *NetOptions `json:"net,omitempty"`
 
 	CgroupConf []string
 

--- a/pkg/domain/infra/abi/healthcheck.go
+++ b/pkg/domain/infra/abi/healthcheck.go
@@ -8,13 +8,15 @@ import (
 )
 
 func (ic *ContainerEngine) HealthCheckRun(ctx context.Context, nameOrID string, options entities.HealthCheckOptions) (*define.HealthCheckResults, error) {
-	status, err := ic.Libpod.HealthCheck(nameOrID)
+	status, err := ic.Libpod.HealthCheck(ctx, nameOrID)
 	if err != nil {
 		return nil, err
 	}
 	hcStatus := define.HealthCheckUnhealthy
 	if status == define.HealthCheckSuccess {
 		hcStatus = define.HealthCheckHealthy
+	} else if status == define.HealthCheckStartup {
+		hcStatus = define.HealthCheckStarting
 	}
 	report := define.HealthCheckResults{
 		Status: hcStatus,

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -527,6 +527,9 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 		options = append(options, libpod.WithHealthCheck(s.ContainerHealthCheckConfig.HealthConfig))
 		logrus.Debugf("New container has a health check")
 	}
+	if s.ContainerHealthCheckConfig.StartupHealthConfig != nil {
+		options = append(options, libpod.WithStartupHealthcheck(s.ContainerHealthCheckConfig.StartupHealthConfig))
+	}
 
 	if s.ContainerHealthCheckConfig.HealthCheckOnFailureAction != define.HealthCheckOnFailureActionNone {
 		options = append(options, libpod.WithHealthCheckOnFailureAction(s.ContainerHealthCheckConfig.HealthCheckOnFailureAction))

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -536,6 +536,10 @@ type ContainerResourceConfig struct {
 type ContainerHealthCheckConfig struct {
 	HealthConfig               *manifest.Schema2HealthConfig     `json:"healthconfig,omitempty"`
 	HealthCheckOnFailureAction define.HealthCheckOnFailureAction `json:"health_check_on_failure_action,omitempty"`
+	// Startup healthcheck for a container.
+	// Requires that HealthConfig be set.
+	// Optional.
+	StartupHealthConfig *define.StartupHealthCheck `json:"startupHealthConfig,omitempty"`
 }
 
 // SpecGenerator creates an OCI spec and Libpod configuration options to create

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -334,4 +334,43 @@ HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 		// Check to make sure characters were not coerced to utf8
 		Expect(inspect[0].Config.Healthcheck).To(HaveField("Test", []string{"CMD-SHELL", "ls -l / 2>&1"}))
 	})
+
+	It("Startup healthcheck success transitions to regular healthcheck", func() {
+		ctrName := "hcCtr"
+		ctrRun := podmanTest.Podman([]string{"run", "-dt", "--name", ctrName, "--health-cmd", "echo regular", "--health-startup-cmd", "cat /test", ALPINE, "top"})
+		ctrRun.WaitWithDefaultTimeout()
+		Expect(ctrRun).Should(Exit(0))
+
+		inspect := podmanTest.InspectContainer(ctrName)
+		Expect(inspect[0].State.Health).To(HaveField("Status", "starting"))
+
+		hc := podmanTest.Podman([]string{"healthcheck", "run", ctrName})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc).Should(Exit(1))
+
+		exec := podmanTest.Podman([]string{"exec", ctrName, "sh", "-c", "touch /test && echo startup > /test"})
+		exec.WaitWithDefaultTimeout()
+		Expect(exec).Should(Exit(0))
+
+		hc = podmanTest.Podman([]string{"healthcheck", "run", ctrName})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc).Should(Exit(0))
+
+		inspect = podmanTest.InspectContainer(ctrName)
+		Expect(inspect[0].State.Health).To(HaveField("Status", define.HealthCheckHealthy))
+
+		hc = podmanTest.Podman([]string{"healthcheck", "run", ctrName})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc).Should(Exit(0))
+
+		inspect = podmanTest.InspectContainer(ctrName)
+		Expect(inspect[0].State.Health).To(HaveField("Status", define.HealthCheckHealthy))
+
+		// Test podman ps --filter heath is working (#11687)
+		ps := podmanTest.Podman([]string{"ps", "--filter", "health=healthy"})
+		ps.WaitWithDefaultTimeout()
+		Expect(ps).Should(Exit(0))
+		Expect(ps.OutputToStringArray()).To(HaveLen(2))
+		Expect(ps.OutputToString()).To(ContainSubstring("hc"))
+	})
 })


### PR DESCRIPTION
TODO: Needs to be wired into `podman inspect`, needs tests written, needs manpages

Add support for startup healthchecks. A startup healthcheck is a healthcheck that runs before the main healthcheck, to accomodate slow-starting containers; inspiration is mostly from K8S startup probes, and we'll be using this as a backend for supporting those in `podman play kube` once this merges.

```release-note
Containers can now have startup healthchecks, allowing a command to be run to ensure the container is fully started before the regular healthcheck is activated.
```