### PR TITLE
healthcheck: set default healthcheck `Interval` if not specified in image

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -67,12 +67,21 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 			// NOTE: the health check is only set for Docker images
 			// but inspect will take care of it.
 			s.HealthConfig = inspectData.HealthCheck
-			if s.HealthConfig != nil && s.HealthConfig.Timeout == 0 {
-				hct, err := time.ParseDuration(define.DefaultHealthCheckTimeout)
-				if err != nil {
-					return nil, err
+			if s.HealthConfig != nil {
+				if s.HealthConfig.Timeout == 0 {
+					hct, err := time.ParseDuration(define.DefaultHealthCheckTimeout)
+					if err != nil {
+						return nil, err
+					}
+					s.HealthConfig.Timeout = hct
 				}
-				s.HealthConfig.Timeout = hct
+				if s.HealthConfig.Interval == 0 {
+					hct, err := time.ParseDuration(define.DefaultHealthCheckInterval)
+					if err != nil {
+						return nil, err
+					}
+					s.HealthConfig.Interval = hct
+				}
 			}
 		}
 

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -325,6 +325,8 @@ HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 		inspect := podmanTest.InspectContainer("hctest")
 		// Check to make sure a default time value was added
 		Expect(inspect[0].Config.Healthcheck.Timeout).To(BeNumerically("==", 30000000000))
+		// Check to make sure a default time interval value was added
+		Expect(inspect[0].Config.Healthcheck.Interval).To(BeNumerically("==", 30000000000))
 		// Check to make sure characters were not coerced to utf8
 		Expect(inspect[0].Config.Healthcheck.Test).To(Equal([]string{"CMD-SHELL", "ls -l / 2>&1"}))
 	})


### PR DESCRIPTION
Set appropriate defaults for `--interval` when
processing a Healthcheck from ContainerImage and `HEALTHCHECK` is used from `Dockerfile`.

Closes: https://github.com/containers/podman/issues/13912