### PR TITLE
Fix e2e tests referencing generic env. var.

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -849,7 +849,7 @@ func (p *PodmanTestIntegration) makeOptions(args []string, noEvents, noCache boo
 	}
 
 	var debug string
-	if _, ok := os.LookupEnv("DEBUG"); ok {
+	if _, ok := os.LookupEnv("E2E_DEBUG"); ok {
 		debug = "--log-level=debug --syslog=true "
 	}
 


### PR DESCRIPTION
Use of `$DEBUG` is highly likely to clash.  Fortunately this one is in
a very specific/special context, so a rename fix should be perfectly
adequate.

See also https://github.com/containers/automation/pull/96
and https://github.com/containers/podman/issues/13932

Signed-off-by: Chris Evich <cevich@redhat.com>