### PR TITLE
system tests: add assert(), and start using it

### DIFF
--- a/test/system/000-TEMPLATE
+++ b/test/system/000-TEMPLATE
@@ -10,7 +10,7 @@ load helpers
 @test "podman subcmd - description of this particular test" {
     args="some sort of argument list"
     run_podman subcmd $args
-    is "$output"   "what we expect"   "output from 'podman subcmd $args'"
+    assert "$output" == "what we expect"   "output from 'podman subcmd $args'"
 }
 
 # vim: filetype=sh
@@ -66,7 +66,7 @@ function teardown() {
     # FIXME: example of dprint. This will trigger if PODMAN_TEST_DEBUG=FOO
     # FIXME:  ...or anything that matches the name assigned in the @test line.
     dprint "podman logs $cid -> '$output'"
-    is "$output" "what are we expecting?" "description of this check"
+    assert "$output" == "what are we expecting?" "description of this check"
 
     # Clean up
     run_podman rm $cid
@@ -90,7 +90,7 @@ size      | -\\\?[0-9]\\\+
     run_podman history --format json $IMAGE
 
     # FIXME: parse_table is what does all the work, giving us test cases.
-    parse_table "$tests" | while read field expect; do
+    while read field expect; do
         # FIXME: this shows a drawback of BATS and bash: we can't include '|'
         # FIXME: in the table, but we need to because some images don't
         # FIXME: have a CID. So, yeah, this is ugly -- but rare.
@@ -104,10 +104,10 @@ size      | -\\\?[0-9]\\\+
             # FIXME: please be sure to note the third field!
             # FIXME: that's the test name. Make it something useful! Include
             # FIXME: loop variables whenever possible. Don't just say "my test"
-            is "$actual"    "$expect\$"    "jq .[$i].$field"
+            assert "$actual" =~ "$expect\$"    "jq .[$i].$field"
             i=$(expr $i + 1)
         done
-    done
+    done < <(parse_table "$tests")
 }
 
 

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -28,9 +28,7 @@ function setup() {
     # Test that build date is reasonable, e.g. after 2019-01-01
     local built=$(expr "$output" : ".*Built: \+\(.*\)" | head -n1)
     local built_t=$(date --date="$built" +%s)
-    if [ $built_t -lt 1546300800 ]; then
-        die "Preposterous 'Built' time in podman version: '$built'"
-    fi
+    assert "$built_t" -gt 1546300800 "Preposterous 'Built' time in podman version"
 }
 
 @test "podman info" {
@@ -114,29 +112,25 @@ See 'podman version --help'" "podman version --remote"
 
     # By default, podman should include '--remote' in its help output
     run_podman --help
-    is "$output" ".* --remote " "podman --help includes the --remote option"
+    assert "$output" =~ " --remote " "podman --help includes the --remote option"
 
     # When it detects CONTAINER_HOST or _CONNECTION, --remote is not an option
     CONTAINER_HOST=foobar run_podman --help
-    if grep -- " --remote " <<<"$output"; then
-        die "podman --help, with CONTAINER_HOST set, is showing --remote"
-    fi
+    assert "$output" !~ " --remote " \
+           "podman --help, with CONTAINER_HOST set, should not show --remote"
 
     CONTAINER_CONNECTION=foobar run_podman --help
-    if grep -- " --remote " <<<"$output"; then
-        die "podman --help, with CONTAINER_CONNECTION set, is showing --remote"
-    fi
+    assert "$output" !~ " --remote " \
+           "podman --help, with CONTAINER_CONNECTION set, should not show --remote"
 
     # When it detects --url or --connection, --remote is not an option
     run_podman --url foobar --help
-    if grep -- " --remote " <<<"$output"; then
-        die "podman --help, with --url set, is showing --remote"
-    fi
+    assert "$output" !~ " --remote " \
+           "podman --help, with --url set, should not show --remote"
 
     run_podman --connection foobar --help
-    if grep -- " --remote " <<<"$output"; then
-        die "podman --help, with --connection set, is showing --remote"
-    fi
+    assert "$output" !~ " --remote " \
+           "podman --help, with --connection set, should not show --remote"
 }
 
 # Check that just calling "podman-remote" prints the usage message even

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -224,9 +224,8 @@ $s_after"
         retries=$((retries - 1))
         sleep 0.1
     done
-    if [[ $retries -eq 0 ]]; then
-        die "Timed out waiting for before&after in podman logs: $output"
-    fi
+    assert $retries -gt 0 \
+           "Timed out waiting for before&after in podman logs: $output"
 
     run_podman logs --until $before test
     is "$output" "" "podman logs --until before"

--- a/test/system/040-ps.bats
+++ b/test/system/040-ps.bats
@@ -98,9 +98,8 @@ RUN sleep 30
 EOF
     local t1=$SECONDS
     local delta_t=$((t1 - t0))
-    if [[ $delta_t -gt 10 ]]; then
-        die "podman build did not get killed within 10 seconds (actual time: $delta_t seconds)"
-    fi
+    assert $delta_t -le 10 \
+           "podman build did not get killed within 10 seconds"
 
     run_podman ps -a
     is "${#lines[@]}" "1" "podman ps -a does not see buildah containers"

--- a/test/system/045-start.bats
+++ b/test/system/045-start.bats
@@ -21,9 +21,8 @@ load helpers
     is "$output" ".*$cid_none_implicit" "started: container with no --restart"
     is "$output" ".*$cid_none_explicit" "started: container with --restart=no"
     is "$output" ".*$cid_on_failure" "started: container with --restart=on-failure"
-    if [[ $output =~ $cid_always ]]; then
-        die "podman start --all restarted a running container"
-    fi
+    assert "$output" !~ "$cid_always" \
+           "podman start --all should not restart a running container"
 
     run_podman wait $cid_none_implicit $cid_none_explicit $cid_on_failure
 

--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -22,10 +22,8 @@ load helpers
     # The initial SIGTERM is ignored, so this operation should take
     # exactly 10 seconds. Give it some leeway.
     delta_t=$(( $t1 - $t0 ))
-    [ $delta_t -gt 8 ]  ||\
-        die "podman stop: ran too quickly! ($delta_t seconds; expected >= 10)"
-    [ $delta_t -le 14 ] ||\
-        die "podman stop: took too long ($delta_t seconds; expected ~10)"
+    assert $delta_t -gt  8 "podman stop: ran too quickly!"
+    assert $delta_t -le 14 "podman stop: took too long"
 
     run_podman rm $cid
 }
@@ -103,8 +101,7 @@ load helpers
 
         # The 'stop' command should return almost instantaneously
         delta_t=$(( $t1 - $t0 ))
-        [ $delta_t -le 2 ] ||\
-            die "podman stop: took too long ($delta_t seconds; expected <= 2)"
+        assert $delta_t -le 2 "podman stop: took too long"
 
         run_podman rm $cid
     done
@@ -138,9 +135,7 @@ load helpers
             break
         fi
         timeout=$((timeout - 1))
-        if [[ $timeout -eq 0 ]]; then
-            die "Timed out waiting for container to receive SIGERM"
-        fi
+        assert $timeout -gt 0 "Timed out waiting for container to receive SIGTERM"
         sleep 0.5
     done
 
@@ -154,9 +149,7 @@ load helpers
     # Time check: make sure we were able to run 'ps' before the container
     # exited. If this takes too long, it means ps had to wait for lock.
     local delta_t=$(( $SECONDS - t0 ))
-    if [[ $delta_t -gt 5 ]]; then
-        die "Operations took too long ($delta_t seconds)"
-    fi
+    assert $delta_t -le 5 "Operations took too long"
 
     run_podman kill stopme
     run_podman wait stopme

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -126,8 +126,7 @@ function _events_disjunctive_filters() {
 events_logfile_path="$events_file"
 EOF
     CONTAINERS_CONF="$containersconf" run_podman --events-backend=file pull $IMAGE
-    run cat $events_file
-    is "$output" ".*\"Name\":\"$IMAGE" "test"
+    assert "$(< $events_file)" =~ "\"Name\":\"$IMAGE\"" "Image found in events"
 }
 
 function _populate_events_file() {

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -52,9 +52,7 @@ verify_iid_and_name() {
     # which redirects stdout and stderr. Here we need to guarantee
     # that podman's stdout is a pipe, not any other form of redirection
     $PODMAN save --format oci-archive $fqin | cat >$archive
-    if [ "$status" -ne 0 ]; then
-        die "Command failed: podman save ... | cat"
-    fi
+    assert "$?" -eq 0 "Command failed: podman save ... | cat"
 
     # Make sure we can reload it
     run_podman rmi $fqin
@@ -265,9 +263,7 @@ verify_iid_and_name() {
     # which redirects stdout and stderr. Here we need to guarantee
     # that podman's stdout is a pipe, not any other form of redirection
     $PODMAN save -m $img1 $img2 | cat >$archive
-    if [ "$status" -ne 0 ]; then
-        die "Command failed: podman save ... | cat"
-    fi
+    assert "$?" -eq 0 "Command failed: podman save ... | cat"
 
     run_podman rmi -f $img1 $img2
     run_podman load -i $archive
@@ -284,7 +280,7 @@ verify_iid_and_name() {
 
     # Create a tarball, unpack it and make sure the layers are uncompressed.
     run_podman save -o $archive --format oci-archive --uncompressed $IMAGE
-    run tar -C $untar -xvf $archive
+    tar -C $untar -xvf $archive
     run file $untar/blobs/sha256/*
     is "$output" ".*POSIX tar archive" "layers are uncompressed"
 }

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -282,9 +282,7 @@ EOF
 
     # (Assert that output is formatted, not a one-line blob: #8011)
     run_podman volume inspect ${v[1]}
-    if [[ "${#lines[*]}" -lt 10 ]]; then
-        die "Output from 'volume inspect' is only ${#lines[*]} lines; see #8011"
-    fi
+    assert "${#lines[*]}" -ge 10 "Output from 'volume inspect'; see #8011"
 
     # Run two containers: one mounting v1, one mounting v2 & v3
     run_podman run --name c1 --volume ${v[1]}:/vol1 $IMAGE date

--- a/test/system/180-blkio.bats
+++ b/test/system/180-blkio.bats
@@ -31,7 +31,8 @@ function teardown() {
     losetup -f ${lofile}
 
     run losetup -l --noheadings --output BACK-FILE,NAME,MAJ:MIN
-    is "$output" ".\+" "Empty output from losetup"
+    assert "$status" -eq 0 "losetup: status"
+    assert "$output" != "" "losetup: output"
 
     lodevice=$(awk "\$1 == \"$lofile\" { print \$2 }" <<<"$output")
     lomajmin=$(awk "\$1 == \"$lofile\" { print \$3 }" <<<"$output")

--- a/test/system/190-run-ipcns.bats
+++ b/test/system/190-run-ipcns.bats
@@ -7,30 +7,25 @@
 load helpers
 
 @test "podman --ipc=host" {
-    run readlink /proc/self/ns/ipc
-    hostipc=$output
+    hostipc="$(readlink /proc/self/ns/ipc)"
     run_podman run --rm --ipc=host $IMAGE readlink /proc/self/ns/ipc
     is "$output" "$hostipc" "HostIPC and container IPC should be same"
 }
 
 @test "podman --ipc=none" {
-    run readlink /proc/self/ns/ipc
-    hostipc=$output
+    hostipc="$(readlink /proc/self/ns/ipc)"
     run_podman run --rm --ipc=none $IMAGE readlink /proc/self/ns/ipc
-    if [[ $output == "$hostipc" ]]; then
-       die "hostipc and containeripc should be different"
-    fi
+    assert "$output" != "$hostipc" "containeripc should != hostipc"
+
     run_podman 1 run --rm --ipc=none $IMAGE ls /dev/shm
     is "$output" "ls: /dev/shm: No such file or directory" "Should fail with missing /dev/shm"
 }
 
 @test "podman --ipc=private" {
-    run readlink /proc/self/ns/ipc
-    hostipc=$output
+    hostipc="$(readlink /proc/self/ns/ipc)"
     run_podman run -d --ipc=private --name test $IMAGE sleep 100
-    if [[ $output == "$hostipc" ]]; then
-       die "hostipc and containeripc should be different"
-    fi
+    assert "$output" != "$hostipc" "containeripc should != hostipc"
+
     run_podman 125 run --ipc=container:test --rm $IMAGE readlink /proc/self/ns/ipc
     is "$output" ".*is not allowed: non-shareable IPC (hint: use IpcMode:shareable for the donor container)" "Containers should not share private ipc namespace"
     run_podman stop -t 0 test
@@ -38,31 +33,26 @@ load helpers
 }
 
 @test "podman --ipc=shareable" {
-    run readlink /proc/self/ns/ipc
-    hostipc=$output
+    hostipc="$(readlink /proc/self/ns/ipc)"
     run_podman run -d --ipc=shareable --name test $IMAGE sleep 100
-    if [[ $output == "$hostipc" ]]; then
-       die "hostipc and containeripc should be different"
-    fi
+    assert "$output" != "$hostipc" "containeripc(shareable) should != hostipc"
+
     run_podman run --ipc=container:test --rm $IMAGE readlink /proc/self/ns/ipc
-    if [[ $output == "$hostipc" ]]; then
-       die "hostipc and containeripc should be different"
-    fi
+    assert "$output" != "$hostipc" "containeripc(:test) should != hostipc"
+
     run_podman stop -t 0 test
     run_podman rm test
 }
 
 @test "podman --ipc=container@test" {
-    run readlink /proc/self/ns/ipc
-    hostipc=$output
+    hostipc="$(readlink /proc/self/ns/ipc)"
     run_podman run -d --name test $IMAGE sleep 100
     run_podman exec test readlink /proc/self/ns/ipc
-    if [[ $output == "$hostipc" ]]; then
-       die "hostipc and containeripc should be different"
-    fi
+    assert "$output" != "$hostipc" "containeripc(exec) should != hostipc"
+
     testipc=$output
     run_podman run --ipc=container:test --rm $IMAGE readlink /proc/self/ns/ipc
-    is "$output" "$testipc" "Containers should share ipc namespace"
+    assert "$output" = "$testipc" "Containers should share ipc namespace"
     run_podman stop -t 0 test
     run_podman rm test
 }

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -178,9 +178,8 @@ function _confirm_update() {
     is "$output" "$oldID" "container rolled back to previous image"
 
     run_podman container inspect --format "{{.ID}}" $cname
-    if [[ $output == $containerID ]]; then
-        die "container has not been restarted during rollback (previous id: $containerID, current id: $output)"
-    fi
+    assert "$output" != "$containerID" \
+           "container has not been restarted during rollback"
 }
 
 @test "podman auto-update - label io.containers.autoupdate=disabled" {
@@ -329,11 +328,9 @@ EOF
     for cname in "${cnames[@]}"; do
         run_podman inspect --format "{{.Image}}" $cname
         if [[ -n "${expect_update[$cname]}" ]]; then
-            if [[ "$output" == "$img_id" ]]; then
-                die "$cname: image ID ($output) did not change"
-            fi
+            assert "$output" != "$img_id" "$cname: image ID did not change"
         else
-            is "$output" "$img_id" "Image should not be changed."
+            assert "$output" = "$img_id" "Image ID should not be changed."
         fi
     done
 }

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -128,9 +128,7 @@ EOF
     # number of links, major, and minor (see below for why). Do it all
     # in one go, to avoid multiple podman-runs
     run_podman '?' run --rm $IMAGE stat -c'%n:%F:%h:%T:%t' /dev/null ${subset[@]}
-    if [[ $status -gt 1 ]]; then
-        die "Unexpected exit status $status: expected 0 or 1"
-    fi
+    assert $status -le 1 "stat exit status: expected 0 or 1"
 
     local devnull=
     for result in "${lines[@]}"; do

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -135,9 +135,8 @@ function check_label() {
 
     # net NS: do not share context
     run_podman run --rm --net container:myctr $IMAGE cat -v /proc/self/attr/current
-    if [[ "$output" = "$context_c1" ]]; then
-	die "run --net : context ($output) is same as running container (it should not be)"
-    fi
+    assert "$output" != "$context_c1" \
+	   "run --net : context should != context of running container"
 
     # The 'myctr2' above was not run with --rm, so it still exists, and
     # we can't remove the original container until this one is gone.
@@ -189,9 +188,8 @@ function check_label() {
 
     # Even after #7902, labels (':c123,c456') should be different
     run_podman run --rm --pod myselinuxpod $IMAGE cat -v /proc/self/attr/current
-    if [[ "$output" = "$context_c1" ]]; then
-	die "context ($output) is the same on two separate containers, it should have been different"
-    fi
+    assert "$output" != "$context_c1" \
+	   "context of two separate containers should be different"
 
     run_podman pod rm myselinuxpod
 }

--- a/test/system/450-interactive.bats
+++ b/test/system/450-interactive.bats
@@ -27,9 +27,7 @@ function setup() {
     retries=5
     while [[ ! -e $PODMAN_TEST_PTY ]]; do
         retries=$(( retries - 1 ))
-        if [[ $retries -eq 0 ]]; then
-            die "Timed out waiting for $PODMAN_TEST_PTY"
-        fi
+        assert $retries -gt 0 "Timed out waiting for $PODMAN_TEST_PTY"
         sleep 0.5
     done
 }

--- a/test/system/520-checkpoint.bats
+++ b/test/system/520-checkpoint.bats
@@ -79,9 +79,8 @@ function teardown() {
     # Get full logs, and make sure something changed
     run_podman logs $cid
     local nlines_after="${#lines[*]}"
-    if [[ $nlines_after -eq $nlines_before ]]; then
-        die "Container failed to output new lines after first restore"
-    fi
+    assert $nlines_after -gt $nlines_before \
+           "Container failed to output new lines after first restore"
 
     # Same thing again: test for https://github.com/containers/crun/issues/756
     # in which, after second checkpoint/restore, we lose logs
@@ -95,9 +94,8 @@ function teardown() {
     sleep 0.3
     run_podman container logs $cid
     nlines_after="${#lines[*]}"
-    if [[ $nlines_after -eq $nlines_before ]]; then
-        die "stdout went away after second restore (crun issue 756)"
-    fi
+    assert $nlines_after -gt $nlines_before \
+           "stdout went away after second restore (crun issue 756)"
 
     run_podman rm -t 0 -f $cid
 }
@@ -159,9 +157,8 @@ function teardown() {
     sleep .3
     run curl --max-time 3 -s $server/mydate
     local date_newroot="$output"
-    if [[ $date_newroot = $date_oldroot ]]; then
-        die "Restored container did not update the timestamp file"
-    fi
+    assert "$date_newroot" != "$date_oldroot" \
+           "Restored container did not update the timestamp file"
 
     run_podman exec $cid cat /myvol/cname
     is "$output" "$cname" "volume transferred fine"

--- a/test/system/600-completion.bats
+++ b/test/system/600-completion.bats
@@ -40,7 +40,7 @@ function check_shell_completion() {
 
         # The line immediately after 'Usage:' gives us a 1-line synopsis
         usage=$(echo "$full_help" | grep -A1 '^Usage:' | tail -1)
-        [ -n "$usage" ] || die "podman $cmd: no Usage message found"
+        assert "$usage" != "" "podman $cmd: no Usage message found"
 
         # If usage ends in '[command]', recurse into subcommands
         if expr "$usage" : '.*\[command\]$' >/dev/null; then
@@ -74,7 +74,8 @@ function check_shell_completion() {
                         # If this fails there is most likely a problem with the cobra library
                         is "${lines[0]}" "--.*" \
                            "$* $cmd: flag(s) listed in suggestions"
-                        [ ${#lines[@]} -gt 2 ] || die "$* $cmd: No flag suggestions"
+                        assert "${#lines[@]}" -gt 2 \
+                               "$* $cmd: No flag suggestions"
                         _check_completion_end NoFileComp
                     fi
                     # continue the outer for args loop
@@ -149,7 +150,7 @@ function check_shell_completion() {
                     ### FIXME how can we get the configured registries?
                     _check_completion_end NoFileComp
                     ### FIXME this fails if no registries are configured
-                    [[ ${#lines[@]} -gt 2 ]] || die "$* $cmd: No REGISTRIES found in suggestions"
+                    assert "${#lines[@]}" -gt 2 "$* $cmd: No REGISTRIES found in suggestions"
 
                     match=true
                     # resume
@@ -174,7 +175,7 @@ function check_shell_completion() {
                         _check_completion_end NoSpace
                     else
                         _check_completion_end Default
-                        [[ ${#lines[@]} -eq 2 ]] || die "$* $cmd: Suggestions are in the output"
+                        assert "${#lines[@]}" -eq 2 "$* $cmd: Suggestions are in the output"
                     fi
                     ;;
 
@@ -210,7 +211,7 @@ function check_shell_completion() {
                 i=0
                 length=$(( ${#lines[@]} - 2 ))
                 while [[ i -lt length ]]; do
-                    [[ "${lines[$i]:0:7}" == "[Debug]" ]] || die "Suggestions are in the output"
+                    assert "${lines[$i]:0:7}" == "[Debug]" "Suggestions are in the output"
                     i=$(( i + 1 ))
                 done
             fi

--- a/test/system/750-trust.bats
+++ b/test/system/750-trust.bats
@@ -37,8 +37,7 @@ load helpers
       subset=$(jq -r '.[1] | .repo_name, .type' <<<"$output" | fmt)
       is "$subset" "docker.io accept" "--json, docker.io should now be accept"
 
-      run cat $policypath
-      policy=$output
+      policy="$(< $policypath)"
       run_podman image trust show --policypath=$policypath --raw
       is "$output" "$policy" "output should show match content of policy.json"
 }


### PR DESCRIPTION
Problem: the system test 'is()' checker was poorly thought out.
For example, there is no way to check for inequality or for
absence of a substring.

Solution, step 1: introduce new assert(), copied almost verbatim
from buildah, where it has been successful in addressing the
gaps in is().

The logical next step is to search the tests for 'die' and
for 'run', looking for negative assertions which we can
replace with assert(). There were a lot, and in the process
I found a number of ugly bugs in the tests themselves. I've
taken the liberty of fixing these.

Important note: at this time we have both assert() and is().
Replacing all instances of is() would be impossible to review.

Signed-off-by: Ed Santiago <santiago@redhat.com>
