### PR TITLE
Optimization: skip tests in some circumstances

### DIFF
--- a/contrib/cirrus/pr-should-include-tests
+++ b/contrib/cirrus/pr-should-include-tests
@@ -30,8 +30,7 @@ fi
 # Nothing changed under test subdirectory.
 #
 # This is OK if the only files being touched are "safe" ones.
-filtered_changes=$(git diff --name-status $base $head |
-                       awk '{print $2}'               |
+filtered_changes=$(git diff --name-only $base $head   |
                        fgrep -vx .cirrus.yml          |
                        fgrep -vx .gitignore           |
                        fgrep -vx Makefile             |


### PR DESCRIPTION
A common pattern is to submit PRs that update only tests or docs.

When the only changes are to test/e2e, there is no point in running
test/system, and vice versa.

When the only changes are to docs, there is no point in running either.

Signed-off-by: Ed Santiago <santiago@redhat.com>
