### PR TITLE
systemd socker activation: check listener

### DIFF
--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -60,11 +60,11 @@ func NewServer(runtime *libpod.Runtime) (*APIServer, error) {
 }
 
 // NewServerWithSettings will create and configure a new API server using provided settings
-func NewServerWithSettings(runtime *libpod.Runtime, listener *net.Listener, opts entities.ServiceOptions) (*APIServer, error) {
+func NewServerWithSettings(runtime *libpod.Runtime, listener net.Listener, opts entities.ServiceOptions) (*APIServer, error) {
 	return newServer(runtime, listener, opts)
 }
 
-func newServer(runtime *libpod.Runtime, listener *net.Listener, opts entities.ServiceOptions) (*APIServer, error) {
+func newServer(runtime *libpod.Runtime, listener net.Listener, opts entities.ServiceOptions) (*APIServer, error) {
 	// If listener not provided try socket activation protocol
 	if listener == nil {
 		if _, found := os.LookupEnv("LISTEN_PID"); !found {
@@ -78,7 +78,7 @@ func newServer(runtime *libpod.Runtime, listener *net.Listener, opts entities.Se
 		if len(listeners) != 1 {
 			return nil, fmt.Errorf("wrong number of file descriptors for socket activation protocol (%d != 1)", len(listeners))
 		}
-		listener = &listeners[0]
+		listener = listeners[0]
 	}
 	if opts.CorsHeaders == "" {
 		logrus.Debug("CORS Headers were not set")
@@ -86,7 +86,7 @@ func newServer(runtime *libpod.Runtime, listener *net.Listener, opts entities.Se
 		logrus.Debugf("CORS Headers were set to %q", opts.CorsHeaders)
 	}
 
-	logrus.Infof("API service listening on %q", (*listener).Addr())
+	logrus.Infof("API service listening on %q", listener.Addr())
 	router := mux.NewRouter().UseEncodedPath()
 	tracker := idle.NewTracker(opts.Timeout)
 
@@ -101,7 +101,7 @@ func newServer(runtime *libpod.Runtime, listener *net.Listener, opts entities.Se
 			IdleTimeout: opts.Timeout * 2,
 		},
 		CorsHeaders: opts.CorsHeaders,
-		Listener:    *listener,
+		Listener:    listener,
 		PProfAddr:   opts.PProfAddr,
 		idleTracker: tracker,
 	}

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -79,6 +79,10 @@ func newServer(runtime *libpod.Runtime, listener net.Listener, opts entities.Ser
 			return nil, fmt.Errorf("wrong number of file descriptors for socket activation protocol (%d != 1)", len(listeners))
 		}
 		listener = listeners[0]
+		// note that activation.Listeners() return nil when it cannot listen on the fd (i.e. udp connection)
+		if listener == nil {
+			return nil, fmt.Errorf("unexpected fd received from systemd: cannot listen on it")
+		}
 	}
 	if opts.CorsHeaders == "" {
 		logrus.Debug("CORS Headers were not set")


### PR DESCRIPTION
activation.Listeners() can return an net.Listener array which contains
nil entries if it cannot listen on the given fds. This can cause podman
to panic so we should check the we have non nil net.Listener first.

[NO NEW TESTS NEEDED] No idea how to reproduce this.

Fixes #13911

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
