### PR TITLE
Fix size-check to display more context

### DIFF
--- a/hack/make-and-check-size
+++ b/hack/make-and-check-size
@@ -92,9 +92,10 @@ if [[ ! -d $context_dir ]]; then
 fi
 
 # This is the original (and primary) purpose of this check: if 'make' fails,
-# there is no point in continuing
+# there is no point in continuing.  Show at least the commit title since
+# the ID may not match anything human recognisable.
 echo
-echo "Building: $(git rev-parse HEAD)"
+echo "Building: $(git log -n 1 --no-show-signature --oneline)"
 make
 
 # Determine size of each built file.


### PR DESCRIPTION
When going through the rebase+build loop, the repository state won't
match the exact branch or PR history.  This results in the `Building:
XYZSHA` indications being entirely useless.  Fix this by at least
including the title line of the commit being built.  This will allow a
human to make sense of any size-check failure WRT their view of history.

Signed-off-by: Chris Evich <cevich@redhat.com>