### PR TITLE
Cirrus: Fix missing git-enforced runtime identity

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -101,6 +101,10 @@ ext_svc_check_task:
           else
               git reset --hard $CIRRUS_CHANGE_IN_REPO
           fi
+          # Some test operations & checks require a git "identity"
+          _gc='git config --file /root/.gitconfig'
+          $_gc user.email "TMcTestFace@example.com"
+          $_gc user.name "Testy McTestface"
           make install.tools
 
     setup_script: &setup '$GOSRC/$SCRIPT_BASE/setup_environment.sh'

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -41,6 +41,11 @@ cp hack/podman-registry /bin
 # Make sure cni network plugins directory exists
 mkdir -p /etc/cni/net.d
 
+# Some test operations & checks require a git "identity"
+_gc='git config --file /root/.gitconfig'
+$_gc user.email "TMcTestFace@example.com"
+$_gc user.name "Testy McTestface"
+
 # Ensure that all lower-level contexts and child-processes have
 # ready access to higher level orchestration (e.g Cirrus-CI)
 # variables.


### PR DESCRIPTION
Newer versions of git (like `2.35`) fail on certain operations (like
`rebase` and `am`) without a local identity.  Add a fake one from the
start, with a clearly identifiable test-value to avoid problems at
runtime.

**Note:** This has to be done twice to cover all tasks that need it.  I tried to avoid the duplication, but it wound up being more complex :confounded: 