### PR TITLE
Fix using --network-backend on podman-remote

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -858,18 +858,15 @@ func (p *PodmanTestIntegration) makeOptions(args []string, noEvents, noCache boo
 		eventsType = "none"
 	}
 
-	networkBackend := p.NetworkBackend.ToString()
-	networkDir := p.NetworkConfigDir
-	if p.NetworkBackend == Netavark {
-		networkDir = p.NetworkConfigDir
-	}
 	podmanOptions := strings.Split(fmt.Sprintf("%s--root %s --runroot %s --runtime %s --conmon %s --network-config-dir %s --cgroup-manager %s --tmpdir %s --events-backend %s",
-		debug, p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, networkDir, p.CgroupManager, p.TmpDir, eventsType), " ")
+		debug, p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, p.NetworkConfigDir, p.CgroupManager, p.TmpDir, eventsType), " ")
 	if os.Getenv("HOOK_OPTION") != "" {
 		podmanOptions = append(podmanOptions, os.Getenv("HOOK_OPTION"))
 	}
 
-	podmanOptions = append(podmanOptions, "--network-backend", networkBackend)
+	if !p.RemoteTest {
+		podmanOptions = append(podmanOptions, "--network-backend", p.NetworkBackend.ToString())
+	}
 
 	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
 	if !noCache {

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -137,6 +137,9 @@ func getRemoteOptions(p *PodmanTestIntegration, args []string) []string {
 	if os.Getenv("HOOK_OPTION") != "" {
 		podmanOptions = append(podmanOptions, os.Getenv("HOOK_OPTION"))
 	}
+	if p.NetworkBackend.ToString() == "netavark" {
+		podmanOptions = append(podmanOptions, "--network-backend", "netavark")
+	}
 	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
 	podmanOptions = append(podmanOptions, args...)
 	return podmanOptions

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -110,7 +110,7 @@ func (p *PodmanTest) PodmanAsUserBase(args []string, uid, gid uint32, cwd string
 	}
 
 	runCmd := append(wrapper, podmanBinary)
-	if p.NetworkBackend == Netavark {
+	if !p.RemoteTest && p.NetworkBackend == Netavark {
 		runCmd = append(runCmd, []string{"--network-backend", "netavark"}...)
 	}
 


### PR DESCRIPTION
When this option was added to the e2e tests, there was no CI Automation
support for running remote tests w/ netavark.  When added, many
e2e test errors/failures are generated due to this option not being
valid for the remote client.  Fix this in the tests by conditionally
adding the option if the test is running the remote client.