### PR TITLE
Workaround criu re-linking output in system test

### DIFF
--- a/test/system/520-checkpoint.bats
+++ b/test/system/520-checkpoint.bats
@@ -47,7 +47,8 @@ function teardown() {
 
     # Checkpoint, and confirm via inspect
     run_podman container checkpoint $cid
-    is "$output" "$cid" "podman container checkpoint"
+    # FIXME: remove the `.*` prefix after fix packaged for https://github.com/checkpoint-restore/criu/pull/1706
+    is "$output" ".*$cid" "podman container checkpoint"
 
     run_podman container inspect \
                --format '{{.State.Status}}:{{.State.Running}}:{{.State.Paused}}:{{.State.Checkpointed}}' $cid


### PR DESCRIPTION
When run on an F36 host using netavark/aardvark-dns, for whatever
underlying reason most checkpoint/restore tests are emitting an error
similar to:

`criu: Symbol `__rseq_offset' has different size in shared object,
consider re-linking`

This extraneous output is causing the basic checkpoint system test to
fail.  Since, all other testing of checkpoint/restore feature is
passing (also with the extraneous message) loosen the system test
sensitivity to match.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
