### PR TITLE
Fix hang in apiv2 test_connect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -616,17 +616,23 @@ remotesystem:
 	fi;\
 	exit $$rc
 
-.PHONY: localapiv2
-localapiv2:
-	# Order is important running python tests first causes the bash tests to fail, see 12-imagesMore
-	# FIXME order of tests should not matter
+.PHONY: localapiv2-bash
+localapiv2-bash:
 	env PODMAN=./bin/podman stdbuf -o0 -e0 ./test/apiv2/test-apiv2
+
+.PHONY: localapiv2-python
+localapiv2-python:
 	env CONTAINERS_CONF=$(CURDIR)/test/apiv2/containers.conf PODMAN=./bin/podman \
-		pytest --disable-warnings ./test/apiv2/python
+		pytest --verbose --disable-warnings ./test/apiv2/python
 	touch test/__init__.py
 	env CONTAINERS_CONF=$(CURDIR)/test/apiv2/containers.conf PODMAN=./bin/podman \
-		pytest --disable-warnings ./test/python/docker
+		pytest --verbose --disable-warnings ./test/python/docker
 	rm -f test/__init__.py
+
+# Order is important running python tests first causes the bash tests
+# to fail, see 12-imagesMore.  FIXME order of tests should not matter
+.PHONY: localapiv2
+localapiv2: localapiv2-bash localapiv2-python
 
 .PHONY: remoteapiv2
 remoteapiv2:

--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -20,6 +20,9 @@ use warnings;
 
 our $VERSION = '0.1';
 
+# Autoflush stdout
+$| = 1;
+
 # For debugging, show data structures using DumpTree($var)
 #use Data::TreeDumper; $Data::TreeDumper::Displayaddress = 0;
 

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -59,8 +59,11 @@ function _run_unit() {
 function _run_apiv2() {
     _bail_if_test_can_be_skipped test/apiv2
 
-    source .venv/requests/bin/activate
-    make localapiv2 |& logformatter
+    (
+        make localapiv2-bash
+        source .venv/requests/bin/activate
+        make localapiv2-python
+    ) |& logformatter
 }
 
 function _run_compose() {

--- a/test/apiv2/python/rest_api/fixtures/podman.py
+++ b/test/apiv2/python/rest_api/fixtures/podman.py
@@ -20,10 +20,6 @@ class Podman:
         cgroupfs = os.getenv("CGROUP_MANAGER", "systemd")
         self.cmd.append(f"--cgroup-manager={cgroupfs}")
 
-        if os.getenv("DEBUG"):
-            self.cmd.append("--log-level=debug")
-            self.cmd.append("--syslog=true")
-
         self.anchor_directory = tempfile.mkdtemp(prefix="podman_restapi_")
         self.cmd.append("--root=" + os.path.join(self.anchor_directory, "crio"))
         self.cmd.append("--runroot=" + os.path.join(self.anchor_directory, "crio-run"))


### PR DESCRIPTION
When executing on F36, starting the podman service in debug-mode causes aardvark to run in debug mode.  This does unexpected things with file-descriptors leading to a test-hang.  Thanks to @Luap99 for the fix.  See also https://github.com/containers/automation_images/pull/128 and https://github.com/containers/podman/pull/13934

Fixes https://github.com/containers/podman/issues/13932