### PR TITLE
Fix upgrade tests assuming storage.conf exists

### DIFF
--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -146,6 +146,12 @@ EOF
     # cause connectivity issues since cni and netavark should never be mixed.
     mkdir -p /run/netns /run/cni /run/containers /var/lib/cni /etc/cni/net.d
 
+    # Containers-common around release 1-55 no-longer supplies this file
+    sconf=/etc/containers/storage.conf
+    v_sconf=
+    if [[ -e "$sconf" ]]; then
+        v_sconf="-v $sconf:$sconf"
+    fi
 
     #
     # Use new-podman to run the above script under old-podman.
@@ -165,7 +171,7 @@ EOF
             --net=host \
             --cgroupns=host \
             --pid=host \
-            -v /etc/containers/storage.conf:/etc/containers/storage.conf \
+            $v_sconf \
             -v /dev/fuse:/dev/fuse \
             -v /run/crun:/run/crun \
             -v /run/netns:/run/netns:rshared \


### PR DESCRIPTION
On F36 / podman 4, at the time of this commit there is no
`/etc/containers/storage.conf` installed by default.  Since the
test volume-mounts this file into the container, it was failing.  Fix
this by using a conditional volume-mount based on the file existing (or
not).