### PR TITLE
specgen-volumes: parse `--mount` using csv-reader instead of split.

### DIFF
--- a/pkg/specgenutil/volumes.go
+++ b/pkg/specgenutil/volumes.go
@@ -1,6 +1,7 @@
 package specgenutil
 
 import (
+	"encoding/csv"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -152,7 +153,15 @@ func findMountType(input string) (mountType string, tokens []string, err error) 
 	// Split by comma, iterate over the slice and look for
 	// "type=$mountType". Everything else is appended to tokens.
 	found := false
-	for _, s := range strings.Split(input, ",") {
+	csvReader := csv.NewReader(strings.NewReader(input))
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		return "", nil, err
+	}
+	if len(records) != 1 {
+		return "", nil, errInvalidSyntax
+	}
+	for _, s := range records[0] {
 		kv := strings.Split(s, "=")
 		if found || !(len(kv) == 2 && kv[0] == "type") {
 			tokens = append(tokens, s)

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -120,6 +120,11 @@ var _ = Describe("Podman run with volumes", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
 
+		// test csv escaping
+		session = podmanTest.Podman([]string{"run", "--rm", "--mount=type=tmpfs,tmpfs-size=512M,\"destination=/test,\"", ALPINE, "ls", "/test,"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", "type=bind,src=/tmp,target=/tmp,tmpcopyup", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())


### PR DESCRIPTION
Following commit ensures that csv escaping is supported while using
inline `--mount=type=......` flag with `podman run` by using
`encoding/csv` to parse options instead of performing a `split.String(`
by `comma`.

Closes: https://github.com/containers/podman/issues/13922