### PR TITLE
replace golint with revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
     - gosec
     - maligned
     - gomoddirectives
-    - revive
     - containedctx
     - contextcheck
     - cyclop
@@ -61,6 +60,10 @@ linters:
     - varnamelen
     - maintidx
     - nilnil
+    # deprecated linters
+    - golint # replaced by revive
+    - scopelint # replaced by exportloopref
+    - interfacer
 linters-settings:
   errcheck:
     check-blank: false

--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -225,7 +225,7 @@ func sortImages(imageS []*entities.ImageSummary) ([]imageReporter, error) {
 				h.ImageSummary = *e
 				h.Repository, h.Tag, err = tokenRepoTag(tag)
 				if err != nil {
-					return nil, errors.Wrapf(err, "error parsing repository tag %q:", tag)
+					return nil, errors.Wrapf(err, "error parsing repository tag: %q", tag)
 				}
 				if h.Tag == "<none>" {
 					untagged = append(untagged, h)

--- a/cmd/podman/images/load.go
+++ b/cmd/podman/images/load.go
@@ -91,7 +91,7 @@ func load(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		if term.IsTerminal(int(os.Stdin.Fd())) {
-			return errors.Errorf("cannot read from terminal. Use command-line redirection or the --input flag.")
+			return errors.Errorf("cannot read from terminal, use command-line redirection or the --input flag")
 		}
 		outFile, err := ioutil.TempFile(util.Tmpdir(), "podman")
 		if err != nil {

--- a/cmd/podman/validate/args.go
+++ b/cmd/podman/validate/args.go
@@ -23,9 +23,9 @@ func SubCommandExists(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		suggestions := cmd.SuggestionsFor(args[0])
 		if len(suggestions) == 0 {
-			return errors.Errorf("unrecognized command `%[1]s %[2]s`\nTry '%[1]s --help' for more information.", cmd.CommandPath(), args[0])
+			return errors.Errorf("unrecognized command `%[1]s %[2]s`\nTry '%[1]s --help' for more information", cmd.CommandPath(), args[0])
 		}
-		return errors.Errorf("unrecognized command `%[1]s %[2]s`\n\nDid you mean this?\n\t%[3]s\n\nTry '%[1]s --help' for more information.", cmd.CommandPath(), args[0], strings.Join(suggestions, "\n\t"))
+		return errors.Errorf("unrecognized command `%[1]s %[2]s`\n\nDid you mean this?\n\t%[3]s\n\nTry '%[1]s --help' for more information", cmd.CommandPath(), args[0], strings.Join(suggestions, "\n\t"))
 	}
 	cmd.Help() // nolint: errcheck
 	return errors.Errorf("missing command '%[1]s COMMAND'", cmd.CommandPath())

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -79,11 +79,11 @@ type ExecConfig struct {
 type ExecSession struct {
 	// Id is the ID of the exec session.
 	// Named somewhat strangely to not conflict with ID().
-	// nolint:stylecheck,golint
+	// nolint:stylecheck,revive
 	Id string `json:"id"`
 	// ContainerId is the ID of the container this exec session belongs to.
 	// Named somewhat strangely to not conflict with ContainerID().
-	// nolint:stylecheck,golint
+	// nolint:stylecheck,revive
 	ContainerId string `json:"containerId"`
 
 	// State is the state of the exec session.

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -264,7 +264,7 @@ func (c *Container) handleRestartPolicy(ctx context.Context) (_ bool, retErr err
 	if c.ensureState(define.ContainerStateRunning, define.ContainerStatePaused) {
 		return false, nil
 	} else if c.state.State == define.ContainerStateUnknown {
-		return false, errors.Wrapf(define.ErrInternal, "invalid container state encountered in restart attempt!")
+		return false, errors.Wrapf(define.ErrInternal, "invalid container state encountered in restart attempt")
 	}
 
 	c.newContainerEvent(events.Restart)

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -3220,7 +3220,7 @@ func (c *Container) getOCICgroupPath() (string, error) {
 }
 
 func (c *Container) copyTimezoneFile(zonePath string) (string, error) {
-	var localtimeCopy string = filepath.Join(c.state.RunDir, "localtime")
+	localtimeCopy := filepath.Join(c.state.RunDir, "localtime")
 	file, err := os.Stat(zonePath)
 	if err != nil {
 		return "", err

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -213,7 +213,7 @@ type YAMLContainer struct {
 func ConvertV1PodToYAMLPod(pod *v1.Pod) *YAMLPod {
 	cs := []*YAMLContainer{}
 	for _, cc := range pod.Spec.Containers {
-		var res *v1.ResourceRequirements = nil
+		var res *v1.ResourceRequirements
 		if len(cc.Resources.Limits) > 0 || len(cc.Resources.Requests) > 0 {
 			res = &cc.Resources
 		}

--- a/libpod/lock/in_memory_locks.go
+++ b/libpod/lock/in_memory_locks.go
@@ -49,7 +49,7 @@ type InMemoryManager struct {
 // of locks.
 func NewInMemoryManager(numLocks uint32) (Manager, error) {
 	if numLocks == 0 {
-		return nil, errors.Errorf("must provide a non-zero number of locks!")
+		return nil, errors.Errorf("must provide a non-zero number of locks")
 	}
 
 	manager := new(InMemoryManager)

--- a/pkg/api/handlers/compat/containers_archive.go
+++ b/pkg/api/handlers/compat/containers_archive.go
@@ -2,7 +2,6 @@ package compat
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"os"
 
@@ -28,7 +27,7 @@ func Archive(w http.ResponseWriter, r *http.Request) {
 	case http.MethodHead, http.MethodGet:
 		handleHeadAndGet(w, r, decoder, runtime)
 	default:
-		utils.Error(w, http.StatusNotImplemented, errors.New(fmt.Sprintf("unsupported method: %v", r.Method)))
+		utils.Error(w, http.StatusNotImplemented, errors.Errorf("unsupported method: %v", r.Method))
 	}
 }
 

--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -45,7 +45,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	// need to check for memory limit to adjust swap
 	if sg.ResourceLimits != nil && sg.ResourceLimits.Memory != nil {
 		s := ""
-		var l int64 = 0
+		var l int64
 		if sg.ResourceLimits.Memory.Swap != nil {
 			s = strconv.Itoa(int(*sg.ResourceLimits.Memory.Swap))
 		}

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -289,7 +289,7 @@ func sshClient(_url *url.URL, secure bool, passPhrase string, identity string) (
 		},
 	)
 	if err != nil {
-		return Connection{}, errors.Wrapf(err, "Connection to bastion host (%s) failed.", _url.String())
+		return Connection{}, errors.Wrapf(err, "connection to bastion host (%s) failed", _url.String())
 	}
 
 	connection := Connection{URI: _url}

--- a/pkg/bindings/test/common_test.go
+++ b/pkg/bindings/test/common_test.go
@@ -51,7 +51,7 @@ var (
 		shortName:   "busybox",
 		tarballName: "busybox.tar",
 	}
-	CACHE_IMAGES = []testImage{alpine, busybox} //nolint:golint,stylecheck
+	CACHE_IMAGES = []testImage{alpine, busybox} //nolint:revive,stylecheck
 )
 
 type bindingTest struct {

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -22,7 +22,7 @@ type NetworkReloadOptions struct {
 
 // NetworkReloadReport describes the results of reloading a container network.
 type NetworkReloadReport struct {
-	// nolint:stylecheck,golint
+	// nolint:stylecheck,revive
 	Id  string
 	Err error
 }

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -270,7 +270,7 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 				invalidPolicyNames = append(invalidPolicyNames, policy)
 			}
 		}
-		var filterValueError error = nil
+		var filterValueError error
 		if len(invalidPolicyNames) > 0 {
 			errPrefix := "invalid restart policy"
 			if len(invalidPolicyNames) > 1 {

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -110,6 +110,10 @@ func (ir *ImageEngine) remoteManifestInspect(ctx context.Context, name string) (
 		if latestErr == nil {
 			latestErr = e
 		} else {
+			// FIXME should we use multierror package instead?
+
+			// we want the new line here so ignore the linter
+			//nolint:revive
 			latestErr = errors.Wrapf(latestErr, "tried %v\n", e)
 		}
 	}

--- a/pkg/domain/infra/abi/trust.go
+++ b/pkg/domain/infra/abi/trust.go
@@ -84,7 +84,7 @@ func (ir *ImageEngine) SetTrust(ctx context.Context, args []string, options enti
 		policyContentStruct.Default = newReposContent
 	} else {
 		if len(policyContentStruct.Default) == 0 {
-			return errors.Errorf("Default trust policy must be set.")
+			return errors.Errorf("default trust policy must be set")
 		}
 		registryExists := false
 		for transport, transportval := range policyContentStruct.Transports {

--- a/pkg/k8s.io/api/core/v1/resource.go
+++ b/pkg/k8s.io/api/core/v1/resource.go
@@ -26,7 +26,7 @@ func (rn ResourceName) String() string {
 }
 
 // Cpu returns the Cpu limit if specified.
-// nolint:golint,stylecheck
+//nolint:revive,stylecheck
 func (rl *ResourceList) Cpu() *resource.Quantity {
 	return rl.Name(ResourceCPU, resource.DecimalSI)
 }

--- a/pkg/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/pkg/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -138,7 +138,7 @@ const (
 
 var (
 	// Errors that could happen while parsing a string.
-	// nolint:golint
+	//nolint:revive
 	ErrFormatWrong = errors.New("quantities must match the regular expression '" + splitREString + "'")
 	ErrNumeric     = errors.New("unable to parse numeric part of quantity")
 	ErrSuffix      = errors.New("unable to parse quantity's suffix")

--- a/pkg/machine/fcos.go
+++ b/pkg/machine/fcos.go
@@ -26,8 +26,8 @@ import (
 // These should eventually be moved into machine/qemu as
 // they are specific to running qemu
 var (
-	artifact string = "qemu"
-	Format   string = "qcow2.xz"
+	artifact = "qemu"
+	Format   = "qcow2.xz"
 )
 
 const (

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -162,7 +162,7 @@ type Monitor struct {
 var (
 	// defaultQMPTimeout is the timeout duration for the
 	// qmp monitor interactions.
-	defaultQMPTimeout time.Duration = 2 * time.Second
+	defaultQMPTimeout = 2 * time.Second
 )
 
 // GetPath returns the working path for a machinefile.  it returns

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -907,7 +907,7 @@ func (v *MachineVM) SSH(_ string, opts machine.SSHOptions) error {
 		return err
 	}
 	if state != machine.Running {
-		return errors.Errorf("vm %q is not running.", v.Name)
+		return errors.Errorf("vm %q is not running", v.Name)
 	}
 
 	username := opts.Username

--- a/pkg/specgen/generate/kube/seccomp.go
+++ b/pkg/specgen/generate/kube/seccomp.go
@@ -11,7 +11,7 @@ import (
 
 // KubeSeccompPaths holds information about a pod YAML's seccomp configuration
 // it holds both container and pod seccomp paths
-// nolint:golint
+//nolint:revive
 type KubeSeccompPaths struct {
 	containerPaths map[string]string
 	podPath        string

--- a/pkg/specgen/generate/kube/volume.go
+++ b/pkg/specgen/generate/kube/volume.go
@@ -17,7 +17,7 @@ const (
 	kubeFilePermission = 0644
 )
 
-// nolint:golint
+//nolint:revive
 type KubeVolumeType int
 
 const (
@@ -26,7 +26,7 @@ const (
 	KubeVolumeTypeConfigMap KubeVolumeType = iota
 )
 
-// nolint:golint
+//nolint:revive
 type KubeVolume struct {
 	// Type of volume to create
 	Type KubeVolumeType

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -222,14 +222,14 @@ func ParseNamespace(ns string) (Namespace, error) {
 	case strings.HasPrefix(ns, "ns:"):
 		split := strings.SplitN(ns, ":", 2)
 		if len(split) != 2 {
-			return toReturn, errors.Errorf("must provide a path to a namespace when specifying ns:")
+			return toReturn, errors.Errorf("must provide a path to a namespace when specifying \"ns:\"")
 		}
 		toReturn.NSMode = Path
 		toReturn.Value = split[1]
 	case strings.HasPrefix(ns, "container:"):
 		split := strings.SplitN(ns, ":", 2)
 		if len(split) != 2 {
-			return toReturn, errors.Errorf("must provide name or ID or a container when specifying container:")
+			return toReturn, errors.Errorf("must provide name or ID or a container when specifying \"container:\"")
 		}
 		toReturn.NSMode = FromContainer
 		toReturn.Value = split[1]
@@ -337,14 +337,14 @@ func ParseNetworkNamespace(ns string, rootlessDefaultCNI bool) (Namespace, map[s
 	case strings.HasPrefix(ns, "ns:"):
 		split := strings.SplitN(ns, ":", 2)
 		if len(split) != 2 {
-			return toReturn, nil, errors.Errorf("must provide a path to a namespace when specifying ns:")
+			return toReturn, nil, errors.Errorf("must provide a path to a namespace when specifying \"ns:\"")
 		}
 		toReturn.NSMode = Path
 		toReturn.Value = split[1]
 	case strings.HasPrefix(ns, string(FromContainer)+":"):
 		split := strings.SplitN(ns, ":", 2)
 		if len(split) != 2 {
-			return toReturn, nil, errors.Errorf("must provide name or ID or a container when specifying container:")
+			return toReturn, nil, errors.Errorf("must provide name or ID or a container when specifying \"container:\"")
 		}
 		toReturn.NSMode = FromContainer
 		toReturn.Value = split[1]
@@ -415,14 +415,14 @@ func ParseNetworkFlag(networks []string) (Namespace, map[string]types.PerNetwork
 	case strings.HasPrefix(ns, "ns:"):
 		split := strings.SplitN(ns, ":", 2)
 		if len(split) != 2 {
-			return toReturn, nil, nil, errors.Errorf("must provide a path to a namespace when specifying ns:")
+			return toReturn, nil, nil, errors.Errorf("must provide a path to a namespace when specifying \"ns:\"")
 		}
 		toReturn.NSMode = Path
 		toReturn.Value = split[1]
 	case strings.HasPrefix(ns, string(FromContainer)+":"):
 		split := strings.SplitN(ns, ":", 2)
 		if len(split) != 2 {
-			return toReturn, nil, nil, errors.Errorf("must provide name or ID or a container when specifying container:")
+			return toReturn, nil, nil, errors.Errorf("must provide name or ID or a container when specifying \"container:\"")
 		}
 		toReturn.NSMode = FromContainer
 		toReturn.Value = split[1]

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -35,12 +35,12 @@ import (
 
 var (
 	//lint:ignore ST1003
-	PODMAN_BINARY      string                        //nolint:golint,stylecheck
-	INTEGRATION_ROOT   string                        //nolint:golint,stylecheck
-	CGROUP_MANAGER     = "systemd"                   //nolint:golint,stylecheck
-	RESTORE_IMAGES     = []string{ALPINE, BB, nginx} //nolint:golint,stylecheck
+	PODMAN_BINARY      string                        //nolint:revive,stylecheck
+	INTEGRATION_ROOT   string                        //nolint:revive,stylecheck
+	CGROUP_MANAGER     = "systemd"                   //nolint:revive,stylecheck
+	RESTORE_IMAGES     = []string{ALPINE, BB, nginx} //nolint:revive,stylecheck
 	defaultWaitTimeout = 90
-	CGROUPSV2, _       = cgroups.IsCgroup2UnifiedMode() //nolint:golint,stylecheck
+	CGROUPSV2, _       = cgroups.IsCgroup2UnifiedMode() //nolint:revive,stylecheck
 )
 
 // PodmanTestIntegration struct for command line options

--- a/test/e2e/config_amd64.go
+++ b/test/e2e/config_amd64.go
@@ -1,16 +1,16 @@
 package integration
 
 var (
-	STORAGE_FS               = "vfs"                                                                                                                         //nolint:golint,stylecheck
-	STORAGE_OPTIONS          = "--storage-driver vfs"                                                                                                        //nolint:golint,stylecheck
-	ROOTLESS_STORAGE_FS      = "vfs"                                                                                                                         //nolint:golint,stylecheck
-	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"                                                                                                        //nolint:golint,stylecheck
-	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, registry, infra, labels, healthcheck, UBI_INIT, UBI_MINIMAL, fedoraToolbox} //nolint:golint,stylecheck
+	STORAGE_FS               = "vfs"                                                                                                                         //nolint:revive,stylecheck
+	STORAGE_OPTIONS          = "--storage-driver vfs"                                                                                                        //nolint:revive,stylecheck
+	ROOTLESS_STORAGE_FS      = "vfs"                                                                                                                         //nolint:revive,stylecheck
+	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"                                                                                                        //nolint:revive,stylecheck
+	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, registry, infra, labels, healthcheck, UBI_INIT, UBI_MINIMAL, fedoraToolbox} //nolint:revive,stylecheck
 	nginx                    = "quay.io/libpod/alpine_nginx:latest"
-	BB_GLIBC                 = "docker.io/library/busybox:glibc" //nolint:golint,stylecheck
+	BB_GLIBC                 = "docker.io/library/busybox:glibc" //nolint:revive,stylecheck
 	registry                 = "quay.io/libpod/registry:2.6"
 	labels                   = "quay.io/libpod/alpine_labels:latest"
-	UBI_MINIMAL              = "registry.access.redhat.com/ubi8-minimal" //nolint:golint,stylecheck
-	UBI_INIT                 = "registry.access.redhat.com/ubi8-init"    //nolint:golint,stylecheck
+	UBI_MINIMAL              = "registry.access.redhat.com/ubi8-minimal" //nolint:revive,stylecheck
+	UBI_INIT                 = "registry.access.redhat.com/ubi8-init"    //nolint:revive,stylecheck
 	cirros                   = "quay.io/libpod/cirros:latest"
 )

--- a/test/system/450-interactive.bats
+++ b/test/system/450-interactive.bats
@@ -75,7 +75,7 @@ function teardown() {
 @test "podman load - will not read from tty" {
     run_podman 125 load <$PODMAN_TEST_PTY
     is "$output" \
-       "Error: cannot read from terminal. Use command-line redirection or the --input flag." \
+       "Error: cannot read from terminal, use command-line redirection or the --input flag" \
        "Diagnostic from 'podman load' without redirection or -i"
 }
 

--- a/test/testvol/main.go
+++ b/test/testvol/main.go
@@ -31,7 +31,7 @@ type cliConfig struct {
 }
 
 // Default configuration is stored here. Will be overwritten by flags.
-var config cliConfig = cliConfig{
+var config = cliConfig{
 	logLevel: "error",
 	sockName: "test-volume-plugin",
 }

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 
 	"github.com/containers/common/pkg/config"
-	. "github.com/onsi/gomega" //nolint:golint,stylecheck
+	. "github.com/onsi/gomega" //nolint:revive,stylecheck
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/matchers"

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -15,9 +15,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/containers/storage/pkg/parsers/kernel"
-	. "github.com/onsi/ginkgo"       //nolint:golint,stylecheck
-	. "github.com/onsi/gomega"       //nolint:golint,stylecheck
-	. "github.com/onsi/gomega/gexec" //nolint:golint,stylecheck
+	. "github.com/onsi/ginkgo"       //nolint:revive,stylecheck
+	. "github.com/onsi/gomega"       //nolint:revive,stylecheck
+	. "github.com/onsi/gomega/gexec" //nolint:revive,stylecheck
 )
 
 type NetworkBackend int


### PR DESCRIPTION
golint, scopelint and interfacer are deprecated. golint is replaced by
revive. This linter is better because it will also check for our error
style: `error strings should not be capitalized or end with punctuation or a newline`

scopelint is replaced by exportloopref (already endabled)
interfacer has no replacement but I do not think this linter is
important.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
