### PR TITLE
libpod/networking_linux.go: switch to sha256 hash generation

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -5,7 +5,7 @@ package libpod
 
 import (
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -402,7 +402,7 @@ func (r *Runtime) GetRootlessNetNs(new bool) (*RootlessNetNS, error) {
 	// the cleanup will check if there are running containers
 	// if you run a several libpod instances with different root/runroot directories this check will fail
 	// we want one netns for each libpod static dir so we use the hash to prevent name collisions
-	hash := sha1.Sum([]byte(r.config.Engine.StaticDir))
+	hash := sha256.Sum256([]byte(r.config.Engine.StaticDir))
 	netnsName := fmt.Sprintf("%s-%x", rootlessNetNsName, hash[:10])
 
 	path := filepath.Join(nsDir, netnsName)


### PR DESCRIPTION
SHA-1 is prone to collisions.

This will likely break connectivity between old containers started
before update and containers started after update. It will also fail to
cleanup old netns. A reboot will fix this, so a reboot is recommended
after update.

[NO NEW TESTS NEEDED]


Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Edit: Update commit message.
