### PR TITLE
Allow filtering of "removing", it is a valid status

### DIFF
--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -52,8 +52,8 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 		}, nil
 	case "status":
 		for _, filterValue := range filterValues {
-			if !util.StringInSlice(filterValue, []string{"created", "running", "paused", "stopped", "exited", "unknown"}) {
-				return nil, errors.Errorf("%s is not a valid status", filterValue)
+			if _, err := define.StringToContainerStatus(filterValue); err != nil {
+				return nil, err
 			}
 		}
 		return func(c *libpod.Container) bool {

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -321,7 +321,11 @@ t GET containers/json?filters='garb1age}' 500 \
 t GET containers/json?filters='{"label":["testl' 500 \
     .cause="unexpected end of JSON input"
 
+
 #libpod api list containers sanity checks
+t GET libpod/containers/json?filters='{"status":["removing"]}' 200 length=0
+t GET libpod/containers/json?filters='{"status":["bogus"]}' 500 \
+    .cause="invalid argument"
 t GET libpod/containers/json?filters='garb1age}' 500 \
     .cause="invalid character 'g' looking for beginning of value"
 t GET libpod/containers/json?filters='{"label":["testl' 500 \


### PR DESCRIPTION
Do not use a list of statuses outside of libpod to validate container
statuses.  Removing status was never added to the list.

Fixes: https://github.com/containers/podman/issues/13986

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
