### PR TITLE
kube: pod name should not contain `_`, honor RFC 1123 for DNS label

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -527,7 +527,7 @@ func simplePodWithV1Containers(ctx context.Context, ctrs []*Container) (*v1.Pod,
 	// Check if the pod name and container name will end up conflicting
 	// Append _pod if so
 	if util.StringInSlice(podName, ctrNames) {
-		podName = podName + "_pod"
+		podName = podName + "-pod"
 	}
 
 	return newPodObject(

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(pod.Spec.DNSConfig).To(BeNil())
 		Expect(pod.Spec.Containers[0].WorkingDir).To(Equal(""))
 		Expect(pod.Spec.Containers[0].Env).To(BeNil())
-		Expect(pod.Name).To(Equal("top_pod"))
+		Expect(pod.Name).To(Equal("top-pod"))
 
 		numContainers := 0
 		for range pod.Spec.Containers {


### PR DESCRIPTION
Pod name should contain underscore and honor kubernetes DNS label scheme
while `generate kube`

See: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
See: https://www.rfc-editor.org/rfc/rfc1123#section-2
See: https://stackoverflow.com/questions/27791913/what-characters-are-allowed-in-kubernetes-port-and-container-names

Closes: https://github.com/containers/podman/issues/13985