### PR TITLE
Rootfull -> Rootful

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var (
@@ -107,18 +106,8 @@ func init() {
 	flags.StringVar(&initOpts.IgnitionPath, IgnitionPathFlagName, "", "Path to ignition file")
 	_ = initCmd.RegisterFlagCompletionFunc(IgnitionPathFlagName, completion.AutocompleteDefault)
 
-	rootfullFlagName := "rootfull"
-	flags.BoolVar(&initOpts.Rootfull, rootfullFlagName, false, "Whether this machine should prefer rootfull container execution")
-	flags.SetNormalizeFunc(aliasFlags)
-}
-
-// aliasFlags is a function to handle backwards compatibility with old flags
-func aliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
-	switch name {
-	case "rootful":
-		name = "rootfull"
-	}
-	return pflag.NormalizedName(name)
+	rootfulFlagName := "rootful"
+	flags.BoolVar(&initOpts.Rootful, rootfulFlagName, false, "Whether this machine should prefer rootful container execution")
 }
 
 // TODO should we allow for a users to append to the qemu cmdline?

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -17,7 +17,7 @@ var (
 		Long:              "Sets an updatable virtual machine setting",
 		RunE:              setMachine,
 		Args:              cobra.MaximumNArgs(1),
-		Example:           `podman machine set --rootfull=false`,
+		Example:           `podman machine set --rootful=false`,
 		ValidArgsFunction: completion.AutocompleteNone,
 	}
 )
@@ -33,9 +33,8 @@ func init() {
 	})
 	flags := setCmd.Flags()
 
-	rootfullFlagName := "rootfull"
-	flags.BoolVar(&setOpts.Rootfull, rootfullFlagName, false, "Whether this machine should prefer rootfull container execution")
-	flags.SetNormalizeFunc(aliasFlags)
+	rootfulFlagName := "rootful"
+	flags.BoolVar(&setOpts.Rootful, rootfulFlagName, false, "Whether this machine should prefer rootful container execution")
 }
 
 func setMachine(cmd *cobra.Command, args []string) error {

--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -207,7 +207,7 @@ END_HTML
 
     print { $out_fh } "<pre> <!-- begin processed output -->\n";
 
-    # Assume rootfull prompt, check for rootless (here and in log itself, below)
+    # Assume rootful prompt, check for rootless (here and in log itself, below)
     my $Prompt = '#';
     $Prompt = '$' if $test_name =~ /rootless/;
 

--- a/contrib/podmanimage/README.md
+++ b/contrib/podmanimage/README.md
@@ -70,4 +70,4 @@ file to `/etc/modules.load.d`.  See `man modules-load.d` for more details.
 
 ### Blog Post with Details
 
-Dan Walsh wrote a blog post on the [Enable Sysadmin](https://www.redhat.com/sysadmin/) site titled [How to use Podman inside of a container](https://www.redhat.com/sysadmin/podman-inside-container).  In it, he details how to use these images as a rootfull and as a rootless user.  Please refer to this blog for more detailed information.
+Dan Walsh wrote a blog post on the [Enable Sysadmin](https://www.redhat.com/sysadmin/) site titled [How to use Podman inside of a container](https://www.redhat.com/sysadmin/podman-inside-container).  In it, he details how to use these images as a rootful and as a rootless user.  Please refer to this blog for more detailed information.

--- a/contrib/remote/containers.conf
+++ b/contrib/remote/containers.conf
@@ -7,5 +7,5 @@
 # Default Remote URI to access the Podman service.
 # Examples:
 #  remote rootless ssh://engineering.lab.company.com/run/user/1000/podman/podman.sock
-#  remote rootfull ssh://root@10.10.1.136:22/run/podman/podman.sock
+#  remote rootful ssh://root@10.10.1.136:22/run/podman/podman.sock
 # remote_uri= ""

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -685,7 +685,7 @@ suitable group name to use as the default setting for this option.
 
 **NOTE:** When this option is specified by a rootless user, the specified
 mappings are relative to the rootless user namespace in the container, rather
-than being relative to the host as it would be when run rootfull.
+than being relative to the host as it would be when run rootful.
 
 #### **--userns-uid-map**=*mapping*
 
@@ -721,7 +721,7 @@ suitable user name to use as the default setting for this option.
 
 **NOTE:** When this option is specified by a rootless user, the specified
 mappings are relative to the rootless user namespace in the container, rather
-than being relative to the host as it would be when run rootfull.
+than being relative to the host as it would be when run rootful.
 
 #### **--uts**=*how*
 

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -429,7 +429,7 @@ container full access to local system services such as D-bus and is therefore
 considered insecure.
 - **ns:**_path_: path to a network namespace to join.
 - **private**: create a new namespace for the container (default)
-- **\<network name|ID\>**: Join the network with the given name or ID, e.g. use `--network mynet` to join the network with the name mynet. Only supported for rootfull users.
+- **\<network name|ID\>**: Join the network with the given name or ID, e.g. use `--network mynet` to join the network with the name mynet. Only supported for rootful users.
 
 #### **--no-cache**
 

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -704,7 +704,7 @@ Set the network mode for the container. Invalid if using **--dns**, **--dns-opt*
 
 Valid _mode_ values are:
 
-- **bridge[:OPTIONS,...]**: Create a network stack on the default bridge. This is the default for rootfull containers. It is possible to specify these additional options:
+- **bridge[:OPTIONS,...]**: Create a network stack on the default bridge. This is the default for rootful containers. It is possible to specify these additional options:
   - **alias=name**: Add network-scoped alias for the container.
   - **ip=IPv4**: Specify a static ipv4 address for this container.
   - **ip=IPv6**: Specify a static ipv6 address for this container.
@@ -717,7 +717,7 @@ Valid _mode_ values are:
 - **container:**_id_: Reuse another container's network stack.
 - **host**: Do not create a network namespace, the container will use the host's network. Note: The host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
 - **ns:**_path_: Path to a network namespace to join.
-- **private**: Create a new namespace for the container. This will use the **bridge** mode for rootfull containers and **slirp4netns** for rootless ones.
+- **private**: Create a new namespace for the container. This will use the **bridge** mode for rootful containers and **slirp4netns** for rootless ones.
 - **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
   - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
   - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
@@ -1118,8 +1118,8 @@ option conflicts with the **--userns** and **--subuidname** options. This
 option provides a way to map host UIDs to container UIDs. It can be passed
 several times to map different ranges.
 
-The _from_uid_ value is based upon the user running the command, either rootfull or rootless users.
-* rootfull user:  *container_uid*:*host_uid*:*amount*
+The _from_uid_ value is based upon the user running the command, either rootful or rootless users.
+* rootful user:  *container_uid*:*host_uid*:*amount*
 * rootless user: *container_uid*:*intermediate_uid*:*amount*
 
 When **podman create** is called by a privileged user, the option **--uidmap**

--- a/docs/source/markdown/podman-image-scp.1.md
+++ b/docs/source/markdown/podman-image-scp.1.md
@@ -8,7 +8,7 @@ podman-image-scp - Securely copy an image from one host to another
 
 ## DESCRIPTION
 **podman image scp** copies container images between hosts on a network. You can load to the remote host or from the remote host as well as in between two remote hosts.
-Note: `::` is used to specify the image name depending on if you are saving or loading. Images can also be transferred from rootfull to rootless storage on the same machine without using sshd. This feature is not supported on the remote client, including Mac and Windows (excluding WSL2) machines.
+Note: `::` is used to specify the image name depending on if you are saving or loading. Images can also be transferred from rootful to rootless storage on the same machine without using sshd. This feature is not supported on the remote client, including Mac and Windows (excluding WSL2) machines.
 
 **podman image scp [GLOBAL OPTIONS]**
 

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -59,9 +59,9 @@ Memory (in MB).
 
 Start the virtual machine immediately after it has been initialized.
 
-#### **--rootfull**=*true|false*
+#### **--rootful**=*true|false*
 
-Whether this machine should prefer rootfull (`true`) or rootless (`false`)
+Whether this machine should prefer rootful (`true`) or rootless (`false`)
 container execution. This option will also determine the remote connection default
 if there is no existing remote connection configurations.
 
@@ -95,7 +95,7 @@ Driver to use for mounting volumes from the host, such as `virtfs`.
 ```
 $ podman machine init
 $ podman machine init myvm
-$ podman machine init --rootfull
+$ podman machine init --rootful
 $ podman machine init --disk-size 50
 $ podman machine init --memory=1024 myvm
 $ podman machine init -v /Users:/mnt/Users

--- a/docs/source/markdown/podman-machine-set.1.md
+++ b/docs/source/markdown/podman-machine-set.1.md
@@ -19,39 +19,39 @@ subset can be changed after machine initialization.
 
 Print usage statement.
 
-#### **--rootfull**=*true|false*
+#### **--rootful**=*true|false*
 
-Whether this machine should prefer rootfull (`true`) or rootless (`false`)
+Whether this machine should prefer rootful (`true`) or rootless (`false`)
 container execution. This option will also update the current podman
 remote connection default if it is currently pointing at the specified
 machine name (or `podman-machine-default` if no name is specified).
 
 Unlike [**podman system connection default**](podman-system-connection-default.1.md)
-this option will also make the API socket, if available, forward to the rootfull/rootless
+this option will also make the API socket, if available, forward to the rootful/rootless
 socket in the VM.
 
 ## EXAMPLES
 
-To switch the default VM `podman-machine-default` from rootless to rootfull:
+To switch the default VM `podman-machine-default` from rootless to rootful:
 
 ```
-$ podman machine set --rootfull
+$ podman machine set --rootful
 ```
 
 or more explicitly:
 
 ```
-$ podman machine set --rootfull=true
+$ podman machine set --rootful=true
 ```
 
-To switch the default VM `podman-machine-default` from rootfull to rootless:
+To switch the default VM `podman-machine-default` from rootful to rootless:
 ```
-$ podman machine set --rootfull=false
+$ podman machine set --rootful=false
 ```
 
-To switch the VM `myvm` from rootless to rootfull:
+To switch the VM `myvm` from rootless to rootful:
 ```
-$ podman machine set --rootfull myvm
+$ podman machine set --rootful myvm
 ```
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-network-reload.1.md
+++ b/docs/source/markdown/podman-network-reload.1.md
@@ -9,7 +9,7 @@ podman\-network\-reload - Reload network configuration for containers
 ## DESCRIPTION
 Reload one or more container network configurations.
 
-Rootfull Podman relies on iptables rules in order to provide network connectivity. If the iptables rules are deleted,
+Rootful Podman relies on iptables rules in order to provide network connectivity. If the iptables rules are deleted,
 this happens for example with `firewall-cmd --reload`, the container loses network connectivity. This command restores
 the network connectivity.
 

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -188,7 +188,7 @@ Note: When joining multiple networks you should use the **--network name:mac=\<m
 Change the network mode of the pod. The host network mode should be configured in the YAML file.
 Valid _mode_ values are:
 
-- **bridge[:OPTIONS,...]**: Create a network stack on the default bridge. This is the default for rootfull containers. It is possible to specify these additional options:
+- **bridge[:OPTIONS,...]**: Create a network stack on the default bridge. This is the default for rootful containers. It is possible to specify these additional options:
   - **alias=name**: Add network-scoped alias for the container.
   - **ip=IPv4**: Specify a static ipv4 address for this container.
   - **ip=IPv6**: Specify a static ipv6 address for this container.
@@ -200,7 +200,7 @@ Valid _mode_ values are:
 - **none**: Create a network namespace for the container but do not configure network interfaces for it, thus the container has no network connectivity.
 - **container:**_id_: Reuse another container's network stack.
 - **ns:**_path_: Path to a network namespace to join.
-- **private**: Create a new namespace for the container. This will use the **bridge** mode for rootfull containers and **slirp4netns** for rootless ones.
+- **private**: Create a new namespace for the container. This will use the **bridge** mode for rootful containers and **slirp4netns** for rootless ones.
 - **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
   - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
   - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -156,7 +156,7 @@ Set the network mode for the pod. Invalid if using **--dns**, **--dns-opt**, or 
 
 Valid _mode_ values are:
 
-- **bridge[:OPTIONS,...]**: Create a network stack on the default bridge. This is the default for rootfull containers. It is possible to specify these additional options:
+- **bridge[:OPTIONS,...]**: Create a network stack on the default bridge. This is the default for rootful containers. It is possible to specify these additional options:
   - **alias=name**: Add network-scoped alias for the container.
   - **ip=IPv4**: Specify a static ipv4 address for this container.
   - **ip=IPv6**: Specify a static ipv6 address for this container.
@@ -169,7 +169,7 @@ Valid _mode_ values are:
 - **container:**_id_: Reuse another container's network stack.
 - **host**: Do not create a network namespace, the container will use the host's network. Note: The host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
 - **ns:**_path_: Path to a network namespace to join.
-- **private**: Create a new namespace for the container. This will use the **bridge** mode for rootfull containers and **slirp4netns** for rootless ones.
+- **private**: Create a new namespace for the container. This will use the **bridge** mode for rootful containers and **slirp4netns** for rootless ones.
 - **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
   - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
   - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).

--- a/docs/source/markdown/podman-pull.1.md
+++ b/docs/source/markdown/podman-pull.1.md
@@ -117,7 +117,7 @@ Using short names is subject to the risk of hitting squatted registry namespaces
 While it is highly recommended to always use fully-qualified image references, existing deployments using short names may not be easily changed. To circumvent the aforementioned ambiguity, so called short-name aliases can be configured that point to a fully-qualified image reference. Distributions often ship a default shortnames.conf expansion file in /etc/containers/registries.conf.d/ directory. Administrators can use this directory to add their own local short-name expansion files.
 
 When pulling an image, if the user does not specify the complete registry, container engines attempt to expand the short-name into a full name. If the command is executed with a tty, the user will be prompted to select a registry from the
-default list unqualified registries defined in registries.conf. The user's selection is then stored in a cache file to be used in all future short-name expansions. Rootfull short-names are stored in /var/cache/containers/short-name-aliases.conf. Rootless short-names are stored in the $HOME/.cache/containers/short-name-aliases.conf file.
+default list unqualified registries defined in registries.conf. The user's selection is then stored in a cache file to be used in all future short-name expansions. Rootful short-names are stored in /var/cache/containers/short-name-aliases.conf. Rootless short-names are stored in the $HOME/.cache/containers/short-name-aliases.conf file.
 
 For more information on short-names, see `containers-registries.conf(5)`
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -730,7 +730,7 @@ Set the network mode for the container. Invalid if using **--dns**, **--dns-opt*
 
 Valid _mode_ values are:
 
-- **bridge[:OPTIONS,...]**: Create a network stack on the default bridge. This is the default for rootfull containers. It is possible to specify these additional options:
+- **bridge[:OPTIONS,...]**: Create a network stack on the default bridge. This is the default for rootful containers. It is possible to specify these additional options:
   - **alias=name**: Add network-scoped alias for the container.
   - **ip=IPv4**: Specify a static ipv4 address for this container.
   - **ip=IPv6**: Specify a static ipv6 address for this container.
@@ -743,7 +743,7 @@ Valid _mode_ values are:
 - **container:**_id_: Reuse another container's network stack.
 - **host**: Do not create a network namespace, the container will use the host's network. Note: The host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
 - **ns:**_path_: Path to a network namespace to join.
-- **private**: Create a new namespace for the container. This will use the **bridge** mode for rootfull containers and **slirp4netns** for rootless ones.
+- **private**: Create a new namespace for the container. This will use the **bridge** mode for rootful containers and **slirp4netns** for rootless ones.
 - **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
   - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
   - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
@@ -1185,8 +1185,8 @@ option conflicts with the **--userns** and **--subuidname** options. This
 option provides a way to map host UIDs to container UIDs. It can be passed
 several times to map different ranges.
 
-The _from_uid_ value is based upon the user running the command, either rootfull or rootless users.
-* rootfull user:  *container_uid*:*host_uid*:*amount*
+The _from_uid_ value is based upon the user running the command, either rootful or rootless users.
+* rootful user:  *container_uid*:*host_uid*:*amount*
 * rootless user: *container_uid*:*intermediate_uid*:*amount*
 
 When **podman run** is called by a privileged user, the option **--uidmap**

--- a/docs/source/markdown/podman-system-service.1.md
+++ b/docs/source/markdown/podman-system-service.1.md
@@ -9,7 +9,7 @@ podman\-system\-service - Run an API service
 ## DESCRIPTION
 The **podman system service** command creates a listening service that will answer API calls for Podman.  You may
 optionally provide an endpoint for the API in URI form.  For example, *unix:///tmp/foobar.sock* or *tcp:localhost:8080*.
-If no endpoint is provided, defaults will be used.  The default endpoint for a rootfull
+If no endpoint is provided, defaults will be used.  The default endpoint for a rootful
 service is *unix:///run/podman/podman.sock* and rootless is *unix://$XDG_RUNTIME_DIR/podman/podman.sock* (for
 example *unix:///run/user/1000/podman/podman.sock*)
 

--- a/docs/tutorials/basic_networking.md
+++ b/docs/tutorials/basic_networking.md
@@ -7,15 +7,15 @@
 It seems once people master the basics of containers, networking is one of the first
 aspects they begin experimenting with.  And regarding networking, it takes very
 little experimentation before ending up on the deep end of the pool.  The following
-guide shows the most common network setups for Podman rootfull and rootless containers.
+guide shows the most common network setups for Podman rootful and rootless containers.
 Each setup is supported with an example.
 
 
-## Differences between rootfull and rootless container networking
+## Differences between rootful and rootless container networking
 
 One of the guiding factors on networking for containers with Podman is going to be
 whether or not the container is run by a root user or not.  This is because unprivileged
-users cannot create networking interfaces on the host.  Therefore, with rootfull
+users cannot create networking interfaces on the host.  Therefore, with rootful
 containers, the default networking mode is to use netavark.
 For rootless, the default network
 mode is slirp4netns. Because of the limited privileges, slirp4netns lacks some of
@@ -32,13 +32,13 @@ ports being opened automatically due to running a container with a port mapping 
 example).  If container traffic does not seem to work properly, check the firewall
 and allow traffic on ports the container is using. A common problem is that
 reloading the firewall deletes the cni iptables rules resulting in a loss of
-network connectivity for rootfull containers. Podman v3 provides the podman
+network connectivity for rootful containers. Podman v3 provides the podman
 network reload command to restore this without having to restart the container.
 
 ## Basic Network Setups
 
 Most containers and pods being run with Podman adhere to a couple of simple scenarios.
-By default, rootfull Podman will create a bridged network.  This is the most straightforward
+By default, rootful Podman will create a bridged network.  This is the most straightforward
 and preferred network setup for Podman. Bridge networking creates an interface for
 the container on an internal bridge network, which is then connected to the internet
 via Network Address Translation(NAT).  We also see users wanting to use `macvlan`
@@ -79,7 +79,7 @@ command. Containers can be joined to a network when they are created with the
 
 As mentioned earlier, slirp4netns is the default network configuration for rootless
 users.  But as of Podman version 4.0, rootless users can also use netavark.
-The user experience of rootless netavark is very akin to a rootfull netavark, except that
+The user experience of rootless netavark is very akin to a rootful netavark, except that
 there is no default network configuration provided.  You simply need to create a
 network, and the one will be created as a bridge network. If you would like to switch from
 CNI networking to netvaark, you must issue the `podman system reset --force` command.
@@ -95,17 +95,17 @@ will be executed inside an extra network namespace. To join this namespace, use
 
 #### Example
 
-By default, rootfull containers use the netavark for its default network if
+By default, rootful containers use the netavark for its default network if
 you have not migrated from Podman v3.
 In this case, no network name must be passed to Podman.  However, you can create
 additional bridged networks with the podman create command.
 
 The following example shows how to set up a web server and expose it to the network
-outside the host as both rootfull and rootless.  It will also show how an outside
+outside the host as both rootful and rootless.  It will also show how an outside
 client can connect to the container.
 
 ```
-(rootfull) $ sudo podman run -dt --name webserver -p 8080:80 quay.io/libpod/banner
+(rootful) $ sudo podman run -dt --name webserver -p 8080:80 quay.io/libpod/banner
 00f3440c7576aae2d5b193c40513c29c7964e96bf797cf0cc352c2b68ccbe66a
 ```
 
@@ -120,7 +120,7 @@ how the host and container ports can be mapped for external access.  The port co
 very well have been 80 as well (except for rootless users).
 
 To connect from an outside client to the webserver, simply point an HTTP client to
-the host’s IP address at port 8080 for rootfull and port 8081 for rootless.
+the host’s IP address at port 8080 for rootful and port 8081 for rootless.
 ```
 (outside_host): $ curl 192.168.99.109:8080
    ___           __

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -210,7 +210,7 @@ func createBasicSlirp4netnsCmdArgs(options *slirp4netnsNetworkOptions, features 
 	return cmdArgs, nil
 }
 
-// setupSlirp4netns can be called in rootfull as well as in rootless
+// setupSlirp4netns can be called in rootful as well as in rootless
 func (r *Runtime) setupSlirp4netns(ctr *Container, netns ns.NetNS) error {
 	path := r.config.Engine.NetworkCmdPath
 	if path == "" {

--- a/pkg/bindings/README.md
+++ b/pkg/bindings/README.md
@@ -9,7 +9,7 @@ The bindings require that the Podman system service is running for the specified
 by calling the service directly.
 
 ### Starting the service with system
-The command to start the Podman service differs slightly depending on the user that is running the service.  For a rootfull service,
+The command to start the Podman service differs slightly depending on the user that is running the service.  For a rootful service,
 start the service like this:
 ```
 # systemctl start podman.socket
@@ -26,7 +26,7 @@ It can be handy to run the system service manually.  Doing so allows you to enab
 $ podman --log-level=debug system service -t0
 ```
 If you do not provide a specific path for the socket, a default is provided.  The location of that socket for
-rootfull connections is `/run/podman/podman.sock` and for rootless it is `/run/USERID#/podman/podman.sock`. For more
+rootful connections is `/run/podman/podman.sock` and for rootless it is `/run/USERID#/podman/podman.sock`. For more
 information about the Podman system service, see `man podman-system-service`.
 
 ### Creating a connection
@@ -35,7 +35,7 @@ as they will be required to compile a Go program making use of the bindings.
 
 
 The first step for using the bindings is to create a connection to the socket.  As mentioned earlier, the destination
-of the socket depends on the user who owns it. In this case, a rootfull connection is made.
+of the socket depends on the user who owns it. In this case, a rootful connection is made.
 
 ```
 import (
@@ -59,7 +59,7 @@ The `conn` variable returned from the `bindings.NewConnection` function can then
 to interact with containers.
 
 ### Examples
-The following examples build upon the connection example from above.  They are all rootfull connections as well.
+The following examples build upon the connection example from above.  They are all rootful connections as well.
 
 Note: Optional arguments to the bindings methods are set using With*() methods on *Option structures.
 Composite types are not duplicated rather the address is used. As such, you should not change an underlying

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -367,7 +367,7 @@ func (ir *ImageEngine) Transfer(ctx context.Context, source entities.ImageScpOpt
 	if rootless.IsRootless() && (len(dest.User) == 0 || dest.User == "root") { // if we are rootless and do not have a destination user we can just use sudo
 		return transferRootless(source, dest, podman, parentFlags)
 	}
-	return transferRootfull(source, dest, podman, parentFlags)
+	return transferRootful(source, dest, podman, parentFlags)
 }
 
 func (ir *ImageEngine) Tag(ctx context.Context, nameOrID string, tags []string, options entities.ImageTagOptions) error {
@@ -785,8 +785,8 @@ func transferRootless(source entities.ImageScpOptions, dest entities.ImageScpOpt
 	return cmdLoad.Run()
 }
 
-// transferRootfull creates new podman processes using exec.Command and a new uid/gid alongside a cleared environment
-func transferRootfull(source entities.ImageScpOptions, dest entities.ImageScpOptions, podman string, parentFlags []string) error {
+// TransferRootful creates new podman processes using exec.Command and a new uid/gid alongside a cleared environment
+func transferRootful(source entities.ImageScpOptions, dest entities.ImageScpOptions, podman string, parentFlags []string) error {
 	basicCommand := []string{podman}
 	basicCommand = append(basicCommand, parentFlags...)
 	saveCommand := append(basicCommand, "save")

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -28,7 +28,7 @@ type InitOptions struct {
 	URI          url.URL
 	Username     string
 	ReExec       bool
-	Rootfull     bool
+	Rootful      bool
 	// The numerical userid of the user that called machine
 	UID string
 }
@@ -95,7 +95,7 @@ type ListResponse struct {
 }
 
 type SetOptions struct {
-	Rootfull bool
+	Rootful bool
 }
 
 type SSHOptions struct {

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -57,8 +57,8 @@ type MachineVMV1 struct {
 	QMPMonitor Monitorv1
 	// RemoteUsername of the vm user
 	RemoteUsername string
-	// Whether this machine should run in a rootfull or rootless manner
-	Rootfull bool
+	// Whether this machine should run in a rootful or rootless manner
+	Rootful bool
 	// UID is the numerical id of the user that called machine
 	UID int
 }
@@ -99,8 +99,8 @@ type ImageConfig struct {
 
 // HostUser describes the host user
 type HostUser struct {
-	// Whether this machine should run in a rootfull or rootless manner
-	Rootfull bool
+	// Whether this machine should run in a rootful or rootless manner
+	Rootful bool
 	// UID is the numerical id of the user that called machine
 	UID int
 }

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -204,7 +204,7 @@ func migrateVM(configPath string, config []byte, vm *MachineVM) error {
 	vm.QMPMonitor = qmpMonitor
 	vm.ReadySocket = readySocket
 	vm.RemoteUsername = old.RemoteUsername
-	vm.Rootfull = old.Rootfull
+	vm.Rootful = old.Rootful
 	vm.UID = old.UID
 
 	// Backup the original config file
@@ -258,7 +258,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	)
 	sshDir := filepath.Join(homedir.Get(), ".ssh")
 	v.IdentityPath = filepath.Join(sshDir, v.Name)
-	v.Rootfull = opts.Rootfull
+	v.Rootful = opts.Rootful
 
 	switch opts.ImagePath {
 	case Testing, Next, Stable, "":
@@ -356,8 +356,8 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 		names := []string{v.Name, v.Name + "-root"}
 
 		// The first connection defined when connections is empty will become the default
-		// regardless of IsDefault, so order according to rootfull
-		if opts.Rootfull {
+		// regardless of IsDefault, so order according to rootful
+		if opts.Rootful {
 			uris[0], names[0], uris[1], names[1] = uris[1], names[1], uris[0], names[0]
 		}
 
@@ -435,7 +435,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 }
 
 func (v *MachineVM) Set(_ string, opts machine.SetOptions) error {
-	if v.Rootfull == opts.Rootfull {
+	if v.Rootful == opts.Rootful {
 		return nil
 	}
 
@@ -459,7 +459,7 @@ func (v *MachineVM) Set(_ string, opts machine.SetOptions) error {
 
 	if changeCon {
 		newDefault := v.Name
-		if opts.Rootfull {
+		if opts.Rootful {
 			newDefault += "-root"
 		}
 		if err := machine.ChangeDefault(newDefault); err != nil {
@@ -467,7 +467,7 @@ func (v *MachineVM) Set(_ string, opts machine.SetOptions) error {
 		}
 	}
 
-	v.Rootfull = opts.Rootfull
+	v.Rootful = opts.Rootful
 	return v.writeConfig()
 }
 
@@ -1117,7 +1117,7 @@ func (v *MachineVM) setupAPIForwarding(cmd []string) ([]string, string, apiForwa
 	destSock := fmt.Sprintf("/run/user/%d/podman/podman.sock", v.UID)
 	forwardUser := "core"
 
-	if v.Rootfull {
+	if v.Rootful {
 		destSock = "/run/podman/podman.sock"
 		forwardUser = "root"
 	}
@@ -1323,11 +1323,11 @@ func (v *MachineVM) waitAPIAndPrintInfo(forwardState apiForwardingState, forward
 	}
 
 	waitAndPingAPI(forwardSock)
-	if !v.Rootfull {
+	if !v.Rootful {
 		fmt.Printf("\nThis machine is currently configured in rootless mode. If your containers\n")
 		fmt.Printf("require root permissions (e.g. ports < 1024), or if you run into compatibility\n")
 		fmt.Printf("issues with non-podman clients, you can switch using the following command: \n")
-		fmt.Printf("\n\tpodman machine set --rootfull%s\n\n", suffix)
+		fmt.Printf("\n\tpodman machine set --rootful%s\n\n", suffix)
 	}
 
 	fmt.Printf("API forwarding listening on: %s\n", forwardSock)

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -165,8 +165,8 @@ type MachineVM struct {
 	Port int
 	// RemoteUsername of the vm user
 	RemoteUsername string
-	// Whether this machine should run in a rootfull or rootless manner
-	Rootfull bool
+	// Whether this machine should run in a rootful or rootless manner
+	Rootful bool
 }
 
 type ExitCodeError struct {
@@ -232,7 +232,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	homeDir := homedir.Get()
 	sshDir := filepath.Join(homeDir, ".ssh")
 	v.IdentityPath = filepath.Join(sshDir, v.Name)
-	v.Rootfull = opts.Rootfull
+	v.Rootful = opts.Rootful
 
 	if err := downloadDistro(v, opts); err != nil {
 		return false, err
@@ -316,8 +316,8 @@ func setupConnections(v *MachineVM, opts machine.InitOptions, sshDir string) err
 	names := []string{v.Name, v.Name + "-root"}
 
 	// The first connection defined when connections is empty will become the default
-	// regardless of IsDefault, so order according to rootfull
-	if opts.Rootfull {
+	// regardless of IsDefault, so order according to rootful
+	if opts.Rootful {
 		uris[0], names[0], uris[1], names[1] = uris[1], names[1], uris[0], names[0]
 	}
 
@@ -733,7 +733,7 @@ func pipeCmdPassThrough(name string, input string, arg ...string) error {
 }
 
 func (v *MachineVM) Set(name string, opts machine.SetOptions) error {
-	if v.Rootfull == opts.Rootfull {
+	if v.Rootful == opts.Rootful {
 		return nil
 	}
 
@@ -744,7 +744,7 @@ func (v *MachineVM) Set(name string, opts machine.SetOptions) error {
 
 	if changeCon {
 		newDefault := v.Name
-		if opts.Rootfull {
+		if opts.Rootful {
 			newDefault += "-root"
 		}
 		if err := machine.ChangeDefault(newDefault); err != nil {
@@ -752,7 +752,7 @@ func (v *MachineVM) Set(name string, opts machine.SetOptions) error {
 		}
 	}
 
-	v.Rootfull = opts.Rootfull
+	v.Rootful = opts.Rootful
 	return v.writeConfig()
 }
 
@@ -768,7 +768,7 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		return errors.Wrap(err, "WSL bootstrap script failed")
 	}
 
-	if !v.Rootfull {
+	if !v.Rootful {
 		fmt.Printf("\nThis machine is currently configured in rootless mode. If your containers\n")
 		fmt.Printf("require root permissions (e.g. ports < 1024), or if you run into compatibility\n")
 		fmt.Printf("issues with non-podman clients, you can switch using the following command: \n")
@@ -777,7 +777,7 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		if name != machine.DefaultMachineName {
 			suffix = " " + name
 		}
-		fmt.Printf("\n\tpodman machine set --rootfull%s\n\n", suffix)
+		fmt.Printf("\n\tpodman machine set --rootful%s\n\n", suffix)
 	}
 
 	globalName, pipeName, err := launchWinProxy(v)
@@ -833,7 +833,7 @@ func launchWinProxy(v *MachineVM) (bool, string, error) {
 	destSock := "/run/user/1000/podman/podman.sock"
 	forwardUser := v.RemoteUsername
 
-	if v.Rootfull {
+	if v.Rootful {
 		destSock = "/run/podman/podman.sock"
 		forwardUser = "root"
 	}

--- a/rootless.md
+++ b/rootless.md
@@ -18,7 +18,7 @@ can easily fail
 * Some system unit configuration options do not work in the rootless container
   * systemd fails to apply several options and failures are silently ignored (e.g. CPUShares, MemoryLimit). Should work on cgroup V2.
   * Use of certain options will cause service startup failures (e.g. PrivateNetwork).  The systemd services requiring `PrivateNetwork` can be made to work by passing `--cap-add SYS_ADMIN`, but the security implications should be carefully evaluated.  In most cases, it's better to create an override.conf drop-in that sets `PrivateNetwork=no`.  This also applies to containers run by root.
-* Can not share container images with CRI-O or other rootfull users
+* Can not share container images with CRI-O or other rootful users
 * Difficult to use additional stores for sharing content
 * Does not work on NFS or parallel filesystem homedirs (e.g. [GPFS](https://www.ibm.com/support/knowledgecenter/en/SSFKCN/gpfs_welcome.html))
   * NFS and parallel filesystems enforce file creation on different UIDs on the server side and does not understand User Namespace.

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec in keep-id container drops privileges", func() {
-		SkipIfNotRootless("This function is not enabled for rootfull podman")
+		SkipIfNotRootless("This function is not enabled for rootful podman")
 		ctrName := "testctr1"
 		testCtr := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, "--userns=keep-id", ALPINE, "top"})
 		testCtr.WaitWithDefaultTimeout()

--- a/test/e2e/mount_rootless_test.go
+++ b/test/e2e/mount_rootless_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Podman mount", func() {
 	)
 
 	BeforeEach(func() {
-		SkipIfNotRootless("This function is not enabled for rootfull podman")
+		SkipIfNotRootless("This function is not enabled for rootful podman")
 		SkipIfRemote("Podman mount not supported for remote connections")
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Podman network", func() {
 
 		expectedNetworks := []string{name}
 		if !rootless.IsRootless() {
-			// rootfull image contains "podman/cni/87-podman-bridge.conflist" for "podman" network
+			// rootful image contains "podman/cni/87-podman-bridge.conflist" for "podman" network
 			expectedNetworks = append(expectedNetworks, "podman")
 		}
 		session := podmanTest.Podman(append([]string{"network", "inspect"}, expectedNetworks...))

--- a/test/system/270-socket-activation.bats
+++ b/test/system/270-socket-activation.bats
@@ -90,7 +90,7 @@ function teardown() {
 
 @test "podman system service - socket activation - kill rootless pause" {
     if ! is_rootless; then
-        skip "there is no pause process when running rootfull"
+        skip "there is no pause process when running rootful"
     fi
     run_podman run -d $IMAGE sleep 90
     cid="$output"

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -83,7 +83,7 @@ load helpers
 }
 
 # Issue #5466 - port-forwarding doesn't work with this option and -d
-@test "podman networking: port with --userns=keep-id for rootless or --uidmap=* for rootfull" {
+@test "podman networking: port with --userns=keep-id for rootless or --uidmap=* for rootful" {
     for cidr in "" "$(random_rfc1918_subnet).0/24"; do
         myport=$(random_free_port 52000-52999)
         if [[ -z $cidr ]]; then

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -483,7 +483,7 @@ function skip_if_root_ubuntu {
     if is_ubuntu; then
         if ! is_remote; then
             if ! is_rootless; then
-                 skip "Cannot run this test on rootfull ubuntu, usually due to user errors"
+                 skip "Cannot run this test on rootful ubuntu, usually due to user errors"
             fi
         fi
     fi

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -423,7 +423,7 @@ function skip_if_rootless() {
 ######################
 function skip_if_not_rootless() {
     if ! is_rootless; then
-        local msg=$(_add_label_if_missing "$1" "rootfull")
+        local msg=$(_add_label_if_missing "$1" "rootful")
         skip "${msg:-not applicable under rootlfull podman}"
     fi
 }


### PR DESCRIPTION
This reverts commit cc3790f332d989440eb1720e24e3619fc97c74ee. And changes more docs. 

We can't change rootful to rootfull because `rootful` is written into the machine config. Changing this will break json unmarshalling, which will break existing machines.

[NO NEW TESTS NEEDED]

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
