### PR TITLE
enable gocritic linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,6 @@ linters:
     - lll
     - unconvert
     - errcheck
-    - gocritic
     - gosec
     - maligned
     - gomoddirectives

--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -327,7 +327,7 @@ func suffixCompSlice(suf string, slice []string) []string {
 		if len(split) > 1 {
 			slice[i] = split[0] + suf + "\t" + split[1]
 		} else {
-			slice[i] = slice[i] + suf
+			slice[i] += suf
 		}
 	}
 	return slice
@@ -647,7 +647,10 @@ func AutocompleteInspect(cmd *cobra.Command, args []string, toComplete string) (
 	pods, _ := getPods(cmd, toComplete, completeDefault)
 	networks, _ := getNetworks(cmd, toComplete, completeDefault)
 	volumes, _ := getVolumes(cmd, toComplete)
-	suggestions := append(containers, images...)
+
+	suggestions := make([]string, 0, len(containers)+len(images)+len(pods)+len(networks)+len(volumes))
+	suggestions = append(suggestions, containers...)
+	suggestions = append(suggestions, images...)
 	suggestions = append(suggestions, pods...)
 	suggestions = append(suggestions, networks...)
 	suggestions = append(suggestions, volumes...)
@@ -961,6 +964,8 @@ func AutocompleteFormat(o interface{}) func(cmd *cobra.Command, args []string, t
 	// this function provides shell completion for go templates
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		// autocomplete json when nothing or json is typed
+		// gocritic complains about the argument order but this is correct in this case
+		//nolint:gocritic
 		if strings.HasPrefix("json", toComplete) {
 			return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -896,7 +896,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(memorySwappinessFlagName, completion.AutocompleteNone)
 	}
-	//anyone can use these
+	// anyone can use these
 	cpusFlagName := "cpus"
 	createFlags.Float64Var(
 		&cf.CPUS,

--- a/cmd/podman/completion/completion.go
+++ b/cmd/podman/completion/completion.go
@@ -31,7 +31,7 @@ var (
 		Example: `podman completion bash
   podman completion zsh -f _podman
   podman completion fish --no-desc`,
-		//don't show this command to users
+		// don't show this command to users
 		Hidden: true,
 	}
 )

--- a/cmd/podman/images/scp.go
+++ b/cmd/podman/images/scp.go
@@ -121,13 +121,8 @@ func scp(cmd *cobra.Command, args []string) (finalErr error) {
 			return err
 		}
 		if flipConnections { // the order of cliConnections matters, we need to flip both arrays since the args are parsed separately sometimes.
-			connect := cliConnections[0]
-			cliConnections[0] = cliConnections[1]
-			cliConnections[1] = connect
-
-			loc := locations[0]
-			locations[0] = locations[1]
-			locations[1] = loc
+			cliConnections[0], cliConnections[1] = cliConnections[1], cliConnections[0]
+			locations[0], locations[1] = locations[1], locations[0]
 		}
 		dest = *locations[1]
 	case len(locations) == 1:

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -224,7 +224,8 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 	sort.Ints(vals)
 	for ind, core := range vals {
-		if core > int(cpuSet) {
+		switch {
+		case core > int(cpuSet):
 			if copy == "" {
 				copy = "0-" + strconv.Itoa(int(cpuSet))
 				infraOptions.CPUSetCPUs = copy
@@ -233,9 +234,9 @@ func create(cmd *cobra.Command, args []string) error {
 				infraOptions.CPUSetCPUs = copy
 				break
 			}
-		} else if ind != 0 {
+		case ind != 0:
 			copy += "," + strconv.Itoa(core)
-		} else {
+		default:
 			copy = "" + strconv.Itoa(core)
 		}
 	}

--- a/cmd/podman/secrets/create.go
+++ b/cmd/podman/secrets/create.go
@@ -62,13 +62,14 @@ func create(cmd *cobra.Command, args []string) error {
 	path := args[1]
 
 	var reader io.Reader
-	if env {
+	switch {
+	case env:
 		envValue := os.Getenv(path)
 		if envValue == "" {
 			return errors.Errorf("cannot create store secret data: environment variable %s is not set", path)
 		}
 		reader = strings.NewReader(envValue)
-	} else if path == "-" || path == "/dev/stdin" {
+	case path == "-" || path == "/dev/stdin":
 		stat, err := os.Stdin.Stat()
 		if err != nil {
 			return err
@@ -77,7 +78,7 @@ func create(cmd *cobra.Command, args []string) error {
 			return errors.New("if `-` is used, data must be passed into stdin")
 		}
 		reader = os.Stdin
-	} else {
+	default:
 		file, err := os.Open(path)
 		if err != nil {
 			return err

--- a/cmd/podman/system/migrate.go
+++ b/cmd/podman/system/migrate.go
@@ -69,6 +69,10 @@ func migrate(cmd *cobra.Command, args []string) {
 	err = engine.Migrate(registry.Context(), cmd.Flags(), registry.PodmanConfig(), migrateOptions)
 	if err != nil {
 		fmt.Println(err)
+
+		// FIXME change this to return the error like other commands
+		// defer will never run on os.Exit()
+		//nolint:gocritic
 		os.Exit(define.ExecErrorCodeGeneric)
 	}
 	os.Exit(0)

--- a/cmd/podman/system/renumber.go
+++ b/cmd/podman/system/renumber.go
@@ -56,6 +56,9 @@ func renumber(cmd *cobra.Command, args []string) {
 	err = engine.Renumber(registry.Context(), cmd.Flags(), registry.PodmanConfig())
 	if err != nil {
 		fmt.Println(err)
+		// FIXME change this to return the error like other commands
+		// defer will never run on os.Exit()
+		//nolint:gocritic
 		os.Exit(define.ExecErrorCodeGeneric)
 	}
 	os.Exit(0)

--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -95,6 +95,9 @@ func reset(cmd *cobra.Command, args []string) {
 
 	if err := engine.Reset(registry.Context()); err != nil {
 		logrus.Error(err)
+		// FIXME change this to return the error like other commands
+		// defer will never run on os.Exit()
+		//nolint:gocritic
 		os.Exit(define.ExecErrorCodeGeneric)
 	}
 	os.Exit(0)

--- a/cmd/podman/utils/alias.go
+++ b/cmd/podman/utils/alias.go
@@ -37,8 +37,7 @@ func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 
 // TimeoutAliasFlags is a function to handle backwards compatibility with old timeout flags
 func TimeoutAliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
-	switch name {
-	case "timeout":
+	if name == "timeout" {
 		name = "time"
 	}
 	return pflag.NormalizedName(name)

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1180,7 +1180,7 @@ func (c *Container) Umask() string {
 	return c.config.Umask
 }
 
-//Secrets return the secrets in the container
+// Secrets return the secrets in the container
 func (c *Container) Secrets() []*ContainerSecret {
 	return c.config.Secrets
 }

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -229,8 +229,7 @@ func (c *Container) Kill(signal uint) error {
 // This function returns when the attach finishes. It does not hold the lock for
 // the duration of its runtime, only using it at the beginning to verify state.
 func (c *Container) Attach(streams *define.AttachStreams, keys string, resize <-chan define.TerminalSize) error {
-	switch c.LogDriver() {
-	case define.PassthroughLogging:
+	if c.LogDriver() == define.PassthroughLogging {
 		return errors.Wrapf(define.ErrNoLogs, "this container is using the 'passthrough' log driver, cannot attach")
 	}
 	if !c.batched {

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -817,16 +817,16 @@ func (c *Container) Exec(config *ExecConfig, streams *define.AttachStreams, resi
 // Please be careful when using this function since it might temporarily unlock
 // the container when os.RemoveAll($bundlePath) fails with ENOTEMPTY or EBUSY
 // errors.
-func (c *Container) cleanupExecBundle(sessionID string) (Err error) {
+func (c *Container) cleanupExecBundle(sessionID string) (err error) {
 	path := c.execBundlePath(sessionID)
 	for attempts := 0; attempts < 50; attempts++ {
-		Err = os.RemoveAll(path)
-		if Err == nil || os.IsNotExist(Err) {
+		err = os.RemoveAll(path)
+		if err == nil || os.IsNotExist(err) {
 			return nil
 		}
-		if pathErr, ok := Err.(*os.PathError); ok {
-			Err = pathErr.Err
-			if errors.Cause(Err) == unix.ENOTEMPTY || errors.Cause(Err) == unix.EBUSY {
+		if pathErr, ok := err.(*os.PathError); ok {
+			err = pathErr.Err
+			if errors.Cause(err) == unix.ENOTEMPTY || errors.Cause(err) == unix.EBUSY {
 				// give other processes a chance to use the container
 				if !c.batched {
 					if err := c.save(); err != nil {

--- a/libpod/container_stat_linux.go
+++ b/libpod/container_stat_linux.go
@@ -94,15 +94,16 @@ func (c *Container) stat(containerMountPoint string, containerPath string) (*def
 		}
 	}
 
-	if statInfo.IsSymlink {
+	switch {
+	case statInfo.IsSymlink:
 		// Symlinks are already evaluated and always relative to the
 		// container's mount point.
 		absContainerPath = statInfo.ImmediateTarget
-	} else if strings.HasPrefix(resolvedPath, containerMountPoint) {
+	case strings.HasPrefix(resolvedPath, containerMountPoint):
 		// If the path is on the container's mount point, strip it off.
 		absContainerPath = strings.TrimPrefix(resolvedPath, containerMountPoint)
 		absContainerPath = filepath.Join("/", absContainerPath)
-	} else {
+	default:
 		// No symlink and not on the container's mount point, so let's
 		// move it back to the original input.  It must have evaluated
 		// to a volume or bind mount but we cannot return host paths.

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -100,7 +100,7 @@ type InspectRestartPolicy struct {
 // InspectLogConfig holds information about a container's configured log driver
 type InspectLogConfig struct {
 	Type   string            `json:"Type"`
-	Config map[string]string `json:"Config"` //idk type, TODO
+	Config map[string]string `json:"Config"`
 	// Path specifies a path to the log file
 	Path string `json:"Path"`
 	// Tag specifies a custom log tag for the container
@@ -680,7 +680,7 @@ type InspectContainerData struct {
 	SizeRootFs      int64                       `json:"SizeRootFs,omitempty"`
 	Mounts          []InspectMount              `json:"Mounts"`
 	Dependencies    []string                    `json:"Dependencies"`
-	NetworkSettings *InspectNetworkSettings     `json:"NetworkSettings"` //TODO
+	NetworkSettings *InspectNetworkSettings     `json:"NetworkSettings"`
 	Namespace       string                      `json:"Namespace"`
 	IsInfra         bool                        `json:"IsInfra"`
 	Config          *InspectContainerConfig     `json:"Config"`

--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -12,7 +12,7 @@ type Info struct {
 	Version    Version                `json:"version"`
 }
 
-//HostInfo describes the libpod host
+// HostInfo describes the libpod host
 type SecurityInfo struct {
 	AppArmorEnabled     bool   `json:"apparmorEnabled"`
 	DefaultCapabilities string `json:"capabilities"`

--- a/libpod/logs/log.go
+++ b/libpod/logs/log.go
@@ -28,7 +28,7 @@ const (
 	// FullLogType signifies a log line is full
 	FullLogType = "F"
 
-	//ANSIEscapeResetCode is a code that resets all colors and text effects
+	// ANSIEscapeResetCode is a code that resets all colors and text effects
 	ANSIEscapeResetCode = "\033[0m"
 )
 
@@ -167,7 +167,7 @@ func getTailLog(path string, tail int) ([]*LogLine, error) {
 	return tailLog, nil
 }
 
-//getColor returns a ANSI escape code for color based on the colorID
+// getColor returns a ANSI escape code for color based on the colorID
 func getColor(colorID int64) string {
 	colors := map[int64]string{
 		0: "\033[37m", // Light Gray

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -579,7 +579,7 @@ func (r *Runtime) GetRootlessNetNs(new bool) (*RootlessNetNS, error) {
 	// lets add /usr/sbin to $PATH ourselves.
 	path = os.Getenv("PATH")
 	if !strings.Contains(path, "/usr/sbin") {
-		path = path + ":/usr/sbin"
+		path += ":/usr/sbin"
 		os.Setenv("PATH", path)
 	}
 
@@ -1148,7 +1148,7 @@ func resultToBasicNetworkConfig(result types.StatusBlock) define.InspectBasicNet
 		for _, netAddress := range netInt.Subnets {
 			size, _ := netAddress.IPNet.Mask.Size()
 			if netAddress.IPNet.IP.To4() != nil {
-				//ipv4
+				// ipv4
 				if config.IPAddress == "" {
 					config.IPAddress = netAddress.IPNet.IP.String()
 					config.IPPrefixLen = size
@@ -1157,7 +1157,7 @@ func resultToBasicNetworkConfig(result types.StatusBlock) define.InspectBasicNet
 					config.SecondaryIPAddresses = append(config.SecondaryIPAddresses, define.Address{Addr: netAddress.IPNet.IP.String(), PrefixLength: size})
 				}
 			} else {
-				//ipv6
+				// ipv6
 				if config.GlobalIPv6Address == "" {
 					config.GlobalIPv6Address = netAddress.IPNet.IP.String()
 					config.GlobalIPv6PrefixLen = size
@@ -1508,7 +1508,7 @@ func ocicniPortsToNetTypesPorts(ports []types.OCICNIPortMapping) []types.PortMap
 			ports[i].Protocol == currentPort.Protocol &&
 			ports[i].HostPort-int32(currentPort.Range) == int32(currentPort.HostPort) &&
 			ports[i].ContainerPort-int32(currentPort.Range) == int32(currentPort.ContainerPort) {
-			currentPort.Range = currentPort.Range + 1
+			currentPort.Range++
 		} else {
 			newPorts = append(newPorts, currentPort)
 			currentPort = types.PortMapping{

--- a/libpod/networking_machine.go
+++ b/libpod/networking_machine.go
@@ -33,9 +33,9 @@ type machineExpose struct {
 func requestMachinePorts(expose bool, ports []types.PortMapping) error {
 	url := "http://" + machineGvproxyEndpoint + "/services/forwarder/"
 	if expose {
-		url = url + "expose"
+		url += "expose"
 	} else {
-		url = url + "unexpose"
+		url += "unexpose"
 	}
 	ctx := context.Background()
 	client := &http.Client{

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -82,7 +82,9 @@ func checkSlirpFlags(path string) (*slirpFeatures, error) {
 }
 
 func parseSlirp4netnsNetworkOptions(r *Runtime, extraOptions []string) (*slirp4netnsNetworkOptions, error) {
-	slirpOptions := append(r.config.Engine.NetworkCmdOptions, extraOptions...)
+	slirpOptions := make([]string, 0, len(r.config.Engine.NetworkCmdOptions)+len(extraOptions))
+	slirpOptions = append(slirpOptions, r.config.Engine.NetworkCmdOptions...)
+	slirpOptions = append(slirpOptions, extraOptions...)
 	slirp4netnsOpts := &slirp4netnsNetworkOptions{
 		// overwrite defaults
 		disableHostLoopback: true,

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -766,13 +766,11 @@ func prepareProcessExec(c *Container, options *ExecOptions, env []string, sessio
 	if execUser.Uid == 0 {
 		pspec.Capabilities.Effective = pspec.Capabilities.Bounding
 		pspec.Capabilities.Permitted = pspec.Capabilities.Bounding
-	} else {
-		if user == c.config.User {
-			pspec.Capabilities.Effective = ctrSpec.Process.Capabilities.Effective
-			pspec.Capabilities.Inheritable = ctrSpec.Process.Capabilities.Effective
-			pspec.Capabilities.Permitted = ctrSpec.Process.Capabilities.Effective
-			pspec.Capabilities.Ambient = ctrSpec.Process.Capabilities.Effective
-		}
+	} else if user == c.config.User {
+		pspec.Capabilities.Effective = ctrSpec.Process.Capabilities.Effective
+		pspec.Capabilities.Inheritable = ctrSpec.Process.Capabilities.Effective
+		pspec.Capabilities.Permitted = ctrSpec.Process.Capabilities.Effective
+		pspec.Capabilities.Ambient = ctrSpec.Process.Capabilities.Effective
 	}
 
 	hasHomeSet := false

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1371,7 +1371,7 @@ func (r *ConmonOCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, p
 	case define.JSONLogging:
 		fallthrough
 	//lint:ignore ST1015 the default case has to be here
-	default: //nolint:stylecheck
+	default: //nolint:stylecheck,gocritic
 		// No case here should happen except JSONLogging, but keep this here in case the options are extended
 		logrus.Errorf("%s logging specified but not supported. Choosing k8s-file logging instead", ctr.LogDriver())
 		fallthrough

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1662,7 +1662,7 @@ func WithTimezone(path string) CtrCreateOption {
 			if err != nil {
 				return err
 			}
-			//We don't want to mount a timezone directory
+			// We don't want to mount a timezone directory
 			if file.IsDir() {
 				return errors.New("Invalid timezone: is a directory")
 			}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -550,6 +550,10 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 				// Check if the pause process was created.  If it was created, then
 				// move it to its own systemd scope.
 				utils.MovePauseProcessToScope(pausePid)
+
+				// gocritic complains because defer is not run on os.Exit()
+				// However this is fine because the lock is released anyway when the process exits
+				//nolint:gocritic
 				os.Exit(ret)
 			}
 		}

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -293,9 +293,10 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 		stateStr = "created"
 	}
 
-	if state == define.ContainerStateConfigured || state == define.ContainerStateCreated {
+	switch state {
+	case define.ContainerStateConfigured, define.ContainerStateCreated:
 		status = "Created"
-	} else if state == define.ContainerStateStopped || state == define.ContainerStateExited {
+	case define.ContainerStateStopped, define.ContainerStateExited:
 		exitCode, _, err := l.ExitCode()
 		if err != nil {
 			return nil, err
@@ -305,7 +306,7 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 			return nil, err
 		}
 		status = fmt.Sprintf("Exited (%d) %s ago", exitCode, units.HumanDuration(time.Since(finishedTime)))
-	} else if state == define.ContainerStateRunning || state == define.ContainerStatePaused {
+	case define.ContainerStateRunning, define.ContainerStatePaused:
 		startedTime, err := l.StartedTime()
 		if err != nil {
 			return nil, err
@@ -314,11 +315,11 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 		if state == define.ContainerStatePaused {
 			status += " (Paused)"
 		}
-	} else if state == define.ContainerStateRemoving {
+	case define.ContainerStateRemoving:
 		status = "Removal In Progress"
-	} else if state == define.ContainerStateStopping {
+	case define.ContainerStateStopping:
 		status = "Stopping"
-	} else {
+	default:
 		status = "Unknown"
 	}
 

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -532,7 +532,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
 		return
 	}
-	if len(query.Names) <= 0 {
+	if len(query.Names) == 0 {
 		utils.Error(w, http.StatusBadRequest, fmt.Errorf("no images to download"))
 		return
 	}

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -286,7 +286,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 				}
-				secrets = append(secrets, strings.Join(modifiedOpt[:], ","))
+				secrets = append(secrets, strings.Join(modifiedOpt, ","))
 			}
 		}
 	}

--- a/pkg/api/handlers/compat/images_prune.go
+++ b/pkg/api/handlers/compat/images_prune.go
@@ -58,7 +58,7 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 		idr = append(idr, types.ImageDeleteResponseItem{
 			Deleted: p.Id,
 		})
-		reclaimedSpace = reclaimedSpace + p.Size
+		reclaimedSpace += p.Size
 	}
 	if errorMsg.Len() > 0 {
 		utils.InternalServerError(w, errors.New(errorMsg.String()))

--- a/pkg/api/handlers/utils/handler.go
+++ b/pkg/api/handlers/utils/handler.go
@@ -150,7 +150,7 @@ func MarshalErrorJSONIsEmpty(ptr unsafe.Pointer) bool {
 }
 
 func MarshalErrorSliceJSONIsEmpty(ptr unsafe.Pointer) bool {
-	return len(*((*[]error)(ptr))) <= 0
+	return len(*((*[]error)(ptr))) == 0
 }
 
 // WriteJSON writes an interface value encoded as JSON to w

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -225,10 +225,8 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 			platform = "linux"
 		}
 		platform += "/" + options.Architecture
-	} else {
-		if len(platform) > 0 {
-			platform += "/" + runtime.GOARCH
-		}
+	} else if len(platform) > 0 {
+		platform += "/" + runtime.GOARCH
 	}
 	if len(platform) > 0 {
 		params.Set("platform", platform)
@@ -447,7 +445,7 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 						}
 					}
 				}
-				secretsForRemote = append(secretsForRemote, strings.Join(modifiedOpt[:], ","))
+				secretsForRemote = append(secretsForRemote, strings.Join(modifiedOpt, ","))
 			}
 		}
 
@@ -603,8 +601,8 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 					// are required to visit all files. :(
 					return nil
 				}
-
-				if d.Type().IsRegular() { // add file item
+				switch {
+				case d.Type().IsRegular(): // add file item
 					info, err := d.Info()
 					if err != nil {
 						return err
@@ -644,7 +642,7 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 						seen[di] = name
 					}
 					return err
-				} else if d.IsDir() { // add folders
+				case d.IsDir(): // add folders
 					info, err := d.Info()
 					if err != nil {
 						return err
@@ -658,7 +656,7 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 					if lerr := tw.WriteHeader(hdr); lerr != nil {
 						return lerr
 					}
-				} else if d.Type()&os.ModeSymlink != 0 { // add symlinks as it, not content
+				case d.Type()&os.ModeSymlink != 0: // add symlinks as it, not content
 					link, err := os.Readlink(path)
 					if err != nil {
 						return err

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -177,7 +177,7 @@ type PullOptions struct {
 	Variant *string
 }
 
-//BuildOptions are optional options for building images
+// BuildOptions are optional options for building images
 type BuildOptions struct {
 	buildahDefine.BuildOptions
 }

--- a/pkg/bindings/network/network.go
+++ b/pkg/bindings/network/network.go
@@ -101,7 +101,7 @@ func List(ctx context.Context, options *ListOptions) ([]types.Network, error) {
 }
 
 // Disconnect removes a container from a given network
-func Disconnect(ctx context.Context, networkName string, ContainerNameOrID string, options *DisconnectOptions) error {
+func Disconnect(ctx context.Context, networkName string, containerNameOrID string, options *DisconnectOptions) error {
 	if options == nil {
 		options = new(DisconnectOptions)
 	}
@@ -114,7 +114,7 @@ func Disconnect(ctx context.Context, networkName string, ContainerNameOrID strin
 		Container string
 		Force     bool
 	}{
-		Container: ContainerNameOrID,
+		Container: containerNameOrID,
 	}
 	if force := options.GetForce(); options.Changed("Force") {
 		disconnect.Force = force

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -104,9 +104,9 @@ var _ = Describe("Podman containers ", func() {
 		// Pause by name
 		err = containers.Pause(bt.conn, name, nil)
 		Expect(err).To(BeNil(), "error from containers.Pause()")
-		//paused := "paused"
-		//_, err = containers.Wait(bt.conn, cid, &paused)
-		//Expect(err).To(BeNil())
+		// paused := "paused"
+		// _, err = containers.Wait(bt.conn, cid, &paused)
+		// Expect(err).To(BeNil())
 		err = containers.Unpause(bt.conn, name, nil)
 		Expect(err).To(BeNil())
 
@@ -332,8 +332,8 @@ var _ = Describe("Podman containers ", func() {
 		// TODO for the life of me, i cannot get this to work. maybe another set
 		// of eyes will
 		// successful healthcheck
-		//status := define.HealthCheckHealthy
-		//for i:=0; i < 10; i++ {
+		// status := define.HealthCheckHealthy
+		// for i:=0; i < 10; i++ {
 		//	result, err := containers.RunHealthCheck(connText, "hc")
 		//	Expect(err).To(BeNil())
 		//	if result.Status != define.HealthCheckHealthy {
@@ -343,18 +343,18 @@ var _ = Describe("Podman containers ", func() {
 		//	}
 		//	status = result.Status
 		//	break
-		//}
-		//Expect(status).To(Equal(define.HealthCheckHealthy))
+		// }
+		// Expect(status).To(Equal(define.HealthCheckHealthy))
 
 		// TODO enable this when wait is working
 		// healthcheck on a stopped container should be a 409
-		//err = containers.Stop(connText, "hc", nil)
-		//Expect(err).To(BeNil())
-		//_, err = containers.Wait(connText, "hc")
-		//Expect(err).To(BeNil())
-		//_, err = containers.RunHealthCheck(connText, "hc")
-		//code, _ = bindings.CheckResponseCode(err)
-		//Expect(code).To(BeNumerically("==", http.StatusConflict))
+		// err = containers.Stop(connText, "hc", nil)
+		// Expect(err).To(BeNil())
+		// _, err = containers.Wait(connText, "hc")
+		// Expect(err).To(BeNil())
+		// _, err = containers.RunHealthCheck(connText, "hc")
+		// code, _ = bindings.CheckResponseCode(err)
+		// Expect(code).To(BeNumerically("==", http.StatusConflict))
 	})
 
 	It("logging", func() {
@@ -490,7 +490,7 @@ var _ = Describe("Podman containers ", func() {
 	})
 
 	It("podman kill a running container by bogus signal", func() {
-		//Killing a running container by bogus signal should fail
+		// Killing a running container by bogus signal should fail
 		var name = "top"
 		cid, err := bt.RunTopContainer(&name, nil)
 		Expect(err).To(BeNil())
@@ -580,7 +580,7 @@ var _ = Describe("Podman containers ", func() {
 
 		// Valid filter params container should be pruned now.
 		filters := map[string][]string{
-			"until": {"5000000000"}, //Friday, June 11, 2128
+			"until": {"5000000000"}, // Friday, June 11, 2128
 		}
 		pruneResponse, err = containers.Prune(bt.conn, new(containers.PruneOptions).WithFilters(filters))
 		Expect(err).To(BeNil())
@@ -594,7 +594,7 @@ var _ = Describe("Podman containers ", func() {
 		Expect(err).To(BeNil())
 
 		filters := map[string][]string{
-			"until": {"5000000000"}, //Friday, June 11, 2128
+			"until": {"5000000000"}, // Friday, June 11, 2128
 		}
 		c, err := containers.List(bt.conn, new(containers.ListOptions).WithFilters(filters).WithAll(true))
 		Expect(err).To(BeNil())

--- a/pkg/bindings/test/pods_test.go
+++ b/pkg/bindings/test/pods_test.go
@@ -43,13 +43,13 @@ var _ = Describe("Podman pods", func() {
 	})
 
 	It("inspect pod", func() {
-		//Inspect an invalid pod name
+		// Inspect an invalid pod name
 		_, err := pods.Inspect(bt.conn, "dummyname", nil)
 		Expect(err).ToNot(BeNil())
 		code, _ := bindings.CheckResponseCode(err)
 		Expect(code).To(BeNumerically("==", http.StatusNotFound))
 
-		//Inspect an valid pod name
+		// Inspect an valid pod name
 		response, err := pods.Inspect(bt.conn, newpod, nil)
 		Expect(err).To(BeNil())
 		Expect(response.Name).To(Equal(newpod))
@@ -57,7 +57,7 @@ var _ = Describe("Podman pods", func() {
 
 	// Test validates the list all api returns
 	It("list pod", func() {
-		//List all the pods in the current instance
+		// List all the pods in the current instance
 		podSummary, err := pods.List(bt.conn, nil)
 		Expect(err).To(BeNil())
 		Expect(len(podSummary)).To(Equal(1))

--- a/pkg/bindings/test/volumes_test.go
+++ b/pkg/bindings/test/volumes_test.go
@@ -18,9 +18,6 @@ import (
 
 var _ = Describe("Podman volumes", func() {
 	var (
-		//tempdir    string
-		//err        error
-		//podmanTest *PodmanTestIntegration
 		bt       *bindingTest
 		s        *gexec.Session
 		connText context.Context
@@ -28,13 +25,6 @@ var _ = Describe("Podman volumes", func() {
 	)
 
 	BeforeEach(func() {
-		//tempdir, err = CreateTempDirInTempDir()
-		//if err != nil {
-		//	os.Exit(1)
-		//}
-		//podmanTest = PodmanTestCreate(tempdir)
-		//podmanTest.Setup()
-		//podmanTest.SeedImages()
 		bt = newBindingTest()
 		bt.RestoreImagesFromCache()
 		s = bt.startAPIService()
@@ -44,9 +34,6 @@ var _ = Describe("Podman volumes", func() {
 	})
 
 	AfterEach(func() {
-		//podmanTest.Cleanup()
-		//f := CurrentGinkgoTestDescription()
-		//processTestResult(f)
 		s.Kill()
 		bt.cleanup()
 	})

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -385,7 +385,7 @@ type ContainerInitReport struct {
 	Id  string //nolint
 }
 
-//ContainerMountOptions describes the input values for mounting containers
+// ContainerMountOptions describes the input values for mounting containers
 // in the CLI
 type ContainerMountOptions struct {
 	All        bool

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -33,7 +33,7 @@ type NetworkRmOptions struct {
 	Timeout *uint
 }
 
-//NetworkRmReport describes the results of network removal
+// NetworkRmReport describes the results of network removal
 type NetworkRmReport struct {
 	Name string
 	Err  error

--- a/pkg/domain/entities/reports/prune.go
+++ b/pkg/domain/entities/reports/prune.go
@@ -34,7 +34,7 @@ func PruneReportsSize(r []*PruneReport) uint64 {
 		if v == nil {
 			continue
 		}
-		size = size + v.Size
+		size += v.Size
 	}
 	return size
 }

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -785,12 +785,19 @@ func transferRootless(source entities.ImageScpOptions, dest entities.ImageScpOpt
 	return cmdLoad.Run()
 }
 
-// TransferRootful creates new podman processes using exec.Command and a new uid/gid alongside a cleared environment
+// transferRootful creates new podman processes using exec.Command and a new uid/gid alongside a cleared environment
 func transferRootful(source entities.ImageScpOptions, dest entities.ImageScpOptions, podman string, parentFlags []string) error {
-	basicCommand := []string{podman}
+	basicCommand := make([]string, 0, len(parentFlags)+1)
+	basicCommand = append(basicCommand, podman)
 	basicCommand = append(basicCommand, parentFlags...)
-	saveCommand := append(basicCommand, "save")
-	loadCommand := append(basicCommand, "load")
+
+	saveCommand := make([]string, 0, len(basicCommand)+4)
+	saveCommand = append(saveCommand, basicCommand...)
+	saveCommand = append(saveCommand, "save")
+
+	loadCommand := make([]string, 0, len(basicCommand)+3)
+	loadCommand = append(loadCommand, basicCommand...)
+	loadCommand = append(loadCommand, "load")
 	if source.Quiet {
 		saveCommand = append(saveCommand, "-q")
 		loadCommand = append(loadCommand, "-q")

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -435,7 +435,7 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		initContainers = append(initContainers, ctr)
 	}
 	for _, container := range podYAML.Spec.Containers {
-		if !strings.Contains("infra", container.Name) {
+		if !strings.Contains(container.Name, "infra") {
 			// Error out if the same name is used for more than one container
 			if _, ok := ctrNames[container.Name]; ok {
 				return nil, errors.Errorf("the pod %q is invalid; duplicate container name %q detected", podName, container.Name)
@@ -770,7 +770,7 @@ func getBuildFile(imageName string, cwd string) (string, error) {
 		logrus.Error(err.Error())
 	}
 
-	_, err = os.Stat(filepath.Join(dockerfilePath))
+	_, err = os.Stat(dockerfilePath)
 	if err == nil {
 		logrus.Debugf("Building %s with %s", imageName, dockerfilePath)
 		return dockerfilePath, nil

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -150,7 +150,7 @@ func (ic *ContainerEngine) SystemPrune(ctx context.Context, options entities.Sys
 		if err != nil {
 			return nil, err
 		}
-		reclaimedSpace = reclaimedSpace + reports.PruneReportsSize(containerPruneReports)
+		reclaimedSpace += reports.PruneReportsSize(containerPruneReports)
 		systemPruneReport.ContainerPruneReports = append(systemPruneReport.ContainerPruneReports, containerPruneReports...)
 		imagePruneOptions := entities.ImagePruneOptions{
 			All:    options.All,
@@ -158,7 +158,7 @@ func (ic *ContainerEngine) SystemPrune(ctx context.Context, options entities.Sys
 		}
 		imageEngine := ImageEngine{Libpod: ic.Libpod}
 		imagePruneReports, err := imageEngine.Prune(ctx, imagePruneOptions)
-		reclaimedSpace = reclaimedSpace + reports.PruneReportsSize(imagePruneReports)
+		reclaimedSpace += reports.PruneReportsSize(imagePruneReports)
 
 		if err != nil {
 			return nil, err
@@ -178,7 +178,7 @@ func (ic *ContainerEngine) SystemPrune(ctx context.Context, options entities.Sys
 			if len(volumePruneReport) > 0 {
 				found = true
 			}
-			reclaimedSpace = reclaimedSpace + reports.PruneReportsSize(volumePruneReport)
+			reclaimedSpace += reports.PruneReportsSize(volumePruneReport)
 			systemPruneReport.VolumePruneReports = append(systemPruneReport.VolumePruneReports, volumePruneReport...)
 		}
 	}

--- a/pkg/domain/infra/abi/trust.go
+++ b/pkg/domain/infra/abi/trust.go
@@ -142,15 +142,15 @@ func getPolicyShowOutput(policyContentStruct trust.PolicyContent, systemRegistri
 				Type:      trustTypeDescription(repoval[0].Type),
 			}
 			// TODO - keyarr is not used and I don't know its intent; commenting out for now for someone to fix later
-			//keyarr := []string{}
+			// keyarr := []string{}
 			uids := []string{}
 			for _, repoele := range repoval {
 				if len(repoele.KeyPath) > 0 {
-					//keyarr = append(keyarr, repoele.KeyPath)
+					// keyarr = append(keyarr, repoele.KeyPath)
 					uids = append(uids, trust.GetGPGIdFromKeyPath(repoele.KeyPath)...)
 				}
 				if len(repoele.KeyData) > 0 {
-					//keyarr = append(keyarr, string(repoele.KeyData))
+					// keyarr = append(keyarr, string(repoele.KeyData))
 					uids = append(uids, trust.GetGPGIdFromKeyData(repoele.KeyData)...)
 				}
 			}

--- a/pkg/hooks/monitor_test.go
+++ b/pkg/hooks/monitor_test.go
@@ -226,7 +226,7 @@ func TestMonitorTwoDirGood(t *testing.T) {
 		assert.Equal(t, primaryInjected, config.Hooks) // masked by primary
 	})
 
-	primaryPath2 := filepath.Join(primaryDir, "0a.json") //0a because it will be before a.json alphabetically
+	primaryPath2 := filepath.Join(primaryDir, "0a.json") // 0a because it will be before a.json alphabetically
 
 	t.Run("bad-primary-new-addition", func(t *testing.T) {
 		err = ioutil.WriteFile(primaryPath2, []byte("{\"version\": \"-1\"}"), 0644)

--- a/pkg/k8s.io/api/core/v1/types.go
+++ b/pkg/k8s.io/api/core/v1/types.go
@@ -1514,7 +1514,7 @@ const (
 // by the node selector terms.
 // +structType=atomic
 type NodeSelector struct {
-	//Required. A list of node selector terms. The terms are ORed.
+	// Required. A list of node selector terms. The terms are ORed.
 	NodeSelectorTerms []NodeSelectorTerm `json:"nodeSelectorTerms"`
 }
 
@@ -3040,7 +3040,7 @@ type ServiceSpec struct {
 	SessionAffinityConfig *SessionAffinityConfig `json:"sessionAffinityConfig,omitempty"`
 
 	// TopologyKeys is tombstoned to show why 16 is reserved protobuf tag.
-	//TopologyKeys []string `json:"topologyKeys,omitempty"`
+	// TopologyKeys []string `json:"topologyKeys,omitempty"`
 
 	// IPFamily is tombstoned to show why 15 is a reserved protobuf tag.
 	// IPFamily *IPFamily `json:"ipFamily,omitempty"`

--- a/pkg/k8s.io/apimachinery/pkg/api/resource/amount.go
+++ b/pkg/k8s.io/apimachinery/pkg/api/resource/amount.go
@@ -231,13 +231,13 @@ func (a int64Amount) AsCanonicalBytes(out []byte) (result []byte, exponent int32
 		if !ok {
 			return infDecAmount{a.AsDec()}.AsCanonicalBytes(out)
 		}
-		exponent = exponent - 1
+		exponent--
 	case 2, -1:
 		amount, ok = int64MultiplyScale100(amount)
 		if !ok {
 			return infDecAmount{a.AsDec()}.AsCanonicalBytes(out)
 		}
-		exponent = exponent - 2
+		exponent -= 2
 	}
 	return strconv.AppendInt(out, amount, 10), exponent
 }

--- a/pkg/k8s.io/apimachinery/pkg/api/resource/math.go
+++ b/pkg/k8s.io/apimachinery/pkg/api/resource/math.go
@@ -171,7 +171,7 @@ func negativeScaleInt64(base int64, scale Scale) (result int64, exact bool) {
 		if !fraction && value%10 != 0 {
 			fraction = true
 		}
-		value = value / 10
+		value /= 10
 		if value == 0 {
 			if fraction {
 				if base > 0 {
@@ -265,18 +265,18 @@ func removeInt64Factors(value int64, base int64) (result int64, times int32) {
 	case 10:
 		for result >= 10 && result%10 == 0 {
 			times++
-			result = result / 10
+			result /= 10
 		}
 	// allow the compiler to optimize the common cases
 	case 1024:
 		for result >= 1024 && result%1024 == 0 {
 			times++
-			result = result / 1024
+			result /= 1024
 		}
 	default:
 		for result >= base && result%base == 0 {
 			times++
-			result = result / base
+			result /= base
 		}
 	}
 	if negative {

--- a/pkg/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/pkg/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1156,7 +1156,7 @@ type ManagedFieldsEntry struct {
 	Time *Time `json:"time,omitempty"`
 
 	// Fields is tombstoned to show why 5 is a reserved protobuf tag.
-	//Fields *Fields `json:"fields,omitempty"`
+	// Fields *Fields `json:"fields,omitempty"`
 
 	// FieldsType is the discriminator for the different fields format and version.
 	// There is currently only one possible value: "FieldsV1"

--- a/pkg/lookup/lookup.go
+++ b/pkg/lookup/lookup.go
@@ -61,7 +61,7 @@ func GetUserGroupInfo(containerMount, containerUser string, override *Overrides)
 		defaultExecUser = override.DefaultUser
 	} else {
 		// Define a default container user
-		//defaultExecUser = &user.ExecUser{
+		// defaultExecUser = &user.ExecUser{
 		//	Uid:  0,
 		//	Gid:  0,
 		//	Home: "/",

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -135,7 +135,7 @@ type InspectInfo struct {
 }
 
 func (rc RemoteConnectionType) MakeSSHURL(host, path, port, userName string) url.URL {
-	//TODO Should this function have input verification?
+	// TODO Should this function have input verification?
 	userInfo := url.User(userName)
 	uri := url.URL{
 		Scheme:     "ssh",

--- a/pkg/machine/fedora.go
+++ b/pkg/machine/fedora.go
@@ -21,6 +21,8 @@ const (
 	githubURL = "http://github.com/fedora-cloud/docker-brew-fedora/"
 )
 
+var fedoraxzRegex = regexp.MustCompile(`fedora[^\"]+xz`)
+
 type FedoraDownload struct {
 	Download
 }
@@ -96,12 +98,8 @@ func getFedoraDownload(releaseStream string) (string, *url.URL, int64, error) {
 		return "", nil, -1, err
 	}
 
-	rx, err := regexp.Compile(`fedora[^\"]+xz`)
-	if err != nil {
-		return "", nil, -1, err
-	}
-	file := rx.FindString(string(body))
-	if len(file) <= 0 {
+	file := fedoraxzRegex.FindString(string(body))
+	if len(file) == 0 {
 		return "", nil, -1, fmt.Errorf("could not locate Fedora download at %s", dirURL)
 	}
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -332,8 +332,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 				}
 			}
 		}
-		switch volumeType {
-		case VolumeTypeVirtfs:
+		if volumeType == VolumeTypeVirtfs {
 			virtfsOptions := fmt.Sprintf("local,path=%s,mount_tag=%s,security_model=mapped-xattr", source, tag)
 			if readonly {
 				virtfsOptions += ",readonly"
@@ -783,7 +782,7 @@ func (v *MachineVM) Stop(_ string, _ machine.StopOptions) error {
 			break
 		}
 		time.Sleep(waitInternal)
-		waitInternal = waitInternal * 2
+		waitInternal *= 2
 	}
 
 	return v.ReadySocket.Delete()
@@ -799,8 +798,7 @@ func NewQMPMonitor(network, name string, timeout time.Duration) (Monitor, error)
 		rtDir = "/run"
 	}
 	rtDir = filepath.Join(rtDir, "podman")
-	if _, err := os.Stat(filepath.Join(rtDir)); os.IsNotExist(err) {
-		// TODO 0644 is fine on linux but macos is weird
+	if _, err := os.Stat(rtDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(rtDir, 0755); err != nil {
 			return Monitor{}, err
 		}
@@ -872,7 +870,7 @@ func (v *MachineVM) Remove(_ string, opts machine.RemoveOptions) (string, func()
 		confirmationMessage += msg + "\n"
 	}
 
-	//remove socket and pid file if any: warn at low priority if things fail
+	// remove socket and pid file if any: warn at low priority if things fail
 	// Remove the pidfile
 	if err := v.PidFilePath.Delete(); err != nil {
 		logrus.Debugf("Error while removing pidfile: %v", err)

--- a/pkg/namespaces/namespaces.go
+++ b/pkg/namespaces/namespaces.go
@@ -375,7 +375,7 @@ func (n NetworkMode) Container() string {
 	return ""
 }
 
-//UserDefined indicates user-created network
+// UserDefined indicates user-created network
 func (n NetworkMode) UserDefined() string {
 	if n.IsUserDefined() {
 		return string(n)

--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -122,19 +122,19 @@ func (s *SpecGenerator) Validate() error {
 	}
 
 	// TODO the specgen does not appear to handle this?  Should it
-	//switch config.Cgroup.Cgroups {
-	//case "disabled":
+	// switch config.Cgroup.Cgroups {
+	// case "disabled":
 	//	if addedResources {
 	//		return errors.New("cannot specify resource limits when cgroups are disabled is specified")
 	//	}
 	//	configSpec.Linux.Resources = &spec.LinuxResources{}
-	//case "enabled", "no-conmon", "":
+	// case "enabled", "no-conmon", "":
 	//	// Do nothing
-	//default:
+	// default:
 	//	return errors.New("unrecognized option for cgroups; supported are 'default', 'disabled', 'no-conmon'")
-	//}
+	// }
 	invalidUlimitFormatError := errors.New("invalid default ulimit definition must be form of type=soft:hard")
-	//set ulimits if not rootless
+	// set ulimits if not rootless
 	if len(s.ContainerResourceConfig.Rlimits) < 1 && !rootless.IsRootless() {
 		// Containers common defines this as something like nproc=4194304:4194304
 		tmpnproc := containerConfig.Ulimits()

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -395,7 +395,7 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, contaierID s
 		} else {
 			switch nameSpaces[i] {
 			case "pid":
-				specg.PidNS = specgen.Namespace{NSMode: specgen.Default} //default
+				specg.PidNS = specgen.Namespace{NSMode: specgen.Default} // default
 			case "net":
 				switch {
 				case conf.NetMode.IsBridge():
@@ -435,7 +435,7 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, contaierID s
 					specg.NetNS = specgen.Namespace{NSMode: specgen.FromPod, Value: strings.Split(string(conf.NetMode), ":")[1]}
 				}
 			case "cgroup":
-				specg.CgroupNS = specgen.Namespace{NSMode: specgen.Default} //default
+				specg.CgroupNS = specgen.Namespace{NSMode: specgen.Default} // default
 			case "ipc":
 				switch conf.ShmDir {
 				case "/dev/shm":
@@ -443,15 +443,15 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, contaierID s
 				case "":
 					specg.IpcNS = specgen.Namespace{NSMode: specgen.None}
 				default:
-					specg.IpcNS = specgen.Namespace{NSMode: specgen.Default} //default
+					specg.IpcNS = specgen.Namespace{NSMode: specgen.Default} // default
 				}
 			case "uts":
-				specg.UtsNS = specgen.Namespace{NSMode: specgen.Default} //default
+				specg.UtsNS = specgen.Namespace{NSMode: specgen.Default} // default
 			case "user":
 				if conf.AddCurrentUserPasswdEntry {
 					specg.UserNS = specgen.Namespace{NSMode: specgen.KeepID}
 				} else {
-					specg.UserNS = specgen.Namespace{NSMode: specgen.Default} //default
+					specg.UserNS = specgen.Namespace{NSMode: specgen.Default} // default
 				}
 			}
 		}

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -434,20 +434,18 @@ func createContainerOptions(rt *libpod.Runtime, s *specgen.SpecGenerator, pod *l
 	// Security options
 	if len(s.SelinuxOpts) > 0 {
 		options = append(options, libpod.WithSecLabels(s.SelinuxOpts))
-	} else {
-		if pod != nil && len(compatibleOptions.SelinuxOpts) == 0 {
-			// duplicate the security options from the pod
-			processLabel, err := pod.ProcessLabel()
+	} else if pod != nil && len(compatibleOptions.SelinuxOpts) == 0 {
+		// duplicate the security options from the pod
+		processLabel, err := pod.ProcessLabel()
+		if err != nil {
+			return nil, err
+		}
+		if processLabel != "" {
+			selinuxOpts, err := label.DupSecOpt(processLabel)
 			if err != nil {
 				return nil, err
 			}
-			if processLabel != "" {
-				selinuxOpts, err := label.DupSecOpt(processLabel)
-				if err != nil {
-					return nil, err
-				}
-				options = append(options, libpod.WithSecLabels(selinuxOpts))
-			}
+			options = append(options, libpod.WithSecLabels(selinuxOpts))
 		}
 	}
 	options = append(options, libpod.WithPrivileged(s.Privileged))

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -449,12 +449,13 @@ func setupLivenessProbe(s *specgen.SpecGenerator, containerYAML v1.Container, re
 		}
 
 		// configure healthcheck on the basis of Handler Actions.
-		if probeHandler.Exec != nil {
+		switch {
+		case probeHandler.Exec != nil:
 			execString := strings.Join(probeHandler.Exec.Command, " ")
 			commandString = fmt.Sprintf("%s || %s", execString, failureCmd)
-		} else if probeHandler.HTTPGet != nil {
+		case probeHandler.HTTPGet != nil:
 			commandString = fmt.Sprintf("curl %s://%s:%d/%s  || %s", probeHandler.HTTPGet.Scheme, probeHandler.HTTPGet.Host, probeHandler.HTTPGet.Port.IntValue(), probeHandler.HTTPGet.Path, failureCmd)
-		} else if probeHandler.TCPSocket != nil {
+		case probeHandler.TCPSocket != nil:
 			commandString = fmt.Sprintf("nc -z -v %s %d || %s", probeHandler.TCPSocket.Host, probeHandler.TCPSocket.Port.IntValue(), failureCmd)
 		}
 		s.HealthConfig, err = makeHealthCheck(commandString, probe.PeriodSeconds, probe.FailureThreshold, probe.TimeoutSeconds, probe.InitialDelaySeconds)
@@ -490,17 +491,17 @@ func makeHealthCheck(inCmd string, interval int32, retries int32, timeout int32,
 	}
 
 	if interval < 1 {
-		//kubernetes interval defaults to 10 sec and cannot be less than 1
+		// kubernetes interval defaults to 10 sec and cannot be less than 1
 		interval = 10
 	}
 	hc.Interval = (time.Duration(interval) * time.Second)
 	if retries < 1 {
-		//kubernetes retries defaults to 3
+		// kubernetes retries defaults to 3
 		retries = 3
 	}
 	hc.Retries = int(retries)
 	if timeout < 1 {
-		//kubernetes timeout defaults to 1
+		// kubernetes timeout defaults to 1
 		timeout = 1
 	}
 	timeoutDuration := (time.Duration(timeout) * time.Second)

--- a/pkg/specgen/generate/kube/kube_test.go
+++ b/pkg/specgen/generate/kube/kube_test.go
@@ -5,7 +5,6 @@ import (
 
 	v1 "github.com/containers/podman/v4/pkg/k8s.io/api/core/v1"
 	"github.com/stretchr/testify/assert"
-	//"github.com/stretchr/testify/require"
 )
 
 func testPropagation(t *testing.T, propagation v1.MountPropagationMode, expected string) {

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -202,10 +202,8 @@ func namespaceOptions(s *specgen.SpecGenerator, rt *libpod.Runtime, pod *libpod.
 	if s.IDMappings != nil {
 		if pod == nil {
 			toReturn = append(toReturn, libpod.WithIDMappings(*s.IDMappings))
-		} else {
-			if pod.HasInfraContainer() && (len(s.IDMappings.UIDMap) > 0 || len(s.IDMappings.GIDMap) > 0) {
-				return nil, errors.Wrapf(define.ErrInvalidArg, "cannot specify a new uid/gid map when entering a pod with an infra container")
-			}
+		} else if pod.HasInfraContainer() && (len(s.IDMappings.UIDMap) > 0 || len(s.IDMappings.GIDMap) > 0) {
+			return nil, errors.Wrapf(define.ErrInvalidArg, "cannot specify a new uid/gid map when entering a pod with an infra container")
 		}
 	}
 	if s.User != "" {
@@ -482,7 +480,7 @@ func GetNamespaceOptions(ns []string, netnsIsHost bool) ([]libpod.PodCreateOptio
 	var options []libpod.PodCreateOption
 	var erroredOptions []libpod.PodCreateOption
 	if ns == nil {
-		//set the default namespaces
+		// set the default namespaces
 		ns = strings.Split(specgen.DefaultKernelNamespaces, ",")
 	}
 	for _, toShare := range ns {

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -298,7 +298,8 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		g.AddAnnotation(key, val)
 	}
 
-	if compatibleOptions.InfraResources == nil && s.ResourceLimits != nil {
+	switch {
+	case compatibleOptions.InfraResources == nil && s.ResourceLimits != nil:
 		out, err := json.Marshal(s.ResourceLimits)
 		if err != nil {
 			return nil, err
@@ -307,7 +308,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		if err != nil {
 			return nil, err
 		}
-	} else if s.ResourceLimits != nil { // if we have predefined resource limits we need to make sure we keep the infra and container limits
+	case s.ResourceLimits != nil: // if we have predefined resource limits we need to make sure we keep the infra and container limits
 		originalResources, err := json.Marshal(s.ResourceLimits)
 		if err != nil {
 			return nil, err
@@ -325,7 +326,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 			return nil, err
 		}
 		g.Config.Linux.Resources = s.ResourceLimits
-	} else {
+	default:
 		g.Config.Linux.Resources = compatibleOptions.InfraResources
 	}
 	// Devices

--- a/pkg/specgen/generate/validate.go
+++ b/pkg/specgen/generate/validate.go
@@ -47,10 +47,8 @@ func verifyContainerResourcesCgroupV1(s *specgen.SpecGenerator) ([]string, error
 			if !sysInfo.MemorySwappiness {
 				warnings = append(warnings, "Your kernel does not support memory swappiness capabilities, or the cgroup is not mounted. Memory swappiness discarded.")
 				memory.Swappiness = nil
-			} else {
-				if *memory.Swappiness > 100 {
-					return warnings, errors.Errorf("invalid value: %v, valid memory swappiness range is 0-100", *memory.Swappiness)
-				}
+			} else if *memory.Swappiness > 100 {
+				return warnings, errors.Errorf("invalid value: %v, valid memory swappiness range is 0-100", *memory.Swappiness)
 			}
 		}
 		if memory.Reservation != nil && !sysInfo.MemoryReservation {

--- a/pkg/specgen/winpath.go
+++ b/pkg/specgen/winpath.go
@@ -47,11 +47,12 @@ func ConvertWinMountPath(path string) (string, error) {
 	path = strings.TrimPrefix(path, `\\?\`)
 
 	// Drive installed via wsl --mount
-	if strings.HasPrefix(path, `\\.\`) {
+	switch {
+	case strings.HasPrefix(path, `\\.\`):
 		path = "/mnt/wsl/" + path[4:]
-	} else if len(path) > 1 && path[1] == ':' {
+	case len(path) > 1 && path[1] == ':':
 		path = "/mnt/" + strings.ToLower(path[0:1]) + path[2:]
-	} else {
+	default:
 		return path, errors.New("unsupported UNC path")
 	}
 

--- a/pkg/specgenutil/createparse.go
+++ b/pkg/specgenutil/createparse.go
@@ -24,11 +24,12 @@ func validate(c *entities.ContainerCreateOptions) error {
 		"ignore": "",
 	}
 	if _, ok := imageVolType[c.ImageVolume]; !ok {
-		if c.IsInfra {
+		switch {
+		case c.IsInfra:
 			c.ImageVolume = "bind"
-		} else if c.IsClone { // the image volume type will be deduced later from the container we are cloning
+		case c.IsClone: // the image volume type will be deduced later from the container we are cloning
 			return nil
-		} else {
+		default:
 			return errors.Errorf("invalid image-volume type %q. Pick one of bind, tmpfs, or ignore", c.ImageVolume)
 		}
 	}

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -1098,9 +1098,9 @@ var cgroupDeviceType = map[string]bool{
 }
 
 var cgroupDeviceAccess = map[string]bool{
-	"r": true, //read
-	"w": true, //write
-	"m": true, //mknod
+	"r": true, // read
+	"w": true, // write
+	"m": true, // mknod
 }
 
 // parseLinuxResourcesDeviceAccess parses the raw string passed with the --device-access-add flag

--- a/pkg/systemd/dbus.go
+++ b/pkg/systemd/dbus.go
@@ -26,39 +26,39 @@ func IsSystemdSessionValid(uid int) bool {
 	if rootless.IsRootless() {
 		conn, err = GetLogindConnection(rootless.GetRootlessUID())
 		if err != nil {
-			//unable to fetch systemd object for logind
+			// unable to fetch systemd object for logind
 			logrus.Debugf("systemd-logind: %s", err)
 			return false
 		}
 		object = conn.Object(dbusDest, godbus.ObjectPath(dbusPath))
 		if err := object.Call(dbusInterface+".GetSeat", 0, "seat0").Store(&seat0Path); err != nil {
-			//unable to get seat0 path.
+			// unable to get seat0 path.
 			logrus.Debugf("systemd-logind: %s", err)
 			return false
 		}
 		seat0Obj := conn.Object(dbusDest, seat0Path)
 		activeSession, err := seat0Obj.GetProperty(dbusDest + ".Seat.ActiveSession")
 		if err != nil {
-			//unable to get active sessions.
+			// unable to get active sessions.
 			logrus.Debugf("systemd-logind: %s", err)
 			return false
 		}
 		activeSessionMap, ok := activeSession.Value().([]interface{})
 		if !ok || len(activeSessionMap) < 2 {
-			//unable to get active session map.
+			// unable to get active session map.
 			logrus.Debugf("systemd-logind: %s", err)
 			return false
 		}
 		activeSessionPath, ok := activeSessionMap[1].(godbus.ObjectPath)
 		if !ok {
-			//unable to fetch active session path.
+			// unable to fetch active session path.
 			logrus.Debugf("systemd-logind: %s", err)
 			return false
 		}
 		activeSessionObj := conn.Object(dbusDest, activeSessionPath)
 		sessionUser, err := activeSessionObj.GetProperty(dbusDest + ".Session.User")
 		if err != nil {
-			//unable to fetch session user from activeSession path.
+			// unable to fetch session user from activeSession path.
 			logrus.Debugf("systemd-logind: %s", err)
 			return false
 		}
@@ -75,7 +75,7 @@ func IsSystemdSessionValid(uid int) bool {
 		if !ok {
 			return false
 		}
-		//active session found which belongs to following rootless user
+		// active session found which belongs to following rootless user
 		if activeUID == uint32(uid) {
 			return true
 		}

--- a/pkg/timetype/timestamp.go
+++ b/pkg/timetype/timestamp.go
@@ -34,13 +34,14 @@ func GetTimestamp(value string, reference time.Time) (string, error) {
 	// if the string has a Z or a + or three dashes use parse otherwise use parseinlocation
 	parseInLocation := !(strings.ContainsAny(value, "zZ+") || strings.Count(value, "-") == 3)
 
-	if strings.Contains(value, ".") { // nolint(gocritic)
+	switch {
+	case strings.Contains(value, "."):
 		if parseInLocation {
 			format = rFC3339NanoLocal
 		} else {
 			format = time.RFC3339Nano
 		}
-	} else if strings.Contains(value, "T") {
+	case strings.Contains(value, "T"):
 		// we want the number of colons in the T portion of the timestamp
 		tcolons := strings.Count(value, ":")
 		// if parseInLocation is off and we have a +/- zone offset (not Z) then
@@ -68,9 +69,9 @@ func GetTimestamp(value string, reference time.Time) (string, error) {
 				format = time.RFC3339
 			}
 		}
-	} else if parseInLocation {
+	case parseInLocation:
 		format = dateLocal
-	} else {
+	default:
 		format = dateWithZone
 	}
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -212,7 +212,7 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 		podmanRemoteBinary = os.Getenv("PODMAN_REMOTE_BINARY")
 	}
 
-	conmonBinary := filepath.Join("/usr/libexec/podman/conmon")
+	conmonBinary := "/usr/libexec/podman/conmon"
 	altConmonBinary := "/usr/bin/conmon"
 	if _, err := os.Stat(conmonBinary); os.IsNotExist(err) {
 		conmonBinary = altConmonBinary
@@ -344,7 +344,7 @@ func imageTarPath(image string) string {
 	}
 
 	// e.g., registry.com/fubar:latest -> registry.com-fubar-latest.tar
-	imageCacheName := strings.Replace(strings.Replace(image, ":", "-", -1), "/", "-", -1) + ".tar"
+	imageCacheName := strings.ReplaceAll(strings.ReplaceAll(image, ":", "-"), "/", "-") + ".tar"
 
 	return filepath.Join(cacheDir, imageCacheName)
 }

--- a/test/e2e/container_clone_test.go
+++ b/test/e2e/container_clone_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Podman container clone", func() {
 		Expect(checkCreate).Should(Exit(0))
 		createArray := checkCreate.OutputToStringArray()
 
-		Expect(cloneArray).To(ContainElements(createArray[:]))
+		Expect(cloneArray).To(ContainElements(createArray))
 
 		ctrInspect := podmanTest.Podman([]string{"inspect", clone.OutputToString()})
 		ctrInspect.WaitWithDefaultTimeout()

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Podman generate kube", func() {
 
 		numContainers := 0
 		for range pod.Spec.Containers {
-			numContainers = numContainers + 1
+			numContainers++
 		}
 		Expect(numContainers).To(Equal(1))
 	})
@@ -169,7 +169,7 @@ var _ = Describe("Podman generate kube", func() {
 
 		numContainers := 0
 		for range pod.Spec.Containers {
-			numContainers = numContainers + 1
+			numContainers++
 		}
 		Expect(numContainers).To(Equal(1))
 	})
@@ -478,11 +478,11 @@ var _ = Describe("Podman generate kube", func() {
 				// for k8s
 				Expect(port.Protocol).To(BeEmpty())
 				if port.HostPort == 4000 {
-					foundPort4000 = foundPort4000 + 1
+					foundPort4000++
 				} else if port.HostPort == 5000 {
-					foundPort5000 = foundPort5000 + 1
+					foundPort5000++
 				} else {
-					foundOtherPort = foundOtherPort + 1
+					foundOtherPort++
 				}
 			}
 		}

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -438,7 +438,7 @@ RUN > file2
 		Expect(result).Should(Exit(0))
 		Expect(result.OutputToStringArray()).To(HaveLen(1))
 
-		//check if really abc is removed
+		// check if really abc is removed
 		result = podmanTest.Podman([]string{"image", "list", "--filter", "label=abc"})
 		Expect(result.OutputToStringArray()).To(BeEmpty())
 
@@ -459,7 +459,7 @@ RUN > file2
 		Expect(result).Should(Exit(0))
 		Expect(result.OutputToStringArray()).To(HaveLen(1))
 
-		//check if really abc is removed
+		// check if really abc is removed
 		result = podmanTest.Podman([]string{"image", "list", "--filter", "label=abc"})
 		Expect(result.OutputToStringArray()).To(BeEmpty())
 

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Podman load", func() {
 
 		compress := SystemExec("gzip", []string{outfile})
 		Expect(compress).Should(Exit(0))
-		outfile = outfile + ".gz"
+		outfile += ".gz"
 
 		rmi := podmanTest.Podman([]string{"rmi", ALPINE})
 		rmi.WaitWithDefaultTimeout()

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Podman namespaces", func() {
 		numCtrs := 0
 		for _, outputLine := range output {
 			if outputLine != "" {
-				numCtrs = numCtrs + 1
+				numCtrs++
 			}
 		}
 		Expect(numCtrs).To(Equal(0))

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2995,7 +2995,7 @@ invalid kube kind
 
 	It("podman play kube with auto update annotations for all containers", func() {
 		ctr01Name := "ctr01"
-		ctr02Name := "ctr02"
+		ctr02Name := "infra"
 		podName := "foo"
 		autoUpdateRegistry := "io.containers.autoupdate"
 		autoUpdateRegistryValue := "registry"

--- a/test/e2e/pod_initcontainers_test.go
+++ b/test/e2e/pod_initcontainers_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Podman init containers", func() {
 		check := podmanTest.Podman([]string{"container", "exists", initContainerID})
 		check.WaitWithDefaultTimeout()
 		// Container was rm'd
-		//Expect(check).Should(Exit(1))
+		// Expect(check).Should(Exit(1))
 		Expect(check.ExitCode()).To(Equal(1), "I dont understand why the other way does not work")
 		// Lets double check with a stop and start
 		stopPod := podmanTest.Podman([]string{"pod", "stop", "foobar"})

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -84,12 +84,12 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		exec.WaitWithDefaultTimeout()
 		Expect(exec).Should(Exit(0))
 
-		containerCgroup := strings.TrimRight(strings.Replace(exec.OutputToString(), "0::", "", -1), "\n")
+		containerCgroup := strings.TrimRight(strings.ReplaceAll(exec.OutputToString(), "0::", ""), "\n")
 
 		// Move the container process to a sub cgroup
 		content, err := ioutil.ReadFile(filepath.Join(cgroupRoot, containerCgroup, "cgroup.procs"))
 		Expect(err).To(BeNil())
-		oldSubCgroupPath := filepath.Join(filepath.Join(cgroupRoot, containerCgroup, "old-container"))
+		oldSubCgroupPath := filepath.Join(cgroupRoot, containerCgroup, "old-container")
 		err = os.MkdirAll(oldSubCgroupPath, 0755)
 		Expect(err).To(BeNil())
 		err = ioutil.WriteFile(filepath.Join(oldSubCgroupPath, "cgroup.procs"), content, 0644)
@@ -102,7 +102,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		run = podmanTest.Podman([]string{"--cgroup-manager=cgroupfs", "run", "--rm", "--cgroupns=host", fmt.Sprintf("--cgroup-parent=%s", newCgroup), fedoraMinimal, "cat", "/proc/self/cgroup"})
 		run.WaitWithDefaultTimeout()
 		Expect(run).Should(Exit(0))
-		cgroupEffective := strings.TrimRight(strings.Replace(run.OutputToString(), "0::", "", -1), "\n")
+		cgroupEffective := strings.TrimRight(strings.ReplaceAll(run.OutputToString(), "0::", ""), "\n")
 
 		Expect(newCgroup).To(Equal(filepath.Dir(cgroupEffective)))
 	})

--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 		counter := 0
 		for {
 			buf := make([]byte, 1024)
-			n, err := uds.Read(buf[:])
+			n, err := uds.Read(buf)
 			if err != nil && err != io.EOF {
 				fmt.Println(err)
 				return
@@ -92,7 +92,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 		counter = 0
 		for {
 			buf := make([]byte, 1024)
-			n, err := uds.Read(buf[:])
+			n, err := uds.Read(buf)
 			if err != nil {
 				fmt.Println(err)
 				return

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Podman run with volumes", func() {
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
 		os.Mkdir(mountPath, 0755)
 
-		//Container should be able to start with custom overlay volume
+		// Container should be able to start with custom overlay volume
 		session := podmanTest.Podman([]string{"run", "--rm", "-v", mountPath + ":/data:O", "--workdir=/data", ALPINE, "echo", "hello"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -729,7 +729,7 @@ VOLUME /test/`, ALPINE)
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring("888:888"))
 
-		vol = vol + ",O"
+		vol += ",O"
 		session = podmanTest.Podman([]string{"run", "--rm", "--user", "888:888", "--userns", "keep-id", "-v", vol, ALPINE, "stat", "-c", "%u:%g", dest})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -108,8 +108,8 @@ func (p *PodmanTest) PodmanAsUserBase(args []string, uid, gid uint32, cwd string
 		timeCmd := append([]string{"/usr/bin/time"}, timeArgs...)
 		wrapper = append(timeCmd, wrapper...)
 	}
-
-	runCmd := append(wrapper, podmanBinary)
+	runCmd := wrapper
+	runCmd = append(runCmd, podmanBinary)
 	if !p.RemoteTest && p.NetworkBackend == Netavark {
 		runCmd = append(runCmd, []string{"--network-backend", "netavark"}...)
 	}
@@ -449,10 +449,10 @@ func GetHostDistributionInfo() HostOS {
 	host.Arch = runtime.GOARCH
 	for l.Scan() {
 		if strings.HasPrefix(l.Text(), "ID=") {
-			host.Distribution = strings.Replace(strings.TrimSpace(strings.Join(strings.Split(l.Text(), "=")[1:], "")), "\"", "", -1)
+			host.Distribution = strings.ReplaceAll(strings.TrimSpace(strings.Join(strings.Split(l.Text(), "=")[1:], "")), "\"", "")
 		}
 		if strings.HasPrefix(l.Text(), "VERSION_ID=") {
-			host.Version = strings.Replace(strings.TrimSpace(strings.Join(strings.Split(l.Text(), "=")[1:], "")), "\"", "", -1)
+			host.Version = strings.ReplaceAll(strings.TrimSpace(strings.Join(strings.Split(l.Text(), "=")[1:], "")), "\"", "")
 		}
 	}
 	return host


### PR DESCRIPTION
The linter ensures a common code style.
- use switch/case instead of else if
- use if instead of switch/case for single case statement
- add space between comment and text
- detect the use of defer with os.Exit()
- use short form var += "..." instead of var = var + "..."
- detect problems with append()
```
newSlice := append(orgSlice, val)
```
  This could lead to nasty bugs because the orgSlice will be changed in
  place if it has enough capacity too hold the new elements. Thus we
  newSlice might not be a copy.

Of course most of the changes are just cosmetic and do not cause any
logic errors but I think it is a good idea to enforce a common style.
This should help maintainability.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
