### PR TITLE
Cirrus: Fix cirrus cache race on bin/podman

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -121,6 +121,7 @@ function _run_bindings() {
 
 function _run_docker-py() {
     source .venv/docker-py/bin/activate
+    make binaries
     make run-docker-py-tests
 }
 


### PR DESCRIPTION
A suspected race on uploading gopath cache is causing the docker-py (and
possibly other) tasks to fail unpredictably with an error from `make`
regarding missing `bin/podman`.  Since this failure is affecting all
development activity, apply a quick/dirty fix to the failing task, by
simply rebuilding the binary.  A more comprehensive/long-term fix will
be worked in a future PR.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
