### PR TITLE
[CI:DOCS] fix staticcheck linter warning for deprecated function

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -363,6 +363,11 @@ func (l psReporter) State() string {
 		state = fmt.Sprintf("Exited (%d) %s ago", l.ExitCode, t)
 	default:
 		// Need to capitalize the first letter to match Docker.
+
+		// strings.Title is deprecated since go 1.18
+		// However for our use case it is still fine. The recommended replacement
+		// is adding about 400kb binary size so lets keep using this for now.
+		//nolint:staticcheck
 		state = strings.Title(l.ListContainer.State)
 	}
 	return state


### PR DESCRIPTION
go1.18 deprecates `strings.Title()`. However for our use case this is
still fine. The recommended replacement is adding about 400kb binary
size so lets keep using this for now.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
