### PR TITLE
[CI:BUILD] Cirrus: Re-fix build-cache miss on main

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -121,7 +121,6 @@ function _run_bindings() {
 
 function _run_docker-py() {
     source .venv/docker-py/bin/activate
-    make binaries
     make run-docker-py-tests
 }
 

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -268,7 +268,7 @@ case "$TEST_FLAVOR" in
         ;;
     docker-py)
         remove_packaged_podman_files
-        make install PREFIX=/usr ETCDIR=/etc
+        make && make install PREFIX=/usr ETCDIR=/etc
 
         msg "Installing previously downloaded/cached packages"
         dnf install -y $PACKAGE_DOWNLOAD_DIR/python3*.rpm


### PR DESCRIPTION
Fix for most builds on `main` being red:
https://cirrus-ci.com/github/containers/podman/main