### PR TITLE
benchmarks: add more image benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ ifeq ($(GOBIN),)
 GOBIN := $(FIRST_GOPATH)/bin
 endif
 
-export PATH := $(PATH):$(GOBIN)
+export PATH := $(PATH):$(GOBIN):$(CURDIR)/hack
 
 GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
 

--- a/hack/podman-registry-go/registry.go
+++ b/hack/podman-registry-go/registry.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	imageKey = "PODMAN_REGISTRY_IMAGE"
-	userKey  = "PODMAN_REGISTRY_USER"
-	passKey  = "PODMAN_REGISTRY_PASS"
-	portKey  = "PODMAN_REGISTRY_PORT"
+	ImageKey = "PODMAN_REGISTRY_IMAGE"
+	UserKey  = "PODMAN_REGISTRY_USER"
+	PassKey  = "PODMAN_REGISTRY_PASS"
+	PortKey  = "PODMAN_REGISTRY_PORT"
 )
 
 var binary = "podman-registry"
@@ -52,13 +52,13 @@ func Start() (*Registry, error) {
 		key := spl[0]
 		val := strings.TrimSuffix(strings.TrimPrefix(spl[1], "\""), "\"")
 		switch key {
-		case imageKey:
+		case ImageKey:
 			registry.Image = val
-		case userKey:
+		case UserKey:
 			registry.User = val
-		case passKey:
+		case PassKey:
 			registry.Password = val
-		case portKey:
+		case PortKey:
 			registry.Port = val
 		default:
 			logrus.Errorf("Unexpected podman-registry output: %q", s)
@@ -67,16 +67,16 @@ func Start() (*Registry, error) {
 
 	// Extra sanity check.
 	if registry.Image == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, imageKey)
+		return nil, errors.Errorf("unexpected output %q: %q missing", out, ImageKey)
 	}
 	if registry.User == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, userKey)
+		return nil, errors.Errorf("unexpected output %q: %q missing", out, UserKey)
 	}
 	if registry.Password == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, passKey)
+		return nil, errors.Errorf("unexpected output %q: %q missing", out, PassKey)
 	}
 	if registry.Port == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, portKey)
+		return nil, errors.Errorf("unexpected output %q: %q missing", out, PortKey)
 	}
 
 	registry.running = true


### PR DESCRIPTION
Add more benchmarks for the most common and performance-critical image
commands.  Benchmarks for `podman build` should go into a separate
section.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
