### PR TITLE
remote: do not join user NS

### DIFF
--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -30,7 +30,7 @@ import (
 )
 
 /*
-#cgo remoteclient CFLAGS: -Wall -Werror -DDISABLE_JOIN_SHORTCUT
+#cgo remote CFLAGS: -Wall -Werror -DDISABLE_JOIN_SHORTCUT
 #include <stdlib.h>
 #include <sys/types.h>
 extern uid_t rootless_uid();


### PR DESCRIPTION
As noticed while debugging #13992, do not join the rootless user NS as a
Linux remote client.

[NO NEW TESTS NEEDED] as existing tests should continue to work.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
