### PR TITLE
Cirrus: Fix skipping all/most tests

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -373,8 +373,9 @@ dotest() {
 function _bail_if_test_can_be_skipped() {
     local head base diffs
 
-    # Cirrus sets these for PRs but not cron. In cron, we never want to skip.
-    for v in CIRRUS_CHANGE_IN_REPO DEST_BRANCH; do
+    # Cirrus sets these for PRs but not branches or cron. In cron and branches,
+    #we never want to skip.
+    for v in CIRRUS_CHANGE_IN_REPO CIRRUS_PR; do
         if [[ -z "${!v}" ]]; then
             msg "[ _cannot do selective skip: \$$v is undefined ]"
             return 0


### PR DESCRIPTION
The originally intent for skipping tests based on change-content was to
optimize the PR workflow.  However, a mistake in a conditional is
causing almost all tasks running for Cron and branches to be skipped.
Fix this by checking for an empty '$CIRRUS_PR' variable.  This value is
always empty when operating outside of PRs.

[Example branch job skipping all/most tests](https://cirrus-ci.com/build/5990816991674368)