### PR TITLE
[backport v4.0-rhel] libpod/networking_linux.go: switch to sha256 hashes

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -4,7 +4,7 @@ package libpod
 
 import (
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -398,7 +398,7 @@ func (r *Runtime) GetRootlessNetNs(new bool) (*RootlessNetNS, error) {
 	// the cleanup will check if there are running containers
 	// if you run a several libpod instances with different root/runroot directories this check will fail
 	// we want one netns for each libpod static dir so we use the hash to prevent name collisions
-	hash := sha1.Sum([]byte(r.config.Engine.StaticDir))
+	hash := sha256.Sum256([]byte(r.config.Engine.StaticDir))
 	netnsName := fmt.Sprintf("%s-%x", rootlessNetNsName, hash[:10])
 
 	path := filepath.Join(nsDir, netnsName)


### PR DESCRIPTION
SHA-1 is prone to collisions.

This will likely break connectivity between old containers started
before update and containers started after update. It will also fail to
cleanup old netns. A reboot will fix this, so a reboot is recommended
after update.

[NO NEW TESTS NEEDED]

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>
(cherry picked from commit 44642bee8720c0a19c97c6e116d725fd5f95daad)
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

@TomSweeneyRedHat @Luap99 @mheon PTAL.

This would be good to get into rhel whenever we are ok to ask users to reboot.

It's cool to delay this if this is not a potential security concern, or else we should try to get this in to the next v4.0-rhel update [rhel 9.0.1].
