### PR TITLE
Truncate annotations when generating kubernetes yaml files

### DIFF
--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -178,7 +178,11 @@ func kube(cmd *cobra.Command, args []string) error {
 		if kubeOptions.Annotations == nil {
 			kubeOptions.Annotations = make(map[string]string)
 		}
-		kubeOptions.Annotations[splitN[0]] = splitN[1]
+		annotation := splitN[1]
+		if len(annotation) > define.MaxKubeAnnotation {
+			return errors.Errorf("annotation exceeds maximum size, %d, of kubernetes annotation: %s", define.MaxKubeAnnotation, annotation)
+		}
+		kubeOptions.Annotations[splitN[0]] = annotation
 	}
 	yamlfile := args[0]
 	if yamlfile == "-" {

--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -135,6 +135,8 @@ const (
 	// creating a checkpoint image to specify the name of host distribution on
 	// which the checkpoint was created.
 	CheckpointAnnotationDistributionName = "io.podman.annotations.checkpoint.distribution.name"
+	// MaxKubeAnnotation is the max length of annotations allowed by Kubernetes.
+	MaxKubeAnnotation = 63
 )
 
 // IsReservedAnnotation returns true if the specified value corresponds to an

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -78,7 +78,11 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 
 			podTemplateSpec.ObjectMeta = podYAML.ObjectMeta
 			podTemplateSpec.Spec = podYAML.Spec
-
+			for name, val := range podYAML.Annotations {
+				if len(val) > define.MaxKubeAnnotation {
+					return nil, errors.Errorf("invalid annotation %q=%q value length exceeds Kubernetetes max %d", name, val, define.MaxKubeAnnotation)
+				}
+			}
 			for name, val := range options.Annotations {
 				if podYAML.Annotations == nil {
 					podYAML.Annotations = make(map[string]string)

--- a/pkg/machine/e2e/config_init.go
+++ b/pkg/machine/e2e/config_init.go
@@ -12,7 +12,7 @@ type initMachine struct {
 	      --image-path string      Path to qcow image (default "testing")
 	  -m, --memory uint            Memory in MB (default 2048)
 	      --now                    Start machine now
-	      --rootful                Whether this machine should prefer rootful container exectution
+	      --rootful                Whether this machine should prefer rootful container execution
 	      --timezone string        Set timezone (default "local")
 	  -v, --volume stringArray     Volumes to mount, source:target
 	      --volume-driver string   Optional volume driver

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -116,7 +116,7 @@ func teardown(origHomeDir string, testDir string, mb *machineTestBuilder) {
 	s := new(stopMachine)
 	for _, name := range mb.names {
 		if _, err := mb.setName(name).setCmd(s).run(); err != nil {
-			fmt.Printf("error occured rm'ing machine: %q\n", err)
+			fmt.Printf("error occurred rm'ing machine: %q\n", err)
 		}
 	}
 	if err := os.RemoveAll(testDir); err != nil {

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -233,3 +233,48 @@ _EOF
     run_podman stop -a -t 0
     run_podman pod rm -t 0 -f test_pod
 }
+
+@test "podman play --annotation > Max" {
+    TESTDIR=$PODMAN_TMPDIR/testdir
+    RANDOMSTRING=$(random_string 65)
+    mkdir -p $TESTDIR
+    echo "$testYaml" | sed "s|TESTDIR|${TESTDIR}|g" > $PODMAN_TMPDIR/test.yaml
+    run_podman 125 play kube --annotation "name=$RANDOMSTRING" $PODMAN_TMPDIR/test.yaml
+    assert "$output" =~ "annotation exceeds maximum size, 63, of kubernetes annotation:" "Expected to fail with Length greater than 63"
+}
+
+@test "podman play Yaml with annotation > Max" {
+   RANDOMSTRING=$(random_string 65)
+   testBadYaml="
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    test: ${RANDOMSTRING}
+  labels:
+    app: test
+  name: test_pod
+spec:
+  containers:
+  - command:
+    - id
+    env:
+    - name: PATH
+      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    - name: TERM
+      value: xterm
+    - name: container
+
+      value: podman
+    image: quay.io/libpod/userimage
+    name: test
+    resources: {}
+status: {}
+"
+    TESTDIR=$PODMAN_TMPDIR/testdir
+    mkdir -p $TESTDIR
+    echo "$testBadYaml" | sed "s|TESTDIR|${TESTDIR}|g" > $PODMAN_TMPDIR/test.yaml
+
+    run_podman 125 play kube - < $PODMAN_TMPDIR/test.yaml
+    assert "$output" =~ "invalid annotation \"test\"=\"$RANDOMSTRING\"" "Expected to fail with annotation length greater than 63"
+}


### PR DESCRIPTION
Kubernetes only allows 63 characters in an annotation.  Make sure
that we only add 63 or less charaters when generating kube. Warn
if containers or pods have longer length and truncate.

Discussion: https://github.com/containers/podman/discussions/13901

Fixes: https://github.com/containers/podman/issues/13962

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
