### PR TITLE
podman machine starting test

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1065,11 +1065,11 @@ func getVMInfos() ([]*machine.ListResponse, error) {
 				return err
 			}
 
-			if !vm.LastUp.IsZero() {
+			if !vm.LastUp.IsZero() { // this means we have already written a time to the config
 				listEntry.LastUp = vm.LastUp
-			} else {
+			} else { // else we just created the machine AKA last up = created time
 				listEntry.LastUp = vm.Created
-				vm.Created = time.Now()
+				vm.LastUp = listEntry.LastUp
 				if err := vm.writeConfig(); err != nil {
 					return err
 				}


### PR DESCRIPTION
add a test to make sure machines are not running while still starting
in order to do this,

 I added a parameter to `run()` to delineate whether
or not the command should block or not. The non blocking run allows for tests
to get and use the `machineSession` pointer and check the exit code to see if it has finished.

also fix a bug (created by #13996) that before started, the machines would 
always say "LastUp" and "Created" Less than one second ago