### PR TITLE
run: honor default volumes if any with newly added volumes

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -129,6 +129,11 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	runOpts.CIDFile = cliVals.CIDFile
 	runOpts.Rm = cliVals.Rm
+	// Do not ignore default volumes if any
+	defaultVolumes := registry.PodmanConfig().Volumes()
+	if len(defaultVolumes) != 0 {
+		cliVals.Volume = append(cliVals.Volume, defaultVolumes...)
+	}
 	if cliVals, err = CreateInit(cmd, cliVals, false); err != nil {
 		return err
 	}


### PR DESCRIPTION
Podman ignores default configured volumes from containers.conf if
additional volume is supplied, we could instead append default
configured volumes with added volumes

Closes: https://github.com/containers/podman/issues/14025