### PR TITLE
play kube respect hostNetwork

### DIFF
--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -199,18 +199,20 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		return nil, err
 	}
 
-	ns, networks, netOpts, err := specgen.ParseNetworkFlag(options.Networks)
-	if err != nil {
-		return nil, err
-	}
+	if len(options.Networks) > 0 {
+		ns, networks, netOpts, err := specgen.ParseNetworkFlag(options.Networks)
+		if err != nil {
+			return nil, err
+		}
 
-	if (ns.IsBridge() && len(networks) == 0) || ns.IsHost() {
-		return nil, errors.Errorf("invalid value passed to --network: bridge or host networking must be configured in YAML")
-	}
+		if (ns.IsBridge() && len(networks) == 0) || ns.IsHost() {
+			return nil, errors.Errorf("invalid value passed to --network: bridge or host networking must be configured in YAML")
+		}
 
-	podOpt.Net.Network = ns
-	podOpt.Net.Networks = networks
-	podOpt.Net.NetworkOptions = netOpts
+		podOpt.Net.Network = ns
+		podOpt.Net.Networks = networks
+		podOpt.Net.NetworkOptions = netOpts
+	}
 
 	// FIXME This is very hard to support properly with a good ux
 	if len(options.StaticIPs) > *ipIndex {


### PR DESCRIPTION
We need to use the host network when it is set in the config and
--network was not used.

This regression was added in 3e9af2029f1f.

Fixes #14015


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
