### PR TITLE
Add CreatedSince & CreatedAt format fields to podman image history

### DIFF
--- a/cmd/podman/images/history.go
+++ b/cmd/podman/images/history.go
@@ -168,3 +168,11 @@ func (h historyReporter) ID() string {
 	}
 	return h.ImageHistoryLayer.ID
 }
+
+func (h historyReporter) CreatedAt() string {
+	return time.Unix(h.ImageHistoryLayer.Created.Unix(), 0).UTC().String()
+}
+
+func (h historyReporter) CreatedSince() string {
+	return h.Created()
+}

--- a/docs/source/markdown/podman-history.1.md
+++ b/docs/source/markdown/podman-history.1.md
@@ -23,10 +23,11 @@ Valid placeholders for the Go template are listed below:
 | --------------- | ----------------------------------------------------------------------------- |
 | .ID             | Image ID                                                                      |
 | .Created        | if --human, time elapsed since creation, otherwise time stamp of creation     |
-| .CreatedBy      | Command used to create the layer                                              |
-| .Size           | Size of layer on disk                                                         |
-| .Comment        | Comment for the layer                                                         |
-
+| .CreatedAt      | Time when the image layer was created                |
+| .CreatedBy      | Command used to create the layer                     |
+| .CreatedSince   | Elapsed time since the image layer was created       |
+| .Size           | Size of layer on disk                                |
+| .Comment        | Comment for the layer                                |
 ## OPTIONS
 
 Print the numeric IDs only (default *false*).

--- a/test/system/110-history.bats
+++ b/test/system/110-history.bats
@@ -55,4 +55,17 @@ size      | -\\\?[0-9]\\\+
 
 }
 
+@test "podman image history Created" {
+    # Values from image LIST
+    run_podman image list --format '{{.CreatedSince}}--{{.CreatedAt}}' $IMAGE
+    from_imagelist="$output"
+    assert "$from_imagelist" =~ "^[0-9].* ago--[0-9]+-[0-9]+-[0-9]+ [0-9:]+ " \
+           "CreatedSince and CreatedAt look reasonable"
+
+    # Values from image HISTORY
+    run_podman image history --format '{{.CreatedSince}}--{{.CreatedAt}}' $IMAGE
+    assert "${lines[0]}" == "$from_imagelist" \
+           "CreatedSince and CreatedAt from image history should == image list"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/14012

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
