### PR TITLE
Produce better test error messages

### DIFF
--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -28,13 +28,13 @@ var _ = Describe("podman machine init", func() {
 		reallyLongName := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		session, err := mb.setName(reallyLongName).setCmd(&i).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session).To(Exit(125))
 	})
 	It("simple init", func() {
 		i := new(initMachine)
 		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 
 		inspectBefore, ec, err := mb.toQemuInspectInfo()
 		Expect(err).To(BeNil())
@@ -52,7 +52,7 @@ var _ = Describe("podman machine init", func() {
 		i := initMachine{}
 		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 
 		inspectBefore, ec, err := mb.toQemuInspectInfo()
 		Expect(ec).To(BeZero())

--- a/pkg/machine/e2e/inspect_test.go
+++ b/pkg/machine/e2e/inspect_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("podman machine stop", func() {
@@ -27,24 +28,24 @@ var _ = Describe("podman machine stop", func() {
 		reallyLongName := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		session, err := mb.setName(reallyLongName).setCmd(&i).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session).To(Exit(125))
 	})
 
 	It("inspect two machines", func() {
 		i := new(initMachine)
 		foo1, err := mb.setName("foo1").setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
-		Expect(foo1.ExitCode()).To(Equal(0))
+		Expect(foo1).To(Exit(0))
 
 		ii := new(initMachine)
 		foo2, err := mb.setName("foo2").setCmd(ii.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
-		Expect(foo2.ExitCode()).To(Equal(0))
+		Expect(foo2).To(Exit(0))
 
 		inspect := new(inspectMachine)
 		inspectSession, err := mb.setName("foo1").setCmd(inspect).run()
 		Expect(err).To(BeNil())
-		Expect(inspectSession.ExitCode()).To(Equal(0))
+		Expect(inspectSession).To(Exit(0))
 
 		type fakeInfos struct {
 			Status string

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("podman machine rm", func() {
@@ -23,14 +24,14 @@ var _ = Describe("podman machine rm", func() {
 		reallyLongName := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		session, err := mb.setName(reallyLongName).setCmd(&i).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session).To(Exit(125))
 	})
 
 	It("Remove machine", func() {
 		i := new(initMachine)
 		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 		rm := rmMachine{}
 		_, err = mb.setCmd(rm.withForce()).run()
 		Expect(err).To(BeNil())
@@ -46,18 +47,18 @@ var _ = Describe("podman machine rm", func() {
 		i := new(initMachine)
 		session, err := mb.setCmd(i.withImagePath(mb.imagePath).withNow()).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 		rm := new(rmMachine)
 
 		// Removing a running machine should fail
 		stop, err := mb.setCmd(rm).run()
 		Expect(err).To(BeNil())
-		Expect(stop.ExitCode()).To(Equal(125))
+		Expect(stop).To(Exit(125))
 
 		// Removing again with force
 		stopAgain, err := mb.setCmd(rm.withForce()).run()
 		Expect(err).To(BeNil())
-		Expect(stopAgain.ExitCode()).To(BeZero())
+		Expect(stopAgain).To(Exit(0))
 
 		// Inspect to be dead sure
 		_, ec, err := mb.toQemuInspectInfo()

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("podman machine set", func() {
@@ -23,24 +24,28 @@ var _ = Describe("podman machine set", func() {
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 
 		set := setMachine{}
 		setSession, err := mb.setName(name).setCmd(set.withCPUs(2)).run()
 		Expect(err).To(BeNil())
-		Expect(setSession.ExitCode()).To(Equal(0))
+		Expect(setSession).To(Exit(0))
 
 		s := new(startMachine)
 		startSession, err := mb.setCmd(s).run()
 		Expect(err).To(BeNil())
-		Expect(startSession.ExitCode()).To(Equal(0))
+		Expect(startSession).To(Exit(0))
 
 		ssh2 := sshMachine{}
 		sshSession2, err := mb.setName(name).setCmd(ssh2.withSSHComand([]string{"lscpu", "|", "grep", "\"CPU(s):\"", "|", "head", "-1"})).run()
 		Expect(err).To(BeNil())
-		Expect(sshSession2.ExitCode()).To(Equal(0))
+		Expect(sshSession2).To(Exit(0))
 		Expect(sshSession2.outputToString()).To(ContainSubstring("2"))
 
+		// Setting a running machine results in 125
+		runner, err := mb.setName(name).setCmd(set.withCPUs(4)).run()
+		Expect(err).To(BeNil())
+		Expect(runner).To(Exit(125))
 	})
 
 	It("increase machine disk size", func() {
@@ -48,61 +53,51 @@ var _ = Describe("podman machine set", func() {
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 
 		set := setMachine{}
 		setSession, err := mb.setName(name).setCmd(set.withDiskSize(102)).run()
 		Expect(err).To(BeNil())
-		Expect(setSession.ExitCode()).To(Equal(0))
+		Expect(setSession).To(Exit(0))
+
+		// shrinking disk size iss verboten
+		shrink, err := mb.setName(name).setCmd(set.withDiskSize(5)).run()
+		Expect(err).To(BeNil())
+		Expect(shrink).To(Exit(125))
 
 		s := new(startMachine)
 		startSession, err := mb.setCmd(s).run()
 		Expect(err).To(BeNil())
-		Expect(startSession.ExitCode()).To(Equal(0))
+		Expect(startSession).To(Exit(0))
 
 		ssh2 := sshMachine{}
 		sshSession2, err := mb.setName(name).setCmd(ssh2.withSSHComand([]string{"sudo", "fdisk", "-l", "|", "grep", "Disk"})).run()
 		Expect(err).To(BeNil())
-		Expect(sshSession2.ExitCode()).To(Equal(0))
+		Expect(sshSession2).To(Exit(0))
 		Expect(sshSession2.outputToString()).To(ContainSubstring("102 GiB"))
 	})
 
-	It("decrease machine disk size should fail", func() {
-		name := randomString(12)
-		i := new(initMachine)
-		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
-		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
-
-		set := setMachine{}
-		setSession, _ := mb.setName(name).setCmd(set.withDiskSize(50)).run()
-		// TODO seems like stderr is not being returned; re-enabled when fixed
-		// Expect(err).To(BeNil())
-		Expect(setSession.ExitCode()).To(Not(Equal(0)))
-	})
-
 	It("set machine ram", func() {
-
 		name := randomString(12)
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 
 		set := setMachine{}
 		setSession, err := mb.setName(name).setCmd(set.withMemory(4000)).run()
 		Expect(err).To(BeNil())
-		Expect(setSession.ExitCode()).To(Equal(0))
+		Expect(setSession).To(Exit(0))
 
 		s := new(startMachine)
 		startSession, err := mb.setCmd(s).run()
 		Expect(err).To(BeNil())
-		Expect(startSession.ExitCode()).To(Equal(0))
+		Expect(startSession).To(Exit(0))
 
 		ssh2 := sshMachine{}
 		sshSession2, err := mb.setName(name).setCmd(ssh2.withSSHComand([]string{"cat", "/proc/meminfo", "|", "numfmt", "--field", "2", "--from-unit=Ki", "--to-unit=Mi", "|", "sed", "'s/ kB/M/g'", "|", "grep", "MemTotal"})).run()
 		Expect(err).To(BeNil())
-		Expect(sshSession2.ExitCode()).To(Equal(0))
+		Expect(sshSession2).To(Exit(0))
 		Expect(sshSession2.outputToString()).To(ContainSubstring("3824"))
 	})
 
@@ -111,28 +106,28 @@ var _ = Describe("podman machine set", func() {
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 
 		set := setMachine{}
 		setSession, err := mb.setName(name).setCmd(&set).run()
 		Expect(err).To(BeNil())
-		Expect(setSession.ExitCode()).To(Equal(0))
+		Expect(setSession).To(Exit(0))
 
 		s := new(startMachine)
 		startSession, err := mb.setCmd(s).run()
 		Expect(err).To(BeNil())
-		Expect(startSession.ExitCode()).To(Equal(0))
+		Expect(startSession).To(Exit(0))
 
 		ssh2 := sshMachine{}
 		sshSession2, err := mb.setName(name).setCmd(ssh2.withSSHComand([]string{"lscpu", "|", "grep", "\"CPU(s):\"", "|", "head", "-1"})).run()
 		Expect(err).To(BeNil())
-		Expect(sshSession2.ExitCode()).To(Equal(0))
+		Expect(sshSession2).To(Exit(0))
 		Expect(sshSession2.outputToString()).To(ContainSubstring("1"))
 
 		ssh3 := sshMachine{}
 		sshSession3, err := mb.setName(name).setCmd(ssh3.withSSHComand([]string{"sudo", "fdisk", "-l", "|", "grep", "Disk"})).run()
 		Expect(err).To(BeNil())
-		Expect(sshSession3.ExitCode()).To(Equal(0))
+		Expect(sshSession3).To(Exit(0))
 		Expect(sshSession3.outputToString()).To(ContainSubstring("100 GiB"))
 	})
 

--- a/pkg/machine/e2e/ssh_test.go
+++ b/pkg/machine/e2e/ssh_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("podman machine ssh", func() {
@@ -23,7 +24,7 @@ var _ = Describe("podman machine ssh", func() {
 		ssh := sshMachine{}
 		session, err := mb.setName(name).setCmd(ssh).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session).To(Exit(125))
 		// TODO seems like stderr is not being returned; re-enabled when fixed
 		//Expect(session.outputToString()).To(ContainSubstring("not exist"))
 	})
@@ -33,14 +34,14 @@ var _ = Describe("podman machine ssh", func() {
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 
 		ssh := sshMachine{}
 		sshSession, err := mb.setName(name).setCmd(ssh).run()
 		Expect(err).To(BeNil())
 		// TODO seems like stderr is not being returned; re-enabled when fixed
 		//Expect(sshSession.outputToString()).To(ContainSubstring("is not running"))
-		Expect(sshSession.ExitCode()).To(Equal(125))
+		Expect(sshSession).To(Exit(125))
 	})
 
 	It("ssh to running machine and check os-type", func() {
@@ -48,12 +49,12 @@ var _ = Describe("podman machine ssh", func() {
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 
 		ssh := sshMachine{}
 		sshSession, err := mb.setName(name).setCmd(ssh.withSSHComand([]string{"cat", "/etc/os-release"})).run()
 		Expect(err).To(BeNil())
-		Expect(sshSession.ExitCode()).To(Equal(0))
+		Expect(sshSession).To(Exit(0))
 		Expect(sshSession.outputToString()).To(ContainSubstring("Fedora CoreOS"))
 	})
 })

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/containers/podman/v4/pkg/machine"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("podman machine start", func() {
@@ -22,11 +23,11 @@ var _ = Describe("podman machine start", func() {
 		i := new(initMachine)
 		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 		s := new(startMachine)
 		startSession, err := mb.setCmd(s).run()
 		Expect(err).To(BeNil())
-		Expect(startSession.ExitCode()).To(Equal(0))
+		Expect(startSession).To(Exit(0))
 
 		info, ec, err := mb.toQemuInspectInfo()
 		Expect(err).To(BeNil())

--- a/pkg/machine/e2e/stop_test.go
+++ b/pkg/machine/e2e/stop_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("podman machine stop", func() {
@@ -23,24 +24,24 @@ var _ = Describe("podman machine stop", func() {
 		reallyLongName := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		session, err := mb.setName(reallyLongName).setCmd(&i).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session).To(Exit(125))
 	})
 
 	It("Stop running machine", func() {
 		i := new(initMachine)
 		session, err := mb.setCmd(i.withImagePath(mb.imagePath).withNow()).run()
 		Expect(err).To(BeNil())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).To(Exit(0))
 
 		stop := new(stopMachine)
 		// Removing a running machine should fail
 		stopSession, err := mb.setCmd(stop).run()
 		Expect(err).To(BeNil())
-		Expect(stopSession.ExitCode()).To(Equal(0))
+		Expect(stopSession).To(Exit(0))
 
 		// Stopping it again should not result in an error
 		stopAgain, err := mb.setCmd(stop).run()
 		Expect(err).To(BeNil())
-		Expect(stopAgain.ExitCode()).To(BeZero())
+		Expect(stopAgain).To(Exit((0)))
 	})
 })

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1466,7 +1466,7 @@ func (v *MachineVM) getIgnitionFile() string {
 	return v.IgnitionFilePath.GetPath()
 }
 
-//resizeDisk increases the size of the machine's disk in GB.
+// resizeDisk increases the size of the machine's disk in GB.
 func (v *MachineVM) resizeDisk(diskSize uint64, oldSize uint64) error {
 	// Resize the disk image to input disk size
 	// only if the virtualdisk size is less than


### PR DESCRIPTION
As Ed has pointed out, the form of Expect(session).To(Exit(0)) provides
much better error messages.  Let's make Ed happy.

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
