### PR TITLE
remove unused codepath for creating/running ctr in a pod

### DIFF
--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -1,7 +1,6 @@
 package libpod
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -296,34 +295,8 @@ func (p *Pod) CgroupPath() (string, error) {
 	if err := p.updatePod(); err != nil {
 		return "", err
 	}
-	if p.state.CgroupPath != "" {
-		return p.state.CgroupPath, nil
-	}
 	if p.state.InfraContainerID == "" {
 		return "", errors.Wrap(define.ErrNoSuchCtr, "pod has no infra container")
-	}
-
-	id, err := p.infraContainerID()
-	if err != nil {
-		return "", err
-	}
-
-	if id != "" {
-		ctr, err := p.infraContainer()
-		if err != nil {
-			return "", errors.Wrapf(err, "could not get infra")
-		}
-		if ctr != nil {
-			ctr.Start(context.Background(), true)
-			cgroupPath, err := ctr.CgroupPath()
-			fmt.Println(cgroupPath)
-			if err != nil {
-				return "", errors.Wrapf(err, "could not get container cgroup")
-			}
-			p.state.CgroupPath = cgroupPath
-			p.save()
-			return cgroupPath, nil
-		}
 	}
 	return p.state.CgroupPath, nil
 }


### PR DESCRIPTION
`pod.CgroupPath()` currently includes a codepath that is never accessed,
which is supposed to start the infra ctr and obtain the cgroup path from there
that is never necessary/safe because p.state.CgroupPath is never empty

[NO NEW TESTS NEEDED]

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>
