### PR TITLE
[WIP] [CI:DOCS] man-page checker: include --format (Go templates)

### DIFF
--- a/docs/source/markdown/podman-container-inspect.1.md
+++ b/docs/source/markdown/podman-container-inspect.1.md
@@ -25,15 +25,15 @@ Valid placeholders for the Go template are listed below:
 | .AppArmorProfile  | FIXME |
 | .Args             | FIXME |
 | .BoundingCaps     | FIXME |
-| .Config           | FIXME |
+| .Config ...       | FIXME |
 | .ConmonPidFile    | FIXME |
 | .Created          | FIXME |
 | .Dependencies     | FIXME |
 | .Driver           | FIXME |
 | .EffectiveCaps    | FIXME |
 | .ExecIDs          | FIXME |
-| .GraphDriver      | FIXME |
-| .HostConfig       | FIXME |
+| .GraphDriver ...  | FIXME |
+| .HostConfig ...   | FIXME |
 | .HostnamePath     | FIXME |
 | .HostsPath        | FIXME |
 | .ID               | FIXME |
@@ -45,7 +45,7 @@ Valid placeholders for the Go template are listed below:
 | .Mounts           | FIXME |
 | .Name             | FIXME |
 | .Namespace        | FIXME |
-| .NetworkSettings  | FIXME |
+| .NetworkSettings ... | FIXME |
 | .OCIConfigPath    | FIXME |
 | .OCIRuntime       | FIXME |
 | .Path             | FIXME |
@@ -57,7 +57,7 @@ Valid placeholders for the Go template are listed below:
 | .Rootfs           | FIXME |
 | .SizeRootFs       | FIXME |
 | .SizeRw           | FIXME |
-| .State            | FIXME |
+| .State ...        | FIXME |
 | .StaticDir        | FIXME |
 
 #### **--latest**, **-l**

--- a/docs/source/markdown/podman-container-inspect.1.md
+++ b/docs/source/markdown/podman-container-inspect.1.md
@@ -18,6 +18,48 @@ all results in a JSON array. If a format is specified, the given template will b
 Format the output using the given Go template.
 The keys of the returned JSON can be used as the values for the --format flag (see examples below).
 
+Valid placeholders for the Go template are listed below:
+
+| **Placeholder**   | **Description**    |
+| ----------------- | ------------------ |
+| .AppArmorProfile  | FIXME |
+| .Args             | FIXME |
+| .BoundingCaps     | FIXME |
+| .Config           | FIXME |
+| .ConmonPidFile    | FIXME |
+| .Created          | FIXME |
+| .Dependencies     | FIXME |
+| .Driver           | FIXME |
+| .EffectiveCaps    | FIXME |
+| .ExecIDs          | FIXME |
+| .GraphDriver      | FIXME |
+| .HostConfig       | FIXME |
+| .HostnamePath     | FIXME |
+| .HostsPath        | FIXME |
+| .ID               | FIXME |
+| .Image            | FIXME |
+| .ImageName        | FIXME |
+| .IsInfra          | FIXME |
+| .IsService        | FIXME |
+| .MountLabel       | FIXME |
+| .Mounts           | FIXME |
+| .Name             | FIXME |
+| .Namespace        | FIXME |
+| .NetworkSettings  | FIXME |
+| .OCIConfigPath    | FIXME |
+| .OCIRuntime       | FIXME |
+| .Path             | FIXME |
+| .PidFile          | FIXME |
+| .Pod              | FIXME |
+| .ProcessLabel     | FIXME |
+| .ResolvConfPath   | FIXME |
+| .RestartCount     | FIXME |
+| .Rootfs           | FIXME |
+| .SizeRootFs       | FIXME |
+| .SizeRw           | FIXME |
+| .State            | FIXME |
+| .StaticDir        | FIXME |
+
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -106,6 +106,7 @@ Format the output to JSON Lines or using the given Go template.
 | .Status             | FIXME |
 | .Time               | FIXME |
 | .Type               | FIXME |
+| .Details ...        | Just an artifact. Not actually useful. |
 
 #### **--help**
 

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -95,6 +95,18 @@ In the case where an ID is used, the ID may be in its full or shortened form.
 
 Format the output to JSON Lines or using the given Go template.
 
+| **Placeholder**     | **Description**    |
+| ------------------- | ------------------ |
+| .Attributes         | FIXME |
+| .ContainerExitCode  | FIXME |
+| .ID                 | FIXME |
+| .Image              | FIXME |
+| .Name               | FIXME |
+| .Network            | FIXME |
+| .Status             | FIXME |
+| .Time               | FIXME |
+| .Type               | FIXME |
+
 #### **--help**
 
 Print usage statement.

--- a/docs/source/markdown/podman-history.1.md
+++ b/docs/source/markdown/podman-history.1.md
@@ -35,6 +35,7 @@ Valid placeholders for the Go template are listed below:
 | .Size           | Size of layer on disk                                |
 | .Comment        | Comment for the layer                                |
 | .Tags           | Image tags |
+| .ImageHistoryLayer ... | Just an artifact. Not actually useful. |
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-image-inspect.1.md
+++ b/docs/source/markdown/podman-image-inspect.1.md
@@ -18,6 +18,32 @@ all results in a JSON array.  If a format is specified, the given template will 
 Format the output using the given Go template.
 The keys of the returned JSON can be used as the values for the --format flag (see examples below).
 
+| **Placeholder**     | **Description**    |
+| ------------------- | ------------------ |
+| .Annotations         | FIXME |
+| .Architecture        | FIXME |
+| .Author              | FIXME |
+| .Comment             | FIXME |
+| .Config              | FIXME |
+| .Created             | FIXME |
+| .Digest              | FIXME |
+| .GraphDriver         | FIXME |
+| .HealthCheck         | FIXME |
+| .History             | FIXME |
+| .ID                  | FIXME |
+| .Labels              | FIXME |
+| .ManifestType        | FIXME |
+| .NamesHistory        | FIXME |
+| .Os                  | FIXME |
+| .Parent              | FIXME |
+| .RepoDigests         | FIXME |
+| .RepoTags            | FIXME |
+| .RootFS              | FIXME |
+| .Size                | FIXME |
+| .User                | FIXME |
+| .Version             | FIXME |
+| .VirtualSize         | FIXME |
+
 ## EXAMPLE
 
 ```

--- a/docs/source/markdown/podman-image-inspect.1.md
+++ b/docs/source/markdown/podman-image-inspect.1.md
@@ -24,11 +24,11 @@ The keys of the returned JSON can be used as the values for the --format flag (s
 | .Architecture        | FIXME |
 | .Author              | FIXME |
 | .Comment             | FIXME |
-| .Config              | FIXME |
+| .Config ...          | FIXME |
 | .Created             | FIXME |
 | .Digest              | FIXME |
-| .GraphDriver         | FIXME |
-| .HealthCheck         | FIXME |
+| .GraphDriver ...     | FIXME |
+| .HealthCheck ...     | FIXME |
 | .History             | FIXME |
 | .ID                  | FIXME |
 | .Labels              | FIXME |
@@ -38,7 +38,7 @@ The keys of the returned JSON can be used as the values for the --format flag (s
 | .Parent              | FIXME |
 | .RepoDigests         | FIXME |
 | .RepoTags            | FIXME |
-| .RootFS              | FIXME |
+| .RootFS ...          | FIXME |
 | .Size                | FIXME |
 | .User                | FIXME |
 | .Version             | FIXME |

--- a/docs/source/markdown/podman-images.1.md
+++ b/docs/source/markdown/podman-images.1.md
@@ -75,7 +75,8 @@ Valid placeholders for the Go template are listed below:
 
 | **Placeholder** | **Description**                                                               |
 | --------------- | ----------------------------------------------------------------------------- |
-| .ID             | Image ID                                                                      |
+| .ID             | Image ID (truncated)                                                          |
+| .Id             | Image ID (full SHA)                                                           |
 | .Repository     | Image repository                                                              |
 | .Tag            | Image tag                                                                     |
 | .Digest         | Image digest                                                                  |
@@ -83,6 +84,21 @@ Valid placeholders for the Go template are listed below:
 | .CreatedAt      | Time when the image was created                                               |
 | .Size           | Size of layer on disk                                                         |
 | .History        | History of the image layer                                                    |
+| .ConfigDigest   | FIXME |
+| .Containers     | FIXME |
+| .Created        | FIXME |
+| .CreatedTime    | FIXME |
+| .Dangling       | FIXME |
+| .IsDangling     | FIXME |
+| .IsReadOnly     | FIXME |
+| .Labels         | FIXME |
+| .Names          | FIXME |
+| .ParentId       | FIXME |
+| .ReadOnly       | FIXME |
+| .RepoDigests    | FIXME |
+| .RepoTags       | FIXME |
+| .SharedSize     | FIXME |
+| .VirtualSize    | FIXME |
 
 #### **--history**
 

--- a/docs/source/markdown/podman-images.1.md
+++ b/docs/source/markdown/podman-images.1.md
@@ -99,6 +99,7 @@ Valid placeholders for the Go template are listed below:
 | .RepoTags       | FIXME |
 | .SharedSize     | FIXME |
 | .VirtualSize    | FIXME |
+| .ImageSummary ... | Just an artifact. Not actually useful. |
 
 #### **--history**
 

--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -25,11 +25,11 @@ Change output format to "json" or a Go template.
 
 | **Placeholder**     | **Info pertaining to ...**              |
 | ------------------- | --------------------------------------- |
-| .Host               | ...the host on which podman is running  |
-| .Store              | ...the storage driver and paths         |
-| .Registries         | ...configured registries                |
-| .Plugins            | ...external plugins                     |
-| .Version            | ...podman version                       |
+| .Host ...           | ...the host on which podman is running  |
+| .Store ...          | ...the storage driver and paths         |
+| .Registries ...     | ...configured registries                |
+| .Plugins ...        | ...external plugins                     |
+| .Version ...        | ...podman version                       |
 
 Each of the above branch out into further subfields, more than can
 reasonably be enumerated in this document.

--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -23,6 +23,16 @@ Show additional information
 
 Change output format to "json" or a Go template.
 
+| **Placeholder**     | **Info pertaining to ...**              |
+| ------------------- | --------------------------------------- |
+| .Host               | ...the host on which podman is running  |
+| .Store              | ...the storage driver and paths         |
+| .Registries         | ...configured registries                |
+| .Plugins            | ...external plugins                     |
+| .Version            | ...podman version                       |
+
+Each of the above branch out into further subfields, more than can
+reasonably be enumerated in this document.
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-machine-inspect.1.md
+++ b/docs/source/markdown/podman-machine-inspect.1.md
@@ -18,6 +18,17 @@ inspected at once.
 
 Print results with a Go template.
 
+| **Placeholder**     | **Description**    |
+| ------------------- | ------------------ |
+| .ConfigPath         | FIXME |
+| .Created            | FIXME |
+| .Image              | FIXME |
+| .LastUp             | FIXME |
+| .Name               | FIXME |
+| .State              | FIXME |
+| .Resources          | FIXME |
+| .SSHConfig          | FIXME |
+
 #### **--help**
 
 Print usage statement.

--- a/docs/source/markdown/podman-machine-inspect.1.md
+++ b/docs/source/markdown/podman-machine-inspect.1.md
@@ -20,14 +20,14 @@ Print results with a Go template.
 
 | **Placeholder**     | **Description**    |
 | ------------------- | ------------------ |
-| .ConfigPath         | FIXME |
+| .ConfigPath ...     | FIXME |
 | .Created            | FIXME |
-| .Image              | FIXME |
+| .Image ...          | FIXME |
 | .LastUp             | FIXME |
 | .Name               | FIXME |
 | .State              | FIXME |
-| .Resources          | FIXME |
-| .SSHConfig          | FIXME |
+| .Resources ...      | FIXME |
+| .SSHConfig ...      | FIXME |
 
 #### **--help**
 

--- a/docs/source/markdown/podman-network-ls.1.md
+++ b/docs/source/markdown/podman-network-ls.1.md
@@ -53,6 +53,7 @@ Valid placeholders for the Go template are listed below:
 | .DNSEnabled       | Network has dns enabled (boolean)         |
 | .NetworkInterface | Name of the network interface on the host |
 | .Subnets          | List of subnets on this network           |
+| .Network ...      | Just an artifact. Not actually useful. |
 
 #### **--no-trunc**
 

--- a/docs/source/markdown/podman-pod-inspect.1.md
+++ b/docs/source/markdown/podman-pod-inspect.1.md
@@ -34,6 +34,18 @@ Valid placeholders for the Go template are listed below:
 | .SharedNamespaces | Pod   shared namespaces                                                       |
 | .NumContainers    | Number of containers in the pod                                               |
 | .Containers       | Pod   containers                                                              |
+| .BlkioDeviceReadBps | FIXME |
+| .CPUPeriod          | FIXME |
+| .CPUQuota           | FIXME |
+| .CPUSetCPUs         | FIXME |
+| .CreateCommand      | FIXME |
+| .Devices            | FIXME |
+| .ExitPolicy         | FIXME |
+| .InfraConfig        | FIXME |
+| .Mounts             | FIXME |
+| .Namespace          | FIXME |
+| .SecurityOpts       | FIXME |
+| .VolumesFrom        | FIXME |
 
 #### **--latest**, **-l**
 

--- a/docs/source/markdown/podman-pod-inspect.1.md
+++ b/docs/source/markdown/podman-pod-inspect.1.md
@@ -41,11 +41,12 @@ Valid placeholders for the Go template are listed below:
 | .CreateCommand      | FIXME |
 | .Devices            | FIXME |
 | .ExitPolicy         | FIXME |
-| .InfraConfig        | FIXME |
+| .InfraConfig ...    | FIXME |
 | .Mounts             | FIXME |
 | .Namespace          | FIXME |
 | .SecurityOpts       | FIXME |
 | .VolumesFrom        | FIXME |
+| .InspectPodData ... | Just an artifact. Not actually useful. |
 
 #### **--latest**, **-l**
 

--- a/docs/source/markdown/podman-pod-ps.1.md
+++ b/docs/source/markdown/podman-pod-ps.1.md
@@ -95,6 +95,7 @@ Valid placeholders for the Go template are listed below:
 | .Id                 | FIXME |
 | .InfraId            | FIXME |
 | .Namespace          | FIXME |
+| .ListPodsReport ... | Just an artifact. Not actually useful. |
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-pod-ps.1.md
+++ b/docs/source/markdown/podman-pod-ps.1.md
@@ -88,6 +88,13 @@ Valid placeholders for the Go template are listed below:
 | .Created            | Creation time of pod                                                                            |
 | .InfraID            | Pod infra container ID                                                                          |
 | .Networks           | Show all networks connected to the infra container                                              |
+| .ContainerIds       | FIXME |
+| .ContainerNames     | FIXME |
+| .ContainerStatuses  | FIXME |
+| .Containers         | FIXME |
+| .Id                 | FIXME |
+| .InfraId            | FIXME |
+| .Namespace          | FIXME |
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -83,6 +83,27 @@ Valid placeholders for the Go template are listed below:
 | .Networks       | Show all networks connected to the container     |
 | .Labels         | All the labels assigned to the container         |
 | .Mounts         | Volumes mounted in the container                 |
+| .AutoRemove     | FIXME                                            |
+| .Cgroup         | FIXME                                            |
+| .CGROUPNS       | FIXME                                            |
+| .Created        | FIXME                                            |
+| .CreatedHuman   | FIXME                                            |
+| .ExitCode       | FIXME                                            |
+| .Exited         | FIXME                                            |
+| .ExitedAt       | FIXME                                            |
+| .IPC            | FIXME                                            |
+| .IsInfra        | FIXME                                            |
+| .MNT            | FIXME                                            |
+| .NET            | FIXME                                            |
+| .Namespaces     | FIXME                                            |
+| .PIDNS          | FIXME                                            |
+| .Pid            | FIXME                                            |
+| .PodName        | FIXME                                            |
+| .StartedAt      | FIXME                                            |
+| .State          | FIXME                                            |
+| .User           | FIXME                                            |
+| .USERNS         | FIXME                                            |
+| .UTS            | FIXME                                            |
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -78,7 +78,7 @@ Valid placeholders for the Go template are listed below:
 | .Status         | Status of container                              |
 | .Pod            | Pod the container is associated with             |
 | .Ports          | Exposed ports                                    |
-| .Size           | Size of container                                |
+| .Size ...       | Size of container                                |
 | .Names          | Name of container                                |
 | .Networks       | Show all networks connected to the container     |
 | .Labels         | All the labels assigned to the container         |
@@ -95,7 +95,7 @@ Valid placeholders for the Go template are listed below:
 | .IsInfra        | FIXME                                            |
 | .MNT            | FIXME                                            |
 | .NET            | FIXME                                            |
-| .Namespaces     | FIXME                                            |
+| .Namespaces ... | FIXME                                            |
 | .PIDNS          | FIXME                                            |
 | .Pid            | FIXME                                            |
 | .PodName        | FIXME                                            |
@@ -104,6 +104,7 @@ Valid placeholders for the Go template are listed below:
 | .User           | FIXME                                            |
 | .USERNS         | FIXME                                            |
 | .UTS            | FIXME                                            |
+| .ListContainer ... | Just an artifact. Not actually useful. |
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-secret-inspect.1.md
+++ b/docs/source/markdown/podman-secret-inspect.1.md
@@ -19,6 +19,13 @@ Secrets can be queried individually by providing their full name or a unique par
 
 Format secret output using Go template.
 
+| **Placeholder**     | **Description**    |
+| ------------------- | ------------------ |
+| .ID                 | ID of secret       |
+| .Spec               | Details of secret (.Name, .Driver...) |
+| .CreatedAt          | When secret was created (relative timestamp, human-readable) |
+| .UpdatedAt          | When secret was last updated (relative timestamp, human-readable) |
+
 #### **--help**
 
 Print usage statement.

--- a/docs/source/markdown/podman-secret-inspect.1.md
+++ b/docs/source/markdown/podman-secret-inspect.1.md
@@ -19,12 +19,16 @@ Secrets can be queried individually by providing their full name or a unique par
 
 Format secret output using Go template.
 
-| **Placeholder**     | **Description**    |
-| ------------------- | ------------------ |
-| .ID                 | ID of secret       |
-| .Spec               | Details of secret (.Name, .Driver...) |
-| .CreatedAt          | When secret was created (relative timestamp, human-readable) |
-| .UpdatedAt          | When secret was last updated (relative timestamp, human-readable) |
+| **Placeholder**          | **Description**                                                   |
+| ------------------------ | ----------------------------------------------------------------- |
+| .ID                      | ID of secret                                                      |
+| .Spec                    | Details of secret                                                 |
+| .Spec.Name               | Name of secret                                                    |
+| .Spec.Driver             | Driver info                                                       |
+| .Spec.Driver.Name        | Driver name (string)                                              |
+| .Spec.Driver.Options ... | Driver options (map of driver-specific options)                   |
+| .CreatedAt               | When secret was created (relative timestamp, human-readable)      |
+| .UpdatedAt               | When secret was last updated (relative timestamp, human-readable) |
 
 #### **--help**
 

--- a/docs/source/markdown/podman-secret-ls.1.md
+++ b/docs/source/markdown/podman-secret-ls.1.md
@@ -28,6 +28,13 @@ Valid filters are listed below:
 
 Format secret output using Go template.
 
+| **Placeholder**     | **Description**    |
+| ------------------- | ------------------ |
+| .ID                 | ID of secret       |
+| .Spec               | FIXME: this does not seem to work |
+| .CreatedAt          | When secret was created (relative timestamp, human-readable) |
+| .UpdatedAt          | When secret was last updated (relative timestamp, human-readable) |
+
 #### **--noheading**
 
 Omit the table headings from the listing of secrets.	.

--- a/docs/source/markdown/podman-secret-ls.1.md
+++ b/docs/source/markdown/podman-secret-ls.1.md
@@ -31,7 +31,7 @@ Format secret output using Go template.
 | **Placeholder**     | **Description**    |
 | ------------------- | ------------------ |
 | .ID                 | ID of secret       |
-| .Spec               | FIXME: this does not seem to work |
+| .Spec ...           | FIXME: this does not seem to work |
 | .CreatedAt          | When secret was created (relative timestamp, human-readable) |
 | .UpdatedAt          | When secret was last updated (relative timestamp, human-readable) |
 

--- a/docs/source/markdown/podman-stats.1.md
+++ b/docs/source/markdown/podman-stats.1.md
@@ -32,15 +32,32 @@ Valid placeholders for the Go template are listed below:
 
 | **Placeholder** | **Description**    |
 | --------------- | ------------------ |
-| .ID             | Container ID       |
+| .ID             | Container ID (truncated) |
+| .ContainerID    | Container ID (full hash) |
 | .Name           | Container Name     |
 | .CPUPerc        | CPU percentage     |
 | .MemUsage       | Memory usage       |
 | .MemUsageBytes  | Memory usage (IEC) |
+| .AvgCPU         | Average CPU (full precision float) |
+| .AVGCPU         | Average CPU (formatted) |
+| .CPU            | Percent CPU (full precision float) |
+| .CPUNano        | CPU Usage, total, in nanoseconds |
+| .CPUSystemNano  | CPU Usage, kernel, in nanoseconds |
+| .Duration       | Same as CPUNano (FIXME: why?) |
+| .MemLimit       | Memory limit, in bytes |
 | .MemPerc        | Memory percentage  |
 | .NetIO          | Network IO         |
 | .BlockIO        | Block IO           |
 | .PIDS           | Number of PIDs     |
+| .NetInput       | Network Input      |
+| .NetOutput      | Network Output     |
+| .BlockInput     | Block Input        |
+| .BlockOutput    | Block Output       |
+| .PerCPU         | FIXME: empty array? |
+| .PIDs           | Number of PIDs     |
+| .SystemNano     | Current system datetime, nanoseconds since epoch |
+| .UpTime         | WTF? This is Duration (CPUNano) in human-readable form?? |
+| .Up             | Same as UpTime (FIXME: why?) |
 
 When using a GO template, you may precede the format with `table` to print headers.
 

--- a/docs/source/markdown/podman-stats.1.md
+++ b/docs/source/markdown/podman-stats.1.md
@@ -58,6 +58,7 @@ Valid placeholders for the Go template are listed below:
 | .SystemNano     | Current system datetime, nanoseconds since epoch |
 | .UpTime         | WTF? This is Duration (CPUNano) in human-readable form?? |
 | .Up             | Same as UpTime (FIXME: why?) |
+| .ContainerStats ... | Just an artifact. Not actually useful. |
 
 When using a GO template, you may precede the format with `table` to print headers.
 

--- a/docs/source/markdown/podman-system-connection-list.1.md
+++ b/docs/source/markdown/podman-system-connection-list.1.md
@@ -24,6 +24,7 @@ Valid placeholders for the Go template listed below:
 | .Identity       | Path to file containing SSH identity |
 | .URI            | URI to podman service. Valid schemes are ssh://[user@]*host*[:port]*Unix domain socket*[?secure=True], unix://*Unix domain socket*, and tcp://localhost[:*port*] |
 | .Default        | Indicates whether connection is the default |
+| .Destination ... | Just an artifact. Not actually useful. |
 
 ## EXAMPLE
 ```

--- a/docs/source/markdown/podman-version.1.md
+++ b/docs/source/markdown/podman-version.1.md
@@ -18,8 +18,8 @@ Change output format to "json" or a Go template.
 
 | **Placeholder**     | **Description**          |
 | ------------------- | ------------------------ |
-| .Client             | Version of local podman  |
-| .Server             | Version of remote podman |
+| .Client ...         | Version of local podman  |
+| .Server ...         | Version of remote podman |
 
 Each of the above fields branch deeper into further subfields
 such as .Version, .APIVersion, .GoVersion, and more.

--- a/docs/source/markdown/podman-version.1.md
+++ b/docs/source/markdown/podman-version.1.md
@@ -16,6 +16,14 @@ OS, and Architecture.
 
 Change output format to "json" or a Go template.
 
+| **Placeholder**     | **Description**          |
+| ------------------- | ------------------------ |
+| .Client             | Version of local podman  |
+| .Server             | Version of remote podman |
+
+Each of the above fields branch deeper into further subfields
+such as .Version, .APIVersion, .GoVersion, and more.
+
 ## Example
 
 A sample output of the `version` command:

--- a/docs/source/markdown/podman-volume-inspect.1.md
+++ b/docs/source/markdown/podman-volume-inspect.1.md
@@ -24,6 +24,23 @@ Inspect all volumes.
 
 Format volume output using Go template
 
+| **Placeholder**     | **Description**    |
+| ------------------- | ------------------ |
+| .Anonymous          | FIXME |
+| .CreatedAt          | FIXME |
+| .Driver             | FIXME |
+| .GID                | FIXME |
+| .Labels             | FIXME |
+| .MountCount         | FIXME |
+| .Mountpoint         | FIXME |
+| .Name               | FIXME |
+| .NeedsChown         | FIXME |
+| .NeedsCopyUp        | FIXME |
+| .Options            | FIXME |
+| .Scope              | FIXME |
+| .Status             | FIXME |
+| .UID                | FIXME |
+
 #### **--help**
 
 Print usage statement

--- a/docs/source/markdown/podman-volume-ls.1.md
+++ b/docs/source/markdown/podman-volume-ls.1.md
@@ -48,6 +48,8 @@ Format volume output using Go template.
 | .Scope              | FIXME |
 | .Status             | FIXME |
 | .UID                | FIXME |
+| .InspectVolumeData    ... | Just an artifact. Not actually useful. |
+| .VolumeConfigResponse ... | Just an artifact. Not actually useful. |
 
 #### **--help**
 

--- a/docs/source/markdown/podman-volume-ls.1.md
+++ b/docs/source/markdown/podman-volume-ls.1.md
@@ -32,6 +32,23 @@ Volumes can be filtered by the following attributes:
 
 Format volume output using Go template.
 
+| **Placeholder**     | **Description**    |
+| ------------------- | ------------------ |
+| .Anonymous          | FIXME |
+| .CreatedAt          | FIXME |
+| .Driver             | FIXME |
+| .GID                | FIXME |
+| .Labels             | FIXME |
+| .MountCount         | FIXME |
+| .Mountpoint         | FIXME |
+| .Name               | FIXME |
+| .NeedsChown         | FIXME |
+| .NeedsCopyUp        | FIXME |
+| .Options            | FIXME |
+| .Scope              | FIXME |
+| .Status             | FIXME |
+| .UID                | FIXME |
+
 #### **--help**
 
 Print usage statement.

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -126,9 +126,19 @@ sub main {
 sub xref_by_help {
     my ($help, $man, @subcommand) = @_;
 
+  OPTION:
     for my $k (sort keys %$help) {
         if (exists $man->{$k}) {
             if (ref $help->{$k}) {
+                # This happens when 'podman foo --format' offers
+                # autocompletion that looks like a Go template, but those
+                # template options aren't documented in the man pages.
+                if ($k eq '--format' && ! ref($man->{$k})) {
+                    warn "$ME: 'podman @subcommand': --format options are available through autocomplete, but are not documented in man page\n";
+                    ++$Errs;
+                    next OPTION;
+                }
+
                 xref_by_help($help->{$k}, $man->{$k}, @subcommand, $k);
             }
             # Otherwise, non-ref is leaf node such as a --option
@@ -152,10 +162,22 @@ sub xref_by_man {
     my ($help, $man, @subcommand) = @_;
 
     # FIXME: this generates way too much output
+  KEYWORD:
     for my $k (grep { $_ ne '_path' } sort keys %$man) {
+        if ($k eq '--format' && ref($man->{$k}) && ! ref($help->{$k})) {
+            warn "$ME: 'podman @subcommand': --format options documented in man page, but not available via autocomplete\n";
+            next KEYWORD;
+        }
+
         if (exists $help->{$k}) {
             if (ref $man->{$k}) {
                 xref_by_man($help->{$k}, $man->{$k}, @subcommand, $k);
+            }
+            elsif ($k =~ /^-/) {
+                # This is OK: we don't recurse into options
+            }
+            else {
+                # FIXME: should never get here, but we do. Figure it out later.
             }
         }
         elsif ($k ne '--help' && $k ne '-h') {
@@ -254,15 +276,39 @@ sub podman_help {
             }
         }
         elsif ($section eq 'options') {
+            my $opt = '';
+
             # Handle '--foo' or '-f, --foo'
             if ($line =~ /^\s{1,10}(--\S+)\s/) {
                 print "> podman @_ $1\n"                        if $debug;
-                $help{$1} = 1;
+                $opt = $1;
+                $help{$opt} = 1;
             }
             elsif ($line =~ /^\s{1,10}(-\S),\s+(--\S+)\s/) {
                 print "> podman @_ $1, $2\n"                    if $debug;
-                $help{$1} = $help{$2} = 1;
+                $opt = $2;
+                $help{$1} = $help{$opt} = 1;
             }
+
+            # Special case for --format: run podman with autocomplete.
+            # If that lists one or more '{{.Foo}}' or '{{.Foo.' entries
+            # (indicating terminal or nonterminal nodes respectively)
+            # convert our option data structure from scalar (indicating
+            # that we just cross-check for existence in the man page)
+            # to hashref (indicating that we recurse down and cross-check
+            # each individual param).
+            if ($opt eq '--format') {
+                my @completions = _completions(@_, '--format', '{{.');
+                for my $c (@completions) {
+                    if ($c =~ /^\{\{(\.\S+)(\.|\}\})$/) {
+                        # First time through: convert to a hashref
+                        $help{$opt} = {}   if ! ref($help{$opt});
+
+                        # Remember this param
+                        $help{$opt}{$1} = 1;
+                    }
+                }
+           }
         }
     }
     close $fh
@@ -372,6 +418,24 @@ sub podman_man {
                     push @most_recent_flags, $1;
                 }
             }
+
+            # --format does not always mean a Go format! E.g., push --format=oci
+            if ($previous_flag eq '--format') {
+                # ...but if there's a table like '| .Foo | blah blah |'
+                # then it's definitely a Go template.
+                if ($line =~ /^\|\s+(\.\S+)\s+\|/) {
+                    # Confirmed: we have a table with '.Foo' strings, so
+                    # this is a Go template. Override previous (scalar)
+                    # setting of the --format flag with a hash, indicating
+                    # that we will recursively cross-check each param.
+                    if (! ref($man{$previous_flag})) {
+                        $man{$previous_flag} = { _path => $subpath };
+                    }
+
+                    # ...and document this format option
+                    $man{$previous_flag}{$1} = 1;
+                }
+            }
         }
 
         # It's easy to make mistakes in the SEE ALSO elements.
@@ -461,6 +525,41 @@ sub podman_rst {
     $rst{image}{trust}{$_} = { _desc => 'ok' } for (qw(set show));
 
     return \%rst;
+}
+
+##################
+#  _completions  #  run podman __completeNoDesc, return list of completions
+##################
+sub _completions {
+    my $kidpid = open my $podman_fh, '-|';
+    if (! defined $kidpid) {
+        die "$ME: Could not fork: $!\n";
+    }
+
+    if ($kidpid == 0) {
+        # We are the child
+        close STDERR;
+        exec $PODMAN, '__completeNoDesc', @_;
+        die "$ME: Could not exec: $!\n";
+    }
+
+    # We are the parent
+    my @completions;
+    while (my $line = <$podman_fh>) {
+        chomp $line;
+        push @completions, $line;
+
+        # Recursively expand Go templates?
+        if ($line =~ /^\{\{\..*\.$/) {
+            # FIXME: Nope nope nope! Increases our count by over 500.
+            # However, keep this for now so we can think about it later.
+#            pop @_;
+#            push @completions, _completions(@_, $line);
+        }
+    }
+    close $podman_fh
+        or warn "$ME: Error running podman __completeNoDesc @_\n";
+    return @completions;
 }
 
 # END   data gathering

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -144,6 +144,16 @@ sub xref_by_help {
             # Otherwise, non-ref is leaf node such as a --option
         }
         else {
+            # Not documented in man. However, handle '...' as a special case
+            # in formatting strings. E.g., 'podman info .Host' is documented
+            # in the man page as '.Host ...' to indicate that the subfields
+            # are way too many to list individually.
+            my $k_copy = $k;
+            while ($k_copy =~ s/\.[^.]+$//) {
+                if (($man->{$k_copy}||'') eq '...') {
+                    next OPTION;
+                }
+            }
             my $man = $man->{_path} || 'man';
             warn "$ME: 'podman @subcommand --help' lists '$k', which is not in $man\n";
             ++$Errs;
@@ -422,8 +432,11 @@ sub podman_man {
             # --format does not always mean a Go format! E.g., push --format=oci
             if ($previous_flag eq '--format') {
                 # ...but if there's a table like '| .Foo | blah blah |'
-                # then it's definitely a Go template.
-                if ($line =~ /^\|\s+(\.\S+)\s+\|/) {
+                # then it's definitely a Go template. '.Foo ...' (three dots)
+                # indicates that .Foo includes a number of subfields .Foo.Xxx,
+                # .Foo.Yyy too numerous to list individually in man pages.
+                #                   1     12   3      32
+                if ($line =~ /^\|\s+(\.\S+)(\s+(\.\.\.))?\s+\|/) {
                     # Confirmed: we have a table with '.Foo' strings, so
                     # this is a Go template. Override previous (scalar)
                     # setting of the --format flag with a hash, indicating
@@ -432,8 +445,10 @@ sub podman_man {
                         $man{$previous_flag} = { _path => $subpath };
                     }
 
-                    # ...and document this format option
-                    $man{$previous_flag}{$1} = 1;
+                    # ...and document this format option. $3, if set,
+                    # will be '...' which indicates that $1 (the format)
+                    # has too many subformats to document individually.
+                    $man{$previous_flag}{$1} = $3 || 1;
                 }
             }
         }
@@ -553,8 +568,12 @@ sub _completions {
         if ($line =~ /^\{\{\..*\.$/) {
             # FIXME: Nope nope nope! Increases our count by over 500.
             # However, keep this for now so we can think about it later.
-#            pop @_;
-#            push @completions, _completions(@_, $line);
+            my @cmd_copy = @_;          # clone of podman subcommands...
+            pop @cmd_copy;              # ...so we can recurse with new format
+            my @subcompletions = _completions(@cmd_copy, $line);
+            my @is_time = grep { /Nanosecond|UnixNano|YearDay/ } @subcompletions;
+            push @completions, @subcompletions
+                unless @is_time >= 3;
         }
     }
     close $podman_fh


### PR DESCRIPTION
Autocomplete is awesome. It offers us a programmatic way to
determine the set of values for a given --format option.
Use that to make sure the man pages document reality.

Signed-off-by: Ed Santiago <santiago@redhat.com>
