### PR TITLE
podman search: truncate by default

### DIFF
--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -23,6 +23,7 @@ type searchOptionsWrapper struct {
 	Compatible   bool   // Docker compat
 	TLSVerifyCLI bool   // Used to convert to an optional bool later
 	Format       string // For go templating
+	NoTrunc      bool
 }
 
 // listEntryTag is a utility structure used for json serialization.
@@ -92,7 +93,7 @@ func searchFlags(cmd *cobra.Command) {
 	flags.IntVar(&searchOptions.Limit, limitFlagName, 0, "Limit the number of results")
 	_ = cmd.RegisterFlagCompletionFunc(limitFlagName, completion.AutocompleteNone)
 
-	flags.Bool("no-trunc", true, "Do not truncate the output. Default: true")
+	flags.BoolVar(&searchOptions.NoTrunc, "no-trunc", false, "Do not truncate the output")
 	flags.BoolVar(&searchOptions.Compatible, "compatible", false, "List stars, official and automated columns (Docker compatibility)")
 
 	authfileFlagName := "authfile"
@@ -139,11 +140,10 @@ func imageSearch(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	noTrunc, _ := cmd.Flags().GetBool("no-trunc")
 	isJSON := report.IsJSON(searchOptions.Format)
 	for i, element := range searchReport {
 		d := strings.ReplaceAll(element.Description, "\n", " ")
-		if len(d) > 44 && !(noTrunc || isJSON) {
+		if len(d) > 44 && !(searchOptions.NoTrunc || isJSON) {
 			d = strings.TrimSpace(d[:44]) + "..."
 		}
 		searchReport[i].Description = d

--- a/docs/source/markdown/podman-search.1.md
+++ b/docs/source/markdown/podman-search.1.md
@@ -90,7 +90,7 @@ The result contains the Image name and its tag, one line for every tag associate
 
 #### **--no-trunc**
 
-Do not truncate the output (default *true*).
+Do not truncate the output (default *false*).
 
 #### **--tls-verify**
 


### PR DESCRIPTION
Truncate by default to avoid long descriptions from rendering the output
unreadable.

[NO NEW TESTS NEEDED]

Fixes: #14044
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
