### PR TITLE
volume: add new option -o o=noquota

### DIFF
--- a/docs/source/markdown/podman-volume-create.1.md
+++ b/docs/source/markdown/podman-volume-create.1.md
@@ -38,7 +38,8 @@ The `device` option sets the device to be mounted, and is equivalent to the `dev
 The `o` option sets options for the mount, and is equivalent to the `-o` flag to **mount(8)** with these exceptions:
 
   - The `o` option supports `uid` and `gid` options to set the UID and GID of the created volume that are not normally supported by **mount(8)**.
-  - The `o` option supports the `size` option to set the maximum size of the created volume and the `inodes` option to set the maximum number of inodes for the volume. Currently these flags are only supported on "xfs" file system mounted with the `prjquota` flag described in the **xfs_quota(8)** man page.
+  - The `o` option supports the `size` option to set the maximum size of the created volume, the `inodes` option to set the maximum number of inodes for the volume and `noquota` to completely disable quota support even for tracking of disk usage. Currently these flags are only supported on "xfs" file system mounted with the `prjquota` flag described in the **xfs_quota(8)** man page.
+  - The `o` option supports .
   - Using volume options other then the UID/GID options with the **local** driver requires root privileges.
 
 When not using the **local** driver, the given options are passed directly to the volume plugin. In this case, supported options are dictated by the plugin in question, not Podman.

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1634,6 +1634,19 @@ func WithVolumeNoChown() VolumeCreateOption {
 	}
 }
 
+// WithVolumeDisableQuota prevents the volume from being assigned a quota.
+func WithVolumeDisableQuota() VolumeCreateOption {
+	return func(volume *Volume) error {
+		if volume.valid {
+			return define.ErrVolumeFinalized
+		}
+
+		volume.config.DisableQuota = true
+
+		return nil
+	}
+}
+
 // withSetAnon sets a bool notifying libpod that this volume is anonymous and
 // should be removed when containers using it are removed and volumes are
 // specified for removal.

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -52,6 +52,9 @@ type VolumeConfig struct {
 	Size uint64 `json:"size"`
 	// Inodes maximum of the volume.
 	Inodes uint64 `json:"inodes"`
+	// DisableQuota indicates that the volume should completely disable using any
+	// quota tracking.
+	DisableQuota bool `json:"disableQuota,omitempty"`
 }
 
 // VolumeState holds the volume's mutable state.

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -52,6 +52,9 @@ func (v *Volume) needsMount() bool {
 	if _, ok := v.config.Options["SIZE"]; ok {
 		index++
 	}
+	if _, ok := v.config.Options["NOQUOTA"]; ok {
+		index++
+	}
 	// when uid or gid is set there is also the "o" option
 	// set so we have to ignore this one as well
 	if index > 0 {

--- a/pkg/domain/infra/abi/parse/parse.go
+++ b/pkg/domain/infra/abi/parse/parse.go
@@ -73,6 +73,11 @@ func VolumeOptions(opts map[string]string) ([]libpod.VolumeCreateOption, error) 
 					finalVal = append(finalVal, o)
 					// set option "GID": "$gid"
 					volumeOptions["GID"] = splitO[1]
+				case "noquota":
+					logrus.Debugf("Removing noquota from options and adding WithVolumeDisableQuota")
+					libpodOptions = append(libpodOptions, libpod.WithVolumeDisableQuota())
+					// set option "NOQUOTA": "true"
+					volumeOptions["NOQUOTA"] = "true"
 				default:
 					finalVal = append(finalVal, o)
 				}

--- a/test/test_podman_baseline.sh
+++ b/test/test_podman_baseline.sh
@@ -309,6 +309,28 @@ else
     echo "Overlay test within limits failed"
 fi
 
+before=`xfs_quota -x -c 'report -N -p' $TMPDIR | grep -c ^#`
+podman $PODMANBASE volume create -o o=noquota test-no-quota
+after=`xfs_quota -x -c 'report -N -p' $TMPDIR | grep -c ^#`
+
+if [ $before != $after ];
+then
+    echo "Test -o=noquota doesn't create a projid failed"
+else
+    echo "Test -o=noquota doesn't create a projid passed"
+fi
+
+before=`xfs_quota -x -c 'report -N -p' $TMPDIR | grep -c ^#`
+podman $PODMANBASE volume create -o test-no-quota
+after=`xfs_quota -x -c 'report -N -p' $TMPDIR | grep -c ^#`
+
+if [ $before == $after ];
+then
+    echo "Test without -o=noquota creates a projid failed"
+else
+    echo "Test without -o=noquota creates a projid passed"
+fi
+
 ########
 # Expected to fail
 ########


### PR DESCRIPTION
add a new option to completely disable xfs quota usage for a volume.

xfs quota set on a volume, even just for tracking disk usage, can
cause weird errors if the volume is later re-used by a container with
a different quota projid.  More specifically, link(2) and rename(2)
might fail with EXDEV if the source file has a projid that is
different from the parent directory.

To prevent such kind of issues, the volume should be created
beforehand with `podman volume create -o o=noquota $ID`

Closes: https://github.com/containers/podman/issues/14049

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
