### PR TITLE
pass networks to container clone

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -288,6 +288,15 @@ func (c *Container) Config() *ContainerConfig {
 		return nil
 	}
 
+	if c != nil {
+		networks, err := c.networks()
+		if err != nil {
+			return nil
+		}
+
+		returnConfig.Networks = networks
+	}
+
 	return returnConfig
 }
 
@@ -1260,7 +1269,10 @@ func (c *Container) NetworkMode() string {
 
 // Unlocked accessor for networks
 func (c *Container) networks() (map[string]types.PerNetworkOptions, error) {
-	return c.runtime.state.GetNetworks(c)
+	if c != nil && c.runtime != nil && c.runtime.state != nil { // can fail if c.networks is called from the tests
+		return c.runtime.state.GetNetworks(c)
+	}
+	return nil, nil
 }
 
 // getInterfaceByName returns a formatted interface name for a given

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1544,6 +1544,12 @@ func (ic *ContainerEngine) ContainerClone(ctx context.Context, ctrCloneOpts enti
 			return nil, err
 		}
 
+		if len(spec.Networks) > 0 && pod.SharesNet() {
+			logrus.Warning("resetting network config, cannot specify a network other than the pod's when sharing the net namespace")
+			spec.Networks = nil
+			spec.NetworkOptions = nil
+		}
+
 		allNamespaces := []struct {
 			isShared bool
 			value    *specgen.Namespace

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -501,6 +501,8 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, contaierID s
 	_, mounts := c.SortUserVolumes(c.Spec())
 	specg.Mounts = mounts
 	specg.HostDeviceList = conf.DeviceHostSrc
+	specg.Networks = conf.Networks
+
 	mapSecurityConfig(conf, specg)
 
 	if c.IsInfra() { // if we are creating this spec for a pod's infra ctr, map the compatible options

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -175,13 +175,15 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 			return nil, nil, nil, errors.New("the given container could not be retrieved")
 		}
 		conf := c.Config()
-		out, err := json.Marshal(conf.Spec.Linux)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		err = json.Unmarshal(out, runtimeSpec.Linux)
-		if err != nil {
-			return nil, nil, nil, err
+		if conf != nil && conf.Spec != nil && conf.Spec.Linux != nil {
+			out, err := json.Marshal(conf.Spec.Linux)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			err = json.Unmarshal(out, runtimeSpec.Linux)
+			if err != nil {
+				return nil, nil, nil, err
+			}
 		}
 		if s.ResourceLimits != nil {
 			switch {


### PR DESCRIPTION
since the network config is a string map, json.unmarshal does not recognize
the config and spec as the same entity, need to map this option manually

resolves #13713

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->
