### PR TITLE
libpod: host netns keep same /etc/resolv.conf

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2279,9 +2279,11 @@ func (c *Container) generateResolvConf() error {
 		networkSearchDomains []string
 	)
 
+	hostns := true
 	resolvConf := "/etc/resolv.conf"
 	for _, namespace := range c.config.Spec.Linux.Namespaces {
 		if namespace.Type == spec.NetworkNamespace {
+			hostns = false
 			if namespace.Path != "" && !strings.HasPrefix(namespace.Path, "/proc/") {
 				definedPath := filepath.Join("/etc/netns", filepath.Base(namespace.Path), "resolv.conf")
 				_, err := os.Stat(definedPath)
@@ -2303,7 +2305,7 @@ func (c *Container) generateResolvConf() error {
 
 	ns := resolvconf.GetNameservers(contents)
 	// check if systemd-resolved is used, assume it is used when 127.0.0.53 is the only nameserver
-	if len(ns) == 1 && ns[0] == "127.0.0.53" {
+	if !hostns && len(ns) == 1 && ns[0] == "127.0.0.53" {
 		// read the actual resolv.conf file for systemd-resolved
 		resolvedContents, err := ioutil.ReadFile("/run/systemd/resolve/resolv.conf")
 		if err != nil {
@@ -2336,7 +2338,7 @@ func (c *Container) generateResolvConf() error {
 
 	// Ensure that the container's /etc/resolv.conf is compatible with its
 	// network configuration.
-	resolv, err := resolvconf.FilterResolvDNS(contents, ipv6, c.config.CreateNetNS)
+	resolv, err := resolvconf.FilterResolvDNS(contents, ipv6, !hostns)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing host resolv.conf")
 	}

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -656,6 +656,15 @@ EOF
     run_podman run --network $netname --rm $IMAGE cat /etc/resolv.conf
     is "$output" "search dns.podman.*" "correct search domain"
     is "$output" ".*nameserver $subnet.1.*" "integrated dns nameserver is set"
+
+    # host network should keep localhost nameservers
+    if grep 127.0.0. /etc/resolv.conf >/dev/null; then
+        run_podman run --network host --rm $IMAGE cat /etc/resolv.conf
+        is "$output" ".*nameserver 127\.0\.0.*" "resolv.conf contains localhost nameserver"
+    fi
+    # host net + dns still works
+    run_podman run --network host --dns 1.1.1.1 --rm $IMAGE cat /etc/resolv.conf
+    is "$output" ".*nameserver 1\.1\.1\.1.*" "resolv.conf contains 1.1.1.1 nameserver"
 }
 
 @test "podman run port forward range" {

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -723,4 +723,19 @@ EOF
     is "${#lines[@]}" "5" "expect 5 host entries in /etc/hosts"
 }
 
+@test "podman run /etc/* permissions" {
+    userns="--userns=keep-id"
+    if ! is_rootless; then
+        userns="--uidmap=0:1111111:65536 --gidmap=0:1111111:65536"
+    fi
+    # check with and without userns
+    for userns in "" "$userns"; do
+        # check the /etc/hosts /etc/hostname /etc/resolv.conf are owned by root
+        run_podman run $userns --rm $IMAGE stat -c %u:%g /etc/hosts /etc/resolv.conf /etc/hostname
+        is "${lines[0]}" "0\:0" "/etc/hosts owned by root"
+        is "${lines[1]}" "0\:0" "/etc/resolv.conf owned by root"
+        is "${lines[2]}" "0\:0" "/etc/hosts owned by root"
+    done
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
When a container is run in the host network namespace we have to keep
the same resolv.conf content and not use the systemd-resolve detection
logic.

But also make sure we still allow --dns options.

Fixes #14055

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman create/run --network host will use the correct nameservers from the host [#14055](https://github.com/containers/podman/issues/14055)
```
