### PR TITLE
podman system reset removed machines incorrectly

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -117,7 +117,7 @@ func initMachine(cmd *cobra.Command, args []string) error {
 		vm  machine.VM
 	)
 
-	provider := getSystemDefaultProvider()
+	provider := GetSystemDefaultProvider()
 	initOpts.Name = defaultMachineName
 	if len(args) > 0 {
 		if len(args[0]) > maxMachineNameSize {

--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -52,7 +52,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 		args = append(args, defaultMachineName)
 	}
 	vms := make([]machine.InspectInfo, 0, len(args))
-	provider := getSystemDefaultProvider()
+	provider := GetSystemDefaultProvider()
 	for _, vmName := range args {
 		vm, err := provider.LoadVMByName(vmName)
 		if err != nil {

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -85,7 +85,7 @@ func list(cmd *cobra.Command, args []string) error {
 		listFlag.format = "{{.Name}}\n"
 	}
 
-	provider := getSystemDefaultProvider()
+	provider := GetSystemDefaultProvider()
 	listResponse, err = provider.List(opts)
 	if err != nil {
 		return errors.Wrap(err, "error listing vms")

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -51,7 +51,7 @@ func autocompleteMachine(cmd *cobra.Command, args []string, toComplete string) (
 
 func getMachines(toComplete string) ([]string, cobra.ShellCompDirective) {
 	suggestions := []string{}
-	provider := getSystemDefaultProvider()
+	provider := GetSystemDefaultProvider()
 	machines, err := provider.List(machine.ListOptions{})
 	if err != nil {
 		cobra.CompErrorln(err.Error())

--- a/cmd/podman/machine/platform.go
+++ b/cmd/podman/machine/platform.go
@@ -8,6 +8,6 @@ import (
 	"github.com/containers/podman/v4/pkg/machine/qemu"
 )
 
-func getSystemDefaultProvider() machine.Provider {
+func GetSystemDefaultProvider() machine.Provider {
 	return qemu.GetQemuProvider()
 }

--- a/cmd/podman/machine/platform_windows.go
+++ b/cmd/podman/machine/platform_windows.go
@@ -5,6 +5,6 @@ import (
 	"github.com/containers/podman/v4/pkg/machine/wsl"
 )
 
-func getSystemDefaultProvider() machine.Provider {
+func GetSystemDefaultProvider() machine.Provider {
 	return wsl.GetWSLProvider()
 }

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -60,7 +60,7 @@ func rm(cmd *cobra.Command, args []string) error {
 		vmName = args[0]
 	}
 
-	provider := getSystemDefaultProvider()
+	provider := GetSystemDefaultProvider()
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
 		return err

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -83,7 +83,7 @@ func setMachine(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && len(args[0]) > 0 {
 		vmName = args[0]
 	}
-	provider := getSystemDefaultProvider()
+	provider := GetSystemDefaultProvider()
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
 		return err

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -51,7 +51,7 @@ func ssh(cmd *cobra.Command, args []string) error {
 
 	// Set the VM to default
 	vmName := defaultMachineName
-	provider := getSystemDefaultProvider()
+	provider := GetSystemDefaultProvider()
 
 	// If len is greater than 0, it means we may have been
 	// provided the VM name.  If so, we check.  The VM name,

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -41,7 +41,7 @@ func start(cmd *cobra.Command, args []string) error {
 		vmName = args[0]
 	}
 
-	provider := getSystemDefaultProvider()
+	provider := GetSystemDefaultProvider()
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
 		return err

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -40,7 +40,7 @@ func stop(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && len(args[0]) > 0 {
 		vmName = args[0]
 	}
-	provider := getSystemDefaultProvider()
+	provider := GetSystemDefaultProvider()
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
 		return err

--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -61,7 +61,9 @@ func reset(cmd *cobra.Command, args []string) {
         - all pods
         - all images
         - all networks
-        - all build cache`)
+        - all build cache
+        - all machines`)
+
 		if len(listCtn) > 0 {
 			fmt.Println(`WARNING! The following external containers will be purged:`)
 			// print first 12 characters of ID and first configured name alias
@@ -103,5 +105,11 @@ func reset(cmd *cobra.Command, args []string) {
 		//nolint:gocritic
 		os.Exit(define.ExecErrorCodeGeneric)
 	}
+
+	// Shutdown podman-machine and delete all machine files
+	if err := resetMachine(); err != nil {
+		logrus.Error(err)
+	}
+
 	os.Exit(0)
 }

--- a/cmd/podman/system/reset_machine.go
+++ b/cmd/podman/system/reset_machine.go
@@ -1,0 +1,13 @@
+//go:build (amd64 && !remote) || (arm64 && !remote)
+// +build amd64,!remote arm64,!remote
+
+package system
+
+import (
+	cmdMach "github.com/containers/podman/v4/cmd/podman/machine"
+)
+
+func resetMachine() error {
+	provider := cmdMach.GetSystemDefaultProvider()
+	return provider.RemoveAndCleanMachines()
+}

--- a/cmd/podman/system/reset_machine_unsupported.go
+++ b/cmd/podman/system/reset_machine_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !amd64 && !arm64
+// +build !amd64,!arm64
+
+package system
+
+func resetMachine() error {
+	return nil
+}

--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -7,7 +7,7 @@ podman\-system\-reset - Reset storage back to initial state
 **podman system reset** [*options*]
 
 ## DESCRIPTION
-**podman system reset** removes all pods, containers, images, networks and volumes.
+**podman system reset** removes all pods, containers, images, networks and volumes, and machines.
 
 This command must be run **before** changing any of the following fields in the
 `containers.conf` or `storage.conf` files: `driver`, `static_dir`, `tmp_dir`
@@ -36,6 +36,7 @@ WARNING! This will remove:
         - all images
         - all networks
         - all build cache
+        - all machines
 Are you sure you want to continue? [y/N] y
 ```
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1543,3 +1543,79 @@ func (v *MachineVM) editCmdLine(flag string, value string) {
 		v.CmdLine = append(v.CmdLine, []string{flag, value}...)
 	}
 }
+
+// RemoveAndCleanMachines removes all machine and cleans up any other files associatied with podman machine
+func (p *Provider) RemoveAndCleanMachines() error {
+	var (
+		vm             machine.VM
+		listResponse   []*machine.ListResponse
+		opts           machine.ListOptions
+		destroyOptions machine.RemoveOptions
+	)
+	destroyOptions.Force = true
+	var prevErr error
+
+	listResponse, err := p.List(opts)
+	if err != nil {
+		return err
+	}
+
+	for _, mach := range listResponse {
+		vm, err = p.LoadVMByName(mach.Name)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		}
+		_, remove, err := vm.Remove(mach.Name, destroyOptions)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		} else {
+			if err := remove(); err != nil {
+				if prevErr != nil {
+					logrus.Error(prevErr)
+				}
+				prevErr = err
+			}
+		}
+	}
+
+	// Clean leftover files in data dir
+	dataDir, err := machine.DataDirPrefix()
+	if err != nil {
+		if prevErr != nil {
+			logrus.Error(prevErr)
+		}
+		prevErr = err
+	} else {
+		err := os.RemoveAll(dataDir)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		}
+	}
+
+	// Clean leftover files in conf dir
+	confDir, err := machine.ConfDirPrefix()
+	if err != nil {
+		if prevErr != nil {
+			logrus.Error(prevErr)
+		}
+		prevErr = err
+	} else {
+		err := os.RemoveAll(confDir)
+		if err != nil {
+			if prevErr != nil {
+				logrus.Error(prevErr)
+			}
+			prevErr = err
+		}
+	}
+	return prevErr
+}

--- a/test/e2e/system_reset_test.go
+++ b/test/e2e/system_reset_test.go
@@ -89,5 +89,12 @@ var _ = Describe("podman system reset", func() {
 		Expect(session).Should(Exit(0))
 		// default network should exists
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
+
+		// TODO: machine tests currently don't run outside of the machine test pkg
+		// no machines are created here to cleanup
+		session = podmanTest.Podman([]string{"machine", "list", "-q"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToStringArray()).To(BeEmpty())
 	})
 })


### PR DESCRIPTION
podman system reset did not clean up machines fully, leaving some config
files, and breaking machines. Now it removes all machines files fully.

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman system reset now properly deletes all podman machines and associated files. 
```
