### PR TITLE
Fix goimports complaint about missing comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ export GOOS GOARCH CGO_ENABLED BINSFX SRCBINDIR
 
 define go-get
 	env GO111MODULE=off \
-		$(GO) get -u ${1}
+		$(GO) install ${1}
 endef
 
 # Need to use CGO for mDNS resolution, but cross builds need CGO disabled


### PR DESCRIPTION
The `go get -u` method of installing has been deprecated for a long
while.  Switch to using `go install` in the `Makefile`.

#### Does this PR introduce a user-facing change?

```release-note
None
```
