### PR TITLE
CI: emergency fix for broken go get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,8 @@ endif
 # Necessary for nested-$(MAKE) calls and docs/remote-docs.sh
 export GOOS GOARCH CGO_ENABLED BINSFX SRCBINDIR
 
-define go-get
-	env GO111MODULE=off \
-		$(GO) get -u ${1}
+define go-install
+		$(GO) install ${1}@latest
 endef
 
 # Need to use CGO for mDNS resolution, but cross builds need CGO disabled
@@ -865,7 +864,7 @@ install.tools: .install.goimports .install.gitvalidation .install.md2man .instal
 
 .install.goimports: .gopathok
 	if [ ! -x "$(GOBIN)/goimports" ]; then \
-		$(call go-get,golang.org/x/tools/cmd/goimports); \
+		$(call go-install,golang.org/x/tools/cmd/goimports); \
 	fi
 	touch .install.goimports
 
@@ -878,7 +877,7 @@ install.tools: .install.goimports .install.gitvalidation .install.md2man .instal
 .PHONY: .install.gitvalidation
 .install.gitvalidation: .gopathok
 	if [ ! -x "$(GOBIN)/git-validation" ]; then \
-		$(call go-get,github.com/vbatts/git-validation); \
+		$(call go-install,github.com/vbatts/git-validation); \
 	fi
 
 .PHONY: .install.golangci-lint
@@ -898,7 +897,7 @@ install.tools: .install.goimports .install.gitvalidation .install.md2man .instal
 .PHONY: .install.md2man
 .install.md2man: .gopathok
 	if [ ! -x "$(GOMD2MAN)" ]; then \
-		$(call go-get,github.com/cpuguy83/go-md2man); \
+		$(call go-install,github.com/cpuguy83/go-md2man); \
 	fi
 
 # $BUILD_TAGS variable is used in hack/golangci-lint.sh


### PR DESCRIPTION
go get is deprecated, we should use go install instead.

Also for some reason go get -u golang.org/x/tools/cmd/goimports is
broken at the moment, thus failing CI jobs where we have to install
this. Switching to go install seems to fix it.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
