### PR TITLE
[v4.0-rhel] CI: emergency fix for broken go get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,9 +173,8 @@ endif
 # Necessary for nested-$(MAKE) calls and docs/remote-docs.sh
 export GOOS GOARCH CGO_ENABLED BINSFX SRCBINDIR
 
-define go-get
-	env GO111MODULE=off \
-		$(GO) get -u ${1}
+define go-install
+		$(GO) install ${1}@latest
 endef
 
 # Need to use CGO for mDNS resolution, but cross builds need CGO disabled
@@ -857,7 +856,7 @@ install.tools: .install.goimports .install.gitvalidation .install.md2man .instal
 
 .install.goimports: .gopathok
 	if [ ! -x "$(GOBIN)/goimports" ]; then \
-		$(call go-get,golang.org/x/tools/cmd/goimports); \
+		$(call go-install,golang.org/x/tools/cmd/goimports); \
 	fi
 	touch .install.goimports
 
@@ -870,7 +869,7 @@ install.tools: .install.goimports .install.gitvalidation .install.md2man .instal
 .PHONY: .install.gitvalidation
 .install.gitvalidation: .gopathok
 	if [ ! -x "$(GOBIN)/git-validation" ]; then \
-		$(call go-get,github.com/vbatts/git-validation); \
+		$(call go-install,github.com/vbatts/git-validation); \
 	fi
 
 .PHONY: .install.golangci-lint
@@ -890,7 +889,7 @@ install.tools: .install.goimports .install.gitvalidation .install.md2man .instal
 .PHONY: .install.md2man
 .install.md2man: .gopathok
 	if [ ! -x "$(GOMD2MAN)" ]; then \
-		$(call go-get,github.com/cpuguy83/go-md2man); \
+		$(call go-install,github.com/cpuguy83/go-md2man); \
 	fi
 
 # $BUILD_TAGS variable is used in hack/golangci-lint.sh

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ endif
 export GOOS GOARCH CGO_ENABLED BINSFX SRCBINDIR
 
 define go-install
-		$(GO) install ${1}@latest
+		$(GO) install ${1}
 endef
 
 # Need to use CGO for mDNS resolution, but cross builds need CGO disabled
@@ -856,7 +856,7 @@ install.tools: .install.goimports .install.gitvalidation .install.md2man .instal
 
 .install.goimports: .gopathok
 	if [ ! -x "$(GOBIN)/goimports" ]; then \
-		$(call go-install,golang.org/x/tools/cmd/goimports); \
+		$(call go-install,golang.org/x/tools/cmd/goimports@v0.1.10); \
 	fi
 	touch .install.goimports
 
@@ -869,7 +869,7 @@ install.tools: .install.goimports .install.gitvalidation .install.md2man .instal
 .PHONY: .install.gitvalidation
 .install.gitvalidation: .gopathok
 	if [ ! -x "$(GOBIN)/git-validation" ]; then \
-		$(call go-install,github.com/vbatts/git-validation); \
+		$(call go-install,github.com/vbatts/git-validation@v1.1.0); \
 	fi
 
 .PHONY: .install.golangci-lint
@@ -889,7 +889,7 @@ install.tools: .install.goimports .install.gitvalidation .install.md2man .instal
 .PHONY: .install.md2man
 .install.md2man: .gopathok
 	if [ ! -x "$(GOMD2MAN)" ]; then \
-		$(call go-install,github.com/cpuguy83/go-md2man); \
+		$(call go-install,github.com/cpuguy83/go-md2man@v2.0.2); \
 	fi
 
 # $BUILD_TAGS variable is used in hack/golangci-lint.sh


### PR DESCRIPTION
go get is deprecated, we should use go install instead.

Also for some reason go get -u golang.org/x/tools/cmd/goimports is
broken at the moment, thus failing CI jobs where we have to install
this. Switching to go install seems to fix it.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

#### Does this PR introduce a user-facing change?

```release-note
None
```
