### PR TITLE
libpod: treat ECONNRESET as EOF

### DIFF
--- a/libpod/oci_attach_linux.go
+++ b/libpod/oci_attach_linux.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/libpod/define"
@@ -259,7 +260,7 @@ func redirectResponseToOutputStreams(outputStream, errorStream io.Writer, writeO
 				}
 			}
 		}
-		if er == io.EOF {
+		if errors.Is(er, io.EOF) || errors.Is(er, syscall.ECONNRESET) {
 			break
 		}
 		if er != nil {


### PR DESCRIPTION
when reading from the attach socket, treat ECONNRESET in the same way
as EOF.

[NO NEW TESTS NEEDED]

Closes: https://github.com/containers/podman/issues/11446

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
