### PR TITLE
Fix usermod call in rootless_tutorial.md

### DIFF
--- a/docs/tutorials/rootless_tutorial.md
+++ b/docs/tutorials/rootless_tutorial.md
@@ -81,10 +81,10 @@ If you update either `/etc/subuid` or `/etc/subgid`, you need to stop all the ru
 Rather than updating the files directly, the `usermod` program can be used to assign UIDs and GIDs to a user.
 
 ```
-usermod --add-subuids 200000-201000 --add-subgids 200000-201000 johndoe
+usermod --add-subuids 100000-165535 --add-subgids 100000-165535 johndoe
 grep johndoe /etc/subuid /etc/subgid
-/etc/subuid:johndoe:200000:1001
-/etc/subgid:johndoe:200000:1001
+/etc/subuid:johndoe:100000:65536
+/etc/subgid:johndoe:100000:65536
 ```
 
 ### Enable unprivileged `ping`


### PR DESCRIPTION
The `usermod` calls in rootless_tutorial.md were only adding a very narrow range for subuids and subgids, which will cause failures with containers where a file is owned by a user or group with a uid/gid > 1001.
