### PR TITLE
e2e cleanups

### DIFF
--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -273,7 +273,10 @@ var _ = Describe("Podman manifest", func() {
 	})
 
 	It("authenticated push", func() {
-		registry, err := podmanRegistry.Start()
+		registryOptions := &podmanRegistry.Options{
+			Image: "docker-archive:" + imageTarPath(registry),
+		}
+		registry, err := podmanRegistry.StartWithOptions(registryOptions)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"manifest", "create", "foo"})

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -100,14 +100,14 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull check all tags", func() {
-		session := podmanTest.Podman([]string{"pull", "--all-tags", "k8s.gcr.io/pause"})
+		session := podmanTest.Podman([]string{"pull", "--all-tags", "quay.io/libpod/testdigest_v2s2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"images"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 4))
+		Expect(len(session.OutputToStringArray())).To(BeNumerically(">=", 2), "Expected at least two images")
 	})
 
 	It("podman pull from docker with nonexistent --authfile", func() {

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -53,13 +53,13 @@ var _ = Describe("Podman pull", func() {
 		Expect(session).Should(Exit(0))
 	})
 
-	It("podman pull from docker a not existing image", func() {
-		session := podmanTest.Podman([]string{"pull", "ibetthisdoesntexistthere:foo"})
+	It("podman pull bogus image", func() {
+		session := podmanTest.Podman([]string{"pull", "quay.io/ibetthis/doesntexistthere:foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
 	})
 
-	It("podman pull from docker with tag", func() {
+	It("podman pull with tag", func() {
 		session := podmanTest.Podman([]string{"pull", "quay.io/libpod/testdigest_v2s2:20200210"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -69,32 +69,12 @@ var _ = Describe("Podman pull", func() {
 		Expect(session).Should(Exit(0))
 	})
 
-	It("podman pull from docker without tag", func() {
+	It("podman pull without tag", func() {
 		session := podmanTest.Podman([]string{"pull", "quay.io/libpod/testdigest_v2s2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"rmi", "testdigest_v2s2"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-	})
-
-	It("podman pull from alternate registry with tag", func() {
-		session := podmanTest.Podman([]string{"pull", cirros})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-
-		session = podmanTest.Podman([]string{"rmi", cirros})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-	})
-
-	It("podman pull from alternate registry without tag", func() {
-		session := podmanTest.Podman([]string{"pull", "quay.io/libpod/cirros"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-
-		session = podmanTest.Podman([]string{"rmi", "quay.io/libpod/cirros"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})
@@ -249,12 +229,6 @@ var _ = Describe("Podman pull", func() {
 		session = podmanTest.Podman([]string{"rmi", ALPINELISTTAG})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-	})
-
-	It("podman pull bogus image", func() {
-		session := podmanTest.Podman([]string{"pull", "umohnani/get-started"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
 	})
 
 	It("podman pull from docker-archive", func() {


### PR DESCRIPTION
A series of commits to speed up the e2e tests.  I focused on the pull tests but did not finish going through all of them due to time constraints. There is still much potential for speed ups and I bet there are more low-hanging fruits.

Please refer to the individual commits for change descriptions.

@containers/podman-maintainers PTAL

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
