### PR TITLE
build: disable and hide `--output` for podman-remote clients

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -190,6 +190,7 @@ func buildFlags(cmd *cobra.Command) {
 		_ = flags.MarkHidden("tls-verify")
 		_ = flags.MarkHidden("compress")
 		_ = flags.MarkHidden("volume")
+		_ = flags.MarkHidden("output")
 	}
 }
 
@@ -199,6 +200,10 @@ func build(cmd *cobra.Command, args []string) error {
 		(cmd.Flags().Changed("squash-all") && cmd.Flags().Changed("layers")) ||
 		(cmd.Flags().Changed("squash-all") && cmd.Flags().Changed("squash")) {
 		return errors.New("cannot specify --squash, --squash-all and --layers options together")
+	}
+
+	if cmd.Flag("output").Changed && registry.IsRemote() {
+		return errors.New("'--output' option is not supported in remote mode")
 	}
 
 	// Extract container files from the CLI (i.e., --file/-f) first.

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -479,7 +479,7 @@ Windows base images, so using this option is usually unnecessary.
 
 Output destination (format: type=local,dest=path)
 
-The --output (or -o) option extends the default behavior of building a container image by allowing users to export the contents of the image as files on the local filesystem, which can be useful for generating local binaries, code generation, etc.
+The --output (or -o) option extends the default behavior of building a container image by allowing users to export the contents of the image as files on the local filesystem, which can be useful for generating local binaries, code generation, etc. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
 The value for --output is a comma-separated sequence of key=value pairs, defining the output type and options.
 


### PR DESCRIPTION
Disable `build --output` for remote clients and update docs.

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]
This does not any new feature instead disables existing feature for `podman-remote`

Fixes: https://github.com/containers/podman/pull/14118#discussion_r865754944 by @Luap99 