### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/libpod/container_internal_linux_test.go
+++ b/libpod/container_internal_linux_test.go
@@ -4,8 +4,6 @@
 package libpod
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -13,12 +11,6 @@ import (
 )
 
 func TestGenerateUserPasswdEntry(t *testing.T) {
-	dir, err := ioutil.TempDir("", "libpod_test_")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	c := Container{
 		config: &ContainerConfig{
 			Spec: &spec.Spec{},

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
@@ -58,7 +56,7 @@ func TestPostDeleteHooks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stateRegexp := `{"ociVersion":"1\.0\.2-dev","id":"123abc","status":"stopped","bundle":"` + strings.TrimSuffix(os.TempDir(), "/") + `/libpod_test_[0-9]*","annotations":{"a":"b"}}`
+	stateRegexp := `{"ociVersion":"1\.0\.2-dev","id":"123abc","status":"stopped","bundle":"` + dir + `","annotations":{"a":"b"}}`
 	for _, p := range []string{statePath, copyPath} {
 		path := p
 		t.Run(path, func(t *testing.T) {

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -19,11 +19,7 @@ var hookPath string
 
 func TestPostDeleteHooks(t *testing.T) {
 	ctx := context.Background()
-	dir, err := ioutil.TempDir("", "libpod_test_")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	statePath := filepath.Join(dir, "state")
 	copyPath := filepath.Join(dir, "copy")
@@ -57,7 +53,7 @@ func TestPostDeleteHooks(t *testing.T) {
 			},
 		},
 	}
-	err = c.postDeleteHooks(ctx)
+	err := c.postDeleteHooks(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libpod/lock/file/file_lock_test.go
+++ b/libpod/lock/file/file_lock_test.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,11 +12,9 @@ import (
 
 // Test that creating and destroying locks work
 func TestCreateAndDeallocate(t *testing.T) {
-	d, err := ioutil.TempDir("", "filelock")
-	assert.NoError(t, err)
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
-	_, err = OpenFileLock(filepath.Join(d, "locks"))
+	_, err := OpenFileLock(filepath.Join(d, "locks"))
 	assert.Error(t, err)
 
 	l, err := CreateFileLock(filepath.Join(d, "locks"))
@@ -47,9 +44,7 @@ func TestCreateAndDeallocate(t *testing.T) {
 
 // Test that creating and destroying locks work
 func TestLockAndUnlock(t *testing.T) {
-	d, err := ioutil.TempDir("", "filelock")
-	assert.NoError(t, err)
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	l, err := CreateFileLock(filepath.Join(d, "locks"))
 	assert.NoError(t, err)

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -20,11 +19,7 @@ var path string
 func TestGoodNew(t *testing.T) {
 	ctx := context.Background()
 
-	dir, err := ioutil.TempDir("", "hooks-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	for i, name := range []string{
 		"01-my-hook.json",
@@ -36,7 +31,7 @@ func TestGoodNew(t *testing.T) {
 		if i == 0 {
 			extraStages = ", \"poststart\", \"poststop\""
 		}
-		err = ioutil.WriteFile(jsonPath, []byte(fmt.Sprintf("{\"version\": \"1.0.0\", \"hook\": {\"path\": \"%s\", \"timeout\": %d}, \"when\": {\"always\": true}, \"stages\": [\"prestart\"%s]}", path, i+1, extraStages)), 0644)
+		err := ioutil.WriteFile(jsonPath, []byte(fmt.Sprintf("{\"version\": \"1.0.0\", \"hook\": {\"path\": \"%s\", \"timeout\": %d}, \"when\": {\"always\": true}, \"stages\": [\"prestart\"%s]}", path, i+1, extraStages)), 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -92,14 +87,10 @@ func TestGoodNew(t *testing.T) {
 func TestBadNew(t *testing.T) {
 	ctx := context.Background()
 
-	dir, err := ioutil.TempDir("", "hooks-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	jsonPath := filepath.Join(dir, "a.json")
-	err = ioutil.WriteFile(jsonPath, []byte("{\"version\": \"-1\"}"), 0644)
+	err := ioutil.WriteFile(jsonPath, []byte("{\"version\": \"-1\"}"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/hooks/monitor_test.go
+++ b/pkg/hooks/monitor_test.go
@@ -15,11 +15,7 @@ import (
 
 func TestMonitorOneDirGood(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	dir, err := ioutil.TempDir("", "hooks-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	manager, err := New(ctx, []string{dir}, []string{})
 	if err != nil {
@@ -114,17 +110,8 @@ func TestMonitorOneDirGood(t *testing.T) {
 
 func TestMonitorTwoDirGood(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	primaryDir, err := ioutil.TempDir("", "hooks-test-primary-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(primaryDir)
-
-	fallbackDir, err := ioutil.TempDir("", "hooks-test-fallback-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(fallbackDir)
+	primaryDir := t.TempDir()
+	fallbackDir := t.TempDir()
 
 	manager, err := New(ctx, []string{fallbackDir, primaryDir}, []string{})
 	if err != nil {

--- a/pkg/hooks/read_test.go
+++ b/pkg/hooks/read_test.go
@@ -29,14 +29,10 @@ func TestUnknownPath(t *testing.T) {
 }
 
 func TestGoodFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "hooks-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	jsonPath := filepath.Join(dir, "hook.json")
-	err = ioutil.WriteFile(jsonPath, []byte(fmt.Sprintf("{\"version\": \"1.0.0\", \"hook\": {\"path\": \"%s\"}, \"when\": {\"always\": true}, \"stages\": [\"prestart\"]}", path)), 0644)
+	err := ioutil.WriteFile(jsonPath, []byte(fmt.Sprintf("{\"version\": \"1.0.0\", \"hook\": {\"path\": \"%s\"}, \"when\": {\"always\": true}, \"stages\": [\"prestart\"]}", path)), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,14 +55,10 @@ func TestGoodFile(t *testing.T) {
 }
 
 func TestBadFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "hooks-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "hook.json")
-	err = ioutil.WriteFile(path, []byte("{\"version\": \"1.0.0\", \"hook\": \"not-a-string\"}"), 0644)
+	err := ioutil.WriteFile(path, []byte("{\"version\": \"1.0.0\", \"hook\": \"not-a-string\"}"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,13 +113,9 @@ func TestInvalidCurrentJSON(t *testing.T) {
 }
 
 func TestGoodDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "hooks-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(dir, "README"), []byte("not a hook"), 0644)
+	err := ioutil.WriteFile(filepath.Join(dir, "README"), []byte("not a hook"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,14 +160,10 @@ func TestUnknownDir(t *testing.T) {
 }
 
 func TestBadDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "hooks-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	jsonPath := filepath.Join(dir, "a.json")
-	err = ioutil.WriteFile(jsonPath, []byte("{\"version\": \"-1\"}"), 0644)
+	err := ioutil.WriteFile(jsonPath, []byte("{\"version\": \"-1\"}"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,14 +177,10 @@ func TestBadDir(t *testing.T) {
 }
 
 func TestHookExecutableDoesNotExit(t *testing.T) {
-	dir, err := ioutil.TempDir("", "hooks-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	jsonPath := filepath.Join(dir, "hook.json")
-	err = ioutil.WriteFile(jsonPath, []byte("{\"version\": \"1.0.0\", \"hook\": {\"path\": \"/does/not/exist\"}, \"when\": {\"always\": true}, \"stages\": [\"prestart\"]}"), 0644)
+	err := ioutil.WriteFile(jsonPath, []byte("{\"version\": \"1.0.0\", \"hook\": {\"path\": \"/does/not/exist\"}, \"when\": {\"always\": true}, \"stages\": [\"prestart\"]}"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/machine/qemu/config_test.go
+++ b/pkg/machine/qemu/config_test.go
@@ -52,23 +52,15 @@ func TestMachineFile_GetPath(t *testing.T) {
 func TestNewMachineFile(t *testing.T) {
 	empty := ""
 
-	homedir, err := os.MkdirTemp("/tmp", "homedir")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(homedir)
-	longTemp, err := os.MkdirTemp("/tmp", "tmpdir")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(longTemp)
+	homedir := t.TempDir()
+	longTemp := t.TempDir()
 	oldhome := os.Getenv("HOME")
 	os.Setenv("HOME", homedir) //nolint: tenv
 	defer os.Setenv("HOME", oldhome)
 
 	p := "/var/tmp/podman/my.sock"
 	longp := filepath.Join(longTemp, utils.RandomString(100), "my.sock")
-	err = os.MkdirAll(filepath.Dir(longp), 0755)
+	err := os.MkdirAll(filepath.Dir(longp), 0755)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/specgen/generate/kube/play_test.go
+++ b/pkg/specgen/generate/kube/play_test.go
@@ -3,9 +3,7 @@ package kube
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
-	"os"
 	"runtime"
 	"strconv"
 	"testing"
@@ -39,9 +37,7 @@ func createSecrets(t *testing.T, d string) *secrets.SecretsManager {
 }
 
 func TestEnvVarsFrom(t *testing.T) {
-	d, err := ioutil.TempDir("", "secrets")
-	assert.NoError(t, err)
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 	secretsManager := createSecrets(t, d)
 
 	tests := []struct {
@@ -191,9 +187,7 @@ func TestEnvVarsFrom(t *testing.T) {
 }
 
 func TestEnvVarValue(t *testing.T) {
-	d, err := ioutil.TempDir("", "secrets")
-	assert.NoError(t, err)
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 	secretsManager := createSecrets(t, d)
 	stringNumCPUs := strconv.Itoa(runtime.NumCPU())
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(dir)

	// now
	tmpDir := t.TempDir()
}
```