### PR TITLE
libpod: add c.ConfigWithNetworks()

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -352,7 +353,10 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, contaierID s
 	if err != nil {
 		return nil, nil, err
 	}
-	conf := c.Config()
+	conf := c.ConfigWithNetworks()
+	if conf == nil {
+		return nil, nil, fmt.Errorf("failed to get config for container %s", c.ID())
+	}
 
 	tmpSystemd := conf.Systemd
 	tmpMounts := conf.Mounts


### PR DESCRIPTION
Reading the networks requires an extra db operation. Most c.Config() callers
do not need them so create a new function which returns the config with
networks.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
