### PR TITLE
fix: Container.cGroupPath() skip empty line to avoid false error logging

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -994,6 +994,10 @@ func (c *Container) cGroupPath() (string, error) {
 
 	var cgroupPath string
 	for _, line := range bytes.Split(lines, []byte("\n")) {
+		// skip last empty line
+		if len(line) == 0 {
+			continue
+		}
 		// cgroups(7) nails it down to three fields with the 3rd
 		// pointing to the cgroup's path which works both on v1 and v2.
 		fields := bytes.Split(line, []byte(":"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

fixup https://github.com/containers/podman/issues/14146

#### Does this PR introduce a user-facing change?


<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
