### PR TITLE
test: fix "podman search format json"

### DIFF
--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -113,11 +113,11 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search format json", func() {
-		search := podmanTest.Podman([]string{"search", "--format", "json", "alpine"})
+		search := podmanTest.Podman([]string{"search", "--format", "json", "busybox"})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
 		Expect(search.OutputToString()).To(BeValidJSON())
-		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
+		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/busybox"))
 
 		// Test for https://github.com/containers/podman/issues/11894
 		contents := make([]entities.ImageSearchReport, 0)


### PR DESCRIPTION
the alpine image used previously returns a description that contains
'...':

$ podman search --format json alpine | fgrep ...\"\,
        "Description": "alpine 3.7 with bash, perl, gzip, wget...",

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
