### PR TITLE
[v4.1] test skipper: check for $DEST_BRANCH

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -74,7 +74,6 @@ PODMAN_SERVER_LOG=$CIRRUS_WORKING_DIR/server.log
 # Defaults when not running under CI
 export CI="${CI:-false}"
 CIRRUS_CI="${CIRRUS_CI:-false}"
-DEST_BRANCH="${DEST_BRANCH:-v4.1}"
 CONTINUOUS_INTEGRATION="${CONTINUOUS_INTEGRATION:-false}"
 CIRRUS_REPO_NAME=${CIRRUS_REPO_NAME:-podman}
 # Cirrus only sets $CIRRUS_BASE_SHA properly for PRs, but $EPOCH_TEST_COMMIT

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -375,7 +375,7 @@ function _bail_if_test_can_be_skipped() {
 
     # Cirrus sets these for PRs but not branches or cron. In cron and branches,
     #we never want to skip.
-    for v in CIRRUS_CHANGE_IN_REPO CIRRUS_PR; do
+    for v in CIRRUS_CHANGE_IN_REPO CIRRUS_PR DEST_BRANCH; do
         if [[ -z "${!v}" ]]; then
             msg "[ _cannot do selective skip: \$$v is undefined ]"
             return 0


### PR DESCRIPTION
The test-skipping optimization is failing as rootless on non-main,
because $DEST_BRANCH is not set. Solution: check for envariable,
skip test if missing. (This was part of my original PR, but was
accidentally removed in #14013)

Fixes: #14131

Signed-off-by: Ed Santiago <santiago@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
