### PR TITLE
test skipper: check for $DEST_BRANCH

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -74,7 +74,6 @@ PODMAN_SERVER_LOG=$CIRRUS_WORKING_DIR/server.log
 # Defaults when not running under CI
 export CI="${CI:-false}"
 CIRRUS_CI="${CIRRUS_CI:-false}"
-DEST_BRANCH="${DEST_BRANCH:-main}"
 CONTINUOUS_INTEGRATION="${CONTINUOUS_INTEGRATION:-false}"
 CIRRUS_REPO_NAME=${CIRRUS_REPO_NAME:-podman}
 # Cirrus only sets $CIRRUS_BASE_SHA properly for PRs, but $EPOCH_TEST_COMMIT

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -375,7 +375,7 @@ function _bail_if_test_can_be_skipped() {
 
     # Cirrus sets these for PRs but not branches or cron. In cron and branches,
     #we never want to skip.
-    for v in CIRRUS_CHANGE_IN_REPO CIRRUS_PR; do
+    for v in CIRRUS_CHANGE_IN_REPO CIRRUS_PR DEST_BRANCH; do
         if [[ -z "${!v}" ]]; then
             msg "[ _cannot do selective skip: \$$v is undefined ]"
             return 0


### PR DESCRIPTION
The test-skipping optimization is failing as rootless on non-main,
because $DEST_BRANCH is not set. Solution: check for envariable,
skip test if missing. (This was part of my original PR, but was
accidentally removed in #14013)

Fixes: #14131

Signed-off-by: Ed Santiago <santiago@redhat.com>
