### PR TITLE
Cirrus: Guarantee $DEST_BRANCH is passed through

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -96,7 +96,7 @@ EPOCH_TEST_COMMIT="$CIRRUS_BASE_SHA"
 # testing operations on all platforms and versions.  This is necessary
 # to avoid needlessly passing through global/system values across
 # contexts, such as host->container or root->rootless user
-PASSTHROUGH_ENV_RE='(^CI.*)|(^CIRRUS)|(^DISTRO_NV)|(^GOPATH)|(^GOCACHE)|(^GOSRC)|(^SCRIPT_BASE)|(CGROUP_MANAGER)|(OCI_RUNTIME)|(^TEST.*)|(^PODBIN_NAME)|(^PRIV_NAME)|(^ALT_NAME)|(^ROOTLESS_USER)|(SKIP_USERNS)|(.*_NAME)|(.*_FQIN)|(NETWORK_BACKEND)'
+PASSTHROUGH_ENV_RE='(^CI.*)|(^CIRRUS)|(^DISTRO_NV)|(^GOPATH)|(^GOCACHE)|(^GOSRC)|(^SCRIPT_BASE)|(CGROUP_MANAGER)|(OCI_RUNTIME)|(^TEST.*)|(^PODBIN_NAME)|(^PRIV_NAME)|(^ALT_NAME)|(^ROOTLESS_USER)|(SKIP_USERNS)|(.*_NAME)|(.*_FQIN)|(NETWORK_BACKEND)|(DEST_BRANCH)'
 # Unsafe env. vars for display
 SECRET_ENV_RE='(ACCOUNT)|(GC[EP]..+)|(SSH)|(PASSWORD)|(TOKEN)'
 

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -25,7 +25,7 @@ msg "************************************************************"
 show_env_vars
 
 req_env_vars USER HOME GOSRC SCRIPT_BASE TEST_FLAVOR TEST_ENVIRON \
-             PODBIN_NAME PRIV_NAME DISTRO_NV
+             PODBIN_NAME PRIV_NAME DISTRO_NV DEST_BRANCH
 
 # Verify basic dependencies
 for depbin in go rsync unzip sha256sum curl make python3 git


### PR DESCRIPTION
There are several runtime contexts (rootless and container) where
`$DEST_BRANCH` is needed but was not supplied.  A prior commit
(c4865767171b) removed the default value, `main` which was being
set incorrectly when CI ran on release branches.  Fix this by ensuring
the variable is non-empty upon entry to `setup_environment.sh`, then
ensure it gets passed through to child environments by way of the
`/etc/ci_environment` file.  This will maintain compatibility with
both CI and `hack/get_ci_vm.sh` use.

Also Ref: https://github.com/containers/podman/issues/14131

#### Does this PR introduce a user-facing change?

```release-note
None
```
