### PR TITLE
Cirrus: Fix Makefile including 'hack' in $PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,8 @@ ifeq ($(GOBIN),)
 GOBIN := $(FIRST_GOPATH)/bin
 endif
 
-export PATH := $(PATH):$(GOBIN):$(CURDIR)/hack
+# This must never include the 'hack' directory
+export PATH := $(PATH):$(GOBIN)
 
 GOMD2MAN ?= $(shell command -v go-md2man || echo './test/tools/build/go-md2man')
 


### PR DESCRIPTION
This path should never, ever, ever be included in `$PATH` as it is
almost guaranteed to cause serious and non-obvious breakage in CI.  Fix
it and include a warning comment.

#### Does this PR introduce a user-facing change?

```release-note
None
```
