### PR TITLE
[CI:DOCS] man pages: fix inconsistencies

### DIFF
--- a/docs/source/markdown/podman-auto-update.1.md
+++ b/docs/source/markdown/podman-auto-update.1.md
@@ -51,15 +51,6 @@ The `UPDATED` field indicates the availability of a new image with "pending".
 Change the default output format.  This can be of a supported type like 'json' or a Go template.
 Valid placeholders for the Go template are listed below:
 
-#### **--rollback**
-
-If restarting a systemd unit after updating the image has failed, rollback to using the previous image and restart the unit another time.  Default is true.
-
-Please note that detecting if a systemd unit has failed is best done by the container sending the READY message via SDNOTIFY.  This way, restarting the unit will wait until having received the message or a timeout kicked in.  Without that, restarting the systemd unit may succeed even if the container has failed shortly after.
-
-For a container to send the READY message via SDNOTIFY it must be created with the `--sdnotify=container` option (see podman-run(1)).  The application running inside the container can then execute `systemd-notify --ready` when ready or use the sdnotify bindings of the specific programming language (e.g., sd_notify(3)).
-
-
 | **Placeholder** | **Description**                        |
 | --------------- | -------------------------------------- |
 | .Unit           | Name of the systemd unit               |
@@ -69,6 +60,14 @@ For a container to send the READY message via SDNOTIFY it must be created with t
 | .Image          | Name of the image                      |
 | .Policy         | Auto-update policy of the container    |
 | .Updated        | Update status: true,false,failed       |
+
+#### **--rollback**
+
+If restarting a systemd unit after updating the image has failed, rollback to using the previous image and restart the unit another time.  Default is true.
+
+Please note that detecting if a systemd unit has failed is best done by the container sending the READY message via SDNOTIFY.  This way, restarting the unit will wait until having received the message or a timeout kicked in.  Without that, restarting the systemd unit may succeed even if the container has failed shortly after.
+
+For a container to send the READY message via SDNOTIFY it must be created with the `--sdnotify=container` option (see podman-run(1)).  The application running inside the container can then execute `systemd-notify --ready` when ready or use the sdnotify bindings of the specific programming language (e.g., sd_notify(3)).
 
 
 ## EXAMPLES

--- a/docs/source/markdown/podman-history.1.md
+++ b/docs/source/markdown/podman-history.1.md
@@ -17,6 +17,12 @@ set, the time of creation and size are printed out in a human readable format.
 The **--quiet** flag displays the ID of the image only when set and the **--format**
 flag is used to print the information using the Go template provided by the user.
 
+## OPTIONS
+
+#### **--format**=*format*
+
+Alter the output for a format like 'json' or a Go template.
+
 Valid placeholders for the Go template are listed below:
 
 | **Placeholder** | **Description**                                                               |
@@ -28,12 +34,7 @@ Valid placeholders for the Go template are listed below:
 | .CreatedSince   | Elapsed time since the image layer was created       |
 | .Size           | Size of layer on disk                                |
 | .Comment        | Comment for the layer                                |
-## OPTIONS
-
-Print the numeric IDs only (default *false*).
-#### **--format**=*format*
-
-Alter the output for a format like 'json' or a Go template.
+| .Tags           | Image tags |
 
 #### **--help**, **-h**
 
@@ -48,6 +49,8 @@ Display sizes and dates in human readable format (default *true*).
 Do not truncate the output (default *false*).
 
 #### **--quiet**, **-q**
+
+Print the numeric IDs only (default *false*).
 
 ## EXAMPLES
 

--- a/docs/source/markdown/podman-system-connection-list.1.md
+++ b/docs/source/markdown/podman-system-connection-list.1.md
@@ -20,10 +20,10 @@ Valid placeholders for the Go template listed below:
 
 | **Placeholder** | **Description**                                                               |
 | --------------- | ----------------------------------------------------------------------------- |
-| *.Name*         | Connection Name/Identifier |
-| *.Identity*     | Path to file containing SSH identity |
-| *.URI*          | URI to podman service. Valid schemes are ssh://[user@]*host*[:port]*Unix domain socket*[?secure=True], unix://*Unix domain socket*, and tcp://localhost[:*port*] |
-| *.Default*      | Indicates whether connection is the default |
+| .Name           | Connection Name/Identifier |
+| .Identity       | Path to file containing SSH identity |
+| .URI            | URI to podman service. Valid schemes are ssh://[user@]*host*[:port]*Unix domain socket*[?secure=True], unix://*Unix domain socket*, and tcp://localhost[:*port*] |
+| .Default        | Indicates whether connection is the default |
 
 ## EXAMPLE
 ```


### PR DESCRIPTION
As part of work done in #14046, fix bugs found in man pages,
basically just moving a few descriptions to the right place
and removing some undesired asterisks.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```