### PR TITLE
sdnotify: send MAINPID only once

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -36,7 +36,6 @@ import (
 	"github.com/containers/podman/v4/utils"
 	"github.com/containers/storage/pkg/homedir"
 	pmount "github.com/containers/storage/pkg/mount"
-	"github.com/coreos/go-systemd/v22/daemon"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
@@ -1279,19 +1278,6 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 		// conmon not having a pid file is a valid state, so don't set it if we don't have it
 		logrus.Infof("Got Conmon PID as %d", conmonPID)
 		ctr.state.ConmonPID = conmonPID
-
-		// Send the MAINPID via sdnotify if needed.
-		switch ctr.config.SdNotifyMode {
-		case define.SdNotifyModeContainer, define.SdNotifyModeIgnore:
-		// Nothing to do or conmon takes care of it already.
-
-		default:
-			if sent, err := daemon.SdNotify(false, fmt.Sprintf("MAINPID=%d", conmonPID)); err != nil {
-				logrus.Errorf("Notifying systemd of Conmon PID: %v", err)
-			} else if sent {
-				logrus.Debugf("Notify MAINPID sent successfully")
-			}
-		}
 	}
 
 	runtimeRestoreDuration := func() int64 {

--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -106,6 +106,9 @@ function _assert_mainpid_is_conmon() {
     cid="$output"
     wait_for_ready $cid
 
+    run_podman container inspect sdnotify_conmon_c --format "{{.State.ConmonPid}}"
+    mainPID="$output"
+
     run_podman logs sdnotify_conmon_c
     is "$output" "READY" "\$NOTIFY_SOCKET in container"
 
@@ -114,12 +117,8 @@ function _assert_mainpid_is_conmon() {
     echo "socat log:"
     echo "$output"
 
-    # ARGH! 'READY=1' should always be the last output line. But sometimes,
-    # for reasons unknown, we get an extra MAINPID=xxx after READY=1 (#8718).
-    # Who knows if this is a systemd bug, or conmon, or what. I don't
-    # even know where to begin asking. So, to eliminate the test flakes,
-    # we look for READY=1 _anywhere_ in the output, not just the last line.
-    is "$output" ".*READY=1.*" "sdnotify sent READY=1"
+    is "$output" "MAINPID=$mainPID
+READY=1" "sdnotify sent MAINPID and READY"
 
     _assert_mainpid_is_conmon "$output"
 


### PR DESCRIPTION
Send the main PID only once.  Previously, `(*Container).start()` and
the conmon handler sent them ~simultaneously and went into a race.

I noticed the issue while debugging a WIP PR.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix --sdnotify=conmon to sent the MAINPID once and not twice.
```

@giuseppe @rhatdan @flouthoc @Luap99 PTAL
