### PR TITLE
shell completion --format: work with pointer functions

### DIFF
--- a/cmd/podman/common/completion_test.go
+++ b/cmd/podman/common/completion_test.go
@@ -25,7 +25,9 @@ func (c Car) Type() string {
 	return ""
 }
 
-func (c Car) Color() string {
+// Note: It is important that this function is *Car and the Type one is just Car.
+// The reflect logic behaves differently for these cases so we have to test both.
+func (c *Car) Color() string {
 	return ""
 }
 
@@ -94,7 +96,7 @@ func TestAutocompleteFormat(t *testing.T) {
 		{
 			"second level struct field name",
 			"{{ .Car.",
-			[]string{"{{ .Car.Brand}}", "{{ .Car.Stats.", "{{ .Car.Extras}}", "{{ .Car.Color}}", "{{ .Car.Type}}"},
+			[]string{"{{ .Car.Color}}", "{{ .Car.Type}}", "{{ .Car.Brand}}", "{{ .Car.Stats.", "{{ .Car.Extras}}"},
 		},
 		{
 			"second level struct field name",
@@ -104,7 +106,7 @@ func TestAutocompleteFormat(t *testing.T) {
 		{
 			"second level nil struct field name",
 			"{{ .Car2.",
-			[]string{"{{ .Car2.Brand}}", "{{ .Car2.Stats.", "{{ .Car2.Extras}}", "{{ .Car2.Color}}", "{{ .Car2.Type}}"},
+			[]string{"{{ .Car2.Color}}", "{{ .Car2.Type}}", "{{ .Car2.Brand}}", "{{ .Car2.Stats.", "{{ .Car2.Extras}}"},
 		},
 		{
 			"three level struct field name",
@@ -134,8 +136,8 @@ func TestAutocompleteFormat(t *testing.T) {
 		{
 			"two variables struct field name",
 			"{{ .Car.Brand }} {{ .Car.",
-			[]string{"{{ .Car.Brand }} {{ .Car.Brand}}", "{{ .Car.Brand }} {{ .Car.Stats.", "{{ .Car.Brand }} {{ .Car.Extras}}",
-				"{{ .Car.Brand }} {{ .Car.Color}}", "{{ .Car.Brand }} {{ .Car.Type}}"},
+			[]string{"{{ .Car.Brand }} {{ .Car.Color}}", "{{ .Car.Brand }} {{ .Car.Type}}", "{{ .Car.Brand }} {{ .Car.Brand}}",
+				"{{ .Car.Brand }} {{ .Car.Stats.", "{{ .Car.Brand }} {{ .Car.Extras}}"},
 		},
 		{
 			"only dot without variable",


### PR DESCRIPTION
The completion logic currently suggest also the functions that are
defined for this type. However this did not work correctly when it was
defined as pointer to that type on not the actual type.

This commit fixes that problem. To test you can compare the difference
between `podman stats --format {{.[TAB]` with and without this commit.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve shell completion for the --format option.
```
