### PR TITLE
Bump Compat API maximum version to v1.41

### DIFF
--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -21,7 +21,7 @@ for i in /version version; do
       .Components[0].Details.APIVersion~4[0-9.-]\\+  \
       .Components[0].Details.MinAPIVersion=4.0.0     \
       .Components[0].Details.Os=linux                \
-      .ApiVersion=1.40                               \
+      .ApiVersion=1.41                               \
       .MinAPIVersion=1.24                            \
       .Os=linux
 done

--- a/version/version.go
+++ b/version/version.go
@@ -41,7 +41,7 @@ var APIVersion = map[Tree]map[Level]semver.Version{
 		MinimalAPI: semver.MustParse("4.0.0"),
 	},
 	Compat: {
-		CurrentAPI: semver.MustParse("1.40.0"),
+		CurrentAPI: semver.MustParse("1.41.0"),
 		MinimalAPI: semver.MustParse("1.24.0"),
 	},
 }


### PR DESCRIPTION
Docker bumped their API, so we should do the same.

Fixes #14204


#### Does this PR introduce a user-facing change?


```release-note
The Compat API now supports the v1.41 API.
```
