### PR TITLE
Deleting an n use image should return conflict not system error

### DIFF
--- a/pkg/api/handlers/compat/images_remove.go
+++ b/pkg/api/handlers/compat/images_remove.go
@@ -52,7 +52,10 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 			utils.ImageNotFound(w, name, errors.Wrapf(err, "failed to find image %s", name))
 			return
 		}
-
+		if errors.Cause(err) == storage.ErrImageUsedByContainer {
+			utils.Error(w, http.StatusConflict, errors.Wrapf(err, "image %s is in use", name))
+			return
+		}
 		utils.Error(w, http.StatusInternalServerError, err)
 		return
 	}

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -156,6 +156,17 @@ t GET images/json?filters='{"reference":["test1"]}' 200 length=1
 
 t DELETE libpod/images/test1:latest 200
 
+# to be used in prune until filter tests
+podman image build -t docker.io/library/test1:latest -<<EOF
+from alpine
+RUN >file4
+EOF
+podman create --name test1 test1 echo hi
+
+t DELETE images/test1:latest 409
+podman rm test1
+t DELETE images/test1:latest 200
+
 t GET "images/get?names=alpine" 200 '[POSIX tar archive]'
 
 podman pull busybox


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/14208

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
