### PR TITLE
[CI:BUILD] Cirrus: Fix building multiarch images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -695,7 +695,7 @@ image_build_task: &image-build
     # this task to a specific Cirrus-Cron entry with this name.
     only_if: $CIRRUS_CRON == 'multiarch'
     depends_on:
-        - ext_svc_check
+        - build
     timeout_in: 120m  # emulation is sssllllooooowwww
     gce_instance:
         <<: *standardvm
@@ -712,22 +712,24 @@ image_build_task: &image-build
         - env:
             CTXDIR: contrib/hello
     env:
+        DISTRO_NV: "${FEDORA_NAME}"  # Required for repo cache extraction
         PODMAN_USERNAME: ENCRYPTED[b9f0f2550029dd2196e086d9dd6c2d1fec7e328630b15990d9bb610f9fcccb5baab8b64a8c3e72b0c1d0f5917cf65aa1]
         PODMAN_PASSWORD: ENCRYPTED[e3444f6072853f0c8db7f964ead5e2204116af485469fa0de367f26b9316b460fd842a9882f552b9e9a83bbaf650d8b4]
         CONTAINERS_USERNAME: ENCRYPTED[54a372d5f22f424173c114c6fb25c3214956cad323d5b285c7393a71041884ce96471d0ff733774e5dab9fa5a3c8795c]
         CONTAINERS_PASSWORD: ENCRYPTED[4ecc3fb534935095a99fb1f2e320ac6bc87f3e7e186746e41cbcc4b5f5379a014b9fc8cc90e1f3d5abdbaf31580a4ab9]
-    clone_script: &noop mkdir -p $CIRRUS_WORKING_DIR
-    script:
+    main_script:
         - set -a; source /etc/automation_environment; set +a
         - main.sh $CIRRUS_REPO_CLONE_URL $CTXDIR
 
 
 test_image_build_task:
     <<: *image-build
-    # Allow this to run inside a PR w/ [CI:BUILD]
-    only_if: $CIRRUS_PR != '' && $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
+    alias: test_image_build
+    # Allow this to run inside a PR w/ [CI:BUILD] only.
+    only_if: $CIRRUS_PR != '' && $CIRRUS_CHANGE_TITLE =~ '.*CI:BUILD.*'
     # This takes a LONG time, only run when requested.  N/B: Any task
     # made to depend on this one will block FOREVER unless triggered.
+    # DO NOT ADD THIS TASK AS DEPENDENCY FOR `success_task`.
     trigger_type: manual
     # Overwrite all 'env', don't push anything, just do the build.
     env:
@@ -756,7 +758,7 @@ meta_task:
         GCPJSON: ENCRYPTED[3a198350077849c8df14b723c0f4c9fece9ebe6408d35982e7adf2105a33f8e0e166ed3ed614875a0887e1af2b8775f4]
         GCPNAME: ENCRYPTED[2f9738ef295a706f66a13891b40e8eaa92a89e0e87faf8bed66c41eca72bf76cfd190a6f2d0e8444c631fdf15ed32ef6]
         GCPPROJECT: libpod-218412
-    clone_script: *noop
+    clone_script: &noop mkdir -p $CIRRUS_WORKING_DIR
     script: /usr/local/bin/entrypoint.sh
 
 


### PR DESCRIPTION
The caching update made in
https://github.com/containers/podman/pull/14016 neglected to attend to
the "git repo." needs of this task.  Fix this so images can build.

Also, make this optional task only appear when the `[CI:BUILD]` magic
string is used.  No reason to tempt every PR author to press a
mysterious button labeled 'trigger'.

Signed-off-by: Chris Evich <cevich@redhat.com>

#### Does this PR introduce a user-facing change?

```release-note
None
```
