### PR TITLE
Robust whitespace split of cpu utilization line from /proc/stat

### DIFF
--- a/libpod/info.go
+++ b/libpod/info.go
@@ -406,26 +406,25 @@ func getCPUUtilization() (*define.CPUUsage, error) {
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
-	// Read firt line of /proc/stat
+	// Read first line of /proc/stat that has entries for system ("cpu" line)
 	for scanner.Scan() {
 		break
 	}
 	// column 1 is user, column 3 is system, column 4 is idle
-	stats := strings.Split(scanner.Text(), " ")
+	stats := strings.Fields(scanner.Text())
 	return statToPercent(stats)
 }
 
 func statToPercent(stats []string) (*define.CPUUsage, error) {
-	// There is always an extra space between cpu and the first metric
-	userTotal, err := strconv.ParseFloat(stats[2], 64)
+	userTotal, err := strconv.ParseFloat(stats[1], 64)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse user value %q", stats[1])
 	}
-	systemTotal, err := strconv.ParseFloat(stats[4], 64)
+	systemTotal, err := strconv.ParseFloat(stats[3], 64)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse system value %q", stats[3])
 	}
-	idleTotal, err := strconv.ParseFloat(stats[5], 64)
+	idleTotal, err := strconv.ParseFloat(stats[4], 64)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to parse idle value %q", stats[4])
 	}

--- a/libpod/info_test.go
+++ b/libpod/info_test.go
@@ -20,7 +20,7 @@ func Test_statToPercent(t *testing.T) {
 	}{
 		{
 			name: "GoodParse",
-			args: args{in0: []string{"cpu", " ", "33628064", "27537", "9696996", "1314806705", "588142", "4775073", "2789228", "0", "598711", "0"}},
+			args: args{in0: []string{"cpu", "33628064", "27537", "9696996", "1314806705", "588142", "4775073", "2789228", "0", "598711", "0"}},
 			want: &define.CPUUsage{
 				UserPercent:   2.48,
 				SystemPercent: 0.71,
@@ -30,19 +30,19 @@ func Test_statToPercent(t *testing.T) {
 		},
 		{
 			name:    "BadUserValue",
-			args:    args{in0: []string{"cpu", " ", "k", "27537", "9696996", "1314806705", "588142", "4775073", "2789228", "0", "598711", "0"}},
+			args:    args{in0: []string{"cpu", "k", "27537", "9696996", "1314806705", "588142", "4775073", "2789228", "0", "598711", "0"}},
 			want:    nil,
 			wantErr: assert.Error,
 		},
 		{
 			name:    "BadSystemValue",
-			args:    args{in0: []string{"cpu", " ", "33628064", "27537", "k", "1314806705", "588142", "4775073", "2789228", "0", "598711", "0"}},
+			args:    args{in0: []string{"cpu", "33628064", "27537", "k", "1314806705", "588142", "4775073", "2789228", "0", "598711", "0"}},
 			want:    nil,
 			wantErr: assert.Error,
 		},
 		{
 			name:    "BadIdleValue",
-			args:    args{in0: []string{"cpu", " ", "33628064", "27537", "9696996", "k", "588142", "4775073", "2789228", "0", "598711", "0"}},
+			args:    args{in0: []string{"cpu", "33628064", "27537", "9696996", "k", "588142", "4775073", "2789228", "0", "598711", "0"}},
 			want:    nil,
 			wantErr: assert.Error,
 		},


### PR DESCRIPTION
Signed-off-by: Sandro Casagrande <sc.casagrande@gmail.com>

**Description**

Using podman inside an lxc container I faced a situation where `podman info` failed with the following message:
```
Error: error getting host info: unable to parse user value "": strconv.ParseFloat: parsing "": invalid syntax
```

**Steps to reproduce the issue**

I installed latest stable version lxc from snap
```
$ lxc version                               
Client version: 5.1
Server version: 5.1
```
started an Ubuntu 22.04 container and inside built the latest release of podman
```
$ podman version
Client:       Podman Engine
Version:      4.1.0
API Version:  4.1.0
Go Version:   go1.18.1
Git Commit:   e4b03902052294d4f342a185bb54702ed5bed8b1
Built:        Fri May 13 23:22:38 2022
OS/Arch:      linux/amd64
```

**Reason for the issue**

This happens due to additional whitespace (three spaces after "cpu") in the first line of `/proc/stat` which was accidentally present in lxcfs compared to two spaces in the mainline kernel <https://github.com/torvalds/linux/blob/f2dd007445b1d4c0581d0292f85fdd5b47387776/fs/proc/stat.c#L153> and the fact that the parsing of `/proc/stat` in `libpod/info.go` splits on single spaces.

The extra space in lxcfs was fixed some hours ago in <https://github.com/lxc/lxcfs/pull/536>. I think it is still a good idea to make the parsing of `/proc/stat` more resilient to whitespace variations, since
  - all users with recent versions of podman inside of lxc are still affected at the moment, and
  - the format of `/proc/stat` is not 100% standardized and rather arbitrarily contains a double space delimiter after "cpu", but single spaces everywhere else, so situations like above could arise again in the future.

**Proposed resolution**

Split `/proc/stat` on whitepace with `strings.Fields` instead of using `strings.Split(..., " ")`.

#### Does this PR introduce a user-facing change?

```release-note
None
```
