### PR TITLE
[v4.1] Cherry-pick windows machine events

### DIFF
--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -115,7 +115,7 @@ func resolveEventSock() ([]string, error) {
 			return err
 		case info.IsDir():
 			return nil
-		case info.Type() != os.ModeSocket:
+		case !isUnixSocket(info):
 			return nil
 		case !re.MatchString(info.Name()):
 			return nil

--- a/cmd/podman/machine/machine_unix.go
+++ b/cmd/podman/machine/machine_unix.go
@@ -1,0 +1,12 @@
+//go:build linux || ignore || aix || ignore || android || ignore || darwin || ignore || freebsd || ignore || hurd || ignore || illumos || ignore || ios || ignore || netbsd || ignore || openbsd || ignore || solaris
+// +build linux ignore aix ignore android ignore darwin ignore freebsd ignore hurd ignore illumos ignore ios ignore netbsd ignore openbsd ignore solaris
+
+package machine
+
+import (
+	"os"
+)
+
+func isUnixSocket(file os.DirEntry) bool {
+	return file.Type()&os.ModeSocket != 0
+}

--- a/cmd/podman/machine/machine_unix.go
+++ b/cmd/podman/machine/machine_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || ignore || aix || ignore || android || ignore || darwin || ignore || freebsd || ignore || hurd || ignore || illumos || ignore || ios || ignore || netbsd || ignore || openbsd || ignore || solaris
-// +build linux ignore aix ignore android ignore darwin ignore freebsd ignore hurd ignore illumos ignore ios ignore netbsd ignore openbsd ignore solaris
+//go:build linux || aix || android || darwin || dragonfly || freebsd || hurd || illumos || ios || netbsd || openbsd || solaris
+// +build linux aix android darwin dragonfly freebsd hurd illumos ios netbsd openbsd solaris
 
 package machine
 

--- a/cmd/podman/machine/machine_windows.go
+++ b/cmd/podman/machine/machine_windows.go
@@ -1,0 +1,11 @@
+package machine
+
+import (
+	"os"
+	"strings"
+)
+
+func isUnixSocket(file os.DirEntry) bool {
+	// Assume a socket on Windows, since sock mode is not supported yet https://github.com/golang/go/issues/33357
+	return !file.Type().IsDir() && strings.HasSuffix(file.Name(), ".sock")
+}

--- a/pkg/util/utils_windows.go
+++ b/pkg/util/utils_windows.go
@@ -4,6 +4,9 @@
 package util
 
 import (
+	"path/filepath"
+
+	"github.com/containers/storage/pkg/homedir"
 	"github.com/pkg/errors"
 )
 
@@ -34,7 +37,12 @@ func GetRootlessPauseProcessPidPathGivenDir(unused string) (string, error) {
 
 // GetRuntimeDir returns the runtime directory
 func GetRuntimeDir() (string, error) {
-	return "", errors.New("this function is not implemented for windows")
+	data, err := homedir.GetDataHome()
+	if err != nil {
+		return "", err
+	}
+	runtimeDir := filepath.Join(data, "containers", "podman")
+	return runtimeDir, nil
 }
 
 // GetRootlessConfigHomeDir returns the config home directory when running as non root


### PR DESCRIPTION
Cherry-picks #14206 #14229 to resolve the warning message generated on all podman machine commands.

[NO NEW TESTS NEEDED]

```release-note
Fixes runtime warning on podman machine commands on Windows
```
