### PR TITLE
Bump to v3.0.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 3.0.2
+### Changed
+- The Go module has been bumped to v3. This release is intended so that the Podman bindings can be used with a v3.0 and higher API server.
+
 ## 3.0.1
 ### Changes
 - Several frequently-occurring `WARN` level log messages have been downgraded to `INFO` or `DEBUG` to not clutter terminal output.

--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ import (
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-var Version = semver.MustParse("3.0.2")
+var Version = semver.MustParse("3.0.3-dev")
 
 // APIVersion is the version for the remote
 // client API.  It is used to determine compatibility

--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ import (
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-var Version = semver.MustParse("3.0.2-dev")
+var Version = semver.MustParse("3.0.2")
 
 // APIVersion is the version for the remote
 // client API.  It is used to determine compatibility


### PR DESCRIPTION
Cut a fresh v3.0.x release including a single change: an update to the Go module version, from v2 to v3 (we forgot the bump originally, it only landed in v3.1). The intention is to allow a v3.0 API client using our bindings to be used against a v3.0 API server. There is no need to update packages with this version; it is intended solely for users connecting to the API.