### PR TITLE
Make errors on removing exec sessions nonfatal

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -732,7 +732,11 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 	// after setting the state to ContainerStateRemoving will prevent that the container is
 	// restarted
 	if err := c.removeAllExecSessions(); err != nil {
-		return err
+		if cleanupErr == nil {
+			cleanupErr = err
+		} else {
+			logrus.Errorf("Remove exec sessions: %v", err)
+		}
 	}
 
 	// Stop the container's storage


### PR DESCRIPTION
Removing exec sessions is guaranteed to evict them from the DB, but in the case of a zombie process (or similar) it may error and
block removal of the container. A subsequent run of `podman rm` would succeed (because the exec sessions have been purged from the DB), which is potentially confusing to users. So let's just continue, instead of erroring out, if removing exec sessions fails.

[NO NEW TESTS NEEDED] I wouldn't want to spawn a zombie in our test VMs even if I could.

Fixes #14252

Signed-off-by: Matthew Heon <matthew.heon@pm.me>

```release-note
Fixed a bug where removing a container with a zombie exec session would fail the first time, but succeed for subsequent calls ([#14252](https://github.com/containers/podman/issues/14252)).
```
