### PR TITLE
shell completion: use more constants in the code

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1208,21 +1208,21 @@ func AutocompleteWaitCondition(cmd *cobra.Command, args []string, toComplete str
 // AutocompleteCgroupManager - Autocomplete cgroup manager options.
 // -> "cgroupfs", "systemd"
 func AutocompleteCgroupManager(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	types := []string{"cgroupfs", "systemd"}
+	types := []string{config.CgroupfsCgroupsManager, config.SystemdCgroupsManager}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteEventBackend - Autocomplete event backend options.
 // -> "file", "journald", "none"
 func AutocompleteEventBackend(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	types := []string{"file", "journald", "none"}
+	types := []string{events.LogFile.String(), events.Journald.String(), events.Null.String()}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteNetworkBackend - Autocomplete network backend options.
 // -> "cni", "netavark"
 func AutocompleteNetworkBackend(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	types := []string{"cni", "netavark"}
+	types := []string{string(types.CNI), string(types.Netavark)}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -1235,7 +1235,7 @@ func AutocompleteLogLevel(cmd *cobra.Command, args []string, toComplete string) 
 // AutocompleteSDNotify - Autocomplete sdnotify options.
 // -> "container", "conmon", "ignore"
 func AutocompleteSDNotify(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	types := []string{"container", "conmon", "ignore"}
+	types := []string{define.SdNotifyModeContainer, define.SdNotifyModeContainer, define.SdNotifyModeIgnore}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -25,6 +25,8 @@ var (
 	ChangeCmds = []string{"CMD", "ENTRYPOINT", "ENV", "EXPOSE", "LABEL", "ONBUILD", "STOPSIGNAL", "USER", "VOLUME", "WORKDIR"}
 	// LogLevels supported by podman
 	LogLevels = []string{"trace", "debug", "info", "warn", "warning", "error", "fatal", "panic"}
+	// ValidSaveFormats is the list of support podman save formats
+	ValidSaveFormats = []string{define.OCIManifestDir, define.OCIArchive, define.V2s2ManifestDir, define.V2s2Archive}
 )
 
 type completeType int
@@ -1192,10 +1194,8 @@ func AutocompletePsSort(cmd *cobra.Command, args []string, toComplete string) ([
 }
 
 // AutocompleteImageSaveFormat - Autocomplete image save format options.
-// -> "oci-archive", "oci-dir", "docker-dir"
 func AutocompleteImageSaveFormat(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	formats := []string{"oci-archive", "oci-dir", "docker-dir"}
-	return formats, cobra.ShellCompDirectiveNoFileComp
+	return ValidSaveFormats, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteWaitCondition - Autocomplete wait condition options.

--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/define"
+	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/rootless"
 	systemdDefine "github.com/containers/podman/v4/pkg/systemd/define"
@@ -1091,11 +1092,21 @@ func getMethodNames(f reflect.Value, prefix string) []string {
 // AutocompleteEventFilter - Autocomplete event filter flag options.
 // -> "container=", "event=", "image=", "pod=", "volume=", "type="
 func AutocompleteEventFilter(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	event := func(_ string) ([]string, cobra.ShellCompDirective) {
+		return []string{events.Attach.String(), events.AutoUpdate.String(), events.Checkpoint.String(), events.Cleanup.String(),
+			events.Commit.String(), events.Create.String(), events.Exec.String(), events.ExecDied.String(),
+			events.Exited.String(), events.Export.String(), events.Import.String(), events.Init.String(), events.Kill.String(),
+			events.LoadFromArchive.String(), events.Mount.String(), events.NetworkConnect.String(),
+			events.NetworkDisconnect.String(), events.Pause.String(), events.Prune.String(), events.Pull.String(),
+			events.Push.String(), events.Refresh.String(), events.Remove.String(), events.Rename.String(),
+			events.Renumber.String(), events.Restart.String(), events.Restore.String(), events.Save.String(),
+			events.Start.String(), events.Stop.String(), events.Sync.String(), events.Tag.String(), events.Unmount.String(),
+			events.Unpause.String(), events.Untag.String(),
+		}, cobra.ShellCompDirectiveNoFileComp
+	}
 	eventTypes := func(_ string) ([]string, cobra.ShellCompDirective) {
-		return []string{"attach", "checkpoint", "cleanup", "commit", "connect", "create", "disconnect", "exec",
-			"exec_died", "exited", "export", "import", "init", "kill", "loadFromArchive", "mount", "pause",
-			"prune", "pull", "push", "refresh", "remove", "rename", "renumber", "restart", "restore", "save",
-			"start", "stop", "sync", "tag", "unmount", "unpause", "untag",
+		return []string{events.Container.String(), events.Image.String(), events.Network.String(),
+			events.Pod.String(), events.System.String(), events.Volume.String(),
 		}, cobra.ShellCompDirectiveNoFileComp
 	}
 	kv := keyValueCompletion{
@@ -1103,7 +1114,7 @@ func AutocompleteEventFilter(cmd *cobra.Command, args []string, toComplete strin
 		"image=":     func(s string) ([]string, cobra.ShellCompDirective) { return getImages(cmd, s) },
 		"pod=":       func(s string) ([]string, cobra.ShellCompDirective) { return getPods(cmd, s, completeDefault) },
 		"volume=":    func(s string) ([]string, cobra.ShellCompDirective) { return getVolumes(cmd, s) },
-		"event=":     eventTypes,
+		"event=":     event,
 		"type=":      eventTypes,
 	}
 	return completeKeyValues(toComplete, kv)

--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1141,9 +1141,8 @@ func AutocompleteImageSort(cmd *cobra.Command, args []string, toComplete string)
 }
 
 // AutocompleteInspectType - Autocomplete inspect type options.
-// -> "container", "image", "all"
 func AutocompleteInspectType(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	types := []string{"container", "image", "all"}
+	types := []string{AllType, ContainerType, ImageType, NetworkType, PodType, VolumeType}
 	return types, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/cmd/podman/common/inspect.go
+++ b/cmd/podman/common/inspect.go
@@ -1,0 +1,16 @@
+package common
+
+const (
+	// AllType can be of type ImageType or ContainerType.
+	AllType = "all"
+	// ContainerType is the container type.
+	ContainerType = "container"
+	// ImageType is the image type.
+	ImageType = "image"
+	// NetworkType is the network type
+	NetworkType = "network"
+	// PodType is the pod type.
+	PodType = "pod"
+	// VolumeType is the volume type
+	VolumeType = "volume"
+)

--- a/cmd/podman/containers/inspect.go
+++ b/cmd/podman/containers/inspect.go
@@ -42,6 +42,6 @@ func init() {
 
 func inspectExec(cmd *cobra.Command, args []string) error {
 	// Force container type
-	inspectOpts.Type = inspect.ContainerType
+	inspectOpts.Type = common.ContainerType
 	return inspect.Inspect(args, *inspectOpts)
 }

--- a/cmd/podman/images/inspect.go
+++ b/cmd/podman/images/inspect.go
@@ -38,6 +38,6 @@ func init() {
 }
 
 func inspectExec(cmd *cobra.Command, args []string) error {
-	inspectOpts.Type = inspect.ImageType
+	inspectOpts.Type = common.ImageType
 	return inspect.Inspect(args, *inspectOpts)
 }

--- a/cmd/podman/images/save.go
+++ b/cmd/podman/images/save.go
@@ -18,7 +18,6 @@ import (
 )
 
 var (
-	validFormats    = []string{define.OCIManifestDir, define.OCIArchive, define.V2s2ManifestDir, define.V2s2Archive}
 	containerConfig = registry.PodmanConfig()
 )
 
@@ -38,8 +37,8 @@ var (
 			if err != nil {
 				return err
 			}
-			if !util.StringInSlice(format, validFormats) {
-				return errors.Errorf("format value must be one of %s", strings.Join(validFormats, " "))
+			if !util.StringInSlice(format, common.ValidSaveFormats) {
+				return errors.Errorf("format value must be one of %s", strings.Join(common.ValidSaveFormats, " "))
 			}
 			return nil
 		},

--- a/cmd/podman/networks/inspect.go
+++ b/cmd/podman/networks/inspect.go
@@ -37,6 +37,6 @@ func init() {
 }
 
 func networkInspect(_ *cobra.Command, args []string) error {
-	inspectOpts.Type = inspect.NetworkType
+	inspectOpts.Type = common.NetworkType
 	return inspect.Inspect(args, *inspectOpts)
 }

--- a/cmd/podman/volumes/export.go
+++ b/cmd/podman/volumes/export.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v4/cmd/podman/common"
-	"github.com/containers/podman/v4/cmd/podman/inspect"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/utils"
@@ -58,7 +57,7 @@ func export(cmd *cobra.Command, args []string) error {
 	if cliExportOpts.Output == "" {
 		return errors.New("expects output path, use --output=[path]")
 	}
-	inspectOpts.Type = inspect.VolumeType
+	inspectOpts.Type = common.VolumeType
 	volumeData, _, err := containerEngine.VolumeInspect(ctx, args, inspectOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/volumes/import.go
+++ b/cmd/podman/volumes/import.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/containers/podman/v4/cmd/podman/common"
-	"github.com/containers/podman/v4/cmd/podman/inspect"
 	"github.com/containers/podman/v4/cmd/podman/parse"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
@@ -60,7 +59,7 @@ func importVol(cmd *cobra.Command, args []string) error {
 		tarFile = os.Stdin
 	}
 
-	inspectOpts.Type = inspect.VolumeType
+	inspectOpts.Type = common.VolumeType
 	volumeData, _, err := containerEngine.VolumeInspect(ctx, volumes, inspectOpts)
 	if err != nil {
 		return err

--- a/cmd/podman/volumes/inspect.go
+++ b/cmd/podman/volumes/inspect.go
@@ -48,6 +48,6 @@ func volumeInspect(cmd *cobra.Command, args []string) error {
 	if (inspectOpts.All && len(args) > 0) || (!inspectOpts.All && len(args) < 1) {
 		return errors.New("provide one or more volume names or use --all")
 	}
-	inspectOpts.Type = inspect.VolumeType
+	inspectOpts.Type = common.VolumeType
 	return inspect.Inspect(args, *inspectOpts)
 }

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -98,6 +98,8 @@ type Type string
 // Status describes the actual event action (stop, start, create, kill)
 type Status string
 
+// When updating this list below please also update the shell completion list in
+// cmd/podman/common/completion.go and the StringToXXX function in events.go.
 const (
 	// Container - event is related to containers
 	Container Type = "container"


### PR DESCRIPTION
see individual commits

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
