### PR TITLE
dependabot: add release-note-none label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,22 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  labels:
+    - "release-note-none"
   open-pull-requests-limit: 10
 
 - package-ecosystem: gomod
   directory: "test/tools"
   schedule:
     interval: daily
+  labels:
+    - "release-note-none"
   open-pull-requests-limit: 10
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
       interval: "daily"
+  labels:
+    - "release-note-none"
   open-pull-requests-limit: 10


### PR DESCRIPTION
Followup to https://github.com/openshift/release/pull/28686
in which we ask openshift-ci-bot to enforce a release-note
label on new PRs.

Dependabot PRs do not need release notes. Add a config setting
(copied from cri-o) that tells dependabot to set release-note-none
on new PRs.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```