### PR TITLE
[v4.1] [BZ #2083997] pod: build pause image in custom user NS

### DIFF
--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -58,6 +58,12 @@ ENTRYPOINT ["/catatonit", "-P"]`, catatonitPath)
 		Quiet:           true,
 		IgnoreFile:      "/dev/null", // makes sure to not read a local .ignorefile (see #13529)
 		IIDFile:         "/dev/null", // prevents Buildah from writing the ID on stdout
+		IDMappingOptions: &buildahDefine.IDMappingOptions{
+			// Use the host UID/GID mappings for the build to avoid issues when
+			// running with a custom mapping (BZ #2083997).
+			HostUIDMapping: true,
+			HostGIDMapping: true,
+		},
 	}
 	if _, _, err := rt.Build(context.Background(), buildOptions, tmpF.Name()); err != nil {
 		return "", err

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -36,6 +36,19 @@ function _require_crun() {
     is "$output" ".*457" "Check group leaked into container"
 }
 
+@test "rootful pod with custom ID mapping" {
+    skip_if_rootless "does not work rootless - rootful feature"
+    skip_if_remote "remote --uidmap is broken (see #14233)"
+    random_pod_name=$(random_string 30)
+    run_podman pod create --uidmap 0:200000:5000 --name=$random_pod_name
+    run_podman pod start $random_pod_name
+
+    # Remove the pod and the pause image
+    run_podman pod rm $random_pod_name
+    run_podman version --format "{{.Server.Version}}-{{.Server.Built}}"
+    run_podman rmi -f localhost/podman-pause:$output
+}
+
 @test "podman --remote --group-add keep-groups " {
     if is_remote; then
         run_podman 125 run --rm --group-add keep-groups $IMAGE id


### PR DESCRIPTION
Use the host UID and host GID mapping when building the local pause
image for a Pod with a custom mapping.  Otherwise, the mappings are off
and the build fails. Propagating the mapping to the build container is
not needed since the pause image ships merely a copied `catatonit` from
the host.

Backport-of: commit c45d51899a8190bd3797cdee71b74b912a634c71
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2083997
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where the pause image of a Pod with a custom ID mapping could not be built (https://bugzilla.redhat.com/show_bug.cgi?id=2083997).
```
@mheon @rhatdan @TomSweeneyRedHat PTAL