### PR TITLE
linter: enable unconvert linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,7 +44,6 @@ linters:
     - goconst
     - gocyclo
     - lll
-    - unconvert
     - gosec
     - maligned
     - gomoddirectives

--- a/cmd/podman/common/create_test.go
+++ b/cmd/podman/common/create_test.go
@@ -28,8 +28,8 @@ func TestPodOptions(t *testing.T) {
 		for j := 0; j < cc.NumField(); j++ {
 			containerField := cc.FieldByIndex([]int{j})
 			containerType := reflect.TypeOf(exampleOptions).Field(j)
-			tagPod := strings.Split(string(podType.Tag.Get("json")), ",")[0]
-			tagContainer := strings.Split(string(containerType.Tag.Get("json")), ",")[0]
+			tagPod := strings.Split(podType.Tag.Get("json"), ",")[0]
+			tagContainer := strings.Split(containerType.Tag.Get("json"), ",")[0]
 			if tagPod == tagContainer && (tagPod != "" && tagContainer != "") {
 				areEqual := true
 				if containerField.Kind() == podField.Kind() {

--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -95,7 +95,7 @@ func kill(_ *cobra.Command, args []string) error {
 		return errors.New("valid signals are 1 through 64")
 	}
 	for _, cidFile := range cidFiles {
-		content, err := ioutil.ReadFile(string(cidFile))
+		content, err := ioutil.ReadFile(cidFile)
 		if err != nil {
 			return errors.Wrap(err, "error reading CIDFile")
 		}

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -102,7 +102,7 @@ func rm(cmd *cobra.Command, args []string) error {
 		rmOptions.Timeout = &stopTimeout
 	}
 	for _, cidFile := range cidFiles {
-		content, err := ioutil.ReadFile(string(cidFile))
+		content, err := ioutil.ReadFile(cidFile)
 		if err != nil {
 			return errors.Wrap(err, "error reading CIDFile")
 		}

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -100,7 +100,7 @@ func stop(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, cidFile := range cidFiles {
-		content, err := ioutil.ReadFile(string(cidFile))
+		content, err := ioutil.ReadFile(cidFile)
 		if err != nil {
 			return errors.Wrap(err, "error reading CIDFile")
 		}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -3282,7 +3282,7 @@ func (c *Container) fixVolumePermissions(v *ContainerNamedVolume) error {
 				return err
 			}
 			stat := st.Sys().(*syscall.Stat_t)
-			atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+			atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) // nolint: unconvert
 			if err := os.Chtimes(mountPoint, atime, st.ModTime()); err != nil {
 				return err
 			}

--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -254,7 +254,7 @@ func KillContainer(w http.ResponseWriter, r *http.Request) {
 			utils.InternalServerError(w, err)
 			return
 		}
-		if sig == 0 || syscall.Signal(sig) == syscall.SIGKILL {
+		if sig == 0 || sig == syscall.SIGKILL {
 			opts := entities.WaitOptions{
 				Condition: []define.ContainerStatus{define.ContainerStateExited, define.ContainerStateStopped},
 				Interval:  time.Millisecond * 250,
@@ -341,8 +341,8 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 	for idx, portMapping := range portMappings {
 		ports[idx] = types.Port{
 			IP:          portMapping.HostIP,
-			PrivatePort: uint16(portMapping.ContainerPort),
-			PublicPort:  uint16(portMapping.HostPort),
+			PrivatePort: portMapping.ContainerPort,
+			PublicPort:  portMapping.HostPort,
 			Type:        portMapping.Protocol,
 		}
 	}

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -605,7 +605,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		Output:                         output,
 		OutputFormat:                   format,
 		PullPolicy:                     pullPolicy,
-		PullPushRetryDelay:             time.Duration(2 * time.Second),
+		PullPushRetryDelay:             2 * time.Second,
 		Quiet:                          query.Quiet,
 		Registry:                       registry,
 		RemoveIntermediateCtrs:         query.Rm,

--- a/pkg/bindings/images/build_unix.go
+++ b/pkg/bindings/images/build_unix.go
@@ -11,7 +11,7 @@ import (
 func checkHardLink(fi os.FileInfo) (devino, bool) {
 	st := fi.Sys().(*syscall.Stat_t)
 	return devino{
-		Dev: uint64(st.Dev),
-		Ino: uint64(st.Ino),
+		Dev: uint64(st.Dev), // nolint: unconvert
+		Ino: st.Ino,
 	}, st.Nlink > 1
 }

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1113,7 +1113,7 @@ func (ic *ContainerEngine) GetContainerExitCode(ctx context.Context, ctr *libpod
 			time.Sleep(250 * time.Millisecond)
 			continue
 		}
-		return int(event.ContainerExitCode)
+		return event.ContainerExitCode
 	}
 	logrus.Errorf("Could not retrieve exit code from event: %v", err)
 	return define.ExecErrorCodeNotFound

--- a/pkg/domain/infra/abi/parse/parse.go
+++ b/pkg/domain/infra/abi/parse/parse.go
@@ -43,7 +43,7 @@ func VolumeOptions(opts map[string]string) ([]libpod.VolumeCreateOption, error) 
 					if err != nil {
 						return nil, errors.Wrapf(err, "cannot convert inodes %s to integer", splitO[1])
 					}
-					libpodOptions = append(libpodOptions, libpod.WithVolumeInodes(uint64(inodes)))
+					libpodOptions = append(libpodOptions, libpod.WithVolumeInodes(inodes))
 					finalVal = append(finalVal, o)
 					// set option "INODES": "$size"
 					volumeOptions["INODES"] = splitO[1]

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -216,9 +216,9 @@ func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.System
 			Tag:        stat.Tag,
 			ImageID:    stat.ID,
 			Created:    stat.Created,
-			Size:       int64(stat.Size),
-			SharedSize: int64(stat.SharedSize),
-			UniqueSize: int64(stat.UniqueSize),
+			Size:       stat.Size,
+			SharedSize: stat.SharedSize,
+			UniqueSize: stat.UniqueSize,
 			Containers: stat.Containers,
 		}
 		dfImages = append(dfImages, &report)

--- a/pkg/k8s.io/apimachinery/pkg/api/resource/amount.go
+++ b/pkg/k8s.io/apimachinery/pkg/api/resource/amount.go
@@ -221,7 +221,7 @@ func (a int64Amount) AsCanonicalBytes(out []byte) (result []byte, exponent int32
 	exponent = int32(a.scale)
 
 	amount, times := removeInt64Factors(mantissa, 10)
-	exponent += int32(times)
+	exponent += times
 
 	// make sure exponent is a multiple of 3
 	var ok bool

--- a/pkg/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/pkg/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -293,7 +293,7 @@ func ParseQuantity(str string) (Quantity, error) {
 		switch {
 		case exponent >= 0 && len(denom) == 0:
 			// only handle positive binary numbers with the fast path
-			mantissa = int64(int64(mantissa) << uint64(exponent))
+			mantissa <<= uint64(exponent)
 			// 1Mi (2^20) has ~6 digits of decimal precision, so exponent*3/10 -1 is roughly the precision
 			precision = 15 - int32(len(num)) - int32(float32(exponent)*3/10) - 1
 		default:
@@ -313,7 +313,7 @@ func ParseQuantity(str string) (Quantity, error) {
 			if err != nil {
 				return Quantity{}, ErrNumeric
 			}
-			if result, ok := int64Multiply(value, int64(mantissa)); ok {
+			if result, ok := int64Multiply(value, mantissa); ok {
 				if !positive {
 					result = -result
 				}

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -327,7 +327,7 @@ func deviceFromPath(path string) (*spec.LinuxDevice, error) {
 	var (
 		devType   string
 		mode      = stat.Mode
-		devNumber = uint64(stat.Rdev)
+		devNumber = uint64(stat.Rdev) // nolint: unconvert
 		m         = os.FileMode(mode)
 	)
 

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -303,8 +303,8 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(uint64(statT.Rdev))))
-			v.Minor = (int64(unix.Minor(uint64(statT.Rdev))))
+			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) // nolint: unconvert
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) // nolint: unconvert
 			if s.ResourceLimits.BlockIO == nil {
 				s.ResourceLimits.BlockIO = new(spec.LinuxBlockIO)
 			}
@@ -317,8 +317,8 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(uint64(statT.Rdev))))
-			v.Minor = (int64(unix.Minor(uint64(statT.Rdev))))
+			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) // nolint: unconvert
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) // nolint: unconvert
 			s.ResourceLimits.BlockIO.ThrottleWriteBpsDevice = append(s.ResourceLimits.BlockIO.ThrottleWriteBpsDevice, v)
 		}
 	}
@@ -328,8 +328,8 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(uint64(statT.Rdev))))
-			v.Minor = (int64(unix.Minor(uint64(statT.Rdev))))
+			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) // nolint: unconvert
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) // nolint: unconvert
 			s.ResourceLimits.BlockIO.ThrottleReadIOPSDevice = append(s.ResourceLimits.BlockIO.ThrottleReadIOPSDevice, v)
 		}
 	}
@@ -339,8 +339,8 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(uint64(statT.Rdev))))
-			v.Minor = (int64(unix.Minor(uint64(statT.Rdev))))
+			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) // nolint: unconvert
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) // nolint: unconvert
 			s.ResourceLimits.BlockIO.ThrottleWriteIOPSDevice = append(s.ResourceLimits.BlockIO.ThrottleWriteIOPSDevice, v)
 		}
 	}

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -377,7 +377,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		if err := unix.Stat(k, &statT); err != nil {
 			return nil, errors.Wrapf(err, "failed to inspect '%s' in --blkio-weight-device", k)
 		}
-		g.AddLinuxResourcesBlockIOWeightDevice((int64(unix.Major(uint64(statT.Rdev)))), (int64(unix.Minor(uint64(statT.Rdev)))), *v.Weight)
+		g.AddLinuxResourcesBlockIOWeightDevice((int64(unix.Major(uint64(statT.Rdev)))), (int64(unix.Minor(uint64(statT.Rdev)))), *v.Weight) // nolint: unconvert
 	}
 
 	BlockAccessToKernelFilesystems(s.Privileged, s.PidNS.IsHost(), s.Mask, s.Unmask, &g)

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Podman login and logout", func() {
 		defer registriesConf.Close()
 		defer os.Remove(registriesConf.Name())
 
-		err = ioutil.WriteFile(registriesConf.Name(), []byte(registriesConfWithSearch), os.ModePerm)
+		err = ioutil.WriteFile(registriesConf.Name(), registriesConfWithSearch, os.ModePerm)
 		Expect(err).To(BeNil())
 
 		// Environment is per-process, so this looks very unsafe; actually it seems fine because tests are not

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -475,7 +475,7 @@ var _ = Describe("Podman network", func() {
 		defer podmanTest.removeNetwork(netName)
 		Expect(session).Should(Exit(0))
 
-		interval := time.Duration(250 * time.Millisecond)
+		interval := 250 * time.Millisecond
 		for i := 0; i < 6; i++ {
 			n := podmanTest.Podman([]string{"network", "exists", netName})
 			n.WaitWithDefaultTimeout()
@@ -490,7 +490,7 @@ var _ = Describe("Podman network", func() {
 		top := podmanTest.Podman([]string{"run", "-dt", "--name=web", "--network=" + netName, "--network-alias=web1", "--network-alias=web2", nginx})
 		top.WaitWithDefaultTimeout()
 		Expect(top).Should(Exit(0))
-		interval = time.Duration(250 * time.Millisecond)
+		interval = 250 * time.Millisecond
 		// Wait for the nginx service to be running
 		for i := 0; i < 6; i++ {
 			// Test curl against the container's name
@@ -526,7 +526,7 @@ var _ = Describe("Podman network", func() {
 		defer podmanTest.removeNetwork(netName)
 		Expect(session).Should(Exit(0))
 
-		interval := time.Duration(250 * time.Millisecond)
+		interval := 250 * time.Millisecond
 		for i := 0; i < 6; i++ {
 			n := podmanTest.Podman([]string{"network", "exists", netName})
 			n.WaitWithDefaultTimeout()
@@ -541,7 +541,7 @@ var _ = Describe("Podman network", func() {
 		top := podmanTest.Podman([]string{"run", "-dt", "--name=web", "--network=" + netName, "--network-alias=web1", "--network-alias=web2", nginx})
 		top.WaitWithDefaultTimeout()
 		Expect(top).Should(Exit(0))
-		interval = time.Duration(250 * time.Millisecond)
+		interval = 250 * time.Millisecond
 		// Wait for the nginx service to be running
 		for i := 0; i < 6; i++ {
 			// Test curl against the container's name

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -731,7 +731,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		linkAttr.Name = name
 		m, err := net.ParseMAC(mac)
 		Expect(err).To(BeNil())
-		linkAttr.HardwareAddr = net.HardwareAddr(m)
+		linkAttr.HardwareAddr = m
 		eth := &netlink.Dummy{LinkAttrs: linkAttr}
 		err = netlink.LinkAdd(eth)
 		Expect(err).To(BeNil())

--- a/test/e2e/system_df_test.go
+++ b/test/e2e/system_df_test.go
@@ -66,7 +66,7 @@ var _ = Describe("podman system df", func() {
 		images := strings.Fields(session.OutputToStringArray()[1])
 		containers := strings.Fields(session.OutputToStringArray()[2])
 		volumes := strings.Fields(session.OutputToStringArray()[3])
-		Expect(images[1]).To(Equal(string(totImages)), "total images expected")
+		Expect(images[1]).To(Equal(totImages), "total images expected")
 		Expect(containers[1]).To(Equal("2"), "total containers expected")
 		Expect(volumes[2]).To(Equal("2"), "total volumes expected")
 		Expect(volumes[6]).To(Equal("(50%)"), "percentage usage expected")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -192,7 +192,7 @@ func moveProcessPIDFileToScope(pidPath, slice, scope string) error {
 }
 
 func moveProcessToScope(pid int, slice, scope string) error {
-	err := RunUnderSystemdScope(int(pid), slice, scope)
+	err := RunUnderSystemdScope(pid, slice, scope)
 	// If the PID is not valid anymore, do not return an error.
 	if dbusErr, ok := err.(dbus.Error); ok {
 		if dbusErr.Name == "org.freedesktop.DBus.Error.UnixProcessIdUnknown" {


### PR DESCRIPTION
Detects unneccessary type conversions and helps in keeping the code base
cleaner.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
