### PR TITLE
auto update: create an event

### DIFF
--- a/libpod/events.go
+++ b/libpod/events.go
@@ -89,8 +89,8 @@ func (p *Pod) newPodEvent(status events.Status) {
 	}
 }
 
-// newSystemEvent creates a new event for libpod as a whole.
-func (r *Runtime) newSystemEvent(status events.Status) {
+// NewSystemEvent creates a new event for libpod as a whole.
+func (r *Runtime) NewSystemEvent(status events.Status) {
 	e := events.NewEvent(status)
 	e.Type = events.System
 

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -150,6 +150,8 @@ func StringToStatus(name string) (Status, error) {
 	switch name {
 	case Attach.String():
 		return Attach, nil
+	case AutoUpdate.String():
+		return AutoUpdate, nil
 	case Build.String():
 		return Build, nil
 	case Checkpoint.String():

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -930,7 +930,7 @@ func (r *Runtime) refresh(alivePath string) error {
 	}
 	defer file.Close()
 
-	r.newSystemEvent(events.Refresh)
+	r.NewSystemEvent(events.Refresh)
 
 	return nil
 }

--- a/libpod/runtime_renumber.go
+++ b/libpod/runtime_renumber.go
@@ -71,7 +71,7 @@ func (r *Runtime) renumberLocks() error {
 		}
 	}
 
-	r.newSystemEvent(events.Renumber)
+	r.NewSystemEvent(events.Renumber)
 
 	return nil
 }

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/libpod/define"
+	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/systemd"
 	systemdDefine "github.com/containers/podman/v4/pkg/systemd/define"
@@ -141,6 +142,8 @@ func AutoUpdate(ctx context.Context, runtime *libpod.Runtime, options entities.A
 		return nil, []error{err}
 	}
 	defer conn.Close()
+
+	runtime.NewSystemEvent(events.AutoUpdate)
 
 	// Update all images/container according to their auto-update policy.
 	var allReports []*entities.AutoUpdateReport


### PR DESCRIPTION
Create an auto-update event for each invocation, independent if images
and containers are updated or not.  Those events will be indicated in
the events already but users will now know why.

Fixes: #14283
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman auto-update` will now create an event.
```
