### PR TITLE
fix compat image resolution

### DIFF
--- a/test/apiv2/70-short-names.at
+++ b/test/apiv2/70-short-names.at
@@ -6,11 +6,16 @@
 # Pull the libpod/quay image which is used in all tests below.
 t POST "images/create?fromImage=quay.io/libpod/alpine:latest" 200 .error~null .status~".*Download complete.*"
 
+# 14291 - let a short-name resolve to a *local* non Docker-Hub image.
+t POST containers/create Image=alpine 201 .Id~[0-9a-f]\\{64\\}
+cid=$(jq -r '.Id' <<<"$output")
+t GET containers/$cid/json 200 .Image="quay.io/libpod/alpine:latest"
+podman rm -f $cid
 
 ########## TAG
 
 t POST   "images/quay.io/libpod/alpine/tag?repo=foo"  201
-t DELETE "images/foo"                                 200
+t DELETE "images/docker.io/library/foo"               200
 
 
 ########## BUILD
@@ -52,9 +57,6 @@ t DELETE "images/foo"                                200
 
 ########## TAG
 
-# Looking up 'alpine' will fail as it gets normalized to docker.io.
-t POST "images/alpine/tag?repo=foo" 404 .cause="image not known"
-
 # The libpod endpoint will resolve to it without issues.
 t GET "libpod/images/alpine/exists" 204
 
@@ -67,22 +69,21 @@ t GET  "libpod/images/docker.io/library/foo/exists" 204
 
 ########## REMOVE
 
-t DELETE "images/alpine" 404 .cause="image not known" # fails since docker.io/library/alpine does not exist
 t DELETE "images/foo"    200                          # removes the previously tagged image
 
 
 ########## GET
 
 # Same procedure as above but with the /get endpoint.
-t GET    "images/alpine/get"                         404 .cause="image not known"
 t POST   "images/quay.io/libpod/alpine/tag?repo=foo" 201
 t GET    "images/foo/get"                            200 '[POSIX tar archive]'
 t DELETE "images/foo"                                200
+t GET    "images/alpine/get"                         200
 
 
 ########## HISTORY
 
-t GET    "images/alpine/history"                     404 .cause="image not known"
+t GET    "images/alpine/history"                     200
 t GET    "images/quay.io/libpod/alpine/history"      200
 t POST   "images/quay.io/libpod/alpine/tag?repo=foo" 201
 t GET    "libpod/images/foo/history"                 200
@@ -91,7 +92,7 @@ t DELETE "images/foo"                                200
 
 ########## PUSH
 
-t POST   "images/alpine/push?destination=localhost:9999/do/not:exist"                404 .cause="image not known"
+t POST   "images/alpine/push?destination=localhost:9999/do:exist"                    200
 t POST   "images/quay.io/libpod/alpine/push?destination=localhost:9999/do/not:exist" 200 # Error is in the response
 t POST   "images/quay.io/libpod/alpine/tag?repo=foo"                                 201
 t POST   "images/foo/push?destination=localhost:9999/do/not:exist"                   200 # Error is in the response
@@ -100,7 +101,7 @@ t DELETE "images/foo"                                                           
 
 ########## CREATE A CONTAINER
 
-t POST   "containers/create"                         Image=alpine                       404 .cause="image not known"
+t POST   "containers/create"                         Image=alpine                       201
 t POST   "containers/create"                         Image=quay.io/libpod/alpine:latest 201
 cid=$(jq -r '.Id' <<<"$output")
 t POST   "images/quay.io/libpod/alpine/tag?repo=foo"                                    201
@@ -113,7 +114,7 @@ t DELETE "containers/$cid"                                                      
 
 t POST   "containers/create"                      Image=quay.io/libpod/alpine:latest 201
 cid=$(jq -r '.Id' <<<"$output")
-t GET    "images/alpine/get"                                                         404 .cause="image not known"
+t GET    "images/alpine/get"                                                         200
 t POST   "commit?container=$cid&repo=foo&tag=tag"                                    201
 t GET    "images/foo/get"                                                            404 .cause="image not known"
 t GET    "images/foo:tag/get"                                                        200


### PR DESCRIPTION
Fix a bug in the resolution of images in the Docker compat API.
When looking up an image by a short name, the name may match
an image that does not live on Docker Hub.  The resolved name
should be used for normalization instead of the input name to
make sure that `busybox` can resolve to `registry.com/busybox`
if present in the local storage.

Fixes: #14291
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in the resolution of images in the Docker compat API when resolving short names for images that do not live on Docker Hub.
```
