### PR TITLE
Support setting image_volume_mode in containers.conf

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -255,9 +255,8 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		_ = cmd.RegisterFlagCompletionFunc(hostUserFlagName, completion.AutocompleteNone)
 
 		imageVolumeFlagName := "image-volume"
-		createFlags.StringVar(
-			&cf.ImageVolume,
-			imageVolumeFlagName, DefaultImageVolume,
+		createFlags.String(
+			imageVolumeFlagName, containerConfig.Engine.ImageVolumeMode,
 			`Tells podman how to handle the builtin image volumes ("bind"|"tmpfs"|"ignore")`,
 		)
 		_ = cmd.RegisterFlagCompletionFunc(imageVolumeFlagName, AutocompleteImageVolume)

--- a/cmd/podman/common/default.go
+++ b/cmd/podman/common/default.go
@@ -5,9 +5,6 @@ import (
 )
 
 var (
-
-	// DefaultImageVolume default value
-	DefaultImageVolume = "bind"
 	// Pull in configured json library
 	json = registry.JSONLibrary()
 )

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -102,13 +102,22 @@ func init() {
 	createFlags(containerCreateCommand)
 }
 
-func create(cmd *cobra.Command, args []string) error {
-	var (
-		err error
-	)
+func commonFlags(cmd *cobra.Command) error {
+	var err error
 	flags := cmd.Flags()
 	cliVals.Net, err = common.NetFlagsToNetOptions(nil, *flags)
 	if err != nil {
+		return err
+	}
+
+	if cmd.Flags().Changed("image-volume") {
+		cliVals.ImageVolume = cmd.Flag("image-volume").Value.String()
+	}
+	return nil
+}
+
+func create(cmd *cobra.Command, args []string) error {
+	if err := commonFlags(cmd); err != nil {
 		return err
 	}
 
@@ -123,7 +132,7 @@ func create(cmd *cobra.Command, args []string) error {
 		cliVals.InitContainerType = initctr
 	}
 
-	cliVals, err = CreateInit(cmd, cliVals, false)
+	cliVals, err := CreateInit(cmd, cliVals, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -109,7 +109,9 @@ func init() {
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	var err error
+	if err := commonFlags(cmd); err != nil {
+		return err
+	}
 
 	// TODO: Breaking change should be made fatal in next major Release
 	if cliVals.TTY && cliVals.Interactive && !term.IsTerminal(int(os.Stdin.Fd())) {
@@ -122,14 +124,10 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	flags := cmd.Flags()
-	cliVals.Net, err = common.NetFlagsToNetOptions(nil, *flags)
-	if err != nil {
-		return err
-	}
 	runOpts.CIDFile = cliVals.CIDFile
 	runOpts.Rm = cliVals.Rm
-	if cliVals, err = CreateInit(cmd, cliVals, false); err != nil {
+	cliVals, err := CreateInit(cmd, cliVals, false)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/specgenutil/createparse.go
+++ b/pkg/specgenutil/createparse.go
@@ -18,20 +18,5 @@ func validate(c *entities.ContainerCreateOptions) error {
 		return err
 	}
 
-	var imageVolType = map[string]string{
-		"bind":   "",
-		"tmpfs":  "",
-		"ignore": "",
-	}
-	if _, ok := imageVolType[c.ImageVolume]; !ok {
-		switch {
-		case c.IsInfra:
-			c.ImageVolume = "bind"
-		case c.IsClone: // the image volume type will be deduced later from the container we are cloning
-			return nil
-		default:
-			return errors.Errorf("invalid image-volume type %q. Pick one of bind, tmpfs, or ignore", c.ImageVolume)
-		}
-	}
-	return nil
+	return config.ValidateImageVolumeMode(c.ImageVolume)
 }

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -229,9 +229,11 @@ func setNamespaces(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions)
 }
 
 func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions, args []string) error {
-	var (
-		err error
-	)
+	rtc, err := config.Default()
+	if err != nil {
+		return err
+	}
+
 	// validate flags as needed
 	if err := validate(c); err != nil {
 		return err
@@ -479,8 +481,13 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	if len(s.HostUsers) == 0 || len(c.HostUsers) != 0 {
 		s.HostUsers = c.HostUsers
 	}
-	if len(s.ImageVolumeMode) == 0 || len(c.ImageVolume) != 0 {
-		s.ImageVolumeMode = c.ImageVolume
+	if len(c.ImageVolume) != 0 {
+		if len(s.ImageVolumeMode) == 0 {
+			s.ImageVolumeMode = c.ImageVolume
+		}
+	}
+	if len(s.ImageVolumeMode) == 0 {
+		s.ImageVolumeMode = rtc.Engine.ImageVolumeMode
 	}
 	if s.ImageVolumeMode == "bind" {
 		s.ImageVolumeMode = "anonymous"
@@ -550,11 +557,6 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		s.CgroupsMode = c.CgroupsMode
 	}
 	if s.CgroupsMode == "" {
-		rtc, err := config.Default()
-		if err != nil {
-			return err
-		}
-
 		s.CgroupsMode = rtc.Cgroups()
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/14230

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
Yes

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman now supports image_volume_mode setting in containers.conf, which allows you to modify the system defaults for the podman run/create --image-volume option.
```