### PR TITLE
addin a case to troubleshooting.md

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1217,3 +1217,17 @@ WARN[0000] Can't stat lower layer "/var/lib/containers/storage/overlay/l/7HS76F2
 It is the user responsibility to make sure images in an additional
 store are not deleted while being used by containers in another
 store.
+
+### 36) rootful containers fail to run with `crun`
+
+#### Symptom
+``` console
+$ sudo podman run -dt --name webserverRoot2 -p 8881:80 quay.io/libpod/banner
+Error: crun: `/proc/thread-self/attr/exec`: OCI runtime error: unable to assign security attribute
+```
+
+#### Solution
+
+set `runtime = "runc"` (default `"crun"`) in `/etc/containers/containers.conf`
+
+Details: https://issuekiller.com/issues/containers/podman/80943707


### PR DESCRIPTION
adding #36 where running a rootful container fails with an *OCI runtime error: unable to assign security attribute* error (which is being discussed in all detail [here](https://issuekiller.com/issues/containers/podman/80943707))

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```None

```
Signed-off-by: Gunnar Wagner [vrms@netcologne.de](mailto:vrms@netcologne.de)