### PR TITLE
[CI:DOCS] fix podman-for-windows.md

### DIFF
--- a/docs/tutorials/podman-for-windows.md
+++ b/docs/tutorials/podman-for-windows.md
@@ -233,15 +233,15 @@ Linux container. This supports several notation schemes, including:
 
 Windows Style Paths:
 
-`podman run -it c:\Users\User\myfolder:/myfolder ubi8-micro ls /myfolder`
+`podman run --rm -v c:\Users\User\myfolder:/myfolder ubi8-micro ls /myfolder`
 
 Unixy Windows Paths:
 
-`podman run -it /c/Users/User/myfolder:/myfolder ubi8-micro ls /myfolder`
+`podman run --rm -v /c/Users/User/myfolder:/myfolder ubi8-micro ls /myfolder`
 
 Linux paths local to the WSL filesystem:
 
-`podman run -it /var/myfolder:/myfolder ubi-micro ls /myfolder`
+`podman run --rm -v /var/myfolder:/myfolder ubi-micro ls /myfolder`
 
 All of the above conventions work, whether running on a Windows prompt or the
 WSL Linux shell. Although when using Windows paths on Linux, appropriately quote


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

I corrected a typo in the below document.
- podman-for-windows.md

When we would like to perform volume mounts from Windows paths into a Linux container,  should use podman option `-v`.  
Without `-v`,  an error occurred.
```powershell
podman run -it /c/Users/User/myfolder:/myfolder ubi8-micro ls /myfolder
Error: invalid reference format
```

In addiotn, I add option `--rm`.  This is because doing so will prevent unnecessary containers from remaining on the host.

```powershell
podman run -v c:\Users\User\myfolder:/myfolder ubi8-micro ls /myfolder
podman container ls -a 
CONTAINER ID  IMAGE                                         COMMAND           CREATED        STATUS                    PORTS       NAMES
2d4e534a3e5e  registry.access.redhat.com/ubi8-micro:latest  ls -l blog-posts  5 seconds ago  Exited (0) 6 seconds ago              loving_mendel

podman run --rm -v c:\Users\User\myfolder:/myfolder ubi8-micro ls /myfolder
podman container ls -a 
CONTAINER ID  IMAGE       COMMAND     CREATED     STATUS      PORTS       NAMES
```
