### PR TITLE
[CI:DOCS] Add play kube support docs

### DIFF
--- a/docs/play_kube_support.md
+++ b/docs/play_kube_support.md
@@ -1,0 +1,152 @@
+# Podman Play Kube Support
+
+This document outlines the kube yaml fields that are currently supported by the **podman play kube** command.
+
+Note: **N/A** means that the option cannot be supported in a single-node Podman environment.
+
+## Pod Fields
+
+| Field                                             | Support |
+|---------------------------------------------------|---------|
+| containers                                        | ✅      |
+| initContainers                                    | ✅      |
+| imagePullSecrets                                  |         |
+| enableServiceLinks                                |         |
+| os<nolink>.name                                   |         |
+| volumes                                           |         |
+| nodeSelector                                      | N/A     |
+| nodeName                                          | N/A     |
+| affinity.nodeAffinity                             | N/A     |
+| affinity.podAffinity                              | N/A     |
+| affinity.podAntiAffinity                          | N/A     |
+| tolerations.key                                   | N/A     |
+| tolerations.operator                              | N/A     |
+| tolerations.effect                                | N/A     |
+| tolerations.tolerationSeconds                     | N/A     |
+| schedulerName                                     | N/A     |
+| runtimeClassName                                  |         |
+| priorityClassName                                 |         |
+| priority                                          |         |
+| topologySpreadConstraints.maxSkew                 | N/A     |
+| topologySpreadConstraints.topologyKey             | N/A     |
+| topologySpreadConstraints.whenUnsatisfiable       | N/A     |
+| topologySpreadConstraints.labelSelector           | N/A     |
+| topologySpreadConstraints.minDomains              | N/A     |
+| restartPolicy                                     | ✅      |
+| terminationGracePeriod                            |         |
+| activeDeadlineSeconds                             |         |
+| readinessGates.conditionType                      |         |
+| hostname                                          | ✅      |
+| setHostnameAsFQDN                                 |         |
+| subdomain                                         |         |
+| hostAliases.hostnames                             | ✅      |
+| hostAliases.ip                                    | ✅      |
+| dnsConfig.nameservers                             | ✅      |
+| dnsConfig<nolink>.options.name                    | ✅      |
+| dnsConfig.options.value                           | ✅      |
+| dnsConfig.searches                                | ✅      |
+| dnsPolicy                                         |         |
+| hostNetwork                                       | ✅      |
+| hostPID                                           |         |
+| hostIPC                                           |         |
+| shareProcessNamespace                             | ✅      |
+| serviceAccountName                                |         |
+| automountServiceAccountToken                      |         |
+| securityContext.runAsUser                         |         |
+| securityContext.runAsNonRoot                      |         |
+| securityContext.runAsGroup                        |         |
+| securityContext.supplementalGroups                |         |
+| securityContext.fsGroup                           |         |
+| securityContext.fsGroupChangePolicy               |         |
+| securityContext.seccompProfile.type               |         |
+| securityContext.seccompProfile.localhostProfile   |         |
+| securityContext.seLinuxOptions.level              |         |
+| securityContext.seLinuxOptions.role               |         |
+| securityContext.seLinuxOptions.type               |         |
+| securityContext.seLinuxOptions.user               |         |
+| securityContext<nolink>.sysctls.name              |         |
+| securityContext.sysctls.value                     |         |
+| securityContext.windowsOptions.gmsaCredentialSpec |         |
+| securityContext.windowsOptions.hostProcess        |         |
+| securityContext.windowsOptions.runAsUserName      |         |
+
+## Container Fields
+
+| Field                                             | Support |
+|---------------------------------------------------|---------|
+| name                                              | ✅      |
+| image                                             | ✅      |
+| imagePullPolicy                                   | ✅      |
+| command                                           | ✅      |
+| args                                              | ✅      |
+| workingDir                                        | ✅      |
+| ports.containerPort                               | ✅      |
+| ports.hostIP                                      | ✅      |
+| ports.hostPort                                    | ✅      |
+| ports<nolink>.name                                | ✅      |
+| ports.protocol                                    | ✅      |
+| env<nolink>.name                                  | ✅      |
+| env.value                                         | ✅      |
+| env.valueFrom.configMapKeyRef.key                 | ✅      |
+| env<nolink>.valueFrom.configMapKeyRef.name        | ✅      |
+| env.valueFrom.configMapKeyRef.optional            | ✅      |
+| env.valueFrom.fieldRef                            | ✅      |
+| env.valueFrom.resourceFieldRef                    | ✅      |
+| env.valueFrom.secretKeyRef.key                    | ✅      |
+| env<nolink>.valueFrom.secretKeyRef.name           | ✅      |
+| env.valueFrom.secretKeyRef.optional               | ✅      |
+| envFrom<nolink>.configMapRef.name                 | ✅      |
+| envFrom.configMapRef.optional                     | ✅      |
+| envFrom.prefix                                    |         |
+| envFrom<nolink>.secretRef.name                    | ✅      |
+| envFrom.secretRef.optional                        | ✅      |
+| volumeMounts.mountPath                            | ✅      |
+| volumeMounts<nolink>.name                         | ✅      |
+| volumeMounts.mountPropagation                     |         |
+| volumeMounts.readOnly                             | ✅      |
+| volumeMounts.subPath                              |         |
+| volumeMounts.subPathExpr                          |         |
+| volumeDevices.devicePath                          |         |
+| volumeDevices<nolink>.name                        |         |
+| resources.limits                                  | ✅      |
+| resources.requests                                | ✅      |
+| lifecycle.postStart                               |         |
+| lifecycle.preStop                                 |         |
+| terminationMessagePath                            |         |
+| terminationMessagePolicy                          |         |
+| livenessProbe                                     | ✅      |
+| readinessProbe                                    |         |
+| startupProbe                                      |         |
+| securityContext.runAsUser                         | ✅      |
+| securityContext.runAsNonRoot                      |         |
+| securityContext.runAsGroup                        | ✅      |
+| securityContext.readOnlyRootFilesystem            | ✅      |
+| securityContext.procMount                         |         |
+| securityContext.privileged                        | ✅      |
+| securityContext.allowPrivilegeEscalation          | ✅      |
+| securityContext.capabilities.add                  | ✅      |
+| securityContext.capabilities.drop                 | ✅      |
+| securityContext.seccompProfile.type               |         |
+| securityContext.seccompProfile.localhostProfile   |         |
+| securityContext.seLinuxOptions.level              | ✅      |
+| securityContext.seLinuxOptions.role               | ✅      |
+| securityContext.seLinuxOptions.type               | ✅      |
+| securityContext.seLinuxOptions.user               | ✅      |
+| securityContext.windowsOptions.gmsaCredentialSpec |         |
+| securityContext.windowsOptions.hostProcess        |         |
+| securityContext.windowsOptions.runAsUserName      |         |
+| stdin                                             |         |
+| stdinOnce                                         |         |
+| tty                                               |         |
+
+## PersistentVolumeClaim Fields
+
+| Field              | Support |
+|--------------------|---------|
+| volumeName         |         |
+| storageClassName   | ✅      |
+| volumeMode         |         |
+| accessModes        | ✅      |
+| selector           |         |
+| resources.limits   |         |
+| resources.requests | ✅      |


### PR DESCRIPTION
Add a doc to outline which kube yaml fields the play
kube command currently supports.
This will be updated as more fields are supported in
the future.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add doc outlining the kube yaml fields supported by podman play kube

```
