### PR TITLE
[macos: podman-machine] look for firmware (edk2-code-fd) based on the path of qemu binary

### DIFF
--- a/pkg/machine/qemu/options_darwin_arm64.go
+++ b/pkg/machine/qemu/options_darwin_arm64.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/containers/common/pkg/config"
 )
 
 var (
@@ -38,6 +40,22 @@ func getOvmfDir(imagePath, vmName string) string {
 }
 
 /*
+ * When QEmu is installed in a non-default location in the system
+ * we can use the qemu-system-* binary path to figure the install
+ * location for Qemu and use it to look for edk2-code-fd
+ */
+func getEdk2CodeFdPathFromQemuBinaryPath() string {
+	cfg, err := config.Default()
+	if err == nil {
+		execPath, err := cfg.FindHelperBinary(QemuCommand, true)
+		if err == nil {
+			return filepath.Clean(filepath.Join(filepath.Dir(execPath), "..", "share", "qemu"))
+		}
+	}
+	return ""
+}
+
+/*
  *  QEmu can be installed in multiple locations on MacOS, especially on
  *  Apple Silicon systems.  A build from source will likely install it in
  *  /usr/local/bin, whereas Homebrew package management standard is to
@@ -45,6 +63,7 @@ func getOvmfDir(imagePath, vmName string) string {
  */
 func getEdk2CodeFd(name string) string {
 	dirs := []string{
+		getEdk2CodeFdPathFromQemuBinaryPath(),
 		"/opt/homebrew/opt/podman/libexec/share/qemu",
 		"/usr/local/share/qemu",
 		"/opt/homebrew/share/qemu",


### PR DESCRIPTION
this allows users to use a qemu installation that is
not in the default /usr/local/bin location

a user can configure engine.helper_binaries_dir key
or update PATH to include the installation location
to find the qemu binary

Signed-off-by: Anjan Nath <kaludios@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
