### PR TITLE
[v4.0-rhel] Cirrus: Use fixed netavark/aardvark-dns branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,9 +8,9 @@ env:
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
     DEST_BRANCH: "v4.0-rhel"
     # Netavark branch to use when TEST_ENVIRON=host-netavark
-    NETAVARK_BRANCH: "main"  # TODO: This should point to a release branch
+    NETAVARK_BRANCH: "v1.0.1-rhel"  # TODO: This should point to a release branch
     # Aardvark branch to use
-    AARDVARK_BRANCH: "main"  # TODO: This should also be a release branch
+    AARDVARK_BRANCH: "v1.0.1-rhel"  # TODO: This should also be a release branch
     # Overrides default location (/tmp/cirrus) for repo clone
     GOPATH: &gopath "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"

--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -6,7 +6,7 @@ die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
 
 function install() {
     echo "Installing golangci-lint v$VERSION into $BIN"
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./bin v$VERSION
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$VERSION
 }
 
 BIN="./bin/golangci-lint"


### PR DESCRIPTION
This is important for the stability of CI in case of a future backport
that happens to be incompatible with netavark/aardvark `main`.  Since CI
doesn't run very often on the podman `v4.0` branch, an incompatible change
may not be noticed.  Fix this by switching off of the `main` branch onto
a netavark/aardvark release branches.

#### Does this PR introduce a user-facing change?

```release-note
None
```
