### PR TITLE
[v4.1] Cirrus: Remove unused netavark/aardvark variables

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,10 +7,6 @@ env:
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
     DEST_BRANCH: "v4.1"
-    # Netavark branch to use when TEST_ENVIRON=host-netavark
-    NETAVARK_BRANCH: "main"
-    # Aardvark branch to use
-    AARDVARK_BRANCH: "main"
     # Overrides default location (/tmp/cirrus) for repo clone
     GOPATH: &gopath "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"


### PR DESCRIPTION
CI on the `v4.1` branch uses netavark & aardvark-dns packages built into
the VM images.  However there were several leftover env. var.
definitions from a previous solution, which may be confusing to future
maintainers.  Delete them.

#### Does this PR introduce a user-facing change?

```release-note
None
```
