### PR TITLE
cmd/podman/common/completion.go: fix FIXMEs

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/config"
@@ -16,6 +17,7 @@ import (
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/rootless"
+	"github.com/containers/podman/v4/pkg/signal"
 	systemdDefine "github.com/containers/podman/v4/pkg/systemd/define"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/spf13/cobra"
@@ -595,7 +597,9 @@ func AutocompleteRunlabelCommand(cmd *cobra.Command, args []string, toComplete s
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	if len(args) == 0 {
-		// FIXME: What labels can we recommend here?
+		// This is unfortunate because the argument order is label followed by image.
+		// If it would be the other way around we could inspect the first arg and get
+		// all labels from it to suggest them.
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	if len(args) == 1 {
@@ -800,8 +804,7 @@ func AutocompleteLogDriver(cmd *cobra.Command, args []string, toComplete string)
 // AutocompleteLogOpt - Autocomplete log-opt options.
 // -> "path=", "tag="
 func AutocompleteLogOpt(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// FIXME: are these the only one? the man page states these but in the current shell completion they are more options
-	logOptions := []string{"path=", "tag="}
+	logOptions := []string{"path=", "tag=", "max-size="}
 	if strings.HasPrefix(toComplete, "path=") {
 		return nil, cobra.ShellCompDirectiveDefault
 	}
@@ -840,10 +843,26 @@ func AutocompleteSecurityOption(cmd *cobra.Command, args []string, toComplete st
 }
 
 // AutocompleteStopSignal - Autocomplete stop signal options.
-// -> "SIGHUP", "SIGINT", "SIGKILL", "SIGTERM"
+// Autocompletes signals both lower or uppercase depending on the user input.
 func AutocompleteStopSignal(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// FIXME: add more/different signals?
-	stopSignals := []string{"SIGHUP", "SIGINT", "SIGKILL", "SIGTERM"}
+	// convertCase will convert a string to lowercase only if the user input is lowercase
+	convertCase := func(s string) string { return s }
+	if len(toComplete) > 0 && unicode.IsLower(rune(toComplete[0])) {
+		convertCase = strings.ToLower
+	}
+
+	prefix := ""
+	// if input starts with "SI" we have to add SIG in front
+	// since the signal map does not have this prefix but the option
+	// allows signals with and without SIG prefix
+	if strings.HasPrefix(toComplete, convertCase("SI")) {
+		prefix = "SIG"
+	}
+
+	stopSignals := make([]string, 0, len(signal.SignalMap))
+	for sig := range signal.SignalMap {
+		stopSignals = append(stopSignals, convertCase(prefix+sig))
+	}
 	return stopSignals, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/pkg/signal/signal_common.go
+++ b/pkg/signal/signal_common.go
@@ -17,7 +17,7 @@ func ParseSignal(rawSignal string) (syscall.Signal, error) {
 		}
 		return syscall.Signal(s), nil
 	}
-	sig, ok := signalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
+	sig, ok := SignalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
 	if !ok {
 		return -1, fmt.Errorf("invalid signal: %s", rawSignal)
 	}
@@ -32,7 +32,7 @@ func ParseSignalNameOrNumber(rawSignal string) (syscall.Signal, error) {
 	if err == nil {
 		return s, nil
 	}
-	for k, v := range signalMap {
+	for k, v := range SignalMap {
 		if k == strings.ToUpper(basename) {
 			return v, nil
 		}

--- a/pkg/signal/signal_linux.go
+++ b/pkg/signal/signal_linux.go
@@ -23,8 +23,8 @@ const (
 	SIGWINCH = syscall.SIGWINCH // For cross-compilation with Windows
 )
 
-// signalMap is a map of Linux signals.
-var signalMap = map[string]syscall.Signal{
+// SignalMap is a map of Linux signals.
+var SignalMap = map[string]syscall.Signal{
 	"ABRT":     unix.SIGABRT,
 	"ALRM":     unix.SIGALRM,
 	"BUS":      unix.SIGBUS,
@@ -94,8 +94,8 @@ var signalMap = map[string]syscall.Signal{
 
 // CatchAll catches all signals and relays them to the specified channel.
 func CatchAll(sigc chan os.Signal) {
-	handledSigs := make([]os.Signal, 0, len(signalMap))
-	for _, s := range signalMap {
+	handledSigs := make([]os.Signal, 0, len(SignalMap))
+	for _, s := range SignalMap {
 		handledSigs = append(handledSigs, s)
 	}
 	signal.Notify(sigc, handledSigs...)

--- a/pkg/signal/signal_linux_mipsx.go
+++ b/pkg/signal/signal_linux_mipsx.go
@@ -24,8 +24,8 @@ const (
 	SIGWINCH = syscall.SIGWINCH
 )
 
-// signalMap is a map of Linux signals.
-var signalMap = map[string]syscall.Signal{
+// SignalMap is a map of Linux signals.
+var SignalMap = map[string]syscall.Signal{
 	"ABRT":     unix.SIGABRT,
 	"ALRM":     unix.SIGALRM,
 	"BUS":      unix.SIGBUS,
@@ -95,8 +95,8 @@ var signalMap = map[string]syscall.Signal{
 
 // CatchAll catches all signals and relays them to the specified channel.
 func CatchAll(sigc chan os.Signal) {
-	handledSigs := make([]os.Signal, 0, len(signalMap))
-	for _, s := range signalMap {
+	handledSigs := make([]os.Signal, 0, len(SignalMap))
+	for _, s := range SignalMap {
 		handledSigs = append(handledSigs, s)
 	}
 	signal.Notify(sigc, handledSigs...)

--- a/pkg/signal/signal_unix.go
+++ b/pkg/signal/signal_unix.go
@@ -16,12 +16,12 @@ const (
 	SIGWINCH = syscall.SIGWINCH
 )
 
-// signalMap is a map of Linux signals.
+// SignalMap is a map of Linux signals.
 // These constants are sourced from the Linux version of golang.org/x/sys/unix
 // (I don't see much risk of this changing).
 // This should work as long as Podman only runs containers on Linux, which seems
 // a safe assumption for now.
-var signalMap = map[string]syscall.Signal{
+var SignalMap = map[string]syscall.Signal{
 	"ABRT":     syscall.Signal(0x6),
 	"ALRM":     syscall.Signal(0xe),
 	"BUS":      syscall.Signal(0x7),

--- a/pkg/signal/signal_unsupported.go
+++ b/pkg/signal/signal_unsupported.go
@@ -16,12 +16,12 @@ const (
 	SIGWINCH = syscall.Signal(0xff)
 )
 
-// signalMap is a map of Linux signals.
+// SignalMap is a map of Linux signals.
 // These constants are sourced from the Linux version of golang.org/x/sys/unix
 // (I don't see much risk of this changing).
 // This should work as long as Podman only runs containers on Linux, which seems
 // a safe assumption for now.
-var signalMap = map[string]syscall.Signal{
+var SignalMap = map[string]syscall.Signal{
 	"ABRT":     syscall.Signal(0x6),
 	"ALRM":     syscall.Signal(0xe),
 	"BUS":      syscall.Signal(0x7),


### PR DESCRIPTION
There is no good way to recommend labels for podman container runlabel.

Add the missing max-size log option. These are the only documented
options so the completion should not suggest something different.

Add proper --stop-signal completion. It will now complete all supported
signal names both upper and lowercase depending on the user input. Also
it work with and without the SIG prefix.

Fixing the TODOs in this file are more complicated since they describe
bigger features.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improved shell completion for podman create/run --stop-signal.
```
