### PR TITLE
Allow podman pod create --share +pid

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -159,7 +159,12 @@ func create(cmd *cobra.Command, args []string) error {
 		if strings.Contains(share, "cgroup") && shareParent {
 			return errors.Wrapf(define.ErrInvalidArg, "cannot define the pod as the cgroup parent at the same time as joining the infra container's cgroupNS")
 		}
-		createOptions.Share = strings.Split(share, ",")
+
+		if strings.HasPrefix(share, "+") {
+			createOptions.Share = append(createOptions.Share, strings.Split(specgen.DefaultKernelNamespaces, ",")...)
+			share = share[1:]
+		}
+		createOptions.Share = append(createOptions.Share, strings.Split(share, ",")...)
 		createOptions.ShareParent = &shareParent
 		if cmd.Flag("infra-command").Changed {
 			// Only send content to server side if user changed defaults

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -13,6 +13,15 @@ containers added to it. The pod id is printed to STDOUT. You can then use
 **podman create --pod `<pod_id|pod_name>` ...** to add containers to the pod, and
 **podman pod start `<pod_id|pod_name>`** to start the pod.
 
+The operator can identify a pod in three ways:
+UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”)
+UUID short identifier (“f78375b1c487”)
+Name (“jonah”)
+
+podman generates a UUID for each pod, and if a name is not assigned
+to the container with **--name** then a random string name will be generated
+for it. The name is useful any place you need to identify a pod.
+
 ## OPTIONS
 
 #### **--add-host**=_host_:_ip_
@@ -266,16 +275,7 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 #### **--share**=*namespace*
 
-A comma-separated list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared. The namespaces to choose from are cgroup, ipc, net, pid, uts.
-
-The operator can identify a pod in three ways:
-UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”)
-UUID short identifier (“f78375b1c487”)
-Name (“jonah”)
-
-podman generates a UUID for each pod, and if a name is not assigned
-to the container with **--name** then a random string name will be generated
-for it. The name is useful any place you need to identify a pod.
+A comma-separated list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared. The namespaces to choose from are cgroup, ipc, net, pid, uts. If the option is prefixed with a "+" then the namespace is appended to the default list, otherwise it replaces the default list. Defaults matches Kubernetes default (ipc, net, uts)
 
 #### **--share-parent**
 

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -335,8 +335,15 @@ EOF
     is "$output" ".*Invalid kernel namespace to share: bogus. Options are: cgroup, ipc, net, pid, uts or none" \
        "pod test for bogus --share option"
     run_podman pod create --share ipc --name $pod_name
+    run_podman pod inspect $pod_name --format "{{.SharedNamespaces}}"
+    is "$output" "[ipc]"
     run_podman run --rm --pod $pod_name --hostname foobar $IMAGE hostname
     is "$output" "foobar" "--hostname should work with non share UTS namespace"
+    run_podman pod create --share +pid --replace --name $pod_name
+    run_podman pod inspect $pod_name --format "{{.SharedNamespaces}}"
+    for ns in uts pid ipc net; do
+        is "$output" ".*$ns"
+    done
 }
 
 @test "podman pod create --pod new:$POD --hostname" {


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/13422

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
No

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman pod create --share now supports "+" prefix, allowing users to add to default namespaces

```
