### PR TITLE
Allow podman pod create to accept name argument

### DIFF
--- a/cmd/podman/volumes/create.go
+++ b/cmd/podman/volumes/create.go
@@ -17,6 +17,7 @@ var (
 
 	createCommand = &cobra.Command{
 		Use:               "create [options] [NAME]",
+		Args:              cobra.MaximumNArgs(1),
 		Short:             "Create a new volume",
 		Long:              createDescription,
 		RunE:              create,
@@ -59,9 +60,6 @@ func create(cmd *cobra.Command, args []string) error {
 	var (
 		err error
 	)
-	if len(args) > 1 {
-		return errors.Errorf("too many arguments, create takes at most 1 argument")
-	}
 	if len(args) > 0 {
 		createOpts.Name = args[0]
 	}

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -4,7 +4,7 @@
 podman\-network-create - Create a Podman network
 
 ## SYNOPSIS
-**podman network create**  [*options*] name
+**podman network create**  [*options*] [*name*]
 
 ## DESCRIPTION
 Create a CNI-network configuration for use with Podman. By default, Podman creates a bridge connection.

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -4,14 +4,15 @@
 podman\-pod\-create - Create a new pod
 
 ## SYNOPSIS
-**podman pod create** [*options*]
+**podman pod create** [*options*] [*name*]
 
 ## DESCRIPTION
 
 Creates an empty pod, or unit of multiple containers, and prepares it to have
-containers added to it. The pod id is printed to STDOUT. You can then use
-**podman create --pod `<pod_id|pod_name>` ...** to add containers to the pod, and
-**podman pod start `<pod_id|pod_name>`** to start the pod.
+containers added to it. The pod can be created with a specific name. If a name
+is not given a random name is generated. The pod id is printed to STDOUT. You
+can then use **podman create --pod `<pod_id|pod_name>` ...** to add containers
+to the pod, and **podman pod start `<pod_id|pod_name>`** to start the pod.
 
 ## OPTIONS
 
@@ -549,9 +550,11 @@ that data on the target.
 ```
 $ podman pod create --name test
 
+$ podman pod create mypod
+
 $ podman pod create --infra=false
 
-$ podman pod create --infra-command /top
+$ podman pod create --infra-command /top toppod
 
 $ podman pod create --publish 8443:443
 

--- a/docs/source/markdown/podman-volume-create.1.md
+++ b/docs/source/markdown/podman-volume-create.1.md
@@ -4,7 +4,7 @@
 podman\-volume\-create - Create a new volume
 
 ## SYNOPSIS
-**podman volume create** [*options*]
+**podman volume create** [*options*] [*name*]
 
 ## DESCRIPTION
 

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -387,20 +387,20 @@ EOF
     is "$output" "false" "Default network sharing should be false"
     run_podman pod rm test
 
-    run_podman pod create --name test --share ipc  --network private
+    run_podman pod create --share ipc  --network private test
     run_podman pod inspect test --format {{.InfraConfig.HostNetwork}}
     is "$output" "false" "Private network sharing with only ipc should be false"
     run_podman pod rm test
 
-    run_podman pod create --name test --share net  --network private
-    run_podman pod inspect test --format {{.InfraConfig.HostNetwork}}
+    local name="$(random_string 10 | tr A-Z a-z)"
+    run_podman pod create --name $name --share net  --network private
+    run_podman pod inspect $name --format {{.InfraConfig.HostNetwork}}
     is "$output" "false" "Private network sharing with only net should be false"
-    run_podman pod rm test
 
-    run_podman pod create --name test --share net --network host
-    run_podman pod inspect test --format {{.InfraConfig.HostNetwork}}
+    run_podman pod create --share net --network host --replace $name
+    run_podman pod inspect $name --format {{.InfraConfig.HostNetwork}}
     is "$output" "true" "Host network sharing with only net should be true"
-    run_podman pod rm test
+    run_podman pod rm $name
 
     run_podman pod create --name test --share ipc --network host
     run_podman pod inspect test --format {{.InfraConfig.HostNetwork}}


### PR DESCRIPTION
I am constantly attempting to add the podname to the last
argument to podman pod create. Allowing this makes it match
podman volume create and podman network create.

It does not match podman container create, since podman container create
arguments specify the arguments to run with the container.

Still need to support the --name option for backwards compatibility.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman pod create now accepts a name argument.
```
