### PR TITLE
implement image scp tagging & add some tests (FIXME)

### DIFF
--- a/cmd/podman/images/scp_utils.go
+++ b/cmd/podman/images/scp_utils.go
@@ -50,21 +50,18 @@ func validateImagePortion(location entities.ImageScpOptions, arg string) (entiti
 }
 
 // validateSCPArgs takes the array of source and destination options and checks for common errors
-func validateSCPArgs(locations []*entities.ImageScpOptions) (bool, error) {
+func validateSCPArgs(locations []*entities.ImageScpOptions) error {
 	if len(locations) > 2 {
-		return false, errors.Wrapf(define.ErrInvalidArg, "cannot specify more than two arguments")
+		return errors.Wrapf(define.ErrInvalidArg, "cannot specify more than two arguments")
 	}
 	switch {
 	case len(locations[0].Image) > 0 && len(locations[1].Image) > 0:
-		return false, errors.Wrapf(define.ErrInvalidArg, "cannot specify an image rename")
+		locations[1].Tag = locations[1].Image
+		locations[1].Image = ""
 	case len(locations[0].Image) == 0 && len(locations[1].Image) == 0:
-		return false, errors.Wrapf(define.ErrInvalidArg, "a source image must be specified")
-	case len(locations[0].Image) == 0 && len(locations[1].Image) != 0:
-		if locations[0].Remote && locations[1].Remote {
-			return true, nil // we need to flip the cliConnections array so the save/load connections are in the right place
-		}
+		return errors.Wrapf(define.ErrInvalidArg, "a source image must be specified")
 	}
-	return false, nil
+	return nil
 }
 
 // validateImageName makes sure that the image given is valid and no injections are occurring

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -325,6 +325,8 @@ type ImageScpOptions struct {
 	Image string `json:"image,omitempty"`
 	// User is used in conjunction with Transfer to determine if a valid user was given to save from/load into
 	User string `json:"user,omitempty"`
+	// Tag is the name to be used for the image on the destination
+	Tag string `json:"tag,omitempty"`
 }
 
 // ImageScpConnections provides the ssh related information used in remote image transfer

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/containers/common/pkg/cgroups"
 	"github.com/containers/podman/v4/libpod/define"
+	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/godbus/dbus/v5"
 	"github.com/pkg/errors"
@@ -251,6 +252,31 @@ func CreateSCPCommand(cmd *exec.Cmd, command []string) *exec.Cmd {
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return cmd
+}
+
+// ScpTag is a helper function for native podman to tag an image after a local load from image SCP
+func ScpTag(cmd *exec.Cmd, podman string, dest entities.ImageScpOptions) error {
+	cmd.Stdout = nil
+	out, err := cmd.Output() // this function captures the output temporarily in order to execute the next command
+	if err != nil {
+		return err
+	}
+	fmt.Println(strings.TrimSuffix(string(out), "\n")) // print output
+	image := ExtractImage(out)
+	if cmd.Args[0] == "sudo" { // transferRootless will need the sudo since we are loading to sudo from a user acct
+		cmd = exec.Command("sudo", podman, "tag", image, dest.Tag)
+	} else {
+		cmd = exec.Command(podman, "tag", image, dest.Tag)
+	}
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
+}
+
+// ExtractImage pulls out the last line of output from save/load (image id)
+func ExtractImage(out []byte) string {
+	stringOut := string(out)                                   // get all output
+	arrOut := strings.Split(stringOut, " ")                    // split it into an array
+	return strings.ReplaceAll(arrOut[len(arrOut)-1], "\n", "") // replace the trailing \n
 }
 
 // LoginUser starts the user process on the host so that image scp can use systemd-run


### PR DESCRIPTION
allow users to pass a "new name" for the image they are transferring
`podman tag` as implemented creates a new image im `image list` when tagging, so this does the same
meaning that when transferring images with tags, podman on the remote machine/user will load two images
ex: `podman image scp computer1::alpine computer2::foobar` creates alpine:latest and localhost/foobar on the remote host

implementing tags means removal of the buggy syntax. In the currently released podman image scp, the user can either specify
`podman image scp source::img dest::` or `podman image scp dest:: source::img`. However, with tags this task becomes really hard to check
which is the image (src) and which is the new tag (dst). Removal of that streamlines the arg parsing process

Signed-off-by: cdoern <cdoern@redhat.com>

#### Does this PR introduce a user-facing change?

```release note
podman image scp syntax change, source now needs to be the first argument and dest needs to be the second argument

```
