### PR TITLE
podman pod create --uidmap patch

### DIFF
--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/containers/common/libnetwork/types"
+	storageTypes "github.com/containers/storage/types"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -222,6 +223,10 @@ type PodResourceConfig struct {
 
 type PodSecurityConfig struct {
 	SecurityOpt []string `json:"security_opt,omitempty"`
+	// IDMappings are UID and GID mappings that will be used by user
+	// namespaces.
+	// Required if UserNS is private.
+	IDMappings *storageTypes.IDMappingOptions `json:"idmappings,omitempty"`
 }
 
 // NewPodSpecGenerator creates a new pod spec

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -38,10 +38,12 @@ function _require_crun() {
 
 @test "rootful pod with custom ID mapping" {
     skip_if_rootless "does not work rootless - rootful feature"
-    skip_if_remote "remote --uidmap is broken (see #14233)"
     random_pod_name=$(random_string 30)
     run_podman pod create --uidmap 0:200000:5000 --name=$random_pod_name
     run_podman pod start $random_pod_name
+    run_podman pod inspect --format '{{.InfraContainerID}}' $random_pod_name
+    run podman inspect --format '{{.HostConfig.IDMappings.UIDMap}}' $output
+    is "$output" ".*0:200000:5000" "UID Map Successful"
 
     # Remove the pod and the pause image
     run_podman pod rm $random_pod_name


### PR DESCRIPTION
podmans remote API does not marshal infra's spec due to
the fact that if it did, all of those options would be available to
the users on the command line. This means we need to manually map "backwards"
some container spec items -> pod spec items before calling PodCreate, this was
one of them that was forgotten

This is a patch that will most likely be reverted (for a better solution) once the new API specgen format is implemented for pods. 

resolves #14233

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
