### PR TITLE
help-message system test: catch more cases

### DIFF
--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -24,7 +24,7 @@ var (
 
 	// Command: podman pod _ps_
 	psCmd = &cobra.Command{
-		Use:               "ps  [options]",
+		Use:               "ps [options]",
 		Aliases:           []string{"ls", "list"},
 		Short:             "List pods",
 		Long:              psDescription,


### PR DESCRIPTION
 - Look for and prevent lower-case arg descriptions:
     podman cmd [arg]

 - Look for and prevent optional-mandatory misordering:
     podman cmd [ARG] ARG

 - Tighter whitespace checks (and fix podman pod ps)

 - simplify a no-longer-necessary mess! #8635 fixed the
   horrible "CONTAINER | IMAGE" strings (with spaces),
   so there's no longer a need to special-case those.
   The one-extra-arg check is now much cleaner.

Minor refactoring.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```