### PR TITLE
WIP: add a label managed-by=systemd in generate systemd

### DIFF
--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -362,6 +362,7 @@ func executeContainerTemplate(info *containerInfo, options entities.GenerateSyst
 		}
 		startCommand = append(startCommand,
 			"run",
+			"--label=podman/managed-by=systemd",
 			"--cidfile={{{{.ContainerIDFile}}}}",
 			"--cgroups=no-conmon",
 			"--rm",


### PR DESCRIPTION
It is useful to identify all the containers that are managed by a unit
file, and labeling them is an easy way to spot them.

`podman generate systemd --new` will add this to the `ExecStart` section:
ExecStart=/var/home/rgolan/src/podman/bin/podman run \
	--label=podman/managed-by=systemd \
	--cidfile=%t/%n.ctr-id \
	--cgroups=no-conmon \
        ...

$ podman ps -f label=podman/managed-by=systemd -q
e6b4673c0e9f

This idea originally brought up while using the gnome-shell-extension-containers,
essentially a gnome menu to manage containers,where it was suggested that some
containers are managed by systemd, and it will be useful to show users at least which containers
those are. See the discussion here ->  https://github.com/rgolangh/gnome-shell-extension-containers/issues/30#issuecomment-1136057861

Signed-off-by: Roy Golan <rgolan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When generating a new systemd file, also add a label 'podman/managed-by=systemd' to easily trace such containers.
This works only for `podman generate systemd --new` because labels can be added at creation time only.
```
