### PR TITLE
work queue: simplify and use a wait group

### DIFF
--- a/libpod/runtime_worker.go
+++ b/libpod/runtime_worker.go
@@ -1,40 +1,17 @@
 package libpod
 
-import (
-	"time"
-)
-
 func (r *Runtime) startWorker() {
-	if r.workerChannel == nil {
-		r.workerChannel = make(chan func(), 1)
-		r.workerShutdown = make(chan bool)
-	}
+	r.workerChannel = make(chan func(), 10)
 	go func() {
-		for {
-			// Make sure to read all workers before
-			// checking if we're about to shutdown.
-			for len(r.workerChannel) > 0 {
-				w := <-r.workerChannel
-				w()
-			}
-
-			select {
-			// We'll read from the shutdown channel only when all
-			// items above have been processed.
-			//
-			// (*Runtime).Shutdown() will block until until the
-			// item is read.
-			case <-r.workerShutdown:
-				return
-
-			default:
-				time.Sleep(100 * time.Millisecond)
-			}
+		for w := range r.workerChannel {
+			w()
+			r.workerGroup.Done()
 		}
 	}()
 }
 
 func (r *Runtime) queueWork(f func()) {
+	r.workerGroup.Add(1)
 	go func() {
 		r.workerChannel <- f
 	}()


### PR DESCRIPTION
Simplify the work-queue implementation by using a wait group. Once all
queued work items are done, the channel can be closed.

The system tests revealed a flake (i.e., #14351) which indicated that
the service container does not always get stopped which suggests a race
condition when queuing items.  Those items are queued in a goroutine to
prevent potential dead locks if the queue ever filled up too quickly.
The race condition in question is that if a work item queues another,
the goroutine for queuing may not be scheduled fast enough and the
runtime shuts down; it seems to happen fairly easily on the slow CI
machines.  The wait group fixes this race and allows for simplifying
the code.

Also increase the queue's buffer size to 10 to make things slightly
faster.

[NO NEW TESTS NEEDED] as we are fixing a flake.

Fixes: #14351
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
