### PR TITLE
[CI:Docs]: note regarding version compatablity between server and client for bug fixes.

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1217,3 +1217,17 @@ WARN[0000] Can't stat lower layer "/var/lib/containers/storage/overlay/l/7HS76F2
 It is the user responsibility to make sure images in an additional
 store are not deleted while being used by containers in another
 store.
+
+### 36) Syncing bugfixes for podman-remote or setups using Podman API
+
+After upgrading Podman to a newer version an issue with the earlier version of Podman still presents itself while using podman-remote.
+
+#### Symptom
+
+While running podman remote commands with the most updated Podman, issues that were fixed in a prior version of Podman can arise either on the Podman client side or the Podman server side.
+
+#### Solution
+
+When upgrading Podman to a particular version for the required fixes, users often make the mistake of only upgrading the Podman client. However, suppose a setup uses `podman-remote` or uses a client that communicates with the Podman server on a remote machine via the REST API. In that case, it is required to upgrade both the Podman client and the Podman server running on the remote machine. Both the Podman client and server must be upgraded to the same version.
+
+Example: If a particular bug was fixed in `v4.1.0` then The Podman client` must have version `v4.1.0` as well the Podman server must have version `v4.1.0`.


### PR DESCRIPTION
Add a small note to troubleshooting docs regaring version parity between
podman-client and podman-server when looking for bug fixes.

[NO TESTS NEEDED]
[NO NEW TESTS NEEDED]

Closes: https://github.com/containers/podman/issues/12660