### PR TITLE
Support remote deadlock errors in rm

### DIFF
--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -123,9 +123,7 @@ func rm(cmd *cobra.Command, args []string) error {
 // removeContainers will set the exit code according to the `podman-rm` man
 // page.
 func removeContainers(namesOrIDs []string, rmOptions entities.RmOptions, setExit bool) error {
-	var (
-		errs utils.OutputErrors
-	)
+	var errs utils.OutputErrors
 	responses, err := registry.ContainerEngine().ContainerRm(context.Background(), namesOrIDs, rmOptions)
 	if err != nil {
 		if setExit {
@@ -135,8 +133,9 @@ func removeContainers(namesOrIDs []string, rmOptions entities.RmOptions, setExit
 	}
 	for _, r := range responses {
 		if r.Err != nil {
-			// TODO this will not work with the remote client
-			if errors.Cause(err) == define.ErrWillDeadlock {
+			// When using the API, errors.Cause(err) will never equal constant define.ErrWillDeadLock
+			if errors.Cause(r.Err) == define.ErrWillDeadlock ||
+				errors.Cause(r.Err).Error() == define.ErrWillDeadlock.Error() {
 				logrus.Errorf("Potential deadlock detected - please run 'podman system renumber' to resolve")
 			}
 			if setExit {


### PR DESCRIPTION
Refactor test for deadlock by comparing error text vs. actual
ErrWillDeadlock constant. When running with --remote the error
constant will always be not equal to the error returned by the API.

```release-note
NONE
```

[NO NEW TESTS NEEDED]

Signed-off-by: Jhon Honce <jhonce@redhat.com>
