### PR TITLE
Fix podman pod unpause TODO

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -520,6 +520,16 @@ func AutocompletePodsRunning(cmd *cobra.Command, args []string, toComplete strin
 	return getPods(cmd, toComplete, completeDefault, "running", "degraded")
 }
 
+// AutoCompletePodsPause - Autocomplete only paused pod names
+// When a pod has a few containers paused, that ends up in degraded state
+// So autocomplete degraded pod names as well
+func AutoCompletePodsPause(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if !validCurrentCmdLine(cmd, args, toComplete) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return getPods(cmd, toComplete, completeDefault, "paused", "degraded")
+}
+
 // AutocompleteForKube - Autocomplete all Podman objects supported by kube generate.
 func AutocompleteForKube(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if !validCurrentCmdLine(cmd, args, toComplete) {

--- a/cmd/podman/pods/unpause.go
+++ b/cmd/podman/pods/unpause.go
@@ -24,9 +24,7 @@ var (
 		Args: func(cmd *cobra.Command, args []string) error {
 			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
-		// TODO have a function which shows only pods which could be unpaused
-		// for now show all
-		ValidArgsFunction: common.AutocompletePods,
+		ValidArgsFunction: common.AutoCompletePodsPause,
 		Example: `podman pod unpause podID1 podID2
   podman pod unpause --all
   podman pod unpause --latest`,
@@ -43,7 +41,7 @@ func init() {
 		Parent:  podCmd,
 	})
 	flags := unpauseCommand.Flags()
-	flags.BoolVarP(&unpauseOptions.All, "all", "a", false, "Pause all running pods")
+	flags.BoolVarP(&unpauseOptions.All, "all", "a", false, "Unpause all running pods")
 	validate.AddLatestFlag(unpauseCommand, &unpauseOptions.Latest)
 }
 

--- a/pkg/domain/infra/abi/pods.go
+++ b/pkg/domain/infra/abi/pods.go
@@ -158,6 +158,14 @@ func (ic *ContainerEngine) PodUnpause(ctx context.Context, namesOrIds []string, 
 		return nil, err
 	}
 	for _, p := range pods {
+		status, err := p.GetPodStatus()
+		if err != nil {
+			return nil, err
+		}
+		// If the pod is not paused or degraded, there is no need to attempt an unpause on it
+		if status != define.PodStatePaused && status != define.PodStateDegraded {
+			continue
+		}
 		report := entities.PodUnpauseReport{Id: p.ID()}
 		errs, err := p.Unpause(ctx)
 		if err != nil && errors.Cause(err) != define.ErrPodPartialFail {

--- a/pkg/domain/infra/tunnel/pods.go
+++ b/pkg/domain/infra/tunnel/pods.go
@@ -80,6 +80,10 @@ func (ic *ContainerEngine) PodUnpause(ctx context.Context, namesOrIds []string, 
 	}
 	reports := make([]*entities.PodUnpauseReport, 0, len(foundPods))
 	for _, p := range foundPods {
+		// If the pod is not paused or degraded, there is no need to attempt an unpause on it
+		if p.Status != define.PodStatePaused && p.Status != define.PodStateDegraded {
+			continue
+		}
 		response, err := pods.Unpause(ic.ClientCtx, p.Id, nil)
 		if err != nil {
 			report := entities.PodUnpauseReport{


### PR DESCRIPTION
Update the podman pod unpause to only show the paused
containers with autocomplete.
Fix a typo in the help command.
Update the unpause function to only attempt an unpause
on pasued pods instead of all the pods.
Update the tests accordingly.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman pod unpause only shows paused pods when using autocomplete

```
