### PR TITLE
Fix TODO in pod/ps.go and parse/net.go

### DIFF
--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -49,7 +49,6 @@ func init() {
 	flags.BoolVar(&psInput.CtrNames, "ctr-names", false, "Display the container names")
 	flags.BoolVar(&psInput.CtrIds, "ctr-ids", false, "Display the container UUIDs. If no-trunc is not set they will be truncated")
 	flags.BoolVar(&psInput.CtrStatus, "ctr-status", false, "Display the container status")
-	// TODO should we make this a [] ?
 
 	filterFlagName := "filter"
 	flags.StringSliceVarP(&inputFilters, filterFlagName, "f", []string{}, "Filter output based on conditions given")


### PR DESCRIPTION
The TODO in cmd/podman/pod/ps.go has already been fixed. Filters is now a []string

Fix up the parseEnv function in cmd/podman/parse/net.go to differentiate
between a label and env when parsing.
Don't do a system lookup when parsing labels.

[NO NEW TESTS NEEDED]

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
