### PR TITLE
Combine the CheckAllLatest CID and PodID functions

### DIFF
--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -31,7 +31,7 @@ var (
 		Long:  checkpointDescription,
 		RunE:  checkpoint,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainersRunning,
 		Example: `podman container checkpoint --keep ctrID

--- a/cmd/podman/containers/cleanup.go
+++ b/cmd/podman/containers/cleanup.go
@@ -27,7 +27,7 @@ var (
 		Long:        cleanupDescription,
 		RunE:        cleanup,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainersExited,
 		Example: `podman container cleanup --latest

--- a/cmd/podman/containers/init.go
+++ b/cmd/podman/containers/init.go
@@ -21,7 +21,7 @@ var (
 		Long:  initDescription,
 		RunE:  initContainer,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainersCreated,
 		Example: `podman init --latest

--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -25,7 +25,7 @@ var (
 		Long:  killDescription,
 		RunE:  kill,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, true)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "cidfile")
 		},
 		ValidArgsFunction: common.AutocompleteContainersRunning,
 		Example: `podman kill mywebserver
@@ -35,7 +35,7 @@ var (
 
 	containerKillCommand = &cobra.Command{
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, true)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "cidfile")
 		},
 		Use:               killCommand.Use,
 		Short:             killCommand.Short,

--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -33,7 +33,7 @@ var (
 		Long:  mountDescription,
 		RunE:  mount,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, true, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, true, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainers,
 	}

--- a/cmd/podman/containers/port.go
+++ b/cmd/podman/containers/port.go
@@ -23,7 +23,7 @@ var (
 		Long:  portDescription,
 		RunE:  port,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, true, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, true, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainerOneArg,
 		Example: `podman port --all
@@ -37,7 +37,7 @@ var (
 		Long:  portDescription,
 		RunE:  portCommand.RunE,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, true, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, true, "")
 		},
 		ValidArgsFunction: portCommand.ValidArgsFunction,
 		Example: `podman container port --all

--- a/cmd/podman/containers/restart.go
+++ b/cmd/podman/containers/restart.go
@@ -26,7 +26,7 @@ var (
 		Long:  restartDescription,
 		RunE:  restart,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainers,
 		Example: `podman restart ctrID

--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -28,7 +28,7 @@ var (
 		Long:  restoreDescription,
 		RunE:  restore,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, true, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, true, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainersAndImages,
 		Example: `podman container restore ctrID

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -28,7 +28,7 @@ var (
 		Long:  rmDescription,
 		RunE:  rm,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, true)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "cidfile")
 		},
 		ValidArgsFunction: common.AutocompleteContainers,
 		Example: `podman rm imageID

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -26,7 +26,7 @@ var (
 		Long:  stopDescription,
 		RunE:  stop,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, true)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "cidfile")
 		},
 		ValidArgsFunction: common.AutocompleteContainersRunning,
 		Example: `podman stop ctrID
@@ -40,7 +40,7 @@ var (
 		Long:  stopCommand.Long,
 		RunE:  stopCommand.RunE,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, true)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "cidfile")
 		},
 		ValidArgsFunction: stopCommand.ValidArgsFunction,
 		Example: `podman container stop ctrID

--- a/cmd/podman/containers/unmount.go
+++ b/cmd/podman/containers/unmount.go
@@ -27,7 +27,7 @@ var (
 		Long:        description,
 		RunE:        unmount,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainers,
 		Example: `podman unmount ctrID
@@ -43,7 +43,7 @@ var (
 		Long:        unmountCommand.Long,
 		RunE:        unmountCommand.RunE,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainers,
 		Example: `podman container unmount ctrID

--- a/cmd/podman/networks/reload.go
+++ b/cmd/podman/networks/reload.go
@@ -21,7 +21,7 @@ var (
 		Long:        networkReloadDescription,
 		RunE:        networkReload,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompleteContainers,
 		Example: `podman network reload --latest

--- a/cmd/podman/pods/kill.go
+++ b/cmd/podman/pods/kill.go
@@ -22,7 +22,7 @@ var (
 		Long:  podKillDescription,
 		RunE:  kill,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompletePodsRunning,
 		Example: `podman pod kill podID

--- a/cmd/podman/pods/pause.go
+++ b/cmd/podman/pods/pause.go
@@ -22,7 +22,7 @@ var (
 		Long:  podPauseDescription,
 		RunE:  pause,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompletePodsRunning,
 		Example: `podman pod pause podID1 podID2

--- a/cmd/podman/pods/restart.go
+++ b/cmd/podman/pods/restart.go
@@ -22,7 +22,7 @@ var (
 		Long:  podRestartDescription,
 		RunE:  restart,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		ValidArgsFunction: common.AutocompletePods,
 		Example: `podman pod restart podID1 podID2

--- a/cmd/podman/pods/rm.go
+++ b/cmd/podman/pods/rm.go
@@ -35,7 +35,7 @@ var (
 		Long:  podRmDescription,
 		RunE:  rm,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndPodIDFile(cmd, args, false, true)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "pod-id-file")
 		},
 		ValidArgsFunction: common.AutocompletePods,
 		Example: `podman pod rm mywebserverpod

--- a/cmd/podman/pods/start.go
+++ b/cmd/podman/pods/start.go
@@ -31,7 +31,7 @@ var (
 		Long:  podStartDescription,
 		RunE:  start,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndPodIDFile(cmd, args, false, true)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "pod-id-file")
 		},
 		ValidArgsFunction: common.AutocompletePods,
 		Example: `podman pod start podID

--- a/cmd/podman/pods/stop.go
+++ b/cmd/podman/pods/stop.go
@@ -36,7 +36,7 @@ var (
 		Long:  podStopDescription,
 		RunE:  stop,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndPodIDFile(cmd, args, false, true)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "pod-id-file")
 		},
 		ValidArgsFunction: common.AutocompletePodsRunning,
 		Example: `podman pod stop mywebserverpod

--- a/cmd/podman/pods/unpause.go
+++ b/cmd/podman/pods/unpause.go
@@ -22,7 +22,7 @@ var (
 		Long:  podUnpauseDescription,
 		RunE:  unpause,
 		Args: func(cmd *cobra.Command, args []string) error {
-			return validate.CheckAllLatestAndCIDFile(cmd, args, false, false)
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "")
 		},
 		// TODO have a function which shows only pods which could be unpaused
 		// for now show all


### PR DESCRIPTION
These two functions were doing the exact same thing just
with cidfile and pod-id-file separately. Combine the functionality
to one function to remove repetative code.
Fix the TODO in cmd/podman/validate/args.go

[NO NEW TESTS NEEDED]

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
