### PR TITLE
Fix swagger model of `InspectPodResponse`

### DIFF
--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -82,6 +82,7 @@ type InspectPodInfraConfig struct {
 	HostNetwork bool
 	// StaticIP is a static IPv4 that will be assigned to the infra
 	// container and then used by the pod.
+	// swagger:strfmt ipv4
 	StaticIP net.IP
 	// StaticMAC is a static MAC address that will be assigned to the infra
 	// container and then used by the pod.


### PR DESCRIPTION
This PR partially addresses #14160 by fixing one instance of `net.IP` being represented as `[]uint8` in the swagger API spec. This fix does not work for the following models, because they contain arrays of `net.IP`.

- `ContainerNetworkConfig#dns_server`
- `NetOptions#dns_server`
- `NetworkConnectOptions#static_ips`
- `PerNetworkOptions#static_ips`
- `PodNetworkConfig#dns_server`
- `PodSpecGenerator#dns_server`
- `SpecGenerator#dns_server`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
