### PR TITLE
[CI:DOCS] Cirrus: Fix several TODOs

### DIFF
--- a/contrib/cirrus/ext_svc_check.sh
+++ b/contrib/cirrus/ext_svc_check.sh
@@ -25,6 +25,23 @@ cat ${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/required_host_ports.txt | \
         fi
     done
 
-# TODO: Pull images required during testing into /dev/null
+# Verify we can pull metadata from a few key testing images on quay.io
+# in the 'libpod' namespace.  This is mostly aimed at validating the
+# quay.io service is up and responsive.  Images were hand-picked with
+# egrep -ro 'quay.io/libpod/.+:latest' test | sort -u
+TEST_IMGS=(\
+    alpine:latest
+    busybox:latest
+    alpine_labels:latest
+    alpine_nginx:latest
+    alpine_healthcheck:latest
+    badhealthcheck:latest
+    cirros:latest
+)
 
-# TODO: Refresh DNF package-cache into /dev/null
+echo "Checking quay.io test image accessibility"
+for testimg in "${TEST_IMGS[@]}"; do
+    fqin="quay.io/libpod/$testimg"
+    echo "    $fqin"
+    skopeo inspect --retry-times 5 "docker://$fqin" | jq . > /dev/null
+done

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -225,11 +225,6 @@ use_netavark() {
     export NETWORK_BACKEND=netavark  # needed for install_test_configs()
     msg "Removing any/all CNI configuration"
     rm -rvf /etc/cni/net.d/*
-
-    # TODO: Remove this when netavark/aardvark-dns development slows down
-    warn "Updating netavark/aardvark-dns to avoid frequent VM image rebuilds"
-    # N/B: This is coming from updates-testing repo in F36
-    lilto dnf update -y netavark aardvark-dns
 }
 
 # Remove all files provided by the distro version of podman.

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -303,10 +303,6 @@ function _run_altbuild() {
 }
 
 function _run_release() {
-    # TODO: These tests should come from code external to the podman repo.
-    # to allow test-changes (and re-runs) in the case of a correctable test
-    # flaw or flake at release tag-push time.  For now, the test is here
-    # given its simplicity.
     msg "podman info:"
     bin/podman info
 


### PR DESCRIPTION
Most were simply deleted, the main one addressed is in the
"pre-testing" `ext_svc_check.sh` script.  It will now verify
accessibility of several key test images we maintain in `quay.io`.

#### Does this PR introduce a user-facing change?

```release-note
None
```