### PR TITLE
[WIP] [CI:BUILD] Cirrus: More info. on artifact DL failures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,7 +56,7 @@ env:
     # Curl-command prefix for downloading task artifacts, simply add the
     # the url-encoded task name, artifact name, and path as a suffix.
     ARTCURL: >-
-        curl --fail --location -O
+        curl --fail-with-body --location -O
         --url https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}
 
 # Default timeout for each task
@@ -206,7 +206,8 @@ validate_task:
     clone_script: &get_gosrc |
         cd /tmp
         echo "$ARTCURL/Build%20for%20${DISTRO_NV}/repo/repo.tbz"
-        time $ARTCURL/Build%20for%20${DISTRO_NV}/repo/repo.tbz
+        if ! time $ARTCURL/Build%20for%20${DISTRO_NV}/repo/repo.tbz; then
+            jq . repo.tbz; exit 1; fi
         time tar xjf /tmp/repo.tbz -C $GOSRC
     setup_script: *setup
     main_script: *main


### PR DESCRIPTION
There's currently a problem affecting curl downloads using the Cirrus-CI
artifacts API endpoint, but only on jobs running for branches.  They have
made some backend changes to provide more details about these failures.
Switch the `curl --fail` argument to the option which provides the full
message returned by the server.  Upon failure, the API returns a JSON
formatted message.  Use jq to parse and print this, on the off-chance
`repo.tbz` - like a network error half-way through downloading.  In this
case, jq will puke on the file, and give a short error message.

Signed-off-by: Chris Evich <cevich@redhat.com>

#### Does this PR introduce a user-facing change?

```release-note
None
```
