### PR TITLE
[CI:DOCS] man pages: document some --format options

### DIFF
--- a/docs/source/markdown/podman-container-inspect.1.md
+++ b/docs/source/markdown/podman-container-inspect.1.md
@@ -18,6 +18,48 @@ all results in a JSON array. If a format is specified, the given template will b
 Format the output using the given Go template.
 The keys of the returned JSON can be used as the values for the --format flag (see examples below).
 
+Valid placeholders for the Go template are listed below:
+
+| **Placeholder**      | **Description**                                    |
+| -----------------    | ------------------                                 |
+| .AppArmorProfile     | AppArmor profile (string)                          |
+| .Args                | Command-line arguments (array of strings)          |
+| .BoundingCaps        | Bounding capability set (array of strings)         |
+| .Config ...          | Structure with config info                         |
+| .ConmonPidFile       | Path to file containing conmon pid (string)        |
+| .Created             | Container creation time (string, ISO3601)          |
+| .Dependencies        | Dependencies (array of strings)                    |
+| .Driver              | Storage driver (string)                            |
+| .EffectiveCaps       | Effective capability set (array of strings)        |
+| .ExecIDs             | Exec IDs (array of strings)                        |
+| .GraphDriver ...     | Further details of graph driver (struct)           |
+| .HostConfig ...      | Host config details (struct)                       |
+| .HostnamePath        | Path to file containing hostname (string)          |
+| .HostsPath           | Path to container /etc/hosts file (string)         |
+| .ID                  | Container ID (full 64-char hash)                   |
+| .Image               | Container image ID (64-char hash)                  |
+| .ImageName           | Container image name (string)                      |
+| .IsInfra             | Is this an infra container? (string: true/false)   |
+| .IsService           | Is this a service container? (string: true/false)  |
+| .MountLabel          | SELinux label of mount (string)                    |
+| .Mounts              | Mounts (array of strings)                          |
+| .Name                | Container name (string)                            |
+| .Namespace           | Container namespace (string)                       |
+| .NetworkSettings ... | Network settings (struct)                          |
+| .OCIConfigPath       | Path to OCI config file (string)                   |
+| .OCIRuntime          | OCI runtime name (string)                          |
+| .Path                | Path to container command (string)                 |
+| .PidFile             | Path to file containing container PID (string)     |
+| .Pod                 | Parent pod (string)                                |
+| .ProcessLabel        | SELinux label of process (string)                  |
+| .ResolvConfPath      | Path to container's resolv.conf file (string)      |
+| .RestartCount        | Number of times container has been restarted (int) |
+| .Rootfs              | Container rootfs (string)                          |
+| .SizeRootFs          | Size of rootfs (int)                               |
+| .SizeRw              | FIXME                                              |
+| .State ...           | Container state info (struct)                      |
+| .StaticDir           | Path to container metadata dir (string)            |
+
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman

--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -23,6 +23,16 @@ Show additional information
 
 Change output format to "json" or a Go template.
 
+| **Placeholder**     | **Info pertaining to ...**              |
+| ------------------- | --------------------------------------- |
+| .Host ...           | ...the host on which podman is running  |
+| .Store ...          | ...the storage driver and paths         |
+| .Registries ...     | ...configured registries                |
+| .Plugins ...        | ...external plugins                     |
+| .Version ...        | ...podman version                       |
+
+Each of the above branch out into further subfields, more than can
+reasonably be enumerated in this document.
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-pod-inspect.1.md
+++ b/docs/source/markdown/podman-pod-inspect.1.md
@@ -18,22 +18,34 @@ Change the default output format.  This can be of a supported type like 'json'
 or a Go template.
 Valid placeholders for the Go template are listed below:
 
-| **Placeholder**   | **Description**                                                               |
-| ----------------- | ----------------------------------------------------------------------------- |
-| .ID               | Pod   ID                                                                      |
-| .Name             | Pod   name                                                                    |
-| .State            | Pod   state                                                                   |
-| .Hostname         | Pod   hostname                                                                |
-| .Labels           | Pod   labels                                                                  |
-| .Created          | Time when the pod was created                                                 |
-| .CreateCgroup     | Whether cgroup was created                                                    |
-| .CgroupParent     | Pod   cgroup parent                                                           |
-| .CgroupPath       | Pod   cgroup path                                                             |
-| .CreateInfra      | Whether infrastructure created                                                |
-| .InfraContainerID | Pod   infrastructure ID                                                       |
-| .SharedNamespaces | Pod   shared namespaces                                                       |
-| .NumContainers    | Number of containers in the pod                                               |
-| .Containers       | Pod   containers                                                              |
+| **Placeholder**     | **Description**                            |
+| -----------------   | ------------------------------------------ |
+| .ID                 | Pod ID                                     |
+| .Name               | Pod name                                   |
+| .State              | Pod state                                  |
+| .Hostname           | Pod hostname                               |
+| .Labels             | Pod labels                                 |
+| .BlkioDeviceReadBps | Block I/O Device Read, in bytes/sec        |
+| .CPUPeriod          | CPU period                                 |
+| .CPUQuota           | CPU quota                                  |
+| .CPUSetCPUs         | CPU Set CPUs                               |
+| .Created            | Time when the pod was created              |
+| .CreateCgroup       | Whether cgroup was created                 |
+| .CgroupParent       | Pod cgroup parent                          |
+| .CgroupPath         | Pod cgroup path                            |
+| .Containers         | Pod containers                             |
+| .CreateCommand      | Create command                             |
+| .CreateInfra        | Whether infrastructure created             |
+| .InfraContainerID   | Pod infrastructure ID                      |
+| .Devices            | Devices                                    |
+| .ExitPolicy         | Exit policy                                |
+| .InfraConfig ...    | Infra config (contains further fields)     |
+| .Mounts             | Mounts                                     |
+| .Namespace          | Namespace                                  |
+| .NumContainers      | Number of containers in the pod            |
+| .SecurityOpts       | Security options                           |
+| .SharedNamespaces   | Pod shared namespaces                      |
+| .VolumesFrom        | Volumes from                               |
 
 #### **--latest**, **-l**
 

--- a/docs/source/markdown/podman-secret-inspect.1.md
+++ b/docs/source/markdown/podman-secret-inspect.1.md
@@ -19,6 +19,17 @@ Secrets can be queried individually by providing their full name or a unique par
 
 Format secret output using Go template.
 
+| **Placeholder**          | **Description**                                                   |
+| ------------------------ | ----------------------------------------------------------------- |
+| .ID                      | ID of secret                                                      |
+| .Spec                    | Details of secret                                                 |
+| .Spec.Name               | Name of secret                                                    |
+| .Spec.Driver             | Driver info                                                       |
+| .Spec.Driver.Name        | Driver name (string)                                              |
+| .Spec.Driver.Options ... | Driver options (map of driver-specific options)                   |
+| .CreatedAt               | When secret was created (relative timestamp, human-readable)      |
+| .UpdatedAt               | When secret was last updated (relative timestamp, human-readable) |
+
 #### **--help**
 
 Print usage statement.

--- a/docs/source/markdown/podman-stats.1.md
+++ b/docs/source/markdown/podman-stats.1.md
@@ -30,17 +30,33 @@ Pretty-print container statistics to JSON or using a Go template
 
 Valid placeholders for the Go template are listed below:
 
-| **Placeholder** | **Description**    |
-| --------------- | ------------------ |
-| .ID             | Container ID       |
-| .Name           | Container Name     |
-| .CPUPerc        | CPU percentage     |
-| .MemUsage       | Memory usage       |
-| .MemUsageBytes  | Memory usage (IEC) |
-| .MemPerc        | Memory percentage  |
-| .NetIO          | Network IO         |
-| .BlockIO        | Block IO           |
-| .PIDS           | Number of PIDs     |
+| **Placeholder**     | **Description**                                          |
+| ---------------     | ------------------                                       |
+| .ID                 | Container ID (truncated)                                 |
+| .ContainerID        | Container ID (full hash)                                 |
+| .Name               | Container Name                                           |
+| .CPUPerc            | CPU percentage                                           |
+| .MemUsage           | Memory usage                                             |
+| .MemUsageBytes      | Memory usage (IEC)                                       |
+| .AvgCPU             | Average CPU (full precision float)                       |
+| .AVGCPU             | Average CPU (formatted)                                  |
+| .CPU                | Percent CPU (full precision float)                       |
+| .CPUNano            | CPU Usage, total, in nanoseconds                         |
+| .CPUSystemNano      | CPU Usage, kernel, in nanoseconds                        |
+| .Duration           | Same as CPUNano (FIXME: why?)                            |
+| .MemLimit           | Memory limit, in bytes                                   |
+| .MemPerc            | Memory percentage                                        |
+| .NetIO              | Network IO                                               |
+| .BlockIO            | Block IO                                                 |
+| .PIDS               | Number of PIDs                                           |
+| .NetInput           | Network Input                                            |
+| .NetOutput          | Network Output                                           |
+| .BlockInput         | Block Input                                              |
+| .BlockOutput        | Block Output                                             |
+| .PIDs               | Number of PIDs                                           |
+| .SystemNano         | Current system datetime, nanoseconds since epoch         |
+| .UpTime             | WTF? This is Duration (CPUNano) in human-readable form?? |
+| .Up                 | Same as UpTime (FIXME: why?)                             |
 
 When using a GO template, you may precede the format with `table` to print headers.
 

--- a/docs/source/markdown/podman-version.1.md
+++ b/docs/source/markdown/podman-version.1.md
@@ -16,6 +16,14 @@ OS, and Architecture.
 
 Change output format to "json" or a Go template.
 
+| **Placeholder**     | **Description**          |
+| ------------------- | ------------------------ |
+| .Client ...         | Version of local podman  |
+| .Server ...         | Version of remote podman |
+
+Each of the above fields branch deeper into further subfields
+such as .Version, .APIVersion, .GoVersion, and more.
+
 ## Example
 
 A sample output of the `version` command:


### PR DESCRIPTION
Baby steps toward merging #14046: document a few of the Go format
command-line options.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
Document the options available via `--format` in certain podman subcommands
```