### PR TITLE
Add support for special IP designator `host-gateway` in `--add-hosts`.

### DIFF
--- a/cmd/podman/parse/net.go
+++ b/cmd/podman/parse/net.go
@@ -54,6 +54,9 @@ func ValidateExtraHost(val string) (string, error) { // nolint
 	if len(arr) != 2 || len(arr[0]) == 0 {
 		return "", fmt.Errorf("bad format for add-host: %q", val)
 	}
+	if (arr[1] == "host-gateway") {
+		return val, nil
+	}
 	if _, err := validateIPAddress(arr[1]); err != nil {
 		return "", fmt.Errorf("invalid IP address in add-host: %q", arr[1])
 	}

--- a/cmd/podman/parse/net_test.go
+++ b/cmd/podman/parse/net_test.go
@@ -54,6 +54,7 @@ func TestValidateExtraHost(t *testing.T) {
 		{name: "bad-ipv6", args: args{val: "foobar:0db8:85a3:0000:0000:8a2e:0370:7334.0000.0000.000"}, want: "", wantErr: true},
 		{name: "noname-ipv6", args: args{val: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"}, want: "", wantErr: true},
 		{name: "noname-ipv6", args: args{val: ":2001:0db8:85a3:0000:0000:8a2e:0370:7334"}, want: "", wantErr: true},
+		{name: "host-gateway", args: args{val: "foobar:host-gateway"}, want: "foobar:host-gateway", wantErr: false}
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/podman/parse/net_test.go
+++ b/cmd/podman/parse/net_test.go
@@ -54,7 +54,7 @@ func TestValidateExtraHost(t *testing.T) {
 		{name: "bad-ipv6", args: args{val: "foobar:0db8:85a3:0000:0000:8a2e:0370:7334.0000.0000.000"}, want: "", wantErr: true},
 		{name: "noname-ipv6", args: args{val: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"}, want: "", wantErr: true},
 		{name: "noname-ipv6", args: args{val: ":2001:0db8:85a3:0000:0000:8a2e:0370:7334"}, want: "", wantErr: true},
-		{name: "host-gateway", args: args{val: "foobar:host-gateway"}, want: "foobar:host-gateway", wantErr: false}
+		{name: "host-gateway", args: args{val: "foobar:host-gateway"}, want: "foobar:host-gateway", wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Implements the behavior described in https://github.com/containers/podman/issues/14390 (feature request).

`host-gateway` is a special designator used in the IP address position of `--add-host` entries. It maps to the container's `host.containers.internal` IP address. moby-engine/docker CLI implement this same option.

This implementation:

- Allows the string "\<hostname\>:host-gateway" as a valid host entry (it is carried through all options that derive from the `NetOptions.AddHosts` field).
- Replaces host entries that are mapped to "host-gateway" with the container's `host.containers.internal` IP address during `etchosts` construction in the linux libpod container driver.

Signed-off-by: Will Temple <will@wtemple.net>

Closes #14390 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Example:

```
$ bin/podman run -it --rm --add-host testhostname:host-gateway alpine   
/ # cat /etc/hosts
192.168.1.228   testhostname
127.0.0.1       localhost
::1     localhost
192.168.1.228   host.containers.internal
10.0.2.100      1b6fcb8904fe vibrant_wescoff
/ # ping testhostname
PING testhostname (192.168.1.228): 56 data bytes
64 bytes from 192.168.1.228: seq=0 ttl=42 time=0.135 ms
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Is this what your CI is expecting?

```release-note
Adds support for the special string `host-gateway` as an "IP address" when using the `--add-host` command-line flag. A mapping to "host-gateway" results in the given hostname being mapped to the host IP address (the same IP as for the default `host.containers.internal` address) in the `/etc/hosts` file within the container.
```