### PR TITLE
no-new-privileges format

### DIFF
--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -622,7 +622,14 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		if opt == "no-new-privileges" {
 			s.ContainerSecurityConfig.NoNewPrivileges = true
 		} else {
-			con := strings.SplitN(opt, "=", 2)
+			// Docker deprecated the ":" syntax but still supports it,
+			// so we need to as well
+			var con []string
+			if strings.Contains(opt, "=") {
+				con = strings.SplitN(opt, "=", 2)
+			} else {
+				con = strings.SplitN(opt, ":", 2)
+			}
 			if len(con) != 2 {
 				return fmt.Errorf("invalid --security-opt 1: %q", opt)
 			}
@@ -650,6 +657,12 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 				}
 			case "unmask":
 				s.ContainerSecurityConfig.Unmask = append(s.ContainerSecurityConfig.Unmask, con[1:]...)
+			case "no-new-privileges":
+				noNewPrivileges, err := strconv.ParseBool(con[1])
+				if err != nil {
+					return fmt.Errorf("invalid --security-opt 2: %q", opt)
+				}
+				s.ContainerSecurityConfig.NoNewPrivileges = noNewPrivileges
 			default:
 				return fmt.Errorf("invalid --security-opt 2: %q", opt)
 			}

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -855,4 +855,15 @@ EOF
     run_podman rmi $test_image
 }
 
+@test "podman create --security-opt" {
+    run_podman create --security-opt no-new-privileges=true $IMAGE
+    run_podman rm $output
+    run_podman create --security-opt no-new-privileges:true $IMAGE
+    run_podman rm $output
+    run_podman create --security-opt no-new-privileges=false $IMAGE
+    run_podman rm $output
+    run_podman create --security-opt no-new-privileges $IMAGE
+    run_podman rm $output
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
In docker, the format of no-new-privileges is
"no-new-privileges:true". However, for Podman
all that's required is "no-new-privileges", leading to issues
when attempting to use features desgined for docker in podman.
Adding support for the ":" format to be used along with the "="
format, depedning on which one is entered by the user.

fixes #14133
Signed-off-by: Niall Crowe <nicrowe@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes a bug in the parsing of --security-opt
```
