### PR TITLE
podman volume export/import: give better error

### DIFF
--- a/cmd/podman/volumes/export.go
+++ b/cmd/podman/volumes/export.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
+	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/podman/v4/utils"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -58,9 +59,12 @@ func export(cmd *cobra.Command, args []string) error {
 		return errors.New("expects output path, use --output=[path]")
 	}
 	inspectOpts.Type = common.VolumeType
-	volumeData, _, err := containerEngine.VolumeInspect(ctx, args, inspectOpts)
+	volumeData, errs, err := containerEngine.VolumeInspect(ctx, args, inspectOpts)
 	if err != nil {
 		return err
+	}
+	if len(errs) > 0 {
+		return errorhandling.JoinErrors(errs)
 	}
 	if len(volumeData) < 1 {
 		return errors.New("no volume data found")

--- a/cmd/podman/volumes/import.go
+++ b/cmd/podman/volumes/import.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/parse"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
+	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/podman/v4/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -60,9 +61,13 @@ func importVol(cmd *cobra.Command, args []string) error {
 	}
 
 	inspectOpts.Type = common.VolumeType
-	volumeData, _, err := containerEngine.VolumeInspect(ctx, volumes, inspectOpts)
+	inspectOpts.Type = common.VolumeType
+	volumeData, errs, err := containerEngine.VolumeInspect(ctx, volumes, inspectOpts)
 	if err != nil {
 		return err
+	}
+	if len(errs) > 0 {
+		return errorhandling.JoinErrors(errs)
 	}
 	if len(volumeData) < 1 {
 		return errors.New("no volume data found")

--- a/docs/source/markdown/podman-volume-import.1.md
+++ b/docs/source/markdown/podman-volume-import.1.md
@@ -1,7 +1,7 @@
 % podman-volume-import(1)
 
 ## NAME
-podman\-volume\-import - Import tarball contents into a podman volume
+podman\-volume\-import - Import tarball contents into an existing podman volume
 
 ## SYNOPSIS
 **podman volume import** *volume* [*source*]
@@ -11,9 +11,9 @@ podman\-volume\-import - Import tarball contents into a podman volume
 **podman volume import** imports the contents of a tarball into the podman volume's mount point.
 **podman volume import** can consume piped input when using `-` as source path.
 
-Note: Following command is not supported by podman-remote.
+The given volume must already exist and will not be created by podman volume import.
 
-**podman volume import VOLUME [SOURCE]**
+Note: Following command is not supported by podman-remote.
 
 #### **--help**
 

--- a/docs/source/markdown/podman-volume.1.md
+++ b/docs/source/markdown/podman-volume.1.md
@@ -16,7 +16,7 @@ podman volume is a set of subcommands that manage volumes.
 | create  | [podman-volume-create(1)](podman-volume-create.1.md)   | Create a new volume.                                                           |
 | exists  | [podman-volume-exists(1)](podman-volume-exists.1.md)   | Check if the given volume exists.                                              |
 | export  | [podman-volume-export(1)](podman-volume-export.1.md)   | Exports volume to external tar.                                                |
-| import  | [podman-volume-import(1)](podman-volume-import.1.md)   | Import tarball contents into a podman volume.                                  |
+| import  | [podman-volume-import(1)](podman-volume-import.1.md)   | Import tarball contents into an existing podman volume.                        |
 | inspect | [podman-volume-inspect(1)](podman-volume-inspect.1.md) | Get detailed information on one or more volumes.                               |
 | ls      | [podman-volume-ls(1)](podman-volume-ls.1.md)           | List all the available volumes.                                                |
 | mount   | [podman-volume-mount(1)](podman-volume-mount.1.md)     | Mount a volume filesystem.                                                     |

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -110,15 +110,24 @@ var _ = Describe("Podman volume create", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("hello"))
 	})
 
-	It("podman import volume should fail", func() {
+	It("podman import/export volume should fail", func() {
 		// try import on volume or source which does not exists
-		if podmanTest.RemoteTest {
-			Skip("Volume export check does not work with a remote client")
-		}
+		SkipIfRemote("Volume export check does not work with a remote client")
 
 		session := podmanTest.Podman([]string{"volume", "import", "notfound", "notfound.tar"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
+		Expect(session.ErrorToString()).To(ContainSubstring("open notfound.tar: no such file or directory"))
+
+		session = podmanTest.Podman([]string{"volume", "import", "notfound", "-"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitWithError())
+		Expect(session.ErrorToString()).To(ContainSubstring("no such volume notfound"))
+
+		session = podmanTest.Podman([]string{"volume", "export", "notfound"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitWithError())
+		Expect(session.ErrorToString()).To(ContainSubstring("no such volume notfound"))
 	})
 
 	It("podman create volume with bad volume option", func() {


### PR DESCRIPTION
When the volume does not exist we should output an error stating so and
not some generic one.

Fixes #14411

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
