### PR TITLE
podman stats: work with network connect/disconnect

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -930,6 +930,8 @@ func (r *Runtime) reloadContainerNetwork(ctr *Container) (map[string]types.Statu
 	return r.configureNetNS(ctr, ctr.state.NetNS)
 }
 
+// TODO (5.0): return the statistics per network interface
+// This would allow better compat with docker.
 func getContainerNetIO(ctr *Container) (*netlink.LinkStatistics, error) {
 	var netStats *netlink.LinkStatistics
 
@@ -943,21 +945,39 @@ func getContainerNetIO(ctr *Container) (*netlink.LinkStatistics, error) {
 		return nil, nil
 	}
 
-	// FIXME get the interface from the container netstatus
-	dev := "eth0"
 	netMode := ctr.config.NetMode
+	netStatus := ctr.getNetworkStatus()
 	if otherCtr != nil {
 		netMode = otherCtr.config.NetMode
+		netStatus = otherCtr.getNetworkStatus()
 	}
 	if netMode.IsSlirp4netns() {
-		dev = "tap0"
+		// create a fake status with correct interface name for the logic below
+		netStatus = map[string]types.StatusBlock{
+			"slirp4netns": {
+				Interfaces: map[string]types.NetInterface{"tap0": {}},
+			},
+		}
 	}
 	err := ns.WithNetNSPath(netNSPath, func(_ ns.NetNS) error {
-		link, err := netlink.LinkByName(dev)
-		if err != nil {
-			return err
+		for _, status := range netStatus {
+			for dev := range status.Interfaces {
+				link, err := netlink.LinkByName(dev)
+				if err != nil {
+					return err
+				}
+				if netStats == nil {
+					netStats = link.Attrs().Statistics
+					continue
+				}
+				// Currently only Tx/RxBytes are used.
+				// In the future we should return all stats per interface so that
+				// api users have a better options.
+				stats := link.Attrs().Statistics
+				netStats.TxBytes += stats.TxBytes
+				netStats.RxBytes += stats.RxBytes
+			}
 		}
-		netStats = link.Attrs().Statistics
 		return nil
 	})
 	return netStats, err

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -114,6 +114,11 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		exec3.WaitWithDefaultTimeout()
 		Expect(exec3).Should(Exit(0))
 		Expect(strings.Contains(exec3.OutputToString(), ns)).To(BeFalse())
+
+		// make sure stats still works https://github.com/containers/podman/issues/13824
+		stats := podmanTest.Podman([]string{"stats", "test", "--no-stream"})
+		stats.WaitWithDefaultTimeout()
+		Expect(stats).Should(Exit(0))
 	})
 
 	It("bad network name in connect should result in error", func() {
@@ -236,6 +241,11 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		exec3.WaitWithDefaultTimeout()
 		Expect(exec3).Should(Exit(0))
 		Expect(strings.Contains(exec3.OutputToString(), ns)).To(BeTrue())
+
+		// make sure stats works https://github.com/containers/podman/issues/13824
+		stats := podmanTest.Podman([]string{"stats", "test", "--no-stream"})
+		stats.WaitWithDefaultTimeout()
+		Expect(stats).Should(Exit(0))
 
 		// make sure no logrus errors are shown https://github.com/containers/podman/issues/9602
 		rm := podmanTest.Podman([]string{"rm", "--time=0", "-f", "test"})


### PR DESCRIPTION
Hardcoding the interface name is a bad idea. We have no control over the
actual interface name since the user can change it.

The correct thing is to read them from the network status. Since the
contianer can have more than one interface we have to add the RX/TX
values. The other values are currently not used.

For podman 5.0 we should change it so that the API can return the
statistics per interface and the client should sum the TX/RX for the
command output. This is what docker is doing.

Fixes #13824

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman stats now works correctly with custom network interface names and when network disconnect was used.
```
