### PR TITLE
fix podman container restore without CreateNetNS

### DIFF
--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -243,12 +243,12 @@ type ContainerNetworkConfig struct {
 	// This cannot be set unless CreateNetNS is set.
 	// If not set, the container will be dynamically assigned an IP by CNI.
 	// Deprecated: Do no use this anymore, this is only for DB backwards compat.
-	StaticIP net.IP `json:"staticIP"`
+	StaticIP net.IP `json:"staticIP,omitempty"`
 	// StaticMAC is a static MAC to request for the container.
 	// This cannot be set unless CreateNetNS is set.
 	// If not set, the container will be dynamically assigned a MAC by CNI.
 	// Deprecated: Do no use this anymore, this is only for DB backwards compat.
-	StaticMAC types.HardwareAddr `json:"staticMAC"`
+	StaticMAC types.HardwareAddr `json:"staticMAC,omitempty"`
 	// PortMappings are the ports forwarded to the container's network
 	// namespace
 	// These are not used unless CreateNetNS is true

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -676,8 +676,8 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 	It("podman checkpoint and restore container with root file-system changes using --ignore-rootfs during restore", func() {
 		// Start the container
-		localRunString := getRunString([]string{"--rm", ALPINE, "top"})
-		session := podmanTest.Podman(localRunString)
+		// test that restore works without network namespace (https://github.com/containers/podman/issues/14389)
+		session := podmanTest.Podman([]string{"run", "--network=none", "-d", "--rm", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))


### PR DESCRIPTION
When a container does not use the default podman netns, for example
--network none or --network ns:/path a restore would fail because the
specgen check validates that c.config.StaticMAC is nil but the
unmarshaller sets it to an empty slice.

While we could make the check use len() > 0 I feel like it is more
common to check with != nil for ip and mac addresses.
Adding omitempty tag makes the json marshal/unmarshal work correctly.
This should not cause any issues.

Fixes #14389

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where podman container restore would fail if the container used --network none or ns:/path 
```
