### PR TITLE
Makefile: Handle unexpected empty var. values

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -312,6 +312,11 @@ function _run_release() {
     if [[ -n "$dev" ]]; then
         die "Releases must never contain '-dev' in output of 'podman info' ($dev)"
     fi
+
+    commit=$(bin/podman info --format='{{.Version.GitCommit}}' | tr -d '[:space:]')
+    if [[ -z "$commit" ]]; then
+        die "Releases must contain a non-empty Version.GitCommit in 'podman info'"
+    fi
     msg "All OK"
 }
 


### PR DESCRIPTION
Fixes #14021

Substitution values built from `$(shell ...)` output can easily be empty
due to the shell's default `pipefail` behavior.  This can also hide
non-zero exit codes, similarly resulting in empty values being set.
While not a perfect fix, the situation is improved by using the
`err_if_empty` function in all cases where empty values would be
unexpected.  Also remove the definitions for `GIT_BRANCH` and
`GIT_BRANCH_CLEAN` which don't seem to actually be used anywhere
(including in code).

#### Does this PR introduce a user-facing change?

```release-note
None
```
