### PR TITLE
pkg/specgen: parse default network mode on server

### DIFF
--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -183,10 +183,12 @@ func (s *SpecGenerator) Validate() error {
 	}
 
 	// Set defaults if network info is not provided
-	if s.NetNS.NSMode == "" {
-		s.NetNS.NSMode = Bridge
+	// when we are rootless we default to slirp4netns
+	if s.NetNS.IsPrivate() || s.NetNS.IsDefault() {
 		if rootless.IsRootless() {
 			s.NetNS.NSMode = Slirp
+		} else {
+			s.NetNS.NSMode = Bridge
 		}
 	}
 	if err := validateNetNS(&s.NetNS); err != nil {

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -141,6 +141,9 @@ func MapSpec(p *specgen.PodSpecGenerator) (*specgen.SpecGenerator, error) {
 	case specgen.Bridge:
 		p.InfraContainerSpec.NetNS.NSMode = specgen.Bridge
 		logrus.Debugf("Pod using bridge network mode")
+	case specgen.Private:
+		p.InfraContainerSpec.NetNS.NSMode = specgen.Private
+		logrus.Debugf("Pod will use default network mode")
 	case specgen.Host:
 		logrus.Debugf("Pod will use host networking")
 		if len(p.InfraContainerSpec.PortMappings) > 0 ||
@@ -151,15 +154,15 @@ func MapSpec(p *specgen.PodSpecGenerator) (*specgen.SpecGenerator, error) {
 		p.InfraContainerSpec.NetNS.NSMode = specgen.Host
 	case specgen.Slirp:
 		logrus.Debugf("Pod will use slirp4netns")
-		if p.InfraContainerSpec.NetNS.NSMode != "host" {
+		if p.InfraContainerSpec.NetNS.NSMode != specgen.Host {
 			p.InfraContainerSpec.NetworkOptions = p.NetworkOptions
-			p.InfraContainerSpec.NetNS.NSMode = specgen.NamespaceMode("slirp4netns")
+			p.InfraContainerSpec.NetNS.NSMode = specgen.Slirp
 		}
 	case specgen.NoNetwork:
 		logrus.Debugf("Pod will not use networking")
 		if len(p.InfraContainerSpec.PortMappings) > 0 ||
 			len(p.InfraContainerSpec.Networks) > 0 ||
-			p.InfraContainerSpec.NetNS.NSMode == "host" {
+			p.InfraContainerSpec.NetNS.NSMode == specgen.Host {
 			return nil, errors.Wrapf(define.ErrInvalidArg, "cannot disable pod network if network-related configuration is specified")
 		}
 		p.InfraContainerSpec.NetNS.NSMode = specgen.NoNetwork

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/common/pkg/cgroups"
 	cutil "github.com/containers/common/pkg/util"
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/storage"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -319,62 +318,6 @@ func ParseUserNamespace(ns string) (Namespace, error) {
 	return ParseNamespace(ns)
 }
 
-// ParseNetworkNamespace parses a network namespace specification in string
-// form.
-// Returns a namespace and (optionally) a list of CNI networks to join.
-func ParseNetworkNamespace(ns string, rootlessDefaultCNI bool) (Namespace, map[string]types.PerNetworkOptions, error) {
-	toReturn := Namespace{}
-	networks := make(map[string]types.PerNetworkOptions)
-	// Net defaults to Slirp on rootless
-	switch {
-	case ns == string(Slirp), strings.HasPrefix(ns, string(Slirp)+":"):
-		toReturn.NSMode = Slirp
-	case ns == string(FromPod):
-		toReturn.NSMode = FromPod
-	case ns == "" || ns == string(Default) || ns == string(Private):
-		if rootless.IsRootless() {
-			if rootlessDefaultCNI {
-				toReturn.NSMode = Bridge
-			} else {
-				toReturn.NSMode = Slirp
-			}
-		} else {
-			toReturn.NSMode = Bridge
-		}
-	case ns == string(Bridge):
-		toReturn.NSMode = Bridge
-	case ns == string(NoNetwork):
-		toReturn.NSMode = NoNetwork
-	case ns == string(Host):
-		toReturn.NSMode = Host
-	case strings.HasPrefix(ns, "ns:"):
-		split := strings.SplitN(ns, ":", 2)
-		if len(split) != 2 {
-			return toReturn, nil, errors.Errorf("must provide a path to a namespace when specifying \"ns:\"")
-		}
-		toReturn.NSMode = Path
-		toReturn.Value = split[1]
-	case strings.HasPrefix(ns, string(FromContainer)+":"):
-		split := strings.SplitN(ns, ":", 2)
-		if len(split) != 2 {
-			return toReturn, nil, errors.Errorf("must provide name or ID or a container when specifying \"container:\"")
-		}
-		toReturn.NSMode = FromContainer
-		toReturn.Value = split[1]
-	default:
-		// Assume we have been given a list of CNI networks.
-		// Which only works in bridge mode, so set that.
-		networkList := strings.Split(ns, ",")
-		for _, net := range networkList {
-			networks[net] = types.PerNetworkOptions{}
-		}
-
-		toReturn.NSMode = Bridge
-	}
-
-	return toReturn, networks, nil
-}
-
 // ParseNetworkFlag parses a network string slice into the network options
 // If the input is nil or empty it will use the default setting from containers.conf
 func ParseNetworkFlag(networks []string) (Namespace, map[string]types.PerNetworkOptions, map[string][]string, error) {
@@ -400,13 +343,7 @@ func ParseNetworkFlag(networks []string) (Namespace, map[string]types.PerNetwork
 	case ns == string(FromPod):
 		toReturn.NSMode = FromPod
 	case ns == "" || ns == string(Default) || ns == string(Private):
-		// Net defaults to Slirp on rootless
-		if rootless.IsRootless() {
-			toReturn.NSMode = Slirp
-			break
-		}
-		// if root we use bridge
-		fallthrough
+		toReturn.NSMode = Private
 	case ns == string(Bridge), strings.HasPrefix(ns, string(Bridge)+":"):
 		toReturn.NSMode = Bridge
 		parts := strings.SplitN(ns, ":", 2)

--- a/pkg/specgen/namespaces_test.go
+++ b/pkg/specgen/namespaces_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/containers/common/libnetwork/types"
-	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,14 +16,6 @@ func parsMacNoErr(mac string) types.HardwareAddr {
 func TestParseNetworkFlag(t *testing.T) {
 	// root and rootless have different defaults
 	defaultNetName := "default"
-	defaultNetworks := map[string]types.PerNetworkOptions{
-		defaultNetName: {},
-	}
-	defaultNsMode := Namespace{NSMode: Bridge}
-	if rootless.IsRootless() {
-		defaultNsMode = Namespace{NSMode: Slirp}
-		defaultNetworks = map[string]types.PerNetworkOptions{}
-	}
 
 	tests := []struct {
 		name     string
@@ -37,26 +28,26 @@ func TestParseNetworkFlag(t *testing.T) {
 		{
 			name:     "empty input",
 			args:     nil,
-			nsmode:   defaultNsMode,
-			networks: defaultNetworks,
+			nsmode:   Namespace{NSMode: Private},
+			networks: map[string]types.PerNetworkOptions{},
 		},
 		{
 			name:     "empty string as input",
 			args:     []string{},
-			nsmode:   defaultNsMode,
-			networks: defaultNetworks,
+			nsmode:   Namespace{NSMode: Private},
+			networks: map[string]types.PerNetworkOptions{},
 		},
 		{
 			name:     "default mode",
 			args:     []string{"default"},
-			nsmode:   defaultNsMode,
-			networks: defaultNetworks,
+			nsmode:   Namespace{NSMode: Private},
+			networks: map[string]types.PerNetworkOptions{},
 		},
 		{
 			name:     "private mode",
 			args:     []string{"private"},
-			nsmode:   defaultNsMode,
-			networks: defaultNetworks,
+			nsmode:   Namespace{NSMode: Private},
+			networks: map[string]types.PerNetworkOptions{},
 		},
 		{
 			name:   "bridge mode",


### PR DESCRIPTION
When podman-remote is used we should not resolve the default network
mode on the client. Defaults should be set on the server. In this case
this is important because we have different defaults for root/rootless.
So when the client is rootless and the server is root we must pick the
root default.

Note that this already worked when --network was set since we did not
parsed the flag in this case. To reproduce you need --network=default.

Also removed a unused function.

[NO NEW TESTS NEEDED] I tested it manually but I am not sure how I can
hook a test like this up in CI. The client would need to run as rootless
and the server as root or the other way around.

Fixes #14368

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The default network mode is now assigned by the server and not the client.
```
