### PR TITLE
podman-restart.service: Add ExecStop and dependencies to fix shutdown 

### DIFF
--- a/contrib/systemd/system/podman-restart.service.in
+++ b/contrib/systemd/system/podman-restart.service.in
@@ -2,12 +2,15 @@
 Description=Podman Start All Containers With Restart Policy Set To Always
 Documentation=man:podman-start(1)
 StartLimitIntervalSec=0
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=oneshot
 RemainAfterExit=true
 Environment=LOGGING="--log-level=info"
 ExecStart=@@PODMAN@@ $LOGGING start --all --filter restart-policy=always
+ExecStop=/bin/sh -c '@@PODMAN@@ $LOGGING stop $(@@PODMAN@@ container ls --filter restart-policy=always -q)'
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
[NO NEW TESTS NEEDED]
Fixes https://github.com/containers/podman/issues/14434

Added ExecStop to gracefully stop containers on shutdown. Added Wants= and After= to make sure startup/shutdown order is correct (like podman generate systemd does).

(new pull request with signoff, replaces #14442)

Signed-off-by: Andrin Brunner <andrin@acloud.one>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```