### PR TITLE
expose podman.sock in machine inspect

### DIFF
--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -138,14 +138,15 @@ type DistributionDownload interface {
 	Get() *Download
 }
 type InspectInfo struct {
-	ConfigPath VMFile
-	Created    time.Time
-	Image      ImageConfig
-	LastUp     time.Time
-	Name       string
-	Resources  ResourceConfig
-	SSHConfig  SSHConfig
-	State      Status
+	ConfigPath     VMFile
+	ConnectionInfo ConnectionConfig
+	Created        time.Time
+	Image          ImageConfig
+	LastUp         time.Time
+	Name           string
+	Resources      ResourceConfig
+	SSHConfig      SSHConfig
+	State          Status
 }
 
 func (rc RemoteConnectionType) MakeSSHURL(host, path, port, userName string) url.URL {
@@ -286,11 +287,11 @@ func NewMachineFile(path string, symlink *string) (*VMFile, error) {
 // makeSymlink for macOS creates a symlink in $HOME/.podman/
 // for a machinefile like a socket
 func (m *VMFile) makeSymlink(symlink *string) error {
-	homedir, err := os.UserHomeDir()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return err
 	}
-	sl := filepath.Join(homedir, ".podman", *symlink)
+	sl := filepath.Join(homeDir, ".podman", *symlink)
 	// make the symlink dir and throw away if it already exists
 	if err := os.MkdirAll(filepath.Dir(sl), 0700); err != nil && !errors2.Is(err, os.ErrNotExist) {
 		return err
@@ -334,4 +335,10 @@ type SSHConfig struct {
 	Port int
 	// RemoteUsername of the vm user
 	RemoteUsername string
+}
+
+// ConnectionConfig contains connections like sockets, etc.
+type ConnectionConfig struct {
+	// PodmanSocket is the exported podman service socket
+	PodmanSocket *VMFile `json:"PodmanSocket"`
 }

--- a/pkg/machine/e2e/inspect_test.go
+++ b/pkg/machine/e2e/inspect_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/containers/podman/v4/pkg/machine/qemu"
@@ -86,6 +87,7 @@ var _ = Describe("podman machine stop", func() {
 		var inspectInfo []machine.InspectInfo
 		err = jsoniter.Unmarshal(inspectSession.Bytes(), &inspectInfo)
 		Expect(err).To(BeNil())
+		Expect(strings.HasSuffix(inspectInfo[0].ConnectionInfo.PodmanSocket.GetPath(), "podman.sock"))
 
 		inspect := new(inspectMachine)
 		inspect = inspect.withFormat("{{.Name}}")

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1471,16 +1471,22 @@ func (v *MachineVM) Inspect() (*machine.InspectInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	connInfo := new(machine.ConnectionConfig)
+	podmanSocket, err := v.forwardSocketPath()
+	if err != nil {
+		return nil, err
+	}
+	connInfo.PodmanSocket = podmanSocket
 	return &machine.InspectInfo{
-		ConfigPath: v.ConfigPath,
-		Created:    v.Created,
-		Image:      v.ImageConfig,
-		LastUp:     v.LastUp,
-		Name:       v.Name,
-		Resources:  v.ResourceConfig,
-		SSHConfig:  v.SSHConfig,
-		State:      state,
+		ConfigPath:     v.ConfigPath,
+		ConnectionInfo: *connInfo,
+		Created:        v.Created,
+		Image:          v.ImageConfig,
+		LastUp:         v.LastUp,
+		Name:           v.Name,
+		Resources:      v.ResourceConfig,
+		SSHConfig:      v.SSHConfig,
+		State:          state,
 	}, nil
 }
 


### PR DESCRIPTION
For consumers of the podman.sock who want a predictable way to find the
podman sock, we now include it under 'ConnectionConfig' in podman
machine inspect.

Fixes: #14231

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman machine inspect now shows the exported podman socket for external use.

```
