### PR TITLE
podman volume create --opt=o=timeout...

### DIFF
--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -41,7 +41,7 @@ func AddInspectFlagSet(cmd *cobra.Command) *entities.InspectOptions {
 	return &opts
 }
 
-// Inspect inspects the specified container/image names or IDs.
+// Inspect inspects the specified container/image/pod/volume names or IDs.
 func Inspect(namesOrIDs []string, options entities.InspectOptions) error {
 	inspector, err := newInspector(options)
 	if err != nil {

--- a/docs/source/markdown/podman-volume-create.1.md
+++ b/docs/source/markdown/podman-volume-create.1.md
@@ -39,8 +39,8 @@ The `o` option sets options for the mount, and is equivalent to the `-o` flag to
 
   - The `o` option supports `uid` and `gid` options to set the UID and GID of the created volume that are not normally supported by **mount(8)**.
   - The `o` option supports the `size` option to set the maximum size of the created volume, the `inodes` option to set the maximum number of inodes for the volume and `noquota` to completely disable quota support even for tracking of disk usage. Currently these flags are only supported on "xfs" file system mounted with the `prjquota` flag described in the **xfs_quota(8)** man page.
-  - The `o` option supports .
-  - Using volume options other then the UID/GID options with the **local** driver requires root privileges.
+  - The `o` option supports using volume options other than the UID/GID options with the **local** driver and requires root privileges.
+  - The `o` options supports the `timeout` option which allows users to set a driver specific timeout in seconds before volume creation fails. For example, **--opts=o=timeout=10** sets a driver timeout of 10 seconds.
 
 When not using the **local** driver, the given options are passed directly to the volume plugin. In this case, supported options are dictated by the plugin in question, not Podman.
 

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -508,7 +508,7 @@ func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bu
 
 	// Retrieve volume driver
 	if volume.UsesVolumeDriver() {
-		plugin, err := s.runtime.getVolumePlugin(volume.config.Driver)
+		plugin, err := s.runtime.getVolumePlugin(volume.config)
 		if err != nil {
 			// We want to fail gracefully here, to ensure that we
 			// can still remove volumes even if their plugin is

--- a/libpod/define/volume_inspect.go
+++ b/libpod/define/volume_inspect.go
@@ -56,4 +56,6 @@ type InspectVolumeData struct {
 	// a container, the container will chown the volume to the container process
 	// UID/GID.
 	NeedsChown bool `json:"NeedsChown,omitempty"`
+	// Timeout is the specified driver timeout if given
+	Timeout int `json:"Timeout,omitempty"`
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1693,6 +1693,18 @@ func withSetAnon() VolumeCreateOption {
 	}
 }
 
+// WithVolumeDriverTimeout sets the volume creation timeout period
+func WithVolumeDriverTimeout(timeout int) VolumeCreateOption {
+	return func(volume *Volume) error {
+		if volume.valid {
+			return define.ErrVolumeFinalized
+		}
+
+		volume.config.Timeout = timeout
+		return nil
+	}
+}
+
 // WithTimezone sets the timezone in the container
 func WithTimezone(path string) CtrCreateOption {
 	return func(ctr *Container) error {

--- a/libpod/plugin/volume_api.go
+++ b/libpod/plugin/volume_api.go
@@ -129,7 +129,7 @@ func validatePlugin(newPlugin *VolumePlugin) error {
 
 // GetVolumePlugin gets a single volume plugin, with the given name, at the
 // given path.
-func GetVolumePlugin(name string, path string) (*VolumePlugin, error) {
+func GetVolumePlugin(name string, path string, timeout int) (*VolumePlugin, error) {
 	pluginsLock.Lock()
 	defer pluginsLock.Unlock()
 
@@ -153,6 +153,13 @@ func GetVolumePlugin(name string, path string) (*VolumePlugin, error) {
 	// And since we can reuse it, might as well cache it.
 	client := new(http.Client)
 	client.Timeout = defaultTimeout
+	// if the user specified a non-zero timeout, use their value. Else, keep the default.
+	if timeout != 0 {
+		if time.Duration(timeout)*time.Second < defaultTimeout {
+			logrus.Warnf("the default timeout for volume creation is %d seconds, setting a time less than that may break this feature.", defaultTimeout)
+		}
+		client.Timeout = time.Duration(timeout) * time.Second
+	}
 	// This bit borrowed from pkg/bindings/connection.go
 	client.Transport = &http.Transport{
 		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1194,9 +1194,11 @@ func (r *Runtime) reloadStorageConf() error {
 	return nil
 }
 
-// getVolumePlugin gets a specific volume plugin given its name.
-func (r *Runtime) getVolumePlugin(name string) (*plugin.VolumePlugin, error) {
+// getVolumePlugin gets a specific volume plugin.
+func (r *Runtime) getVolumePlugin(volConfig *VolumeConfig) (*plugin.VolumePlugin, error) {
 	// There is no plugin for local.
+	name := volConfig.Driver
+	timeout := volConfig.Timeout
 	if name == define.VolumeDriverLocal || name == "" {
 		return nil, nil
 	}
@@ -1206,7 +1208,7 @@ func (r *Runtime) getVolumePlugin(name string) (*plugin.VolumePlugin, error) {
 		return nil, errors.Wrapf(define.ErrMissingPlugin, "no volume plugin with name %s available", name)
 	}
 
-	return plugin.GetVolumePlugin(name, pluginPath)
+	return plugin.GetVolumePlugin(name, pluginPath, timeout)
 }
 
 // GetSecretsStorageDir returns the directory that the secrets manager should take

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -56,7 +56,7 @@ func (r *Runtime) newVolume(options ...VolumeCreateOption) (_ *Volume, deferredE
 
 	// Plugin can be nil if driver is local, but that's OK - superfluous
 	// assignment doesn't hurt much.
-	plugin, err := r.getVolumePlugin(volume.config.Driver)
+	plugin, err := r.getVolumePlugin(volume.config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "volume %s uses volume plugin %s but it could not be retrieved", volume.config.Name, volume.config.Driver)
 	}

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -55,6 +55,8 @@ type VolumeConfig struct {
 	// DisableQuota indicates that the volume should completely disable using any
 	// quota tracking.
 	DisableQuota bool `json:"disableQuota,omitempty"`
+	// Timeout allows users to override the default driver timeout of 5 seconds
+	Timeout int
 }
 
 // VolumeState holds the volume's mutable state.

--- a/libpod/volume_inspect.go
+++ b/libpod/volume_inspect.go
@@ -63,6 +63,7 @@ func (v *Volume) Inspect() (*define.InspectVolumeData, error) {
 	data.MountCount = v.state.MountCount
 	data.NeedsCopyUp = v.state.NeedsCopyUp
 	data.NeedsChown = v.state.NeedsChown
+	data.Timeout = v.config.Timeout
 
 	return data, nil
 }

--- a/pkg/domain/infra/abi/parse/parse.go
+++ b/pkg/domain/infra/abi/parse/parse.go
@@ -78,6 +78,16 @@ func VolumeOptions(opts map[string]string) ([]libpod.VolumeCreateOption, error) 
 					libpodOptions = append(libpodOptions, libpod.WithVolumeDisableQuota())
 					// set option "NOQUOTA": "true"
 					volumeOptions["NOQUOTA"] = "true"
+				case "timeout":
+					if len(splitO) != 2 {
+						return nil, errors.Wrapf(define.ErrInvalidArg, "timeout option must provide a valid timeout in seconds")
+					}
+					intTimeout, err := strconv.Atoi(splitO[1])
+					if err != nil {
+						return nil, errors.Wrapf(err, "cannot convert Timeout %s to an integer", splitO[1])
+					}
+					logrus.Debugf("Removing timeout from options and adding WithTimeout for Timeout %d", intTimeout)
+					libpodOptions = append(libpodOptions, libpod.WithVolumeDriverTimeout(intTimeout))
 				default:
 					finalVal = append(finalVal, o)
 				}

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -162,4 +162,19 @@ var _ = Describe("Podman volume create", func() {
 		Expect(inspectOpts).Should(Exit(0))
 		Expect(inspectOpts.OutputToString()).To(Equal(optionStrFormatExpect))
 	})
+
+	It("podman create volume with o=timeout", func() {
+		volName := "testVol"
+		timeout := 10
+		timeoutStr := "10"
+		session := podmanTest.Podman([]string{"volume", "create", "--opt", fmt.Sprintf("o=timeout=%d", timeout), volName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		inspectTimeout := podmanTest.Podman([]string{"volume", "inspect", "--format", "{{ .Timeout }}", volName})
+		inspectTimeout.WaitWithDefaultTimeout()
+		Expect(inspectTimeout).Should(Exit(0))
+		Expect(inspectTimeout.OutputToString()).To(Equal(timeoutStr))
+
+	})
 })


### PR DESCRIPTION
add an option to configure the driver timeout when creating a volume.
The default is 5 seconds but this value is too small for some custom drivers.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2080458

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add the volume creation option --opt=o=timeout=INT allowing users to specify a volume specific creation timeout for custom drivers.
```
