### PR TITLE
remote: enable support for additional `--build-context` on macOS and remote

### DIFF
--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -99,7 +99,7 @@ different stages in COPY instruction.
 
 Valid values could be:
 
-* Local directory – e.g. --build-context project2=../path/to/project2/src (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+* Local directory – e.g. --build-context project2=../path/to/project2/src (This option is not available with the remote Podman client. On Podman machine setup (i.e macOS and Winows) path must exists on the machine VM)
 * HTTP URL to a tarball – e.g. --build-context src=https://example.org/releases/src.tar
 * Container image – specified with a container-image:// prefix, e.g. --build-context alpine=container-image://alpine:3.15, (also accepts docker://, docker-image://)
 

--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -99,7 +99,7 @@ different stages in COPY instruction.
 
 Valid values could be:
 
-* Local directory – e.g. --build-context project2=../path/to/project2/src
+* Local directory – e.g. --build-context project2=../path/to/project2/src (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 * HTTP URL to a tarball – e.g. --build-context src=https://example.org/releases/src.tar
 * Container image – specified with a container-image:// prefix, e.g. --build-context alpine=container-image://alpine:3.15, (also accepts docker://, docker-image://)
 

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -70,68 +70,69 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	query := struct {
-		AddHosts               string   `schema:"extrahosts"`
-		AdditionalCapabilities string   `schema:"addcaps"`
-		AllPlatforms           bool     `schema:"allplatforms"`
-		Annotations            string   `schema:"annotations"`
-		AppArmor               string   `schema:"apparmor"`
-		BuildArgs              string   `schema:"buildargs"`
-		CacheFrom              string   `schema:"cachefrom"`
-		CgroupParent           string   `schema:"cgroupparent"` // nolint
-		Compression            uint64   `schema:"compression"`
-		ConfigureNetwork       string   `schema:"networkmode"`
-		CPPFlags               string   `schema:"cppflags"`
-		CpuPeriod              uint64   `schema:"cpuperiod"`  // nolint
-		CpuQuota               int64    `schema:"cpuquota"`   // nolint
-		CpuSetCpus             string   `schema:"cpusetcpus"` // nolint
-		CpuSetMems             string   `schema:"cpusetmems"` // nolint
-		CpuShares              uint64   `schema:"cpushares"`  // nolint
-		DNSOptions             string   `schema:"dnsoptions"`
-		DNSSearch              string   `schema:"dnssearch"`
-		DNSServers             string   `schema:"dnsservers"`
-		Devices                string   `schema:"devices"`
-		Dockerfile             string   `schema:"dockerfile"`
-		DropCapabilities       string   `schema:"dropcaps"`
-		Envs                   []string `schema:"setenv"`
-		Excludes               string   `schema:"excludes"`
-		ForceRm                bool     `schema:"forcerm"`
-		From                   string   `schema:"from"`
-		HTTPProxy              bool     `schema:"httpproxy"`
-		IdentityLabel          bool     `schema:"identitylabel"`
-		Ignore                 bool     `schema:"ignore"`
-		Isolation              string   `schema:"isolation"`
-		Jobs                   int      `schema:"jobs"` // nolint
-		LabelOpts              string   `schema:"labelopts"`
-		Labels                 string   `schema:"labels"`
-		Layers                 bool     `schema:"layers"`
-		LogRusage              bool     `schema:"rusage"`
-		Manifest               string   `schema:"manifest"`
-		MemSwap                int64    `schema:"memswap"`
-		Memory                 int64    `schema:"memory"`
-		NamespaceOptions       string   `schema:"nsoptions"`
-		NoCache                bool     `schema:"nocache"`
-		OSFeatures             []string `schema:"osfeature"`
-		OSVersion              string   `schema:"osversion"`
-		OutputFormat           string   `schema:"outputformat"`
-		Platform               []string `schema:"platform"`
-		Pull                   bool     `schema:"pull"`
-		PullPolicy             string   `schema:"pullpolicy"`
-		Quiet                  bool     `schema:"q"`
-		Registry               string   `schema:"registry"`
-		Rm                     bool     `schema:"rm"`
-		RusageLogFile          string   `schema:"rusagelogfile"`
-		Remote                 string   `schema:"remote"`
-		Seccomp                string   `schema:"seccomp"`
-		Secrets                string   `schema:"secrets"`
-		SecurityOpt            string   `schema:"securityopt"`
-		ShmSize                int      `schema:"shmsize"`
-		Squash                 bool     `schema:"squash"`
-		TLSVerify              bool     `schema:"tlsVerify"`
-		Tags                   []string `schema:"t"`
-		Target                 string   `schema:"target"`
-		Timestamp              int64    `schema:"timestamp"`
-		Ulimits                string   `schema:"ulimits"`
-		UnsetEnvs              []string `schema:"unsetenv"`
+		AddHosts                string   `schema:"extrahosts"`
+		AdditionalCapabilities  string   `schema:"addcaps"`
+		AdditionalBuildContexts string   `schema:"additionalbuildcontexts"`
+		AllPlatforms            bool     `schema:"allplatforms"`
+		Annotations             string   `schema:"annotations"`
+		AppArmor                string   `schema:"apparmor"`
+		BuildArgs               string   `schema:"buildargs"`
+		CacheFrom               string   `schema:"cachefrom"`
+		CgroupParent            string   `schema:"cgroupparent"` // nolint
+		Compression             uint64   `schema:"compression"`
+		ConfigureNetwork        string   `schema:"networkmode"`
+		CPPFlags                string   `schema:"cppflags"`
+		CpuPeriod               uint64   `schema:"cpuperiod"`  // nolint
+		CpuQuota                int64    `schema:"cpuquota"`   // nolint
+		CpuSetCpus              string   `schema:"cpusetcpus"` // nolint
+		CpuSetMems              string   `schema:"cpusetmems"` // nolint
+		CpuShares               uint64   `schema:"cpushares"`  // nolint
+		DNSOptions              string   `schema:"dnsoptions"`
+		DNSSearch               string   `schema:"dnssearch"`
+		DNSServers              string   `schema:"dnsservers"`
+		Devices                 string   `schema:"devices"`
+		Dockerfile              string   `schema:"dockerfile"`
+		DropCapabilities        string   `schema:"dropcaps"`
+		Envs                    []string `schema:"setenv"`
+		Excludes                string   `schema:"excludes"`
+		ForceRm                 bool     `schema:"forcerm"`
+		From                    string   `schema:"from"`
+		HTTPProxy               bool     `schema:"httpproxy"`
+		IdentityLabel           bool     `schema:"identitylabel"`
+		Ignore                  bool     `schema:"ignore"`
+		Isolation               string   `schema:"isolation"`
+		Jobs                    int      `schema:"jobs"` // nolint
+		LabelOpts               string   `schema:"labelopts"`
+		Labels                  string   `schema:"labels"`
+		Layers                  bool     `schema:"layers"`
+		LogRusage               bool     `schema:"rusage"`
+		Manifest                string   `schema:"manifest"`
+		MemSwap                 int64    `schema:"memswap"`
+		Memory                  int64    `schema:"memory"`
+		NamespaceOptions        string   `schema:"nsoptions"`
+		NoCache                 bool     `schema:"nocache"`
+		OSFeatures              []string `schema:"osfeature"`
+		OSVersion               string   `schema:"osversion"`
+		OutputFormat            string   `schema:"outputformat"`
+		Platform                []string `schema:"platform"`
+		Pull                    bool     `schema:"pull"`
+		PullPolicy              string   `schema:"pullpolicy"`
+		Quiet                   bool     `schema:"q"`
+		Registry                string   `schema:"registry"`
+		Rm                      bool     `schema:"rm"`
+		RusageLogFile           string   `schema:"rusagelogfile"`
+		Remote                  string   `schema:"remote"`
+		Seccomp                 string   `schema:"seccomp"`
+		Secrets                 string   `schema:"secrets"`
+		SecurityOpt             string   `schema:"securityopt"`
+		ShmSize                 int      `schema:"shmsize"`
+		Squash                  bool     `schema:"squash"`
+		TLSVerify               bool     `schema:"tlsVerify"`
+		Tags                    []string `schema:"t"`
+		Target                  string   `schema:"target"`
+		Timestamp               int64    `schema:"timestamp"`
+		Ulimits                 string   `schema:"ulimits"`
+		UnsetEnvs               []string `schema:"unsetenv"`
 	}{
 		Dockerfile:    "Dockerfile",
 		IdentityLabel: true,
@@ -375,6 +376,14 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		additionalTags = append(additionalTags, possiblyNormalizedTag)
 	}
 
+	var additionalBuildContexts = map[string]*buildahDefine.AdditionalBuildContext{}
+	if _, found := r.URL.Query()["additionalbuildcontexts"]; found {
+		if err := json.Unmarshal([]byte(query.AdditionalBuildContexts), &additionalBuildContexts); err != nil {
+			utils.BadRequest(w, "additionalbuildcontexts", query.AdditionalBuildContexts, err)
+			return
+		}
+	}
+
 	var buildArgs = map[string]string{}
 	if _, found := r.URL.Query()["buildargs"]; found {
 		if err := json.Unmarshal([]byte(query.BuildArgs), &buildArgs); err != nil {
@@ -562,12 +571,13 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	buildOptions := buildahDefine.BuildOptions{
-		AddCapabilities: addCaps,
-		AdditionalTags:  additionalTags,
-		Annotations:     annotations,
-		CPPFlags:        cppflags,
-		Args:            buildArgs,
-		AllPlatforms:    query.AllPlatforms,
+		AddCapabilities:         addCaps,
+		AdditionalBuildContexts: additionalBuildContexts,
+		AdditionalTags:          additionalTags,
+		Annotations:             annotations,
+		CPPFlags:                cppflags,
+		Args:                    buildArgs,
+		AllPlatforms:            query.AllPlatforms,
 		CommonBuildOpts: &buildah.CommonBuildOptions{
 			AddHost:            addhosts,
 			ApparmorProfile:    apparmor,

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -81,6 +81,13 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 	for _, tag := range options.AdditionalTags {
 		params.Add("t", tag)
 	}
+	if additionalBuildContexts := options.AdditionalBuildContexts; len(additionalBuildContexts) > 0 {
+		additionalBuildContextMap, err := jsoniter.Marshal(additionalBuildContexts)
+		if err != nil {
+			return nil, err
+		}
+		params.Set("additionalbuildcontexts", string(additionalBuildContextMap))
+	}
 	if buildArgs := options.Args; len(buildArgs) > 0 {
 		bArgs, err := jsoniter.MarshalToString(buildArgs)
 		if err != nil {

--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -196,6 +196,8 @@ skip_if_remote "volumes don't work with podman-remote" \
 skip_if_remote "--build-context option not implemented in podman-remote" \
                "build-with-additional-build-context and COPY, additional context from host" \
                "build-with-additional-build-context and RUN --mount=from=, additional-context not image and also test conflict with stagename" \
+
+skip_if_remote "env-variable for Containerfile.in pre-processing is not propogated on remote" \
                "bud with Containerfile.in, via envariable" \
 
 # Requires a local file outside context dir

--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -193,21 +193,10 @@ skip_if_remote "volumes don't work with podman-remote" \
                "buildah bud --volume" \
                "buildah-bud-policy"
 
-# Most of this should work in podman remote after API implementation other than where context is host.
 skip_if_remote "--build-context option not implemented in podman-remote" \
-               "build-with-additional-build-context and COPY, test pinning image" \
-               "build-with-additional-build-context and COPY, stagename and additional-context conflict" \
-               "build-with-additional-build-context and COPY, additionalContext and numeric value of stage" \
-               "build-with-additional-build-context and COPY, additionalContext and numeric value of stage" \
                "build-with-additional-build-context and COPY, additional context from host" \
-               "build-with-additional-build-context and COPY, additional context from external URL" \
-               "build-with-additional-build-context and RUN --mount=from=, additional-context is URL and mounted from subdir" \
                "build-with-additional-build-context and RUN --mount=from=, additional-context not image and also test conflict with stagename" \
-               "build-with-additional-build-context and RUN --mount=from=, additional-context and also test conflict with stagename" \
-               "bud-multiple-platform for --all-platform with additional-build-context" \
-               "build-with-additional-build-context and FROM, stagename and additional-context conflict" \
                "bud with Containerfile.in, via envariable" \
-               "build-with-additional-build-context and FROM, pin busybox to alpine"
 
 # Requires a local file outside context dir
 skip_if_remote "local keyfile not sent to podman-remote" \


### PR DESCRIPTION
Feature of additional build context added here https://github.com/containers/buildah/pull/3978
already exists on `podman` following PR just enables this feature of
`podman-remote` and `podman on macOS` setups.

Follow up to : https://github.com/containers/podman/pull/14320

#### Does this PR introduce a user-facing change?
```
Enables additional build context for podman-remote and macOS using --build-context
```