### PR TITLE
Fix {name:.*} regular expressions to {name} in api server routes

### DIFF
--- a/pkg/api/server/register_generate.go
+++ b/pkg/api/server/register_generate.go
@@ -104,7 +104,7 @@ func (s *APIServer) registerGenerateHandlers(r *mux.Router) error {
 	//         type: string
 	//   500:
 	//     $ref: "#/responses/internalError"
-	r.HandleFunc(VersionedPath("/libpod/generate/{name:.*}/systemd"), s.APIHandler(libpod.GenerateSystemd)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/libpod/generate/{name}/systemd"), s.APIHandler(libpod.GenerateSystemd)).Methods(http.MethodGet)
 
 	// swagger:operation GET /libpod/generate/kube libpod GenerateKubeLibpod
 	// ---

--- a/pkg/api/server/register_healthcheck.go
+++ b/pkg/api/server/register_healthcheck.go
@@ -31,6 +31,6 @@ func (s *APIServer) registerHealthCheckHandlers(r *mux.Router) error {
 	//     description: container has no healthcheck or is not running
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/libpod/containers/{name:.*}/healthcheck"), s.APIHandler(libpod.RunHealthCheck)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/containers/{name}/healthcheck"), s.APIHandler(libpod.RunHealthCheck)).Methods(http.MethodGet)
 	return nil
 }

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -241,9 +241,9 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/conflictError'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/images/{name:.*}"), s.APIHandler(compat.RemoveImage)).Methods(http.MethodDelete)
+	r.Handle(VersionedPath("/images/{name}"), s.APIHandler(compat.RemoveImage)).Methods(http.MethodDelete)
 	// Added non version path to URI to support docker non versioned paths
-	r.Handle("/images/{name:.*}", s.APIHandler(compat.RemoveImage)).Methods(http.MethodDelete)
+	r.Handle("/images/{name}", s.APIHandler(compat.RemoveImage)).Methods(http.MethodDelete)
 	// swagger:operation POST /images/{name}/push compat ImagePush
 	// ---
 	// tags:
@@ -288,9 +288,9 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/imageNotFound'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/images/{name:.*}/push"), s.APIHandler(compat.PushImage)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/images/{name}/push"), s.APIHandler(compat.PushImage)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
-	r.Handle("/images/{name:.*}/push", s.APIHandler(compat.PushImage)).Methods(http.MethodPost)
+	r.Handle("/images/{name}/push", s.APIHandler(compat.PushImage)).Methods(http.MethodPost)
 	// swagger:operation GET /images/{name}/get compat ImageGet
 	// ---
 	// tags:
@@ -313,9 +313,9 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//      format: binary
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/images/{name:.*}/get"), s.APIHandler(compat.ExportImage)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/images/{name}/get"), s.APIHandler(compat.ExportImage)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
-	r.Handle("/images/{name:.*}/get", s.APIHandler(compat.ExportImage)).Methods(http.MethodGet)
+	r.Handle("/images/{name}/get", s.APIHandler(compat.ExportImage)).Methods(http.MethodGet)
 	// swagger:operation GET /images/get compat ImageGetAll
 	// ---
 	// tags:
@@ -362,9 +362,9 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/imageNotFound"
 	//   500:
 	//     $ref: "#/responses/internalError"
-	r.Handle(VersionedPath("/images/{name:.*}/history"), s.APIHandler(compat.HistoryImage)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/images/{name}/history"), s.APIHandler(compat.HistoryImage)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
-	r.Handle("/images/{name:.*}/history", s.APIHandler(compat.HistoryImage)).Methods(http.MethodGet)
+	r.Handle("/images/{name}/history", s.APIHandler(compat.HistoryImage)).Methods(http.MethodGet)
 	// swagger:operation GET /images/{name}/json compat ImageInspect
 	// ---
 	// tags:
@@ -386,9 +386,9 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/imageNotFound"
 	//   500:
 	//     $ref: "#/responses/internalError"
-	r.Handle(VersionedPath("/images/{name:.*}/json"), s.APIHandler(compat.GetImage)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/images/{name}/json"), s.APIHandler(compat.GetImage)).Methods(http.MethodGet)
 	// Added non version path to URI to support docker non versioned paths
-	r.Handle("/images/{name:.*}/json", s.APIHandler(compat.GetImage)).Methods(http.MethodGet)
+	r.Handle("/images/{name}/json", s.APIHandler(compat.GetImage)).Methods(http.MethodGet)
 	// swagger:operation POST /images/{name}/tag compat ImageTag
 	// ---
 	// tags:
@@ -422,9 +422,9 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/conflictError'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/images/{name:.*}/tag"), s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/images/{name}/tag"), s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
-	r.Handle("/images/{name:.*}/tag", s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
+	r.Handle("/images/{name}/tag", s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
 	// swagger:operation POST /commit compat ImageCommit
 	// ---
 	// tags:
@@ -746,7 +746,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/imageNotFound'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/libpod/images/{name:.*}/push"), s.APIHandler(libpod.PushImage)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/images/{name}/push"), s.APIHandler(libpod.PushImage)).Methods(http.MethodPost)
 	// swagger:operation GET /libpod/images/{name}/exists libpod ImageExistsLibpod
 	// ---
 	// tags:
@@ -768,7 +768,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/imageNotFound'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/libpod/images/{name:.*}/exists"), s.APIHandler(libpod.ImageExists)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/images/{name}/exists"), s.APIHandler(libpod.ImageExists)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/images/{name}/tree libpod ImageTreeLibpod
 	// ---
 	// tags:
@@ -794,7 +794,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/imageNotFound'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/libpod/images/{name:.*}/tree"), s.APIHandler(libpod.ImageTree)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/images/{name}/tree"), s.APIHandler(libpod.ImageTree)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/images/{name}/history libpod ImageHistoryLibpod
 	// ---
 	// tags:
@@ -816,7 +816,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/imageNotFound'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/libpod/images/{name:.*}/history"), s.APIHandler(compat.HistoryImage)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/images/{name}/history"), s.APIHandler(compat.HistoryImage)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/images/json libpod ImageListLibpod
 	// ---
 	// tags:
@@ -987,7 +987,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/conflictError'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/libpod/images/{name:.*}"), s.APIHandler(libpod.ImagesRemove)).Methods(http.MethodDelete)
+	r.Handle(VersionedPath("/libpod/images/{name}"), s.APIHandler(libpod.ImagesRemove)).Methods(http.MethodDelete)
 	// swagger:operation POST /libpod/images/pull libpod ImagePullLibpod
 	// ---
 	// tags:
@@ -1158,7 +1158,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/imageNotFound'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/libpod/images/{name:.*}/get"), s.APIHandler(libpod.ExportImage)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/images/{name}/get"), s.APIHandler(libpod.ExportImage)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/images/export libpod ImageExportLibpod
 	// ---
 	// tags:
@@ -1218,7 +1218,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/imageNotFound'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/libpod/images/{name:.*}/json"), s.APIHandler(libpod.GetImage)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/images/{name}/json"), s.APIHandler(libpod.GetImage)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/images/{name}/tag libpod ImageTagLibpod
 	// ---
 	// tags:
@@ -1252,7 +1252,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/conflictError'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/libpod/images/{name:.*}/tag"), s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/images/{name}/tag"), s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/commit libpod ImageCommitLibpod
 	// ---
 	// tags:
@@ -1338,7 +1338,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/conflictError'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	r.Handle(VersionedPath("/libpod/images/{name:.*}/untag"), s.APIHandler(libpod.UntagImage)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/images/{name}/untag"), s.APIHandler(libpod.UntagImage)).Methods(http.MethodPost)
 
 	// swagger:operation GET /libpod/images/{name}/changes libpod ImageChangesLibpod
 	// ---

--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -85,7 +85,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/manifestNotFound"
 	//   500:
 	//     $ref: "#/responses/internalError"
-	v4.Handle("/{name:.*}/registry/{destination:.*}", s.APIHandler(libpod.ManifestPush)).Methods(http.MethodPost)
+	v4.Handle("/{name}/registry/{destination}", s.APIHandler(libpod.ManifestPush)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/manifests manifests ManifestCreateLibpod
 	// ---
 	// summary: Create
@@ -129,7 +129,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/internalError"
 	v3.Handle("/create", s.APIHandler(libpod.ManifestCreate)).Methods(http.MethodPost)
-	v4.Handle("/{name:.*}", s.APIHandler(libpod.ManifestCreate)).Methods(http.MethodPost)
+	v4.Handle("/{name}", s.APIHandler(libpod.ManifestCreate)).Methods(http.MethodPost)
 	// swagger:operation GET /libpod/manifests/{name}/exists manifests ManifestExistsLibpod
 	// ---
 	// summary: Exists
@@ -152,8 +152,8 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/manifestNotFound'
 	//   500:
 	//     $ref: '#/responses/internalError'
-	v3.Handle("/{name:.*}/exists", s.APIHandler(libpod.ManifestExists)).Methods(http.MethodGet)
-	v4.Handle("/{name:.*}/exists", s.APIHandler(libpod.ManifestExists)).Methods(http.MethodGet)
+	v3.Handle("/{name}/exists", s.APIHandler(libpod.ManifestExists)).Methods(http.MethodGet)
+	v4.Handle("/{name}/exists", s.APIHandler(libpod.ManifestExists)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/manifests/{name}/json manifests ManifestInspectLibpod
 	// ---
 	// summary: Inspect
@@ -173,8 +173,8 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/manifestNotFound"
 	//   500:
 	//     $ref: "#/responses/internalError"
-	v3.Handle("/{name:.*}/json", s.APIHandler(libpod.ManifestInspect)).Methods(http.MethodGet)
-	v4.Handle("/{name:.*}/json", s.APIHandler(libpod.ManifestInspect)).Methods(http.MethodGet)
+	v3.Handle("/{name}/json", s.APIHandler(libpod.ManifestInspect)).Methods(http.MethodGet)
+	v4.Handle("/{name}/json", s.APIHandler(libpod.ManifestInspect)).Methods(http.MethodGet)
 	// swagger:operation PUT /libpod/manifests/{name} manifests ManifestModifyLibpod
 	// ---
 	// summary: Modify manifest list
@@ -217,7 +217,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//       $ref: "#/definitions/ManifestModifyReport"
 	//   500:
 	//     $ref: "#/responses/internalError"
-	v4.Handle("/{name:.*}", s.APIHandler(libpod.ManifestModify)).Methods(http.MethodPut)
+	v4.Handle("/{name}", s.APIHandler(libpod.ManifestModify)).Methods(http.MethodPut)
 	// swagger:operation POST /libpod/manifests/{name}/add manifests ManifestAddLibpod
 	// ---
 	// summary: Add image
@@ -248,7 +248,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/badParamError"
 	//   500:
 	//     $ref: "#/responses/internalError"
-	v3.Handle("/{name:.*}/add", s.APIHandler(libpod.ManifestAddV3)).Methods(http.MethodPost)
+	v3.Handle("/{name}/add", s.APIHandler(libpod.ManifestAddV3)).Methods(http.MethodPost)
 	// swagger:operation DELETE /libpod/manifests/{name} manifests ManifestDeleteV3Libpod
 	// ---
 	// summary: Remove image from a manifest list
@@ -278,7 +278,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/manifestNotFound"
 	//   500:
 	//     $ref: "#/responses/internalError"
-	v3.Handle("/{name:.*}", s.APIHandler(libpod.ManifestRemoveDigestV3)).Methods(http.MethodDelete)
+	v3.Handle("/{name}", s.APIHandler(libpod.ManifestRemoveDigestV3)).Methods(http.MethodDelete)
 	// swagger:operation DELETE /libpod/manifests/{name} manifests ManifestDeleteLibpod
 	// ---
 	// summary: Delete manifest list
@@ -301,6 +301,6 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/manifestNotFound"
 	//   500:
 	//     $ref: "#/responses/internalError"
-	v4.Handle("/{name:.*}", s.APIHandler(libpod.ManifestDelete)).Methods(http.MethodDelete)
+	v4.Handle("/{name}", s.APIHandler(libpod.ManifestDelete)).Methods(http.MethodDelete)
 	return nil
 }


### PR DESCRIPTION
I tried to use `podman manifest push` against remote podman machine and it didn't work. I debugged it and realized that requests are actually going to another route.

When using `{name}` form for route parameters, `gorilla/mux` router cautiously replaces them with `[^/]+` regular expressions. However, if you provide your own regular expressions like `{name:.*}` you are not safe. Suppose you have `"/{name:.*}"` route. It greedily captures any input even if you intended to hit `"/{name}/registry/{destination}"` route with URI like `/a/registry/b`.

At first, I thought that `.*` regexps was used intentionally because image names actually allow `"/"` symbol. But client implementation effectively escapes the input so it's safe to capture parameters using `[^/]+` regexp.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
