### PR TITLE
Align docker load and podman load output

### DIFF
--- a/cmd/podman/images/load.go
+++ b/cmd/podman/images/load.go
@@ -110,6 +110,6 @@ func load(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("Loaded image(s): " + strings.Join(response.Names, ","))
+	fmt.Println("Loaded image: " + strings.Join(response.Names, "\nLoaded image: "))
 	return nil
 }

--- a/docs/source/markdown/podman-image-scp.1.md
+++ b/docs/source/markdown/podman-image-scp.1.md
@@ -33,7 +33,7 @@ Suppress the output
 
 ```
 $ podman image scp alpine
-Loaded image(s): docker.io/library/alpine:latest
+Loaded image: docker.io/library/alpine:latest
 ```
 
 ```
@@ -43,12 +43,12 @@ Copying blob 72e830a4dff5 done
 Copying config 85f9dc67c7 done
 Writing manifest to image destination
 Storing signatures
-Loaded image(s): docker.io/library/alpine:latest
+Loaded image: docker.io/library/alpine:latest
 ```
 
 ```
 $ podman image scp Fedora::alpine RHEL::
-Loaded image(s): docker.io/library/alpine:latest
+Loaded image: docker.io/library/alpine:latest
 ```
 
 ```
@@ -59,7 +59,7 @@ Copying blob 9450ef9feb15 [--------------------------------------] 0.0b / 0.0b
 Copying config 1f97f0559c done
 Writing manifest to image destination
 Storing signatures
-Loaded image(s): docker.io/library/alpine:latest
+Loaded image: docker.io/library/alpine:latest
 ```
 
 ```
@@ -73,7 +73,7 @@ Copying blob 5eb901baf107 skipped: already exists
 Copying config 696d33ca15 done
 Writing manifest to image destination
 Storing signatures
-Loaded image(s): docker.io/library/alpine:latest
+Loaded image: docker.io/library/alpine:latest
 ```
 
 ```
@@ -87,7 +87,7 @@ Copying blob 5eb901baf107
 Copying config 696d33ca15 done
 Writing manifest to image destination
 Storing signatures
-Loaded image(s): docker.io/library/alpine:latest
+Loaded image: docker.io/library/alpine:latest
 ```
 
 ## SEE ALSO

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -121,7 +121,7 @@ verify_iid_and_name() {
     run_podman untag $IMAGE $newname
     run_podman image scp -q ${notme}@localhost::$newname
 
-    expect="Loaded image(s): $newname"
+    expect="Loaded image: $newname"
     is "$output" "$expect" "-q silences output"
 
     # Confirm that we have it, and that its digest matches our original


### PR DESCRIPTION
The comma-separated podman load output isn't conducive for using the
subsequent images. For tarballs with multiple images, the comma
separator must be manually identified and a suitable range identified.

Docker CLI on the other hand, has one image identifier per line:

```
Loaded image: repo1/name1:latest
Loaded image: repo1/name1:tag1
Loaded image: repo2/name2:tag1
```

(as of Docker version 20.10.16, build aa7e414).

Switch `podman load` to this format for consistency and usability.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

#### Does this PR introduce a user-facing change?

```release-note
podman load CLI now mirrors docker load's imported image list output format
```

/cc: @baude 