### PR TITLE
fix pod network handling with a host network

### DIFF
--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -42,6 +42,9 @@ func GetDefaultNamespaceMode(nsType string, cfg *config.Config, pod *libpod.Pod)
 			podMode = true
 		case nsType == "net" && pod.SharesNet():
 			podMode = true
+		case nsType == "net" && pod.NetworkMode() == "host":
+			toReturn.NSMode = specgen.Host
+			return toReturn, nil
 		case nsType == "cgroup" && pod.SharesCgroup():
 			podMode = true
 		}

--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -125,6 +125,19 @@ var _ = Describe("Podman pod create", func() {
 		session = podmanTest.Podman([]string{"run", fedoraMinimal, "curl", "-f", "localhost"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
+
+		session = podmanTest.Podman([]string{"pod", "create", "--network", "host"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"run", "-dt", "--pod", session.OutputToString(), ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"inspect", "--format", "'{{.NetworkSettings.SandboxKey}}'", session.OutputToString()})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).Should(ContainSubstring("''")) // no network path... host
 	})
 
 	It("podman pod correctly sets up IPCNS", func() {


### PR DESCRIPTION
the function `GetDefaultNamespaceMode` for pods checks if we are sharing each namespace
and if not, returns the default which in the case of a network is slirp.

add a switch case for explicitly checking if the pod's network mode is host
and if so, return specgen.Host for the container

resolves #13763

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>
Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
