### PR TITLE
Improve robustness of `podman system reset`

### DIFF
--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -91,18 +91,10 @@ func reset(cmd *cobra.Command, args []string) {
 	registry.ContainerEngine().Shutdown(registry.Context())
 	registry.ImageEngine().Shutdown(registry.Context())
 
-	engine, err := infra.NewSystemEngine(entities.ResetMode, registry.PodmanConfig())
-	if err != nil {
+	// Do not try to shut the engine down, as a Reset engine is not valid
+	// after its creation.
+	if _, err := infra.NewSystemEngine(entities.ResetMode, registry.PodmanConfig()); err != nil {
 		logrus.Error(err)
-		os.Exit(define.ExecErrorCodeGeneric)
-	}
-	defer engine.Shutdown(registry.Context())
-
-	if err := engine.Reset(registry.Context()); err != nil {
-		logrus.Error(err)
-		// FIXME change this to return the error like other commands
-		// defer will never run on os.Exit()
-		//nolint:gocritic
 		os.Exit(define.ExecErrorCodeGeneric)
 	}
 

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -435,6 +435,21 @@ func WithDefaultInfraCommand(cmd string) RuntimeOption {
 	}
 }
 
+// WithReset instructs libpod to reset all storage to factory defaults.
+// All containers, pods, volumes, images, and networks will be removed.
+// All directories created by Libpod will be removed.
+func WithReset() RuntimeOption {
+	return func(rt *Runtime) error {
+		if rt.valid {
+			return define.ErrRuntimeFinalized
+		}
+
+		rt.doReset = true
+
+		return nil
+	}
+}
+
 // WithRenumber instructs libpod to perform a lock renumbering while
 // initializing. This will handle migrations from early versions of libpod with
 // file locks to newer versions with SHM locking, as well as changes in the

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -328,7 +328,7 @@ func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.System
 }
 
 func (se *SystemEngine) Reset(ctx context.Context) error {
-	return se.Libpod.Reset(ctx)
+	return nil
 }
 
 func (se *SystemEngine) Renumber(ctx context.Context, flags *pflag.FlagSet, config *entities.PodmanConfig) error {

--- a/pkg/domain/infra/runtime_abi.go
+++ b/pkg/domain/infra/runtime_abi.go
@@ -53,7 +53,7 @@ func NewSystemEngine(setup entities.EngineSetup, facts *entities.PodmanConfig) (
 		case entities.RenumberMode:
 			r, err = GetRuntimeRenumber(context.Background(), facts.FlagSet, facts)
 		case entities.ResetMode:
-			r, err = GetRuntimeRenumber(context.Background(), facts.FlagSet, facts)
+			r, err = GetRuntimeReset(context.Background(), facts.FlagSet, facts)
 		case entities.MigrateMode:
 			name, flagErr := facts.FlagSet.GetString("new-runtime")
 			if flagErr != nil {

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -37,6 +37,7 @@ type engineOpts struct {
 	migrate  bool
 	noStore  bool
 	withFDS  bool
+	reset    bool
 	config   *entities.PodmanConfig
 }
 
@@ -48,6 +49,7 @@ func GetRuntimeMigrate(ctx context.Context, fs *flag.FlagSet, cfg *entities.Podm
 		migrate:  true,
 		noStore:  false,
 		withFDS:  true,
+		reset:    false,
 		config:   cfg,
 	})
 }
@@ -59,6 +61,7 @@ func GetRuntimeDisableFDs(ctx context.Context, fs *flag.FlagSet, cfg *entities.P
 		migrate:  false,
 		noStore:  false,
 		withFDS:  false,
+		reset:    false,
 		config:   cfg,
 	})
 }
@@ -70,6 +73,7 @@ func GetRuntimeRenumber(ctx context.Context, fs *flag.FlagSet, cfg *entities.Pod
 		migrate:  false,
 		noStore:  false,
 		withFDS:  true,
+		reset:    false,
 		config:   cfg,
 	})
 }
@@ -82,6 +86,7 @@ func GetRuntime(ctx context.Context, flags *flag.FlagSet, cfg *entities.PodmanCo
 			migrate:  false,
 			noStore:  false,
 			withFDS:  true,
+			reset:    false,
 			config:   cfg,
 		})
 	})
@@ -95,6 +100,18 @@ func GetRuntimeNoStore(ctx context.Context, fs *flag.FlagSet, cfg *entities.Podm
 		migrate:  false,
 		noStore:  true,
 		withFDS:  true,
+		reset:    false,
+		config:   cfg,
+	})
+}
+
+func GetRuntimeReset(ctx context.Context, fs *flag.FlagSet, cfg *entities.PodmanConfig) (*libpod.Runtime, error) {
+	return getRuntime(ctx, fs, &engineOpts{
+		renumber: false,
+		migrate:  false,
+		noStore:  false,
+		withFDS:  true,
+		reset:    true,
 		config:   cfg,
 	})
 }
@@ -159,6 +176,10 @@ func getRuntime(ctx context.Context, fs *flag.FlagSet, opts *engineOpts) (*libpo
 		if opts.name != "" {
 			options = append(options, libpod.WithMigrateRuntime(opts.name))
 		}
+	}
+
+	if opts.reset {
+		options = append(options, libpod.WithReset())
 	}
 
 	if opts.renumber {


### PR DESCRIPTION
Firstly, reset is now managed by the runtime itself as a part of initialization. This ensures that it can be used even with runtimes that would otherwise fail to be created - most notably, when the user has changed a core path (runroot/root/tmpdir/staticdir).

Secondly, we now attempt a best-effort removal even if the store completely fails to be configured.

Third, we now hold the alive lock for the entire reset operation. This ensures that no other Podman process can start while we are running a system reset, and removes any possibility of a race where a user tries to create containers or pull images while we
are trying to perform a reset. 

[NO NEW TESTS NEEDED] we do not test reset last I checked.

Fixes #9075

```release-note
Fixed a bug where the `podman system reset` command could race against other Podman commands.
```
