### PR TITLE
test/e2e/save_test.go: fix flake

### DIFF
--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -226,13 +226,17 @@ default-docker:
 	})
 
 	It("podman save --multi-image-archive (untagged images)", func() {
-		// Refer to images via ID instead of tag.
-		session := podmanTest.Podman([]string{"images", "--format", "{{.ID}}"})
+		// #14468: to make execution time more predictable, save at
+		// most three images and sort them by size.
+		session := podmanTest.Podman([]string{"images", "--sort", "size", "--format", "{{.ID}}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		ids := session.OutputToStringArray()
 
 		Expect(len(ids)).To(BeNumerically(">", 1), "We need to have *some* images to save")
+		if len(ids) > 3 {
+			ids = ids[:3]
+		}
 		multiImageSave(podmanTest, ids)
 	})
 })


### PR DESCRIPTION
Save at most three images and sort them by size.  The test started to
flake as _all_ local images were saved which is not neccessary.

Fixes: #14468
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@edsantiago @Luap99 @flouthoc PTAL