### PR TITLE
image list: do not reformat `.CreatedAt`

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -172,7 +172,7 @@ func writeJSON(images []imageReporter) error {
 		var h image
 		h.ImageSummary = e.ImageSummary
 		h.Created = e.ImageSummary.Created
-		h.CreatedAt = e.created().Format(time.RFC3339Nano)
+		h.CreatedAt = e.created().String()
 		h.RepoTags = nil
 
 		imgs = append(imgs, h)


### PR DESCRIPTION
As shown in #14456, the `.CreatedAt` fields for `image list` and of
`image history` can differ by one.  The discussed theory is that the
off-by-one is caused by rounding.

Indeed, the field of `image list` is reformatted.  `image history` is
returning the UNIX time; just as the `.CreatedAt` field should.

I am unable to create a reproducer for the issue but double-checked
what the docker client does: return the UNIX time.

[NO NEW TESTS NEEDED]

Fixes: #14456
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in when formatting the `.CreatedAt` field in `podman image list`.
```

@edsantiago @rhatdan PTAL