### PR TITLE
podman logs k8s-file: do not reassemble partial log lines

### DIFF
--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -75,7 +75,6 @@ func (c *Container) readFromLogFile(ctx context.Context, options *logs.LogOption
 	go func() {
 		defer options.WaitGroup.Done()
 
-		var partial string
 		for line := range t.Lines {
 			select {
 			case <-ctx.Done():
@@ -88,13 +87,6 @@ func (c *Container) readFromLogFile(ctx context.Context, options *logs.LogOption
 			if err != nil {
 				logrus.Errorf("Getting new log line: %v", err)
 				continue
-			}
-			if nll.Partial() {
-				partial += nll.Msg
-				continue
-			} else if !nll.Partial() && len(partial) > 0 {
-				nll.Msg = partial + nll.Msg
-				partial = ""
 			}
 			nll.CID = c.ID()
 			nll.CName = c.Name()


### PR DESCRIPTION
The backend should not convert partial lines to full log lines. While
this works for most cases it cannot work when the last line is partial
since it will just be lost. The frontend logic can already display
partial lines correctly. The journald driver also works correctly since
it does not such conversion.

Fixes #14458

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman logs will now correctly display all output when the last line did not end with an newline.
```
