### PR TITLE
Use logDriver instead of query.LogDriver for podman play kube

### DIFF
--- a/pkg/api/handlers/libpod/play.go
+++ b/pkg/api/handlers/libpod/play.go
@@ -77,7 +77,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 			utils.Error(w, http.StatusInternalServerError, err)
 			return
 		}
-		query.LogDriver = config.Containers.LogDriver
+		logDriver = config.Containers.LogDriver
 	}
 
 	containerEngine := abi.ContainerEngine{Libpod: runtime}
@@ -89,7 +89,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 		Networks:    query.Network,
 		NoHosts:     query.NoHosts,
 		Quiet:       true,
-		LogDriver:   query.LogDriver,
+		LogDriver:   logDriver,
 		LogOptions:  query.LogOptions,
 		StaticIPs:   staticIPs,
 		StaticMACs:  staticMACs,


### PR DESCRIPTION
Quick fix in play.go to use logDriver to set the correct
log driver rather than overwriting query.LogDriver.
[NO NEW TESTS NEEDED]

Signed-off-by: Niall Crowe <nicrowe@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
