### PR TITLE
systemctl stop podman.service after each reset

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -685,10 +685,14 @@ func SkipIfNotSystemd(manager, reason string) {
 }
 
 func SkipIfNotFedora() {
-	info := GetHostDistributionInfo()
-	if info.Distribution != "fedora" {
+	if !IsFedora() {
 		Skip("Test can only run on Fedora")
 	}
+}
+
+func IsFedora() bool {
+	info := GetHostDistributionInfo()
+	return info.Distribution == "fedora"
 }
 
 func isRootless() bool {

--- a/test/e2e/system_dial_stdio_test.go
+++ b/test/e2e/system_dial_stdio_test.go
@@ -3,8 +3,10 @@ package integration
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
 	. "github.com/containers/podman/v4/test/utils"
+	"github.com/containers/podman/v4/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -44,6 +46,23 @@ var _ = Describe("podman system dial-stdio", func() {
 		if IsRemote() {
 			Skip("this test is only for non-remote")
 		}
+		SkipIfInContainer("systemd does not run in the containerized tests")
+
+		// due to other tests modifying the service, we need to stop it here.
+		sys, err := exec.LookPath("systemctl")
+		if err != nil || !utils.RunsOnSystemd() {
+			Skip("systemctl not installed")
+		}
+
+		args := []string{}
+		if isRootless() {
+			args = append(args, "--user")
+		}
+		args = append(args, "stop", "podman")
+		stop := StartSystemExec(sys, args)
+		stop.WaitWithDefaultTimeout()
+		Expect(stop.Exited).ShouldNot(Receive(), "Failed to stop podman.service")
+
 		session := podmanTest.Podman([]string{"system", "dial-stdio"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(125))


### PR DESCRIPTION
users were running into issues with system reset and invalid db configs
resolve this by restarting the podman user service each time we reset.

resolves #12076

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
