### PR TITLE
[CI:DOCS] PodmanImage Readme touchup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,9 @@ Thanks for sending a pull request!
 
 Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).
 
-In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
+In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.
 
-Finally, be sure to sign commits with your real name.  Since by opening
+Finally, be sure to sign commits with your real name. Since by opening
 a PR you already have commits, you can add signatures if needed with
 something like `git commit -s --amend`.
 -->
@@ -18,7 +18,7 @@ is required: Enter your extended release note in the block below. If the PR
 requires additional action from users switching to the new release, include the
 string "action required".
 
-For more information on release notes please follow the kubernetes model:
+For more information on release notes, please follow the Kubernetes model:
 https://git.k8s.io/community/contributors/guide/release-notes.md
 -->
 

--- a/contrib/podmanimage/README.md
+++ b/contrib/podmanimage/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This directory contains the Dockerfiles necessary to create the podmanimage container
+This directory contains the Containerfiles necessary to create the podmanimage container
 images that are housed on quay.io under the Podman account.  All repositories where
 the images live are public and can be pulled without credentials.  These container images are secured and the
 resulting containers can run safely with privileges within the container.


### PR DESCRIPTION
@cevich recently renamed all the files named Dockerfile to Containerfile
in this directory.  Touching up the README.md to reflect that.

Also, as I was doing the submit, I noticed a couple of nits in the PR
request template and cleaned those up.

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
