### PR TITLE
runtime: make error clearer

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1123,7 +1123,7 @@ func (r *Runtime) mergeDBConfig(dbConfig *DBConfig) {
 	if !r.storageSet.GraphDriverNameSet && dbConfig.GraphDriver != "" {
 		if r.storageConfig.GraphDriverName != dbConfig.GraphDriver &&
 			r.storageConfig.GraphDriverName != "" {
-			logrus.Errorf("User-selected graph driver %q overwritten by graph driver %q from database - delete libpod local files to resolve",
+			logrus.Errorf("User-selected graph driver %q overwritten by graph driver %q from database - delete libpod local files to resolve.  May prevent use of images created by other tools",
 				r.storageConfig.GraphDriverName, dbConfig.GraphDriver)
 		}
 		r.storageConfig.GraphDriverName = dbConfig.GraphDriver


### PR DESCRIPTION
make the error clearer and state that images created by other tools
might not be visible to Podman when it overrides the graph driver.

Closes: https://github.com/containers/podman/issues/13970

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

```release-note
None
```
