### PR TITLE
podman pod create --uts support

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -544,13 +544,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(userFlagName, AutocompleteUserFlag)
 
-		utsFlagName := "uts"
-		createFlags.String(
-			utsFlagName, "",
-			"UTS namespace to use",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(utsFlagName, AutocompleteNamespace)
-
 		mountFlagName := "mount"
 		createFlags.StringArrayVar(
 			&cf.Mount,
@@ -683,6 +676,14 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			"User namespace to use",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(usernsFlagName, AutocompleteUserNamespace)
+
+		utsFlagName := "uts"
+		createFlags.StringVar(
+			&cf.UTS,
+			utsFlagName, "",
+			"UTS namespace to use",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(utsFlagName, AutocompleteNamespace)
 
 		cgroupParentFlagName := "cgroup-parent"
 		createFlags.StringVar(

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -224,7 +224,6 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 			return vals, errors.New("--cpu-quota and --cpus cannot be set together")
 		}
 		vals.IPC = c.Flag("ipc").Value.String()
-		vals.UTS = c.Flag("uts").Value.String()
 		vals.PID = c.Flag("pid").Value.String()
 		vals.CgroupNS = c.Flag("cgroupns").Value.String()
 

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -277,6 +277,7 @@ func create(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+
 		podSpec.Volumes = podSpec.InfraContainerSpec.Volumes
 		podSpec.ImageVolumes = podSpec.InfraContainerSpec.ImageVolumes
 		podSpec.OverlayVolumes = podSpec.InfraContainerSpec.OverlayVolumes

--- a/docs/source/markdown/podman-pod-clone.1.md
+++ b/docs/source/markdown/podman-pod-clone.1.md
@@ -211,6 +211,15 @@ Valid _mode_ values are:
 
   - *nomap*: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is ignored for containers created by the root user.
 
+#### **--uts**=*mode*
+
+Set the UTS namespace mode for the pod. The following values are supported:
+
+- **host**: use the host's UTS namespace inside the pod.
+- **private**: create a new namespace for the pod (default).
+- **ns:[path]**: run the pod in the given existing UTS namespace.
+
+
 #### **--volume**, **-v**[=*[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*]
 
 Create a bind mount. If ` -v /HOST-DIR:/CONTAINER-DIR` is specified, Podman

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -381,6 +381,14 @@ Valid _mode_ values are:
 
   - *nomap*: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is not allowed for containers created by the root user.
 
+#### **--uts**=*mode*
+
+Set the UTS namespace mode for the pod. The following values are supported:
+
+- **host**: use the host's UTS namespace inside the pod.
+- **private**: create a new namespace for the pod (default).
+- **ns:[path]**: run the pod in the given existing UTS namespace.
+
 #### **--volume**, **-v**[=*[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*]
 
 Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Podman

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1336,3 +1336,52 @@ func (c *Container) getNetworkStatus() map[string]types.StatusBlock {
 	}
 	return nil
 }
+
+func (c *Container) NamespaceMode(ns spec.LinuxNamespaceType, ctrSpec *spec.Spec) string {
+	switch ns {
+	case spec.UTSNamespace:
+		if c.config.UTSNsCtr != "" {
+			return fmt.Sprintf("container:%s", c.config.UTSNsCtr)
+		}
+	case spec.CgroupNamespace:
+		if c.config.CgroupNsCtr != "" {
+			return fmt.Sprintf("container:%s", c.config.CgroupNsCtr)
+		}
+	case spec.IPCNamespace:
+		if c.config.IPCNsCtr != "" {
+			return fmt.Sprintf("container:%s", c.config.IPCNsCtr)
+		}
+	case spec.PIDNamespace:
+		if c.config.PIDNsCtr != "" {
+			return fmt.Sprintf("container:%s", c.config.PIDNsCtr)
+		}
+	case spec.UserNamespace:
+		if c.config.UserNsCtr != "" {
+			return fmt.Sprintf("container:%s", c.config.UserNsCtr)
+		}
+	case spec.NetworkNamespace:
+		if c.config.NetNsCtr != "" {
+			return fmt.Sprintf("container:%s", c.config.NetNsCtr)
+		}
+	case spec.MountNamespace:
+		if c.config.MountNsCtr != "" {
+			return fmt.Sprintf("container:%s", c.config.MountNsCtr)
+		}
+	}
+
+	if ctrSpec.Linux != nil {
+		// Locate the spec's given namespace.
+		// If there is none, it's namespace=host.
+		// If there is one and it has a path, it's "ns:".
+		// If there is no path, it's default - the empty string.
+		for _, availableNS := range ctrSpec.Linux.Namespaces {
+			if availableNS.Type == ns {
+				if availableNS.Path != "" {
+					return fmt.Sprintf("ns:%s", availableNS.Path)
+				}
+				return "private"
+			}
+		}
+	}
+	return "host"
+}

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -794,28 +794,8 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 	hostConfig.PidMode = pidMode
 
 	// UTS namespace mode
-	utsMode := ""
-	if c.config.UTSNsCtr != "" {
-		utsMode = fmt.Sprintf("container:%s", c.config.UTSNsCtr)
-	} else if ctrSpec.Linux != nil {
-		// Locate the spec's UTS namespace.
-		// If there is none, it's uts=host.
-		// If there is one and it has a path, it's "ns:".
-		// If there is no path, it's default - the empty string.
-		for _, ns := range ctrSpec.Linux.Namespaces {
-			if ns.Type == spec.UTSNamespace {
-				if ns.Path != "" {
-					utsMode = fmt.Sprintf("ns:%s", ns.Path)
-				} else {
-					utsMode = "private"
-				}
-				break
-			}
-		}
-		if utsMode == "" {
-			utsMode = "host"
-		}
-	}
+	utsMode := c.NamespaceMode(spec.UTSNamespace, ctrSpec)
+
 	hostConfig.UTSMode = utsMode
 
 	// User namespace mode

--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -122,6 +122,8 @@ type InspectPodInfraConfig struct {
 	PidNS string `json:"pid_ns,omitempty"`
 	// UserNS is the usernamespace that all the containers in the pod will join.
 	UserNS string `json:"userns,omitempty"`
+	// UtsNS is the uts namespace that all containers in the pod will join
+	UtsNS string `json:"uts_ns,omitempty"`
 }
 
 // InspectPodContainerInfo contains information on a container in a pod.

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -676,6 +676,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		infraConfig.CPUSetCPUs = p.ResourceLim().CPU.Cpus
 		infraConfig.PidNS = p.NamespaceMode(specs.PIDNamespace)
 		infraConfig.UserNS = p.NamespaceMode(specs.UserNamespace)
+		infraConfig.UtsNS = p.NamespaceMode(specs.UTSNamespace)
 		namedVolumes, mounts := infra.SortUserVolumes(infra.config.Spec)
 		inspectMounts, err = infra.GetMounts(namedVolumes, infra.config.ImageVolumes, mounts)
 		infraSecurity = infra.GetSecurityOptions()

--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -59,6 +59,7 @@ func (s *SpecGenerator) Validate() error {
 		if s.ContainerBasicConfig.UtsNS.IsPod() {
 			return errors.Wrap(ErrInvalidSpecConfig, "cannot set hostname when joining the pod UTS namespace")
 		}
+
 		return errors.Wrap(ErrInvalidSpecConfig, "cannot set hostname when running in the host UTS namespace")
 	}
 	// systemd values must be true, false, or always

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -133,6 +133,12 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 
 		options = append(options, libpod.WithRootFSFromImage(newImage.ID(), resolvedImageName, s.RawImageName))
 	}
+
+	_, err = rt.LookupPod(s.Hostname)
+	if len(s.Hostname) > 0 && !s.UtsNS.IsPrivate() && err == nil {
+		// ok, we are incorrectly setting the pod as the hostname, lets undo that before validation
+		s.Hostname = ""
+	}
 	if err := s.Validate(); err != nil {
 		return nil, nil, nil, errors.Wrap(err, "invalid config provided")
 	}

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -60,6 +60,7 @@ func MakePod(p *entities.PodSpec, rt *libpod.Runtime) (*libpod.Pod, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		spec.Pod = pod.ID()
 		opts = append(opts, rt.WithPod(pod))
 		spec.CgroupParent = pod.CgroupParent()


### PR DESCRIPTION
add support for the --uts flag in pod create, allowing users to avoid
issues with default values in containers.conf.

uts follows the same format as other namespace flags:
--uts=private (default), --uts=host, --uts=ns:PATH

resolves #13714

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Users can now specify the --uts option when creating pods, specifying a pod wide uts mode for all containers.
```
