### PR TITLE
libpod: store network status when userns is used

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1000,6 +1000,9 @@ func (c *Container) completeNetworkSetup() error {
 	if err := c.runtime.setupNetNS(c); err != nil {
 		return err
 	}
+	if err := c.save(); err != nil {
+		return err
+	}
 	state := c.state
 	// collect any dns servers that cni tells us to use (dnsname)
 	for _, status := range c.getNetworkStatus() {

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -111,6 +111,10 @@ load helpers
                    $IMAGE nc -l -n -v -p $myport
         cid="$output"
 
+        # check that podman stores the network info correctly when a userns is used (#14465)
+        run_podman container inspect --format "{{.NetworkSettings.SandboxKey}}" $cid
+        assert "$output" =~ ".*/netns/netns-.*" "Netns path should be set"
+
         wait_for_output "listening on .*:$myport .*" $cid
 
         # emit random string, and check it


### PR DESCRIPTION
When a container with a userns is created the network setup is special.
Normally the netns is setup before the oci runtime container is created,
however with a userns the container is created first and then the network
is setup. In the second case we never saved the container state
afterwards. Because of it, podman inspect would not show the network info
and network teardown will not happen.

This worked with local podman  because there was a save() call later in the
code path which then also saved the network status. But in the podman API
code path this save never happened thus all containers started via API had
this problem.

Fixes #14465

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where network cleanup was not happening when a container used a custom user namespace and were initialized via API ([#14465](https://github.com/containers/podman/issues/14465)).
```
