### PR TITLE
[v3.2.3-rhel] Cirrus: Avoid build-each-commit check

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -303,8 +303,8 @@ alt_build_task:
         TEST_FLAVOR: "altbuild"
     gce_instance: *standardvm
     matrix:
-      - env:
-            ALT_NAME: 'Build Each Commit'
+      #- env:
+      #      ALT_NAME: 'Build Each Commit'
       - env:
             ALT_NAME: 'Windows Cross'
       - env:


### PR DESCRIPTION
This check is breaking on PRs and branches, for example:

```
Rebasing (5/24)
error: could not apply e6ed1d4bf... cirrus: update image
Resolve all conflicts manually, mark them as resolved with
"git add/rm <conflicted_files>", then run "git rebase --continue".
You can instead skip this commit: run "git rebase --skip".
To abort and get back to the state before "git rebase", run "git rebase
--abort".
Could not apply e6ed1d4bf... cirrus: update image
Auto-merging .cirrus.yml
CONFLICT (content): Merge conflict in .cirrus.yml
make: *** [Makefile:269: build-all-new-commits] Error 1
```

Stop running this check rather than debugging/fixing it because this is
a release branch that will not likely ever see a PR containing more than
one commit.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
