### PR TITLE
Infra Inheritance patch

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -542,6 +542,16 @@ func Inherit(infra libpod.Container, s *specgen.SpecGenerator, rt *libpod.Runtim
 	infraConf := infra.Config()
 	infraSpec := infraConf.Spec
 
+	// need to set compatOptions to the currently filled specgenOptions so we do not overwrite
+	compatibleOptions.CapAdd = append(compatibleOptions.CapAdd, s.CapAdd...)
+	compatibleOptions.CapDrop = append(compatibleOptions.CapDrop, s.CapDrop...)
+	compatibleOptions.HostDeviceList = append(compatibleOptions.HostDeviceList, s.HostDeviceList...)
+	compatibleOptions.ImageVolumes = append(compatibleOptions.ImageVolumes, s.ImageVolumes...)
+	compatibleOptions.Mounts = append(compatibleOptions.Mounts, s.Mounts...)
+	compatibleOptions.OverlayVolumes = append(compatibleOptions.OverlayVolumes, s.OverlayVolumes...)
+	compatibleOptions.SelinuxOpts = append(compatibleOptions.SelinuxOpts, s.SelinuxOpts...)
+	compatibleOptions.Volumes = append(compatibleOptions.Volumes, s.Volumes...)
+
 	compatByte, err := json.Marshal(compatibleOptions)
 	if err != nil {
 		return nil, nil, nil, err

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -1112,4 +1112,26 @@ ENTRYPOINT ["sleep","99999"]
 
 	})
 
+	It("podman pod create infra inheritance test", func() {
+		volName := "testVol1"
+		volCreate := podmanTest.Podman([]string{"volume", "create", volName})
+		volCreate.WaitWithDefaultTimeout()
+		Expect(volCreate).Should(Exit(0))
+
+		session := podmanTest.Podman([]string{"pod", "create", "-v", volName + ":/vol1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		volName2 := "testVol2"
+		volCreate = podmanTest.Podman([]string{"volume", "create", volName2})
+		volCreate.WaitWithDefaultTimeout()
+		Expect(volCreate).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"run", "--pod", session.OutputToString(), "-v", volName2 + ":/vol2", ALPINE, "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).Should(ContainSubstring("/vol1"))
+		Expect(session.OutputToString()).Should(ContainSubstring("/vol2"))
+	})
+
 })


### PR DESCRIPTION
infra was overriding options that it should be appending rather than resetting.
fix this by appending the given container's spec to the compatible options before marshaling/unmarshaling

resolves #14454

Signed-off-by: cdoern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
 
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
