### PR TITLE
Do not error on signalling a just-stopped container

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -411,8 +411,8 @@ func (r *ConmonOCIRuntime) KillContainer(ctr *Container, signal uint, all bool) 
 		if err2 := r.UpdateContainerStatus(ctr); err2 != nil {
 			logrus.Infof("Error updating status for container %s: %v", ctr.ID(), err2)
 		}
-		if ctr.state.State == define.ContainerStateExited {
-			return nil
+		if ctr.ensureState(define.ContainerStateStopped, define.ContainerStateExited) {
+			return define.ErrCtrStateInvalid
 		}
 		return errors.Wrapf(err, "error sending signal to container %s", ctr.ID())
 	}


### PR DESCRIPTION
Previous PR #12394 tried to address this, but made a mistake: containers that have just exited do not move to the Exited state but rather the Stopped state - as such, the code would never have run (there is no way we start `podman kill`, and the container
transitions to Exited while we are doing it - that requires holding the container lock, which Kill already does).

Fix the code to check Stopped as well (we omit Exited entirely but it's a cheap check and our state logic could change in the
future). Also, return an error, instead of exiting cleanly - the Kill failed, after all. ErrCtrStateInvalid is already handled by the sig-proxy logic so there won't be issues.


```release-note
Fixed a bug where Podman could print error messages when signals were forwarded to a container via `--sig-proxy` to a container as the container process exited.
```
