### PR TITLE
APIv2 tests: (try to) fix flaky registry panic

### DIFF
--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -443,12 +443,18 @@ function start_registry() {
     # If invoked with auth=htpasswd, create credentials
     REGISTRY_USERNAME=
     REGISTRY_PASSWORD=
+    declare -a registry_auth_params=(-e "REGISTRY_AUTH=$auth")
     if [[ "$auth" = "htpasswd" ]]; then
         REGISTRY_USERNAME=u$(random_string 7)
         REGISTRY_PASSWORD=p$(random_string 7)
 
         htpasswd -Bbn ${REGISTRY_USERNAME} ${REGISTRY_PASSWORD} \
                  > $AUTHDIR/htpasswd
+
+        registry_auth_params+=(
+            -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm"
+            -e "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd"
+        )
     fi
 
     # Run the registry, and wait for it to come up
@@ -456,9 +462,7 @@ function start_registry() {
            -p ${REGISTRY_PORT}:5000 \
            --name registry \
            -v $AUTHDIR:/auth:Z \
-           -e "REGISTRY_AUTH=$auth" \
-           -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
-           -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+           "${registry_auth_params[@]}" \
            -e REGISTRY_HTTP_TLS_CERTIFICATE=/auth/domain.crt \
            -e REGISTRY_HTTP_TLS_KEY=/auth/domain.key \
            ${REGISTRY_IMAGE}


### PR DESCRIPTION
APIv2 tests are flaky after this morning's merge of #14543.

Symptom:
   test-apiv2: Timed out (10s) waiting for service (/dev/tcp/localhost/5564)

journal shows:
   registry[7421]: panic: unable to configure authorization (htpasswd):
      no access controller registered with name: none

Possible cause:
   Mix of REGISTRY_AUTH=none with REGISTRY_AUTH_HTPASSWD_* vars.
      https://github.com/distribution/distribution/issues/1168

Solution:
   only set _HTPASSWD_* vars when AUTH=htpasswd

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```