### PR TITLE
[v1.6.4-rhel] Fix webserver startup w/ systemd

### DIFF
--- a/pkg/systemdgen/systemdgen.go
+++ b/pkg/systemdgen/systemdgen.go
@@ -71,6 +71,8 @@ const containerTemplate = `# {{.ServiceName}}.service
 [Unit]
 Description=Podman {{.ServiceName}}.service
 Documentation=man:podman-generate-systemd(1)
+Wants=network.target
+After=network-online.target
 {{- if .BoundToServices}}
 RefuseManualStart=yes
 RefuseManualStop=yes

--- a/pkg/systemdgen/systemdgen_test.go
+++ b/pkg/systemdgen/systemdgen_test.go
@@ -39,6 +39,8 @@ func TestCreateContainerSystemdUnit(t *testing.T) {
 [Unit]
 Description=Podman container-639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401.service
 Documentation=man:podman-generate-systemd(1)
+Wants=network.target
+After=network-online.target
 
 [Service]
 Restart=always
@@ -57,6 +59,8 @@ WantedBy=multi-user.target`
 [Unit]
 Description=Podman container-foobar.service
 Documentation=man:podman-generate-systemd(1)
+Wants=network.target
+After=network-online.target
 
 [Service]
 Restart=always
@@ -75,6 +79,8 @@ WantedBy=multi-user.target`
 [Unit]
 Description=Podman container-foobar.service
 Documentation=man:podman-generate-systemd(1)
+Wants=network.target
+After=network-online.target
 RefuseManualStart=yes
 RefuseManualStop=yes
 BindsTo=a.service b.service c.service pod.service
@@ -97,6 +103,8 @@ WantedBy=multi-user.target`
 [Unit]
 Description=Podman pod-123abc.service
 Documentation=man:podman-generate-systemd(1)
+Wants=network.target
+After=network-online.target
 Requires=container-1.service container-2.service
 Before=container-1.service container-2.service
 


### PR DESCRIPTION
Allow a webserver to come backup after it is restarted by systemd.
This was backported to all other Podman releases already, but not to
v1.6.4 at the time.  However, this BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=2091721 is asking for the
fix.

Backport of https://github.com/containers/podman/commit/05a0bf7c07e5

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
