### PR TITLE
Fix M1 QEMU flags

### DIFF
--- a/pkg/machine/qemu/options_darwin_arm64.go
+++ b/pkg/machine/qemu/options_darwin_arm64.go
@@ -15,8 +15,8 @@ func (v *MachineVM) addArchOptions() []string {
 	opts := []string{
 		"-accel", "hvf",
 		"-accel", "tcg",
-		"-cpu", "cortex-a57",
-		"-M", "virt,highmem=off",
+		"-cpu", "host",
+		"-M", "virt,highmem=on",
 		"-drive", "file=" + getEdk2CodeFd("edk2-aarch64-code.fd") + ",if=pflash,format=raw,readonly=on",
 		"-drive", "file=" + ovmfDir + ",if=pflash,format=raw"}
 	return opts


### PR DESCRIPTION
When calling QEMU, the CPU arch should be host, and highmem should be on, or else the VM start fails.

[NO NEW TESTS NEEDED]

Signed-off-by: Ashley Cui <acui@redhat.com>

Fixes: https://github.com/containers/podman/issues/14303

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where podman machine fails to start with memory > 3072 on M1
```
