### PR TITLE
Cirrus: Add podman-machine integration test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,8 +30,10 @@ env:
     PRIOR_FEDORA_NAME: "fedora-35"
     UBUNTU_NAME: "ubuntu-2110"
 
-    # Google-cloud VM Images
+    # Image identifiers
     IMAGE_SUFFIX: "c6211193021923328"
+    FEDORA_AMI_ID: "ami-06a41d8a81ab56afa"
+    # Complete image names
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
@@ -65,6 +67,8 @@ timeout_in: 60m
 
 
 gcp_credentials: ENCRYPTED[a28959877b2c9c36f151781b0a05407218cda646c7d047fc556e42f55e097e897ab63ee78369dae141dcf0b46a9d0cdd]
+
+aws_credentials: ENCRYPTED[4ca070bffe28eb9b27d63c568b52970dd46f119c3a83b8e443241e895dbf1737580b4d84eed27a311a2b74287ef9f79f]
 
 
 # Attempt to prevent flakes by confirming all required external/3rd-party
@@ -577,6 +581,35 @@ rootless_integration_test_task:
     always: *int_logs_artifacts
 
 
+podman_machine_task:
+    name: *std_name_fmt
+    alias: podman_machine
+    only_if: *not_tag_branch_build_docs
+    # Manually-triggered task: This is "expensive" to run.
+    # DO NOT ADD THIS TASK AS DEPENDENCY FOR `success_task`
+    # it will cause 'success' to block.
+    trigger_type: manual
+    depends_on:
+        - build
+        - local_integration_test
+        - remote_integration_test
+        - container_integration_test
+        - rootless_integration_test
+    ec2_instance:
+        image: "${VM_IMAGE_NAME}"
+        type: m5zn.metal  # Bare-metal instance is required
+        region: us-east-1
+    env:
+      TEST_FLAVOR: "machine"
+      PRIV_NAME: "rootless"  # intended use-case
+      DISTRO_NV: "${FEDORA_NAME}"
+      VM_IMAGE_NAME: "${FEDORA_AMI_ID}"
+    clone_script: *get_gosrc
+    setup_script: *setup
+    main_script: *main
+    always: *int_logs_artifacts
+
+
 # Always run subsequent to integration tests.  While parallelism is lost
 # with runtime, debugging system-test failures can be more challenging
 # for some golang developers.  Otherwise the following tasks run across
@@ -842,6 +875,9 @@ success_task:
         - remote_integration_test
         - container_integration_test
         - rootless_integration_test
+        # Manually triggered task. If made automatic, remove bypass
+        # in contrib/cirrus/cirrus_yaml_test.py for this task.
+        # - podman_machine
         - local_system_test
         - remote_system_test
         - rootless_system_test

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,10 @@ LIBSECCOMP_COMMIT := v2.3.3
 # Rarely if ever should integration tests take more than 50min,
 # caller may override in special circumstances if needed.
 GINKGOTIMEOUT ?= -timeout=90m
+# By default, run test/e2e
+GINKGOWHAT ?= test/e2e/.
+# By default, run tests in parallel across 3 nodes.
+GINKGONODES ?= 3
 
 # Conditional required to produce empty-output if binary not built yet.
 RELEASE_VERSION = $(shell if test -x test/version/version; then test/version/version; fi)
@@ -524,7 +528,7 @@ test: localunit localintegration remoteintegration localsystem remotesystem  ## 
 .PHONY: ginkgo-run
 ginkgo-run:
 	ACK_GINKGO_RC=true ginkgo version
-	ACK_GINKGO_RC=true ginkgo -v $(TESTFLAGS) -tags "$(TAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes 3 -debug test/e2e/. $(HACK)
+	ACK_GINKGO_RC=true ginkgo -v $(TESTFLAGS) -tags "$(TAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes $(GINKGONODES) -debug $(GINKGOWHAT) $(HACK)
 
 .PHONY: ginkgo
 ginkgo:
@@ -539,6 +543,10 @@ localintegration: test-binaries ginkgo
 
 .PHONY: remoteintegration
 remoteintegration: test-binaries ginkgo-remote
+
+.PHONY: localmachine
+localmachine: test-binaries
+	$(MAKE) ginkgo-run GINKGONODES=1 GINKGOWHAT=pkg/machine/e2e/. HACK=
 
 .PHONY: localbenchmarks
 localbenchmarks: test-binaries

--- a/contrib/cirrus/cirrus_yaml_test.py
+++ b/contrib/cirrus/cirrus_yaml_test.py
@@ -26,7 +26,7 @@ class TestCaseBase(unittest.TestCase):
 class TestDependsOn(TestCaseBase):
 
     ALL_TASK_NAMES = None
-    SUCCESS_DEPS_EXCLUDE = set(['success', 'artifacts',
+    SUCCESS_DEPS_EXCLUDE = set(['success', 'artifacts', 'podman_machine',
         'test_image_build', 'release', 'release_test'])
 
     def setUp(self):

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -379,6 +379,13 @@ dotest() {
         |& logformatter
 }
 
+_run_machine() {
+    # TODO: This is a manually-triggered task, if that ever changes need to
+    # add something like:
+    # _bail_if_test_can_be_skipped docs test/e2e test/system test/python
+    make localmachine |& logformatter
+}
+
 # Optimization: will exit if the only PR diffs are under docs/ or tests/
 # with the exception of any given arguments. E.g., don't run e2e or upgrade
 # or bud tests if the only PR changes are in test/system.

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -313,6 +313,13 @@ case "$TEST_FLAVOR" in
 
         install_test_configs
         ;;
+    machine)
+        rpm -ivh $PACKAGE_DOWNLOAD_DIR/podman-gvproxy*
+        remove_packaged_podman_files
+        make install.tools
+        make install PREFIX=/usr ETCDIR=/etc
+        install_test_configs
+        ;;
     gitlab)
         # This only runs on Ubuntu for now
         if [[ "$OS_RELEASE_ID" != "ubuntu" ]]; then


### PR DESCRIPTION
The podman-machine integration tests are designed to execute on
bare-metal, since they perform significant work with virtual-machines.
This test is costly to run at scale, so it is limited to being manually
triggered by developers (for now).  A 'trigger' button will appear in the
task status page of the Github WebUI once all test dependencies are met.
In the Cirrus-CI WebUI, there is also a 'pre-trigger' button that may be
pressed if a developer doesn't wish to wait. Also:

* Add a `localmachine` target in the `Makefile` on the off-chance
  developers wish to execute locally.  Update the `ginkgo-run` target
  to accommodate re-use by the new `localmachine` target.
* Exclude `podman_machine` task from `success` dependency verification.
  This also involves adding an exception to `cirrus_yaml_test.py`
  otherwise it will complain loudly.
* ***NOTE:*** Inclusion of `ec2_instance` in *any* task will cause
  `hack/get_ci_vm.sh` to barf and be non-functional.  Future updates will
  be made to restore functionality.  Before then, simply comment out
  the `ec2_instance` section as a temporarily workaround.

**Example error**:

```
...
  File "/usr/share/automation/bin/cirrus-ci_env.py", line 213, in init_task_type_image
    raise ValueError(f"Invalid instance type "
ValueError: Invalid instance type (None) or image (None) for task ({'alias': 'podman_machine', 'env': {'TEST_FLAVOR': 'machine', 'PRIV_NAME': 'rootless', 'DISTRO_NV': 'fedora-36', 'VM_IMAGE_NAME': 'ami-06a41d8a81ab56afa'}})

# Finalizing get_ci_vm
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
