### PR TITLE
Fix: Use absolute path to WSL binary to create ssh keys for `machine init` on Windows (Issue #14416)

### DIFF
--- a/pkg/machine/keys.go
+++ b/pkg/machine/keys.go
@@ -59,7 +59,16 @@ func generatekeysPrefix(dir string, file string, passThru bool, prefix ...string
 	args := append([]string{}, prefix[1:]...)
 	args = append(args, sshCommand...)
 	args = append(args, file)
-	cmd := exec.Command(prefix[0], args...)
+
+	binary, err := exec.LookPath(prefix[0])
+	if err != nil {
+		return err
+	}
+	binary, err = filepath.Abs(binary)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(binary, args...)
 	cmd.Dir = dir
 	if passThru {
 		cmd.Stdin = os.Stdin


### PR DESCRIPTION
Fixes #14416 

#### Does this PR introduce a user-facing change?
Yes

```release-note
- Fix: #14416 : `machine init` fails when ran from C:\Windows\System32 on Windows
```

[NO NEW TESTS NEEDED]