### PR TITLE
Non-running containers now report statistics via the `podman stats`

### DIFF
--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -214,10 +214,6 @@ func (s *containerStats) BlockIO() string {
 }
 
 func (s *containerStats) PIDS() string {
-	if s.PIDs == 0 {
-		// If things go bazinga, return a safe value
-		return "--"
-	}
 	return fmt.Sprintf("%d", s.PIDs)
 }
 
@@ -231,7 +227,7 @@ func (s *containerStats) MemUsageBytes() string {
 
 func floatToPercentString(f float64) string {
 	strippedFloat, err := utils.RemoveScientificNotationFromFloat(f)
-	if err != nil || strippedFloat == 0 {
+	if err != nil {
 		// If things go bazinga, return a safe value
 		return "--"
 	}
@@ -239,16 +235,10 @@ func floatToPercentString(f float64) string {
 }
 
 func combineHumanValues(a, b uint64) string {
-	if a == 0 && b == 0 {
-		return "-- / --"
-	}
 	return fmt.Sprintf("%s / %s", units.HumanSize(float64(a)), units.HumanSize(float64(b)))
 }
 
 func combineBytesValues(a, b uint64) string {
-	if a == 0 && b == 0 {
-		return "-- / --"
-	}
 	return fmt.Sprintf("%s / %s", units.BytesSize(float64(a)), units.BytesSize(float64(b)))
 }
 

--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -34,8 +34,9 @@ func (c *Container) GetContainerStats(previousStats *define.ContainerStats) (*de
 		}
 	}
 
+	// returns stats with the fields' default values respective of their type
 	if c.state.State != define.ContainerStateRunning && c.state.State != define.ContainerStatePaused {
-		return stats, define.ErrCtrStateInvalid
+		return stats, nil
 	}
 
 	if previousStats == nil {

--- a/pkg/api/handlers/compat/containers_stats.go
+++ b/pkg/api/handlers/compat/containers_stats.go
@@ -44,18 +44,6 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If the container isn't running, then let's not bother and return
-	// immediately.
-	state, err := ctnr.State()
-	if err != nil {
-		utils.InternalServerError(w, err)
-		return
-	}
-	if state != define.ContainerStateRunning {
-		utils.Error(w, http.StatusConflict, define.ErrCtrStateInvalid)
-		return
-	}
-
 	stats, err := ctnr.GetContainerStats(nil)
 	if err != nil {
 		utils.InternalServerError(w, errors.Wrapf(err, "failed to obtain Container %s stats", name))

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Podman pause", func() {
 		// check we can read stats for a paused container
 		result = podmanTest.Podman([]string{"stats", "--no-stream", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result).To(ExitWithError())
+		Expect(result).Should(Exit(0))
 	})
 
 	It("podman pause a running container by id", func() {

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -236,4 +236,15 @@ var _ = Describe("Podman stats", func() {
 
 		Expect(customLimit).To(BeNumerically("<", defaultLimit))
 	})
+
+	It("podman stats with a container that is not running", func() {
+		ctr := "created_container"
+		session := podmanTest.Podman([]string{"create", "--name", ctr, ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"stats", "--no-stream", ctr})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+	})
 })


### PR DESCRIPTION
command

Previously, if a container was not running, and the user ran the `podman
stats` command, an error would be reported: 
```
Error: container state improper
```

Podman now reports stats as the fields' default values for their
respective type if the container is not running:

```
$ podman stats --no-stream demo

ID            NAME        CPU %       MEM USAGE / LIMIT  MEM %       NET IO      BLOCK IO    PIDS        CPU TIME    AVG CPU %
4b4bf8ce84ed  demo        0.00%       0B / 0B            0.00%       0B / 0B     0B / 0B     0           0s          0.00%
```

Closes: #14498

Signed-off-by: Jake Correnti <jcorrenti13@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where using the `podman stats` command on a non-running container would return an error instead of zeroed values
```
