### PR TITLE
buildah-bud tests: add arg sanity check

### DIFF
--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -61,7 +61,12 @@ function _skip() {
     local skip=$1;   shift
     local reason=$1; shift
 
-    # All further arguments are test names
+    # All further arguments are test names. Make sure we're invoked with some!
+    if [[ -z "$*" ]]; then
+        echo "$ME: FATAL: Invalid use of '${FUNCNAME[1]}' at line ${BASH_LINENO[1]}: missing test-name argument(s)." >&2
+        exit 1
+    fi
+
     for t in "$@"; do
         if fgrep -qx "@test \"$t\" {" $BUD; then
             $ECHO "@test \"$t\" : $skip \"$reason\""


### PR DESCRIPTION
Fix bad design decision (mine) by adding a simple usage check to 'skip'
and 'skip_if_remote' functions: if invoked without test-name args,
fail loudly and immediately.

Background: yeah, their usage is not intuitive. Making the first arg
be a comment helps with _reading_ the code, but not _writing_ new
additions. A developer in a hurry could write "skip this-test" and,
until now, that would be a silent NOP.

Tested by adding broken skip/skip_if_remote calls inline; I confirm
that the line number and funcname usage is correct.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```