### PR TITLE
container: do not create .containerenv with -v SRC:/run

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2249,8 +2249,19 @@ func (c *Container) makeBindMounts() error {
 		}
 	}
 
+	_, hasRunContainerenv := c.state.BindMounts["/run/.containerenv"]
+	if !hasRunContainerenv {
+		// check in the spec mounts
+		for _, m := range c.config.Spec.Mounts {
+			if m.Destination == "/run/.containerenv" || m.Destination == "/run" {
+				hasRunContainerenv = true
+				break
+			}
+		}
+	}
+
 	// Make .containerenv if it does not exist
-	if _, ok := c.state.BindMounts["/run/.containerenv"]; !ok {
+	if !hasRunContainerenv {
 		containerenv := c.runtime.graphRootMountedFlag(c.config.Spec.Mounts)
 		isRootless := 0
 		if rootless.IsRootless() {

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -908,6 +908,20 @@ USER testuser`, fedoraMinimal)
 		Expect(session.OutputToString()).To(Equal(perms))
 	})
 
+	It("podman run with -v $SRC:/run does not create /run/.containerenv", func() {
+		mountSrc := filepath.Join(podmanTest.TempDir, "vol-test1")
+		err := os.MkdirAll(mountSrc, 0755)
+		Expect(err).To(BeNil())
+
+		session := podmanTest.Podman([]string{"run", "-v", mountSrc + ":/run", ALPINE, "true"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		// the file should not have been created
+		_, err = os.Stat(filepath.Join(mountSrc, ".containerenv"))
+		Expect(err).To(Not(BeNil()))
+	})
+
 	It("podman volume with uid and gid works", func() {
 		volName := "testVol"
 		volCreate := podmanTest.Podman([]string{"volume", "create", "--opt", "o=uid=1000", volName})


### PR DESCRIPTION
if /run is on a volume do not create the file /run/.containerenv as it
would leak outside of the container.

Closes: https://github.com/containers/podman/issues/14577

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
If /run is on a volume then the file `/run/.containerenv` is not created automatically anymore
```
