### PR TITLE
golangci-lint: add systemd build tag

### DIFF
--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -4,10 +4,9 @@
 set -e
 
 declare -A BUILD_TAGS
-# TODO: add systemd tag
 BUILD_TAGS[default]="apparmor,seccomp,selinux,linter"
-BUILD_TAGS[abi]="${BUILD_TAGS[default]},!remoteclient"
-BUILD_TAGS[tunnel]="${BUILD_TAGS[default]},remote,remoteclient"
+BUILD_TAGS[abi]="${BUILD_TAGS[default]},systemd"
+BUILD_TAGS[tunnel]="${BUILD_TAGS[default]},remote"
 
 declare -A SKIP_DIRS
 SKIP_DIRS[abi]="pkg/machine/e2e"

--- a/libpod/container_log_linux.go
+++ b/libpod/container_log_linux.go
@@ -292,11 +292,12 @@ func formatterPrefix(entry *sdjournal.JournalEntry) (string, error) {
 	if !ok {
 		return "", errors.Errorf("no PRIORITY field present in journal entry")
 	}
-	if priority == journaldLogOut {
+	switch priority {
+	case journaldLogOut:
 		output += "stdout "
-	} else if priority == journaldLogErr {
+	case journaldLogErr:
 		output += "stderr "
-	} else {
+	default:
 		return "", errors.Errorf("unexpected PRIORITY field in journal entry")
 	}
 

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -64,7 +64,7 @@ func (e EventJournalD) Write(ee Event) error {
 	case Volume:
 		m["PODMAN_NAME"] = ee.Name
 	}
-	return journal.Send(string(ee.ToHumanReadable(false)), journal.PriInfo, m)
+	return journal.Send(ee.ToHumanReadable(false), journal.PriInfo, m)
 }
 
 // Read reads events from the journal and sends qualified events to the event channel
@@ -167,7 +167,6 @@ func (e EventJournalD) Read(ctx context.Context, options ReadOptions) error {
 		}
 	}
 	return nil
-
 }
 
 func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) { //nolint


### PR DESCRIPTION
Lint the systemd code and fix the reported problems.
The remoteclient tag is no longer used so I just removed it.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
