### PR TITLE
golangci-lint: enable nolintlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,6 @@ linters:
   enable-all: true
   disable:
     # All these break for one reason or another
-    - nolintlint # some linter must be disabled (see `nolint` in the code)
     - tagliatelle # too many JSON keys cannot be changed due to compat
     - gocognit
     - testpackage
@@ -64,3 +63,6 @@ linters-settings:
   errcheck:
     check-blank: false
     ignore: fmt:.*
+  nolintlint:
+    allow-leading-space: false
+    require-specific: true

--- a/cmd/podman/common/completion_test.go
+++ b/cmd/podman/common/completion_test.go
@@ -50,7 +50,7 @@ func (c *Car) Color() string {
 }
 
 // This is for reflect testing required.
-// nolint:unused
+//nolint:unused
 func (c Car) internal() int {
 	return 0
 }

--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -454,7 +454,7 @@ func resolvePathOnDestinationContainer(container string, containerPath string, i
 	containerInfo, err = registry.ContainerEngine().ContainerStat(registry.GetContext(), container, containerPath)
 	if err == nil {
 		baseName = filepath.Base(containerInfo.LinkTarget)
-		return // nolint: nilerr
+		return //nolint: nilerr
 	}
 
 	if strings.HasSuffix(containerPath, "/") {

--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -244,10 +244,10 @@ func combineBytesValues(a, b uint64) string {
 
 func outputJSON(stats []containerStats) error {
 	type jstat struct {
-		Id         string `json:"id"` // nolint
+		Id         string `json:"id"` //nolint:revive,stylecheck
 		Name       string `json:"name"`
 		CPUTime    string `json:"cpu_time"`
-		CpuPercent string `json:"cpu_percent"` // nolint
+		CpuPercent string `json:"cpu_percent"` //nolint:revive,stylecheck
 		AverageCPU string `json:"avg_cpu"`
 		MemUsage   string `json:"mem_usage"`
 		MemPerc    string `json:"mem_percent"`

--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -93,7 +93,7 @@ func newInspector(options entities.InspectOptions) (*inspector, error) {
 // inspect inspects the specified container/image names or IDs.
 func (i *inspector) inspect(namesOrIDs []string) error {
 	// data - dumping place for inspection results.
-	var data []interface{} // nolint
+	var data []interface{}
 	var errs []error
 	ctx := context.Background()
 
@@ -249,7 +249,7 @@ func printTmpl(typ, row string, data []interface{}) error {
 }
 
 func (i *inspector) inspectAll(ctx context.Context, namesOrIDs []string) ([]interface{}, []error, error) {
-	var data []interface{} // nolint
+	var data []interface{}
 	allErrs := []error{}
 	for _, name := range namesOrIDs {
 		ctrData, errs, err := i.containerEngine.ContainerInspect(ctx, []string{name}, i.options)

--- a/cmd/podman/parse/net.go
+++ b/cmd/podman/parse/net.go
@@ -1,4 +1,3 @@
-// nolint
 // most of these validate and parse functions have been taken from projectatomic/docker
 // and modified for cri-o
 package parse
@@ -16,25 +15,9 @@ import (
 )
 
 const (
-	Protocol_TCP Protocol = 0
-	Protocol_UDP Protocol = 1
-	LabelType    string   = "label"
-	ENVType      string   = "env"
+	LabelType string = "label"
+	ENVType   string = "env"
 )
-
-type Protocol int32
-
-// PortMapping specifies the port mapping configurations of a sandbox.
-type PortMapping struct {
-	// Protocol of the port mapping.
-	Protocol Protocol `protobuf:"varint,1,opt,name=protocol,proto3,enum=runtime.Protocol" json:"protocol,omitempty"`
-	// Port number within the container. Default: 0 (not specified).
-	ContainerPort int32 `protobuf:"varint,2,opt,name=container_port,json=containerPort,proto3" json:"container_port,omitempty"`
-	// Port number on the host. Default: 0 (not specified).
-	HostPort int32 `protobuf:"varint,3,opt,name=host_port,json=hostPort,proto3" json:"host_port,omitempty"`
-	// Host IP.
-	HostIp string `protobuf:"bytes,4,opt,name=host_ip,json=hostIp,proto3" json:"host_ip,omitempty"`
-}
 
 // Note: for flags that are in the form <number><unit>, use the RAMInBytes function
 // from the units package in docker/go-units/size.go
@@ -48,7 +31,7 @@ var (
 // validateExtraHost validates that the specified string is a valid extrahost and returns it.
 // ExtraHost is in the form of name:ip where the ip has to be a valid ip (ipv4 or ipv6).
 // for add-host flag
-func ValidateExtraHost(val string) (string, error) { // nolint
+func ValidateExtraHost(val string) (string, error) {
 	// allow for IPv6 addresses in extra hosts by only splitting on first ":"
 	arr := strings.SplitN(val, ":", 2)
 	if len(arr) != 2 || len(arr[0]) == 0 {

--- a/cmd/podman/parse/net_test.go
+++ b/cmd/podman/parse/net_test.go
@@ -1,4 +1,3 @@
-// nolint
 // most of these validate and parse functions have been taken from projectatomic/docker
 // and modified for cri-o
 package parse
@@ -23,7 +22,6 @@ func createTmpFile(content []byte) (string, error) {
 
 	if _, err := tmpfile.Write(content); err != nil {
 		return "", err
-
 	}
 	if err := tmpfile.Close(); err != nil {
 		return "", err

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -211,7 +211,7 @@ func (l ListPodReporter) ID() string {
 }
 
 // Id returns the Pod id
-func (l ListPodReporter) Id() string { // nolint
+func (l ListPodReporter) Id() string { //nolint:revive,stylecheck
 	if noTrunc {
 		return l.ListPodsReport.Id
 	}
@@ -225,7 +225,7 @@ func (l ListPodReporter) InfraID() string {
 
 // InfraId returns the infra container id for the pod
 // depending on trunc
-func (l ListPodReporter) InfraId() string { // nolint
+func (l ListPodReporter) InfraId() string { //nolint:revive,stylecheck
 	if len(l.ListPodsReport.InfraId) == 0 {
 		return ""
 	}

--- a/cmd/podman/system/df.go
+++ b/cmd/podman/system/df.go
@@ -150,7 +150,7 @@ func printSummary(cmd *cobra.Command, reports *entities.SystemDfReport) error {
 	return writeTemplate(rpt, hdrs, dfSummaries)
 }
 
-func printVerbose(cmd *cobra.Command, reports *entities.SystemDfReport) error { // nolint:interfacer
+func printVerbose(cmd *cobra.Command, reports *entities.SystemDfReport) error { //nolint:interfacer
 	rpt := report.New(os.Stdout, cmd.Name())
 	defer rpt.Flush()
 

--- a/cmd/podman/validate/args.go
+++ b/cmd/podman/validate/args.go
@@ -27,7 +27,7 @@ func SubCommandExists(cmd *cobra.Command, args []string) error {
 		}
 		return errors.Errorf("unrecognized command `%[1]s %[2]s`\n\nDid you mean this?\n\t%[3]s\n\nTry '%[1]s --help' for more information", cmd.CommandPath(), args[0], strings.Join(suggestions, "\n\t"))
 	}
-	cmd.Help() // nolint: errcheck
+	cmd.Help() //nolint: errcheck
 	return errors.Errorf("missing command '%[1]s COMMAND'", cmd.CommandPath())
 }
 

--- a/cmd/rootlessport/main.go
+++ b/cmd/rootlessport/main.go
@@ -226,8 +226,8 @@ outer:
 	// https://github.com/containers/podman/issues/11248
 	// Copy /dev/null to stdout and stderr to prevent SIGPIPE errors
 	if f, err := os.OpenFile("/dev/null", os.O_WRONLY, 0755); err == nil {
-		unix.Dup2(int(f.Fd()), 1) // nolint:errcheck
-		unix.Dup2(int(f.Fd()), 2) // nolint:errcheck
+		unix.Dup2(int(f.Fd()), 1) //nolint:errcheck
+		unix.Dup2(int(f.Fd()), 2) //nolint:errcheck
 		f.Close()
 	}
 	// write and close ReadyFD (convention is same as slirp4netns --ready-fd)

--- a/cmd/rootlessport/wsl_test.go
+++ b/cmd/rootlessport/wsl_test.go
@@ -20,7 +20,7 @@ type SpecData struct {
 }
 
 func TestDualStackSplit(t *testing.T) {
-	//nolint
+	//nolint:revive,stylecheck
 	const (
 		IP4_ALL = "0.0.0.0"
 		IP4__LO = "127.0.0.1"

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -79,11 +79,11 @@ type ExecConfig struct {
 type ExecSession struct {
 	// Id is the ID of the exec session.
 	// Named somewhat strangely to not conflict with ID().
-	// nolint:stylecheck,revive
+	//nolint:stylecheck,revive
 	Id string `json:"id"`
 	// ContainerId is the ID of the container this exec session belongs to.
 	// Named somewhat strangely to not conflict with ContainerID().
-	// nolint:stylecheck,revive
+	//nolint:stylecheck,revive
 	ContainerId string `json:"containerId"`
 
 	// State is the state of the exec session.

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2632,7 +2632,7 @@ func (c *Container) generateUserGroupEntry(addedGID int) (string, error) {
 
 	gid, err := strconv.ParseUint(group, 10, 32)
 	if err != nil {
-		return "", nil // nolint: nilerr
+		return "", nil //nolint: nilerr
 	}
 
 	if addedGID != 0 && addedGID == int(gid) {
@@ -2788,7 +2788,7 @@ func (c *Container) generateUserPasswdEntry(addedUID int) (string, error) {
 	// If a non numeric User, then don't generate passwd
 	uid, err := strconv.ParseUint(userspec, 10, 32)
 	if err != nil {
-		return "", nil // nolint: nilerr
+		return "", nil //nolint: nilerr
 	}
 
 	if addedUID != 0 && int(uid) == addedUID {
@@ -3213,7 +3213,7 @@ func (c *Container) fixVolumePermissions(v *ContainerNamedVolume) error {
 				return err
 			}
 			stat := st.Sys().(*syscall.Stat_t)
-			atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) // nolint: unconvert
+			atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)) //nolint: unconvert
 			if err := os.Chtimes(mountPoint, atime, st.ModTime()); err != nil {
 				return err
 			}

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -259,9 +259,7 @@ type HealthCheckLog struct {
 // as possible from the spec and container config.
 // Some things cannot be inferred. These will be populated by spec annotations
 // (if available).
-// Field names are fixed for compatibility and cannot be changed.
-// As such, silence lint warnings about them.
-//nolint
+//nolint:revive,stylecheck // Field names are fixed for compatibility and cannot be changed.
 type InspectContainerHostConfig struct {
 	// Binds contains an array of user-added mounts.
 	// Both volume mounts and named volumes are included.

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -43,8 +43,8 @@ func GenerateForKube(ctx context.Context, ctrs []*Container) (*v1.Pod, error) {
 func (p *Pod) GenerateForKube(ctx context.Context) (*v1.Pod, []v1.ServicePort, error) {
 	// Generate the v1.Pod yaml description
 	var (
-		ports        []v1.ContainerPort //nolint
-		servicePorts []v1.ServicePort   //nolint
+		ports        []v1.ContainerPort
+		servicePorts []v1.ServicePort
 	)
 
 	allContainers, err := p.allContainers()

--- a/libpod/lock/file/file_lock.go
+++ b/libpod/lock/file/file_lock.go
@@ -14,7 +14,7 @@ import (
 
 // FileLocks is a struct enabling POSIX lock locking in a shared memory
 // segment.
-type FileLocks struct { // nolint
+type FileLocks struct { //nolint:revive // struct name stutters
 	lockPath string
 	valid    bool
 }

--- a/libpod/lock/shm/shm_lock.go
+++ b/libpod/lock/shm/shm_lock.go
@@ -28,7 +28,7 @@ var (
 
 // SHMLocks is a struct enabling POSIX semaphore locking in a shared memory
 // segment.
-type SHMLocks struct { // nolint
+type SHMLocks struct {
 	lockStruct *C.shm_struct_t
 	maxLocks   uint32
 	valid      bool

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1014,7 +1014,7 @@ func (r *ConmonOCIRuntime) getLogTag(ctr *Container) (string, error) {
 	data, err := ctr.inspectLocked(false)
 	if err != nil {
 		// FIXME: this error should probably be returned
-		return "", nil // nolint: nilerr
+		return "", nil //nolint: nilerr
 	}
 	tmpl, err := template.New("container").Parse(logTag)
 	if err != nil {

--- a/libpod/plugin/volume_api.go
+++ b/libpod/plugin/volume_api.go
@@ -35,8 +35,6 @@ var (
 	hostVirtualPath = "/VolumeDriver.Path"
 	mountPath       = "/VolumeDriver.Mount"
 	unmountPath     = "/VolumeDriver.Unmount"
-	// nolint
-	capabilitiesPath = "/VolumeDriver.Capabilities"
 )
 
 const (

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -165,7 +165,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "CommitFailure"))
 		return
 	}
-	utils.WriteResponse(w, http.StatusCreated, entities.IDResponse{ID: commitImage.ID()}) // nolint
+	utils.WriteResponse(w, http.StatusCreated, entities.IDResponse{ID: commitImage.ID()})
 }
 
 func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
@@ -237,7 +237,7 @@ func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
 		Status         string            `json:"status"`
 		Progress       string            `json:"progress"`
 		ProgressDetail map[string]string `json:"progressDetail"`
-		Id             string            `json:"id"` // nolint
+		Id             string            `json:"id"` //nolint:revive,stylecheck
 	}{
 		Status:         report.Id,
 		ProgressDetail: map[string]string{},
@@ -333,7 +333,7 @@ loop: // break out of for/select infinite loop
 				Total   int64  `json:"total,omitempty"`
 			} `json:"progressDetail,omitempty"`
 			Error string `json:"error,omitempty"`
-			Id    string `json:"id,omitempty"` // nolint
+			Id    string `json:"id,omitempty"` //nolint:revive,stylecheck
 		}
 		select {
 		case e := <-progress:

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -78,15 +78,15 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		AppArmor                string   `schema:"apparmor"`
 		BuildArgs               string   `schema:"buildargs"`
 		CacheFrom               string   `schema:"cachefrom"`
-		CgroupParent            string   `schema:"cgroupparent"` // nolint
+		CgroupParent            string   `schema:"cgroupparent"`
 		Compression             uint64   `schema:"compression"`
 		ConfigureNetwork        string   `schema:"networkmode"`
 		CPPFlags                string   `schema:"cppflags"`
-		CpuPeriod               uint64   `schema:"cpuperiod"`  // nolint
-		CpuQuota                int64    `schema:"cpuquota"`   // nolint
-		CpuSetCpus              string   `schema:"cpusetcpus"` // nolint
-		CpuSetMems              string   `schema:"cpusetmems"` // nolint
-		CpuShares               uint64   `schema:"cpushares"`  // nolint
+		CpuPeriod               uint64   `schema:"cpuperiod"`  //nolint:revive,stylecheck
+		CpuQuota                int64    `schema:"cpuquota"`   //nolint:revive,stylecheck
+		CpuSetCpus              string   `schema:"cpusetcpus"` //nolint:revive,stylecheck
+		CpuSetMems              string   `schema:"cpusetmems"` //nolint:revive,stylecheck
+		CpuShares               uint64   `schema:"cpushares"`  //nolint:revive,stylecheck
 		DNSOptions              string   `schema:"dnsoptions"`
 		DNSSearch               string   `schema:"dnssearch"`
 		DNSServers              string   `schema:"dnsservers"`
@@ -101,7 +101,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		IdentityLabel           bool     `schema:"identitylabel"`
 		Ignore                  bool     `schema:"ignore"`
 		Isolation               string   `schema:"isolation"`
-		Jobs                    int      `schema:"jobs"` // nolint
+		Jobs                    int      `schema:"jobs"`
 		LabelOpts               string   `schema:"labelopts"`
 		Labels                  string   `schema:"labels"`
 		Layers                  bool     `schema:"layers"`
@@ -366,7 +366,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	var additionalTags []string // nolint
+	var additionalTags []string
 	for i := 1; i < len(tags); i++ {
 		possiblyNormalizedTag, err := utils.NormalizeToDockerHub(r, tags[i])
 		if err != nil {
@@ -799,7 +799,7 @@ func parseNetworkConfigurationPolicy(network string) buildah.NetworkConfiguratio
 	}
 }
 
-func parseLibPodIsolation(isolation string) (buildah.Isolation, error) { // nolint
+func parseLibPodIsolation(isolation string) (buildah.Isolation, error) {
 	if val, err := strconv.Atoi(isolation); err == nil {
 		return buildah.Isolation(val), nil
 	}

--- a/pkg/api/handlers/compat/images_save.go
+++ b/pkg/api/handlers/compat/images_save.go
@@ -6,7 +6,7 @@ import (
 	"os"
 )
 
-func SaveFromBody(f *os.File, r *http.Request) error { // nolint
+func SaveFromBody(f *os.File, r *http.Request) error {
 	if _, err := io.Copy(f, r.Body); err != nil {
 		return err
 	}

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -562,7 +562,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "CommitFailure"))
 		return
 	}
-	utils.WriteResponse(w, http.StatusOK, entities.IDResponse{ID: commitImage.ID()}) // nolint
+	utils.WriteResponse(w, http.StatusOK, entities.IDResponse{ID: commitImage.ID()})
 }
 
 func UntagImage(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/handlers/utils/images.go
+++ b/pkg/api/handlers/utils/images.go
@@ -68,7 +68,7 @@ func IsRegistryReference(name string) error {
 	imageRef, err := alltransports.ParseImageName(name)
 	if err != nil {
 		// No supported transport -> assume a docker-stype reference.
-		return nil // nolint: nilerr
+		return nil //nolint: nilerr
 	}
 	if imageRef.Transport().Name() == docker.Transport.Name() {
 		return nil

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -148,7 +148,7 @@ func newServer(runtime *libpod.Runtime, listener net.Listener, opts entities.Ser
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
 		// If in trace mode log request and response bodies
 		router.Use(loggingHandler())
-		router.Walk(func(route *mux.Route, r *mux.Router, ancestors []*mux.Route) error { // nolint
+		_ = router.Walk(func(route *mux.Route, r *mux.Router, ancestors []*mux.Route) error {
 			path, err := route.GetPathTemplate()
 			if err != nil {
 				path = "<N/A>"

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -315,7 +315,8 @@ func unixClient(_url *url.URL) Connection {
 	return connection
 }
 
-// DoRequest assembles the http request and returns the response
+// DoRequest assembles the http request and returns the response.
+// The caller must close the response body.
 func (c *Connection) DoRequest(ctx context.Context, httpBody io.Reader, httpMethod, endpoint string, queryParams url.Values, headers http.Header, pathValues ...string) (*APIResponse, error) {
 	var (
 		err      error
@@ -361,7 +362,7 @@ func (c *Connection) DoRequest(ctx context.Context, httpBody io.Reader, httpMeth
 
 	// Give the Do three chances in the case of a comm/service hiccup
 	for i := 1; i <= 3; i++ {
-		response, err = c.Client.Do(req) // nolint
+		response, err = c.Client.Do(req) //nolint:bodyclose // The caller has to close the body.
 		if err == nil {
 			break
 		}

--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -25,7 +25,7 @@ var (
 // the most recent number of containers.  The pod and size booleans indicate that pod information and rootfs
 // size information should also be included.  Finally, the sync bool synchronizes the OCI runtime and
 // container state.
-func List(ctx context.Context, options *ListOptions) ([]entities.ListContainer, error) { // nolint:typecheck
+func List(ctx context.Context, options *ListOptions) ([]entities.ListContainer, error) {
 	if options == nil {
 		options = new(ListOptions)
 	}
@@ -339,7 +339,7 @@ func Unpause(ctx context.Context, nameOrID string, options *UnpauseOptions) erro
 // Wait blocks until the given container reaches a condition. If not provided, the condition will
 // default to stopped.  If the condition is stopped, an exit code for the container will be provided. The
 // nameOrID can be a container name or a partial/full ID.
-func Wait(ctx context.Context, nameOrID string, options *WaitOptions) (int32, error) { // nolint
+func Wait(ctx context.Context, nameOrID string, options *WaitOptions) (int32, error) {
 	if options == nil {
 		options = new(WaitOptions)
 	}

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -616,7 +616,7 @@ func nTar(excludes []string, sources ...string) (io.ReadCloser, error) {
 				}
 				name := filepath.ToSlash(strings.TrimPrefix(path, s+string(filepath.Separator)))
 
-				excluded, err := pm.Matches(name) // nolint:staticcheck
+				excluded, err := pm.Matches(name) //nolint:staticcheck
 				if err != nil {
 					return errors.Wrapf(err, "error checking if %q is excluded", name)
 				}

--- a/pkg/bindings/images/build_unix.go
+++ b/pkg/bindings/images/build_unix.go
@@ -11,7 +11,7 @@ import (
 func checkHardLink(fi os.FileInfo) (devino, bool) {
 	st := fi.Sys().(*syscall.Stat_t)
 	return devino{
-		Dev: uint64(st.Dev), // nolint: unconvert
+		Dev: uint64(st.Dev), //nolint: unconvert
 		Ino: st.Ino,
 	}, st.Nlink > 1
 }

--- a/pkg/ctime/ctime_linux.go
+++ b/pkg/ctime/ctime_linux.go
@@ -11,6 +11,6 @@ import (
 
 func created(fi os.FileInfo) time.Time {
 	st := fi.Sys().(*syscall.Stat_t)
-	//nolint
+	//nolint:unconvert // need to type cast on some cpu architectures
 	return time.Unix(int64(st.Ctim.Sec), int64(st.Ctim.Nsec))
 }

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -56,7 +56,7 @@ type WaitOptions struct {
 }
 
 type WaitReport struct {
-	Id       string //nolint
+	Id       string //nolint:revive,stylecheck
 	Error    error
 	ExitCode int32
 }
@@ -76,7 +76,7 @@ type PauseUnPauseOptions struct {
 
 type PauseUnpauseReport struct {
 	Err error
-	Id  string //nolint
+	Id  string //nolint:revive,stylecheck
 }
 
 type StopOptions struct {
@@ -88,7 +88,7 @@ type StopOptions struct {
 
 type StopReport struct {
 	Err      error
-	Id       string //nolint
+	Id       string //nolint:revive,stylecheck
 	RawInput string
 }
 
@@ -110,7 +110,7 @@ type KillOptions struct {
 
 type KillReport struct {
 	Err      error
-	Id       string //nolint
+	Id       string //nolint:revive,stylecheck
 	RawInput string
 }
 
@@ -123,7 +123,7 @@ type RestartOptions struct {
 
 type RestartReport struct {
 	Err error
-	Id  string //nolint
+	Id  string //nolint:revive,stylecheck
 }
 
 type RmOptions struct {
@@ -170,7 +170,7 @@ type CopyOptions struct {
 }
 
 type CommitReport struct {
-	Id string //nolint
+	Id string //nolint:revive,stylecheck
 }
 
 type ContainerExportOptions struct {
@@ -196,7 +196,7 @@ type CheckpointOptions struct {
 
 type CheckpointReport struct {
 	Err             error                                   `json:"-"`
-	Id              string                                  `json:"Id` //nolint
+	Id              string                                  `json:"Id"` //nolint:revive,stylecheck
 	RuntimeDuration int64                                   `json:"runtime_checkpoint_duration"`
 	CRIUStatistics  *define.CRIUCheckpointRestoreStatistics `json:"criu_statistics"`
 }
@@ -222,13 +222,13 @@ type RestoreOptions struct {
 
 type RestoreReport struct {
 	Err             error                                   `json:"-"`
-	Id              string                                  `json:"Id` //nolint
+	Id              string                                  `json:"Id"` //nolint:revive,stylecheck
 	RuntimeDuration int64                                   `json:"runtime_restore_duration"`
 	CRIUStatistics  *define.CRIUCheckpointRestoreStatistics `json:"criu_statistics"`
 }
 
 type ContainerCreateReport struct {
-	Id string //nolint
+	Id string //nolint:revive,stylecheck
 }
 
 // AttachOptions describes the cli and other values
@@ -307,7 +307,7 @@ type ContainerStartOptions struct {
 // ContainerStartReport describes the response from starting
 // containers from the cli
 type ContainerStartReport struct {
-	Id       string //nolint
+	Id       string //nolint:revive,stylecheck
 	RawInput string
 	Err      error
 	ExitCode int
@@ -351,7 +351,7 @@ type ContainerRunOptions struct {
 // a container
 type ContainerRunReport struct {
 	ExitCode int
-	Id       string //nolint
+	Id       string //nolint:revive,stylecheck
 }
 
 // ContainerCleanupOptions are the CLI values for the
@@ -368,7 +368,7 @@ type ContainerCleanupOptions struct {
 // container cleanup
 type ContainerCleanupReport struct {
 	CleanErr error
-	Id       string //nolint
+	Id       string //nolint:revive,stylecheck
 	RmErr    error
 	RmiErr   error
 }
@@ -384,7 +384,7 @@ type ContainerInitOptions struct {
 // container init
 type ContainerInitReport struct {
 	Err error
-	Id  string //nolint
+	Id  string //nolint:revive,stylecheck
 }
 
 // ContainerMountOptions describes the input values for mounting containers
@@ -406,7 +406,7 @@ type ContainerUnmountOptions struct {
 // ContainerMountReport describes the response from container mount
 type ContainerMountReport struct {
 	Err  error
-	Id   string //nolint
+	Id   string //nolint:revive,stylecheck
 	Name string
 	Path string
 }
@@ -414,7 +414,7 @@ type ContainerMountReport struct {
 // ContainerUnmountReport describes the response from umounting a container
 type ContainerUnmountReport struct {
 	Err error
-	Id  string //nolint
+	Id  string //nolint:revive,stylecheck
 }
 
 // ContainerPruneOptions describes the options needed
@@ -433,7 +433,7 @@ type ContainerPortOptions struct {
 // ContainerPortReport describes the output needed for
 // the CLI to output ports
 type ContainerPortReport struct {
-	Id    string //nolint
+	Id    string //nolint:revive,stylecheck
 	Ports []nettypes.PortMapping
 }
 

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -46,14 +46,14 @@ type Image struct {
 	HealthCheck   *manifest.Schema2HealthConfig `json:",omitempty"`
 }
 
-func (i *Image) Id() string { // nolint
+func (i *Image) Id() string { //nolint:revive,stylecheck
 	return i.ID
 }
 
 // swagger:model LibpodImageSummary
 type ImageSummary struct {
 	ID          string `json:"Id"`
-	ParentId    string // nolint
+	ParentId    string //nolint:revive,stylecheck
 	RepoTags    []string
 	RepoDigests []string
 	Created     int64
@@ -71,7 +71,7 @@ type ImageSummary struct {
 	History []string `json:",omitempty"`
 }
 
-func (i *ImageSummary) Id() string { // nolint
+func (i *ImageSummary) Id() string { //nolint:revive,stylecheck
 	return i.ID
 }
 
@@ -290,7 +290,7 @@ type ImageImportOptions struct {
 }
 
 type ImageImportReport struct {
-	Id string // nolint
+	Id string //nolint:revive,stylecheck
 }
 
 // ImageSaveOptions provide options for saving images.
@@ -397,7 +397,7 @@ type ImageUnmountOptions struct {
 
 // ImageMountReport describes the response from image mount
 type ImageMountReport struct {
-	Id           string // nolint
+	Id           string //nolint:revive,stylecheck
 	Name         string
 	Repositories []string
 	Path         string
@@ -406,5 +406,5 @@ type ImageMountReport struct {
 // ImageUnmountReport describes the response from umounting an image
 type ImageUnmountReport struct {
 	Err error
-	Id  string // nolint
+	Id  string //nolint:revive,stylecheck
 }

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -22,7 +22,7 @@ type NetworkReloadOptions struct {
 
 // NetworkReloadReport describes the results of reloading a container network.
 type NetworkReloadReport struct {
-	// nolint:stylecheck,revive
+	//nolint:stylecheck,revive
 	Id  string
 	Err error
 }

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -20,15 +20,15 @@ type PodKillOptions struct {
 
 type PodKillReport struct {
 	Errs []error
-	Id   string // nolint
+	Id   string //nolint:revive,stylecheck
 }
 
 type ListPodsReport struct {
 	Cgroup     string
 	Containers []*ListPodContainer
 	Created    time.Time
-	Id         string // nolint
-	InfraId    string // nolint
+	Id         string //nolint:revive,stylecheck
+	InfraId    string //nolint:revive,stylecheck
 	Name       string
 	Namespace  string
 	// Network names connected to infra container
@@ -38,7 +38,7 @@ type ListPodsReport struct {
 }
 
 type ListPodContainer struct {
-	Id     string // nolint
+	Id     string //nolint:revive,stylecheck
 	Names  string
 	Status string
 }
@@ -50,7 +50,7 @@ type PodPauseOptions struct {
 
 type PodPauseReport struct {
 	Errs []error
-	Id   string // nolint
+	Id   string //nolint:revive,stylecheck
 }
 
 type PodunpauseOptions struct {
@@ -60,7 +60,7 @@ type PodunpauseOptions struct {
 
 type PodUnpauseReport struct {
 	Errs []error
-	Id   string // nolint
+	Id   string //nolint:revive,stylecheck
 }
 
 type PodStopOptions struct {
@@ -72,7 +72,7 @@ type PodStopOptions struct {
 
 type PodStopReport struct {
 	Errs []error
-	Id   string // nolint
+	Id   string //nolint:revive,stylecheck
 }
 
 type PodRestartOptions struct {
@@ -82,7 +82,7 @@ type PodRestartOptions struct {
 
 type PodRestartReport struct {
 	Errs []error
-	Id   string // nolint
+	Id   string //nolint:revive,stylecheck
 }
 
 type PodStartOptions struct {
@@ -92,7 +92,7 @@ type PodStartOptions struct {
 
 type PodStartReport struct {
 	Errs []error
-	Id   string // nolint
+	Id   string //nolint:revive,stylecheck
 }
 
 type PodRmOptions struct {
@@ -105,7 +105,7 @@ type PodRmOptions struct {
 
 type PodRmReport struct {
 	Err error
-	Id  string // nolint
+	Id  string //nolint:revive,stylecheck
 }
 
 // PddSpec is an abstracted version of PodSpecGen designed to eventually accept options
@@ -287,7 +287,7 @@ func NewInfraContainerCreateOptions() ContainerCreateOptions {
 }
 
 type PodCreateReport struct {
-	Id string // nolint
+	Id string //nolint:revive,stylecheck
 }
 
 func (p *PodCreateOptions) CPULimits() *specs.LinuxCPU {
@@ -389,7 +389,7 @@ type PodPruneOptions struct {
 
 type PodPruneReport struct {
 	Err error
-	Id  string // nolint
+	Id  string //nolint:revive,stylecheck
 }
 
 type PodTopOptions struct {

--- a/pkg/domain/entities/reports/containers.go
+++ b/pkg/domain/entities/reports/containers.go
@@ -1,7 +1,7 @@
 package reports
 
 type RmReport struct {
-	Id  string `json:"Id"` //nolint
+	Id  string `json:"Id"` //nolint:revive,stylecheck
 	Err error  `json:"Err,omitempty"`
 }
 

--- a/pkg/domain/entities/reports/prune.go
+++ b/pkg/domain/entities/reports/prune.go
@@ -1,7 +1,7 @@
 package reports
 
 type PruneReport struct {
-	Id   string `json:"Id"` //nolint
+	Id   string `json:"Id"` //nolint:revive,stylecheck
 	Err  error  `json:"Err,omitempty"`
 	Size uint64 `json:"Size"`
 }

--- a/pkg/domain/entities/types.go
+++ b/pkg/domain/entities/types.go
@@ -21,7 +21,7 @@ type Volume struct {
 }
 
 type Report struct {
-	Id  []string // nolint
+	Id  []string //nolint:revive,stylecheck
 	Err map[string]error
 }
 

--- a/pkg/domain/entities/volumes.go
+++ b/pkg/domain/entities/volumes.go
@@ -33,7 +33,7 @@ type VolumeRmOptions struct {
 
 type VolumeRmReport struct {
 	Err error
-	Id  string // nolint
+	Id  string //nolint:revive,stylecheck
 }
 
 type VolumeInspectReport struct {
@@ -61,7 +61,7 @@ type VolumeListReport struct {
 // VolumeMountReport describes the response from volume mount
 type VolumeMountReport struct {
 	Err  error
-	Id   string // nolint
+	Id   string //nolint:revive,stylecheck
 	Name string
 	Path string
 }
@@ -69,5 +69,5 @@ type VolumeMountReport struct {
 // VolumeUnmountReport describes the response from umounting a volume
 type VolumeUnmountReport struct {
 	Err error
-	Id  string // nolint
+	Id  string //nolint:revive,stylecheck
 }

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -593,7 +593,7 @@ func (ir *ImageEngine) Remove(ctx context.Context, images []string, opts entitie
 
 	rmErrors = libimageErrors
 
-	return //nolint
+	return
 }
 
 // Shutdown Libpod engine

--- a/pkg/domain/infra/abi/terminal/sigproxy_linux.go
+++ b/pkg/domain/infra/abi/terminal/sigproxy_linux.go
@@ -20,7 +20,7 @@ const signalBufferSize = 2048
 func ProxySignals(ctr *libpod.Container) {
 	// Stop catching the shutdown signals (SIGINT, SIGTERM) - they're going
 	// to the container now.
-	shutdown.Stop() // nolint: errcheck
+	shutdown.Stop() //nolint: errcheck
 
 	sigBuffer := make(chan os.Signal, signalBufferSize)
 	signal.CatchAll(sigBuffer)

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -172,7 +172,7 @@ func (ic *ContainerEngine) VolumeMounted(ctx context.Context, nameOrID string) (
 	mountCount, err := vol.MountCount()
 	if err != nil {
 		// FIXME: this error should probably be returned
-		return &entities.BoolReport{Value: false}, nil // nolint: nilerr
+		return &entities.BoolReport{Value: false}, nil //nolint: nilerr
 	}
 	if mountCount > 0 {
 		return &entities.BoolReport{Value: true}, nil

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -570,7 +570,7 @@ func (ic *ContainerEngine) ContainerExecDetached(ctx context.Context, nameOrID s
 	return sessionID, nil
 }
 
-func startAndAttach(ic *ContainerEngine, name string, detachKeys *string, input, output, errput *os.File) error { //nolint
+func startAndAttach(ic *ContainerEngine, name string, detachKeys *string, input, output, errput *os.File) error {
 	attachErr := make(chan error)
 	attachReady := make(chan bool)
 	options := new(containers.AttachOptions).WithStream(true)
@@ -863,7 +863,7 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 	if eventsErr != nil || lastEvent == nil {
 		logrus.Errorf("Cannot get exit code: %v", err)
 		report.ExitCode = define.ExecErrorCodeNotFound
-		return &report, nil // nolint: nilerr
+		return &report, nil //nolint: nilerr
 	}
 
 	report.ExitCode = lastEvent.ContainerExitCode

--- a/pkg/errorhandling/errorhandling.go
+++ b/pkg/errorhandling/errorhandling.go
@@ -86,7 +86,7 @@ func Contains(err error, sub error) bool {
 // PodConflictErrorModel is used in remote connections with podman
 type PodConflictErrorModel struct {
 	Errs []string
-	Id   string // nolint
+	Id   string //nolint:revive,stylecheck
 }
 
 // ErrorModel is used in remote connections with podman

--- a/pkg/hooks/exec/runtimeconfigfilter_test.go
+++ b/pkg/hooks/exec/runtimeconfigfilter_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestRuntimeConfigFilter(t *testing.T) {
-	unexpectedEndOfJSONInput := json.Unmarshal([]byte("{\n"), nil) //nolint
+	unexpectedEndOfJSONInput := json.Unmarshal([]byte("{\n"), nil) //nolint:govet // this should force the error
 	fileMode := os.FileMode(0600)
 	rootUint32 := uint32(0)
 	binUser := int(1)

--- a/pkg/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/pkg/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -138,7 +138,6 @@ const (
 
 var (
 	// Errors that could happen while parsing a string.
-	//nolint:revive
 	ErrFormatWrong = errors.New("quantities must match the regular expression '" + splitREString + "'")
 	ErrNumeric     = errors.New("unable to parse numeric part of quantity")
 	ErrSuffix      = errors.New("unable to parse quantity's suffix")
@@ -258,7 +257,7 @@ Suffix:
 	// we encountered a non decimal in the Suffix loop, but the last character
 	// was not a valid exponent
 	err = ErrFormatWrong
-	// nolint:nakedret
+	//nolint:nakedret
 	return
 }
 
@@ -579,9 +578,9 @@ func (q Quantity) MarshalJSON() ([]byte, error) {
 	// if CanonicalizeBytes needed more space than our slice provided, we may need to allocate again so use
 	// append
 	result = result[:1]
-	result = append(result, number...) // nolint: makezero
-	result = append(result, suffix...) // nolint: makezero
-	result = append(result, '"')       // nolint: makezero
+	result = append(result, number...) //nolint: makezero
+	result = append(result, suffix...) //nolint: makezero
+	result = append(result, '"')       //nolint: makezero
 	return result, nil
 }
 

--- a/pkg/machine/fcos.go
+++ b/pkg/machine/fcos.go
@@ -139,7 +139,7 @@ func getStreamURL(streamType string) url2.URL {
 
 // This should get Exported and stay put as it will apply to all fcos downloads
 // getFCOS parses fedoraCoreOS's stream and returns the image download URL and the release version
-func GetFCOSDownload(imageStream string) (*FcosDownloadInfo, error) { //nolint:staticcheck
+func GetFCOSDownload(imageStream string) (*FcosDownloadInfo, error) {
 	var (
 		fcosstable stream.Stream
 		altMeta    release.Release

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -770,7 +770,7 @@ func (v *MachineVM) Stop(_ string, _ machine.StopOptions) error {
 
 	if err := qmpMonitor.Disconnect(); err != nil {
 		// FIXME: this error should probably be returned
-		return nil // nolint: nilerr
+		return nil //nolint: nilerr
 	}
 
 	disconnected = true

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -50,7 +50,7 @@ func TryJoinPauseProcess(pausePidPath string) (bool, int, error) {
 	if err != nil {
 		// It is still failing.  We can safely remove it.
 		os.Remove(pausePidPath)
-		return false, -1, nil // nolint: nilerr
+		return false, -1, nil //nolint: nilerr
 	}
 	return became, ret, err
 }

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -164,7 +164,7 @@ func addDevice(g *generate.Generator, device string) error {
 }
 
 // ParseDevice parses device mapping string to a src, dest & permissions string
-func ParseDevice(device string) (string, string, string, error) { //nolint
+func ParseDevice(device string) (string, string, string, error) {
 	var src string
 	var dst string
 	permissions := "rwm"

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -303,8 +303,8 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) // nolint: unconvert
-			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) // nolint: unconvert
+			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) //nolint: unconvert
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) //nolint: unconvert
 			if s.ResourceLimits.BlockIO == nil {
 				s.ResourceLimits.BlockIO = new(spec.LinuxBlockIO)
 			}
@@ -317,8 +317,8 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) // nolint: unconvert
-			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) // nolint: unconvert
+			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) //nolint: unconvert
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) //nolint: unconvert
 			s.ResourceLimits.BlockIO.ThrottleWriteBpsDevice = append(s.ResourceLimits.BlockIO.ThrottleWriteBpsDevice, v)
 		}
 	}
@@ -328,8 +328,8 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) // nolint: unconvert
-			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) // nolint: unconvert
+			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) //nolint: unconvert
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) //nolint: unconvert
 			s.ResourceLimits.BlockIO.ThrottleReadIOPSDevice = append(s.ResourceLimits.BlockIO.ThrottleReadIOPSDevice, v)
 		}
 	}
@@ -339,8 +339,8 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 			if err := unix.Stat(k, &statT); err != nil {
 				return err
 			}
-			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) // nolint: unconvert
-			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) // nolint: unconvert
+			v.Major = (int64(unix.Major(uint64(statT.Rdev)))) //nolint: unconvert
+			v.Minor = (int64(unix.Minor(uint64(statT.Rdev)))) //nolint: unconvert
 			s.ResourceLimits.BlockIO.ThrottleWriteIOPSDevice = append(s.ResourceLimits.BlockIO.ThrottleWriteIOPSDevice, v)
 		}
 	}

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -371,7 +371,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 		if err := unix.Stat(k, &statT); err != nil {
 			return nil, errors.Wrapf(err, "failed to inspect '%s' in --blkio-weight-device", k)
 		}
-		g.AddLinuxResourcesBlockIOWeightDevice((int64(unix.Major(uint64(statT.Rdev)))), (int64(unix.Minor(uint64(statT.Rdev)))), *v.Weight) // nolint: unconvert
+		g.AddLinuxResourcesBlockIOWeightDevice((int64(unix.Major(uint64(statT.Rdev)))), (int64(unix.Minor(uint64(statT.Rdev)))), *v.Weight) //nolint: unconvert
 	}
 
 	BlockAccessToKernelFilesystems(s.Privileged, s.PidNS.IsHost(), s.Mask, s.Unmask, &g)

--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -176,7 +176,7 @@ func DeviceFromPath(path string) (*spec.LinuxDevice, error) {
 	var (
 		devType   string
 		mode      = stat.Mode
-		devNumber = uint64(stat.Rdev) // nolint: unconvert
+		devNumber = uint64(stat.Rdev) //nolint: unconvert
 		m         = os.FileMode(mode)
 	)
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -41,7 +41,7 @@ var (
 	CGROUP_MANAGER     = "systemd"                   //nolint:revive,stylecheck
 	RESTORE_IMAGES     = []string{ALPINE, BB, nginx} //nolint:revive,stylecheck
 	defaultWaitTimeout = 90
-	CGROUPSV2, _       = cgroups.IsCgroup2UnifiedMode() //nolint:revive,stylecheck
+	CGROUPSV2, _       = cgroups.IsCgroup2UnifiedMode()
 )
 
 // PodmanTestIntegration struct for command line options


### PR DESCRIPTION
The nolintlint linter does not deny the use of `//nolint`
Instead it allows us to enforce a common nolint style:
- force that a linter name must be specified
- do not add a space between `//` and `nolint`
- make sure nolint is only used when there is actually a problem


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
