### PR TITLE
Use Regexp in volume ls --filter name

### DIFF
--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -2,6 +2,7 @@ package filters
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/containers/podman/v4/libpod"
@@ -15,9 +16,12 @@ func GenerateVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, error) {
 		for _, val := range v {
 			switch filter {
 			case "name":
-				nameVal := val
+				nameRegexp, err := regexp.Compile(val)
+				if err != nil {
+					return nil, err
+				}
 				vf = append(vf, func(v *libpod.Volume) bool {
-					return nameVal == v.Name()
+					return nameRegexp.MatchString(v.Name())
 				})
 			case "driver":
 				driverVal := val

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -152,6 +152,37 @@ var _ = Describe("Podman volume ls", func() {
 		Expect(lsDangling).Should(Exit(0))
 		Expect(lsDangling.OutputToString()).To(ContainSubstring(volName1))
 	})
+
+	It("podman ls volume with --filter name", func() {
+		volName1 := "volume1"
+		session := podmanTest.Podman([]string{"volume", "create", volName1})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		volName2 := "volume2"
+		session2 := podmanTest.Podman([]string{"volume", "create", volName2})
+		session2.WaitWithDefaultTimeout()
+		Expect(session2).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "name=volume1*"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToStringArray()).To(HaveLen(3))
+		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName1))
+		Expect(session.OutputToStringArray()[2]).To(ContainSubstring(volName2))
+
+		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "name=volumex"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToStringArray()).To(BeEmpty())
+
+		session = podmanTest.Podman([]string{"volume", "ls", "--filter", "name=volume1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToStringArray()).To(HaveLen(2))
+		Expect(session.OutputToStringArray()[1]).To(ContainSubstring(volName1))
+	})
+
 	It("podman ls volume with multiple --filter flag", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--label", "foo=bar", "myvol"})
 		volName := session.OutputToString()

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -64,6 +64,29 @@ function teardown() {
 }
 
 
+# Filter volumes by name
+@test "podman volume filter --name" {
+    suffix=$(random_string)
+    prefix="volume"
+
+    for i in 1 2; do
+        myvolume=${prefix}_${i}_${suffix}
+        run_podman volume create $myvolume
+        is "$output" "$myvolume" "output from volume create $i"
+    done
+
+    run_podman volume ls --filter name=${prefix}_1.+ --format "{{.Name}}"
+    is "$output" "${prefix}_1_${suffix}" "--filter name=${prefix}_1.+ shows only one volume"
+
+    # The _1* is intentional as asterisk has different meaning in glob and regexp. Make sure this is regexp
+    run_podman volume ls --filter name=${prefix}_1* --format "{{.Name}}"
+    is "$output" "${prefix}_1_${suffix}.*${prefix}_2_${suffix}.*" "--filter name=${prefix}_1* shows ${prefix}_1_${suffix} and ${prefix}_2_${suffix}"
+
+    for i in 1 2; do
+        run_podman volume rm ${prefix}_${i}_${suffix}
+    done
+}
+
 # Named volumes
 @test "podman volume create / run" {
     myvolume=myvol$(random_string)


### PR DESCRIPTION
closes #14583  
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added Regexp support to filtering volumes by name
```
