### PR TITLE
systemd socket activation: check listener to prevent panic

### DIFF
--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -46,6 +46,10 @@ func restService(flags *pflag.FlagSet, cfg *entities.PodmanConfig, opts entities
 			return fmt.Errorf("wrong number of file descriptors for socket activation protocol (%d != 1)", len(listeners))
 		}
 		listener = listeners[0]
+		// note that activation.Listeners() returns nil when it cannot listen on the fd (i.e. udp connection)
+		if listener == nil {
+			return fmt.Errorf("unexpected fd received from systemd: cannot listen on it")
+		}
 		libpodRuntime.SetRemoteURI(listeners[0].Addr().String())
 	} else {
 		uri, err := url.Parse(opts.URI)

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -169,7 +169,7 @@ func (e EventJournalD) Read(ctx context.Context, options ReadOptions) error {
 	return nil
 }
 
-func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) { //nolint
+func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) {
 	newEvent := Event{}
 	eventType, err := StringToType(entry.Fields["PODMAN_TYPE"])
 	if err != nil {


### PR DESCRIPTION
Commit 5fa6f686db added a regression which was fixed in eb71712626f9.
Apply the same fix again to prevent a panic and return a proper error
instead.

To not regress again I added a e2e test which makes sure we do not panic.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
