### PR TITLE
system tests: avoid rmi -a ... plus cleanup

### DIFF
--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -757,7 +757,7 @@ EOF
         is "$output" "[no instance of 'Using cache']" "no cache used"
     fi
 
-    run_podman rmi -a --force
+    run_podman rmi -f build_test
 }
 
 # Caveat lector: this test was mostly copy-pasted from buildah in #9275.


### PR DESCRIPTION
I noticed 'rmi -a' in a test. I tried to fix it. Hilarity ensued.

'rmi -a' is evil: it forces a fresh pull of our test image,
which in turn almost guarantees a flake some day. We avoid
it, but once in a while it slips in.

While fixing it, I noticed a bevy of other problems that
needed cleanup.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```