### PR TITLE
golangci-lint: update to v1.46.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,6 +55,8 @@ linters:
     - varnamelen
     - maintidx
     - nilnil
+    - nonamedreturns
+    - exhaustruct
     # deprecated linters
     - golint # replaced by revive
     - scopelint # replaced by exportloopref

--- a/Makefile
+++ b/Makefile
@@ -829,7 +829,7 @@ install.tools: .install.ginkgo .install.golangci-lint .install.bats ## Install n
 
 .PHONY: .install.golangci-lint
 .install.golangci-lint:
-	VERSION=1.45.2 ./hack/install_golangci.sh
+	VERSION=1.46.2 ./hack/install_golangci.sh
 
 .PHONY: .install.md2man
 .install.md2man:

--- a/test/e2e/systemd_activate_test.go
+++ b/test/e2e/systemd_activate_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -61,9 +62,10 @@ var _ = Describe("Systemd activate", func() {
 		host := "127.0.0.1"
 		port, err := podmanUtils.GetRandomPort()
 		Expect(err).ToNot(HaveOccurred())
+		addr := net.JoinHostPort(host, strconv.Itoa(port))
 
 		activateSession := testUtils.StartSystemExec(activate, []string{
-			fmt.Sprintf("--listen=%s:%d", host, port),
+			"--listen", addr,
 			podmanTest.PodmanBinary,
 			"--root=" + filepath.Join(tempDir, "server_root"),
 			"system", "service",
@@ -73,7 +75,7 @@ var _ = Describe("Systemd activate", func() {
 
 		// Curried functions for specialized podman calls
 		podmanRemote := func(args ...string) *testUtils.PodmanSession {
-			args = append([]string{"--url", fmt.Sprintf("tcp://%s:%d", host, port)}, args...)
+			args = append([]string{"--url", "tcp://" + addr}, args...)
 			return testUtils.SystemExec(podmanTest.RemotePodmanBinary, args)
 		}
 
@@ -111,7 +113,7 @@ var _ = Describe("Systemd activate", func() {
 		port, err := podmanUtils.GetRandomPort()
 		Expect(err).ToNot(HaveOccurred())
 
-		addr := fmt.Sprintf("%s:%d", host, port)
+		addr := net.JoinHostPort(host, strconv.Itoa(port))
 
 		// start systemd activation with datagram socket
 		activateSession := testUtils.StartSystemExec(activate, []string{


### PR DESCRIPTION
Update to the latest golangci-lint version. v1.46 added new linters.
I disabled nonamedreturns and exhaustruct since they enforce a certain
code style and using them would require big changes to the code base.

The nosprintfhostport is new and I fixed one problem in the tests. While
the test itself is fine because it uses ipv4 only the linter still looks
good because the sprintf use will fail for ipv6 addresses.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
