### PR TITLE
test/system/410-selinux: fix for newer runc

### DIFF
--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -205,7 +205,11 @@ function check_label() {
 	#   from /proc/thread-self/attr/exec`: .* unable to assign
 	#   to   /proc/self/attr/keycreate`: .* unable to process
 	crun) expect="\`/proc/.*\`: OCI runtime error: unable to \(assign\|process\) security attribute" ;;
-	runc) expect="OCI runtime error: .*: failed to set /proc/self/attr/keycreate on procfs" ;;
+	# runc 1.1 changed the error message because of new selinux pkg that uses standard os.PathError, see
+	# https://github.com/opencontainers/selinux/pull/148/commits/a5dc47f74c56922d58ead05d1fdcc5f7f52d5f4e
+	#   from failed to set /proc/self/attr/keycreate on procfs
+	#   to   write /proc/self/attr/keycreate: invalid argument
+	runc) expect="OCI runtime error: .*: \(failed to set|write\) /proc/self/attr/keycreate" ;;
 	*)    skip "Unknown runtime '$runtime'";;
     esac
 


### PR DESCRIPTION
With runc 1.1, we have the following failure:
```
 # #|     FAIL: podman emits useful diagnostic on failure
 # #| expected: 'Error.*: OCI runtime error: .*: failed to set /proc/self/attr/keycreate on procfs' (using expr)
 # #|   actual: 'Error: OCI runtime error: runc: runc create failed: unable to start container process: error during container init: write /proc/self/attr/keycreate: invalid argument'
```

which is caused by the fact that runc 1.1 uses newer opencontainers/selinux
package, which changes custom errors to standard os.PathError instances (so
that they can be unwrapped if needed).

Fix the test case accordingly. NOT TESTED.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
