### PR TITLE
[CI:DOCS] fix typos in prerequisites for Fedora and make binaries sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ You need install some dependencies before building a binary.
 #### Fedora
 
   ```shell
-  $ sudo dnf install gpgme-devel libseccomp-devel.x86_64 libseccomp-devel.x86_64 systemd-devel
+  $ sudo dnf install gpgme-devel libseccomp-devel.x86_64 systemd-devel
   $ export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
   ```
 
@@ -103,8 +103,8 @@ To test your changes do `make binaries` to generate your binaries.
 
 Your binaries are created inside the `bin/` directory and you can test your changes:
 ```shell
-$ bin/podman -h
-bin/podman -h
+$ bin/podman --help
+bin/podman --help
 NAME:
    podman - manage pods and images
 


### PR DESCRIPTION
- prerequisites in Fedora section has libseccomp-devel.x86_64 named twice
- bin/podman flag "-h" does not work, "--help" is required

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
