### PR TITLE
fix "podman -h" help output

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func main() {
@@ -101,6 +103,13 @@ func parseCommands() *cobra.Command {
 }
 
 func flagErrorFuncfunc(c *cobra.Command, e error) error {
+	// cobra compares via == and not errors.Is so we cannot wrap that error.
+	// This is required to make podman -h work.
+	// This can be removed once https://github.com/spf13/cobra/pull/1730
+	// is merged and vendored into podman.
+	if errors.Is(e, pflag.ErrHelp) {
+		return e
+	}
 	e = fmt.Errorf("%w\nSee '%s --help'", e, c.CommandPath())
 	return e
 }

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -199,7 +199,7 @@ function check_help() {
     check_help
 
     # Test for regression of #7273 (spurious "--remote" help on output)
-    for helpopt in help --help; do
+    for helpopt in help --help -h; do
         run_podman $helpopt
         is "${lines[0]}" "Manage pods, containers and images" \
            "podman $helpopt: first line of output"


### PR DESCRIPTION
`podman -h` currently returns an error:
`Error: pflag: help requested`

This bug was introduced in 44d037898ebc, the problem is that we wrap the
error and cobra lib checks with `==` for this one and not errors.Is().
I have a PR upstream to fix this but for now this also works.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where `podman -h` did not show the help output.
```
