### PR TITLE
Docker-compose disable healthcheck properly handled

### DIFF
--- a/libpod/define/healthchecks.go
+++ b/libpod/define/healthchecks.go
@@ -47,3 +47,13 @@ const (
 	// DefaultHealthCheckTimeout default value
 	DefaultHealthCheckTimeout = "30s"
 )
+
+// HealthConfig.Test options
+const (
+	// HealthConfigTestNone disables healthcheck
+	HealthConfigTestNone = "NONE"
+	// HealthConfigTestCmd execs arguments directly
+	HealthConfigTestCmd = "CMD"
+	// HealthConfigTestCmdShell runs commands with the system's default shell
+	HealthConfigTestCmdShell = "CMD-SHELL"
+)

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -47,11 +47,11 @@ func (c *Container) runHealthCheck() (define.HealthCheckStatus, error) {
 		return define.HealthCheckNotDefined, errors.Errorf("container %s has no defined healthcheck", c.ID())
 	}
 	switch hcCommand[0] {
-	case "", "NONE":
+	case "", define.HealthConfigTestNone:
 		return define.HealthCheckNotDefined, errors.Errorf("container %s has no defined healthcheck", c.ID())
-	case "CMD":
+	case define.HealthConfigTestCmd:
 		newCommand = hcCommand[1:]
-	case "CMD-SHELL":
+	case define.HealthConfigTestCmdShell:
 		// TODO: SHELL command from image not available in Container - use Docker default
 		newCommand = []string{"/bin/sh", "-c", strings.Join(hcCommand[1:], " ")}
 	default:

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -511,12 +511,12 @@ func makeHealthCheck(inCmd string, interval int32, retries int32, timeout int32,
 	cmd := []string{}
 
 	if inCmd == "none" {
-		cmd = []string{"NONE"}
+		cmd = []string{define.HealthConfigTestNone}
 	} else {
 		err := json.Unmarshal([]byte(inCmd), &cmd)
 		if err != nil {
 			// ...otherwise pass it to "/bin/sh -c" inside the container
-			cmd = []string{"CMD-SHELL"}
+			cmd = []string{define.HealthConfigTestCmdShell}
 			cmd = append(cmd, strings.Split(inCmd, " ")...)
 		}
 	}

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -873,23 +873,23 @@ func makeHealthCheckFromCli(inCmd, interval string, retries uint, timeout, start
 	}
 
 	var concat string
-	if cmdArr[0] == "CMD" || cmdArr[0] == "none" { // this is for compat, we are already split properly for most compat cases
+	if strings.ToUpper(cmdArr[0]) == define.HealthConfigTestCmd || strings.ToUpper(cmdArr[0]) == define.HealthConfigTestNone { // this is for compat, we are already split properly for most compat cases
 		cmdArr = strings.Fields(inCmd)
-	} else if cmdArr[0] != "CMD-SHELL" { // this is for podman side of things, won't contain the keywords
+	} else if strings.ToUpper(cmdArr[0]) != define.HealthConfigTestCmdShell { // this is for podman side of things, won't contain the keywords
 		if isArr && len(cmdArr) > 1 { // an array of consecutive commands
-			cmdArr = append([]string{"CMD"}, cmdArr...)
+			cmdArr = append([]string{define.HealthConfigTestCmd}, cmdArr...)
 		} else { // one singular command
 			if len(cmdArr) == 1 {
 				concat = cmdArr[0]
 			} else {
 				concat = strings.Join(cmdArr[0:], " ")
 			}
-			cmdArr = append([]string{"CMD-SHELL"}, concat)
+			cmdArr = append([]string{define.HealthConfigTestCmdShell}, concat)
 		}
 	}
 
-	if cmdArr[0] == "none" { // if specified to remove healtcheck
-		cmdArr = []string{"NONE"}
+	if strings.ToUpper(cmdArr[0]) == define.HealthConfigTestNone { // if specified to remove healtcheck
+		cmdArr = []string{define.HealthConfigTestNone}
 	}
 
 	// healthcheck is by default an array, so we simply pass the user input

--- a/test/compose/disable_healthcheck/docker-compose.yml
+++ b/test/compose/disable_healthcheck/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.7"
+services:
+  noHc:
+    image: alpine
+    container_name: noHc
+    ports:
+      - "4000:80"
+    restart: unless-stopped
+    healthcheck:
+      disable: true

--- a/test/compose/disable_healthcheck/tests.sh
+++ b/test/compose/disable_healthcheck/tests.sh
@@ -1,0 +1,2 @@
+podman inspect --format='{{.Config.Healthcheck.Test}}' noHc
+like $output "[NONE]" "$testname: healthcheck properly disabled"


### PR DESCRIPTION
Previously, if a container had healthchecks disabled in the
docker-compose.yml file and the user did a `podman inspect <container>`,
they would have an incorrect output:

```
"Healthcheck":{
   "Test":[
      "CMD-SHELL",
      "NONE"
   ],
   "Interval":30000000000,
   "Timeout":30000000000,
   "Retries":3
}
```

After a quick change, the correct output is now the result:
```
"Healthcheck":{
   "Test":[
      "NONE"
   ]
}
```

Closes: #14493

Signed-off-by: Jake Correnti <jcorrenti13@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where disabling healthchecks in a docker-compose.yml file was improperly handled (#14493)
```
