### PR TITLE
CI: Eliminate triply-redundant rootless-remote jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -624,16 +624,15 @@ rootless_remote_system_test_task:
       # Minimal sanity testing: only the latest Fedora
       - env:
           DISTRO_NV: ${FEDORA_NAME}
-          # Not used here, is used in other tasks
           VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
           CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-          # ID for re-use of build output
-          _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
     gce_instance: *standardvm
     env:
         TEST_FLAVOR: sys
         PODBIN_NAME: remote
         PRIV_NAME: rootless
+        # ID for re-use of build output
+        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
 
 
 rootless_system_test_task:


### PR DESCRIPTION
We somehow ended up running 'sys remote fedora-36 rootless host'
three times in each CI run. Flatten that task, by removing a
slight difference in the matrix field.

Fixes: #14623

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```