### PR TITLE
Open Windows tutorial after MSI installation

### DIFF
--- a/contrib/msi/podman.wxs
+++ b/contrib/msi/podman.wxs
@@ -41,7 +41,7 @@
 
     <CustomAction Id="AddPath" ExeCommand="add" FileKey="8F507E28-A61D-4E64-A92B-B5A00F023AE8" Execute="deferred" Impersonate="yes" Return="check"/>
     <CustomAction Id="RemovePath" ExeCommand="remove" FileKey="8F507E28-A61D-4E64-A92B-B5A00F023AE8" Execute="deferred" Impersonate="yes" Return="check"/>
-
+    <CustomAction Id='LaunchFile' ExeCommand="open &quot;[INSTALLDIR]podman-for-windows.html&quot;" FileKey="8F507E28-A61D-4E64-A92B-B5A00F023AE8"  Execute="immediate"  Impersonate="yes" Return="check"/>
     <Feature Id="Complete" Level="1">
       <ComponentRef Id="INSTALLDIR_Component"/>
       <ComponentRef Id="MainExecutable"/>
@@ -55,8 +55,9 @@
 
     <InstallExecuteSequence>
       <RemoveExistingProducts Before="InstallInitialize"/>
-      <Custom Action="AddPath" After="InstallFiles">NOT Installed</Custom>
+      <Custom Action="AddPath" Before="InstallFinalize"  After="InstallFiles">NOT Installed</Custom>
       <Custom Action="RemovePath" Before="RemoveFiles" After="InstallInitialize">(REMOVE="ALL") AND (NOT UPGRADINGPRODUCTCODE)</Custom>
+      <Custom Action='LaunchFile' After='InstallFinalize'>(NOT Installed) AND (NOT UILevel=2)</Custom>
     </InstallExecuteSequence>
 
   </Product>

--- a/docs/remote-docs.sh
+++ b/docs/remote-docs.sh
@@ -86,6 +86,16 @@ function html_fn() {
         -o $TARGET/${file%%.*}.html $markdown
 }
 
+function html_standalone() {
+    local markdown=$1
+    local title=$2
+    local file=$(basename $markdown)
+    local dir=$(dirname $markdown)
+    (cd $dir; pandoc --ascii --from markdown-smart -c ../standalone-styling.css \
+           --standalone --self-contained --metadata title="$2" -V title= \
+           $file)  > $TARGET/${file%%.*}.html
+}
+
 # Run 'podman help' (possibly against a subcommand, e.g. 'podman help image')
 # and return a list of each first word under 'Available Commands', that is,
 # the command name but not its description.
@@ -165,3 +175,6 @@ for s in $SOURCES; do
     fi
 done
 rename
+if [[ "$PLATFORM" == "windows" ]]; then
+    html_standalone docs/tutorials/podman-for-windows.md 'Podman for Windows'
+fi

--- a/docs/standalone-styling.css
+++ b/docs/standalone-styling.css
@@ -1,0 +1,603 @@
+/* github.com/n1hility/standalone-styling (modified variant of github.com/bgw/pan-am) */
+/*! normalize.css v3.0.0 | MIT License | git.io/normalize */
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS text size adjust after orientation change, without disabling
+ *    user zoom.
+ */
+html {
+  font-family: sans-serif;
+  /* 1 */
+  -ms-text-size-adjust: 100%;
+  /* 2 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */ }
+
+/**
+ * Remove default margin.
+ */
+body {
+  margin: 0; }
+
+/* HTML5 display definitions
+   ========================================================================== */
+/**
+ * Correct `block` display not defined in IE 8/9.
+ */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+nav,
+section,
+summary {
+  display: block; }
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+  /* 1 */
+  vertical-align: baseline;
+  /* 2 */ }
+
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+audio:not([controls]) {
+  display: none;
+  height: 0; }
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9.
+ * Hide the `template` element in IE, Safari, and Firefox < 22.
+ */
+[hidden],
+template {
+  display: none; }
+
+/* Links
+   ========================================================================== */
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+a {
+  background: transparent; }
+
+/**
+ * Improve readability when focused and also mouse hovered in all browsers.
+ */
+a:active,
+a:hover {
+  outline: 0; }
+
+/* Text-level semantics
+   ========================================================================== */
+/**
+ * Address styling not present in IE 8/9, Safari 5, and Chrome.
+ */
+abbr[title] {
+  border-bottom: 1px dotted; }
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome.
+ */
+b,
+strong {
+  font-weight: bold; }
+
+/**
+ * Address styling not present in Safari 5 and Chrome.
+ */
+dfn {
+  font-style: italic; }
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari 5, and Chrome.
+ */
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0; }
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+mark {
+  background: #ff0;
+  color: #000; }
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+small {
+  font-size: 80%; }
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline; }
+
+sup {
+  top: -0.5em; }
+
+sub {
+  bottom: -0.25em; }
+
+/* Embedded content
+   ========================================================================== */
+/**
+ * Remove border when inside `a` element in IE 8/9.
+ */
+img {
+  border: 0; }
+
+/**
+ * Correct overflow displayed oddly in IE 9.
+ */
+svg:not(:root) {
+  overflow: hidden; }
+
+/* Grouping content
+   ========================================================================== */
+/**
+ * Address margin not present in IE 8/9 and Safari 5.
+ */
+figure {
+  margin: 1em 40px; }
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0; }
+
+/**
+ * Contain overflow in all browsers.
+ */
+pre {
+  overflow: auto; }
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em; }
+
+/* Forms
+   ========================================================================== */
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari 5, and Chrome.
+ */
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+  margin: 0;
+  /* 3 */ }
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10.
+ */
+button {
+  overflow: visible; }
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8+, and Opera
+ * Correct `select` style inheritance in Firefox.
+ */
+button,
+select {
+  text-transform: none; }
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  /* 2 */
+  cursor: pointer;
+  /* 3 */ }
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+button[disabled],
+html input[disabled] {
+  cursor: default; }
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0; }
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+input {
+  line-height: normal; }
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box;
+  /* 1 */
+  padding: 0;
+  /* 2 */ }
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto; }
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari 5 and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari 5 and Chrome
+ *    (include `-moz` to future-proof).
+ */
+input[type="search"] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+  /* 2 */
+  box-sizing: content-box; }
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none; }
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em; }
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+legend {
+  border: 0;
+  /* 1 */
+  padding: 0;
+  /* 2 */ }
+
+/**
+ * Remove default vertical scrollbar in IE 8/9.
+ */
+textarea {
+  overflow: auto; }
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+optgroup {
+  font-weight: bold; }
+
+/* Tables
+   ========================================================================== */
+/**
+ * Remove most spacing between table cells.
+ */
+table {
+  border-collapse: collapse;
+  border-spacing: 0; }
+
+td,
+th {
+  padding: 0; }
+
+body {
+  font-family: san-serif;
+  background-color: #F8F8F8;
+  color: #111;
+  line-height: 1.3;
+  text-align: justify;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto; }
+  @media (max-width: 400px) {
+    body {
+      font-size: 12px;
+      margin-left: 10px;
+      margin-right: 10px;
+      margin-top: 10px;
+      margin-bottom: 15px; } }
+  @media (min-width: 401px) and (max-width: 600px) {
+    body {
+      font-size: 14px;
+      margin-left: 10px;
+      margin-right: 10px;
+      margin-top: 10px;
+      margin-bottom: 15px; } }
+  @media (min-width: 601px) and (max-width: 900px) {
+    body {
+      font-size: 15px;
+      margin-left: 100px;
+      margin-right: 100px;
+      margin-top: 20px;
+      margin-bottom: 25px; } }
+  @media (min-width: 901px) and (max-width: 1800px) {
+    body {
+      font-size: 17px;
+      margin-left: 200px;
+      margin-right: 200px;
+      margin-top: 30px;
+      margin-bottom: 25px;
+      max-width: 800px; } }
+  @media (min-width: 1801px) {
+    body {
+      font-size: 18px;
+      margin-left: 20%;
+      margin-right: 20%;
+      margin-top: 30px;
+      margin-bottom: 25px;
+      max-width: 1000px; } }
+
+p {
+  margin-top: 10px;
+  margin-bottom: 18px; }
+
+em {
+  font-style: italic; }
+
+strong {
+  font-weight: bold; }
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: bold;
+  padding-top: 0.25em;
+  margin-bottom: 0.15em; }
+
+header {
+  line-height: 2.475em;
+  padding-bottom: 0.7em;
+  border-bottom: 1px solid #BBB;
+  margin-bottom: 1.2em; }
+  header > h1 {
+    border: none;
+    padding: 0;
+    margin: 0;
+    font-size: 225%; }
+  header > h2 {
+    border: none;
+    padding: 0;
+    margin: 0;
+    font-style: normal;
+    font-size: 175%; }
+  header > h3 {
+    padding: 0;
+    margin: 0;
+    font-size: 125%;
+    font-style: italic; }
+  header + h1 {
+    border-top: none;
+    padding-top: 0px; }
+
+h1 {
+  border-top: 1px solid #BBB;
+  padding-top: 15px;
+  font-size: 150%;
+  margin-bottom: 10px; }
+  h1:first-of-type {
+    border: none; }
+
+h2 {
+  font-size: 125%; }
+
+h3 {
+  font-size: 105%; }
+
+hr {
+  border: 0px;
+  border-top: 1px solid #BBB;
+  width: 100%;
+  height: 0px; }
+  hr + h1 {
+    border-top: none;
+    padding-top: 0px; }
+
+ul, ol {
+  font-size: 90%;
+  margin-top: 10px;
+  margin-bottom: 15px;
+  padding-left: 30px; }
+
+ul {
+  list-style: circle; }
+
+ol {
+  list-style: decimal; }
+
+ul ul, ol ol, ul ol, ol ul {
+  font-size: inherit; }
+
+li {
+  margin-top: 5px;
+  margin-bottom: 7px; }
+
+q, blockquote, dd {
+  font-style: italic;
+  font-size: 90%; }
+
+blockquote, dd {
+  quotes: none;
+  border-left: 0.35em #BBB solid;
+  padding-left: 1.15em;
+  margin: 0 1.5em 0 0; }
+
+blockquote blockquote, dd blockquote, blockquote dd, dd dd, ol blockquote, ol dd, ul blockquote, ul dd, blockquote ol, dd ol,
+blockquote ul,
+dd ul {
+  font-size: inherit; }
+
+a, a:link, a:visited, a:hover {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dashed #111; }
+  a:hover, a:link:hover, a:visited:hover, a:hover:hover {
+    border-bottom-style: solid; }
+  a.footnoteRef, a:link.footnoteRef, a:visited.footnoteRef, a:hover.footnoteRef {
+    border-bottom: none;
+    color: #666; }
+
+code {
+  font-family: "Consolas", "Monaco", monospace;
+  font-size: 85%;
+  background-color: #DDD;
+  border: 1px solid #BBB;
+  padding: 0px 0.15em 0px 0.15em;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px; }
+
+pre {
+  margin-right: 1.5em;
+  display: block; }
+  pre > code {
+    display: block;
+    font-size: 70%;
+    padding: 10px;
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;
+    border-radius: 5px;
+    overflow-x: auto; }
+
+blockquote pre, dd pre, ul pre, ol pre {
+  margin-left: 0;
+  margin-right: 0; }
+  blockquote pre > code, dd pre > code, ul pre > code, ol pre > code {
+    font-size: 77.7777777778%; }
+
+caption, figcaption {
+  font-size: 80%;
+  font-style: italic;
+  text-align: right;
+  margin-bottom: 5px; }
+  caption:empty, figcaption:empty {
+    display: none; }
+
+table {
+  width: 100%;
+  margin-top: 1em;
+  margin-bottom: 1em; }
+  table + h1 {
+    border-top: none; }
+
+tr td, tr th {
+  padding: 0.2em 0.7em; }
+tr.header {
+  border-top: 1px solid #222;
+  border-bottom: 1px solid #222;
+  font-weight: 700; }
+tr.odd {
+  background-color: #EEEEEE; }
+tr.even {
+  background-color: #CCCCCC; }
+
+tbody:last-child {
+  border-bottom: 1px solid #222; }
+
+dt {
+  font-weight: 700; }
+  dt:after {
+    font-weight: normal;
+    content: ":"; }
+
+dd {
+  margin-bottom: 10px; }
+
+figure {
+  margin: 1.3em 0 1.3em 0;
+  text-align: center;
+  padding: 0px;
+  width: 100%;
+  background-color: #DDD;
+  border: 1px solid #BBB;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  border-radius: 8px;
+  overflow: hidden; }
+
+img {
+  display: block;
+  margin: 0px auto;
+  padding: 0px;
+  max-width: 100%; }
+
+figcaption {
+  margin: 5px 10px 5px 30px; }
+
+.footnotes {
+  color: #666;
+  font-size: 70%;
+  font-style: italic; }
+  .footnotes li p:last-child a:last-child {
+    border-bottom: none; }

--- a/docs/tutorials/podman-for-windows.md
+++ b/docs/tutorials/podman-for-windows.md
@@ -1,4 +1,4 @@
-![PODMAN logo](../../logo/podman-logo-source.svg)
+![](../../logo/podman-logo-source.svg)
 
 Podman for Windows
 ==================


### PR DESCRIPTION
Until  msitools is released with the UI featureset in main, we are limited to a basic progress bar. After install it's not clear to the user the installation is actually done or what steps they should take next. To improve the UX, this PR opens the Windows tutorial after a successful install.

Changes:
- Render Windows tutorial to standalone html file and include it in the install
- Modify the winpath helper to have a hidden open command to support the installer
- Change installer to open the tutorial after a successful installation (unless a quiet install is selected)

[NO NEW TESTS NEEDED]

```release-note
Change Windows installer to open tutorial after install
```
