### PR TITLE
Revert "Fix M1 QEMU flags"

### DIFF
--- a/pkg/machine/qemu/options_darwin_arm64.go
+++ b/pkg/machine/qemu/options_darwin_arm64.go
@@ -17,8 +17,8 @@ func (v *MachineVM) addArchOptions() []string {
 	opts := []string{
 		"-accel", "hvf",
 		"-accel", "tcg",
-		"-cpu", "host",
-		"-M", "virt,highmem=on",
+		"-cpu", "cortex-a57",
+		"-M", "virt,highmem=off",
 		"-drive", "file=" + getEdk2CodeFd("edk2-aarch64-code.fd") + ",if=pflash,format=raw,readonly=on",
 		"-drive", "file=" + ovmfDir + ",if=pflash,format=raw"}
 	return opts


### PR DESCRIPTION
This reverts commit 8d3e6577ae4b5c6a6ed25ff5c332df042094e415.
The reverted commit causes a kernel panic on M1 macs when attempting to
intialize and start a new machine, due to the usage of the currently
unsupported `highmem` option. See #14633 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Closes #14633
```
