### PR TITLE
[v3.2.3-rhel] Cirrus: Prune testing tasks for long-term reliability

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -320,47 +320,6 @@ alt_build_task:
     always: *binary_artifacts
 
 
-# Confirm building the remote client, natively on a Mac OS-X VM.
-osx_alt_build_task:
-    name: "OSX Cross"
-    alias: osx_alt_build
-    depends_on:
-        - build
-    env:
-        <<: *stdenvars
-        # OSX platform variation prevents this being included in alt_build_task
-        TEST_FLAVOR: "altbuild"
-        ALT_NAME: 'OSX Cross'
-    osx_instance:
-        image: 'catalina-base'
-    script:
-        - brew install go
-        - brew install go-md2man
-        - make podman-remote-release-darwin.zip
-    always: *binary_artifacts
-
-
-# This task is a stub: In the future it will be used to verify
-# podman is compatible with the docker python-module.
-docker-py_test_task:
-    name: Docker-py Compat.
-    alias: docker-py_test
-    skip: *tags
-    only_if: *not_docs
-    depends_on:
-        - build
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: docker-py
-        TEST_ENVIRON: container
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
-
-
 # Does exactly what it says, execute the podman unit-tests on all primary
 # platforms and release versions.
 unit_test_task:
@@ -379,125 +338,6 @@ unit_test_task:
     setup_script: *setup
     main_script: *main
     always: *runner_stats
-
-
-#apiv2_test_task:
-#    name: "APIv2 test on $DISTRO_NV"
-#    alias: apiv2_test
-#    skip: *tags
-#    depends_on:
-#        - validate
-#    gce_instance: *standardvm
-#    env:
-#        <<: *stdenvars
-#        TEST_FLAVOR: apiv2
-#    clone_script: *noop  # Comes from cache
-#    gopath_cache: *ro_gopath_cache
-#    setup_script: *setup
-#    main_script: *main
-#    always: &logs_artifacts
-#        <<: *runner_stats
-#        # Required for `contrib/cirrus/logformatter` to work properly
-#        html_artifacts:
-#            path: ./*.html
-#            type: text/html
-#        package_versions_script: '$SCRIPT_BASE/logcollector.sh packages'
-#        df_script: '$SCRIPT_BASE/logcollector.sh df'
-#        audit_log_script: '$SCRIPT_BASE/logcollector.sh audit'
-#        journal_script: '$SCRIPT_BASE/logcollector.sh journal'
-#        podman_system_info_script: '$SCRIPT_BASE/logcollector.sh podman'
-#        time_script: '$SCRIPT_BASE/logcollector.sh time'
-
-
-# Execute the podman integration tests on all primary platforms and release
-# versions, as root, without involving the podman-remote client.
-#local_integration_test_task: &local_integration_test_task
-#    # Integration-test task name convention:
-#    # <int.|sys.> <podman|remote> <Distro NV> <root|rootless>
-#    name: &std_name_fmt "$TEST_FLAVOR $PODBIN_NAME $DISTRO_NV $PRIV_NAME $TEST_ENVIRON"
-#    alias: local_integration_test
-#    only_if: *not_docs
-#    skip: *branches_and_tags
-#    depends_on:
-#        - unit_test
-#    matrix: *platform_axis
-#    gce_instance: *standardvm
-#    timeout_in: 90m
-#    env:
-#        TEST_FLAVOR: int
-#    clone_script: *noop  # Comes from cache
-#    gopath_cache: *ro_gopath_cache
-#    setup_script: *setup
-#    main_script: *main
-#    always: &int_logs_artifacts
-#        <<: *logs_artifacts
-#        ginkgo_node_logs_artifacts:
-#            path: ./test/e2e/ginkgo-node-*.log
-#            type: text/plain
-
-
-# Nearly identical to `local_integration_test` except all operations
-# are performed through the podman-remote client vs a podman "server"
-# running on the same host.
-#remote_integration_test_task:
-#    <<: *local_integration_test_task
-#    alias: remote_integration_test
-#    env:
-#        TEST_FLAVOR: int
-#        PODBIN_NAME: remote
-
-
-# Run the complete set of integration tests from inside a container.
-# This verifies all/most operations function with "podman-in-podman".
-#container_integration_test_task:
-#    name: *std_name_fmt
-#    alias: container_integration_test
-#    only_if: *not_docs
-#    skip: *branches_and_tags
-#    depends_on:
-#        - unit_test
-#    matrix: &fedora_vm_axis
-#        - env:
-#              DISTRO_NV: ${FEDORA_NAME}
-#              _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-#              VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-#              CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-#        - env:
-#              DISTRO_NV: ${PRIOR_FEDORA_NAME}
-#              _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-#              VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-#              CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
-#    gce_instance: *standardvm
-#    timeout_in: 90m
-#    env:
-#        TEST_FLAVOR: int
-#        TEST_ENVIRON: container
-#    clone_script: *noop  # Comes from cache
-#    gopath_cache: *ro_gopath_cache
-#    setup_script: *setup
-#    main_script: *main
-#    always: *int_logs_artifacts
-
-
-# Execute most integration tests as a regular (non-root) user.
-#rootless_integration_test_task:
-#    name: *std_name_fmt
-#    alias: rootless_integration_test
-#    only_if: *not_docs
-#    skip: *branches_and_tags
-#    depends_on:
-#        - unit_test
-#    matrix: *platform_axis
-#    gce_instance: *standardvm
-#    timeout_in: 90m
-#    env:
-#        TEST_FLAVOR: int
-#        PRIV_NAME: rootless
-#    clone_script: *noop  # Comes from cache
-#    gopath_cache: *ro_gopath_cache
-#    setup_script: *setup
-#    main_script: *main
-#    always: *int_logs_artifacts
 
 
 # Always run subsequent to integration tests.  While parallelism is lost
@@ -532,30 +372,6 @@ remote_system_test_task:
         TEST_FLAVOR: sys
         PODBIN_NAME: remote
 
-#buildah_bud_test_task:
-#    name: *std_name_fmt
-#    alias: buildah_bud_test
-#    skip: *tags
-#    only_if: *not_docs
-#    depends_on:
-#      - unit_test
-#    env:
-#        TEST_FLAVOR: bud
-#        DISTRO_NV: ${FEDORA_NAME}
-#        # Not used here, is used in other tasks
-#        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-#        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-#        # ID for re-use of build output
-#        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-#        PODBIN_NAME: podman
-#    gce_instance: *standardvm
-#    timeout_in: 45m
-#    clone_script: *noop
-#    gopath_cache: *ro_gopath_cache
-#    setup_script: *setup
-#    main_script: *main
-#    always: &int_logs_artifacts
-#        <<: *logs_artifacts
 
 rootless_system_test_task:
     name: *std_name_fmt
@@ -576,38 +392,6 @@ rootless_system_test_task:
     always: &int_logs_artifacts
         <<: *logs_artifacts
 
-# FIXME: we may want to consider running this from nightly cron instead of CI.
-# The tests are actually pretty quick (less than a minute) but they do rely
-# on pulling images from quay.io, which means we're subject to network flakes.
-#
-# FIXME: how does this env matrix work, anyway? Does it spin up multiple VMs?
-# We might just want to encode the version matrix in runner.sh instead
-upgrade_test_task:
-    name: "Upgrade test: from $PODMAN_UPGRADE_FROM"
-    alias: upgrade_test
-    skip: *tags
-    only_if: *not_docs
-    depends_on:
-      - local_system_test
-    matrix:
-        - env:
-              PODMAN_UPGRADE_FROM: v1.9.0
-        - env:
-              PODMAN_UPGRADE_FROM: v2.0.6
-        - env:
-              PODMAN_UPGRADE_FROM: v2.1.1
-    gce_instance: *standardvm
-    env:
-        TEST_FLAVOR: upgrade_test
-        DISTRO_NV: ${FEDORA_NAME}
-        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-        # ID for re-use of build output
-        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-    clone_script: *noop
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
 
 # This task is critical.  It updates the "last-used by" timestamp stored
 # in metadata for all VM images.  This mechanism functions in tandem with
@@ -651,13 +435,10 @@ success_task:
         - swagger
         - consistency
         - alt_build
-        - osx_alt_build
-        - docker-py_test
         - unit_test
         - local_system_test
         - remote_system_test
         - rootless_system_test
-        - upgrade_test
         - meta
     container: *smallcontainer
     env:


### PR DESCRIPTION
As release branches age, it becomes less valuable to execute
comprehensive CI testing.  Further given occasional flakes, it becomes
more burdensome to maintain.  Trim back some non-essential testing tasks
for improved long-term reliability and reduced maintenance.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
