### PR TITLE
[v3.4] Cirrus: Prune testing tasks for long-term reliability

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -317,76 +317,6 @@ alt_build_task:
     always: *binary_artifacts
 
 
-# Confirm building a statically-linked binary is successful
-static_alt_build_task:
-    name: "Static Build"
-    alias: static_alt_build
-    only_if: *not_docs
-    depends_on:
-        - build
-    # Community-maintained task, may fail on occasion.  If so, uncomment
-    # the next line and file an issue with details about the failure.
-    # allow_failures: $CI == $CI
-    gce_instance: *bigvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: "altbuild"
-        # gce_instance variation prevents this being included in alt_build_task
-        ALT_NAME: 'Static build'
-        # Do not use 'latest', fixed-version tag for runtime stability.
-        CTR_FQIN: "docker.io/nixos/nix:2.3.6"
-        # Authentication token for pushing the build cache to cachix.
-        # This is critical, it helps to avoid a very lengthy process of
-        # statically building every dependency needed to build podman.
-        # Assuming the pinned nix dependencies in nix/nixpkgs.json have not
-        # changed, this cache will ensure that only the static podman binary is
-        # built.
-        CACHIX_AUTH_TOKEN: ENCRYPTED[df0d4d0a67474e8ea49cc503221dcb912b7e2ba45c8ec4bf2e5fd9c49a18ac21c24bacee59b5393355ed9e4358d2baef]
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts
-
-
-# Confirm building the remote client, natively on a Mac OS-X VM.
-osx_alt_build_task:
-    name: "OSX Cross"
-    alias: osx_alt_build
-    depends_on:
-        - build
-    env:
-        <<: *stdenvars
-        # OSX platform variation prevents this being included in alt_build_task
-        TEST_FLAVOR: "altbuild"
-        ALT_NAME: 'OSX Cross'
-    osx_instance:
-        image: 'catalina-base'
-    script:
-        - brew install go
-        - brew install go-md2man
-        - make podman-remote-release-darwin.zip
-    always: *binary_artifacts
-
-
-# Verify podman is compatible with the docker python-module.
-docker-py_test_task:
-    name: Docker-py Compat.
-    alias: docker-py_test
-    skip: *tags
-    only_if: *not_docs
-    depends_on:
-        - build
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: docker-py
-        TEST_ENVIRON: container
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *runner_stats
-
-
 # Does exactly what it says, execute the podman unit-tests on all primary
 # platforms and release versions.
 unit_test_task:
@@ -415,56 +345,6 @@ unit_test_task:
     always: *runner_stats
 
 
-apiv2_test_task:
-    name: "APIv2 test on $DISTRO_NV"
-    alias: apiv2_test
-    only_if: *not_docs
-    skip: *tags
-    depends_on:
-        - validate
-    gce_instance: *standardvm
-    # Test is normally pretty quick, about 10-minutes.  If it hangs,
-    # don't make developers wait the full 1-hour timeout.
-    timeout_in: 20m
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: apiv2
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: &logs_artifacts
-        <<: *html_artifacts
-        package_versions_script: '$SCRIPT_BASE/logcollector.sh packages'
-        df_script: '$SCRIPT_BASE/logcollector.sh df'
-        audit_log_script: '$SCRIPT_BASE/logcollector.sh audit'
-        journal_script: '$SCRIPT_BASE/logcollector.sh journal'
-        podman_system_info_script: '$SCRIPT_BASE/logcollector.sh podman'
-        time_script: '$SCRIPT_BASE/logcollector.sh time'
-
-compose_test_task:
-    name: "compose test on $DISTRO_NV ($PRIV_NAME)"
-    alias: compose_test
-    only_if: *not_docs
-    skip: *tags
-    depends_on:
-        - validate
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: compose
-    matrix:
-      - env:
-            PRIV_NAME: root
-      - env:
-            PRIV_NAME: rootless
-    clone_script: *noop  # Comes from cache
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
-
-
 # Execute the podman integration tests on all primary platforms and release
 # versions, as root, without involving the podman-remote client.
 local_integration_test_task: &local_integration_test_task
@@ -485,8 +365,15 @@ local_integration_test_task: &local_integration_test_task
     gopath_cache: *ro_gopath_cache
     setup_script: *setup
     main_script: *main
-    always: &int_logs_artifacts
-        <<: *logs_artifacts
+    always: &logs_artifacts
+        <<: *html_artifacts
+        package_versions_script: '$SCRIPT_BASE/logcollector.sh packages'
+        df_script: '$SCRIPT_BASE/logcollector.sh df'
+        audit_log_script: '$SCRIPT_BASE/logcollector.sh audit'
+        journal_script: '$SCRIPT_BASE/logcollector.sh journal'
+        podman_system_info_script: '$SCRIPT_BASE/logcollector.sh podman'
+        time_script: '$SCRIPT_BASE/logcollector.sh time'
+
         ginkgo_node_logs_artifacts:
             path: ./test/e2e/ginkgo-node-*.log
             type: text/plain
@@ -532,7 +419,7 @@ container_integration_test_task:
     gopath_cache: *ro_gopath_cache
     setup_script: *setup
     main_script: *main
-    always: *int_logs_artifacts
+    always: *logs_artifacts
 
 
 # Execute most integration tests as a regular (non-root) user.
@@ -553,7 +440,7 @@ rootless_integration_test_task:
     gopath_cache: *ro_gopath_cache
     setup_script: *setup
     main_script: *main
-    always: *int_logs_artifacts
+    always: *logs_artifacts
 
 
 # Always run subsequent to integration tests.  While parallelism is lost
@@ -587,33 +474,6 @@ remote_system_test_task:
         TEST_FLAVOR: sys
         PODBIN_NAME: remote
 
-buildah_bud_test_task:
-    name: *std_name_fmt
-    alias: buildah_bud_test
-    skip: *tags
-    only_if: *not_docs
-    depends_on:
-      - local_integration_test
-    env:
-        TEST_FLAVOR: bud
-        DISTRO_NV: ${FEDORA_NAME}
-        # Not used here, is used in other tasks
-        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-        # ID for re-use of build output
-        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-    matrix:
-        - env:
-            PODBIN_NAME: podman
-        - env:
-            PODBIN_NAME: remote
-    gce_instance: *standardvm
-    timeout_in: 45m
-    clone_script: *noop
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *int_logs_artifacts
 
 rootless_system_test_task:
     name: *std_name_fmt
@@ -633,34 +493,6 @@ rootless_system_test_task:
     main_script: *main
     always: *logs_artifacts
 
-upgrade_test_task:
-    name: "Upgrade test: from $PODMAN_UPGRADE_FROM"
-    alias: upgrade_test
-    skip: *tags
-    only_if: $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' || $CIRRUS_CRON != ''
-    depends_on:
-      - local_system_test
-    matrix:
-        - env:
-              PODMAN_UPGRADE_FROM: v1.9.0
-        - env:
-              PODMAN_UPGRADE_FROM: v2.0.6
-        - env:
-              PODMAN_UPGRADE_FROM: v2.1.1
-        - env:
-              PODMAN_UPGRADE_FROM: v3.1.2
-    gce_instance: *standardvm
-    env:
-        TEST_FLAVOR: upgrade_test
-        DISTRO_NV: ${FEDORA_NAME}
-        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
-        # ID for re-use of build output
-        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
-    clone_script: *noop
-    gopath_cache: *ro_gopath_cache
-    setup_script: *setup
-    main_script: *main
-    always: *logs_artifacts
 
 # This task is critical.  It updates the "last-used by" timestamp stored
 # in metadata for all VM images.  This mechanism functions in tandem with
@@ -703,12 +535,7 @@ success_task:
         - swagger
         - consistency
         - alt_build
-        - static_alt_build
-        - osx_alt_build
-        - docker-py_test
         - unit_test
-        - apiv2_test
-        - compose_test
         - local_integration_test
         - remote_integration_test
         - rootless_integration_test
@@ -716,8 +543,6 @@ success_task:
         - local_system_test
         - remote_system_test
         - rootless_system_test
-        - upgrade_test
-        - buildah_bud_test
         - meta
     container: *smallcontainer
     env:

--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -6,7 +6,7 @@ die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
 
 function install() {
     echo "Installing golangci-lint v$VERSION into $BIN"
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./bin v$VERSION
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$VERSION
 }
 
 BIN="./bin/golangci-lint"

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -136,6 +136,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search no-trunc flag", func() {
+		Skip("Problematic test.  Skipping for long-term stability on release branch.")
 		search := podmanTest.Podman([]string{"search", "--no-trunc", "alpine"})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))


### PR DESCRIPTION
As release branches age, it becomes less valuable to execute
comprehensive CI testing.  Further given occasional flakes, it becomes
more burdensome to maintain.  Trim back some non-essential testing tasks
for improved long-term reliability and reduced maintenance.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
