### PR TITLE
[CI:DOCS] "setup" -> "set up" in source code comments

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -71,7 +71,7 @@ func setupImageEngine(cmd *cobra.Command) (entities.ImageEngine, error) {
 		return nil, err
 	}
 	// we also need to set up the container engine since this
-	// is required to setup the rootless namespace
+	// is required to set up the rootless namespace
 	if _, err = setupContainerEngine(cmd); err != nil {
 		return nil, err
 	}

--- a/libpod/container_config.go
+++ b/libpod/container_config.go
@@ -194,7 +194,7 @@ type ContainerSecurityConfig struct {
 	// If not explicitly set, an unused random MLS label will be assigned by
 	// containers/storage (but only if SELinux is enabled).
 	MountLabel string `json:"MountLabel,omitempty"`
-	// LabelOpts are options passed in by the user to setup SELinux labels.
+	// LabelOpts are options passed in by the user to set up SELinux labels.
 	// These are used by the containers/storage library.
 	LabelOpts []string `json:"labelopts,omitempty"`
 	// User and group to use in the container. Can be specified as only user
@@ -386,7 +386,7 @@ type ContainerMiscConfig struct {
 	IsService bool `json:"isService"`
 	// SdNotifyMode tells libpod what to do with a NOTIFY_SOCKET if passed
 	SdNotifyMode string `json:"sdnotifyMode,omitempty"`
-	// Systemd tells libpod to setup the container in systemd mode, a value of nil denotes false
+	// Systemd tells libpod to set up the container in systemd mode, a value of nil denotes false
 	Systemd *bool `json:"systemd,omitempty"`
 	// HealthCheckConfig has the health check command and related timings
 	HealthCheckConfig *manifest.Schema2HealthConfig `json:"healthcheck"`

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -367,7 +367,7 @@ func (c *Container) getUserOverrides() *lookup.Overrides {
 
 func lookupHostUser(name string) (*runcuser.ExecUser, error) {
 	var execUser runcuser.ExecUser
-	// Lookup User on host
+	// Look up User on host
 	u, err := util.LookupUser(name)
 	if err != nil {
 		return &execUser, err
@@ -2600,13 +2600,13 @@ func (c *Container) generateCurrentUserGroupEntry() (string, int, error) {
 		return "", 0, errors.Wrapf(err, "failed to get current group")
 	}
 
-	// Lookup group name to see if it exists in the image.
+	// Look up group name to see if it exists in the image.
 	_, err = lookup.GetGroup(c.state.Mountpoint, g.Name)
 	if err != runcuser.ErrNoGroupEntries {
 		return "", 0, err
 	}
 
-	// Lookup GID to see if it exists in the image.
+	// Look up GID to see if it exists in the image.
 	_, err = lookup.GetGroup(c.state.Mountpoint, g.Gid)
 	if err != runcuser.ErrNoGroupEntries {
 		return "", 0, err
@@ -2676,7 +2676,7 @@ func (c *Container) generatePasswdEntry() (string, error) {
 
 	addedUID := 0
 	for _, userid := range c.config.HostUsers {
-		// Lookup User on host
+		// Look up User on host
 		u, err := util.LookupUser(userid)
 		if err != nil {
 			return "", err
@@ -2728,13 +2728,13 @@ func (c *Container) generateCurrentUserPasswdEntry() (string, int, int, error) {
 }
 
 func (c *Container) userPasswdEntry(u *user.User) (string, error) {
-	// Lookup the user to see if it exists in the container image.
+	// Look up the user to see if it exists in the container image.
 	_, err := lookup.GetUser(c.state.Mountpoint, u.Username)
 	if err != runcuser.ErrNoPasswdEntries {
 		return "", err
 	}
 
-	// Lookup the UID to see if it exists in the container image.
+	// Look up the UID to see if it exists in the container image.
 	_, err = lookup.GetUser(c.state.Mountpoint, u.Uid)
 	if err != runcuser.ErrNoPasswdEntries {
 		return "", err
@@ -2806,7 +2806,7 @@ func (c *Container) generateUserPasswdEntry(addedUID int) (string, error) {
 		return "", nil
 	}
 
-	// Lookup the user to see if it exists in the container image
+	// Look up the user to see if it exists in the container image
 	_, err = lookup.GetUser(c.state.Mountpoint, userspec)
 	if err != runcuser.ErrNoPasswdEntries {
 		return "", err

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -109,7 +109,7 @@ func (r *RootlessNetNS) getPath(path string) string {
 func (r *RootlessNetNS) Do(toRun func() error) error {
 	err := r.ns.Do(func(_ ns.NetNS) error {
 		// Before we can run the given function,
-		// we have to setup all mounts correctly.
+		// we have to set up all mounts correctly.
 
 		// The order of the mounts is IMPORTANT.
 		// The idea of the extra mount ns is to make /run and /var/lib/cni writeable
@@ -419,7 +419,7 @@ func (r *Runtime) GetRootlessNetNs(new bool) (*RootlessNetNS, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating rootless network namespace")
 		}
-		// setup slirp4netns here
+		// set up slirp4netns here
 		path := r.config.Engine.NetworkCmdPath
 		if path == "" {
 			var err error
@@ -656,9 +656,9 @@ func (r *Runtime) configureNetNS(ctr *Container, ctrNS ns.NetNS) (status map[str
 		return nil, err
 	}
 
-	// setup rootless port forwarder when rootless with ports and the network status is empty,
+	// set up rootless port forwarder when rootless with ports and the network status is empty,
 	// if this is called from network reload the network status will not be empty and we should
-	// not setup port because they are still active
+	// not set up port because they are still active
 	if rootless.IsRootless() && len(ctr.config.PortMappings) > 0 && ctr.getNetworkStatus() == nil {
 		// set up port forwarder for rootless netns
 		netnsPath := ctrNS.Path()


### PR DESCRIPTION
* Replace "setup", "lookup" with "set up", "look up"
  when used as verbs.

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
