### PR TITLE
Remove logrus.Infof on bindings start and attach

### DIFF
--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -164,7 +164,7 @@ func pingNewConnection(ctx context.Context) (*semver.Version, error) {
 	if response.StatusCode == http.StatusOK {
 		versionHdr := response.Header.Get("Libpod-API-Version")
 		if versionHdr == "" {
-			logrus.Info("Service did not provide Libpod-API-Version Header")
+			logrus.Warn("Service did not provide Libpod-API-Version Header")
 			return new(semver.Version), nil
 		}
 		versionSrv, err := semver.ParseTolerant(versionHdr)

--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -54,8 +54,6 @@ func Attach(ctx context.Context, nameOrID string, stdin io.Reader, stdout io.Wri
 		stderr = (io.Writer)(nil)
 	}
 
-	logrus.Infof("Going to attach to container %q", nameOrID)
-
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return err
@@ -357,7 +355,7 @@ func attachHandleResize(ctx, winCtx context.Context, winChange chan os.Signal, i
 			resizeErr = ResizeContainerTTY(ctx, id, new(ResizeTTYOptions).WithHeight(h).WithWidth(w))
 		}
 		if resizeErr != nil {
-			logrus.Infof("Failed to resize TTY: %v", resizeErr)
+			logrus.Debugf("Failed to resize TTY: %v", resizeErr)
 		}
 	}
 

--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -201,7 +200,6 @@ func Start(ctx context.Context, nameOrID string, options *StartOptions) error {
 	if options == nil {
 		options = new(StartOptions)
 	}
-	logrus.Infof("Going to start container %q", nameOrID)
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
We are only doing logrus.Info on a couple of bindings. I see no reason
to only do this on a couple, seems like debugging information more then
useful to the caller. We had a complaint about this so removing.

Fixes: https://github.com/containers/podman/issues/13504

[NO NEW TESTS NEEDED]

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
