### PR TITLE
API: containers/json always set application/json content type

### DIFF
--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -115,10 +115,6 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
-	if len(pss) == 0 {
-		utils.WriteResponse(w, http.StatusOK, "[]")
-		return
-	}
 	utils.WriteResponse(w, http.StatusOK, pss)
 }
 

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -16,7 +16,12 @@ podman pull $ENV_WORKDIR_IMG &>/dev/null
 # Ensure clean slate
 podman rm -a -f &>/dev/null
 
-t GET "libpod/containers/json (at start: clean slate)" 200 length=0
+t GET "libpod/containers/json (at start: clean slate)" 200 \
+  "[]" \
+  length=0
+# check content type: https://github.com/containers/podman/issues/14647
+response_headers=$(cat "$WORKDIR/curl.headers.out")
+like "$response_headers" ".*Content-Type: application/json.*" "header does not contain application/json"
 
 # Regression test for #12904 (race condition in logging code)
 mytext="hi-there-$(random_string 15)"


### PR DESCRIPTION
When we return no containers we just return `[]` but we still have to keep
the content type header `application/json` so external tools can correctly
parse the output.

Fixes #14647

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where the /libpod/containers/json endpoint did not return the application/json content type header when the container list is empty.
```
