### PR TITLE
podman machine init --now: respect proxy envs

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -109,7 +109,7 @@ func init() {
 	flags.BoolVar(&initOpts.Rootful, rootfulFlagName, false, "Whether this machine should prefer rootful container execution")
 }
 
-func initMachine(_ *cobra.Command, args []string) error {
+func initMachine(cmd *cobra.Command, args []string) error {
 	var (
 		err error
 		vm  machine.VM
@@ -147,17 +147,12 @@ func initMachine(_ *cobra.Command, args []string) error {
 	fmt.Println("Machine init complete")
 
 	if now {
-		err = vm.Start(initOpts.Name, machine.StartOptions{})
-		if err == nil {
-			fmt.Printf("Machine %q started successfully\n", initOpts.Name)
-			newMachineEvent(events.Start, events.Event{Name: initOpts.Name})
-		}
-	} else {
-		extra := ""
-		if initOpts.Name != defaultMachineName {
-			extra = " " + initOpts.Name
-		}
-		fmt.Printf("To start your machine run:\n\n\tpodman machine start%s\n\n", extra)
+		return start(cmd, args)
 	}
+	extra := ""
+	if initOpts.Name != defaultMachineName {
+		extra = " " + initOpts.Name
+	}
+	fmt.Printf("To start your machine run:\n\n\tpodman machine start%s\n\n", extra)
 	return err
 }


### PR DESCRIPTION
podman machine start contains more logic than just the simple vm.Start()
call. Instead of duplicating this into inti we just call start().

[NO NEW TESTS NEEDED] I have no way to test this right now.

Fixes #14640

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman machine init --now` now respects the proxy environment variables like `podman machine start`.
```
