### PR TITLE
Make `podman machine stop` wait for qemu to exit

### DIFF
--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -72,8 +72,10 @@ type MachineVM struct {
 	Mounts []machine.Mount
 	// Name of VM
 	Name string
-	// PidFilePath is the where the PID file lives
+	// PidFilePath is the where the Proxy PID file lives
 	PidFilePath machine.VMFile
+	// VMPidFilePath is the where the VM PID file lives
+	VMPidFilePath machine.VMFile
 	// QMPMonitor is the qemu monitor object for sending commands
 	QMPMonitor Monitor
 	// ReadySocket tells host when vm is booted


### PR DESCRIPTION
After `podman machine stop` successfully exits the `qemu` process may still be running, which can cause issues, especially if an attempt is made to start the machine again.

In my trials I found the `qemu` process normally takes about 1s to exit after `podman machine stop`, which means `podman machine stop && podman machine start` can create problems, for example. I've also found that the `qemu` process could hang from time to time after an attempted stop. I'm able to reproduce this most reliably by stopping the machine while a container is running, it then takes about 90s for the `qemu` process to exit. This last example should be an issue on its own, but all this to say `podman machine stop` should only exit after `qemu` does.

In this PR we use the `-pidfile` flag when running `qemu` and store its path in the MachineVM config. The `podman machine stop` command now waits for the `qemu` command to exit before itself exiting. Two commits are included for a bit of separation.

A couple notes:

- The MachineVM update requires a migration. I've simply followed what was already done, but do wonder if there might be a better way.

- The `podman machine stop` does not have a timeout, it'll wait for `qemu` to exit indefinitely. Perhaps it should?

- The user could interrupt (ie: CTRL-C) a `podman machine stop` that's taking a while, but the `qemu` process will still be alive.

- We could potentially send a `kill` signal to the `qemu` process after a timeout and/or a user interrupt.

- The pidfile can be used elsewhere in the future. For example, it could inform the state of a VM, or at least prevent a `podman machine start`.

Fixes #14148

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman machine stop` command on macOS now waits for the machine to be completely stopped.
```
