### PR TITLE
Fix unnecessarily installing bats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -837,9 +837,12 @@ install.tools: .install.ginkgo .install.golangci-lint .install.bats ## Install n
 		make -C test/tools build/go-md2man ; \
 	fi
 
-.PHONY: .install.bats
-.install.bats:
+# Avoid calling script if hard-coded binary path exists
+/usr/local/bin/bats:
 	VERSION=v1.1.0 ./hack/install_bats.sh
+
+.PHONY: .install.bats
+.install.bats: /usr/local/bin/bats
 
 .PHONY: .install.pre-commit
 .install.pre-commit:

--- a/hack/install_bats.sh
+++ b/hack/install_bats.sh
@@ -4,9 +4,9 @@ set -e
 
 die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
 
-if [[ "$(type -t bats)" != "" ]]; then
-	# bats is already installed.
-	exit 0
+if [[ -n "$(type -P bats)" ]]; then
+    echo "bats is already installed."
+    exit 0
 fi
 
 buildDir=$(mktemp -d)


### PR DESCRIPTION
This tool is pre-installed in all CI VM images, but may be installed by
developers locally.  However, it's not mentioned as a make target
dependency, and the 'already installed' check in the script is broken.
This results in trying to install bats every time CI runs or the make
target is required.  Fix both.

Fixes https://github.com/containers/automation_images/issues/139

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
