### PR TITLE
Fix system prune output message

### DIFF
--- a/cmd/podman/utils/utils.go
+++ b/cmd/podman/utils/utils.go
@@ -44,7 +44,7 @@ func PrintPodPruneResults(podPruneReports []*entities.PodPruneReport, heading bo
 
 func PrintContainerPruneResults(containerPruneReports []*reports.PruneReport, heading bool) error {
 	var errs OutputErrors
-	if heading && (len(containerPruneReports) > 0) {
+	if heading && len(containerPruneReports) > 0 {
 		fmt.Println("Deleted Containers")
 	}
 	for _, v := range containerPruneReports {
@@ -72,7 +72,7 @@ func PrintVolumePruneResults(volumePruneReport []*reports.PruneReport, heading b
 }
 
 func PrintImagePruneResults(imagePruneReports []*reports.PruneReport, heading bool) error {
-	if heading {
+	if heading && len(imagePruneReports) > 0 {
 		fmt.Println("Deleted Images")
 	}
 	for _, r := range imagePruneReports {


### PR DESCRIPTION
'podman system prune' command always outputs "Deleted Images" message,
even though there is no dangling or unused image to remove.
This message should be output only if dangling or unused image exists.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
