### PR TITLE
Fix machine list: --format implies --noheading

### DIFF
--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -138,7 +138,7 @@ func outputTemplate(cmd *cobra.Command, responses []*ListReporter) error {
 	switch {
 	case cmd.Flags().Changed("format"):
 		row = cmd.Flag("format").Value.String()
-		listFlag.noHeading = !report.HasTable(row)
+		printHeader = report.HasTable(row)
 		row = report.NormalizeFormat(row)
 	default:
 		row = cmd.Flag("format").Value.String()

--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -116,7 +116,7 @@ var _ = Describe("podman machine list", func() {
 
 		// go format
 		list := new(listMachine)
-		listSession, err := mb.setCmd(list.withFormat("{{.Name}}").withNoHeading()).run()
+		listSession, err := mb.setCmd(list.withFormat("{{.Name}}")).run()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(listSession).To(Exit(0))
 		Expect(len(listSession.outputToStringSlice())).To(Equal(1))
@@ -135,6 +135,15 @@ var _ = Describe("podman machine list", func() {
 		var listResponse []*machine.ListReporter
 		err = jsoniter.Unmarshal(listSession.Bytes(), &listResponse)
 		Expect(err).To(BeNil())
+
+		// table format includes the header
+		list = new(listMachine)
+		listSession3, err3 := mb.setCmd(list.withFormat("table {{.Name}}")).run()
+		Expect(err3).NotTo(HaveOccurred())
+		Expect(listSession3).To(Exit(0))
+		listNames3 := listSession3.outputToStringSlice()
+		Expect(len(listNames3)).To(Equal(2))
+		Expect(listNames3).To(ContainSubstring("NAME"))
 	})
 })
 

--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -29,7 +29,7 @@ var _ = Describe("podman machine list", func() {
 		firstList, err := mb.setCmd(list).run()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(firstList).Should(Exit(0))
-		Expect(len(firstList.outputToStringSlice())).To(Equal(1)) // just the header
+		Expect(firstList.outputToStringSlice()).To(HaveLen(1)) // just the header
 
 		i := new(initMachine)
 		session, err := mb.setCmd(i.withImagePath(mb.imagePath)).run()
@@ -39,7 +39,7 @@ var _ = Describe("podman machine list", func() {
 		secondList, err := mb.setCmd(list).run()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(secondList).To(Exit(0))
-		Expect(len(secondList.outputToStringSlice())).To(Equal(2)) // one machine and the header
+		Expect(secondList.outputToStringSlice()).To(HaveLen(2)) // one machine and the header
 	})
 
 	It("list machines with quiet or noheading", func() {
@@ -51,12 +51,12 @@ var _ = Describe("podman machine list", func() {
 		firstList, err := mb.setCmd(list.withQuiet()).run()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(firstList).Should(Exit(0))
-		Expect(len(firstList.outputToStringSlice())).To(Equal(0)) // No header with quiet
+		Expect(firstList.outputToStringSlice()).To(HaveLen(0)) // No header with quiet
 
 		noheaderSession, err := mb.setCmd(list.withNoHeading()).run() // noheader
 		Expect(err).NotTo(HaveOccurred())
 		Expect(noheaderSession).Should(Exit(0))
-		Expect(len(noheaderSession.outputToStringSlice())).To(Equal(0))
+		Expect(noheaderSession.outputToStringSlice()).To(HaveLen(0))
 
 		i := new(initMachine)
 		session, err := mb.setName(name1).setCmd(i.withImagePath(mb.imagePath)).run()
@@ -70,7 +70,7 @@ var _ = Describe("podman machine list", func() {
 		secondList, err := mb.setCmd(list.withQuiet()).run()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(secondList).To(Exit(0))
-		Expect(len(secondList.outputToStringSlice())).To(Equal(2)) // two machines, no header
+		Expect(secondList.outputToStringSlice()).To(HaveLen(2)) // two machines, no header
 
 		listNames := secondList.outputToStringSlice()
 		stripAsterisk(listNames)
@@ -119,7 +119,7 @@ var _ = Describe("podman machine list", func() {
 		listSession, err := mb.setCmd(list.withFormat("{{.Name}}")).run()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(listSession).To(Exit(0))
-		Expect(len(listSession.outputToStringSlice())).To(Equal(1))
+		Expect(listSession.outputToStringSlice()).To(HaveLen(1))
 
 		listNames := listSession.outputToStringSlice()
 		stripAsterisk(listNames)
@@ -142,7 +142,7 @@ var _ = Describe("podman machine list", func() {
 		Expect(err3).NotTo(HaveOccurred())
 		Expect(listSession3).To(Exit(0))
 		listNames3 := listSession3.outputToStringSlice()
-		Expect(len(listNames3)).To(Equal(2))
+		Expect(listNames3).To(HaveLen(2))
 		Expect(listNames3).To(ContainSubstring("NAME"))
 	})
 })


### PR DESCRIPTION
A small bug fix - closes #14682.

It seems like previously if `--format` was changed then `listFlag.noHeading` is changed accordingly however `printHeader` is used to determine whether to print header or not.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
