### PR TITLE
Docker compat returning unknown "initialized" for `status.status`

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -289,8 +289,10 @@ func LibpodToContainer(l *libpod.Container, sz bool) (*handlers.Container, error
 		return nil, err
 	}
 	stateStr := state.String()
-	if stateStr == "configured" {
-		stateStr = "created"
+
+	// Some docker states are not the same as ours. This makes sure the state string stays true to the Docker API
+	if state == define.ContainerStateCreated {
+		stateStr = define.ContainerStateConfigured.String()
 	}
 
 	switch state {
@@ -420,9 +422,9 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 		state.Running = true
 	}
 
-	// docker calls the configured state "created"
-	if state.Status == define.ContainerStateConfigured.String() {
-		state.Status = define.ContainerStateCreated.String()
+	// Dockers created state is our configured state
+	if state.Status == define.ContainerStateCreated.String() {
+		state.Status = define.ContainerStateConfigured.String()
 	}
 
 	if l.HasHealthCheck() && state.Status != "created" {

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -502,3 +502,27 @@ done
 
 stop_service
 start_service
+
+# Our states are different from Docker's.
+# Regression test for #14700 (Docker compat returning unknown "initialized" for status.status) to ensure the stay compatible
+podman create --name status-test $IMAGE sh -c "sleep 3"
+t GET containers/status-test/json 200 .State.Status="created"
+
+podman init status-test
+t GET containers/status-test/json 200 .State.Status="created"
+
+podman start status-test
+t GET containers/status-test/json 200 .State.Status="running"
+
+podman pause status-test
+t GET containers/status-test/json 200 .State.Status="paused"
+
+podman unpause status-test
+t GET containers/status-test/json 200 .State.Status="running"
+
+podman stop status-test &
+sleep 1
+t GET containers/status-test/json 200 .State.Status="stopping"
+
+sleep 3
+t GET containers/status-test/json 200 .State.Status="exited"


### PR DESCRIPTION
Some background for this PR is in discussion #14641. In short, ever so often a container inspect will return a `status.status` of `initialized` from the Docker compat socket.

From the discussion I found these lines which tries to fix a "configured" status to "created".
https://github.com/containers/podman/blob/c936d1e61154b6826e9d8df46e9660aba6c86cfe/pkg/api/handlers/compat/containers.go#L291-L294

However, commit 141de8686289 (Revamp Libpod state strings for Docker compat) removed the "configured" return value from the `String()` method called on line 291 above. Thus, making the `if` check redundant as it will never hit. But the same commit also introduces a return for "initialized" which this `if` should probably have been adapted for.

Tests added to prevent a regression

Signed-off-by: Pieter Engelbrecht <pieter@shuttle.rs>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
