### PR TITLE
fix system connection and scp testing

### DIFF
--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -47,9 +47,7 @@ var _ = Describe("podman system connection", func() {
 		}
 
 		f := CurrentGinkgoTestDescription()
-		_, _ = GinkgoWriter.Write(
-			[]byte(
-				fmt.Sprintf("Test: %s completed in %f seconds", f.TestText, f.Duration.Seconds())))
+		processTestResult(f)
 	})
 
 	Context("without running API service", func() {
@@ -58,7 +56,7 @@ var _ = Describe("podman system connection", func() {
 				"--default",
 				"--identity", "~/.ssh/id_rsa",
 				"QA",
-				"ssh://root@server.fubar.com:2222/run/podman/podman.sock",
+				"ssh://root@podman.test:2222/run/podman/podman.sock",
 			}
 			session := podmanTest.Podman(cmd)
 			session.WaitWithDefaultTimeout()
@@ -67,10 +65,10 @@ var _ = Describe("podman system connection", func() {
 
 			cfg, err := config.ReadCustomConfig()
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(cfg).To(HaveActiveService("QA"))
+			Expect(cfg).Should(HaveActiveService("QA"))
 			Expect(cfg).Should(VerifyService(
 				"QA",
-				"ssh://root@server.fubar.com:2222/run/podman/podman.sock",
+				"ssh://root@podman.test:2222/run/podman/podman.sock",
 				"~/.ssh/id_rsa",
 			))
 
@@ -82,7 +80,7 @@ var _ = Describe("podman system connection", func() {
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
 
-			Expect(config.ReadCustomConfig()).To(HaveActiveService("QE"))
+			Expect(config.ReadCustomConfig()).Should(HaveActiveService("QE"))
 		})
 
 		It("add UDS", func() {
@@ -141,7 +139,7 @@ var _ = Describe("podman system connection", func() {
 				"--default",
 				"--identity", "~/.ssh/id_rsa",
 				"QA",
-				"ssh://root@server.fubar.com:2222/run/podman/podman.sock",
+				"ssh://root@podman.test:2222/run/podman/podman.sock",
 			})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
@@ -155,8 +153,8 @@ var _ = Describe("podman system connection", func() {
 
 				cfg, err := config.ReadCustomConfig()
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(cfg.Engine.ActiveService).To(BeEmpty())
-				Expect(cfg.Engine.ServiceDestinations).To(BeEmpty())
+				Expect(cfg.Engine.ActiveService).Should(BeEmpty())
+				Expect(cfg.Engine.ServiceDestinations).Should(BeEmpty())
 			}
 		})
 
@@ -165,7 +163,7 @@ var _ = Describe("podman system connection", func() {
 				"--default",
 				"--identity", "~/.ssh/id_rsa",
 				"QA",
-				"ssh://root@server.fubar.com:2222/run/podman/podman.sock",
+				"ssh://root@podman.test:2222/run/podman/podman.sock",
 			})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
@@ -187,7 +185,7 @@ var _ = Describe("podman system connection", func() {
 					"--default",
 					"--identity", "~/.ssh/id_rsa",
 					name,
-					"ssh://root@server.fubar.com:2222/run/podman/podman.sock",
+					"ssh://root@podman.test:2222/run/podman/podman.sock",
 				}
 				session := podmanTest.Podman(cmd)
 				session.WaitWithDefaultTimeout()


### PR DESCRIPTION
podman image scp and podman system connection tests were querying an existing website during testing.
Change to a URL that will never exist given an improper domain extension

also just generally clean up a few things in both scp and connection testing

resolves #14699

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
