### PR TITLE
Only allow Rootless runs of Podman Machine

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -20,6 +20,7 @@ var (
 		Use:               "init [options] [NAME]",
 		Short:             "Initialize a virtual machine",
 		Long:              "initialize a virtual machine ",
+		PersistentPreRunE: rootlessOnly,
 		RunE:              initMachine,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine init myvm`,

--- a/cmd/podman/machine/inspect.go
+++ b/cmd/podman/machine/inspect.go
@@ -20,6 +20,7 @@ var (
 		Use:               "inspect [options] [MACHINE...]",
 		Short:             "Inspect an existing machine",
 		Long:              "Provide details on a managed virtual machine",
+		PersistentPreRunE: rootlessOnly,
 		RunE:              inspect,
 		Example:           `podman machine inspect myvm`,
 		ValidArgsFunction: autocompleteMachine,

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -27,6 +27,7 @@ var (
 		Aliases:           []string{"ls"},
 		Short:             "List machines",
 		Long:              "List managed virtual machines.",
+		PersistentPreRunE: rootlessOnly,
 		RunE:              list,
 		Args:              validate.NoArgs,
 		ValidArgsFunction: completion.AutocompleteNone,

--- a/cmd/podman/machine/machine.go
+++ b/cmd/podman/machine/machine.go
@@ -5,6 +5,7 @@ package machine
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -159,6 +161,13 @@ func closeMachineEvents(cmd *cobra.Command, _ []string) error {
 	logrus.Debugf("Called machine %s.PersistentPostRunE(%s)", cmd.Name(), strings.Join(os.Args, " "))
 	for _, sock := range sockets {
 		_ = sock.Close()
+	}
+	return nil
+}
+
+func rootlessOnly(cmd *cobra.Command, args []string) error {
+	if !rootless.IsRootless() {
+		return fmt.Errorf("cannot run command %q as root", cmd.CommandPath())
 	}
 	return nil
 }

--- a/cmd/podman/machine/rm.go
+++ b/cmd/podman/machine/rm.go
@@ -20,6 +20,7 @@ var (
 		Use:               "rm [options] [MACHINE]",
 		Short:             "Remove an existing machine",
 		Long:              "Remove a managed virtual machine ",
+		PersistentPreRunE: rootlessOnly,
 		RunE:              rm,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine rm myvm`,

--- a/cmd/podman/machine/set.go
+++ b/cmd/podman/machine/set.go
@@ -18,6 +18,7 @@ var (
 		Use:               "set [options] [NAME]",
 		Short:             "Sets a virtual machine setting",
 		Long:              "Sets an updatable virtual machine setting",
+		PersistentPreRunE: rootlessOnly,
 		RunE:              setMachine,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine set --rootful=false`,

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -17,10 +17,11 @@ import (
 
 var (
 	sshCmd = &cobra.Command{
-		Use:   "ssh [options] [NAME] [COMMAND [ARG ...]]",
-		Short: "SSH into an existing machine",
-		Long:  "SSH into a managed virtual machine ",
-		RunE:  ssh,
+		Use:               "ssh [options] [NAME] [COMMAND [ARG ...]]",
+		Short:             "SSH into an existing machine",
+		Long:              "SSH into a managed virtual machine ",
+		PersistentPreRunE: rootlessOnly,
+		RunE:              ssh,
 		Example: `podman machine ssh myvm
   podman machine ssh myvm echo hello`,
 		ValidArgsFunction: autocompleteMachineSSH,

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -18,6 +18,7 @@ var (
 		Use:               "start [MACHINE]",
 		Short:             "Start an existing machine",
 		Long:              "Start a managed virtual machine ",
+		PersistentPreRunE: rootlessOnly,
 		RunE:              start,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine start myvm`,

--- a/cmd/podman/machine/stop.go
+++ b/cmd/podman/machine/stop.go
@@ -17,6 +17,7 @@ var (
 		Use:               "stop [MACHINE]",
 		Short:             "Stop an existing machine",
 		Long:              "Stop a managed virtual machine ",
+		PersistentPreRunE: rootlessOnly,
 		RunE:              stop,
 		Args:              cobra.MaximumNArgs(1),
 		Example:           `podman machine stop myvm`,

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -10,9 +10,12 @@ podman\-machine\-init - Initialize a new virtual machine
 
 Initialize a new virtual machine for Podman.
 
-Podman on macOS requires a virtual machine. This is because containers are Linux -
+Rootless only.
+
+Podman on MacOS and Windows requires a virtual machine. This is because containers are Linux -
 containers do not run on any other OS because containers' core functionality are
-tied to the Linux kernel.
+tied to the Linux kernel. Podman machine must be used to manage MacOS and Windows machines,
+but can be optionally used on Linux.
 
 **podman machine init** initializes a new Linux virtual machine where containers are run.
 SSH keys are automatically generated to access the VM, and system connections to the root account

--- a/docs/source/markdown/podman-machine-inspect.1.md
+++ b/docs/source/markdown/podman-machine-inspect.1.md
@@ -13,6 +13,8 @@ Inspect one or more virtual machines
 Obtain greater detail about Podman virtual machines.  More than one virtual machine can be
 inspected at once.
 
+Rootless only.
+
 ## OPTIONS
 #### **--format**
 

--- a/docs/source/markdown/podman-machine-list.1.md
+++ b/docs/source/markdown/podman-machine-list.1.md
@@ -12,9 +12,12 @@ podman\-machine\-list - List virtual machines
 
 List Podman managed virtual machines.
 
-Podman on macOS requires a virtual machine. This is because containers are Linux -
-containers do not run on any other OS because containers' core functionality is
-tied to the Linux kernel.
+Podman on MacOS and Windows requires a virtual machine. This is because containers are Linux -
+containers do not run on any other OS because containers' core functionality are
+tied to the Linux kernel. Podman machine must be used to manage MacOS and Windows machines,
+but can be optionally used on Linux.
+
+Rootless only.
 
 ## OPTIONS
 

--- a/docs/source/markdown/podman-machine-rm.1.md
+++ b/docs/source/markdown/podman-machine-rm.1.md
@@ -16,6 +16,7 @@ generated for that VM are also removed as is its image file on the filesystem.
 Users get a display of what will be deleted and are required to confirm unless the option `--force`
 is used.
 
+Rootless only.
 
 ## OPTIONS
 

--- a/docs/source/markdown/podman-machine-set.1.md
+++ b/docs/source/markdown/podman-machine-set.1.md
@@ -10,6 +10,8 @@ podman\-machine\-set - Sets a virtual machine setting
 
 Change a machine setting.
 
+Rootless only.
+
 ## OPTIONS
 
 #### **--cpus**=*number*

--- a/docs/source/markdown/podman-machine-ssh.1.md
+++ b/docs/source/markdown/podman-machine-ssh.1.md
@@ -16,6 +16,8 @@ with the virtual machine is established.
 
 The exit code from ssh command will be forwarded to the podman machine ssh caller, see [Exit Codes](#Exit-Codes).
 
+Rootless only.
+
 ## OPTIONS
 
 #### **--help**

--- a/docs/source/markdown/podman-machine-start.1.md
+++ b/docs/source/markdown/podman-machine-start.1.md
@@ -10,9 +10,12 @@ podman\-machine\-start - Start a virtual machine
 
 Starts a virtual machine for Podman.
 
-Podman on macOS requires a virtual machine. This is because containers are Linux -
+Rootless only.
+
+Podman on MacOS and Windows requires a virtual machine. This is because containers are Linux -
 containers do not run on any other OS because containers' core functionality are
-tied to the Linux kernel.
+tied to the Linux kernel. Podman machine must be used to manage MacOS and Windows machines,
+but can be optionally used on Linux.
 
 Only one Podman managed VM can be active at a time. If a VM is already running,
 `podman machine start` will return an error.

--- a/docs/source/markdown/podman-machine-stop.1.md
+++ b/docs/source/markdown/podman-machine-stop.1.md
@@ -10,9 +10,12 @@ podman\-machine\-stop - Stop a virtual machine
 
 Stops a virtual machine.
 
-Podman on macOS requires a virtual machine. This is because containers are Linux -
+Rootless only.
+
+Podman on MacOS and Windows requires a virtual machine. This is because containers are Linux -
 containers do not run on any other OS because containers' core functionality are
-tied to the Linux kernel.
+tied to the Linux kernel. Podman machine must be used to manage MacOS and Windows machines,
+but can be optionally used on Linux.
 
 **podman machine stop** stops a Linux virtual machine where containers are run.
 

--- a/docs/source/markdown/podman-machine.1.md
+++ b/docs/source/markdown/podman-machine.1.md
@@ -7,7 +7,14 @@ podman\-machine - Manage Podman's virtual machine
 **podman machine** *subcommand*
 
 ## DESCRIPTION
-`podman machine` is a set of subcommands that manage Podman's virtual machine on macOS.
+`podman machine` is a set of subcommands that manage Podman's virtual machine.
+
+Podman on MacOS and Windows requires a virtual machine. This is because containers are Linux -
+containers do not run on any other OS because containers' core functionality are
+tied to the Linux kernel. Podman machine must be used to manage MacOS and Windows machines,
+but can be optionally used on Linux.
+
+All `podman machine` commands are rootless only.
 
 ## SUBCOMMANDS
 

--- a/test/e2e/system_reset_test.go
+++ b/test/e2e/system_reset_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/containers/podman/v4/pkg/rootless"
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -92,9 +93,12 @@ var _ = Describe("podman system reset", func() {
 
 		// TODO: machine tests currently don't run outside of the machine test pkg
 		// no machines are created here to cleanup
-		session = podmanTest.Podman([]string{"machine", "list", "-q"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-		Expect(session.OutputToStringArray()).To(BeEmpty())
+		// machine commands are rootless only
+		if rootless.IsRootless() {
+			session = podmanTest.Podman([]string{"machine", "list", "-q"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(0))
+			Expect(session.OutputToStringArray()).To(BeEmpty())
+		}
 	})
 })


### PR DESCRIPTION
Podman Machine crashes if run as root, as we need the UID of the core user to match the UID of the user on the host. If the user on the host is root, the core UID and the Root UID collide, causing a the VM not to boot.

[NO NEW TESTS NEEDED]

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow `podman machine` to only be run rootless, as the VM refuses to boot when run as root. 

```
