### PR TITLE
Fix runtime check during restore

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -143,16 +143,15 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 					cmd.Flag("import").Value.String(),
 				)
 			}
-			if cfg.RuntimePath == "" {
+
+			runtimeFlag := cmd.Root().Flag("runtime")
+			if runtimeFlag == nil {
+				return errors.New("failed to load --runtime flag")
+			}
+
+			if !runtimeFlag.Changed {
 				// If the user did not select a runtime, this takes the one from
 				// the checkpoint archives and tells Podman to use it for the restore.
-				runtimeFlag := cmd.Root().Flags().Lookup("runtime")
-				if runtimeFlag == nil {
-					return errors.Errorf(
-						"setting runtime to '%s' for restore",
-						*runtime,
-					)
-				}
 				if err := runtimeFlag.Value.Set(*runtime); err != nil {
 					return err
 				}


### PR DESCRIPTION
[cfg.RuntimePath](https://github.com/containers/podman/blob/8e88abda85f7bf44b6857ad5d62c8ef58206fce5/cmd/podman/root.go#L146) was set to default runtime, so the empty string check fails. Instead we could check if the flag was changed.

It is a minor bug that was already mentioned in the issue below, so I didn't think I should create a new issue. Please let me know if this is a requirement.

Fixes: #11945

Signed-off-by: Zeyad Yasser <zeyady98@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
