### PR TITLE
Fix: Prevent OCI runtime directory remain

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1309,8 +1309,9 @@ func (c *Container) stop(timeout uint) error {
 		if err := c.syncContainer(); err != nil {
 			switch errors.Cause(err) {
 			// If the container has already been removed (e.g., via
-			// the cleanup process), there's nothing left to do.
+			// the cleanup process), set the container state to "stopped".
 			case define.ErrNoSuchCtr, define.ErrCtrRemoved:
+				c.state.State = define.ContainerStateStopped
 				return stopErr
 			default:
 				if stopErr != nil {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -715,6 +715,10 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 		// Do a quick ping of the database to check if the container
 		// still exists.
 		if ok, _ := r.state.HasContainer(c.ID()); !ok {
+			// When the container has already been removed, the OCI runtime directory remain.
+			if err := c.cleanupRuntime(ctx); err != nil {
+				return errors.Wrapf(err, "error cleaning up container %s from OCI runtime", c.ID())
+			}
 			return nil
 		}
 	}

--- a/test/system/050-stop.bats
+++ b/test/system/050-stop.bats
@@ -171,4 +171,19 @@ load helpers
     run_podman --noout stop -t 0 stopme
     is "$output" "" "output should be empty"
 }
+
+@test "podman stop, with --rm container" {
+    OCIDir=/run/$(podman_runtime)
+
+    if is_rootless; then
+        OCIDir=/run/user/$(id -u)/$(podman_runtime)
+    fi
+
+    run_podman run --rm -d --name rmstop $IMAGE sleep infinity
+    local cid="$output"
+    run_podman stop rmstop
+
+    # Check the OCI runtime directory has removed.
+    is "$(ls $OCIDir | grep $cid)" "" "The OCI runtime directory should have been removed"
+}
 # vim: filetype=sh


### PR DESCRIPTION
This bug was introduced in https://github.com/containers/podman/pull/8906.

When we use `podman rm/restart/stop/kill etc...` command to
the container running with `--rm`, the OCI runtime directory
remains at `/run/<runtime name>` (root user) or
`/run/user/<user id>/<runtime name>` (rootless user).

This bug could cause other bugs.
For example, when we checkpoint the container running with
`--rm` (podman checkpoint --export) and restore it
(podman restore --import) with crun, error message
`Error: OCI runtime error: crun: container '<container id>'
already exists` is outputted.
This error is caused by an attempt to restore the container with
the same container ID as the remaining OCI runtime's container ID.

Therefore, I fix that the `cleanupRuntime()` function runs to
remove the OCI runtime directory,
even if the container has already been removed by `--rm` option.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
This fix prevents the OCI runtime directory from remaining. It also prevents other bugs occurring.
```
