### PR TITLE
Fix "podman run port forward range" flake

### DIFF
--- a/test/system/150-login.bats
+++ b/test/system/150-login.bats
@@ -314,7 +314,7 @@ function _test_skopeo_credential_sharing() {
     fi
 
     # Make sure socket is closed
-    if { exec 3<> /dev/tcp/127.0.0.1/${PODMAN_LOGIN_REGISTRY_PORT}; } &>/dev/null; then
+    if ! port_is_free $PODMAN_LOGIN_REGISTRY_PORT; then
         die "Socket still seems open"
     fi
 }

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -676,12 +676,12 @@ EOF
 
 @test "podman run port forward range" {
     for netmode in bridge slirp4netns:port_handler=slirp4netns slirp4netns:port_handler=rootlesskit; do
-        local port=$(random_free_port)
-        local end_port=$(( $port + 2 ))
-        local range="$port-$end_port:$port-$end_port"
+        local range=$(random_free_port_range 3)
+        local port="${test%-*}"
+        local end_port="${test#-*}"
         local random=$(random_string)
 
-        run_podman run --network $netmode -p "$range" -d $IMAGE sleep inf
+        run_podman run --network $netmode -p "$range:$range" -d $IMAGE sleep inf
         cid="$output"
         for port in $(seq $port $end_port); do
             run_podman exec -d $cid nc -l -p $port -e /bin/cat


### PR DESCRIPTION
The test must ensure that all ports in the range are free not just
the first. This flakes often because port 5355 is always in use by
systemd-resolved on fedora.

Fixes #14716

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
