### PR TITLE
[CI:DOCS] Minor update to podmanimage upstream docs

### DIFF
--- a/contrib/podmanimage/README.md
+++ b/contrib/podmanimage/README.md
@@ -32,7 +32,9 @@ The container images are:
   * `quay.io/podman/upstream:latest` - This image is built daily using the latest
     code found in this GitHub repository.  Due to the image changing frequently,
     it's not guaranteed to be stable or even executable.  The image is built with
-    [the upstream Containerfile](upstream/Containerfile).
+    [the upstream Containerfile](upstream/Containerfile). Note the actual compilation
+    of upstream podman [occurs continuously in
+    COPR](https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/).
 
 ## Sample Usage
 


### PR DESCRIPTION
Add a reference to where/how podman is compiled for the 'upstream'
flavored image.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
