### PR TITLE
implement podman container createspec

### DIFF
--- a/cmd/podman/containers/createspec.go
+++ b/cmd/podman/containers/createspec.go
@@ -1,0 +1,98 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/containers/common/pkg/completion"
+	"github.com/containers/podman/v4/cmd/podman/common"
+	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/pkg/domain/entities"
+	"github.com/containers/podman/v4/pkg/specgen"
+	"github.com/containers/podman/v4/pkg/specgenutil"
+	"github.com/spf13/cobra"
+)
+
+var (
+	createSpecDescription = `Creates a new container from the given json file cntaining a filled out specgen`
+	createSpecCommand     = &cobra.Command{
+		Use:               "createspec [options] FILE",
+		Short:             "Create a new container from json",
+		Long:              createSpecDescription,
+		RunE:              createspec,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.AutocompleteNone,
+		Example:           `podman container createspec --cpus=5 ~/Documents/spec.json`,
+	}
+)
+
+var (
+	containerOpts entities.ContainerCreateOptions
+	startCtr      bool
+)
+
+func createSpecFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
+	startFlagName := "start"
+	flags.BoolVar(&startCtr, startFlagName, false, "start the new container")
+
+	flags.SetInterspersed(false)
+	common.DefineCreateDefaults(&containerOpts)
+	common.DefineCreateFlags(cmd, &containerOpts, false, false)
+	common.DefineNetFlags(cmd)
+}
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: createSpecCommand,
+		Parent:  containerCmd,
+	})
+
+	createSpecFlags(createSpecCommand)
+}
+
+func createspec(cmd *cobra.Command, args []string) error {
+	f, err := os.Open(args[0])
+	if err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(f.Name())
+	if err != nil {
+		return err
+	}
+
+	spec := &specgen.SpecGenerator{}
+
+	err = json.Unmarshal(data, spec)
+	if err != nil {
+		return err
+	}
+
+	err = specgenutil.FillOutSpecGen(spec, &containerOpts, []string{})
+	if err != nil {
+		return err
+	}
+
+	var id string
+	rep, err := registry.ContainerEngine().ContainerCreate(context.Background(), spec)
+	if err != nil {
+		return err
+	}
+
+	id = rep.Id
+
+	if startCtr {
+		rep, err := registry.ContainerEngine().ContainerStart(context.Background(), []string{rep.Id}, entities.ContainerStartOptions{})
+		if err != nil {
+			return err
+		}
+		id = rep[0].Id
+	}
+
+	fmt.Println(id)
+
+	return nil
+}

--- a/test/e2e/createspec_test.go
+++ b/test/e2e/createspec_test.go
@@ -1,0 +1,170 @@
+package integration
+
+import (
+	"os"
+
+	. "github.com/containers/podman/v4/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var jsonSpec = `{
+    "httpproxy":true,
+    "annotations":{
+        "io.kubernetes.cri-o.TTY":"false"
+    },
+    "stop_timeout":10,
+    "log_configuration":{
+        "driver":"journald"
+    },
+    "raw_image_name":"alpine",
+    "systemd":"true",
+    "sdnotifyMode":"container",
+    "pidns":{
+    },
+    "utsns":{
+    },
+    "containerCreateCommand":[
+        "bin/podman",
+        "create",
+        "--cpus=5",
+        "alpine",
+        "ls",
+        "/sys/fs"
+    ],
+    "init_container_type":"",
+    "manage_password":true,
+    "image":"alpine",
+    "image_volume_mode":"anonymous",
+    "ipcns":{
+    },
+    "seccomp_policy":"default",
+    "userns":{
+    },
+    "idmappings":{
+        "HostUIDMapping":true,
+        "HostGIDMapping":true,
+        "UIDMap":null,
+        "GIDMap":null,
+        "AutoUserNs":false,
+        "AutoUserNsOpts":{
+            "Size":0,
+            "InitialSize":0,
+            "PasswdFile":"",
+            "GroupFile":"",
+            "AdditionalUIDMappings":null,
+            "AdditionalGIDMappings":null
+        }
+    },
+    "umask":"0022",
+    "cgroupns":{
+    },
+    "cgroups_mode":"enabled",
+    "netns":{
+    },
+    "Networks":null,
+    "use_image_hosts":false,
+    "resource_limits":{
+        "cpu":{
+            "quota":500000,
+            "period":100000
+        }
+    }
+
+}`
+
+var sparseSpec = `{
+    "image":"alpine",
+    "systemd":"true",
+    "sdnotifyMode":"container",
+	"cgroups_mode":"enabled",
+	"resource_limits":{
+        "cpu":{
+            "quota":500000,
+            "period":100000
+        }
+    }
+}
+`
+
+var _ = Describe("Podman createspec", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest *PodmanTestIntegration
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		Expect(err).To(BeNil())
+		podmanTest = PodmanTestCreate(tempdir)
+		podmanTest.Setup()
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+		f := CurrentGinkgoTestDescription()
+		processTestResult(f)
+
+	})
+
+	It("podman createspec basic test", func() {
+		f, err := os.CreateTemp(tempdir, "podman")
+		Expect(err).Should(BeNil())
+
+		defer func() {
+			err := os.Remove(f.Name())
+			Expect(err).Should(BeNil())
+		}()
+
+		_, err = f.WriteString(jsonSpec)
+		Expect(err).Should(BeNil())
+
+		session := podmanTest.Podman([]string{"container", "createspec", f.Name()})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+	})
+
+	It("podman createspec override from command line", func() {
+		f, err := os.CreateTemp(tempdir, "podman")
+		Expect(err).Should(BeNil())
+
+		defer func() {
+			err := os.Remove(f.Name())
+			Expect(err).Should(BeNil())
+		}()
+
+		_, err = f.WriteString(jsonSpec)
+		Expect(err).Should(BeNil())
+
+		session := podmanTest.Podman([]string{"container", "createspec", "--start", "--cpus=2", f.Name()})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"container", "inspect", session.OutputToString()})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		out := session.InspectContainerToJSON()
+		// override successful
+		Expect(out[0].HostConfig.CpuQuota).Should(Equal(int64(200000)))
+	})
+
+	It("podman createspec sparse spec should work", func() {
+		f, err := os.CreateTemp(tempdir, "podman")
+		Expect(err).Should(BeNil())
+
+		defer func() {
+			err := os.Remove(f.Name())
+			Expect(err).Should(BeNil())
+		}()
+
+		_, err = f.WriteString(sparseSpec)
+		Expect(err).Should(BeNil())
+
+		session := podmanTest.Podman([]string{"container", "createspec", "--start", f.Name()})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+	})
+})


### PR DESCRIPTION
first implementation at a command which turns a json specgen into a container.
The spec can be as empty or as complete as users want, as long as an image is provided this command will work.
Also, since this just uses the specgen and create functions, users can pass in all of the run/create flags currently available

a flag that is unique to this command is --start which runs the new container once it is created

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
implemented a new command createspec, which allows users to generate containers from json/text files.
```
