### PR TITLE
bindings: Add support for `Delete` for deleting manifest list from local storage.

### DIFF
--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -117,6 +117,26 @@ func Remove(ctx context.Context, name, digest string, _ *RemoveOptions) (string,
 	return Modify(ctx, name, []string{digest}, optionsv4)
 }
 
+// Delete removes specified manifest from local storage.
+func Delete(ctx context.Context, name string) (*entities.ManifestRemoveReport, error) {
+	var report entities.ManifestRemoveReport
+	conn, err := bindings.GetClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	response, err := conn.DoRequest(ctx, nil, http.MethodDelete, "/manifests/%s", nil, nil, name)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if err := response.Process(&report); err != nil {
+		return nil, err
+	}
+
+	return &report, errorhandling.JoinErrors(errorhandling.StringsToErrors(report.Errors))
+}
+
 // Push takes a manifest list and pushes to a destination.  If the destination is not specified,
 // the name will be used instead.  If the optional all boolean is specified, all images specified
 // in the list will be pushed as well.

--- a/pkg/bindings/test/manifests_test.go
+++ b/pkg/bindings/test/manifests_test.go
@@ -62,6 +62,19 @@ var _ = Describe("podman manifest", func() {
 		Expect(len(list.Manifests)).To(BeNumerically("==", 1))
 	})
 
+	It("delete manifest", func() {
+		id, err := manifests.Create(bt.conn, "quay.io/libpod/foobar:latest", []string{}, nil)
+		Expect(err).ToNot(HaveOccurred(), err)
+		list, err := manifests.Inspect(bt.conn, id, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(len(list.Manifests)).To(BeZero())
+
+		removeReport, err := manifests.Delete(bt.conn, "quay.io/libpod/foobar:latest")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(removeReport.Deleted)).To(BeNumerically("==", 1))
+	})
+
 	It("inspect", func() {
 		_, err := manifests.Inspect(bt.conn, "larry", nil)
 		Expect(err).To(HaveOccurred())

--- a/pkg/domain/entities/manifest.go
+++ b/pkg/domain/entities/manifest.go
@@ -67,6 +67,21 @@ type ManifestModifyOptions struct {
 type ManifestRemoveOptions struct {
 }
 
+// ManifestRemoveReport provides the model for the removed manifest
+//
+// swagger:model
+type ManifestRemoveReport struct {
+	// Deleted manifest list.
+	Deleted []string `json:",omitempty"`
+	// Untagged images. Can be longer than Deleted.
+	Untagged []string `json:",omitempty"`
+	// Errors associated with operation
+	Errors []string `json:",omitempty"`
+	// ExitCode describes the exit codes as described in the `podman rmi`
+	// man page.
+	ExitCode int
+}
+
 // ManifestModifyReport provides the model for removed digests and changed manifest
 //
 // swagger:model


### PR DESCRIPTION
Bindings already support `Remove` which removes a manifest from the list
following function adds support for removing entire manifest for local
storage.

Similar functionality can be also used indirectly by using `Remove` defined in
image bindings

Closes: https://github.com/containers/podman/issues/14735

#### Does this PR introduce a user-facing change?

```
Bindings: Manifest package now exposes ManifestRemove to remove manifest list from local storage
```