### PR TITLE
pod: ps does not race with rm

### DIFF
--- a/pkg/domain/infra/abi/pods.go
+++ b/pkg/domain/infra/abi/pods.go
@@ -483,6 +483,9 @@ func (ic *ContainerEngine) PodPs(ctx context.Context, options entities.PodPSOpti
 	for _, p := range pds {
 		r, err := ic.listPodReportFromPod(p)
 		if err != nil {
+			if errors.Is(err, define.ErrNoSuchPod) || errors.Is(err, define.ErrNoSuchCtr) {
+				continue
+			}
 			return nil, err
 		}
 		reports = append(reports, r)

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -495,7 +495,22 @@ spec:
     local actual2=$(< /sys/fs/cgroup/$path2/cpu.max)
     is "$actual2" "500000 100000" "resource limits set properly"
     run_podman --cgroup-manager=cgroupfs pod rm $name2
+}
 
+@test "podman pod ps doesn't race with pod rm" {
+    # create a few pods
+    for i in {0..10}; do
+        run_podman pod create
+    done
+
+    # and delete them
+    $PODMAN pod rm -a &
+
+    # pod ps should not fail while pods are deleted
+    run_podman pod ps -q
+
+    # wait for pod rm -a
+    wait
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
the "pod ps" command first retrieves the list of all pods, then
iterates over the list to inspect each pod.  This introduce a race
since a pod could be deleted in the meanwhile by another process.

Solve it by ignoring the define.ErrNoSuchPod error.

Closes: https://github.com/containers/podman/issues/14736

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now podman ps doesn't race with podman pod rm
```
