### PR TITLE
vendor containers/common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.1.1
 	github.com/containernetworking/plugins v1.1.1
 	github.com/containers/buildah v1.26.1-0.20220609225314-e66309ebde8c
-	github.com/containers/common v0.48.1-0.20220627112538-97d9656daba8
+	github.com/containers/common v0.48.1-0.20220628131511-a8336c1613fe
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.21.2-0.20220617075545-929f14a56f5c
 	github.com/containers/ocicrypt v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -338,8 +338,8 @@ github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19
 github.com/containers/buildah v1.26.1-0.20220609225314-e66309ebde8c h1:/fKyiLFFuceBPZGJ0Lig7ElURhfsslAOw1BOcItD+X8=
 github.com/containers/buildah v1.26.1-0.20220609225314-e66309ebde8c/go.mod h1:b0L+u2Dam7soWGn5sVTK31L++Xrf80AbGvK5z9D2+lw=
 github.com/containers/common v0.48.1-0.20220608111710-dbecabbe82c9/go.mod h1:WBLwq+i7bicCpH54V70HM6s7jqDAESTlYnd05XXp0ac=
-github.com/containers/common v0.48.1-0.20220627112538-97d9656daba8 h1:d9CnUqml4SeEWGfQ781UR4quow9xdf7Q0hYqBYFRH4E=
-github.com/containers/common v0.48.1-0.20220627112538-97d9656daba8/go.mod h1:UDe7OTpNdtJA2T80Sp7yB0yTaj79f4kMNQbTsNxsqoY=
+github.com/containers/common v0.48.1-0.20220628131511-a8336c1613fe h1:H5YI9PXhDB974IkSCUaha+AF60TunRdHaGElZroYx7M=
+github.com/containers/common v0.48.1-0.20220628131511-a8336c1613fe/go.mod h1:UDe7OTpNdtJA2T80Sp7yB0yTaj79f4kMNQbTsNxsqoY=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.21.2-0.20220511203756-fe4fd4ed8be4/go.mod h1:OsX9sFexyGF0FCNAjfcVFv3IwMqDyLyV/WQY/roLPcE=

--- a/vendor/github.com/containers/common/libimage/normalize.go
+++ b/vendor/github.com/containers/common/libimage/normalize.go
@@ -1,50 +1,12 @@
 package libimage
 
 import (
-	"runtime"
 	"strings"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
-
-// NormalizePlatform normalizes (according to the OCI spec) the specified os,
-// arch and variant.  If left empty, the individual item will not be normalized.
-func NormalizePlatform(rawOS, rawArch, rawVariant string) (os, arch, variant string) {
-	os, arch, variant = rawOS, rawArch, rawVariant
-	if os == "" {
-		os = runtime.GOOS
-	}
-	if arch == "" {
-		arch = runtime.GOARCH
-	}
-	rawPlatform := os + "/" + arch
-	if variant != "" {
-		rawPlatform += "/" + variant
-	}
-
-	normalizedPlatform, err := platforms.Parse(rawPlatform)
-	if err != nil {
-		logrus.Debugf("Error normalizing platform: %v", err)
-		return rawOS, rawArch, rawVariant
-	}
-	logrus.Debugf("Normalized platform %s to %s", rawPlatform, normalizedPlatform)
-	os = rawOS
-	if rawOS != "" {
-		os = normalizedPlatform.OS
-	}
-	arch = rawArch
-	if rawArch != "" {
-		arch = normalizedPlatform.Architecture
-	}
-	variant = rawVariant
-	if rawVariant != "" {
-		variant = normalizedPlatform.Variant
-	}
-	return os, arch, variant
-}
 
 // NormalizeName normalizes the provided name according to the conventions by
 // Podman and Buildah.  If tag and digest are missing, the "latest" tag will be

--- a/vendor/github.com/containers/common/libimage/platform.go
+++ b/vendor/github.com/containers/common/libimage/platform.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/sirupsen/logrus"
 )
 
 // PlatformPolicy controls the behavior of image-platform matching.
@@ -16,11 +19,42 @@ const (
 	PlatformPolicyWarn
 )
 
-func toPlatformString(architecture, os, variant string) string {
-	if variant == "" {
-		return fmt.Sprintf("%s/%s", os, architecture)
+// NormalizePlatform normalizes (according to the OCI spec) the specified os,
+// arch and variant.  If left empty, the individual item will not be normalized.
+func NormalizePlatform(rawOS, rawArch, rawVariant string) (os, arch, variant string) {
+	rawPlatform := toPlatformString(rawOS, rawArch, rawVariant)
+	normalizedPlatform, err := platforms.Parse(rawPlatform)
+	if err != nil {
+		logrus.Debugf("Error normalizing platform: %v", err)
+		return rawOS, rawArch, rawVariant
 	}
-	return fmt.Sprintf("%s/%s/%s", os, architecture, variant)
+	logrus.Debugf("Normalized platform %s to %s", rawPlatform, normalizedPlatform)
+	os = rawOS
+	if rawOS != "" {
+		os = normalizedPlatform.OS
+	}
+	arch = rawArch
+	if rawArch != "" {
+		arch = normalizedPlatform.Architecture
+	}
+	variant = rawVariant
+	if rawVariant != "" {
+		variant = normalizedPlatform.Variant
+	}
+	return os, arch, variant
+}
+
+func toPlatformString(os, arch, variant string) string {
+	if os == "" {
+		os = runtime.GOOS
+	}
+	if arch == "" {
+		arch = runtime.GOARCH
+	}
+	if variant == "" {
+		return fmt.Sprintf("%s/%s", os, arch)
+	}
+	return fmt.Sprintf("%s/%s/%s", os, arch, variant)
 }
 
 // Checks whether the image matches the specified platform.
@@ -28,36 +62,26 @@ func toPlatformString(architecture, os, variant string) string {
 //  * 1) a matching error that can be used for logging (or returning) what does not match
 //  * 2) a bool indicating whether architecture, os or variant were set (some callers need that to decide whether they need to throw an error)
 //  * 3) a fatal error that occurred prior to check for matches (e.g., storage errors etc.)
-func (i *Image) matchesPlatform(ctx context.Context, architecture, os, variant string) (error, bool, error) {
-	customPlatform := len(architecture)+len(os)+len(variant) != 0
-
-	if len(architecture) == 0 {
-		architecture = runtime.GOARCH
-	}
-	if len(os) == 0 {
-		os = runtime.GOOS
-	}
-
+func (i *Image) matchesPlatform(ctx context.Context, os, arch, variant string) (error, bool, error) {
 	inspectInfo, err := i.inspectInfo(ctx)
 	if err != nil {
-		return nil, customPlatform, fmt.Errorf("inspecting image: %w", err)
+		return nil, false, fmt.Errorf("inspecting image: %w", err)
 	}
 
-	matches := true
-	switch {
-	case architecture != inspectInfo.Architecture:
-		matches = false
-	case os != inspectInfo.Os:
-		matches = false
-	case variant != "" && variant != inspectInfo.Variant:
-		matches = false
+	customPlatform := len(os)+len(arch)+len(variant) != 0
+
+	expected, err := platforms.Parse(toPlatformString(os, arch, variant))
+	if err != nil {
+		return nil, false, fmt.Errorf("parsing host platform: %v", err)
+	}
+	fromImage, err := platforms.Parse(toPlatformString(inspectInfo.Os, inspectInfo.Architecture, inspectInfo.Variant))
+	if err != nil {
+		return nil, false, fmt.Errorf("parsing image platform: %v", err)
 	}
 
-	if matches {
+	if platforms.NewMatcher(expected).Match(fromImage) {
 		return nil, customPlatform, nil
 	}
 
-	imagePlatform := toPlatformString(inspectInfo.Architecture, inspectInfo.Os, inspectInfo.Variant)
-	expectedPlatform := toPlatformString(architecture, os, variant)
-	return fmt.Errorf("image platform (%s) does not match the expected platform (%s)", imagePlatform, expectedPlatform), customPlatform, nil
+	return fmt.Errorf("image platform (%s) does not match the expected platform (%s)", fromImage, expected), customPlatform, nil
 }

--- a/vendor/github.com/containers/common/libimage/pull.go
+++ b/vendor/github.com/containers/common/libimage/pull.go
@@ -169,7 +169,7 @@ func (r *Runtime) Pull(ctx context.Context, name string, pullPolicy config.PullP
 		// Note that we can ignore the 2nd return value here. Some
 		// images may ship with "wrong" platform, but we already warn
 		// about it. Throwing an error is not (yet) the plan.
-		matchError, _, err := image.matchesPlatform(ctx, options.Architecture, options.OS, options.Variant)
+		matchError, _, err := image.matchesPlatform(ctx, options.OS, options.Architecture, options.Variant)
 		if err != nil {
 			return nil, fmt.Errorf("checking platform of image %s: %w", name, err)
 		}

--- a/vendor/github.com/containers/common/libimage/runtime.go
+++ b/vendor/github.com/containers/common/libimage/runtime.go
@@ -396,7 +396,7 @@ func (r *Runtime) lookupImageInLocalStorage(name, candidate string, options *Loo
 	// Ignore the (fatal) error since the image may be corrupted, which
 	// will bubble up at other places.  During lookup, we just return it as
 	// is.
-	if matchError, customPlatform, _ := image.matchesPlatform(context.Background(), options.Architecture, options.OS, options.Variant); matchError != nil {
+	if matchError, customPlatform, _ := image.matchesPlatform(context.Background(), options.OS, options.Architecture, options.Variant); matchError != nil {
 		if customPlatform {
 			logrus.Debugf("%v", matchError)
 			// Return nil if the user clearly requested a custom

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.48.1-0.20220627112538-97d9656daba8
+# github.com/containers/common v0.48.1-0.20220628131511-a8336c1613fe
 ## explicit
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
Pull in fixes for platform checks to silence annoying warnings when
pulling images by platforms using uname values.

Fixes: #14669
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
