### PR TITLE
WIP: Switch to golang native error wrapping

### DIFF
--- a/cmd/podman-mac-helper/install.go
+++ b/cmd/podman-mac-helper/install.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -14,7 +15,6 @@ import (
 	"syscall"
 	"text/template"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -111,7 +111,7 @@ func install(cmd *cobra.Command, args []string) error {
 
 	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, rw_r_r)
 	if err != nil {
-		return errors.Wrap(err, "error creating helper plist file")
+		return fmt.Errorf("error creating helper plist file: %w", err)
 	}
 	defer file.Close()
 	_, err = buf.WriteTo(file)
@@ -120,7 +120,7 @@ func install(cmd *cobra.Command, args []string) error {
 	}
 
 	if err = runDetectErr("launchctl", "load", fileName); err != nil {
-		return errors.Wrap(err, "launchctl failed loading service")
+		return fmt.Errorf("launchctl failed loading service: %w", err)
 	}
 
 	return nil
@@ -133,13 +133,13 @@ func restrictRecursive(targetDir string, until string) error {
 			return err
 		}
 		if info.Mode()&fs.ModeSymlink != 0 {
-			return errors.Errorf("symlinks not allowed in helper paths (remove them and rerun): %s", targetDir)
+			return fmt.Errorf("symlinks not allowed in helper paths (remove them and rerun): %s", targetDir)
 		}
 		if err = os.Chown(targetDir, 0, 0); err != nil {
-			return errors.Wrap(err, "could not update ownership of helper path")
+			return fmt.Errorf("could not update ownership of helper path: %w", err)
 		}
 		if err = os.Chmod(targetDir, rwx_rx_rx|fs.ModeSticky); err != nil {
-			return errors.Wrap(err, "could not update permissions of helper path")
+			return fmt.Errorf("could not update permissions of helper path: %w", err)
 		}
 		targetDir = filepath.Dir(targetDir)
 	}
@@ -162,7 +162,7 @@ func verifyRootDeep(path string) error {
 
 		stat := info.Sys().(*syscall.Stat_t)
 		if stat.Uid != 0 {
-			return errors.Errorf("installation target path must be solely owned by root: %s is not", current)
+			return fmt.Errorf("installation target path must be solely owned by root: %s is not", current)
 		}
 
 		if info.Mode()&fs.ModeSymlink != 0 {
@@ -206,7 +206,7 @@ func installExecutable(user string) (string, error) {
 
 	targetDir := filepath.Join(installPrefix, "podman", "helper", user)
 	if err := os.MkdirAll(targetDir, rwx_rx_rx); err != nil {
-		return "", errors.Wrap(err, "could not create helper directory structure")
+		return "", fmt.Errorf("could not create helper directory structure: %w", err)
 	}
 
 	// Correct any incorrect perms on previously existing directories and verify no symlinks

--- a/cmd/podman-mac-helper/main.go
+++ b/cmd/podman-mac-helper/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/podman-mac-helper/uninstall.go
+++ b/cmd/podman-mac-helper/uninstall.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -48,13 +47,13 @@ func uninstall(cmd *cobra.Command, args []string) error {
 
 	if err := os.Remove(fileName); err != nil {
 		if !os.IsNotExist(err) {
-			return errors.Errorf("could not remove plist file: %s", fileName)
+			return fmt.Errorf("could not remove plist file: %s", fileName)
 		}
 	}
 
 	helperPath := filepath.Join(installPrefix, "podman", "helper", userName)
 	if err := os.RemoveAll(helperPath); err != nil {
-		return errors.Errorf("could not remove helper binary path: %s", helperPath)
+		return fmt.Errorf("could not remove helper binary path: %s", helperPath)
 	}
 	return nil
 }

--- a/cmd/podman/auto-update.go
+++ b/cmd/podman/auto-update.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/errorhandling"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -63,7 +62,7 @@ func init() {
 func autoUpdate(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		// Backwards compat. System tests expect this error string.
-		return errors.Errorf("`%s` takes no arguments", cmd.CommandPath())
+		return fmt.Errorf("`%s` takes no arguments", cmd.CommandPath())
 	}
 
 	allReports, failures := registry.ContainerEngine().AutoUpdate(registry.GetContext(), autoUpdateOptions.AutoUpdateOptions)

--- a/cmd/podman/common/diffChanges.go
+++ b/cmd/podman/common/diffChanges.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/storage/pkg/archive"
-	"github.com/pkg/errors"
 )
 
 type ChangesReportJSON struct {
@@ -26,7 +25,7 @@ func ChangesToJSON(diffs *entities.DiffReport) error {
 		case archive.ChangeModify:
 			body.Changed = append(body.Changed, row.Path)
 		default:
-			return errors.Errorf("output kind %q not recognized", row.Kind)
+			return fmt.Errorf("output kind %q not recognized", row.Kind)
 		}
 	}
 

--- a/cmd/podman/common/netflags.go
+++ b/cmd/podman/common/netflags.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/containers/common/libnetwork/types"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/specgenutil"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -125,13 +125,13 @@ func NetFlagsToNetOptions(opts *entities.NetOptions, flags pflag.FlagSet) (*enti
 			if d == "none" {
 				opts.UseImageResolvConf = true
 				if len(servers) > 1 {
-					return nil, errors.Errorf("%s is not allowed to be specified with other DNS ip addresses", d)
+					return nil, fmt.Errorf("%s is not allowed to be specified with other DNS ip addresses", d)
 				}
 				break
 			}
 			dns := net.ParseIP(d)
 			if dns == nil {
-				return nil, errors.Errorf("%s is not an ip address", d)
+				return nil, fmt.Errorf("%s is not an ip address", d)
 			}
 			opts.DNSServers = append(opts.DNSServers, dns)
 		}
@@ -154,7 +154,7 @@ func NetFlagsToNetOptions(opts *entities.NetOptions, flags pflag.FlagSet) (*enti
 		for _, dom := range dnsSearches {
 			if dom == "." {
 				if len(dnsSearches) > 1 {
-					return nil, errors.Errorf("cannot pass additional search domains when also specifying '.'")
+					return nil, fmt.Errorf("cannot pass additional search domains when also specifying '.'")
 				}
 				continue
 			}
@@ -218,18 +218,18 @@ func NetFlagsToNetOptions(opts *entities.NetOptions, flags pflag.FlagSet) (*enti
 			if ip != "" {
 				// if pod create --infra=false
 				if infra, err := flags.GetBool("infra"); err == nil && !infra {
-					return nil, errors.Wrapf(define.ErrInvalidArg, "cannot set --%s without infra container", ipFlagName)
+					return nil, fmt.Errorf("cannot set --%s without infra container: %w", ipFlagName, define.ErrInvalidArg)
 				}
 
 				staticIP := net.ParseIP(ip)
 				if staticIP == nil {
-					return nil, errors.Errorf("%q is not an ip address", ip)
+					return nil, fmt.Errorf("%q is not an ip address", ip)
 				}
 				if !opts.Network.IsBridge() && !opts.Network.IsDefault() {
-					return nil, errors.Wrapf(define.ErrInvalidArg, "--%s can only be set when the network mode is bridge", ipFlagName)
+					return nil, fmt.Errorf("--%s can only be set when the network mode is bridge: %w", ipFlagName, define.ErrInvalidArg)
 				}
 				if len(opts.Networks) != 1 {
-					return nil, errors.Wrapf(define.ErrInvalidArg, "--%s can only be set for a single network", ipFlagName)
+					return nil, fmt.Errorf("--%s can only be set for a single network: %w", ipFlagName, define.ErrInvalidArg)
 				}
 				for name, netOpts := range opts.Networks {
 					netOpts.StaticIPs = append(netOpts.StaticIPs, staticIP)
@@ -245,17 +245,17 @@ func NetFlagsToNetOptions(opts *entities.NetOptions, flags pflag.FlagSet) (*enti
 		if len(m) > 0 {
 			// if pod create --infra=false
 			if infra, err := flags.GetBool("infra"); err == nil && !infra {
-				return nil, errors.Wrap(define.ErrInvalidArg, "cannot set --mac without infra container")
+				return nil, fmt.Errorf("cannot set --mac without infra container: %w", define.ErrInvalidArg)
 			}
 			mac, err := net.ParseMAC(m)
 			if err != nil {
 				return nil, err
 			}
 			if !opts.Network.IsBridge() && !opts.Network.IsDefault() {
-				return nil, errors.Wrap(define.ErrInvalidArg, "--mac-address can only be set when the network mode is bridge")
+				return nil, fmt.Errorf("--mac-address can only be set when the network mode is bridge: %w", define.ErrInvalidArg)
 			}
 			if len(opts.Networks) != 1 {
-				return nil, errors.Wrap(define.ErrInvalidArg, "--mac-address can only be set for a single network")
+				return nil, fmt.Errorf("--mac-address can only be set for a single network: %w", define.ErrInvalidArg)
 			}
 			for name, netOpts := range opts.Networks {
 				netOpts.StaticMAC = types.HardwareAddr(mac)
@@ -270,10 +270,10 @@ func NetFlagsToNetOptions(opts *entities.NetOptions, flags pflag.FlagSet) (*enti
 		if len(aliases) > 0 {
 			// if pod create --infra=false
 			if infra, err := flags.GetBool("infra"); err == nil && !infra {
-				return nil, errors.Wrap(define.ErrInvalidArg, "cannot set --network-alias without infra container")
+				return nil, fmt.Errorf("cannot set --network-alias without infra container: %w", define.ErrInvalidArg)
 			}
 			if !opts.Network.IsBridge() && !opts.Network.IsDefault() {
-				return nil, errors.Wrap(define.ErrInvalidArg, "--network-alias can only be set when the network mode is bridge")
+				return nil, fmt.Errorf("--network-alias can only be set when the network mode is bridge: %w", define.ErrInvalidArg)
 			}
 			for name, netOpts := range opts.Networks {
 				netOpts.Aliases = aliases

--- a/cmd/podman/containers/attach.go
+++ b/cmd/podman/containers/attach.go
@@ -1,13 +1,13 @@
 package containers
 
 import (
+	"errors"
 	"os"
 
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -70,7 +70,7 @@ func init() {
 
 func attach(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 || (len(args) == 0 && !attachOpts.Latest) {
-		return errors.Errorf("attach requires the name or id of one running container or the latest flag")
+		return errors.New("attach requires the name or id of one running container or the latest flag")
 	}
 
 	var name string

--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -15,7 +16,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/storage/pkg/archive"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -90,7 +90,7 @@ func checkpoint(cmd *cobra.Command, args []string) error {
 	podmanStart := time.Now()
 	if cmd.Flags().Changed("compress") {
 		if checkpointOptions.Export == "" {
-			return errors.Errorf("--compress can only be used with --export")
+			return errors.New("--compress can only be used with --export")
 		}
 		compress, _ := cmd.Flags().GetString("compress")
 		switch strings.ToLower(compress) {
@@ -101,7 +101,7 @@ func checkpoint(cmd *cobra.Command, args []string) error {
 		case "zstd":
 			checkpointOptions.Compression = archive.Zstd
 		default:
-			return errors.Errorf("Selected compression algorithm (%q) not supported. Please select one from: gzip, none, zstd", compress)
+			return fmt.Errorf("Selected compression algorithm (%q) not supported. Please select one from: gzip, none, zstd", compress)
 		}
 	} else {
 		checkpointOptions.Compression = archive.Zstd
@@ -110,13 +110,13 @@ func checkpoint(cmd *cobra.Command, args []string) error {
 		return errors.New("checkpointing a container requires root")
 	}
 	if checkpointOptions.Export == "" && checkpointOptions.IgnoreRootFS {
-		return errors.Errorf("--ignore-rootfs can only be used with --export")
+		return errors.New("--ignore-rootfs can only be used with --export")
 	}
 	if checkpointOptions.Export == "" && checkpointOptions.IgnoreVolumes {
-		return errors.Errorf("--ignore-volumes can only be used with --export")
+		return errors.New("--ignore-volumes can only be used with --export")
 	}
 	if checkpointOptions.WithPrevious && checkpointOptions.PreCheckPoint {
-		return errors.Errorf("--with-previous can not be used with --pre-checkpoint")
+		return errors.New("--with-previous can not be used with --pre-checkpoint")
 	}
 	if (checkpointOptions.WithPrevious || checkpointOptions.PreCheckPoint) && !criu.MemTrack() {
 		return errors.New("system (architecture/kernel/CRIU) does not support memory tracking")

--- a/cmd/podman/containers/cleanup.go
+++ b/cmd/podman/containers/cleanup.go
@@ -1,6 +1,7 @@
 package containers
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/containers/common/pkg/completion"
@@ -9,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -65,11 +65,11 @@ func cleanup(cmd *cobra.Command, args []string) error {
 	if cleanupOptions.Exec != "" {
 		switch {
 		case cleanupOptions.All:
-			return errors.Errorf("exec and all options conflict")
+			return errors.New("exec and all options conflict")
 		case len(args) > 1:
-			return errors.Errorf("cannot use exec option when more than one container is given")
+			return errors.New("cannot use exec option when more than one container is given")
 		case cleanupOptions.RemoveImage:
-			return errors.Errorf("exec and rmi options conflict")
+			return errors.New("exec and rmi options conflict")
 		}
 	}
 

--- a/cmd/podman/containers/clone.go
+++ b/cmd/podman/containers/clone.go
@@ -7,7 +7,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -56,7 +55,7 @@ func init() {
 func clone(cmd *cobra.Command, args []string) error {
 	switch len(args) {
 	case 0:
-		return errors.Wrapf(define.ErrInvalidArg, "must specify at least 1 argument")
+		return fmt.Errorf("must specify at least 1 argument: %w", define.ErrInvalidArg)
 	case 2:
 		ctrClone.CreateOpts.Name = args[1]
 	case 3:
@@ -73,7 +72,7 @@ func clone(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if ctrClone.Force && !ctrClone.Destroy {
-		return errors.Wrapf(define.ErrInvalidArg, "cannot set --force without --destroy")
+		return fmt.Errorf("cannot set --force without --destroy: %w", define.ErrInvalidArg)
 	}
 
 	ctrClone.ID = args[0]

--- a/cmd/podman/containers/commit.go
+++ b/cmd/podman/containers/commit.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -109,7 +108,7 @@ func commit(cmd *cobra.Command, args []string) error {
 	}
 	if len(iidFile) > 0 {
 		if err = ioutil.WriteFile(iidFile, []byte(response.Id), 0644); err != nil {
-			return errors.Wrap(err, "failed to write image ID")
+			return fmt.Errorf("failed to write image ID: %w", err)
 		}
 	}
 	fmt.Println(response.Id)

--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -1,6 +1,8 @@
 package containers
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -17,7 +19,6 @@ import (
 	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/idtools"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -102,7 +103,7 @@ func containerMustExist(container string) error {
 		return err
 	}
 	if !exists.Value {
-		return errors.Errorf("container %q does not exist", container)
+		return fmt.Errorf("container %q does not exist", container)
 	}
 	return nil
 }
@@ -131,7 +132,7 @@ func copyContainerToContainer(sourceContainer string, sourcePath string, destCon
 
 	sourceContainerInfo, err := registry.ContainerEngine().ContainerStat(registry.GetContext(), sourceContainer, sourcePath)
 	if err != nil {
-		return errors.Wrapf(err, "%q could not be found on container %s", sourcePath, sourceContainer)
+		return fmt.Errorf("%q could not be found on container %s: %w", sourcePath, sourceContainer, err)
 	}
 
 	destContainerBaseName, destContainerInfo, destResolvedToParentDir, err := resolvePathOnDestinationContainer(destContainer, destPath, false)
@@ -170,7 +171,7 @@ func copyContainerToContainer(sourceContainer string, sourcePath string, destCon
 			return err
 		}
 		if err := copyFunc(); err != nil {
-			return errors.Wrap(err, "error copying from container")
+			return fmt.Errorf("error copying from container: %w", err)
 		}
 		return nil
 	}
@@ -190,7 +191,7 @@ func copyContainerToContainer(sourceContainer string, sourcePath string, destCon
 			return err
 		}
 		if err := copyFunc(); err != nil {
-			return errors.Wrap(err, "error copying to container")
+			return fmt.Errorf("error copying to container: %w", err)
 		}
 		return nil
 	}
@@ -212,7 +213,7 @@ func copyFromContainer(container string, containerPath string, hostPath string) 
 
 	containerInfo, err := registry.ContainerEngine().ContainerStat(registry.GetContext(), container, containerPath)
 	if err != nil {
-		return errors.Wrapf(err, "%q could not be found on container %s", containerPath, container)
+		return fmt.Errorf("%q could not be found on container %s: %w", containerPath, container, err)
 	}
 
 	var hostBaseName string
@@ -220,13 +221,13 @@ func copyFromContainer(container string, containerPath string, hostPath string) 
 	hostInfo, hostInfoErr := copy.ResolveHostPath(hostPath)
 	if hostInfoErr != nil {
 		if strings.HasSuffix(hostPath, "/") {
-			return errors.Wrapf(hostInfoErr, "%q could not be found on the host", hostPath)
+			return fmt.Errorf("%q could not be found on the host: %w", hostPath, hostInfoErr)
 		}
 		// If it doesn't exist, then let's have a look at the parent dir.
 		parentDir := filepath.Dir(hostPath)
 		hostInfo, err = copy.ResolveHostPath(parentDir)
 		if err != nil {
-			return errors.Wrapf(hostInfoErr, "%q could not be found on the host", hostPath)
+			return fmt.Errorf("%q could not be found on the host: %w", hostPath, hostInfoErr)
 		}
 		// If the specified path does not exist, we need to assume that
 		// it'll be created while copying.  Hence, we use it as the
@@ -241,7 +242,7 @@ func copyFromContainer(container string, containerPath string, hostPath string) 
 
 	if !isStdout {
 		if err := validateFileInfo(hostInfo); err != nil {
-			return errors.Wrap(err, "invalid destination")
+			return fmt.Errorf("invalid destination: %w", err)
 		}
 	}
 
@@ -313,7 +314,7 @@ func copyFromContainer(container string, containerPath string, hostPath string) 
 			dir = filepath.Dir(dir)
 		}
 		if err := buildahCopiah.Put(dir, "", putOptions, reader); err != nil {
-			return errors.Wrap(err, "error copying to host")
+			return fmt.Errorf("error copying to host: %w", err)
 		}
 		return nil
 	}
@@ -325,7 +326,7 @@ func copyFromContainer(container string, containerPath string, hostPath string) 
 			return err
 		}
 		if err := copyFunc(); err != nil {
-			return errors.Wrap(err, "error copying from container")
+			return fmt.Errorf("error copying from container: %w", err)
 		}
 		return nil
 	}
@@ -347,7 +348,7 @@ func copyToContainer(container string, containerPath string, hostPath string) er
 	// Make sure that host path exists.
 	hostInfo, err := copy.ResolveHostPath(hostPath)
 	if err != nil {
-		return errors.Wrapf(err, "%q could not be found on the host", hostPath)
+		return fmt.Errorf("%q could not be found on the host: %w", hostPath, err)
 	}
 
 	containerBaseName, containerInfo, containerResolvedToParentDir, err := resolvePathOnDestinationContainer(container, containerPath, isStdin)
@@ -422,7 +423,7 @@ func copyToContainer(container string, containerPath string, hostPath string) er
 			getOptions.Rename = map[string]string{filepath.Base(hostTarget): containerBaseName}
 		}
 		if err := buildahCopiah.Get("/", "", getOptions, []string{hostTarget}, writer); err != nil {
-			return errors.Wrap(err, "error copying from host")
+			return fmt.Errorf("error copying from host: %w", err)
 		}
 		return nil
 	}
@@ -439,7 +440,7 @@ func copyToContainer(container string, containerPath string, hostPath string) er
 			return err
 		}
 		if err := copyFunc(); err != nil {
-			return errors.Wrap(err, "error copying to container")
+			return fmt.Errorf("error copying to container: %w", err)
 		}
 		return nil
 	}
@@ -458,7 +459,7 @@ func resolvePathOnDestinationContainer(container string, containerPath string, i
 	}
 
 	if strings.HasSuffix(containerPath, "/") {
-		err = errors.Wrapf(err, "%q could not be found on container %s", containerPath, container)
+		err = fmt.Errorf("%q could not be found on container %s: %w", containerPath, container, err)
 		return
 	}
 	if isStdin {
@@ -479,13 +480,13 @@ func resolvePathOnDestinationContainer(container string, containerPath string, i
 
 	parentDir, err := containerParentDir(container, path)
 	if err != nil {
-		err = errors.Wrapf(err, "could not determine parent dir of %q on container %s", path, container)
+		err = fmt.Errorf("could not determine parent dir of %q on container %s: %w", path, container, err)
 		return
 	}
 
 	containerInfo, err = registry.ContainerEngine().ContainerStat(registry.GetContext(), container, parentDir)
 	if err != nil {
-		err = errors.Wrapf(err, "%q could not be found on container %s", containerPath, container)
+		err = fmt.Errorf("%q could not be found on container %s: %w", containerPath, container, err)
 		return
 	}
 
@@ -505,7 +506,7 @@ func containerParentDir(container string, containerPath string) (string, error) 
 		return "", err
 	}
 	if len(inspectData) != 1 {
-		return "", errors.Errorf("inspecting container %q: expected 1 data item but got %d", container, len(inspectData))
+		return "", fmt.Errorf("inspecting container %q: expected 1 data item but got %d", container, len(inspectData))
 	}
 	workDir := filepath.Join("/", inspectData[0].Config.WorkingDir)
 	workDir = filepath.Join(workDir, containerPath)
@@ -518,5 +519,5 @@ func validateFileInfo(info *copy.FileInfo) error {
 	if info.Mode.IsDir() || info.Mode.IsRegular() {
 		return nil
 	}
-	return errors.Errorf("%q must be a directory or a regular file", info.LinkTarget)
+	return fmt.Errorf("%q must be a directory or a regular file", info.LinkTarget)
 }

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -21,7 +22,6 @@ import (
 	"github.com/containers/podman/v4/pkg/specgenutil"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/mattn/go-isatty"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -128,7 +128,7 @@ func create(cmd *cobra.Command, args []string) error {
 			return errors.New("must specify pod value with init-ctr")
 		}
 		if !cutil.StringInSlice(initctr, []string{define.AlwaysInitContainer, define.OneShotInitContainer}) {
-			return errors.Errorf("init-ctr value must be '%s' or '%s'", define.AlwaysInitContainer, define.OneShotInitContainer)
+			return fmt.Errorf("init-ctr value must be '%s' or '%s'", define.AlwaysInitContainer, define.OneShotInitContainer)
 		}
 		cliVals.InitContainerType = initctr
 	}
@@ -218,10 +218,10 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 
 	if !isInfra {
 		if c.Flag("cpu-period").Changed && c.Flag("cpus").Changed {
-			return vals, errors.Errorf("--cpu-period and --cpus cannot be set together")
+			return vals, errors.New("--cpu-period and --cpus cannot be set together")
 		}
 		if c.Flag("cpu-quota").Changed && c.Flag("cpus").Changed {
-			return vals, errors.Errorf("--cpu-quota and --cpus cannot be set together")
+			return vals, errors.New("--cpu-quota and --cpus cannot be set together")
 		}
 		vals.IPC = c.Flag("ipc").Value.String()
 		vals.UTS = c.Flag("uts").Value.String()
@@ -268,30 +268,30 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 		if c.Flags().Changed("env") {
 			env, err := c.Flags().GetStringArray("env")
 			if err != nil {
-				return vals, errors.Wrapf(err, "retrieve env flag")
+				return vals, fmt.Errorf("retrieve env flag: %w", err)
 			}
 			vals.Env = env
 		}
 		if c.Flag("cgroups").Changed && vals.CgroupsMode == "split" && registry.IsRemote() {
-			return vals, errors.Errorf("the option --cgroups=%q is not supported in remote mode", vals.CgroupsMode)
+			return vals, fmt.Errorf("the option --cgroups=%q is not supported in remote mode", vals.CgroupsMode)
 		}
 
 		if c.Flag("pod").Changed && !strings.HasPrefix(c.Flag("pod").Value.String(), "new:") && c.Flag("userns").Changed {
-			return vals, errors.Errorf("--userns and --pod cannot be set together")
+			return vals, errors.New("--userns and --pod cannot be set together")
 		}
 	}
 	if c.Flag("shm-size").Changed {
 		vals.ShmSize = c.Flag("shm-size").Value.String()
 	}
 	if (c.Flag("dns").Changed || c.Flag("dns-opt").Changed || c.Flag("dns-search").Changed) && vals.Net != nil && (vals.Net.Network.NSMode == specgen.NoNetwork || vals.Net.Network.IsContainer()) {
-		return vals, errors.Errorf("conflicting options: dns and the network mode: " + string(vals.Net.Network.NSMode))
+		return vals, fmt.Errorf("conflicting options: dns and the network mode: " + string(vals.Net.Network.NSMode))
 	}
 	noHosts, err := c.Flags().GetBool("no-hosts")
 	if err != nil {
 		return vals, err
 	}
 	if noHosts && c.Flag("add-host").Changed {
-		return vals, errors.Errorf("--no-hosts and --add-host cannot be set together")
+		return vals, errors.New("--no-hosts and --add-host cannot be set together")
 	}
 
 	if !isInfra && c.Flag("entrypoint").Changed {
@@ -314,7 +314,7 @@ func PullImage(imageName string, cliVals entities.ContainerCreateOptions) (strin
 	if cliVals.Platform != "" || cliVals.Arch != "" || cliVals.OS != "" {
 		if cliVals.Platform != "" {
 			if cliVals.Arch != "" || cliVals.OS != "" {
-				return "", errors.Errorf("--platform option can not be specified with --arch or --os")
+				return "", errors.New("--platform option can not be specified with --arch or --os")
 			}
 			split := strings.SplitN(cliVals.Platform, "/", 2)
 			cliVals.OS = split[0]
@@ -362,7 +362,7 @@ func createPodIfNecessary(cmd *cobra.Command, s *specgen.SpecGenerator, netOpts 
 	}
 	podName := strings.Replace(s.Pod, "new:", "", 1)
 	if len(podName) < 1 {
-		return errors.Errorf("new pod name must be at least one character")
+		return errors.New("new pod name must be at least one character")
 	}
 
 	var err error

--- a/cmd/podman/containers/diff.go
+++ b/cmd/podman/containers/diff.go
@@ -1,13 +1,14 @@
 package containers
 
 import (
+	"errors"
+
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/diff"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	envLib "github.com/containers/podman/v4/pkg/env"
 	"github.com/containers/podman/v4/pkg/rootless"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -126,14 +126,14 @@ func exec(_ *cobra.Command, args []string) error {
 
 	cliEnv, err := envLib.ParseSlice(envInput)
 	if err != nil {
-		return errors.Wrap(err, "error parsing environment variables")
+		return fmt.Errorf("error parsing environment variables: %w", err)
 	}
 
 	execOpts.Envs = envLib.Join(execOpts.Envs, cliEnv)
 
 	for fd := 3; fd < int(3+execOpts.PreserveFDs); fd++ {
 		if !rootless.IsFdInherited(fd) {
-			return errors.Errorf("file descriptor %d is not available - the preserve-fds option requires that file descriptors must be passed", fd)
+			return fmt.Errorf("file descriptor %d is not available - the preserve-fds option requires that file descriptors must be passed", fd)
 		}
 	}
 

--- a/cmd/podman/containers/export.go
+++ b/cmd/podman/containers/export.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"github.com/containers/common/pkg/completion"
@@ -9,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/parse"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -70,7 +70,7 @@ func export(cmd *cobra.Command, args []string) error {
 	if len(exportOpts.Output) == 0 {
 		file := os.Stdout
 		if term.IsTerminal(int(file.Fd())) {
-			return errors.Errorf("refusing to export to terminal. Use -o flag or redirect")
+			return errors.New("refusing to export to terminal. Use -o flag or redirect")
 		}
 		exportOpts.Output = "/dev/stdout"
 	} else if err := parse.ValidateFileName(exportOpts.Output); err != nil {

--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/signal"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -97,7 +97,7 @@ func kill(_ *cobra.Command, args []string) error {
 	for _, cidFile := range cidFiles {
 		content, err := ioutil.ReadFile(cidFile)
 		if err != nil {
-			return errors.Wrap(err, "error reading CIDFile")
+			return fmt.Errorf("error reading CIDFile: %w", err)
 		}
 		id := strings.Split(string(content), "\n")[0]
 		args = append(args, id)

--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -1,6 +1,8 @@
 package containers
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/containers/common/pkg/completion"
@@ -9,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -125,7 +126,7 @@ func logs(_ *cobra.Command, args []string) error {
 		// parse time, error out if something is wrong
 		since, err := util.ParseInputTime(logsOptions.SinceRaw, true)
 		if err != nil {
-			return errors.Wrapf(err, "error parsing --since %q", logsOptions.SinceRaw)
+			return fmt.Errorf("error parsing --since %q: %w", logsOptions.SinceRaw, err)
 		}
 		logsOptions.Since = since
 	}
@@ -133,7 +134,7 @@ func logs(_ *cobra.Command, args []string) error {
 		// parse time, error out if something is wrong
 		until, err := util.ParseInputTime(logsOptions.UntilRaw, false)
 		if err != nil {
-			return errors.Wrapf(err, "error parsing --until %q", logsOptions.UntilRaw)
+			return fmt.Errorf("error parsing --until %q: %w", logsOptions.UntilRaw, err)
 		}
 		logsOptions.Until = until
 	}

--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -1,6 +1,7 @@
 package containers
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -83,7 +83,7 @@ func init() {
 
 func mount(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && mountOpts.Latest {
-		return errors.Errorf("--latest and containers cannot be used together")
+		return errors.New("--latest and containers cannot be used together")
 	}
 	reports, err := registry.ContainerEngine().ContainerMount(registry.GetContext(), args, mountOpts)
 	if err != nil {
@@ -108,7 +108,7 @@ func mount(cmd *cobra.Command, args []string) error {
 	case mountOpts.Format == "":
 		break // print defaults
 	default:
-		return errors.Errorf("unknown --format argument: %q", mountOpts.Format)
+		return fmt.Errorf("unknown --format argument: %q", mountOpts.Format)
 	}
 
 	mrs := make([]mountReporter, 0, len(reports))

--- a/cmd/podman/containers/pause.go
+++ b/cmd/podman/containers/pause.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containers/common/pkg/cgroups"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/rootless"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -73,7 +73,7 @@ func pause(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) < 1 && !pauseOpts.All {
-		return errors.Errorf("you must provide at least one container name or id")
+		return errors.New("you must provide at least one container name or id")
 	}
 	responses, err := registry.ContainerEngine().ContainerPause(context.Background(), args, pauseOpts)
 	if err != nil {

--- a/cmd/podman/containers/port.go
+++ b/cmd/podman/containers/port.go
@@ -1,6 +1,7 @@
 package containers
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -9,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -77,14 +77,14 @@ func port(_ *cobra.Command, args []string) error {
 	)
 
 	if len(args) == 0 && !portOpts.Latest && !portOpts.All {
-		return errors.Errorf("you must supply a running container name or id")
+		return errors.New("you must supply a running container name or id")
 	}
 	if !portOpts.Latest && len(args) >= 1 {
 		container = args[0]
 	}
 	port := ""
 	if len(args) > 2 {
-		return errors.Errorf("`port` accepts at most 2 arguments")
+		return errors.New("`port` accepts at most 2 arguments")
 	}
 	if len(args) > 1 && !portOpts.Latest {
 		port = args[1]
@@ -95,7 +95,7 @@ func port(_ *cobra.Command, args []string) error {
 	if len(port) > 0 {
 		fields := strings.Split(port, "/")
 		if len(fields) > 2 || len(fields) < 1 {
-			return errors.Errorf("port formats are port/protocol. '%s' is invalid", port)
+			return fmt.Errorf("port formats are port/protocol. '%s' is invalid", port)
 		}
 		if len(fields) == 1 {
 			fields = append(fields, "tcp")
@@ -149,7 +149,7 @@ func port(_ *cobra.Command, args []string) error {
 			}
 		}
 		if !found && port != "" {
-			return errors.Errorf("failed to find published port %q", port)
+			return fmt.Errorf("failed to find published port %q", port)
 		}
 	}
 	return nil

--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -1,6 +1,7 @@
 package containers
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -16,7 +17,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -108,18 +108,18 @@ func listFlagSet(cmd *cobra.Command) {
 func checkFlags(c *cobra.Command) error {
 	// latest, and last are mutually exclusive.
 	if listOpts.Last >= 0 && listOpts.Latest {
-		return errors.Errorf("last and latest are mutually exclusive")
+		return errors.New("last and latest are mutually exclusive")
 	}
 	// Quiet conflicts with size and namespace and is overridden by a Go
 	// template.
 	if listOpts.Quiet {
 		if listOpts.Size || listOpts.Namespace {
-			return errors.Errorf("quiet conflicts with size and namespace")
+			return errors.New("quiet conflicts with size and namespace")
 		}
 	}
 	// Size and namespace conflict with each other
 	if listOpts.Size && listOpts.Namespace {
-		return errors.Errorf("size and namespace options conflict")
+		return errors.New("size and namespace options conflict")
 	}
 
 	if listOpts.Watch > 0 && listOpts.Latest {
@@ -191,7 +191,7 @@ func ps(cmd *cobra.Command, _ []string) error {
 	for _, f := range filters {
 		split := strings.SplitN(f, "=", 2)
 		if len(split) == 1 {
-			return errors.Errorf("invalid filter %q", f)
+			return fmt.Errorf("invalid filter %q", f)
 		}
 		listOpts.Filters[split[0]] = append(listOpts.Filters[split[0]], split[1])
 	}

--- a/cmd/podman/containers/rename.go
+++ b/cmd/podman/containers/rename.go
@@ -1,10 +1,11 @@
 package containers
 
 import (
+	"errors"
+
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -44,7 +45,7 @@ func init() {
 
 func rename(cmd *cobra.Command, args []string) error {
 	if len(args) > 2 {
-		return errors.Errorf("must provide at least two arguments to rename")
+		return errors.New("must provide at least two arguments to rename")
 	}
 	renameOpts := entities.ContainerRenameOptions{
 		NewName: args[1],

--- a/cmd/podman/containers/restart.go
+++ b/cmd/podman/containers/restart.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -85,10 +84,10 @@ func restart(cmd *cobra.Command, args []string) error {
 		errs utils.OutputErrors
 	)
 	if len(args) < 1 && !restartOptions.Latest && !restartOptions.All {
-		return errors.Wrapf(define.ErrInvalidArg, "you must provide at least one container name or ID")
+		return fmt.Errorf("you must provide at least one container name or ID: %w", define.ErrInvalidArg)
 	}
 	if len(args) > 0 && restartOptions.Latest {
-		return errors.Wrapf(define.ErrInvalidArg, "--latest and containers cannot be used together")
+		return fmt.Errorf("--latest and containers cannot be used together: %w", define.ErrInvalidArg)
 	}
 
 	if cmd.Flag("time").Changed {

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/specgenutil"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -134,7 +133,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	for fd := 3; fd < int(3+runOpts.PreserveFDs); fd++ {
 		if !rootless.IsFdInherited(fd) {
-			return errors.Errorf("file descriptor %d is not available - the preserve-fds option requires that file descriptors must be passed", fd)
+			return fmt.Errorf("file descriptor %d is not available - the preserve-fds option requires that file descriptors must be passed", fd)
 		}
 	}
 
@@ -165,7 +164,7 @@ func run(cmd *cobra.Command, args []string) error {
 	// If attach is set, clear stdin/stdout/stderr and only attach requested
 	if cmd.Flag("attach").Changed {
 		if passthrough {
-			return errors.Wrapf(define.ErrInvalidArg, "cannot specify --attach with --log-driver=passthrough")
+			return fmt.Errorf("cannot specify --attach with --log-driver=passthrough: %w", define.ErrInvalidArg)
 		}
 		runOpts.OutputStream = nil
 		runOpts.ErrorStream = nil
@@ -182,7 +181,7 @@ func run(cmd *cobra.Command, args []string) error {
 			case "stdin":
 				runOpts.InputStream = os.Stdin
 			default:
-				return errors.Wrapf(define.ErrInvalidArg, "invalid stream %q for --attach - must be one of stdin, stdout, or stderr", stream)
+				return fmt.Errorf("invalid stream %q for --attach - must be one of stdin, stdout, or stderr: %w", stream, define.ErrInvalidArg)
 			}
 		}
 	}

--- a/cmd/podman/containers/start.go
+++ b/cmd/podman/containers/start.go
@@ -1,6 +1,7 @@
 package containers
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -11,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -88,19 +88,19 @@ func validateStart(cmd *cobra.Command, args []string) error {
 		return errors.New("start requires at least one argument")
 	}
 	if startOptions.All && startOptions.Latest {
-		return errors.Errorf("--all and --latest cannot be used together")
+		return errors.New("--all and --latest cannot be used together")
 	}
 	if len(args) > 0 && startOptions.Latest {
-		return errors.Errorf("--latest and containers cannot be used together")
+		return errors.New("--latest and containers cannot be used together")
 	}
 	if len(args) > 1 && startOptions.Attach {
-		return errors.Errorf("you cannot start and attach multiple containers at once")
+		return errors.New("you cannot start and attach multiple containers at once")
 	}
 	if (len(args) > 0 || startOptions.Latest) && startOptions.All {
-		return errors.Errorf("either start all containers or the container(s) provided in the arguments")
+		return errors.New("either start all containers or the container(s) provided in the arguments")
 	}
 	if startOptions.Attach && startOptions.All {
-		return errors.Errorf("you cannot start and attach all containers at once")
+		return errors.New("you cannot start and attach all containers at once")
 	}
 	return nil
 }
@@ -114,7 +114,7 @@ func start(cmd *cobra.Command, args []string) error {
 	startOptions.SigProxy = sigProxy
 
 	if sigProxy && !startOptions.Attach {
-		return errors.Wrapf(define.ErrInvalidArg, "you cannot use sig-proxy without --attach")
+		return fmt.Errorf("you cannot use sig-proxy without --attach: %w", define.ErrInvalidArg)
 	}
 	if startOptions.Attach {
 		startOptions.Stdin = os.Stdin
@@ -127,7 +127,7 @@ func start(cmd *cobra.Command, args []string) error {
 		for _, f := range filters {
 			split := strings.SplitN(f, "=", 2)
 			if len(split) == 1 {
-				return errors.Errorf("invalid filter %q", f)
+				return fmt.Errorf("invalid filter %q", f)
 			}
 			startOptions.Filters[split[0]] = append(startOptions.Filters[split[0]], split[1])
 		}

--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -1,6 +1,7 @@
 package containers
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/utils"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -105,7 +105,7 @@ func checkStatOptions(cmd *cobra.Command, args []string) error {
 		opts++
 	}
 	if opts > 1 {
-		return errors.Errorf("--all, --latest and containers cannot be used together")
+		return errors.New("--all, --latest and containers cannot be used together")
 	}
 	return nil
 }

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -102,7 +101,7 @@ func stop(cmd *cobra.Command, args []string) error {
 	for _, cidFile := range cidFiles {
 		content, err := ioutil.ReadFile(cidFile)
 		if err != nil {
-			return errors.Wrap(err, "error reading CIDFile")
+			return fmt.Errorf("error reading CIDFile: %w", err)
 		}
 		id := strings.Split(string(content), "\n")[0]
 		args = append(args, id)

--- a/cmd/podman/containers/top.go
+++ b/cmd/podman/containers/top.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -88,7 +88,7 @@ func top(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) < 1 && !topOptions.Latest {
-		return errors.Errorf("you must provide the name or id of a running container")
+		return errors.New("you must provide the name or id of a running container")
 	}
 
 	if topOptions.Latest {

--- a/cmd/podman/containers/unpause.go
+++ b/cmd/podman/containers/unpause.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containers/common/pkg/cgroups"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/rootless"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -70,7 +70,7 @@ func unpause(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if len(args) < 1 && !unPauseOptions.All {
-		return errors.Errorf("you must provide at least one container name or id")
+		return errors.New("you must provide at least one container name or id")
 	}
 	responses, err := registry.ContainerEngine().ContainerUnpause(context.Background(), args, unPauseOptions)
 	if err != nil {

--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -86,7 +86,7 @@ func wait(cmd *cobra.Command, args []string) error {
 	}
 
 	if !waitOptions.Latest && len(args) == 0 {
-		return errors.Errorf("%q requires a name, id, or the \"--latest\" flag", cmd.CommandPath())
+		return fmt.Errorf("%q requires a name, id, or the \"--latest\" flag", cmd.CommandPath())
 	}
 	if waitOptions.Latest && len(args) > 0 {
 		return errors.New("--latest and containers cannot be used together")

--- a/cmd/podman/diff/diff.go
+++ b/cmd/podman/diff/diff.go
@@ -2,6 +2,7 @@ package diff
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/storage/pkg/archive"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +46,7 @@ func changesToJSON(diffs *entities.DiffReport) error {
 		case archive.ChangeModify:
 			body.Changed = append(body.Changed, row.Path)
 		default:
-			return errors.Errorf("output kind %q not recognized", row.Kind)
+			return fmt.Errorf("output kind %q not recognized", row.Kind)
 		}
 	}
 
@@ -73,7 +73,7 @@ func ValidateContainerDiffArgs(cmd *cobra.Command, args []string) error {
 		return errors.New("--latest and containers cannot be used together")
 	}
 	if len(args) == 0 && !given {
-		return errors.Errorf("%q requires a name, id, or the \"--latest\" flag", cmd.CommandPath())
+		return fmt.Errorf("%q requires a name, id, or the \"--latest\" flag", cmd.CommandPath())
 	}
 	return nil
 }

--- a/cmd/podman/early_init_linux.go
+++ b/cmd/podman/early_init_linux.go
@@ -6,7 +6,6 @@ import (
 	"syscall"
 
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/pkg/errors"
 )
 
 func setRLimits() error {
@@ -15,11 +14,11 @@ func setRLimits() error {
 	rlimits.Max = define.RLimitDefaultValue
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
 		if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
-			return errors.Wrapf(err, "error getting rlimits")
+			return fmt.Errorf("error getting rlimits: %w", err)
 		}
 		rlimits.Cur = rlimits.Max
 		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
-			return errors.Wrapf(err, "error setting new rlimits")
+			return fmt.Errorf("error setting new rlimits: %w", err)
 		}
 	}
 	return nil

--- a/cmd/podman/generate/kube.go
+++ b/cmd/podman/generate/kube.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -68,10 +67,10 @@ func kube(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flags().Changed("filename") {
 		if _, err := os.Stat(kubeFile); err == nil {
-			return errors.Errorf("cannot write to %q; file exists", kubeFile)
+			return fmt.Errorf("cannot write to %q; file exists", kubeFile)
 		}
 		if err := ioutil.WriteFile(kubeFile, content, 0644); err != nil {
-			return errors.Wrapf(err, "cannot write to %q", kubeFile)
+			return fmt.Errorf("cannot write to %q: %w", kubeFile, err)
 		}
 		return nil
 	}

--- a/cmd/podman/generate/systemd.go
+++ b/cmd/podman/generate/systemd.go
@@ -2,6 +2,7 @@ package pods
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	systemDefine "github.com/containers/podman/v4/pkg/systemd/define"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -156,7 +156,7 @@ func systemd(cmd *cobra.Command, args []string) error {
 	if files {
 		cwd, err := os.Getwd()
 		if err != nil {
-			return errors.Wrap(err, "error getting current working directory")
+			return fmt.Errorf("error getting current working directory: %w", err)
 		}
 		for name, content := range reports.Units {
 			path := filepath.Join(cwd, fmt.Sprintf("%s.service", name))
@@ -189,7 +189,7 @@ func systemd(cmd *cobra.Command, args []string) error {
 	case format == "":
 		return printDefault(reports.Units)
 	default:
-		return errors.Errorf("unknown --format argument: %s", format)
+		return fmt.Errorf("unknown --format argument: %s", format)
 	}
 }
 

--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -1,6 +1,7 @@
 package images
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -23,7 +24,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -222,7 +222,7 @@ func build(cmd *cobra.Command, args []string) error {
 		// The context directory could be a URL.  Try to handle that.
 		tempDir, subDir, err := buildahDefine.TempDirForURL("", "buildah", args[0])
 		if err != nil {
-			return errors.Wrapf(err, "error prepping temporary context directory")
+			return fmt.Errorf("error prepping temporary context directory: %w", err)
 		}
 		if tempDir != "" {
 			// We had to download it to a temporary directory.
@@ -237,7 +237,7 @@ func build(cmd *cobra.Command, args []string) error {
 			// Nope, it was local.  Use it as is.
 			absDir, err := filepath.Abs(args[0])
 			if err != nil {
-				return errors.Wrapf(err, "error determining path to directory %q", args[0])
+				return fmt.Errorf("error determining path to directory %q: %w", args[0], err)
 			}
 			contextDir = absDir
 		}
@@ -253,7 +253,7 @@ func build(cmd *cobra.Command, args []string) error {
 			}
 			absFile, err := filepath.Abs(containerFiles[i])
 			if err != nil {
-				return errors.Wrapf(err, "error determining path to file %q", containerFiles[i])
+				return fmt.Errorf("error determining path to file %q: %w", containerFiles[i], err)
 			}
 			contextDir = filepath.Dir(absFile)
 			containerFiles[i] = absFile
@@ -262,10 +262,10 @@ func build(cmd *cobra.Command, args []string) error {
 	}
 
 	if contextDir == "" {
-		return errors.Errorf("no context directory and no Containerfile specified")
+		return errors.New("no context directory and no Containerfile specified")
 	}
 	if !utils.IsDir(contextDir) {
-		return errors.Errorf("context must be a directory: %q", contextDir)
+		return fmt.Errorf("context must be a directory: %q", contextDir)
 	}
 	if len(containerFiles) == 0 {
 		if utils.FileExists(filepath.Join(contextDir, "Containerfile")) {
@@ -296,13 +296,13 @@ func build(cmd *cobra.Command, args []string) error {
 		if registry.IsRemote() {
 			// errors from server does not contain ExitCode
 			// so parse exit code from error message
-			remoteExitCode, parseErr := utils.ExitCodeFromBuildError(fmt.Sprint(errors.Cause(err)))
+			remoteExitCode, parseErr := utils.ExitCodeFromBuildError(err.Error())
 			if parseErr == nil {
 				exitCode = remoteExitCode
 			}
 		}
 
-		if ee, ok := (errors.Cause(err)).(*exec.ExitError); ok {
+		if ee, ok := (err).(*exec.ExitError); ok {
 			exitCode = ee.ExitCode()
 		}
 
@@ -356,7 +356,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 	}
 
 	if pullFlagsCount > 1 {
-		return nil, errors.Errorf("can only set one of 'pull' or 'pull-always' or 'pull-never'")
+		return nil, errors.New("can only set one of 'pull' or 'pull-always' or 'pull-never'")
 	}
 
 	// Allow for --pull, --pull=true, --pull=false, --pull=never, --pull=always
@@ -477,7 +477,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 	case strings.HasPrefix(flags.Format, buildahDefine.DOCKER):
 		format = buildahDefine.Dockerv2ImageManifest
 	default:
-		return nil, errors.Errorf("unrecognized image type %q", flags.Format)
+		return nil, fmt.Errorf("unrecognized image type %q", flags.Format)
 	}
 
 	runtimeFlags := []string{}
@@ -500,7 +500,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 
 	decConfig, err := getDecryptConfig(flags.DecryptionKeys)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to obtain decrypt config")
+		return nil, fmt.Errorf("unable to obtain decrypt config: %w", err)
 	}
 
 	additionalBuildContext := make(map[string]*buildahDefine.AdditionalBuildContext)
@@ -510,7 +510,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 			if len(av) > 1 {
 				parseAdditionalBuildContext, err := parse.GetAdditionalBuildContext(av[1])
 				if err != nil {
-					return nil, errors.Wrapf(err, "while parsing additional build context")
+					return nil, fmt.Errorf("while parsing additional build context: %w", err)
 				}
 				additionalBuildContext[av[0]] = &parseAdditionalBuildContext
 			} else {
@@ -580,7 +580,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *buil
 	if flags.IgnoreFile != "" {
 		excludes, err := parseDockerignore(flags.IgnoreFile)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to obtain decrypt config")
+			return nil, fmt.Errorf("unable to obtain decrypt config: %w", err)
 		}
 		opts.Excludes = excludes
 	}
@@ -599,7 +599,7 @@ func getDecryptConfig(decryptionKeys []string) (*encconfig.DecryptConfig, error)
 		// decryption
 		dcc, err := enchelpers.CreateCryptoConfig([]string{}, decryptionKeys)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid decryption keys")
+			return nil, fmt.Errorf("invalid decryption keys: %w", err)
 		}
 		cc := encconfig.CombineCryptoConfigs([]encconfig.CryptoConfig{dcc})
 		decConfig = cc.DecryptConfig

--- a/cmd/podman/images/history.go
+++ b/cmd/podman/images/history.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -132,7 +131,7 @@ func history(cmd *cobra.Command, args []string) error {
 		})
 
 		if err := rpt.Execute(hdrs); err != nil {
-			return errors.Wrapf(err, "failed to write report column headers")
+			return fmt.Errorf("failed to write report column headers: %w", err)
 		}
 	}
 	return rpt.Execute(hr)

--- a/cmd/podman/images/import.go
+++ b/cmd/podman/images/import.go
@@ -2,6 +2,7 @@ package images
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -102,7 +102,7 @@ func importCon(cmd *cobra.Command, args []string) error {
 	)
 	switch len(args) {
 	case 0:
-		return errors.Errorf("need to give the path to the tarball, or must specify a tarball of '-' for stdin")
+		return errors.New("need to give the path to the tarball, or must specify a tarball of '-' for stdin")
 	case 1:
 		source = args[0]
 	case 2:
@@ -112,20 +112,20 @@ func importCon(cmd *cobra.Command, args []string) error {
 		// instead of the localhost ones
 		reference = args[1]
 	default:
-		return errors.Errorf("too many arguments. Usage TARBALL [REFERENCE]")
+		return errors.New("too many arguments. Usage TARBALL [REFERENCE]")
 	}
 
 	if source == "-" {
 		outFile, err := ioutil.TempFile("", "podman")
 		if err != nil {
-			return errors.Errorf("creating file %v", err)
+			return fmt.Errorf("creating file: %w", err)
 		}
 		defer os.Remove(outFile.Name())
 		defer outFile.Close()
 
 		_, err = io.Copy(outFile, os.Stdin)
 		if err != nil {
-			return errors.Errorf("copying file %v", err)
+			return fmt.Errorf("copying file: %w", err)
 		}
 		source = outFile.Name()
 	}

--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -1,6 +1,7 @@
 package images
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -15,7 +16,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -225,7 +225,7 @@ func sortImages(imageS []*entities.ImageSummary) ([]imageReporter, error) {
 				h.ImageSummary = *e
 				h.Repository, h.Tag, err = tokenRepoTag(tag)
 				if err != nil {
-					return nil, errors.Wrapf(err, "error parsing repository tag: %q", tag)
+					return nil, fmt.Errorf("error parsing repository tag: %q: %w", tag, err)
 				}
 				if h.Tag == "<none>" {
 					untagged = append(untagged, h)

--- a/cmd/podman/images/load.go
+++ b/cmd/podman/images/load.go
@@ -2,6 +2,7 @@ package images
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -91,18 +91,18 @@ func load(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		if term.IsTerminal(int(os.Stdin.Fd())) {
-			return errors.Errorf("cannot read from terminal, use command-line redirection or the --input flag")
+			return errors.New("cannot read from terminal, use command-line redirection or the --input flag")
 		}
 		outFile, err := ioutil.TempFile(util.Tmpdir(), "podman")
 		if err != nil {
-			return errors.Errorf("creating file %v", err)
+			return fmt.Errorf("creating file: %w", err)
 		}
 		defer os.Remove(outFile.Name())
 		defer outFile.Close()
 
 		_, err = io.Copy(outFile, os.Stdin)
 		if err != nil {
-			return errors.Errorf("copying file %v", err)
+			return fmt.Errorf("copying file: %w", err)
 		}
 		loadOpts.Input = outFile.Name()
 	}

--- a/cmd/podman/images/mount.go
+++ b/cmd/podman/images/mount.go
@@ -1,6 +1,7 @@
 package images
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -84,7 +84,7 @@ func mount(cmd *cobra.Command, args []string) error {
 	case mountOpts.Format == "":
 		break // see default format below
 	default:
-		return errors.Errorf("unknown --format argument: %q", mountOpts.Format)
+		return fmt.Errorf("unknown --format argument: %q", mountOpts.Format)
 	}
 
 	mrs := make([]mountReporter, 0, len(reports))

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -1,6 +1,7 @@
 package images
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -138,7 +138,7 @@ func imagePull(cmd *cobra.Command, args []string) error {
 	}
 	if platform != "" {
 		if pullOptions.Arch != "" || pullOptions.OS != "" {
-			return errors.Errorf("--platform option can not be specified with --arch or --os")
+			return errors.New("--platform option can not be specified with --arch or --os")
 		}
 		split := strings.SplitN(platform, "/", 2)
 		pullOptions.OS = split[0]

--- a/cmd/podman/images/rm.go
+++ b/cmd/podman/images/rm.go
@@ -1,13 +1,13 @@
 package images
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/errorhandling"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -62,10 +62,10 @@ func imageRemoveFlagSet(flags *pflag.FlagSet) {
 
 func rm(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 && !imageOpts.All {
-		return errors.Errorf("image name or ID must be specified")
+		return errors.New("image name or ID must be specified")
 	}
 	if len(args) > 0 && imageOpts.All {
-		return errors.Errorf("when using the --all switch, you may not pass any images names or IDs")
+		return errors.New("when using the --all switch, you may not pass any images names or IDs")
 	}
 
 	// Note: certain image-removal errors are non-fatal.  Hence, the report

--- a/cmd/podman/images/save.go
+++ b/cmd/podman/images/save.go
@@ -2,6 +2,8 @@ package images
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -12,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -31,14 +32,14 @@ var (
 		RunE:  save,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return errors.Errorf("need at least 1 argument")
+				return errors.New("need at least 1 argument")
 			}
 			format, err := cmd.Flags().GetString("format")
 			if err != nil {
 				return err
 			}
 			if !util.StringInSlice(format, common.ValidSaveFormats) {
-				return errors.Errorf("format value must be one of %s", strings.Join(common.ValidSaveFormats, " "))
+				return fmt.Errorf("format value must be one of %s", strings.Join(common.ValidSaveFormats, " "))
 			}
 			return nil
 		},
@@ -103,13 +104,13 @@ func save(cmd *cobra.Command, args []string) (finalErr error) {
 		succeeded = false
 	)
 	if cmd.Flag("compress").Changed && (saveOpts.Format != define.OCIManifestDir && saveOpts.Format != define.V2s2ManifestDir) {
-		return errors.Errorf("--compress can only be set when --format is either 'oci-dir' or 'docker-dir'")
+		return errors.New("--compress can only be set when --format is either 'oci-dir' or 'docker-dir'")
 	}
 	if len(saveOpts.Output) == 0 {
 		saveOpts.Quiet = true
 		fi := os.Stdout
 		if term.IsTerminal(int(fi.Fd())) {
-			return errors.Errorf("refusing to save to terminal. Use -o flag or redirect")
+			return errors.New("refusing to save to terminal. Use -o flag or redirect")
 		}
 		pipePath, cleanup, err := setupPipe()
 		if err != nil {

--- a/cmd/podman/images/scp_utils.go
+++ b/cmd/podman/images/scp_utils.go
@@ -1,12 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 )
 
 // parseImageSCPArg returns the valid connection, and source/destination data based off of the information provided by the user
@@ -52,13 +52,13 @@ func validateImagePortion(location entities.ImageScpOptions, arg string) (entiti
 // validateSCPArgs takes the array of source and destination options and checks for common errors
 func validateSCPArgs(locations []*entities.ImageScpOptions) (bool, error) {
 	if len(locations) > 2 {
-		return false, errors.Wrapf(define.ErrInvalidArg, "cannot specify more than two arguments")
+		return false, fmt.Errorf("cannot specify more than two arguments: %w", define.ErrInvalidArg)
 	}
 	switch {
 	case len(locations[0].Image) > 0 && len(locations[1].Image) > 0:
-		return false, errors.Wrapf(define.ErrInvalidArg, "cannot specify an image rename")
+		return false, fmt.Errorf("cannot specify an image rename: %w", define.ErrInvalidArg)
 	case len(locations[0].Image) == 0 && len(locations[1].Image) == 0:
-		return false, errors.Wrapf(define.ErrInvalidArg, "a source image must be specified")
+		return false, fmt.Errorf("a source image must be specified: %w", define.ErrInvalidArg)
 	case len(locations[0].Image) == 0 && len(locations[1].Image) != 0:
 		if locations[0].Remote && locations[1].Remote {
 			return true, nil // we need to flip the cliConnections array so the save/load connections are in the right place

--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -1,6 +1,7 @@
 package images
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -111,11 +111,11 @@ func imageSearch(cmd *cobra.Command, args []string) error {
 	case 1:
 		searchTerm = args[0]
 	default:
-		return errors.Errorf("search requires exactly one argument")
+		return errors.New("search requires exactly one argument")
 	}
 
 	if searchOptions.ListTags && len(searchOptions.Filters) != 0 {
-		return errors.Errorf("filters are not applicable to list tags result")
+		return errors.New("filters are not applicable to list tags result")
 	}
 
 	// TLS verification in c/image is controlled via a `types.OptionalBool`
@@ -155,7 +155,7 @@ func imageSearch(cmd *cobra.Command, args []string) error {
 	switch {
 	case searchOptions.ListTags:
 		if len(searchOptions.Filters) != 0 {
-			return errors.Errorf("filters are not applicable to list tags result")
+			return errors.New("filters are not applicable to list tags result")
 		}
 		if isJSON {
 			listTagsEntries := buildListTagsJSON(searchReport)
@@ -181,7 +181,7 @@ func imageSearch(cmd *cobra.Command, args []string) error {
 	if rpt.RenderHeaders {
 		hdrs := report.Headers(entities.ImageSearchReport{}, nil)
 		if err := rpt.Execute(hdrs); err != nil {
-			return errors.Wrapf(err, "failed to write report column headers")
+			return fmt.Errorf("failed to write report column headers: %w", err)
 		}
 	}
 	return rpt.Execute(searchReport)

--- a/cmd/podman/images/sign.go
+++ b/cmd/podman/images/sign.go
@@ -1,6 +1,7 @@
 package images
 
 import (
+	"errors"
 	"os"
 
 	"github.com/containers/common/pkg/auth"
@@ -8,7 +9,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +57,7 @@ func init() {
 
 func sign(cmd *cobra.Command, args []string) error {
 	if signOptions.SignBy == "" {
-		return errors.Errorf("please provide an identity")
+		return errors.New("please provide an identity")
 	}
 
 	var sigStoreDir string

--- a/cmd/podman/images/trust_set.go
+++ b/cmd/podman/images/trust_set.go
@@ -1,6 +1,7 @@
 package images
 
 import (
+	"fmt"
 	"net/url"
 	"regexp"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -61,7 +61,7 @@ func setTrust(cmd *cobra.Command, args []string) error {
 	}
 
 	if !util.StringInSlice(setOptions.Type, validTrustTypes) {
-		return errors.Errorf("invalid choice: %s (choose from 'accept', 'reject', 'signedBy')", setOptions.Type)
+		return fmt.Errorf("invalid choice: %s (choose from 'accept', 'reject', 'signedBy')", setOptions.Type)
 	}
 	return registry.ImageEngine().SetTrust(registry.Context(), args, setOptions)
 }
@@ -71,17 +71,17 @@ func isValidImageURI(imguri string) (bool, error) {
 	uri := "http://" + imguri
 	u, err := url.Parse(uri)
 	if err != nil {
-		return false, errors.Wrapf(err, "invalid image uri: %s", imguri)
+		return false, fmt.Errorf("invalid image uri: %s: %w", imguri, err)
 	}
 	reg := regexp.MustCompile(`^[a-zA-Z0-9-_\.]+\/?:?[0-9]*[a-z0-9-\/:]*$`)
 	ret := reg.FindAllString(u.Host, -1)
 	if len(ret) == 0 {
-		return false, errors.Wrapf(err, "invalid image uri: %s", imguri)
+		return false, fmt.Errorf("invalid image uri: %s: %w", imguri, err)
 	}
 	reg = regexp.MustCompile(`^[a-z0-9-:\./]*$`)
 	ret = reg.FindAllString(u.Fragment, -1)
 	if len(ret) == 0 {
-		return false, errors.Wrapf(err, "invalid image uri: %s", imguri)
+		return false, fmt.Errorf("invalid image uri: %s: %w", imguri, err)
 	}
 	return true, nil
 }

--- a/cmd/podman/images/unmount.go
+++ b/cmd/podman/images/unmount.go
@@ -1,13 +1,13 @@
 package images
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/podman/images/utils_linux.go
+++ b/cmd/podman/images/utils_linux.go
@@ -1,12 +1,12 @@
 package images
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -26,7 +26,7 @@ func setupPipe() (string, func() <-chan error, error) {
 		if e := os.RemoveAll(pipeDir); e != nil {
 			logrus.Errorf("Removing named pipe: %q", e)
 		}
-		return "", nil, errors.Wrapf(err, "error creating named pipe")
+		return "", nil, fmt.Errorf("error creating named pipe: %w", err)
 	}
 	go func() {
 		fpipe, err := os.Open(pipePath)

--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -3,6 +3,7 @@ package inspect
 import (
 	"context"
 	"encoding/json" // due to a bug in json-iterator it cannot be used here
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -16,7 +17,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -64,19 +64,19 @@ func newInspector(options entities.InspectOptions) (*inspector, error) {
 	case common.ImageType, common.ContainerType, common.AllType, common.PodType, common.NetworkType, common.VolumeType:
 		// Valid types.
 	default:
-		return nil, errors.Errorf("invalid type %q: must be %q, %q, %q, %q, %q, or %q", options.Type,
+		return nil, fmt.Errorf("invalid type %q: must be %q, %q, %q, %q, %q, or %q", options.Type,
 			common.ImageType, common.ContainerType, common.PodType, common.NetworkType, common.VolumeType, common.AllType)
 	}
 	if options.Type == common.ImageType {
 		if options.Latest {
-			return nil, errors.Errorf("latest is not supported for type %q", common.ImageType)
+			return nil, fmt.Errorf("latest is not supported for type %q", common.ImageType)
 		}
 		if options.Size {
-			return nil, errors.Errorf("size is not supported for type %q", common.ImageType)
+			return nil, fmt.Errorf("size is not supported for type %q", common.ImageType)
 		}
 	}
 	if options.Type == common.PodType && options.Size {
-		return nil, errors.Errorf("size is not supported for type %q", common.PodType)
+		return nil, fmt.Errorf("size is not supported for type %q", common.PodType)
 	}
 	podOpts := entities.PodInspectOptions{
 		Latest: options.Latest,
@@ -145,8 +145,7 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 			i.podOptions.NameOrID = pod
 			podData, err := i.containerEngine.PodInspect(ctx, i.podOptions)
 			if err != nil {
-				cause := errors.Cause(err)
-				if !strings.Contains(cause.Error(), define.ErrNoSuchPod.Error()) {
+				if !errors.Is(err, define.ErrNoSuchPod) {
 					errs = []error{err}
 				} else {
 					return err
@@ -159,8 +158,7 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 		if i.podOptions.Latest { // latest means there are no names in the namesOrID array
 			podData, err := i.containerEngine.PodInspect(ctx, i.podOptions)
 			if err != nil {
-				cause := errors.Cause(err)
-				if !strings.Contains(cause.Error(), define.ErrNoSuchPod.Error()) {
+				if !errors.Is(err, define.ErrNoSuchPod) {
 					errs = []error{err}
 				} else {
 					return err
@@ -189,7 +187,7 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 			data = append(data, volumeData[i])
 		}
 	default:
-		return errors.Errorf("invalid type %q: must be %q, %q, %q, %q, %q, or %q", i.options.Type,
+		return fmt.Errorf("invalid type %q: must be %q, %q, %q, %q, %q, or %q", i.options.Type,
 			common.ImageType, common.ContainerType, common.PodType, common.NetworkType, common.VolumeType, common.AllType)
 	}
 	// Always print an empty array
@@ -218,7 +216,7 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 				fmt.Fprintf(os.Stderr, "error inspecting object: %v\n", err)
 			}
 		}
-		return errors.Errorf("inspecting object: %v", errs[0])
+		return fmt.Errorf("inspecting object: %v", errs[0])
 	}
 	return nil
 }
@@ -287,8 +285,7 @@ func (i *inspector) inspectAll(ctx context.Context, namesOrIDs []string) ([]inte
 		i.podOptions.NameOrID = name
 		podData, err := i.containerEngine.PodInspect(ctx, i.podOptions)
 		if err != nil {
-			cause := errors.Cause(err)
-			if !strings.Contains(cause.Error(), define.ErrNoSuchPod.Error()) {
+			if !errors.Is(err, define.ErrNoSuchPod) {
 				return nil, nil, err
 			}
 		} else {
@@ -296,7 +293,7 @@ func (i *inspector) inspectAll(ctx context.Context, namesOrIDs []string) ([]inte
 			continue
 		}
 		if len(errs) > 0 {
-			allErrs = append(allErrs, errors.Errorf("no such object: %q", name))
+			allErrs = append(allErrs, fmt.Errorf("no such object: %q", name))
 			continue
 		}
 	}

--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/machine"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -119,12 +118,12 @@ func initMachine(cmd *cobra.Command, args []string) error {
 	initOpts.Name = defaultMachineName
 	if len(args) > 0 {
 		if len(args[0]) > maxMachineNameSize {
-			return errors.Errorf("machine name %q must be %d characters or less", args[0], maxMachineNameSize)
+			return fmt.Errorf("machine name %q must be %d characters or less", args[0], maxMachineNameSize)
 		}
 		initOpts.Name = args[0]
 	}
 	if _, err := provider.LoadVMByName(initOpts.Name); err == nil {
-		return errors.Wrap(machine.ErrVMAlreadyExists, initOpts.Name)
+		return fmt.Errorf("%s: %w", initOpts.Name, machine.ErrVMAlreadyExists)
 	}
 	for idx, vol := range initOpts.Volumes {
 		initOpts.Volumes[idx] = os.ExpandEnv(vol)

--- a/cmd/podman/machine/list.go
+++ b/cmd/podman/machine/list.go
@@ -4,6 +4,7 @@
 package machine
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"strconv"
@@ -17,7 +18,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -88,7 +88,7 @@ func list(cmd *cobra.Command, args []string) error {
 	provider := GetSystemDefaultProvider()
 	listResponse, err = provider.List(opts)
 	if err != nil {
-		return errors.Wrap(err, "error listing vms")
+		return fmt.Errorf("error listing vms: %w", err)
 	}
 
 	// Sort by last run
@@ -157,7 +157,7 @@ func outputTemplate(cmd *cobra.Command, responses []*ListReporter) error {
 	defer w.Flush()
 	if printHeader {
 		if err := tmpl.Execute(w, headers); err != nil {
-			return errors.Wrapf(err, "failed to write report column headers")
+			return fmt.Errorf("failed to write report column headers: %w", err)
 		}
 	}
 	return tmpl.Execute(w, responses)

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -4,6 +4,7 @@
 package machine
 
 import (
+	"fmt"
 	"net/url"
 
 	"github.com/containers/common/pkg/completion"
@@ -11,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/machine"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -88,7 +88,7 @@ func ssh(cmd *cobra.Command, args []string) error {
 
 	vm, err = provider.LoadVMByName(vmName)
 	if err != nil {
-		return errors.Wrapf(err, "vm %s not found", vmName)
+		return fmt.Errorf("vm %s not found: %w", vmName, err)
 	}
 	err = vm.SSH(vmName, sshOpts)
 	return utils.HandleOSExecError(err)

--- a/cmd/podman/machine/start.go
+++ b/cmd/podman/machine/start.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/machine"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -54,9 +53,9 @@ func start(_ *cobra.Command, args []string) error {
 	}
 	if active {
 		if vmName == activeName {
-			return errors.Wrapf(machine.ErrVMAlreadyRunning, "cannot start VM %s", vmName)
+			return fmt.Errorf("cannot start VM %s: %w", vmName, machine.ErrVMAlreadyRunning)
 		}
-		return errors.Wrapf(machine.ErrMultipleActiveVM, "cannot start VM %s. VM %s is currently running or starting", vmName, activeName)
+		return fmt.Errorf("cannot start VM %s. VM %s is currently running or starting: %w", vmName, activeName, machine.ErrMultipleActiveVM)
 	}
 	fmt.Printf("Starting machine %q\n", vmName)
 	if err := vm.Start(vmName, machine.StartOptions{}); err != nil {

--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/containers/common/pkg/auth"
@@ -11,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -88,10 +88,10 @@ func push(cmd *cobra.Command, args []string) error {
 	listImageSpec := args[0]
 	destSpec := args[1]
 	if listImageSpec == "" {
-		return errors.Errorf(`invalid image name "%s"`, listImageSpec)
+		return fmt.Errorf(`invalid image name "%s"`, listImageSpec)
 	}
 	if destSpec == "" {
-		return errors.Errorf(`invalid destination "%s"`, destSpec)
+		return fmt.Errorf(`invalid destination "%s"`, destSpec)
 	}
 
 	if manifestPushOpts.CredentialsCLI != "" {

--- a/cmd/podman/manifest/remove.go
+++ b/cmd/podman/manifest/remove.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +30,7 @@ func init() {
 func remove(cmd *cobra.Command, args []string) error {
 	updatedListID, err := registry.ImageEngine().ManifestRemoveDigest(registry.Context(), args[0], args[1])
 	if err != nil {
-		return errors.Wrapf(err, "error removing from manifest list %s", args[0])
+		return fmt.Errorf("error removing from manifest list %s: %w", args[0], err)
 	}
 	fmt.Println(updatedListID)
 	return nil

--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/parse"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -97,11 +97,11 @@ func networkCreate(cmd *cobra.Command, args []string) error {
 	var err error
 	networkCreateOptions.Labels, err = parse.GetAllLabels([]string{}, labels)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse labels")
+		return fmt.Errorf("failed to parse labels: %w", err)
 	}
 	networkCreateOptions.Options, err = parse.GetAllLabels([]string{}, opts)
 	if err != nil {
-		return errors.Wrapf(err, "unable to parse options")
+		return fmt.Errorf("unable to parse options: %w", err)
 	}
 
 	network := types.Network{
@@ -181,11 +181,11 @@ func parseRange(iprange string) (*types.LeaseRange, error) {
 
 	startIP, err := util.FirstIPInSubnet(subnet)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get first ip in range")
+		return nil, fmt.Errorf("failed to get first ip in range: %w", err)
 	}
 	lastIP, err := util.LastIPInSubnet(subnet)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get last ip in range")
+		return nil, fmt.Errorf("failed to get last ip in range: %w", err)
 	}
 	return &types.LeaseRange{
 		StartIP: startIP,

--- a/cmd/podman/networks/rm.go
+++ b/cmd/podman/networks/rm.go
@@ -1,8 +1,8 @@
 package network
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v4/cmd/podman/common"
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -78,15 +77,9 @@ func networkRm(cmd *cobra.Command, args []string) error {
 }
 
 func setExitCode(err error) {
-	cause := errors.Cause(err)
-	switch {
-	case cause == define.ErrNoSuchNetwork:
+	if errors.Is(err, define.ErrNoSuchNetwork) {
 		registry.SetExitCode(1)
-	case strings.Contains(cause.Error(), define.ErrNoSuchNetwork.Error()):
-		registry.SetExitCode(1)
-	case cause == define.ErrNetworkInUse:
-		registry.SetExitCode(2)
-	case strings.Contains(cause.Error(), define.ErrNetworkInUse.Error()):
+	} else if errors.Is(err, define.ErrNetworkInUse) {
 		registry.SetExitCode(2)
 	}
 }

--- a/cmd/podman/parse/filters.go
+++ b/cmd/podman/parse/filters.go
@@ -1,10 +1,9 @@
 package parse
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 func FilterArgumentsIntoFilters(filters []string) (url.Values, error) {
@@ -12,7 +11,7 @@ func FilterArgumentsIntoFilters(filters []string) (url.Values, error) {
 	for _, f := range filters {
 		t := strings.SplitN(f, "=", 2)
 		if len(t) < 2 {
-			return parsedFilters, errors.Errorf("filter input must be in the form of filter=value: %s is invalid", f)
+			return parsedFilters, fmt.Errorf("filter input must be in the form of filter=value: %s is invalid", f)
 		}
 		parsedFilters.Add(t[0], t[1])
 	}

--- a/cmd/podman/parse/net.go
+++ b/cmd/podman/parse/net.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -81,7 +79,7 @@ func GetAllLabels(labelFile, inputLabels []string) (map[string]string, error) {
 	for _, label := range inputLabels {
 		split := strings.SplitN(label, "=", 2)
 		if split[0] == "" {
-			return nil, errors.Errorf("invalid label format: %q", label)
+			return nil, fmt.Errorf("invalid label format: %q", label)
 		}
 		value := ""
 		if len(split) > 1 {
@@ -97,13 +95,13 @@ func parseEnvOrLabel(env map[string]string, line, configType string) error {
 
 	// catch invalid variables such as "=" or "=A"
 	if data[0] == "" {
-		return errors.Errorf("invalid environment variable: %q", line)
+		return fmt.Errorf("invalid environment variable: %q", line)
 	}
 
 	// trim the front of a variable, but nothing else
 	name := strings.TrimLeft(data[0], whiteSpaces)
 	if strings.ContainsAny(name, whiteSpaces) {
-		return errors.Errorf("name %q has white spaces, poorly formatted name", name)
+		return fmt.Errorf("name %q has white spaces, poorly formatted name", name)
 	}
 
 	if len(data) > 1 {
@@ -157,7 +155,7 @@ func parseEnvOrLabelFile(envOrLabel map[string]string, filename, configType stri
 // as it is currently not supported
 func ValidateFileName(filename string) error {
 	if strings.Contains(filename, ":") {
-		return errors.Errorf("invalid filename (should not contain ':') %q", filename)
+		return fmt.Errorf("invalid filename (should not contain ':') %q", filename)
 	}
 	return nil
 }
@@ -166,10 +164,10 @@ func ValidateFileName(filename string) error {
 func ValidURL(urlStr string) error {
 	url, err := url.ParseRequestURI(urlStr)
 	if err != nil {
-		return errors.Wrapf(err, "invalid url %q", urlStr)
+		return fmt.Errorf("invalid url %q: %w", urlStr, err)
 	}
 	if url.Scheme == "" {
-		return errors.Errorf("invalid url %q: missing scheme", urlStr)
+		return fmt.Errorf("invalid url %q: missing scheme", urlStr)
 	}
 	return nil
 }

--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -1,6 +1,7 @@
 package pods
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -16,7 +17,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -188,14 +188,14 @@ func kube(cmd *cobra.Command, args []string) error {
 	for _, annotation := range annotations {
 		splitN := strings.SplitN(annotation, "=", 2)
 		if len(splitN) > 2 {
-			return errors.Errorf("annotation %q must include an '=' sign", annotation)
+			return fmt.Errorf("annotation %q must include an '=' sign", annotation)
 		}
 		if kubeOptions.Annotations == nil {
 			kubeOptions.Annotations = make(map[string]string)
 		}
 		annotation := splitN[1]
 		if len(annotation) > define.MaxKubeAnnotation {
-			return errors.Errorf("annotation exceeds maximum size, %d, of kubernetes annotation: %s", define.MaxKubeAnnotation, annotation)
+			return fmt.Errorf("annotation exceeds maximum size, %d, of kubernetes annotation: %s", define.MaxKubeAnnotation, annotation)
 		}
 		kubeOptions.Annotations[splitN[0]] = annotation
 	}
@@ -235,7 +235,7 @@ func teardown(yamlfile string) error {
 	defer f.Close()
 	reports, err := registry.ContainerEngine().PlayKubeDown(registry.GetContext(), f, *options)
 	if err != nil {
-		return errors.Wrap(err, yamlfile)
+		return fmt.Errorf("%s: %w", yamlfile, err)
 	}
 
 	// Output stopped pods
@@ -273,7 +273,7 @@ func playkube(yamlfile string) error {
 	defer f.Close()
 	report, err := registry.ContainerEngine().PlayKube(registry.GetContext(), f, kubeOptions.PlayKubeOptions)
 	if err != nil {
-		return errors.Wrap(err, yamlfile)
+		return fmt.Errorf("%s: %w", yamlfile, err)
 	}
 	// Print volumes report
 	for i, volume := range report.Volumes {
@@ -320,7 +320,7 @@ func playkube(yamlfile string) error {
 	}
 
 	if ctrsFailed > 0 {
-		return errors.Errorf("failed to start %d containers", ctrsFailed)
+		return fmt.Errorf("failed to start %d containers", ctrsFailed)
 	}
 
 	return nil

--- a/cmd/podman/pods/clone.go
+++ b/cmd/podman/pods/clone.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +66,7 @@ func init() {
 func clone(cmd *cobra.Command, args []string) error {
 	switch len(args) {
 	case 0:
-		return errors.Wrapf(define.ErrInvalidArg, "must specify at least 1 argument")
+		return fmt.Errorf("must specify at least 1 argument: %w", define.ErrInvalidArg)
 	case 2:
 		podClone.CreateOpts.Name = args[1]
 	}

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -2,6 +2,7 @@ package pods
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -23,7 +24,6 @@ import (
 	"github.com/containers/podman/v4/pkg/specgenutil"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/docker/docker/pkg/parsers"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -119,7 +119,7 @@ func create(cmd *cobra.Command, args []string) error {
 	)
 	if len(args) > 0 {
 		if len(createOptions.Name) > 0 {
-			return fmt.Errorf("cannot specify --name and NAME at the same time")
+			return errors.New("cannot specify --name and NAME at the same time")
 		}
 		createOptions.Name = args[0]
 	}
@@ -127,7 +127,7 @@ func create(cmd *cobra.Command, args []string) error {
 	labels = infraOptions.Label
 	createOptions.Labels, err = parse.GetAllLabels(labelFile, labels)
 	if err != nil {
-		return errors.Wrapf(err, "unable to process labels")
+		return fmt.Errorf("unable to process labels: %w", err)
 	}
 
 	if cmd.Flag("infra-image").Changed {
@@ -136,7 +136,7 @@ func create(cmd *cobra.Command, args []string) error {
 	img := imageName
 	if !createOptions.Infra {
 		if cmd.Flag("no-hosts").Changed {
-			return fmt.Errorf("cannot specify --no-hosts without an infra container")
+			return errors.New("cannot specify --no-hosts without an infra container")
 		}
 		flags := cmd.Flags()
 		createOptions.Net, err = common.NetFlagsToNetOptions(nil, *flags)
@@ -165,7 +165,7 @@ func create(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if strings.Contains(share, "cgroup") && shareParent {
-			return errors.Wrapf(define.ErrInvalidArg, "cannot define the pod as the cgroup parent at the same time as joining the infra container's cgroupNS")
+			return fmt.Errorf("cannot define the pod as the cgroup parent at the same time as joining the infra container's cgroupNS: %w", define.ErrInvalidArg)
 		}
 
 		if strings.HasPrefix(share, "+") {
@@ -193,10 +193,10 @@ func create(cmd *cobra.Command, args []string) error {
 	if cmd.Flag("pod-id-file").Changed {
 		podIDFD, err = util.OpenExclusiveFile(podIDFile)
 		if err != nil && os.IsExist(err) {
-			return errors.Errorf("pod id file exists. Ensure another pod is not using it or delete %s", podIDFile)
+			return fmt.Errorf("pod id file exists. Ensure another pod is not using it or delete %s", podIDFile)
 		}
 		if err != nil {
-			return errors.Errorf("opening pod-id-file %s", podIDFile)
+			return fmt.Errorf("opening pod-id-file %s", podIDFile)
 		}
 		defer errorhandling.CloseQuiet(podIDFD)
 		defer errorhandling.SyncQuiet(podIDFD)
@@ -204,7 +204,7 @@ func create(cmd *cobra.Command, args []string) error {
 
 	if len(createOptions.Net.PublishPorts) > 0 {
 		if !createOptions.Infra {
-			return errors.Errorf("you must have an infra container to publish port bindings to the host")
+			return errors.New("you must have an infra container to publish port bindings to the host")
 		}
 	}
 
@@ -231,7 +231,7 @@ func create(cmd *cobra.Command, args []string) error {
 	ret, err := parsers.ParseUintList(copy)
 	copy = ""
 	if err != nil {
-		return errors.Wrapf(err, "could not parse list")
+		return fmt.Errorf("could not parse list: %w", err)
 	}
 	var vals []int
 	for ind, val := range ret {
@@ -301,7 +301,7 @@ func create(cmd *cobra.Command, args []string) error {
 
 	if len(podIDFile) > 0 {
 		if err = ioutil.WriteFile(podIDFile, []byte(response.Id), 0644); err != nil {
-			return errors.Wrapf(err, "failed to write pod ID to file")
+			return fmt.Errorf("failed to write pod ID to file: %w", err)
 		}
 	}
 	fmt.Println(response.Id)

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -2,6 +2,7 @@ package pods
 
 import (
 	"context"
+	"errors"
 	"os"
 	"text/template"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -49,10 +49,10 @@ func init() {
 
 func inspect(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 && !inspectOptions.Latest {
-		return errors.Errorf("you must provide the name or id of a running pod")
+		return errors.New("you must provide the name or id of a running pod")
 	}
 	if len(args) > 0 && inspectOptions.Latest {
-		return errors.Errorf("--latest and containers cannot be used together")
+		return errors.New("--latest and containers cannot be used together")
 	}
 
 	if !inspectOptions.Latest {

--- a/cmd/podman/pods/logs.go
+++ b/cmd/podman/pods/logs.go
@@ -1,6 +1,8 @@
 package pods
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/containers/common/pkg/completion"
@@ -10,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -100,7 +101,7 @@ func logs(_ *cobra.Command, args []string) error {
 		// parse time, error out if something is wrong
 		since, err := util.ParseInputTime(logsPodOptions.SinceRaw, true)
 		if err != nil {
-			return errors.Wrapf(err, "error parsing --since %q", logsPodOptions.SinceRaw)
+			return fmt.Errorf("error parsing --since %q: %w", logsPodOptions.SinceRaw, err)
 		}
 		logsPodOptions.Since = since
 	}
@@ -108,14 +109,14 @@ func logs(_ *cobra.Command, args []string) error {
 		// parse time, error out if something is wrong
 		until, err := util.ParseInputTime(logsPodOptions.UntilRaw, false)
 		if err != nil {
-			return errors.Wrapf(err, "error parsing --until %q", logsPodOptions.UntilRaw)
+			return fmt.Errorf("error parsing --until %q: %w", logsPodOptions.UntilRaw, err)
 		}
 		logsPodOptions.Until = until
 	}
 
 	// Remote can only process one container at a time
 	if registry.IsRemote() && logsPodOptions.ContainerName == "" {
-		return errors.Wrapf(define.ErrInvalidArg, "-c or --container cannot be empty")
+		return fmt.Errorf("-c or --container cannot be empty: %w", define.ErrInvalidArg)
 	}
 
 	logsPodOptions.StdoutWriter = os.Stdout

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -2,6 +2,7 @@ package pods
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -15,7 +16,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -80,7 +80,7 @@ func pods(cmd *cobra.Command, _ []string) error {
 		for _, f := range inputFilters {
 			split := strings.SplitN(f, "=", 2)
 			if len(split) < 2 {
-				return errors.Errorf("filter input must be in the form of filter=value: %s is invalid", f)
+				return fmt.Errorf("filter input must be in the form of filter=value: %s is invalid", f)
 			}
 			psInput.Filters[split[0]] = append(psInput.Filters[split[0]], split[1])
 		}
@@ -276,7 +276,7 @@ func sortPodPsOutput(sortBy string, lprs []*entities.ListPodsReport) error {
 	case "status":
 		sort.Sort(podPsSortedStatus{lprs})
 	default:
-		return errors.Errorf("invalid option for --sort, options are: id, names, or number")
+		return errors.New("invalid option for --sort, options are: id, names, or number")
 	}
 	return nil
 }

--- a/cmd/podman/pods/rm.go
+++ b/cmd/podman/pods/rm.go
@@ -2,8 +2,8 @@ package pods
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v4/cmd/podman/common"
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/specgenutil"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -112,11 +111,7 @@ func removePods(namesOrIDs []string, rmOptions entities.PodRmOptions, printIDs b
 }
 
 func setExitCode(err error) {
-	cause := errors.Cause(err)
-	switch {
-	case cause == define.ErrNoSuchPod:
-		registry.SetExitCode(1)
-	case strings.Contains(cause.Error(), define.ErrNoSuchPod.Error()):
+	if errors.Is(err, define.ErrNoSuchPod) {
 		registry.SetExitCode(1)
 	}
 }

--- a/cmd/podman/pods/top.go
+++ b/cmd/podman/pods/top.go
@@ -2,6 +2,7 @@ package pods
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +67,7 @@ func top(_ *cobra.Command, args []string) error {
 	}
 
 	if len(args) < 1 && !topOptions.Latest {
-		return errors.Errorf("you must provide the name or id of a running pod")
+		return errors.New("you must provide the name or id of a running pod")
 	}
 
 	if topOptions.Latest {

--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -99,7 +98,7 @@ func setXdgDirs() error {
 			return err
 		}
 		if err := os.Setenv("XDG_RUNTIME_DIR", dir); err != nil {
-			return errors.Wrapf(err, "cannot set XDG_RUNTIME_DIR="+dir)
+			return fmt.Errorf("cannot set XDG_RUNTIME_DIR=: %w"+dir, err)
 		}
 	}
 
@@ -117,7 +116,7 @@ func setXdgDirs() error {
 			return err
 		}
 		if err := os.Setenv("XDG_CONFIG_HOME", cfgHomeDir); err != nil {
-			return errors.Wrapf(err, "cannot set XDG_CONFIG_HOME="+cfgHomeDir)
+			return fmt.Errorf("cannot set XDG_CONFIG_HOME=: %w"+cfgHomeDir, err)
 		}
 	}
 	return nil

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,7 +21,6 @@ import (
 	"github.com/containers/podman/v4/pkg/parallel"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/version"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -137,10 +137,10 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 		if cmd.Flag("import").Changed {
 			runtime, err := crutils.CRGetRuntimeFromArchive(cmd.Flag("import").Value.String())
 			if err != nil {
-				return errors.Wrapf(
-					err,
-					"failed extracting runtime information from %s",
+				return fmt.Errorf(
+					"failed extracting runtime information from %s: %w",
 					cmd.Flag("import").Value.String(),
+					err,
 				)
 			}
 			if cfg.RuntimePath == "" {
@@ -148,7 +148,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 				// the checkpoint archives and tells Podman to use it for the restore.
 				runtimeFlag := cmd.Root().Flags().Lookup("runtime")
 				if runtimeFlag == nil {
-					return errors.Errorf(
+					return fmt.Errorf(
 						"setting runtime to '%s' for restore",
 						*runtime,
 					)
@@ -161,7 +161,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 			} else if cfg.RuntimePath != *runtime {
 				// If the user selected a runtime on the command-line this checks if
 				// it is the same then during checkpointing and errors out if not.
-				return errors.Errorf(
+				return fmt.Errorf(
 					"checkpoint archive %s was created with runtime '%s' and cannot be restored with runtime '%s'",
 					cmd.Flag("import").Value.String(),
 					*runtime,
@@ -179,15 +179,15 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 		var err error
 		cfg.URI, cfg.Identity, err = cfg.ActiveDestination()
 		if err != nil {
-			return errors.Wrap(err, "failed to resolve active destination")
+			return fmt.Errorf("failed to resolve active destination: %w", err)
 		}
 
 		if err := cmd.Root().LocalFlags().Set("url", cfg.URI); err != nil {
-			return errors.Wrap(err, "failed to override --url flag")
+			return fmt.Errorf("failed to override --url flag: %w", err)
 		}
 
 		if err := cmd.Root().LocalFlags().Set("identity", cfg.Identity); err != nil {
-			return errors.Wrap(err, "failed to override --identity flag")
+			return fmt.Errorf("failed to override --identity flag: %w", err)
 		}
 	}
 
@@ -256,7 +256,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if cfg.MaxWorks <= 0 {
-			return errors.Errorf("maximum workers must be set to a positive number (got %d)", cfg.MaxWorks)
+			return fmt.Errorf("maximum workers must be set to a positive number (got %d)", cfg.MaxWorks)
 		}
 		if err := parallel.SetMaxThreads(uint(cfg.MaxWorks)); err != nil {
 			return err
@@ -298,12 +298,12 @@ func persistentPostRunE(cmd *cobra.Command, args []string) error {
 	if cmd.Flag("memory-profile").Changed {
 		f, err := os.Create(registry.PodmanConfig().MemoryProfile)
 		if err != nil {
-			return errors.Wrap(err, "creating memory profile")
+			return fmt.Errorf("creating memory profile: %w", err)
 		}
 		defer f.Close()
 		runtime.GC() // get up-to-date GC statistics
 		if err := pprof.WriteHeapProfile(f); err != nil {
-			return errors.Wrap(err, "writing memory profile")
+			return fmt.Errorf("writing memory profile: %w", err)
 		}
 	}
 
@@ -482,7 +482,7 @@ func resolveDestination() (string, string, string) {
 
 	cfg, err := config.ReadCustomConfig()
 	if err != nil {
-		logrus.Warning(errors.Wrap(err, "unable to read local containers.conf"))
+		logrus.Warning(fmt.Errorf("unable to read local containers.conf: %w", err))
 		return "", registry.DefaultAPIAddress(), ""
 	}
 
@@ -495,7 +495,7 @@ func resolveDestination() (string, string, string) {
 
 func formatError(err error) string {
 	var message string
-	if errors.Cause(err) == define.ErrOCIRuntime {
+	if errors.Is(err, define.ErrOCIRuntime) {
 		// OCIRuntimeErrors include the reason for the failure in the
 		// second to last message in the error chain.
 		message = fmt.Sprintf(

--- a/cmd/podman/root_test.go
+++ b/cmd/podman/root_test.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/pkg/errors"
 )
 
 func TestFormatError(t *testing.T) {
@@ -22,7 +22,7 @@ func TestFormatError(t *testing.T) {
 func TestFormatOCIError(t *testing.T) {
 	expectedPrefix := "Error: "
 	expectedSuffix := "OCI runtime output"
-	err := errors.Wrap(define.ErrOCIRuntime, expectedSuffix)
+	err := fmt.Errorf("%s: %w", expectedSuffix, define.ErrOCIRuntime)
 	output := formatError(err)
 
 	if !strings.HasPrefix(output, expectedPrefix) {

--- a/cmd/podman/secrets/create.go
+++ b/cmd/podman/secrets/create.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -66,7 +66,7 @@ func create(cmd *cobra.Command, args []string) error {
 	case env:
 		envValue := os.Getenv(path)
 		if envValue == "" {
-			return errors.Errorf("cannot create store secret data: environment variable %s is not set", path)
+			return fmt.Errorf("cannot create store secret data: environment variable %s is not set", path)
 		}
 		reader = strings.NewReader(envValue)
 	case path == "-" || path == "/dev/stdin":

--- a/cmd/podman/secrets/inspect.go
+++ b/cmd/podman/secrets/inspect.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -78,7 +77,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 				fmt.Fprintf(os.Stderr, "error inspecting secret: %v\n", err)
 			}
 		}
-		return errors.Errorf("inspecting secret: %v", errs[0])
+		return fmt.Errorf("inspecting secret: %w", errs[0])
 	}
 	return nil
 }

--- a/cmd/podman/secrets/list.go
+++ b/cmd/podman/secrets/list.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -108,7 +108,7 @@ func outputTemplate(cmd *cobra.Command, responses []*entities.SecretListReport) 
 
 	if !listFlag.noHeading {
 		if err := tmpl.Execute(w, headers); err != nil {
-			return errors.Wrapf(err, "failed to write report column headers")
+			return fmt.Errorf("failed to write report column headers: %w", err)
 		}
 	}
 	return tmpl.Execute(w, responses)

--- a/cmd/podman/system/connection/remove.go
+++ b/cmd/podman/system/connection/remove.go
@@ -1,11 +1,12 @@
 package connection
 
 import (
+	"errors"
+
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/system"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/podman/system/connection/shared.go
+++ b/cmd/podman/system/connection/shared.go
@@ -2,8 +2,8 @@ package connection
 
 import (
 	"bytes"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -21,7 +21,7 @@ func ExecRemoteCommand(dial *ssh.Client, run string) ([]byte, error) {
 	sess.Stdout = &buffer                 // output from client funneled into buffer
 	sess.Stderr = &bufferErr              // err form client funneled into buffer
 	if err := sess.Run(run); err != nil { // run the command on the ssh client
-		return nil, errors.Wrapf(err, bufferErr.String())
+		return nil, fmt.Errorf("%v: %w", bufferErr, err)
 	}
 	return buffer.Bytes(), nil
 }

--- a/cmd/podman/system/dial_stdio.go
+++ b/cmd/podman/system/dial_stdio.go
@@ -2,13 +2,14 @@ package system
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/bindings"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -40,15 +41,15 @@ func runDialStdio() error {
 	defer cancel()
 	bindCtx, err := bindings.NewConnection(ctx, cfg.URI)
 	if err != nil {
-		return errors.Wrap(err, "failed to open connection to podman")
+		return fmt.Errorf("failed to open connection to podman: %w", err)
 	}
 	conn, err := bindings.GetClient(bindCtx)
 	if err != nil {
-		return errors.Wrap(err, "failed to get connection after initialization")
+		return fmt.Errorf("failed to get connection after initialization: %w", err)
 	}
 	netConn, err := conn.GetDialer(bindCtx)
 	if err != nil {
-		return errors.Wrap(err, "failed to open the raw stream connection")
+		return fmt.Errorf("failed to open the raw stream connection: %w", err)
 	}
 	defer netConn.Close()
 
@@ -95,7 +96,7 @@ func copier(to halfWriteCloser, from halfReadCloser, debugDescription string) er
 		}
 	}()
 	if _, err := io.Copy(to, from); err != nil {
-		return errors.Wrapf(err, "error while Copy (%s)", debugDescription)
+		return fmt.Errorf("error while Copy (%s): %w", debugDescription, err)
 	}
 	return nil
 }

--- a/cmd/podman/system/unshare.go
+++ b/cmd/podman/system/unshare.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"errors"
 	"os"
 
 	"github.com/containers/common/pkg/completion"
@@ -8,7 +9,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/rootless"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -47,14 +47,14 @@ func init() {
 
 func unshare(cmd *cobra.Command, args []string) error {
 	if isRootless := rootless.IsRootless(); !isRootless {
-		return errors.Errorf("please use unshare with rootless")
+		return errors.New("please use unshare with rootless")
 	}
 	// exec the specified command, if there is one
 	if len(args) < 1 {
 		// try to exec the shell, if one's set
 		shell, shellSet := os.LookupEnv("SHELL")
 		if !shellSet {
-			return errors.Errorf("no command specified and no $SHELL specified")
+			return errors.New("no command specified and no $SHELL specified")
 		}
 		args = []string{shell}
 	}

--- a/cmd/podman/validate/args.go
+++ b/cmd/podman/validate/args.go
@@ -1,12 +1,12 @@
 package validate
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/containers/podman/v4/cmd/podman/registry"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -23,12 +23,12 @@ func SubCommandExists(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		suggestions := cmd.SuggestionsFor(args[0])
 		if len(suggestions) == 0 {
-			return errors.Errorf("unrecognized command `%[1]s %[2]s`\nTry '%[1]s --help' for more information", cmd.CommandPath(), args[0])
+			return fmt.Errorf("unrecognized command `%[1]s %[2]s`\nTry '%[1]s --help' for more information", cmd.CommandPath(), args[0])
 		}
-		return errors.Errorf("unrecognized command `%[1]s %[2]s`\n\nDid you mean this?\n\t%[3]s\n\nTry '%[1]s --help' for more information", cmd.CommandPath(), args[0], strings.Join(suggestions, "\n\t"))
+		return fmt.Errorf("unrecognized command `%[1]s %[2]s`\n\nDid you mean this?\n\t%[3]s\n\nTry '%[1]s --help' for more information", cmd.CommandPath(), args[0], strings.Join(suggestions, "\n\t"))
 	}
 	cmd.Help() //nolint: errcheck
-	return errors.Errorf("missing command '%[1]s COMMAND'", cmd.CommandPath())
+	return fmt.Errorf("missing command '%[1]s COMMAND'", cmd.CommandPath())
 }
 
 // IDOrLatestArgs used to validate a nameOrId was provided or the "--latest" flag
@@ -75,7 +75,7 @@ func CheckAllLatestAndIDFile(c *cobra.Command, args []string, ignoreArgLen bool,
 			if idFileFlag == "" {
 				return errors.New("unable to look up values for 'latest' or 'all'")
 			} else if c.Flags().Lookup(idFileFlag) == nil {
-				return errors.Errorf("unable to look up values for 'latest', 'all', or '%s'", idFileFlag)
+				return fmt.Errorf("unable to look up values for 'latest', 'all', or '%s'", idFileFlag)
 			}
 		}
 	}
@@ -87,13 +87,13 @@ func CheckAllLatestAndIDFile(c *cobra.Command, args []string, ignoreArgLen bool,
 	}
 
 	if specifiedIDFile && (specifiedAll || specifiedLatest) {
-		return errors.Errorf("--all, --latest, and --%s cannot be used together", idFileFlag)
+		return fmt.Errorf("--all, --latest, and --%s cannot be used together", idFileFlag)
 	} else if specifiedAll && specifiedLatest {
-		return errors.Errorf("--all and --latest cannot be used together")
+		return errors.New("--all and --latest cannot be used together")
 	}
 
 	if (argLen > 0) && specifiedAll {
-		return errors.Errorf("no arguments are needed with --all")
+		return errors.New("no arguments are needed with --all")
 	}
 
 	if ignoreArgLen {
@@ -102,9 +102,9 @@ func CheckAllLatestAndIDFile(c *cobra.Command, args []string, ignoreArgLen bool,
 
 	if argLen > 0 {
 		if specifiedLatest {
-			return errors.Errorf("--latest and containers cannot be used together")
+			return errors.New("--latest and containers cannot be used together")
 		} else if idFileFlag != "" && (specifiedLatest || specifiedIDFile) {
-			return errors.Errorf("no arguments are needed with --latest or --%s", idFileFlag)
+			return fmt.Errorf("no arguments are needed with --latest or --%s", idFileFlag)
 		}
 	}
 
@@ -113,7 +113,7 @@ func CheckAllLatestAndIDFile(c *cobra.Command, args []string, ignoreArgLen bool,
 	}
 
 	if argLen < 1 && !specifiedAll && !specifiedLatest && !specifiedIDFile {
-		return errors.Errorf("you must provide at least one name or id")
+		return errors.New("you must provide at least one name or id")
 	}
 	return nil
 }

--- a/cmd/podman/volumes/create.go
+++ b/cmd/podman/volumes/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/parse"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -65,11 +64,11 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 	createOpts.Label, err = parse.GetAllLabels([]string{}, opts.Label)
 	if err != nil {
-		return errors.Wrapf(err, "unable to process labels")
+		return fmt.Errorf("unable to process labels: %w", err)
 	}
 	createOpts.Options, err = parse.GetAllLabels([]string{}, opts.Opts)
 	if err != nil {
-		return errors.Wrapf(err, "unable to process options")
+		return fmt.Errorf("unable to process options: %w", err)
 	}
 	response, err := registry.ContainerEngine().VolumeCreate(context.Background(), createOpts)
 	if err != nil {

--- a/cmd/podman/volumes/export.go
+++ b/cmd/podman/volumes/export.go
@@ -2,6 +2,7 @@ package volumes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containers/common/pkg/completion"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/podman/v4/utils"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/podman/volumes/import.go
+++ b/cmd/podman/volumes/import.go
@@ -1,6 +1,7 @@
 package volumes
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/podman/v4/utils"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/podman/volumes/inspect.go
+++ b/cmd/podman/volumes/inspect.go
@@ -1,12 +1,13 @@
 package volumes
 
 import (
+	"errors"
+
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/inspect"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -2,6 +2,7 @@ package volumes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -119,7 +119,7 @@ func outputTemplate(cmd *cobra.Command, responses []*entities.VolumeListReport) 
 
 	if !(noHeading || cliOpts.Quiet || cmd.Flag("format").Changed) {
 		if err := tmpl.Execute(w, headers); err != nil {
-			return errors.Wrapf(err, "failed to write report column headers")
+			return fmt.Errorf("failed to write report column headers: %w", err)
 		}
 	}
 	return tmpl.Execute(w, responses)

--- a/cmd/podman/volumes/rm.go
+++ b/cmd/podman/volumes/rm.go
@@ -2,8 +2,8 @@ package volumes
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v4/cmd/podman/common"
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -80,15 +79,9 @@ func rm(cmd *cobra.Command, args []string) error {
 }
 
 func setExitCode(err error) {
-	cause := errors.Cause(err)
-	switch {
-	case cause == define.ErrNoSuchVolume:
+	if errors.Is(err, define.ErrNoSuchVolume) {
 		registry.SetExitCode(1)
-	case strings.Contains(cause.Error(), define.ErrNoSuchVolume.Error()):
-		registry.SetExitCode(1)
-	case cause == define.ErrVolumeBeingUsed:
-		registry.SetExitCode(2)
-	case strings.Contains(cause.Error(), define.ErrVolumeBeingUsed.Error()):
+	} else if errors.Is(err, define.ErrVolumeBeingUsed) {
 		registry.SetExitCode(2)
 	}
 }

--- a/hack/podman-registry-go/registry.go
+++ b/hack/podman-registry-go/registry.go
@@ -1,10 +1,10 @@
 package registry
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/containers/podman/v4/utils"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -57,7 +57,7 @@ func StartWithOptions(options *Options) (*Registry, error) {
 	// Start a registry.
 	out, err := utils.ExecCmd(binary, args...)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error running %q: %s", binary, out)
+		return nil, fmt.Errorf("error running %q: %s: %w", binary, out, err)
 	}
 
 	// Parse the output.
@@ -68,7 +68,7 @@ func StartWithOptions(options *Options) (*Registry, error) {
 		}
 		spl := strings.Split(s, "=")
 		if len(spl) != 2 {
-			return nil, errors.Errorf("unexpected output format %q: want 'PODMAN_...=...'", s)
+			return nil, fmt.Errorf("unexpected output format %q: want 'PODMAN_...=...'", s)
 		}
 		key := spl[0]
 		val := strings.TrimSuffix(strings.TrimPrefix(spl[1], "\""), "\"")
@@ -88,16 +88,16 @@ func StartWithOptions(options *Options) (*Registry, error) {
 
 	// Extra sanity check.
 	if registry.Image == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, ImageKey)
+		return nil, fmt.Errorf("unexpected output %q: %q missing", out, ImageKey)
 	}
 	if registry.User == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, UserKey)
+		return nil, fmt.Errorf("unexpected output %q: %q missing", out, UserKey)
 	}
 	if registry.Password == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, PassKey)
+		return nil, fmt.Errorf("unexpected output %q: %q missing", out, PassKey)
 	}
 	if registry.Port == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, PortKey)
+		return nil, fmt.Errorf("unexpected output %q: %q missing", out, PortKey)
 	}
 
 	registry.running = true
@@ -112,7 +112,7 @@ func (r *Registry) Stop() error {
 		return nil
 	}
 	if _, err := utils.ExecCmd(binary, "-P", r.Port, "stop"); err != nil {
-		return errors.Wrapf(err, "error stopping registry (%v) with %q", *r, binary)
+		return fmt.Errorf("error stopping registry (%v) with %q: %w", *r, binary, err)
 	}
 	r.running = false
 	return nil

--- a/libpod/define/containerstate.go
+++ b/libpod/define/containerstate.go
@@ -1,9 +1,8 @@
 package define
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // ContainerStatus represents the current state of a container
@@ -91,7 +90,7 @@ func StringToContainerStatus(status string) (ContainerStatus, error) {
 	case ContainerStateRemoving.String():
 		return ContainerStateRemoving, nil
 	default:
-		return ContainerStateUnknown, errors.Wrapf(ErrInvalidArg, "unknown container state: %s", status)
+		return ContainerStateUnknown, fmt.Errorf("unknown container state: %s: %w", status, ErrInvalidArg)
 	}
 }
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -30,7 +31,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -618,14 +618,14 @@ func (p *PodmanTestIntegration) RunHealthCheck(cid string) error {
 				restart := p.Podman([]string{"restart", cid})
 				restart.WaitWithDefaultTimeout()
 				if restart.ExitCode() != 0 {
-					return errors.Errorf("unable to restart %s", cid)
+					return fmt.Errorf("unable to restart %s", cid)
 				}
 			}
 		}
 		fmt.Printf("Waiting for %s to pass healthcheck\n", cid)
 		time.Sleep(1 * time.Second)
 	}
-	return errors.Errorf("unable to detect %s as running", cid)
+	return fmt.Errorf("unable to detect %s as running", cid)
 }
 
 func (p *PodmanTestIntegration) CreateSeccompJSON(in []byte) (string, error) {

--- a/utils/ports.go
+++ b/utils/ports.go
@@ -1,26 +1,25 @@
 package utils
 
 import (
+	"fmt"
 	"net"
 	"strconv"
-
-	"github.com/pkg/errors"
 )
 
 // Find a random, open port on the host.
 func GetRandomPort() (int, error) {
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to get free TCP port")
+		return 0, fmt.Errorf("unable to get free TCP port: %w", err)
 	}
 	defer l.Close()
 	_, randomPort, err := net.SplitHostPort(l.Addr().String())
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to determine free port")
+		return 0, fmt.Errorf("unable to determine free port: %w", err)
 	}
 	rp, err := strconv.Atoi(randomPort)
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to convert random port to int")
+		return 0, fmt.Errorf("unable to convert random port to int: %w", err)
 	}
 	return rp, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -16,7 +16,6 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/godbus/dbus/v5"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -114,7 +113,7 @@ func UntarToFileSystem(dest string, tarball *os.File, options *archive.TarOption
 func CreateTarFromSrc(source string, dest string) error {
 	file, err := os.Create(dest)
 	if err != nil {
-		return errors.Wrapf(err, "Could not create tarball file '%s'", dest)
+		return fmt.Errorf("Could not create tarball file '%s': %w", dest, err)
 	}
 	defer file.Close()
 	return TarToFilesystem(source, file)
@@ -154,7 +153,7 @@ func RemoveScientificNotationFromFloat(x float64) (float64, error) {
 	}
 	result, err := strconv.ParseFloat(bigNum, 64)
 	if err != nil {
-		return x, errors.Wrapf(err, "unable to remove scientific number from calculations")
+		return x, fmt.Errorf("unable to remove scientific number from calculations: %w", err)
 	}
 	return result, nil
 }
@@ -181,11 +180,11 @@ func moveProcessPIDFileToScope(pidPath, slice, scope string) error {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return errors.Wrapf(err, "cannot read pid file %s", pidPath)
+		return fmt.Errorf("cannot read pid file %s: %w", pidPath, err)
 	}
 	pid, err := strconv.ParseUint(string(data), 10, 0)
 	if err != nil {
-		return errors.Wrapf(err, "cannot parse pid file %s", pidPath)
+		return fmt.Errorf("cannot parse pid file %s: %w", pidPath, err)
 	}
 
 	return moveProcessToScope(int(pid), slice, scope)

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/podman/v4/pkg/rootless"
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/godbus/dbus/v5"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -77,7 +76,7 @@ func getCgroupProcess(procFile string, allowRoot bool) (string, error) {
 		line := scanner.Text()
 		parts := strings.SplitN(line, ":", 3)
 		if len(parts) != 3 {
-			return "", errors.Errorf("cannot parse cgroup line %q", line)
+			return "", fmt.Errorf("cannot parse cgroup line %q", line)
 		}
 		if strings.HasPrefix(line, "0::") {
 			cgroup = line[3:]
@@ -88,7 +87,7 @@ func getCgroupProcess(procFile string, allowRoot bool) (string, error) {
 		}
 	}
 	if len(cgroup) == 0 || (!allowRoot && cgroup == "/") {
-		return "", errors.Errorf("could not find cgroup mount in %q", procFile)
+		return "", fmt.Errorf("could not find cgroup mount in %q", procFile)
 	}
 	return cgroup, nil
 }
@@ -133,7 +132,7 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 		line := scanner.Text()
 		parts := strings.SplitN(line, ":", 3)
 		if len(parts) != 3 {
-			return errors.Errorf("cannot parse cgroup line %q", line)
+			return fmt.Errorf("cannot parse cgroup line %q", line)
 		}
 
 		// root cgroup, skip it

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -3,7 +3,7 @@
 
 package utils
 
-import "github.com/pkg/errors"
+import "errors"
 
 func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 	return errors.New("not implemented for windows")


### PR DESCRIPTION
Switching to golang native error wrapping instead of using github.com/pkg/errors. 
#### Does this PR introduce a user-facing change?


```release-note
None
```

This is still WIP since it misses the whole pkg and libpod packages.