### PR TITLE
runtime: unpause the container before killing it

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -664,9 +664,6 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 	}
 
 	if c.state.State == define.ContainerStatePaused {
-		if err := c.ociRuntime.KillContainer(c, 9, false); err != nil {
-			return err
-		}
 		isV2, err := cgroups.IsCgroup2UnifiedMode()
 		if err != nil {
 			return err
@@ -676,6 +673,9 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 			if err := c.unpause(); err != nil {
 				return err
 			}
+		}
+		if err := c.ociRuntime.KillContainer(c, 9, false); err != nil {
+			return err
 		}
 		// Need to update container state to make sure we know it's stopped
 		if err := c.waitForExitFileAndSync(); err != nil {


### PR DESCRIPTION
the new version of runc has the same check in place and it
automatically resume the container if it is paused.  So when Podman
tries to resume it again, it fails since the container is not in the
paused state.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2100740

[NO NEW TESTS NEEDED] the CI doesn't use a new runc on cgroup v1 systems.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
It solves a problem with new runc versions where it is not possible to remove a paused container.
```
