### PR TITLE
api,images: add support for `LookupManifest` to `Image removal` REST API

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -615,10 +615,11 @@ func ImagesBatchRemove(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := struct {
-		All    bool     `schema:"all"`
-		Force  bool     `schema:"force"`
-		Ignore bool     `schema:"ignore"`
-		Images []string `schema:"images"`
+		All            bool     `schema:"all"`
+		Force          bool     `schema:"force"`
+		Ignore         bool     `schema:"ignore"`
+		LookupManifest bool     `schema:"lookupManifest"`
+		Images         []string `schema:"images"`
 	}{}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
@@ -626,7 +627,7 @@ func ImagesBatchRemove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	opts := entities.ImageRemoveOptions{All: query.All, Force: query.Force, Ignore: query.Ignore}
+	opts := entities.ImageRemoveOptions{All: query.All, Force: query.Force, Ignore: query.Ignore, LookupManifest: query.LookupManifest}
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 	rmReport, rmErrors := imageEngine.Remove(r.Context(), query.Images, opts)
 	strErrs := errorhandling.ErrorsToStrings(rmErrors)
@@ -639,7 +640,8 @@ func ImagesRemove(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := struct {
-		Force bool `schema:"force"`
+		Force          bool `schema:"force"`
+		LookupManifest bool `schema:"lookupManifest"`
 	}{
 		Force: false,
 	}
@@ -649,7 +651,7 @@ func ImagesRemove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	opts := entities.ImageRemoveOptions{Force: query.Force}
+	opts := entities.ImageRemoveOptions{Force: query.Force, LookupManifest: query.LookupManifest}
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 	rmReport, rmErrors := imageEngine.Remove(r.Context(), []string{utils.GetName(r)}, opts)
 

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -948,6 +948,10 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     name: ignore
 	//     description: Ignore if a specified image does not exist and do not throw an error.
 	//     type: boolean
+	//   - in: query
+	//     name: lookupManifest
+	//     description: Resolves to manifest list instead of image.
+	//     type: boolean
 	// produces:
 	// - application/json
 	// responses:

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -13,6 +13,8 @@ type RemoveOptions struct {
 	Force *bool
 	// Ignore if a specified image does not exist and do not throw an error.
 	Ignore *bool
+	// Confirms if given name is a manifest list and removes it, otherwise returns error.
+	LookupManifest *bool
 }
 
 //go:generate go run ../generator/generator.go DiffOptions

--- a/pkg/bindings/images/types_remove_options.go
+++ b/pkg/bindings/images/types_remove_options.go
@@ -61,3 +61,18 @@ func (o *RemoveOptions) GetIgnore() bool {
 	}
 	return *o.Ignore
 }
+
+// WithLookupManifest set field LookupManifest to given value
+func (o *RemoveOptions) WithLookupManifest(value bool) *RemoveOptions {
+	o.LookupManifest = &value
+	return o
+}
+
+// GetLookupManifest returns value of field LookupManifest
+func (o *RemoveOptions) GetLookupManifest() bool {
+	if o.LookupManifest == nil {
+		var z bool
+		return z
+	}
+	return *o.LookupManifest
+}

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -28,7 +28,7 @@ func (ir *ImageEngine) Exists(_ context.Context, nameOrID string) (*entities.Boo
 }
 
 func (ir *ImageEngine) Remove(ctx context.Context, imagesArg []string, opts entities.ImageRemoveOptions) (*entities.ImageRemoveReport, []error) {
-	options := new(images.RemoveOptions).WithForce(opts.Force).WithIgnore(opts.Ignore).WithAll(opts.All)
+	options := new(images.RemoveOptions).WithForce(opts.Force).WithIgnore(opts.Ignore).WithAll(opts.All).WithLookupManifest(opts.LookupManifest)
 	return images.Remove(ir.ClientCtx, imagesArg, options)
 }
 

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -405,4 +405,32 @@ var _ = Describe("Podman manifest", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})
+
+	It("manifest rm should not remove image and should be able to remove tagged manifest list", func() {
+		// manifest rm should fail with `image is not a manifest list`
+		session := podmanTest.Podman([]string{"manifest", "rm", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(125))
+		Expect(session.ErrorToString()).To(ContainSubstring("image is not a manifest list"))
+
+		manifestName := "testmanifest:sometag"
+		session = podmanTest.Podman([]string{"manifest", "create", manifestName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		// verify if manifest exists
+		session = podmanTest.Podman([]string{"manifest", "exists", manifestName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		// manifest rm should be able to remove tagged manifest list
+		session = podmanTest.Podman([]string{"manifest", "rm", manifestName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		// verify that manifest should not exist
+		session = podmanTest.Podman([]string{"manifest", "exists", manifestName})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(1))
+	})
 })


### PR DESCRIPTION
ImagesBatchRemoval and ImageRemoval now honors and accepts
`LookupManifest` parameter which further tells libimage to resolve to
manifest list if it exists instead of actual image.

Following PR also makes `podman-remote manifest rm` functional which was
broken till now.

Closes: https://github.com/containers/podman/issues/14763

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
* podman-remote manifest rm now actually removes only manifest list and not image
* libpod REST API for image removal now supports additional LookupManifest parameter
   which allows end-users to remove manifest instead of images.
```
