### PR TITLE
service: do not run under the root cgroup

### DIFF
--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -137,7 +137,7 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 		}
 
 		// root cgroup, skip it
-		if parts[2] == "/" {
+		if parts[2] == "/" && !(unifiedMode && parts[1] == "") {
 			continue
 		}
 


### PR DESCRIPTION
at startup, when running on a cgroup v2 system, check if the current process is running in the root cgroup and move it to a sub-cgroup, otherwise Podman is not able to create cgroups and move processes there.

 Closes: https://github.com/containers/podman/issues/14573   

[NO NEW TESTS NEEDED] it needs nested podman

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman system service automatically creates a sub-cgroup when running in the root cgroup
```
