### PR TITLE
libpod/runtime: switch to golang native error wrapping

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -40,7 +41,6 @@ import (
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/docker/docker/pkg/namesgenerator"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -146,7 +146,7 @@ func SetXdgDirs() error {
 		}
 	}
 	if err := os.Setenv("XDG_RUNTIME_DIR", runtimeDir); err != nil {
-		return errors.Wrapf(err, "cannot set XDG_RUNTIME_DIR")
+		return fmt.Errorf("cannot set XDG_RUNTIME_DIR: %w", err)
 	}
 
 	if rootless.IsRootless() && os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
@@ -163,7 +163,7 @@ func SetXdgDirs() error {
 			return err
 		}
 		if err := os.Setenv("XDG_CONFIG_HOME", cfgHomeDir); err != nil {
-			return errors.Wrapf(err, "cannot set XDG_CONFIG_HOME")
+			return fmt.Errorf("cannot set XDG_CONFIG_HOME: %w", err)
 		}
 	}
 	return nil
@@ -214,7 +214,7 @@ func newRuntimeFromConfig(conf *config.Config, options ...RuntimeOption) (*Runti
 	// Overwrite config with user-given configuration options
 	for _, opt := range options {
 		if err := opt(runtime); err != nil {
-			return nil, errors.Wrapf(err, "error configuring runtime")
+			return nil, fmt.Errorf("error configuring runtime: %w", err)
 		}
 	}
 
@@ -225,12 +225,12 @@ func newRuntimeFromConfig(conf *config.Config, options ...RuntimeOption) (*Runti
 		}
 		os.Exit(1)
 		return nil
-	}); err != nil && errors.Cause(err) != shutdown.ErrHandlerExists {
+	}); err != nil && !errors.Is(err, shutdown.ErrHandlerExists) {
 		logrus.Errorf("Registering shutdown handler for libpod: %v", err)
 	}
 
 	if err := shutdown.Start(); err != nil {
-		return nil, errors.Wrapf(err, "error starting shutdown signal handler")
+		return nil, fmt.Errorf("error starting shutdown signal handler: %w", err)
 	}
 
 	if err := makeRuntime(runtime); err != nil {
@@ -256,10 +256,10 @@ func getLockManager(runtime *Runtime) (lock.Manager, error) {
 		lockPath := filepath.Join(runtime.config.Engine.TmpDir, "locks")
 		manager, err = lock.OpenFileLockManager(lockPath)
 		if err != nil {
-			if os.IsNotExist(errors.Cause(err)) {
+			if errors.Is(err, os.ErrNotExist) {
 				manager, err = lock.NewFileLockManager(lockPath)
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed to get new file lock manager")
+					return nil, fmt.Errorf("failed to get new file lock manager: %w", err)
 				}
 			} else {
 				return nil, err
@@ -275,19 +275,19 @@ func getLockManager(runtime *Runtime) (lock.Manager, error) {
 		manager, err = lock.OpenSHMLockManager(lockPath, runtime.config.Engine.NumLocks)
 		if err != nil {
 			switch {
-			case os.IsNotExist(errors.Cause(err)):
+			case errors.Is(err, os.ErrNotExist):
 				manager, err = lock.NewSHMLockManager(lockPath, runtime.config.Engine.NumLocks)
 				if err != nil {
-					return nil, errors.Wrapf(err, "failed to get new shm lock manager")
+					return nil, fmt.Errorf("failed to get new shm lock manager: %w", err)
 				}
-			case errors.Cause(err) == syscall.ERANGE && runtime.doRenumber:
+			case errors.Is(err, syscall.ERANGE) && runtime.doRenumber:
 				logrus.Debugf("Number of locks does not match - removing old locks")
 
 				// ERANGE indicates a lock numbering mismatch.
 				// Since we're renumbering, this is not fatal.
 				// Remove the earlier set of locks and recreate.
 				if err := os.Remove(filepath.Join("/dev/shm", lockPath)); err != nil {
-					return nil, errors.Wrapf(err, "error removing libpod locks file %s", lockPath)
+					return nil, fmt.Errorf("error removing libpod locks file %s: %w", lockPath, err)
 				}
 
 				manager, err = lock.NewSHMLockManager(lockPath, runtime.config.Engine.NumLocks)
@@ -299,7 +299,7 @@ func getLockManager(runtime *Runtime) (lock.Manager, error) {
 			}
 		}
 	default:
-		return nil, errors.Wrapf(define.ErrInvalidArg, "unknown lock type %s", runtime.config.Engine.LockType)
+		return nil, fmt.Errorf("unknown lock type %s: %w", runtime.config.Engine.LockType, define.ErrInvalidArg)
 	}
 	return manager, nil
 }
@@ -315,17 +315,17 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 	runtime.conmonPath = cPath
 
 	if runtime.noStore && runtime.doReset {
-		return errors.Wrapf(define.ErrInvalidArg, "cannot perform system reset if runtime is not creating a store")
+		return fmt.Errorf("cannot perform system reset if runtime is not creating a store: %w", define.ErrInvalidArg)
 	}
 	if runtime.doReset && runtime.doRenumber {
-		return errors.Wrapf(define.ErrInvalidArg, "cannot perform system reset while renumbering locks")
+		return fmt.Errorf("cannot perform system reset while renumbering locks: %w", define.ErrInvalidArg)
 	}
 
 	// Make the static files directory if it does not exist
 	if err := os.MkdirAll(runtime.config.Engine.StaticDir, 0700); err != nil {
 		// The directory is allowed to exist
-		if !os.IsExist(err) {
-			return errors.Wrap(err, "error creating runtime static files directory")
+		if !errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("error creating runtime static files directory: %w", err)
 		}
 	}
 
@@ -337,9 +337,9 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 	// package.
 	switch runtime.config.Engine.StateType {
 	case config.InMemoryStateStore:
-		return errors.Wrapf(define.ErrInvalidArg, "in-memory state is currently disabled")
+		return fmt.Errorf("in-memory state is currently disabled: %w", define.ErrInvalidArg)
 	case config.SQLiteStateStore:
-		return errors.Wrapf(define.ErrInvalidArg, "SQLite state is currently disabled")
+		return fmt.Errorf("SQLite state is currently disabled: %w", define.ErrInvalidArg)
 	case config.BoltDBStateStore:
 		dbPath := filepath.Join(runtime.config.Engine.StaticDir, "bolt_state.db")
 
@@ -349,7 +349,7 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 		}
 		runtime.state = state
 	default:
-		return errors.Wrapf(define.ErrInvalidArg, "unrecognized state type passed (%v)", runtime.config.Engine.StateType)
+		return fmt.Errorf("unrecognized state type passed (%v): %w", runtime.config.Engine.StateType, define.ErrInvalidArg)
 	}
 
 	// Grab config from the database so we can reset some defaults
@@ -369,7 +369,7 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 			}
 		}
 
-		return errors.Wrapf(err, "error retrieving runtime configuration from database")
+		return fmt.Errorf("error retrieving runtime configuration from database: %w", err)
 	}
 
 	runtime.mergeDBConfig(dbConfig)
@@ -412,7 +412,7 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 	}
 
 	if err := runtime.state.SetNamespace(runtime.config.Engine.Namespace); err != nil {
-		return errors.Wrapf(err, "error setting libpod namespace in state")
+		return fmt.Errorf("error setting libpod namespace in state: %w", err)
 	}
 	logrus.Debugf("Set libpod namespace to %q", runtime.config.Engine.Namespace)
 
@@ -468,16 +468,16 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 	// Create the tmpDir
 	if err := os.MkdirAll(runtime.config.Engine.TmpDir, 0751); err != nil {
 		// The directory is allowed to exist
-		if !os.IsExist(err) {
-			return errors.Wrap(err, "error creating tmpdir")
+		if !errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("error creating tmpdir: %w", err)
 		}
 	}
 
 	// Create events log dir
 	if err := os.MkdirAll(filepath.Dir(runtime.config.Engine.EventsLogFilePath), 0700); err != nil {
 		// The directory is allowed to exist
-		if !os.IsExist(err) {
-			return errors.Wrap(err, "error creating events dirs")
+		if !errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("error creating events dirs: %w", err)
 		}
 	}
 
@@ -514,7 +514,7 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 		} else {
 			ociRuntime, ok := runtime.ociRuntimes[runtime.config.Engine.OCIRuntime]
 			if !ok {
-				return errors.Wrapf(define.ErrInvalidArg, "default OCI runtime %q not found", runtime.config.Engine.OCIRuntime)
+				return fmt.Errorf("default OCI runtime %q not found: %w", runtime.config.Engine.OCIRuntime, define.ErrInvalidArg)
 			}
 			runtime.defaultOCIRuntime = ociRuntime
 		}
@@ -523,19 +523,19 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 
 	// Do we have at least one valid OCI runtime?
 	if len(runtime.ociRuntimes) == 0 {
-		return errors.Wrapf(define.ErrInvalidArg, "no OCI runtime has been configured")
+		return fmt.Errorf("no OCI runtime has been configured: %w", define.ErrInvalidArg)
 	}
 
 	// Do we have a default runtime?
 	if runtime.defaultOCIRuntime == nil {
-		return errors.Wrapf(define.ErrInvalidArg, "no default OCI runtime was configured")
+		return fmt.Errorf("no default OCI runtime was configured: %w", define.ErrInvalidArg)
 	}
 
 	// Make the per-boot files directory if it does not exist
 	if err := os.MkdirAll(runtime.config.Engine.TmpDir, 0755); err != nil {
 		// The directory is allowed to exist
-		if !os.IsExist(err) {
-			return errors.Wrapf(err, "error creating runtime temporary files directory")
+		if !errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("error creating runtime temporary files directory: %w", err)
 		}
 	}
 
@@ -556,7 +556,7 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 	runtimeAliveFile := filepath.Join(runtime.config.Engine.TmpDir, "alive")
 	aliveLock, err := storage.GetLockfile(runtimeAliveLock)
 	if err != nil {
-		return errors.Wrapf(err, "error acquiring runtime init lock")
+		return fmt.Errorf("error acquiring runtime init lock: %w", err)
 	}
 	// Acquire the lock and hold it until we return
 	// This ensures that no two processes will be in runtime.refresh at once
@@ -586,7 +586,7 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 			aliveLock.Unlock() // Unlock to avoid deadlock as BecomeRootInUserNS will reexec.
 			pausePid, err := util.GetRootlessPauseProcessPidPathGivenDir(runtime.config.Engine.TmpDir)
 			if err != nil {
-				return errors.Wrapf(err, "could not get pause process pid file path")
+				return fmt.Errorf("could not get pause process pid file path: %w", err)
 			}
 			became, ret, err := rootless.BecomeRootInUserNS(pausePid)
 			if err != nil {
@@ -607,10 +607,10 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 		// This will trigger on first use as well, but refreshing an
 		// empty state only creates a single file
 		// As such, it's not really a performance concern
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			doRefresh = true
 		} else {
-			return errors.Wrapf(err, "error reading runtime status file %s", runtimeAliveFile)
+			return fmt.Errorf("error reading runtime status file %s: %w", runtimeAliveFile, err)
 		}
 	}
 
@@ -704,14 +704,14 @@ func findConmon(conmonPaths []string) (string, error) {
 	}
 
 	if foundOutdatedConmon {
-		return "", errors.Wrapf(define.ErrConmonOutdated,
-			"please update to v%d.%d.%d or later",
-			conmonMinMajorVersion, conmonMinMinorVersion, conmonMinPatchVersion)
+		return "", fmt.Errorf(
+			"please update to v%d.%d.%d or later: %w",
+			conmonMinMajorVersion, conmonMinMinorVersion, conmonMinPatchVersion, define.ErrConmonOutdated)
 	}
 
-	return "", errors.Wrapf(define.ErrInvalidArg,
-		"could not find a working conmon binary (configured options: %v)",
-		conmonPaths)
+	return "", fmt.Errorf(
+		"could not find a working conmon binary (configured options: %v): %w",
+		conmonPaths, define.ErrInvalidArg)
 }
 
 // probeConmon calls conmon --version and verifies it is a new enough version for
@@ -728,11 +728,11 @@ func probeConmon(conmonBinary string) error {
 
 	matches := r.FindStringSubmatch(out.String())
 	if len(matches) != 4 {
-		return errors.Wrap(err, define.ErrConmonVersionFormat)
+		return fmt.Errorf("%v: %w", define.ErrConmonVersionFormat, err)
 	}
 	major, err := strconv.Atoi(matches[1])
 	if err != nil {
-		return errors.Wrap(err, define.ErrConmonVersionFormat)
+		return fmt.Errorf("%v: %w", define.ErrConmonVersionFormat, err)
 	}
 	if major < conmonMinMajorVersion {
 		return define.ErrConmonOutdated
@@ -743,7 +743,7 @@ func probeConmon(conmonBinary string) error {
 
 	minor, err := strconv.Atoi(matches[2])
 	if err != nil {
-		return errors.Wrap(err, define.ErrConmonVersionFormat)
+		return fmt.Errorf("%v: %w", define.ErrConmonVersionFormat, err)
 	}
 	if minor < conmonMinMinorVersion {
 		return define.ErrConmonOutdated
@@ -754,7 +754,7 @@ func probeConmon(conmonBinary string) error {
 
 	patch, err := strconv.Atoi(matches[3])
 	if err != nil {
-		return errors.Wrap(err, define.ErrConmonVersionFormat)
+		return fmt.Errorf("%v: %w", define.ErrConmonVersionFormat, err)
 	}
 	if patch < conmonMinPatchVersion {
 		return define.ErrConmonOutdated
@@ -798,7 +798,7 @@ func (r *Runtime) GetConfig() (*config.Config, error) {
 
 	// Copy so the caller won't be able to modify the actual config
 	if err := JSONDeepCopy(rtConfig, config); err != nil {
-		return nil, errors.Wrapf(err, "error copying config")
+		return nil, fmt.Errorf("error copying config: %w", err)
 	}
 
 	return config, nil
@@ -909,7 +909,7 @@ func (r *Runtime) Shutdown(force bool) error {
 
 		// Note that the libimage runtime shuts down the store.
 		if err := r.libimageRuntime.Shutdown(force); err != nil {
-			lastError = errors.Wrapf(err, "error shutting down container storage")
+			lastError = fmt.Errorf("error shutting down container storage: %w", err)
 		}
 	}
 	if err := r.state.Close(); err != nil {
@@ -941,15 +941,15 @@ func (r *Runtime) refresh(alivePath string) error {
 	// Containers, pods, and volumes must also reacquire their locks.
 	ctrs, err := r.state.AllContainers()
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving all containers from state")
+		return fmt.Errorf("error retrieving all containers from state: %w", err)
 	}
 	pods, err := r.state.AllPods()
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving all pods from state")
+		return fmt.Errorf("error retrieving all pods from state: %w", err)
 	}
 	vols, err := r.state.AllVolumes()
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving all volumes from state")
+		return fmt.Errorf("error retrieving all volumes from state: %w", err)
 	}
 	// No locks are taken during pod, volume, and container refresh.
 	// Furthermore, the pod/volume/container refresh() functions are not
@@ -977,7 +977,7 @@ func (r *Runtime) refresh(alivePath string) error {
 	// Create a file indicating the runtime is alive and ready
 	file, err := os.OpenFile(alivePath, os.O_RDONLY|os.O_CREATE, 0644)
 	if err != nil {
-		return errors.Wrap(err, "error creating runtime status file")
+		return fmt.Errorf("error creating runtime status file: %w", err)
 	}
 	defer file.Close()
 
@@ -998,13 +998,13 @@ func (r *Runtime) generateName() (string, error) {
 		// Make sure container with this name does not exist
 		if _, err := r.state.LookupContainer(name); err == nil {
 			continue
-		} else if errors.Cause(err) != define.ErrNoSuchCtr {
+		} else if !errors.Is(err, define.ErrNoSuchCtr) {
 			return "", err
 		}
 		// Make sure pod with this name does not exist
 		if _, err := r.state.LookupPod(name); err == nil {
 			continue
-		} else if errors.Cause(err) != define.ErrNoSuchPod {
+		} else if !errors.Is(err, define.ErrNoSuchPod) {
 			return "", err
 		}
 		return name, nil
@@ -1203,7 +1203,7 @@ func (r *Runtime) getVolumePlugin(name string) (*plugin.VolumePlugin, error) {
 
 	pluginPath, ok := r.config.Engine.VolumePlugins[name]
 	if !ok {
-		return nil, errors.Wrapf(define.ErrMissingPlugin, "no volume plugin with name %s available", name)
+		return nil, fmt.Errorf("no volume plugin with name %s available: %w", name, define.ErrMissingPlugin)
 	}
 
 	return plugin.GetVolumePlugin(name, pluginPath)

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -26,7 +27,6 @@ import (
 	"github.com/docker/go-units"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -86,7 +86,7 @@ func (r *Runtime) RestoreContainer(ctx context.Context, rSpec *spec.Spec, config
 
 	ctr, err := r.initContainerVariables(rSpec, config)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error initializing container variables")
+		return nil, fmt.Errorf("error initializing container variables: %w", err)
 	}
 	// For an imported checkpoint no one has ever set the StartedTime. Set it now.
 	ctr.state.StartedTime = time.Now()
@@ -126,7 +126,7 @@ func (r *Runtime) RenameContainer(ctx context.Context, ctr *Container, newName s
 	// the config was re-written.
 	newConf, err := r.state.GetContainerConfig(ctr.ID())
 	if err != nil {
-		return nil, errors.Wrapf(err, "error retrieving container %s configuration from DB to remove", ctr.ID())
+		return nil, fmt.Errorf("error retrieving container %s configuration from DB to remove: %w", ctr.ID(), err)
 	}
 	ctr.config = newConf
 
@@ -143,7 +143,7 @@ func (r *Runtime) RenameContainer(ctx context.Context, ctr *Container, newName s
 		// Set config back to the old name so reflect what is actually
 		// present in the DB.
 		ctr.config.Name = oldName
-		return nil, errors.Wrapf(err, "error renaming container %s", ctr.ID())
+		return nil, fmt.Errorf("error renaming container %s: %w", ctr.ID(), err)
 	}
 
 	// Step 3: rename the container in c/storage.
@@ -162,7 +162,7 @@ func (r *Runtime) RenameContainer(ctx context.Context, ctr *Container, newName s
 
 func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConfig) (*Container, error) {
 	if rSpec == nil {
-		return nil, errors.Wrapf(define.ErrInvalidArg, "must provide a valid runtime spec to create container")
+		return nil, fmt.Errorf("must provide a valid runtime spec to create container: %w", define.ErrInvalidArg)
 	}
 	ctr := new(Container)
 	ctr.config = new(ContainerConfig)
@@ -172,7 +172,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 		ctr.config.ID = stringid.GenerateNonCryptoID()
 		size, err := units.FromHumanSize(r.config.Containers.ShmSize)
 		if err != nil {
-			return nil, errors.Wrapf(err, "converting containers.conf ShmSize %s to an int", r.config.Containers.ShmSize)
+			return nil, fmt.Errorf("converting containers.conf ShmSize %s to an int: %w", r.config.Containers.ShmSize, err)
 		}
 		ctr.config.ShmSize = size
 		ctr.config.NoShm = false
@@ -184,7 +184,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 		// This is a restore from an imported checkpoint
 		ctr.restoreFromCheckpoint = true
 		if err := JSONDeepCopy(config, ctr.config); err != nil {
-			return nil, errors.Wrapf(err, "error copying container config for restore")
+			return nil, fmt.Errorf("error copying container config for restore: %w", err)
 		}
 		// If the ID is empty a new name for the restored container was requested
 		if ctr.config.ID == "" {
@@ -224,12 +224,12 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 	ctr, err = r.initContainerVariables(rSpec, nil)
 
 	if err != nil {
-		return nil, errors.Wrapf(err, "error initializing container variables")
+		return nil, fmt.Errorf("error initializing container variables: %w", err)
 	}
 
 	for _, option := range options {
 		if err := option(ctr); err != nil {
-			return nil, errors.Wrapf(err, "error running container create option")
+			return nil, fmt.Errorf("error running container create option: %w", err)
 		}
 	}
 
@@ -248,7 +248,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 			if opts.InterfaceName != "" {
 				// check that no name is assigned to more than network
 				if cutil.StringInSlice(opts.InterfaceName, usedIfNames) {
-					return nil, errors.Errorf("network interface name %q is already assigned to another network", opts.InterfaceName)
+					return nil, fmt.Errorf("network interface name %q is already assigned to another network", opts.InterfaceName)
 				}
 				usedIfNames = append(usedIfNames, opts.InterfaceName)
 			}
@@ -296,7 +296,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 	// Allocate a lock for the container
 	lock, err := r.lockManager.AllocateLock()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error allocating lock for new container")
+		return nil, fmt.Errorf("error allocating lock for new container: %w", err)
 	}
 	ctr.lock = lock
 	ctr.config.LockID = ctr.lock.ID()
@@ -319,7 +319,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 	} else {
 		ociRuntime, ok := r.ociRuntimes[ctr.config.OCIRuntime]
 		if !ok {
-			return nil, errors.Wrapf(define.ErrInvalidArg, "requested OCI runtime %s is not available", ctr.config.OCIRuntime)
+			return nil, fmt.Errorf("requested OCI runtime %s is not available: %w", ctr.config.OCIRuntime, define.ErrInvalidArg)
 		}
 		ctr.ociRuntime = ociRuntime
 	}
@@ -327,7 +327,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 	// Check NoCgroups support
 	if ctr.config.NoCgroups {
 		if !ctr.ociRuntime.SupportsNoCgroups() {
-			return nil, errors.Wrapf(define.ErrInvalidArg, "requested OCI runtime %s is not compatible with NoCgroups", ctr.ociRuntime.Name())
+			return nil, fmt.Errorf("requested OCI runtime %s is not compatible with NoCgroups: %w", ctr.ociRuntime.Name(), define.ErrInvalidArg)
 		}
 	}
 
@@ -336,7 +336,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		// Get the pod from state
 		pod, err = r.state.Pod(ctr.config.Pod)
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot add container %s to pod %s", ctr.ID(), ctr.config.Pod)
+			return nil, fmt.Errorf("cannot add container %s to pod %s: %w", ctr.ID(), ctr.config.Pod, err)
 		}
 	}
 
@@ -350,14 +350,14 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 				if pod != nil && pod.config.UsePodCgroup && !ctr.IsInfra() {
 					podCgroup, err := pod.CgroupPath()
 					if err != nil {
-						return nil, errors.Wrapf(err, "error retrieving pod %s cgroup", pod.ID())
+						return nil, fmt.Errorf("error retrieving pod %s cgroup: %w", pod.ID(), err)
 					}
 					expectPodCgroup, err := ctr.expectPodCgroup()
 					if err != nil {
 						return nil, err
 					}
 					if expectPodCgroup && podCgroup == "" {
-						return nil, errors.Wrapf(define.ErrInternal, "pod %s cgroup is not set", pod.ID())
+						return nil, fmt.Errorf("pod %s cgroup is not set: %w", pod.ID(), define.ErrInternal)
 					}
 					canUseCgroup := !rootless.IsRootless() || isRootlessCgroupSet(podCgroup)
 					if canUseCgroup {
@@ -367,7 +367,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 					ctr.config.CgroupParent = CgroupfsDefaultCgroupParent
 				}
 			} else if strings.HasSuffix(path.Base(ctr.config.CgroupParent), ".slice") {
-				return nil, errors.Wrapf(define.ErrInvalidArg, "systemd slice received as cgroup parent when using cgroupfs")
+				return nil, fmt.Errorf("systemd slice received as cgroup parent when using cgroupfs: %w", define.ErrInvalidArg)
 			}
 		case config.SystemdCgroupsManager:
 			if ctr.config.CgroupParent == "" {
@@ -375,7 +375,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 				case pod != nil && pod.config.UsePodCgroup && !ctr.IsInfra():
 					podCgroup, err := pod.CgroupPath()
 					if err != nil {
-						return nil, errors.Wrapf(err, "error retrieving pod %s cgroup", pod.ID())
+						return nil, fmt.Errorf("error retrieving pod %s cgroup: %w", pod.ID(), err)
 					}
 					ctr.config.CgroupParent = podCgroup
 				case rootless.IsRootless() && ctr.config.CgroupsMode != cgroupSplit:
@@ -384,10 +384,10 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 					ctr.config.CgroupParent = SystemdDefaultCgroupParent
 				}
 			} else if len(ctr.config.CgroupParent) < 6 || !strings.HasSuffix(path.Base(ctr.config.CgroupParent), ".slice") {
-				return nil, errors.Wrapf(define.ErrInvalidArg, "did not receive systemd slice as cgroup parent when using systemd to manage cgroups")
+				return nil, fmt.Errorf("did not receive systemd slice as cgroup parent when using systemd to manage cgroups: %w", define.ErrInvalidArg)
 			}
 		default:
-			return nil, errors.Wrapf(define.ErrInvalidArg, "unsupported Cgroup manager: %s - cannot validate cgroup parent", r.config.Engine.CgroupManager)
+			return nil, fmt.Errorf("unsupported Cgroup manager: %s - cannot validate cgroup parent: %w", r.config.Engine.CgroupManager, define.ErrInvalidArg)
 		}
 	}
 
@@ -470,8 +470,8 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 				ctrNamedVolumes = append(ctrNamedVolumes, dbVol)
 				// The volume exists, we're good
 				continue
-			} else if errors.Cause(err) != define.ErrNoSuchVolume {
-				return nil, errors.Wrapf(err, "error retrieving named volume %s for new container", vol.Name)
+			} else if !errors.Is(err, define.ErrNoSuchVolume) {
+				return nil, fmt.Errorf("error retrieving named volume %s for new container: %w", vol.Name, err)
 			}
 		}
 
@@ -504,7 +504,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		}
 		newVol, err := r.newVolume(false, volOptions...)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error creating named volume %q", vol.Name)
+			return nil, fmt.Errorf("error creating named volume %q: %w", vol.Name, err)
 		}
 
 		ctrNamedVolumes = append(ctrNamedVolumes, newVol)
@@ -527,7 +527,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		ctr.config.ShmDir = filepath.Join(ctr.bundlePath(), "shm")
 		if err := os.MkdirAll(ctr.config.ShmDir, 0700); err != nil {
 			if !os.IsExist(err) {
-				return nil, errors.Wrap(err, "unable to create shm dir")
+				return nil, fmt.Errorf("unable to create shm dir: %w", err)
 			}
 		}
 		ctr.config.Mounts = append(ctr.config.Mounts, ctr.config.ShmDir)
@@ -596,7 +596,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 	// exist once we're done.
 	newConf, err := r.state.GetContainerConfig(c.ID())
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving container %s configuration from DB to remove", c.ID())
+		return fmt.Errorf("error retrieving container %s configuration from DB to remove: %w", c.ID(), err)
 	}
 	c.config = newConf
 
@@ -611,12 +611,12 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 	if c.config.Pod != "" && !removePod {
 		pod, err = r.state.Pod(c.config.Pod)
 		if err != nil {
-			return errors.Wrapf(err, "container %s is in pod %s, but pod cannot be retrieved", c.ID(), pod.ID())
+			return fmt.Errorf("container %s is in pod %s, but pod cannot be retrieved: %w", c.ID(), pod.ID(), err)
 		}
 
 		// Lock the pod while we're removing container
 		if pod.config.LockID == c.config.LockID {
-			return errors.Wrapf(define.ErrWillDeadlock, "container %s and pod %s share lock ID %d", c.ID(), pod.ID(), c.config.LockID)
+			return fmt.Errorf("container %s and pod %s share lock ID %d: %w", c.ID(), pod.ID(), c.config.LockID, define.ErrWillDeadlock)
 		}
 		pod.lock.Lock()
 		defer pod.lock.Unlock()
@@ -626,7 +626,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 
 		infraID := pod.state.InfraContainerID
 		if c.ID() == infraID {
-			return errors.Errorf("container %s is the infra container of pod %s and cannot be removed without removing the pod", c.ID(), pod.ID())
+			return fmt.Errorf("container %s is the infra container of pod %s and cannot be removed without removing the pod", c.ID(), pod.ID())
 		}
 	}
 
@@ -693,7 +693,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 		}
 		if len(deps) != 0 {
 			depsStr := strings.Join(deps, ", ")
-			return errors.Wrapf(define.ErrCtrExists, "container %s has dependent containers which must be removed before it: %s", c.ID(), depsStr)
+			return fmt.Errorf("container %s has dependent containers which must be removed before it: %s: %w", c.ID(), depsStr, define.ErrCtrExists)
 		}
 	}
 
@@ -705,8 +705,8 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 		}
 		// Ignore ErrConmonDead - we couldn't retrieve the container's
 		// exit code properly, but it's still stopped.
-		if err := c.stop(time); err != nil && errors.Cause(err) != define.ErrConmonDead {
-			return errors.Wrapf(err, "cannot remove container %s as it could not be stopped", c.ID())
+		if err := c.stop(time); err != nil && !errors.Is(err, define.ErrConmonDead) {
+			return fmt.Errorf("cannot remove container %s as it could not be stopped: %w", c.ID(), err)
 		}
 
 		// We unlocked as part of stop() above - there's a chance someone
@@ -717,7 +717,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 		if ok, _ := r.state.HasContainer(c.ID()); !ok {
 			// When the container has already been removed, the OCI runtime directory remain.
 			if err := c.cleanupRuntime(ctx); err != nil {
-				return errors.Wrapf(err, "error cleaning up container %s from OCI runtime", c.ID())
+				return fmt.Errorf("error cleaning up container %s from OCI runtime: %w", c.ID(), err)
 			}
 			return nil
 		}
@@ -729,7 +729,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 	// Do this before we set ContainerStateRemoving, to ensure that we can
 	// actually remove from the OCI runtime.
 	if err := c.cleanup(ctx); err != nil {
-		cleanupErr = errors.Wrapf(err, "error cleaning up container %s", c.ID())
+		cleanupErr = fmt.Errorf("error cleaning up container %s: %w", c.ID(), err)
 	}
 
 	// Set ContainerStateRemoving
@@ -739,7 +739,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 		if cleanupErr != nil {
 			logrus.Errorf(err.Error())
 		}
-		return errors.Wrapf(err, "unable to set container %s removing state in database", c.ID())
+		return fmt.Errorf("unable to set container %s removing state in database: %w", c.ID(), err)
 	}
 
 	// Remove all active exec sessions
@@ -789,7 +789,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 	// Deallocate the container's lock
 	if err := c.lock.Free(); err != nil {
 		if cleanupErr == nil {
-			cleanupErr = errors.Wrapf(err, "error freeing lock for container %s", c.ID())
+			cleanupErr = fmt.Errorf("error freeing lock for container %s: %w", c.ID(), err)
 		} else {
 			logrus.Errorf("Free container lock: %v", err)
 		}
@@ -809,8 +809,8 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 			if !volume.Anonymous() {
 				continue
 			}
-			if err := runtime.removeVolume(ctx, volume, false, timeout, false); err != nil && errors.Cause(err) != define.ErrNoSuchVolume {
-				if errors.Cause(err) == define.ErrVolumeBeingUsed {
+			if err := runtime.removeVolume(ctx, volume, false, timeout, false); err != nil && !errors.Is(err, define.ErrNoSuchVolume) {
+				if errors.Is(err, define.ErrVolumeBeingUsed) {
 					// Ignore error, since podman will report original error
 					volumesFrom, _ := c.volumesFrom()
 					if len(volumesFrom) > 0 {
@@ -891,7 +891,7 @@ func (r *Runtime) evictContainer(ctx context.Context, idOrName string, removeVol
 	c := new(Container)
 	c.config, err = r.state.GetContainerConfig(id)
 	if err != nil {
-		return id, errors.Wrapf(err, "failed to retrieve config for ctr ID %q", id)
+		return id, fmt.Errorf("failed to retrieve config for ctr ID %q: %w", id, err)
 	}
 	c.state = new(ContainerState)
 
@@ -903,7 +903,7 @@ func (r *Runtime) evictContainer(ctx context.Context, idOrName string, removeVol
 	if c.config.Pod != "" {
 		pod, err = r.state.Pod(c.config.Pod)
 		if err != nil {
-			return id, errors.Wrapf(err, "container %s is in pod %s, but pod cannot be retrieved", c.ID(), pod.ID())
+			return id, fmt.Errorf("container %s is in pod %s, but pod cannot be retrieved: %w", c.ID(), pod.ID(), err)
 		}
 
 		// Lock the pod while we're removing container
@@ -918,7 +918,7 @@ func (r *Runtime) evictContainer(ctx context.Context, idOrName string, removeVol
 			return "", err
 		}
 		if c.ID() == infraID {
-			return id, errors.Errorf("container %s is the infra container of pod %s and cannot be removed without removing the pod", c.ID(), pod.ID())
+			return id, fmt.Errorf("container %s is the infra container of pod %s and cannot be removed without removing the pod", c.ID(), pod.ID())
 		}
 	}
 
@@ -1115,7 +1115,7 @@ func (r *Runtime) GetContainersByList(containers []string) ([]*Container, error)
 	for _, inputContainer := range containers {
 		ctr, err := r.LookupContainer(inputContainer)
 		if err != nil {
-			return ctrs, errors.Wrapf(err, "unable to look up container %s", inputContainer)
+			return ctrs, fmt.Errorf("unable to look up container %s: %w", inputContainer, err)
 		}
 		ctrs = append(ctrs, ctr)
 	}
@@ -1128,7 +1128,7 @@ func (r *Runtime) GetLatestContainer() (*Container, error) {
 	var lastCreatedTime time.Time
 	ctrs, err := r.GetAllContainers()
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to find latest container")
+		return nil, fmt.Errorf("unable to find latest container: %w", err)
 	}
 	if len(ctrs) == 0 {
 		return nil, define.ErrNoSuchCtr
@@ -1209,7 +1209,7 @@ func (r *Runtime) PruneContainers(filterFuncs []ContainerFilter) ([]*reports.Pru
 // MountStorageContainer mounts the storage container's root filesystem
 func (r *Runtime) MountStorageContainer(id string) (string, error) {
 	if _, err := r.GetContainer(id); err == nil {
-		return "", errors.Wrapf(define.ErrCtrExists, "ctr %s is a libpod container", id)
+		return "", fmt.Errorf("ctr %s is a libpod container: %w", id, define.ErrCtrExists)
 	}
 	container, err := r.store.Container(id)
 	if err != nil {
@@ -1217,7 +1217,7 @@ func (r *Runtime) MountStorageContainer(id string) (string, error) {
 	}
 	mountPoint, err := r.store.Mount(container.ID, "")
 	if err != nil {
-		return "", errors.Wrapf(err, "error mounting storage for container %s", id)
+		return "", fmt.Errorf("error mounting storage for container %s: %w", id, err)
 	}
 	return mountPoint, nil
 }
@@ -1225,7 +1225,7 @@ func (r *Runtime) MountStorageContainer(id string) (string, error) {
 // UnmountStorageContainer unmounts the storage container's root filesystem
 func (r *Runtime) UnmountStorageContainer(id string, force bool) (bool, error) {
 	if _, err := r.GetContainer(id); err == nil {
-		return false, errors.Wrapf(define.ErrCtrExists, "ctr %s is a libpod container", id)
+		return false, fmt.Errorf("ctr %s is a libpod container: %w", id, define.ErrCtrExists)
 	}
 	container, err := r.store.Container(id)
 	if err != nil {
@@ -1239,7 +1239,7 @@ func (r *Runtime) UnmountStorageContainer(id string, force bool) (bool, error) {
 func (r *Runtime) IsStorageContainerMounted(id string) (bool, string, error) {
 	var path string
 	if _, err := r.GetContainer(id); err == nil {
-		return false, "", errors.Wrapf(define.ErrCtrExists, "ctr %s is a libpod container", id)
+		return false, "", fmt.Errorf("ctr %s is a libpod container: %w", id, define.ErrCtrExists)
 	}
 
 	mountCnt, err := r.storageService.MountedContainerImage(id)
@@ -1265,13 +1265,13 @@ func (r *Runtime) StorageContainers() ([]storage.Container, error) {
 
 	storeContainers, err := r.store.Containers()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error reading list of all storage containers")
+		return nil, fmt.Errorf("error reading list of all storage containers: %w", err)
 	}
 	retCtrs := []storage.Container{}
 	for _, container := range storeContainers {
 		exists, err := r.state.HasContainer(container.ID)
 		if err != nil && err != define.ErrNoSuchCtr {
-			return nil, errors.Wrapf(err, "failed to check if %s container exists in database", container.ID)
+			return nil, fmt.Errorf("failed to check if %s container exists in database: %w", container.ID, err)
 		}
 		if exists {
 			continue

--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -2,11 +2,12 @@ package libpod
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/containers/common/pkg/util"
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/pkg/errors"
 )
 
 // Contains the public Runtime API for pods
@@ -112,7 +113,7 @@ func (r *Runtime) GetLatestPod() (*Pod, error) {
 	var lastCreatedTime time.Time
 	pods, err := r.GetAllPods()
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get all pods")
+		return nil, fmt.Errorf("unable to get all pods: %w", err)
 	}
 	if len(pods) == 0 {
 		return nil, define.ErrNoSuchPod
@@ -146,7 +147,7 @@ func (r *Runtime) GetRunningPods() ([]*Pod, error) {
 			pods = append(pods, c.PodID())
 			pod, err := r.GetPod(c.PodID())
 			if err != nil {
-				if errors.Cause(err) == define.ErrPodRemoved || errors.Cause(err) == define.ErrNoSuchPod {
+				if errors.Is(err, define.ErrPodRemoved) || errors.Is(err, define.ErrNoSuchPod) {
 					continue
 				}
 				return nil, err

--- a/libpod/runtime_renumber.go
+++ b/libpod/runtime_renumber.go
@@ -1,8 +1,9 @@
 package libpod
 
 import (
+	"fmt"
+
 	"github.com/containers/podman/v4/libpod/events"
-	"github.com/pkg/errors"
 )
 
 // renumberLocks reassigns lock numbers for all containers and pods in the
@@ -26,7 +27,7 @@ func (r *Runtime) renumberLocks() error {
 	for _, ctr := range allCtrs {
 		lock, err := r.lockManager.AllocateLock()
 		if err != nil {
-			return errors.Wrapf(err, "error allocating lock for container %s", ctr.ID())
+			return fmt.Errorf("error allocating lock for container %s: %w", ctr.ID(), err)
 		}
 
 		ctr.config.LockID = lock.ID()
@@ -43,7 +44,7 @@ func (r *Runtime) renumberLocks() error {
 	for _, pod := range allPods {
 		lock, err := r.lockManager.AllocateLock()
 		if err != nil {
-			return errors.Wrapf(err, "error allocating lock for pod %s", pod.ID())
+			return fmt.Errorf("error allocating lock for pod %s: %w", pod.ID(), err)
 		}
 
 		pod.config.LockID = lock.ID()
@@ -60,7 +61,7 @@ func (r *Runtime) renumberLocks() error {
 	for _, vol := range allVols {
 		lock, err := r.lockManager.AllocateLock()
 		if err != nil {
-			return errors.Wrapf(err, "error allocating lock for volume %s", vol.Name())
+			return fmt.Errorf("error allocating lock for volume %s: %w", vol.Name(), err)
 		}
 
 		vol.config.LockID = lock.ID()

--- a/libpod/runtime_volume.go
+++ b/libpod/runtime_volume.go
@@ -2,11 +2,11 @@ package libpod
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
-	"github.com/pkg/errors"
 )
 
 // Contains the public Runtime API for volumes
@@ -133,7 +133,7 @@ func (r *Runtime) PruneVolumes(ctx context.Context, filterFuncs []VolumeFilter) 
 		report.Id = vol.Name()
 		var timeout *uint
 		if err := r.RemoveVolume(ctx, vol, false, timeout); err != nil {
-			if errors.Cause(err) != define.ErrVolumeBeingUsed && errors.Cause(err) != define.ErrVolumeRemoved {
+			if !errors.Is(err, define.ErrVolumeBeingUsed) && !errors.Is(err, define.ErrVolumeRemoved) {
 				report.Err = err
 			} else {
 				// We didn't remove the volume for some reason

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -231,7 +231,7 @@ func Modify(ctx context.Context, name string, images []string, options *ModifyOp
 		err = errorhandling.JoinErrors(report.Errors)
 		if err != nil {
 			errModel := errorhandling.ErrorModel{
-				Because:      (errors.Cause(err)).Error(),
+				Because:      errorhandling.Cause(err).Error(),
 				Message:      err.Error(),
 				ResponseCode: response.StatusCode,
 			}

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -2,6 +2,7 @@ package abi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -32,7 +33,6 @@ import (
 	"github.com/containers/podman/v4/pkg/specgenutil"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/storage"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -80,7 +80,7 @@ func getContainersByContext(all, latest bool, names []string, runtime *libpod.Ru
 func (ic *ContainerEngine) ContainerExists(ctx context.Context, nameOrID string, options entities.ContainerExistsOptions) (*entities.BoolReport, error) {
 	_, err := ic.Libpod.LookupContainer(nameOrID)
 	if err != nil {
-		if errors.Cause(err) != define.ErrNoSuchCtr {
+		if !errors.Is(err, define.ErrNoSuchCtr) {
 			return nil, err
 		}
 		if options.External {
@@ -120,7 +120,7 @@ func (ic *ContainerEngine) ContainerPause(ctx context.Context, namesOrIds []stri
 	report := make([]*entities.PauseUnpauseReport, 0, len(ctrs))
 	for _, c := range ctrs {
 		err := c.Pause()
-		if err != nil && options.All && errors.Cause(err) == define.ErrCtrStateInvalid {
+		if err != nil && options.All && errors.Is(err, define.ErrCtrStateInvalid) {
 			logrus.Debugf("Container %s is not running", c.ID())
 			continue
 		}
@@ -137,7 +137,7 @@ func (ic *ContainerEngine) ContainerUnpause(ctx context.Context, namesOrIds []st
 	report := make([]*entities.PauseUnpauseReport, 0, len(ctrs))
 	for _, c := range ctrs {
 		err := c.Unpause()
-		if err != nil && options.All && errors.Cause(err) == define.ErrCtrStateInvalid {
+		if err != nil && options.All && errors.Is(err, define.ErrCtrStateInvalid) {
 			logrus.Debugf("Container %s is not paused", c.ID())
 			continue
 		}
@@ -148,7 +148,7 @@ func (ic *ContainerEngine) ContainerUnpause(ctx context.Context, namesOrIds []st
 func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []string, options entities.StopOptions) ([]*entities.StopReport, error) {
 	names := namesOrIds
 	ctrs, rawInputs, err := getContainersAndInputByContext(options.All, options.Latest, names, ic.Libpod)
-	if err != nil && !(options.Ignore && errors.Cause(err) == define.ErrNoSuchCtr) {
+	if err != nil && !(options.Ignore && errors.Is(err, define.ErrNoSuchCtr)) {
 		return nil, err
 	}
 	ctrMap := map[string]string{}
@@ -166,13 +166,13 @@ func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []strin
 		}
 		if err != nil {
 			switch {
-			case errors.Cause(err) == define.ErrCtrStopped:
+			case errors.Is(err, define.ErrCtrStopped):
 				logrus.Debugf("Container %s is already stopped", c.ID())
-			case options.All && errors.Cause(err) == define.ErrCtrStateInvalid:
+			case options.All && errors.Is(err, define.ErrCtrStateInvalid):
 				logrus.Debugf("Container %s is not running, could not stop", c.ID())
 			// container never created in OCI runtime
 			// docker parity: do nothing just return container id
-			case errors.Cause(err) == define.ErrCtrStateInvalid:
+			case errors.Is(err, define.ErrCtrStateInvalid):
 				logrus.Debugf("Container %s is either not created on runtime or is in a invalid state", c.ID())
 			default:
 				return err
@@ -238,7 +238,7 @@ func (ic *ContainerEngine) ContainerKill(ctx context.Context, namesOrIds []strin
 	reports := make([]*entities.KillReport, 0, len(ctrs))
 	for _, con := range ctrs {
 		err := con.Kill(uint(sig))
-		if options.All && errors.Cause(err) == define.ErrCtrStateInvalid {
+		if options.All && errors.Is(err, define.ErrCtrStateInvalid) {
 			logrus.Debugf("Container %s is not running", con.ID())
 			continue
 		}
@@ -289,8 +289,7 @@ func (ic *ContainerEngine) removeContainer(ctx context.Context, ctr *libpod.Cont
 		return nil
 	}
 	logrus.Debugf("Failed to remove container %s: %s", ctr.ID(), err.Error())
-	switch errors.Cause(err) {
-	case define.ErrNoSuchCtr:
+	if errors.Is(err, define.ErrNoSuchCtr) {
 		// Ignore if the container does not exist (anymore) when either
 		// it has been requested by the user of if the container is a
 		// service one.  Service containers are removed along with its
@@ -301,7 +300,7 @@ func (ic *ContainerEngine) removeContainer(ctx context.Context, ctr *libpod.Cont
 			logrus.Debugf("Ignoring error (--allow-missing): %v", err)
 			return nil
 		}
-	case define.ErrCtrRemoved:
+	} else if errors.Is(err, define.ErrCtrRemoved) {
 		return nil
 	}
 	return err
@@ -317,15 +316,15 @@ func (ic *ContainerEngine) ContainerRm(ctx context.Context, namesOrIds []string,
 	for _, ctr := range names {
 		report := reports.RmReport{Id: ctr}
 		report.Err = ic.Libpod.RemoveStorageContainer(ctr, options.Force)
-		switch errors.Cause(report.Err) {
-		case nil:
+		//nolint:gocritic
+		if report.Err == nil {
 			// remove container names that we successfully deleted
 			rmReports = append(rmReports, &report)
-		case define.ErrNoSuchCtr, define.ErrCtrExists:
+		} else if errors.Is(report.Err, define.ErrNoSuchCtr) || errors.Is(report.Err, define.ErrCtrExists) {
 			// There is still a potential this is a libpod container
 			tmpNames = append(tmpNames, ctr)
-		default:
-			if _, err := ic.Libpod.LookupContainer(ctr); errors.Cause(err) == define.ErrNoSuchCtr {
+		} else {
+			if _, err := ic.Libpod.LookupContainer(ctr); errors.Is(err, define.ErrNoSuchCtr) {
 				// remove container failed, but not a libpod container
 				rmReports = append(rmReports, &report)
 				continue
@@ -337,7 +336,7 @@ func (ic *ContainerEngine) ContainerRm(ctx context.Context, namesOrIds []string,
 	names = tmpNames
 
 	ctrs, err := getContainersByContext(options.All, options.Latest, names, ic.Libpod)
-	if err != nil && !(options.Ignore && errors.Cause(err) == define.ErrNoSuchCtr) {
+	if err != nil && !(options.Ignore && errors.Is(err, define.ErrNoSuchCtr)) {
 		// Failed to get containers. If force is specified, get the containers ID
 		// and evict them
 		if !options.Force {
@@ -349,7 +348,7 @@ func (ic *ContainerEngine) ContainerRm(ctx context.Context, namesOrIds []string,
 			report := reports.RmReport{Id: ctr}
 			_, err := ic.Libpod.EvictContainer(ctx, ctr, options.Volumes)
 			if err != nil {
-				if options.Ignore && errors.Cause(err) == define.ErrNoSuchCtr {
+				if options.Ignore && errors.Is(err, define.ErrNoSuchCtr) {
 					logrus.Debugf("Ignoring error (--allow-missing): %v", err)
 					rmReports = append(rmReports, &report)
 					continue
@@ -426,7 +425,7 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 		ctr, err := ic.Libpod.GetLatestContainer()
 		if err != nil {
 			if errors.Is(err, define.ErrNoSuchCtr) {
-				return nil, []error{errors.Wrapf(err, "no containers to inspect")}, nil
+				return nil, []error{fmt.Errorf("no containers to inspect: %w", err)}, nil
 			}
 			return nil, nil, err
 		}
@@ -452,7 +451,7 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 			// ErrNoSuchCtr is non-fatal, other errors will be
 			// treated as fatal.
 			if errors.Is(err, define.ErrNoSuchCtr) {
-				errs = append(errs, errors.Errorf("no such container %s", name))
+				errs = append(errs, fmt.Errorf("no such container %s", name))
 				continue
 			}
 			return nil, nil, err
@@ -463,7 +462,7 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 			// ErrNoSuchCtr is non-fatal, other errors will be
 			// treated as fatal.
 			if errors.Is(err, define.ErrNoSuchCtr) {
-				errs = append(errs, errors.Errorf("no such container %s", name))
+				errs = append(errs, fmt.Errorf("no such container %s", name))
 				continue
 			}
 			return nil, nil, err
@@ -487,7 +486,7 @@ func (ic *ContainerEngine) ContainerTop(ctx context.Context, options entities.To
 		container, err = ic.Libpod.LookupContainer(options.NameOrID)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to look up requested container")
+		return nil, fmt.Errorf("unable to look up requested container: %w", err)
 	}
 
 	// Run Top.
@@ -512,12 +511,12 @@ func (ic *ContainerEngine) ContainerCommit(ctx context.Context, nameOrID string,
 	case "oci":
 		mimeType = buildah.OCIv1ImageManifest
 		if len(options.Message) > 0 {
-			return nil, errors.Errorf("messages are only compatible with the docker image format (-f docker)")
+			return nil, fmt.Errorf("messages are only compatible with the docker image format (-f docker)")
 		}
 	case "docker":
 		mimeType = manifest.DockerV2Schema2MediaType
 	default:
-		return nil, errors.Errorf("unrecognized image format %q", options.Format)
+		return nil, fmt.Errorf("unrecognized image format %q", options.Format)
 	}
 
 	sc := ic.Libpod.SystemContext()
@@ -660,7 +659,7 @@ func (ic *ContainerEngine) ContainerRestore(ctx context.Context, namesOrIds []st
 					// CRImportCheckpoint is expected to import exactly one container from checkpoint image
 					checkpointImageImportErrors = append(
 						checkpointImageImportErrors,
-						errors.Errorf("unable to import checkpoint from image: %q: %v", nameOrID, err),
+						fmt.Errorf("unable to import checkpoint from image: %q: %v", nameOrID, err),
 					)
 				} else {
 					containers = append(containers, importedContainers[0])
@@ -720,16 +719,16 @@ func (ic *ContainerEngine) ContainerAttach(ctx context.Context, nameOrID string,
 	ctr := ctrs[0]
 	conState, err := ctr.State()
 	if err != nil {
-		return errors.Wrapf(err, "unable to determine state of %s", ctr.ID())
+		return fmt.Errorf("unable to determine state of %s: %w", ctr.ID(), err)
 	}
 	if conState != define.ContainerStateRunning {
-		return errors.Errorf("you can only attach to running containers")
+		return fmt.Errorf("you can only attach to running containers")
 	}
 
 	// If the container is in a pod, also set to recursively start dependencies
 	err = terminal.StartAttachCtr(ctx, ctr, options.Stdout, options.Stderr, options.Stdin, options.DetachKeys, options.SigProxy, false)
-	if err != nil && errors.Cause(err) != define.ErrDetach {
-		return errors.Wrapf(err, "error attaching to container %s", ctr.ID())
+	if err != nil && !errors.Is(err, define.ErrDetach) {
+		return fmt.Errorf("error attaching to container %s: %w", ctr.ID(), err)
 	}
 	os.Stdout.WriteString("\n")
 	return nil
@@ -751,12 +750,12 @@ func makeExecConfig(options entities.ExecOptions, rt *libpod.Runtime) (*libpod.E
 	storageConfig := rt.StorageConfig()
 	runtimeConfig, err := rt.GetConfig()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error retrieving Libpod configuration to build exec exit command")
+		return nil, fmt.Errorf("error retrieving Libpod configuration to build exec exit command: %w", err)
 	}
 	// TODO: Add some ability to toggle syslog
 	exitCommandArgs, err := specgenutil.CreateExitCommandArgs(storageConfig, runtimeConfig, logrus.IsLevelEnabled(logrus.DebugLevel), false, true)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error constructing exit command for exec session")
+		return nil, fmt.Errorf("error constructing exit command for exec session: %w", err)
 	}
 	execConfig.ExitCommand = exitCommandArgs
 
@@ -774,7 +773,7 @@ func checkExecPreserveFDs(options entities.ExecOptions) error {
 		for _, e := range entries {
 			i, err := strconv.Atoi(e.Name())
 			if err != nil {
-				return errors.Wrapf(err, "cannot parse %s in /proc/self/fd", e.Name())
+				return fmt.Errorf("cannot parse %s in /proc/self/fd: %w", e.Name(), err)
 			}
 			m[i] = true
 		}
@@ -891,7 +890,7 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 
 		if options.Attach {
 			err = terminal.StartAttachCtr(ctx, ctr, options.Stdout, options.Stderr, options.Stdin, options.DetachKeys, options.SigProxy, !ctrRunning)
-			if errors.Cause(err) == define.ErrDetach {
+			if errors.Is(err, define.ErrDetach) {
 				// User manually detached
 				// Exit cleanly immediately
 				reports = append(reports, &entities.ContainerStartReport{
@@ -903,7 +902,7 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 				return reports, nil
 			}
 
-			if errors.Cause(err) == define.ErrWillDeadlock {
+			if errors.Is(err, define.ErrWillDeadlock) {
 				logrus.Debugf("Deadlock error: %v", err)
 				reports = append(reports, &entities.ContainerStartReport{
 					Id:       ctr.ID(),
@@ -911,7 +910,7 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 					Err:      err,
 					ExitCode: define.ExitCode(err),
 				})
-				return reports, errors.Errorf("attempting to start container %s would cause a deadlock; please run 'podman system renumber' to resolve", ctr.ID())
+				return reports, fmt.Errorf("attempting to start container %s would cause a deadlock; please run 'podman system renumber' to resolve", ctr.ID())
 			}
 
 			if ctrRunning {
@@ -936,7 +935,7 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 						logrus.Errorf("Removing container %s: %v", ctr.ID(), err)
 					}
 				}
-				return reports, errors.Wrapf(err, "unable to start container %s", ctr.ID())
+				return reports, fmt.Errorf("unable to start container %s: %w", ctr.ID(), err)
 			}
 
 			exitCode = ic.GetContainerExitCode(ctx, ctr)
@@ -960,12 +959,12 @@ func (ic *ContainerEngine) ContainerStart(ctx context.Context, namesOrIds []stri
 			}
 			if err := ctr.Start(ctx, true); err != nil {
 				report.Err = err
-				if errors.Cause(err) == define.ErrWillDeadlock {
-					report.Err = errors.Wrapf(err, "please run 'podman system renumber' to resolve deadlocks")
+				if errors.Is(err, define.ErrWillDeadlock) {
+					report.Err = fmt.Errorf("please run 'podman system renumber' to resolve deadlocks: %w", err)
 					reports = append(reports, report)
 					continue
 				}
-				report.Err = errors.Wrapf(err, "unable to start container %q", ctr.ID())
+				report.Err = fmt.Errorf("unable to start container %q: %w", ctr.ID(), err)
 				reports = append(reports, report)
 				if ctr.AutoRemove() {
 					if err := ic.removeContainer(ctx, ctr, entities.RmOptions{}); err != nil {
@@ -1001,7 +1000,7 @@ func (ic *ContainerEngine) Diff(ctx context.Context, namesOrIDs []string, opts e
 	if opts.Latest {
 		ctnr, err := ic.Libpod.GetLatestContainer()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to get latest container")
+			return nil, fmt.Errorf("unable to get latest container: %w", err)
 		}
 		base = ctnr.ID()
 	}
@@ -1064,7 +1063,7 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 		// We've manually detached from the container
 		// Do not perform cleanup, or wait for container exit code
 		// Just exit immediately
-		if errors.Cause(err) == define.ErrDetach {
+		if errors.Is(err, define.ErrDetach) {
 			report.ExitCode = 0
 			return &report, nil
 		}
@@ -1074,10 +1073,10 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 				logrus.Debugf("unable to remove container %s after failing to start and attach to it", ctr.ID())
 			}
 		}
-		if errors.Cause(err) == define.ErrWillDeadlock {
+		if errors.Is(err, define.ErrWillDeadlock) {
 			logrus.Debugf("Deadlock error on %q: %v", ctr.ID(), err)
 			report.ExitCode = define.ExitCode(err)
-			return &report, errors.Errorf("attempting to start container %s would cause a deadlock; please run 'podman system renumber' to resolve", ctr.ID())
+			return &report, fmt.Errorf("attempting to start container %s would cause a deadlock; please run 'podman system renumber' to resolve", ctr.ID())
 		}
 		report.ExitCode = define.ExitCode(err)
 		return &report, err
@@ -1086,8 +1085,8 @@ func (ic *ContainerEngine) ContainerRun(ctx context.Context, opts entities.Conta
 	if opts.Rm && !ctr.ShouldRestart(ctx) {
 		var timeout *uint
 		if err := ic.Libpod.RemoveContainer(ctx, ctr, false, true, timeout); err != nil {
-			if errors.Cause(err) == define.ErrNoSuchCtr ||
-				errors.Cause(err) == define.ErrCtrRemoved {
+			if errors.Is(err, define.ErrNoSuchCtr) ||
+				errors.Is(err, define.ErrCtrRemoved) {
 				logrus.Infof("Container %s was already removed, skipping --rm", ctr.ID())
 			} else {
 				logrus.Errorf("Removing container %s: %v", ctr.ID(), err)
@@ -1180,12 +1179,12 @@ func (ic *ContainerEngine) ContainerCleanup(ctx context.Context, namesOrIds []st
 			var timeout *uint
 			err = ic.Libpod.RemoveContainer(ctx, ctr, false, true, timeout)
 			if err != nil {
-				report.RmErr = errors.Wrapf(err, "failed to clean up and remove container %v", ctr.ID())
+				report.RmErr = fmt.Errorf("failed to clean up and remove container %v: %w", ctr.ID(), err)
 			}
 		} else {
 			err := ctr.Cleanup(ctx)
 			if err != nil {
-				report.CleanErr = errors.Wrapf(err, "failed to clean up container %v", ctr.ID())
+				report.CleanErr = fmt.Errorf("failed to clean up container %v: %w", ctr.ID(), err)
 			}
 		}
 
@@ -1212,7 +1211,7 @@ func (ic *ContainerEngine) ContainerInit(ctx context.Context, namesOrIds []strin
 		err := ctr.Init(ctx, ctr.PodID() != "")
 
 		// If we're initializing all containers, ignore invalid state errors
-		if options.All && errors.Cause(err) == define.ErrCtrStateInvalid {
+		if options.All && errors.Is(err, define.ErrCtrStateInvalid) {
 			err = nil
 		}
 		report.Err = err
@@ -1323,7 +1322,7 @@ func (ic *ContainerEngine) ContainerUnmount(ctx context.Context, nameOrIDs []str
 			if mounted {
 				report := entities.ContainerUnmountReport{Id: sctr.ID}
 				if _, report.Err = ic.Libpod.UnmountStorageContainer(sctr.ID, options.Force); report.Err != nil {
-					if errors.Cause(report.Err) != define.ErrCtrExists {
+					if !errors.Is(report.Err, define.ErrCtrExists) {
 						reports = append(reports, &report)
 					}
 				} else {
@@ -1357,11 +1356,11 @@ func (ic *ContainerEngine) ContainerUnmount(ctx context.Context, nameOrIDs []str
 
 		report := entities.ContainerUnmountReport{Id: ctr.ID()}
 		if err := ctr.Unmount(options.Force); err != nil {
-			if options.All && errors.Cause(err) == storage.ErrLayerNotMounted {
+			if options.All && errors.Is(err, storage.ErrLayerNotMounted) {
 				logrus.Debugf("Error umounting container %s, storage.ErrLayerNotMounted", ctr.ID())
 				continue
 			}
-			report.Err = errors.Wrapf(err, "error unmounting container %s", ctr.ID())
+			report.Err = fmt.Errorf("error unmounting container %s: %w", ctr.ID(), err)
 		}
 		reports = append(reports, &report)
 	}
@@ -1410,7 +1409,7 @@ func (ic *ContainerEngine) Shutdown(_ context.Context) {
 
 func (ic *ContainerEngine) ContainerStats(ctx context.Context, namesOrIds []string, options entities.ContainerStatsOptions) (statsChan chan entities.ContainerStatsReport, err error) {
 	if options.Interval < 1 {
-		return nil, errors.New("Invalid interval, must be a positive number greater zero")
+		return nil, errors.New("invalid interval, must be a positive number greater zero")
 	}
 	if rootless.IsRootless() {
 		unified, err := cgroups.IsCgroup2UnifiedMode()
@@ -1465,19 +1464,18 @@ func (ic *ContainerEngine) ContainerStats(ctx context.Context, namesOrIds []stri
 		computeStats := func() ([]define.ContainerStats, error) {
 			containers, err = containerFunc()
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to get list of containers")
+				return nil, fmt.Errorf("unable to get list of containers: %w", err)
 			}
 
 			reportStats := []define.ContainerStats{}
 			for _, ctr := range containers {
 				stats, err := ctr.GetContainerStats(containerStats[ctr.ID()])
 				if err != nil {
-					cause := errors.Cause(err)
-					if queryAll && (cause == define.ErrCtrRemoved || cause == define.ErrNoSuchCtr || cause == define.ErrCtrStateInvalid) {
+					if queryAll && (errors.Is(err, define.ErrCtrRemoved) || errors.Is(err, define.ErrNoSuchCtr) || errors.Is(err, define.ErrCtrStateInvalid)) {
 						continue
 					}
-					if cause == cgroups.ErrCgroupV1Rootless {
-						err = cause
+					if errors.Is(err, cgroups.ErrCgroupV1Rootless) {
+						err = cgroups.ErrCgroupV1Rootless
 					}
 					return nil, err
 				}

--- a/pkg/errorhandling/errorhandling.go
+++ b/pkg/errorhandling/errorhandling.go
@@ -1,11 +1,11 @@
 package errorhandling
 
 import (
+	"errors"
 	"os"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -120,4 +120,23 @@ func (e PodConflictErrorModel) Error() string {
 
 func (e PodConflictErrorModel) Code() int {
 	return 409
+}
+
+// Cause returns the most underlying error for the provided one. There is a
+// maximum error depth of 100 to avoid endless loops. An additional error log
+// message will be created if this maximum has reached.
+func Cause(err error) (cause error) {
+	cause = err
+
+	const maxDepth = 100
+	for i := 0; i <= maxDepth; i++ {
+		res := errors.Unwrap(cause)
+		if res == nil {
+			return cause
+		}
+		cause = res
+	}
+
+	logrus.Errorf("Max error depth of %d reached, cannot unwrap until root cause: %v", maxDepth, err)
+	return cause
 }

--- a/pkg/errorhandling/errorhandling_test.go
+++ b/pkg/errorhandling/errorhandling_test.go
@@ -1,0 +1,53 @@
+package errorhandling
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCause(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		err         func() error
+		expectedErr error
+	}{
+		{
+			name:        "nil error",
+			err:         func() error { return nil },
+			expectedErr: nil,
+		},
+		{
+			name:        "equal errors",
+			err:         func() error { return errors.New("foo") },
+			expectedErr: errors.New("foo"),
+		},
+		{
+			name:        "wrapped error",
+			err:         func() error { return fmt.Errorf("baz: %w", fmt.Errorf("bar: %w", errors.New("foo"))) },
+			expectedErr: errors.New("foo"),
+		},
+		{
+			name: "max depth reached",
+			err: func() error {
+				err := errors.New("error")
+				for i := 0; i <= 101; i++ {
+					err = fmt.Errorf("%d: %w", i, err)
+				}
+				return err
+			},
+			expectedErr: fmt.Errorf("0: %w", errors.New("error")),
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := Cause(tc.err())
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -16,7 +16,6 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/godbus/dbus/v5"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -114,7 +113,7 @@ func UntarToFileSystem(dest string, tarball *os.File, options *archive.TarOption
 func CreateTarFromSrc(source string, dest string) error {
 	file, err := os.Create(dest)
 	if err != nil {
-		return errors.Wrapf(err, "Could not create tarball file '%s'", dest)
+		return fmt.Errorf("could not create tarball file '%s': %w", dest, err)
 	}
 	defer file.Close()
 	return TarToFilesystem(source, file)
@@ -154,7 +153,7 @@ func RemoveScientificNotationFromFloat(x float64) (float64, error) {
 	}
 	result, err := strconv.ParseFloat(bigNum, 64)
 	if err != nil {
-		return x, errors.Wrapf(err, "unable to remove scientific number from calculations")
+		return x, fmt.Errorf("unable to remove scientific number from calculations: %w", err)
 	}
 	return result, nil
 }
@@ -181,11 +180,11 @@ func moveProcessPIDFileToScope(pidPath, slice, scope string) error {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return errors.Wrapf(err, "cannot read pid file %s", pidPath)
+		return fmt.Errorf("cannot read pid file %s: %w", pidPath, err)
 	}
 	pid, err := strconv.ParseUint(string(data), 10, 0)
 	if err != nil {
-		return errors.Wrapf(err, "cannot parse pid file %s", pidPath)
+		return fmt.Errorf("cannot parse pid file %s: %w", pidPath, err)
 	}
 
 	return moveProcessToScope(int(pid), slice, scope)


### PR DESCRIPTION
We now use the golang error wrapping format specifier `%w` instead of the deprecated github.com/pkg/errors package.

Part of #14784 

#### Does this PR introduce a user-facing change?


```release-note
None
```
