### PR TITLE
specgen: fix parsing of cgroup devices rule

### DIFF
--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -1134,17 +1134,21 @@ func parseLinuxResourcesDeviceAccess(device string) (specs.LinuxDeviceCgroup, er
 	}
 
 	number := strings.SplitN(value[1], ":", 2)
-	i, err := strconv.ParseInt(number[0], 10, 64)
-	if err != nil {
-		return specs.LinuxDeviceCgroup{}, err
-	}
-	major = &i
-	if len(number) == 2 && number[1] != "*" {
-		i, err := strconv.ParseInt(number[1], 10, 64)
+	if number[0] != "*" {
+		i, err := strconv.ParseUint(number[0], 10, 64)
 		if err != nil {
 			return specs.LinuxDeviceCgroup{}, err
 		}
-		minor = &i
+		m := int64(i)
+		major = &m
+	}
+	if len(number) == 2 && number[1] != "*" {
+		i, err := strconv.ParseUint(number[1], 10, 64)
+		if err != nil {
+			return specs.LinuxDeviceCgroup{}, err
+		}
+		m := int64(i)
+		minor = &m
 	}
 	access = value[2]
 	for _, c := range strings.Split(access, "") {

--- a/pkg/specgenutil/specgenutil_test.go
+++ b/pkg/specgenutil/specgenutil_test.go
@@ -75,3 +75,82 @@ func TestWinPath(t *testing.T) {
 		}
 	}
 }
+
+func TestParseLinuxResourcesDeviceAccess(t *testing.T) {
+	d, err := parseLinuxResourcesDeviceAccess("a *:* rwm")
+	assert.Nil(t, err, "err is nil")
+	assert.True(t, d.Allow, "allow is true")
+	assert.Equal(t, d.Type, "a", "type is 'a'")
+	assert.Nil(t, d.Minor, "minor is nil")
+	assert.Nil(t, d.Major, "major is nil")
+
+	d, err = parseLinuxResourcesDeviceAccess("b 3:* rwm")
+	assert.Nil(t, err, "err is nil")
+	assert.True(t, d.Allow, "allow is true")
+	assert.Equal(t, d.Type, "b", "type is 'b'")
+	assert.Nil(t, d.Minor, "minor is nil")
+	assert.NotNil(t, d.Major, "major is not nil")
+	assert.Equal(t, *d.Major, int64(3), "major is 3")
+
+	d, err = parseLinuxResourcesDeviceAccess("a *:3 rwm")
+	assert.Nil(t, err, "err is nil")
+	assert.True(t, d.Allow, "allow is true")
+	assert.Equal(t, d.Type, "a", "type is 'a'")
+	assert.Nil(t, d.Major, "major is nil")
+	assert.NotNil(t, d.Minor, "minor is not nil")
+	assert.Equal(t, *d.Minor, int64(3), "minor is 3")
+
+	d, err = parseLinuxResourcesDeviceAccess("c 1:2 rwm")
+	assert.Nil(t, err, "err is nil")
+	assert.True(t, d.Allow, "allow is true")
+	assert.Equal(t, d.Type, "c", "type is 'c'")
+	assert.NotNil(t, d.Major, "minor is not nil")
+	assert.Equal(t, *d.Major, int64(1), "minor is 1")
+	assert.NotNil(t, d.Minor, "minor is not nil")
+	assert.Equal(t, *d.Minor, int64(2), "minor is 2")
+
+	_, err = parseLinuxResourcesDeviceAccess("q *:* rwm")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("a a:* rwm")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("a *:a rwm")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("a *:* abc")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("* *:* *")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("* *:a2 *")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("*")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("*:*")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("a *:*")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("a *:*")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("a 12a:* r")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("a a12:* r")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("a 0x1:* r")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("a -2:* r")
+	assert.NotNil(t, err, "err is not nil")
+
+	_, err = parseLinuxResourcesDeviceAccess("a *:-3 r")
+	assert.NotNil(t, err, "err is not nil")
+}

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -730,7 +730,7 @@ EOF
     run_podman 125 run --device-cgroup-rule="x 7:* rmw" --rm $IMAGE
     is "$output" "Error: invalid device type in device-access-add: x"
     run_podman 125 run --device-cgroup-rule="a a:* rmw" --rm $IMAGE
-    is "$output" "Error: strconv.ParseInt: parsing \"a\": invalid syntax"
+    is "$output" "Error: strconv.ParseUint: parsing \"a\": invalid syntax"
 }
 
 @test "podman run closes stdin" {


### PR DESCRIPTION
Fix the parse for the cgroup devices rule to correctly handle the
wildcard syntax for the device major.

Also make sure the device major and minor are not negative numbers.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman parses correctly the wildcard for the device major number to `--device-cgroup-rule`
```
