### PR TITLE
overlay,mount: convert source to absolute path for `overlay` mounts of paths

### DIFF
--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -139,7 +139,13 @@ func GenVolumeMounts(volumeFlag []string) (map[string]spec.Mount, map[string]*Na
 				// This is a overlay volume
 				newOverlayVol := new(OverlayVolume)
 				newOverlayVol.Destination = dest
-				newOverlayVol.Source = src
+				// convert src to absolute path so we don't end up passing
+				// relative values as lowerdir for overlay mounts
+				source, err := filepath.Abs(src)
+				if err != nil {
+					return nil, nil, nil, errors.Wrapf(err, "failed while resolving absolute path for source %v for overlay mount", src)
+				}
+				newOverlayVol.Source = source
 				newOverlayVol.Options = options
 
 				if _, ok := overlayVolumes[newOverlayVol.Destination]; ok {

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -678,6 +678,15 @@ VOLUME /test/`, ALPINE)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
+		// Test overlay mount when lowerdir is relative path.
+		f, err = os.Create("hello")
+		Expect(err).To(BeNil(), "os.Create")
+		f.Close()
+		session = podmanTest.Podman([]string{"run", "--rm", "-v", ".:/app:O", ALPINE, "ls", "/app"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.OutputToString()).To(ContainSubstring("hello"))
+		Expect(session).Should(Exit(0))
+
 		// Make sure modifications in container do not show up on host
 		session = podmanTest.Podman([]string{"run", "--rm", "-v", volumeFlag, ALPINE, "touch", "/run/test/container"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
When mounting paths as overlay mounts we end up passing source as is to
`lowerdir` options, resolve all relative paths in such cases for overlay
mounts.

Closes: https://github.com/containers/podman/issues/14797

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allows users to use relative values with mounting paths directly as overlay. Example `-v .:/target:O`
```
