### PR TITLE
make 9p security model configurable; document

### DIFF
--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -76,15 +76,33 @@ Set the timezone for the machine and containers.  Valid values are `local` or
 a `timezone` such as `America/Chicago`.  A value of `local`, which is the default,
 means to use the timezone of the machine host.
 
-#### **--volume**, **-v**=*source:target*
+#### **--volume**, **-v**=*source:target[:options]*
 
 Mounts a volume from source to target.
 
 Create a mount. If /host-dir:/machine-dir is specified as the `*source:target*`,
 Podman mounts _host-dir_ in the host to _machine-dir_ in the Podman machine.
 
-The root filesystem is mounted read-only in the default operating system,
-so mounts must be created under the /mnt directory.
+Additional options may be specified as a comma-separated string. Recognized
+options are:
+* **ro**: mount volume read-only
+* **rw**: mount volume read/write (default)
+* **security_model=[model]**: specify 9p security model (see below)
+
+The 9p security model [determines] https://wiki.qemu.org/Documentation/9psetup#Starting_the_Guest_directly
+if and how the 9p filesystem translates some filesystem operations before
+actual storage on the host. The
+default value of *mapped-xattr* specifies that 9p store symlinks and some file
+attributes as extended attributes on the host. This is suitable when the host
+and the guest do not need to interoperate on the shared filesystem, but has
+caveats for actual shared access; notably, symlinks on the host are not usable
+on the guest and vice versa. If interoperability is required, then choose
+*none* instead, but keep in mind that the guest will not be able to do things
+that the user running the virtual machine cannot do, e.g. create files owned by
+another user. Using *none* is almost certainly the best choice for read-only
+volumes.
+
+Example: `-v "$HOME/git:$HOME/git:ro,security_model=none"`
 
 Default volume mounts are defined in *containers.conf*.  Unless changed, the default values
 is `$HOME:$HOME`.

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -318,6 +318,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 		source := paths[0]
 		target := source
 		readonly := false
+		securityModel := "mapped-xattr"
 		if len(paths) > 1 {
 			target = paths[1]
 		}
@@ -325,18 +326,20 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 			options := paths[2]
 			volopts := strings.Split(options, ",")
 			for _, o := range volopts {
-				switch o {
-				case "rw":
+				switch {
+				case o == "rw":
 					readonly = false
-				case "ro":
+				case o == "ro":
 					readonly = true
+				case strings.HasPrefix(o, "security_model="):
+					securityModel = strings.Split(o, "=")[1]
 				default:
 					fmt.Printf("Unknown option: %s\n", o)
 				}
 			}
 		}
 		if volumeType == VolumeTypeVirtfs {
-			virtfsOptions := fmt.Sprintf("local,path=%s,mount_tag=%s,security_model=mapped-xattr", source, tag)
+			virtfsOptions := fmt.Sprintf("local,path=%s,mount_tag=%s,security_model=%s", source, tag, securityModel)
 			if readonly {
 				virtfsOptions += ",readonly"
 			}


### PR DESCRIPTION
#### Does this PR introduce a user-facing change?
Yes, but defaults are unchanged.

```release-note
Support specification of the 9p security model for `podman machine` volumes ([#13784](https://github.com/containers/podman/issues/13784)).
```

Please see this bug for background information:
https://github.com/containers/podman/issues/13784

Thanks,
Corey