### PR TITLE
Podman system df JSON format outputs `Size` and `Reclaimable`

### DIFF
--- a/cmd/podman/system/df.go
+++ b/cmd/podman/system/df.go
@@ -78,11 +78,11 @@ func printSummary(cmd *cobra.Command, reports *entities.SystemDfReport) error {
 		}
 	}
 	imageSummary := dfSummary{
-		Type:        "Images",
-		Total:       len(reports.Images),
-		Active:      active,
-		size:        size,
-		reclaimable: reclaimable,
+		Type:           "Images",
+		Total:          len(reports.Images),
+		Active:         active,
+		RawSize:        size,
+		RawReclaimable: reclaimable,
 	}
 	dfSummaries = append(dfSummaries, &imageSummary)
 
@@ -100,11 +100,11 @@ func printSummary(cmd *cobra.Command, reports *entities.SystemDfReport) error {
 		conSize += c.RWSize
 	}
 	containerSummary := dfSummary{
-		Type:        "Containers",
-		Total:       len(reports.Containers),
-		Active:      conActive,
-		size:        conSize,
-		reclaimable: conReclaimable,
+		Type:           "Containers",
+		Total:          len(reports.Containers),
+		Active:         conActive,
+		RawSize:        conSize,
+		RawReclaimable: conReclaimable,
 	}
 	dfSummaries = append(dfSummaries, &containerSummary)
 
@@ -120,11 +120,11 @@ func printSummary(cmd *cobra.Command, reports *entities.SystemDfReport) error {
 		volumesReclaimable += v.ReclaimableSize
 	}
 	volumeSummary := dfSummary{
-		Type:        "Local Volumes",
-		Total:       len(reports.Volumes),
-		Active:      activeVolumes,
-		size:        volumesSize,
-		reclaimable: volumesReclaimable,
+		Type:           "Local Volumes",
+		Total:          len(reports.Volumes),
+		Active:         activeVolumes,
+		RawSize:        volumesSize,
+		RawReclaimable: volumesReclaimable,
 	}
 	dfSummaries = append(dfSummaries, &volumeSummary)
 
@@ -277,22 +277,22 @@ func (d *dfVolume) Size() string {
 }
 
 type dfSummary struct {
-	Type        string
-	Total       int
-	Active      int
-	size        int64
-	reclaimable int64
+	Type           string
+	Total          int
+	Active         int
+	RawSize        int64 `json:"Size"`
+	RawReclaimable int64 `json:"Reclaimable"`
 }
 
 func (d *dfSummary) Size() string {
-	return units.HumanSize(float64(d.size))
+	return units.HumanSize(float64(d.RawSize))
 }
 
 func (d *dfSummary) Reclaimable() string {
 	percent := 0
 	// make sure to check this to prevent div by zero problems
-	if d.size > 0 {
-		percent = int(math.Round(float64(d.reclaimable) / float64(d.size) * float64(100)))
+	if d.RawSize > 0 {
+		percent = int(math.Round(float64(d.RawReclaimable) / float64(d.RawSize) * float64(100)))
 	}
-	return fmt.Sprintf("%s (%d%%)", units.HumanSize(float64(d.reclaimable)), percent)
+	return fmt.Sprintf("%s (%d%%)", units.HumanSize(float64(d.RawReclaimable)), percent)
 }

--- a/test/e2e/system_df_test.go
+++ b/test/e2e/system_df_test.go
@@ -86,4 +86,17 @@ var _ = Describe("podman system df", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})
+
+	It("podman system df --format \"{{ json . }}\"", func() {
+		session := podmanTest.Podman([]string{"create", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"system", "df", "--format", "{{ json . }}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.LineInOutputContains("Size"))
+		Expect(session.LineInOutputContains("Reclaimable"))
+		Expect(session.IsJSONOutputValid())
+	})
 })


### PR DESCRIPTION
Previously, `podman system df --format "{{json .}}"` would not output
`Size` and `Reclaimable` like `podman system df` would.

```
{"Type":"Images","Total":5,"Active":0,"Size":39972240,"Reclaimable":39972240}
{"Type":"Containers","Total":0,"Active":0,"Size":0,"Reclaimable":0}
{"Type":"Local Volumes","Total":0,"Active":0,"Size":0,"Reclaimable":0}
```

Closes: #14769

Signed-off-by: Jake Correnti <jcorrenti13@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where `podman system df --format "{{ json . }}"` would not output the `Size` and `Reclaimable` fields (#14769)
```
