### PR TITLE
[CI:DOCS] Remove -s from systemctl enable --now sshd

### DIFF
--- a/docs/tutorials/remote_client.md
+++ b/docs/tutorials/remote_client.md
@@ -54,7 +54,7 @@ host:
 
 In order for the Podman client to communicate with the server you need to enable and start the SSH daemon on your Linux machine, if it is not currently enabled.
 ```
-sudo systemctl enable --now -s sshd
+sudo systemctl enable --now sshd
 ```
 
 #### Setting up SSH


### PR DESCRIPTION
This flag does not work (e.g. on Fedora 36) and not appear to be required (anymore?).

#### Does this PR introduce a user-facing change?

```release-note
None
```
