### PR TITLE
docs: Add missing --url to first podman --remote example

### DIFF
--- a/docs/tutorials/remote_client.md
+++ b/docs/tutorials/remote_client.md
@@ -38,10 +38,10 @@ sudo loginctl enable-linger $USER
 ```
 This is only required if you are not running Podman as root.
 
-You can verify that the socket is listening with a simple Podman command.
+You can verify that the socket is listening with a simple first Podman command on the server machine:
 
 ```
-podman --remote info
+podman --remote --url unix://run/user/$UID/podman/podman.sock info
 host:
   arch: amd64
   buildahVersion: 1.16.0-dev


### PR DESCRIPTION
It does not actually work without that argument, looks like the default URL changed or something:

`Error: unable to connect to Podman. failed to create sshClient: connection to bastion host (ssh://core@localhost:43325/run/user/1000/podman/podman.sock) failed: dial tcp [::1]:43325: connect: connection refused`

#### Does this PR introduce a user-facing change?

```release-note
None
```
