### PR TITLE
test: drop pod-create --device-read-bps test

### DIFF
--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -899,27 +899,6 @@ ENTRYPOINT ["sleep","99999"]
 
 	})
 
-	It("podman pod create --device-read-bps", func() {
-		SkipIfRootless("Cannot create devices in /dev in rootless mode")
-		SkipIfRootlessCgroupsV1("Setting device-read-bps not supported on cgroupv1 for rootless users")
-
-		podName := "testPod"
-		session := podmanTest.Podman([]string{"pod", "create", "--device-read-bps", "/dev/zero:1mb", "--name", podName})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-
-		if CGROUPSV2 {
-			session = podmanTest.Podman([]string{"run", "--rm", "--pod", podName, ALPINE, "sh", "-c", "cat /sys/fs/cgroup/$(sed -e 's|0::||' < /proc/self/cgroup)/io.max"})
-		} else {
-			session = podmanTest.Podman([]string{"run", "--rm", "--pod", podName, ALPINE, "cat", "/sys/fs/cgroup/blkio/blkio.throttle.read_bps_device"})
-		}
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-		if !CGROUPSV2 {
-			Expect(session.OutputToString()).To(ContainSubstring("1048576"))
-		}
-	})
-
 	It("podman pod create --volumes-from", func() {
 		volName := "testVol"
 		volCreate := podmanTest.Podman([]string{"volume", "create", volName})


### PR DESCRIPTION
the test is not doing what it believes to do.  The containers are not
supposed to be joining the infra container cgroup.

In addition, the result is validated only on cgroup v1 systems (that
are not used in the CI).

We may want to add it back, or a variant of it, once the
--device-read-bps option applies to the pod parent cgroup.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
