### PR TITLE
podman wait can take multiple conditions

### DIFF
--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -99,9 +99,8 @@ func WaitContainerDocker(w http.ResponseWriter, r *http.Request) {
 
 func WaitContainerLibpod(w http.ResponseWriter, r *http.Request) {
 	var (
-		err        error
-		interval   = time.Millisecond * 250
-		conditions = []define.ContainerStatus{define.ContainerStateStopped, define.ContainerStateExited}
+		err      error
+		interval = time.Millisecond * 250
 	)
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := waitQueryLibpod{}
@@ -118,17 +117,10 @@ func WaitContainerLibpod(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if _, found := r.URL.Query()["condition"]; found {
-		if len(query.Condition) > 0 {
-			conditions = query.Condition
-		}
-	}
-
 	name := GetName(r)
 
 	waitFn := createContainerWaitFn(r.Context(), name, interval)
-
-	exitCode, err := waitFn(conditions...)
+	exitCode, err := waitFn(query.Condition...)
 	if err != nil {
 		if errors.Is(err, define.ErrNoSuchCtr) {
 			ContainerNotFound(w, name, err)

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -101,6 +101,9 @@ func (ic *ContainerEngine) ContainerWait(ctx context.Context, namesOrIds []strin
 	responses := make([]entities.WaitReport, 0, len(ctrs))
 	for _, c := range ctrs {
 		response := entities.WaitReport{Id: c.ID()}
+		if options.Condition == nil {
+			options.Condition = []define.ContainerStatus{define.ContainerStateStopped, define.ContainerStateExited}
+		}
 		exitCode, err := c.WaitForConditionWithInterval(ctx, options.Interval, options.Condition...)
 		if err != nil {
 			response.Error = err

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -124,7 +124,7 @@ function _log_test_restarted() {
     # FIXME: #9597
     # run/start is flaking for remote so let's wait for the container condition
     # to stop wasting energy until the root cause gets fixed.
-    run_podman container wait --condition=exited logtest
+    run_podman container wait --condition=exited --condition=stopped logtest
     run_podman ${events_backend} start -a logtest
     logfile=$(mktemp -p ${PODMAN_TMPDIR} logfileXXXXXXXX)
     $PODMAN $_PODMAN_TEST_OPTS ${events_backend} logs -f logtest > $logfile


### PR DESCRIPTION
Podman wait should not be defaulting to just stopped.  By default
wait API waits for stopped and exited.  We should not override this on
the client side.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman wait an now take multiple --condition flags
```
