### PR TITLE
kill: record exit code

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -230,10 +230,9 @@ func (c *Container) Kill(signal uint) error {
 	}
 
 	c.state.StoppedByUser = true
-
 	c.newContainerEvent(events.Kill)
 
-	return c.save()
+	return c.recordExitCode()
 }
 
 // Attach attaches to a container.

--- a/test/system/130-kill.bats
+++ b/test/system/130-kill.bats
@@ -130,4 +130,14 @@ load helpers
     is "$output" $cname
 }
 
+@test "podman kill - concurrent stop" {
+    # 14761 - concurrent kill/stop must record the exit code
+    random_name=$(random_string 10)
+    run_podman run -d --replace --name=$random_name alpine sh -c "trap 'echo Received SIGTERM, ignoring' SIGTERM; echo READY; while :; do sleep 0.2; done"
+    $PODMAN stop -t 1 $random_name &
+    run_podman kill $random_name
+    run_podman wait $random_name
+    run_podman rm -f $random_name
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Make sure to record the exit code after killing a container.
Otherwise, a concurrent `stop` may not record the exit code
and yield the container unusable.

Fixes: #14761
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

No release note as it's fixing a bug that never made it into any version.

```release-note
None
```

@mheon @baude PTAL