### PR TITLE
fix flake in aardvark tests

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1042,18 +1042,15 @@ var IPRegex = `(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01
 // digShort execs into the given container and does a dig lookup with a timeout
 // backoff.  If it gets a response, it ensures that the output is in the correct
 // format and iterates a string array for match
-func digShort(container, lookupName string, matchNames []string, p *PodmanTestIntegration) {
+func digShort(container, lookupName, expectedIP string, p *PodmanTestIntegration) {
 	digInterval := time.Millisecond * 250
 	for i := 0; i < 6; i++ {
 		time.Sleep(digInterval * time.Duration(i))
 		dig := p.Podman([]string{"exec", container, "dig", "+short", lookupName})
 		dig.WaitWithDefaultTimeout()
-		if dig.ExitCode() == 0 {
-			output := dig.OutputToString()
-			Expect(output).To(MatchRegexp(IPRegex))
-			for _, name := range matchNames {
-				Expect(output).To(Equal(name))
-			}
+		output := dig.OutputToString()
+		if dig.ExitCode() == 0 && output != "" {
+			Expect(output).To(Equal(expectedIP))
 			// success
 			return
 		}

--- a/test/e2e/run_aardvark_test.go
+++ b/test/e2e/run_aardvark_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Podman run networking", func() {
 		cip := ctrIP.OutputToString()
 		Expect(cip).To(MatchRegexp(IPRegex))
 
-		digShort(cid, "aone", []string{cip}, podmanTest)
+		digShort(cid, "aone", cip, podmanTest)
 
 		reverseLookup := podmanTest.Podman([]string{"exec", cid, "dig", "+short", "-x", cip})
 		reverseLookup.WaitWithDefaultTimeout()
@@ -94,9 +94,9 @@ var _ = Describe("Podman run networking", func() {
 		cip2 := ctrIP2.OutputToString()
 		Expect(cip2).To(MatchRegexp(IPRegex))
 
-		digShort("aone", "atwo", []string{cip2}, podmanTest)
+		digShort("aone", "atwo", cip2, podmanTest)
 
-		digShort("atwo", "aone", []string{cip1}, podmanTest)
+		digShort("atwo", "aone", cip1, podmanTest)
 
 		reverseLookup12 := podmanTest.Podman([]string{"exec", cid1, "dig", "+short", "-x", cip2})
 		reverseLookup12.WaitWithDefaultTimeout()
@@ -143,17 +143,17 @@ var _ = Describe("Podman run networking", func() {
 		cip2 := ctrIP2.OutputToString()
 		Expect(cip2).To(MatchRegexp(IPRegex))
 
-		digShort("aone", "atwo", []string{cip2}, podmanTest)
+		digShort("aone", "atwo", cip2, podmanTest)
 
-		digShort("aone", "alias_a2", []string{cip2}, podmanTest)
+		digShort("aone", "alias_a2", cip2, podmanTest)
 
-		digShort("aone", "alias_2a", []string{cip2}, podmanTest)
+		digShort("aone", "alias_2a", cip2, podmanTest)
 
-		digShort("atwo", "aone", []string{cip1}, podmanTest)
+		digShort("atwo", "aone", cip1, podmanTest)
 
-		digShort("atwo", "alias_a1", []string{cip1}, podmanTest)
+		digShort("atwo", "alias_a1", cip1, podmanTest)
 
-		digShort("atwo", "alias_1a", []string{cip1}, podmanTest)
+		digShort("atwo", "alias_1a", cip1, podmanTest)
 
 	})
 
@@ -250,13 +250,13 @@ var _ = Describe("Podman run networking", func() {
 		cipA2B22 := ctrIPA2B22.OutputToString()
 		Expect(cipA2B22).To(MatchRegexp(IPRegex))
 
-		digShort("aone", "atwobtwo", []string{cipA2B21}, podmanTest)
+		digShort("aone", "atwobtwo", cipA2B21, podmanTest)
 
-		digShort("bone", "atwobtwo", []string{cipA2B22}, podmanTest)
+		digShort("bone", "atwobtwo", cipA2B22, podmanTest)
 
-		digShort("atwobtwo", "aone", []string{cipA1}, podmanTest)
+		digShort("atwobtwo", "aone", cipA1, podmanTest)
 
-		digShort("atwobtwo", "bone", []string{cipB1}, podmanTest)
+		digShort("atwobtwo", "bone", cipB1, podmanTest)
 	})
 
 	It("Aardvark Test 6: Three subnets, first container on 1/2 and second on 2/3, w/ network aliases", func() {
@@ -304,10 +304,9 @@ var _ = Describe("Podman run networking", func() {
 		Expect(ctrIPCB2).Should(Exit(0))
 		cipCB2 := ctrIPCB2.OutputToString()
 
-		digShort("aone", "testB2_nw", []string{cipCB2}, podmanTest)
+		digShort("aone", "testB2_nw", cipCB2, podmanTest)
 
-		digShort("cone", "testB1_nw", []string{cipAB1}, podmanTest)
-
+		digShort("cone", "testB1_nw", cipAB1, podmanTest)
 	})
 
 })


### PR DESCRIPTION
The retry logic in digshort() did not work because dig always exits with
0 even when the domain name is not found. To make it work we have to
check the standard output.

We work on fixing the underlying issue in aardvark/netavark but
this will take more time.

Fixes #14173
Fixes #14171

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
