### PR TITLE
envVarValueResourceFieldRef: use int64 for value

### DIFF
--- a/pkg/machine/config_test.go
+++ b/pkg/machine/config_test.go
@@ -1,3 +1,6 @@
+//go:build amd64 || arm64
+// +build amd64 arm64
+
 package machine
 
 import (

--- a/pkg/machine/qemu/config_test.go
+++ b/pkg/machine/qemu/config_test.go
@@ -1,3 +1,6 @@
+//go:build (amd64 && !windows) || (arm64 && !windows)
+// +build amd64,!windows arm64,!windows
+
 package qemu
 
 import (

--- a/pkg/machine/qemu/machine_test.go
+++ b/pkg/machine/qemu/machine_test.go
@@ -1,3 +1,6 @@
+//go:build (amd64 && !windows) || (arm64 && !windows)
+// +build amd64,!windows arm64,!windows
+
 package qemu
 
 import (

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -810,8 +810,8 @@ func envVarValueResourceFieldRef(env v1.EnvVar, opts *CtrSpecGenOptions) (*strin
 	}
 
 	// k8s rounds up the result to the nearest integer
-	intValue := int(math.Ceil(value.AsApproximateFloat64() / divisor.AsApproximateFloat64()))
-	stringValue := strconv.Itoa(intValue)
+	intValue := int64(math.Ceil(value.AsApproximateFloat64() / divisor.AsApproximateFloat64()))
+	stringValue := strconv.FormatInt(intValue, 10)
 
 	return &stringValue, nil
 }

--- a/pkg/specgen/generate/kube/play_test.go
+++ b/pkg/specgen/generate/kube/play_test.go
@@ -2,7 +2,6 @@ package kube
 
 import (
 	"encoding/json"
-	"fmt"
 	"math"
 	"runtime"
 	"strconv"
@@ -777,8 +776,7 @@ func TestEnvVarValue(t *testing.T) {
 			if test.expected == nilString {
 				assert.Nil(t, result)
 			} else {
-				fmt.Println(*result, test.expected)
-				assert.Equal(t, &(test.expected), result)
+				assert.Equal(t, test.expected, *result)
 			}
 		})
 	}


### PR DESCRIPTION
int can be 32 or 64 bit depending on the architecture.
The total memory is int64 so we have to use int64 for the value as
well otherwise we get an overflow on 32 bit systems.

Fixes https://github.com/containers/podman/issues/14819

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug with podman play kube on 32 bit systems where the total memory was calculated incorrectly.
```
