### PR TITLE
Silence setlocale warnings from `podman machine ssh`

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1013,7 +1013,7 @@ func (v *MachineVM) SSH(_ string, opts machine.SSHOptions) error {
 	port := strconv.Itoa(v.Port)
 
 	args := []string{"-i", v.IdentityPath, "-p", port, sshDestination, "-o", "UserKnownHostsFile=/dev/null",
-		"-o", "StrictHostKeyChecking=no", "-o", "LogLevel=ERROR"}
+		"-o", "StrictHostKeyChecking=no", "-o", "LogLevel=ERROR", "-o", "SetEnv=LC_ALL="}
 	if len(opts.Args) > 0 {
 		args = append(args, opts.Args...)
 	} else {


### PR DESCRIPTION
Connecting with `podman machine ssh` can results in the following warning:

```
/usr/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_CA.UTF-8)
/usr/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_CA.UTF-8)
/usr/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_CA.UTF-8)
/usr/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_CA.UTF-8)
```

Best would probably be to remove `LC_ALL` (and other locale and lang env vars) from `/etc/ssh/sshd_config.d/50-redhat.conf` in the CoreOS image, but I'm not terribly sure how, so this is a quick alternative.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Silence setlocale warning in machine ssh
```
