### PR TITLE
Refactored networkPrune function

### DIFF
--- a/cmd/podman/networks/prune.go
+++ b/cmd/podman/networks/prune.go
@@ -52,10 +52,7 @@ func init() {
 }
 
 func networkPrune(cmd *cobra.Command, _ []string) error {
-	var (
-		errs utils.OutputErrors
-		err  error
-	)
+	var err error
 	if !force {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Println("WARNING! This will remove all networks not used by at least one container.")
@@ -77,13 +74,5 @@ func networkPrune(cmd *cobra.Command, _ []string) error {
 		setExitCode(err)
 		return err
 	}
-	for _, r := range responses {
-		if r.Error == nil {
-			fmt.Println(r.Name)
-		} else {
-			setExitCode(r.Error)
-			errs = append(errs, r.Error)
-		}
-	}
-	return errs.PrintErrors()
+	return utils.PrintNetworkPruneResults(responses, false)
 }

--- a/cmd/podman/utils/utils.go
+++ b/cmd/podman/utils/utils.go
@@ -85,16 +85,16 @@ func PrintImagePruneResults(imagePruneReports []*reports.PruneReport, heading bo
 	return nil
 }
 
-func PrintNetworkPruneResults(networkPruneReport []*reports.PruneReport, heading bool) error {
+func PrintNetworkPruneResults(networkPruneReport []*entities.NetworkPruneReport, heading bool) error {
 	var errs OutputErrors
 	if heading && len(networkPruneReport) > 0 {
 		fmt.Println("Deleted Networks")
 	}
 	for _, r := range networkPruneReport {
-		if r.Err == nil {
-			fmt.Println(r.Id)
+		if r.Error == nil {
+			fmt.Println(r.Name)
 		} else {
-			errs = append(errs, r.Err)
+			errs = append(errs, r.Error)
 		}
 	}
 	return errs.PrintErrors()

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -81,8 +81,7 @@ type NetworkPruneReport struct {
 	Error error
 }
 
-// NetworkPruneOptions describes options for pruning
-// unused cni networks
+// NetworkPruneOptions describes options for pruning unused networks
 type NetworkPruneOptions struct {
 	Filters map[string][]string
 }

--- a/pkg/domain/entities/system.go
+++ b/pkg/domain/entities/system.go
@@ -28,7 +28,7 @@ type SystemPruneReport struct {
 	PodPruneReport        []*PodPruneReport
 	ContainerPruneReports []*reports.PruneReport
 	ImagePruneReports     []*reports.PruneReport
-	NetworkPruneReports   []*reports.PruneReport
+	NetworkPruneReports   []*NetworkPruneReport
 	VolumePruneReports    []*reports.PruneReport
 	ReclaimedSpace        uint64
 }

--- a/pkg/domain/infra/tunnel/network.go
+++ b/pkg/domain/infra/tunnel/network.go
@@ -95,7 +95,7 @@ func (ic *ContainerEngine) NetworkExists(ctx context.Context, networkname string
 	}, nil
 }
 
-// Network prune removes unused cni networks
+// Network prune removes unused networks
 func (ic *ContainerEngine) NetworkPrune(ctx context.Context, options entities.NetworkPruneOptions) ([]*entities.NetworkPruneReport, error) {
 	opts := new(network.PruneOptions).WithFilters(options.Filters)
 	return network.Prune(ic.ClientCtx, opts)

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -259,11 +259,12 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system prune networks", func() {
-		// About netavark network backend test.
+		// Create new network.
 		session := podmanTest.Podman([]string{"network", "create", "test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
+		// Remove all unused networks.
 		session = podmanTest.Podman([]string{"system", "prune", "-f"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -274,7 +275,7 @@ var _ = Describe("Podman prune", func() {
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToStringArray()).To(HaveLen(1))
 
-		// Remove all unused networks.
+		// Unused networks removed.
 		session = podmanTest.Podman([]string{"network", "ls", "-q", "--filter", "name=^test$"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))


### PR DESCRIPTION
Refactored the networkPrune function to improve readability.

This commit unifies the structure containing the pruned network name
from `entities.NetworkPruneReport` to `reports.PruneReport`.

[NO NEW TESTS NEEDED]

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
