### PR TITLE
specgen,run: support running container from valid manifest list using `--platform`

### DIFF
--- a/cmd/podman/containers/clone.go
+++ b/cmd/podman/containers/clone.go
@@ -63,7 +63,7 @@ func clone(cmd *cobra.Command, args []string) error {
 		ctrClone.Image = args[2]
 		if !cliVals.RootFS {
 			rawImageName := args[0]
-			name, err := PullImage(ctrClone.Image, ctrClone.CreateOpts)
+			name, err := PullImage(ctrClone.Image, &ctrClone.CreateOpts)
 			if err != nil {
 				return err
 			}

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -141,7 +141,7 @@ func create(cmd *cobra.Command, args []string) error {
 	rawImageName := ""
 	if !cliVals.RootFS {
 		rawImageName = args[0]
-		name, err := PullImage(args[0], cliVals)
+		name, err := PullImage(args[0], &cliVals)
 		if err != nil {
 			return err
 		}
@@ -305,7 +305,8 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 	return vals, nil
 }
 
-func PullImage(imageName string, cliVals entities.ContainerCreateOptions) (string, error) {
+// Pulls image if any also parses and populates OS, Arch and Variant in specified container create options
+func PullImage(imageName string, cliVals *entities.ContainerCreateOptions) (string, error) {
 	pullPolicy, err := config.ParsePullPolicy(cliVals.Pull)
 	if err != nil {
 		return "", err

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -141,7 +141,7 @@ func run(cmd *cobra.Command, args []string) error {
 	rawImageName := ""
 	if !cliVals.RootFS {
 		rawImageName = args[0]
-		name, err := PullImage(args[0], cliVals)
+		name, err := PullImage(args[0], &cliVals)
 		if err != nil {
 			return err
 		}
@@ -192,6 +192,9 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	s.RawImageName = rawImageName
+	s.ImageOS = cliVals.OS
+	s.ImageArch = cliVals.Arch
+	s.ImageVariant = cliVals.Variant
 	s.Passwd = &runOpts.Passwd
 	runOpts.Spec = s
 

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -103,6 +103,12 @@ type ContainerBasicConfig struct {
 	// RawImageName is the user-specified and unprocessed input referring
 	// to a local or a remote image.
 	RawImageName string `json:"raw_image_name,omitempty"`
+	// ImageOS is the user-specified image OS
+	ImageOS string `json:"image_os,omitempty"`
+	// ImageArch is the user-specified image architecture
+	ImageArch string `json:"image_arch,omitempty"`
+	// ImageVariant is the user-specified image variant
+	ImageVariant string `json:"image_variant,omitempty"`
 	// RestartPolicy is the container's restart policy - an action which
 	// will be taken when the container exits.
 	// If not given, the default policy, which does nothing, will be used.

--- a/test/e2e/build/Containerfile.with-platform
+++ b/test/e2e/build/Containerfile.with-platform
@@ -1,0 +1,1 @@
+FROM --platform=$TARGETPLATFORM alpine


### PR DESCRIPTION
Following PR adds support for running containers from a manifest list
present on localstorage. Before this PR podman only supports running
containers from valid images but not from manifest list.

So `podman run -it --platform <some> <manifest-list> command` should
become functional now and users should be able to resolve images on the
bases of provided `--platform` string.

Example
```
podman manifest create test
podman build --platform linux/amd64,linux/arm64 --manifest test .
podman run --rm --platform linux/arm64/v8 test uname -a
```

Closes: https://github.com/containers/podman/issues/14773


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add supports for running containers from manifest list with --platform
```
