### PR TITLE
libpod: switch to golang native error wrapping

### DIFF
--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/storage"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
 )
@@ -195,7 +195,7 @@ func checkRuntimeConfig(db *bolt.DB, rt *Runtime) error {
 			}
 
 			if err := configBkt.Put(missing.key, dbValue); err != nil {
-				return errors.Wrapf(err, "error updating %s in DB runtime config", missing.name)
+				return fmt.Errorf("error updating %s in DB runtime config: %w", missing.name, err)
 			}
 		}
 
@@ -236,8 +236,8 @@ func readOnlyValidateConfig(bucket *bolt.Bucket, toCheck dbConfigValidation) (bo
 			return true, nil
 		}
 
-		return true, errors.Wrapf(define.ErrDBBadConfig, "database %s %q does not match our %s %q",
-			toCheck.name, dbValue, toCheck.name, toCheck.runtimeValue)
+		return true, fmt.Errorf("database %s %q does not match our %s %q: %w",
+			toCheck.name, dbValue, toCheck.name, toCheck.runtimeValue, define.ErrDBBadConfig)
 	}
 
 	return true, nil
@@ -254,7 +254,7 @@ func (s *BoltState) getDBCon() (*bolt.DB, error) {
 
 	db, err := bolt.Open(s.dbPath, 0600, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error opening database %s", s.dbPath)
+		return nil, fmt.Errorf("error opening database %s: %w", s.dbPath, err)
 	}
 
 	return db, nil
@@ -283,7 +283,7 @@ func (s *BoltState) closeDBCon(db *bolt.DB) error {
 func getIDBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(idRegistryBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "id registry bucket not found in DB")
+		return nil, fmt.Errorf("id registry bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -291,7 +291,7 @@ func getIDBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getNamesBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(nameRegistryBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "name registry bucket not found in DB")
+		return nil, fmt.Errorf("name registry bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -299,7 +299,7 @@ func getNamesBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getNSBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(nsRegistryBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "namespace registry bucket not found in DB")
+		return nil, fmt.Errorf("namespace registry bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -307,7 +307,7 @@ func getNSBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getCtrBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(ctrBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "containers bucket not found in DB")
+		return nil, fmt.Errorf("containers bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -315,7 +315,7 @@ func getCtrBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getAllCtrsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(allCtrsBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "all containers bucket not found in DB")
+		return nil, fmt.Errorf("all containers bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -323,7 +323,7 @@ func getAllCtrsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getPodBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(podBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "pods bucket not found in DB")
+		return nil, fmt.Errorf("pods bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -331,7 +331,7 @@ func getPodBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getAllPodsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(allPodsBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "all pods bucket not found in DB")
+		return nil, fmt.Errorf("all pods bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -339,7 +339,7 @@ func getAllPodsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getVolBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(volBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "volumes bucket not found in DB")
+		return nil, fmt.Errorf("volumes bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -347,7 +347,7 @@ func getVolBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getAllVolsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(allVolsBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "all volumes bucket not found in DB")
+		return nil, fmt.Errorf("all volumes bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -355,7 +355,7 @@ func getAllVolsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getExecBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(execBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "exec bucket not found in DB")
+		return nil, fmt.Errorf("exec bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -363,7 +363,7 @@ func getExecBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getRuntimeConfigBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(runtimeConfigBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "runtime configuration bucket not found in DB")
+		return nil, fmt.Errorf("runtime configuration bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -371,7 +371,7 @@ func getRuntimeConfigBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getExitCodeBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(exitCodeBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "exit-code container bucket not found in DB")
+		return nil, fmt.Errorf("exit-code container bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -379,7 +379,7 @@ func getExitCodeBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getExitCodeTimeStampBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(exitCodeTimeStampBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(define.ErrDBBadConfig, "exit-code time stamp bucket not found in DB")
+		return nil, fmt.Errorf("exit-code time stamp bucket not found in DB: %w", define.ErrDBBadConfig)
 	}
 	return bkt, nil
 }
@@ -387,23 +387,23 @@ func getExitCodeTimeStampBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func (s *BoltState) getContainerConfigFromDB(id []byte, config *ContainerConfig, ctrsBkt *bolt.Bucket) error {
 	ctrBkt := ctrsBkt.Bucket(id)
 	if ctrBkt == nil {
-		return errors.Wrapf(define.ErrNoSuchCtr, "container %s not found in DB", string(id))
+		return fmt.Errorf("container %s not found in DB: %w", string(id), define.ErrNoSuchCtr)
 	}
 
 	if s.namespaceBytes != nil {
 		ctrNamespaceBytes := ctrBkt.Get(namespaceKey)
 		if !bytes.Equal(s.namespaceBytes, ctrNamespaceBytes) {
-			return errors.Wrapf(define.ErrNSMismatch, "cannot retrieve container %s as it is part of namespace %q and we are in namespace %q", string(id), string(ctrNamespaceBytes), s.namespace)
+			return fmt.Errorf("cannot retrieve container %s as it is part of namespace %q and we are in namespace %q: %w", string(id), string(ctrNamespaceBytes), s.namespace, define.ErrNSMismatch)
 		}
 	}
 
 	configBytes := ctrBkt.Get(configKey)
 	if configBytes == nil {
-		return errors.Wrapf(define.ErrInternal, "container %s missing config key in DB", string(id))
+		return fmt.Errorf("container %s missing config key in DB: %w", string(id), define.ErrInternal)
 	}
 
 	if err := json.Unmarshal(configBytes, config); err != nil {
-		return errors.Wrapf(err, "error unmarshalling container %s config", string(id))
+		return fmt.Errorf("error unmarshalling container %s config: %w", string(id), err)
 	}
 
 	// convert ports to the new format if needed
@@ -426,7 +426,7 @@ func (s *BoltState) getContainerFromDB(id []byte, ctr *Container, ctrsBkt *bolt.
 	// Get the lock
 	lock, err := s.runtime.lockManager.RetrieveLock(ctr.config.LockID)
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving lock for container %s", string(id))
+		return fmt.Errorf("error retrieving lock for container %s: %w", string(id), err)
 	}
 	ctr.lock = lock
 
@@ -473,29 +473,29 @@ func (s *BoltState) getContainerFromDB(id []byte, ctr *Container, ctrsBkt *bolt.
 func (s *BoltState) getPodFromDB(id []byte, pod *Pod, podBkt *bolt.Bucket) error {
 	podDB := podBkt.Bucket(id)
 	if podDB == nil {
-		return errors.Wrapf(define.ErrNoSuchPod, "pod with ID %s not found", string(id))
+		return fmt.Errorf("pod with ID %s not found: %w", string(id), define.ErrNoSuchPod)
 	}
 
 	if s.namespaceBytes != nil {
 		podNamespaceBytes := podDB.Get(namespaceKey)
 		if !bytes.Equal(s.namespaceBytes, podNamespaceBytes) {
-			return errors.Wrapf(define.ErrNSMismatch, "cannot retrieve pod %s as it is part of namespace %q and we are in namespace %q", string(id), string(podNamespaceBytes), s.namespace)
+			return fmt.Errorf("cannot retrieve pod %s as it is part of namespace %q and we are in namespace %q: %w", string(id), string(podNamespaceBytes), s.namespace, define.ErrNSMismatch)
 		}
 	}
 
 	podConfigBytes := podDB.Get(configKey)
 	if podConfigBytes == nil {
-		return errors.Wrapf(define.ErrInternal, "pod %s is missing configuration key in DB", string(id))
+		return fmt.Errorf("pod %s is missing configuration key in DB: %w", string(id), define.ErrInternal)
 	}
 
 	if err := json.Unmarshal(podConfigBytes, pod.config); err != nil {
-		return errors.Wrapf(err, "error unmarshalling pod %s config from DB", string(id))
+		return fmt.Errorf("error unmarshalling pod %s config from DB: %w", string(id), err)
 	}
 
 	// Get the lock
 	lock, err := s.runtime.lockManager.RetrieveLock(pod.config.LockID)
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving lock for pod %s", string(id))
+		return fmt.Errorf("error retrieving lock for pod %s: %w", string(id), err)
 	}
 	pod.lock = lock
 
@@ -508,23 +508,23 @@ func (s *BoltState) getPodFromDB(id []byte, pod *Pod, podBkt *bolt.Bucket) error
 func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bucket) error {
 	volDB := volBkt.Bucket(name)
 	if volDB == nil {
-		return errors.Wrapf(define.ErrNoSuchVolume, "volume with name %s not found", string(name))
+		return fmt.Errorf("volume with name %s not found: %w", string(name), define.ErrNoSuchVolume)
 	}
 
 	volConfigBytes := volDB.Get(configKey)
 	if volConfigBytes == nil {
-		return errors.Wrapf(define.ErrInternal, "volume %s is missing configuration key in DB", string(name))
+		return fmt.Errorf("volume %s is missing configuration key in DB: %w", string(name), define.ErrInternal)
 	}
 
 	if err := json.Unmarshal(volConfigBytes, volume.config); err != nil {
-		return errors.Wrapf(err, "error unmarshalling volume %s config from DB", string(name))
+		return fmt.Errorf("error unmarshalling volume %s config from DB: %w", string(name), err)
 	}
 
 	// Volume state is allowed to be nil for legacy compatibility
 	volStateBytes := volDB.Get(stateKey)
 	if volStateBytes != nil {
 		if err := json.Unmarshal(volStateBytes, volume.state); err != nil {
-			return errors.Wrapf(err, "error unmarshalling volume %s state from DB", string(name))
+			return fmt.Errorf("error unmarshalling volume %s state from DB: %w", string(name), err)
 		}
 	}
 
@@ -546,7 +546,7 @@ func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bu
 	// Get the lock
 	lock, err := s.runtime.lockManager.RetrieveLock(volume.config.LockID)
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving lock for volume %q", string(name))
+		return fmt.Errorf("error retrieving lock for volume %q: %w", string(name), err)
 	}
 	volume.lock = lock
 
@@ -560,8 +560,8 @@ func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bu
 // If pod is not nil, the container is added to the pod as well
 func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 	if s.namespace != "" && s.namespace != ctr.config.Namespace {
-		return errors.Wrapf(define.ErrNSMismatch, "cannot add container %s as it is in namespace %q and we are in namespace %q",
-			ctr.ID(), s.namespace, ctr.config.Namespace)
+		return fmt.Errorf("cannot add container %s as it is in namespace %q and we are in namespace %q: %w",
+			ctr.ID(), s.namespace, ctr.config.Namespace, define.ErrNSMismatch)
 	}
 
 	// Set the original networks to nil. We can save some space by not storing it in the config
@@ -572,11 +572,11 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 	// JSON container structs to insert into DB
 	configJSON, err := json.Marshal(ctr.config)
 	if err != nil {
-		return errors.Wrapf(err, "error marshalling container %s config to JSON", ctr.ID())
+		return fmt.Errorf("error marshalling container %s config to JSON: %w", ctr.ID(), err)
 	}
 	stateJSON, err := json.Marshal(ctr.state)
 	if err != nil {
-		return errors.Wrapf(err, "error marshalling container %s state to JSON", ctr.ID())
+		return fmt.Errorf("error marshalling container %s state to JSON: %w", ctr.ID(), err)
 	}
 	netNSPath := getNetNSPath(ctr)
 	dependsCtrs := ctr.Dependencies()
@@ -594,16 +594,16 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 	for net, opts := range configNetworks {
 		// Check that we don't have any empty network names
 		if net == "" {
-			return errors.Wrapf(define.ErrInvalidArg, "network names cannot be an empty string")
+			return fmt.Errorf("network names cannot be an empty string: %w", define.ErrInvalidArg)
 		}
 		if opts.InterfaceName == "" {
-			return errors.Wrapf(define.ErrInvalidArg, "network interface name cannot be an empty string")
+			return fmt.Errorf("network interface name cannot be an empty string: %w", define.ErrInvalidArg)
 		}
 		// always add the short id as alias for docker compat
 		opts.Aliases = append(opts.Aliases, ctr.config.ID[:12])
 		optBytes, err := json.Marshal(opts)
 		if err != nil {
-			return errors.Wrapf(err, "error marshalling network options JSON for container %s", ctr.ID())
+			return fmt.Errorf("error marshalling network options JSON for container %s: %w", ctr.ID(), err)
 		}
 		networks[net] = optBytes
 	}
@@ -659,17 +659,17 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 			podDB = podBucket.Bucket(podID)
 			if podDB == nil {
 				pod.valid = false
-				return errors.Wrapf(define.ErrNoSuchPod, "pod %s does not exist in database", pod.ID())
+				return fmt.Errorf("pod %s does not exist in database: %w", pod.ID(), define.ErrNoSuchPod)
 			}
 			podCtrs = podDB.Bucket(containersBkt)
 			if podCtrs == nil {
-				return errors.Wrapf(define.ErrInternal, "pod %s does not have a containers bucket", pod.ID())
+				return fmt.Errorf("pod %s does not have a containers bucket: %w", pod.ID(), define.ErrInternal)
 			}
 
 			podNS := podDB.Get(namespaceKey)
 			if !bytes.Equal(podNS, ctrNamespace) {
-				return errors.Wrapf(define.ErrNSMismatch, "container %s is in namespace %s and pod %s is in namespace %s",
-					ctr.ID(), ctr.config.Namespace, pod.ID(), pod.config.Namespace)
+				return fmt.Errorf("container %s is in namespace %s and pod %s is in namespace %s: %w",
+					ctr.ID(), ctr.config.Namespace, pod.ID(), pod.config.Namespace, define.ErrNSMismatch)
 			}
 		}
 
@@ -680,7 +680,7 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 			if allCtrsBucket.Get(idExist) == nil {
 				err = define.ErrPodExists
 			}
-			return errors.Wrapf(err, "ID \"%s\" is in use", ctr.ID())
+			return fmt.Errorf("ID \"%s\" is in use: %w", ctr.ID(), err)
 		}
 		nameExist := namesBucket.Get(ctrName)
 		if nameExist != nil {
@@ -688,66 +688,66 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 			if allCtrsBucket.Get(nameExist) == nil {
 				err = define.ErrPodExists
 			}
-			return errors.Wrapf(err, "name \"%s\" is in use", ctr.Name())
+			return fmt.Errorf("name \"%s\" is in use: %w", ctr.Name(), err)
 		}
 
 		// No overlapping containers
 		// Add the new container to the DB
 		if err := idsBucket.Put(ctrID, ctrName); err != nil {
-			return errors.Wrapf(err, "error adding container %s ID to DB", ctr.ID())
+			return fmt.Errorf("error adding container %s ID to DB: %w", ctr.ID(), err)
 		}
 		if err := namesBucket.Put(ctrName, ctrID); err != nil {
-			return errors.Wrapf(err, "error adding container %s name (%s) to DB", ctr.ID(), ctr.Name())
+			return fmt.Errorf("error adding container %s name (%s) to DB: %w", ctr.ID(), ctr.Name(), err)
 		}
 		if ctrNamespace != nil {
 			if err := nsBucket.Put(ctrID, ctrNamespace); err != nil {
-				return errors.Wrapf(err, "error adding container %s namespace (%q) to DB", ctr.ID(), ctr.Namespace())
+				return fmt.Errorf("error adding container %s namespace (%q) to DB: %w", ctr.ID(), ctr.Namespace(), err)
 			}
 		}
 		if err := allCtrsBucket.Put(ctrID, ctrName); err != nil {
-			return errors.Wrapf(err, "error adding container %s to all containers bucket in DB", ctr.ID())
+			return fmt.Errorf("error adding container %s to all containers bucket in DB: %w", ctr.ID(), err)
 		}
 
 		newCtrBkt, err := ctrBucket.CreateBucket(ctrID)
 		if err != nil {
-			return errors.Wrapf(err, "error adding container %s bucket to DB", ctr.ID())
+			return fmt.Errorf("error adding container %s bucket to DB: %w", ctr.ID(), err)
 		}
 
 		if err := newCtrBkt.Put(configKey, configJSON); err != nil {
-			return errors.Wrapf(err, "error adding container %s config to DB", ctr.ID())
+			return fmt.Errorf("error adding container %s config to DB: %w", ctr.ID(), err)
 		}
 		if err := newCtrBkt.Put(stateKey, stateJSON); err != nil {
-			return errors.Wrapf(err, "error adding container %s state to DB", ctr.ID())
+			return fmt.Errorf("error adding container %s state to DB: %w", ctr.ID(), err)
 		}
 		if ctrNamespace != nil {
 			if err := newCtrBkt.Put(namespaceKey, ctrNamespace); err != nil {
-				return errors.Wrapf(err, "error adding container %s namespace to DB", ctr.ID())
+				return fmt.Errorf("error adding container %s namespace to DB: %w", ctr.ID(), err)
 			}
 		}
 		if pod != nil {
 			if err := newCtrBkt.Put(podIDKey, []byte(pod.ID())); err != nil {
-				return errors.Wrapf(err, "error adding container %s pod to DB", ctr.ID())
+				return fmt.Errorf("error adding container %s pod to DB: %w", ctr.ID(), err)
 			}
 		}
 		if netNSPath != "" {
 			if err := newCtrBkt.Put(netNSKey, []byte(netNSPath)); err != nil {
-				return errors.Wrapf(err, "error adding container %s netns path to DB", ctr.ID())
+				return fmt.Errorf("error adding container %s netns path to DB: %w", ctr.ID(), err)
 			}
 		}
 		if len(networks) > 0 {
 			ctrNetworksBkt, err := newCtrBkt.CreateBucket(networksBkt)
 			if err != nil {
-				return errors.Wrapf(err, "error creating networks bucket for container %s", ctr.ID())
+				return fmt.Errorf("error creating networks bucket for container %s: %w", ctr.ID(), err)
 			}
 			for network, opts := range networks {
 				if err := ctrNetworksBkt.Put([]byte(network), opts); err != nil {
-					return errors.Wrapf(err, "error adding network %q to networks bucket for container %s", network, ctr.ID())
+					return fmt.Errorf("error adding network %q to networks bucket for container %s: %w", network, ctr.ID(), err)
 				}
 			}
 		}
 
 		if _, err := newCtrBkt.CreateBucket(dependenciesBkt); err != nil {
-			return errors.Wrapf(err, "error creating dependencies bucket for container %s", ctr.ID())
+			return fmt.Errorf("error creating dependencies bucket for container %s: %w", ctr.ID(), err)
 		}
 
 		// Add dependencies for the container
@@ -756,42 +756,42 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 
 			depCtrBkt := ctrBucket.Bucket(depCtrID)
 			if depCtrBkt == nil {
-				return errors.Wrapf(define.ErrNoSuchCtr, "container %s depends on container %s, but it does not exist in the DB", ctr.ID(), dependsCtr)
+				return fmt.Errorf("container %s depends on container %s, but it does not exist in the DB: %w", ctr.ID(), dependsCtr, define.ErrNoSuchCtr)
 			}
 
 			depCtrPod := depCtrBkt.Get(podIDKey)
 			if pod != nil {
 				// If we're part of a pod, make sure the dependency is part of the same pod
 				if depCtrPod == nil {
-					return errors.Wrapf(define.ErrInvalidArg, "container %s depends on container %s which is not in pod %s", ctr.ID(), dependsCtr, pod.ID())
+					return fmt.Errorf("container %s depends on container %s which is not in pod %s: %w", ctr.ID(), dependsCtr, pod.ID(), define.ErrInvalidArg)
 				}
 
 				if string(depCtrPod) != pod.ID() {
-					return errors.Wrapf(define.ErrInvalidArg, "container %s depends on container %s which is in a different pod (%s)", ctr.ID(), dependsCtr, string(depCtrPod))
+					return fmt.Errorf("container %s depends on container %s which is in a different pod (%s): %w", ctr.ID(), dependsCtr, string(depCtrPod), define.ErrInvalidArg)
 				}
 			} else if depCtrPod != nil {
 				// If we're not part of a pod, we cannot depend on containers in a pod
-				return errors.Wrapf(define.ErrInvalidArg, "container %s depends on container %s which is in a pod - containers not in pods cannot depend on containers in pods", ctr.ID(), dependsCtr)
+				return fmt.Errorf("container %s depends on container %s which is in a pod - containers not in pods cannot depend on containers in pods: %w", ctr.ID(), dependsCtr, define.ErrInvalidArg)
 			}
 
 			depNamespace := depCtrBkt.Get(namespaceKey)
 			if !bytes.Equal(ctrNamespace, depNamespace) {
-				return errors.Wrapf(define.ErrNSMismatch, "container %s in namespace %q depends on container %s in namespace %q - namespaces must match", ctr.ID(), ctr.config.Namespace, dependsCtr, string(depNamespace))
+				return fmt.Errorf("container %s in namespace %q depends on container %s in namespace %q - namespaces must match: %w", ctr.ID(), ctr.config.Namespace, dependsCtr, string(depNamespace), define.ErrNSMismatch)
 			}
 
 			depCtrDependsBkt := depCtrBkt.Bucket(dependenciesBkt)
 			if depCtrDependsBkt == nil {
-				return errors.Wrapf(define.ErrInternal, "container %s does not have a dependencies bucket", dependsCtr)
+				return fmt.Errorf("container %s does not have a dependencies bucket: %w", dependsCtr, define.ErrInternal)
 			}
 			if err := depCtrDependsBkt.Put(ctrID, ctrName); err != nil {
-				return errors.Wrapf(err, "error adding ctr %s as dependency of container %s", ctr.ID(), dependsCtr)
+				return fmt.Errorf("error adding ctr %s as dependency of container %s: %w", ctr.ID(), dependsCtr, err)
 			}
 		}
 
 		// Add ctr to pod
 		if pod != nil && podCtrs != nil {
 			if err := podCtrs.Put(ctrID, ctrName); err != nil {
-				return errors.Wrapf(err, "error adding container %s to pod %s", ctr.ID(), pod.ID())
+				return fmt.Errorf("error adding container %s to pod %s: %w", ctr.ID(), pod.ID(), err)
 			}
 		}
 
@@ -799,16 +799,16 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 		for _, vol := range ctr.config.NamedVolumes {
 			volDB := volBkt.Bucket([]byte(vol.Name))
 			if volDB == nil {
-				return errors.Wrapf(define.ErrNoSuchVolume, "no volume with name %s found in database when adding container %s", vol.Name, ctr.ID())
+				return fmt.Errorf("no volume with name %s found in database when adding container %s: %w", vol.Name, ctr.ID(), define.ErrNoSuchVolume)
 			}
 
 			ctrDepsBkt, err := volDB.CreateBucketIfNotExists(volDependenciesBkt)
 			if err != nil {
-				return errors.Wrapf(err, "error creating volume %s dependencies bucket to add container %s", vol.Name, ctr.ID())
+				return fmt.Errorf("error creating volume %s dependencies bucket to add container %s: %w", vol.Name, ctr.ID(), err)
 			}
 			if depExists := ctrDepsBkt.Get(ctrID); depExists == nil {
 				if err := ctrDepsBkt.Put(ctrID, ctrID); err != nil {
-					return errors.Wrapf(err, "error adding container %s to volume %s dependencies", ctr.ID(), vol.Name)
+					return fmt.Errorf("error adding container %s to volume %s dependencies: %w", ctr.ID(), vol.Name, err)
 				}
 			}
 		}
@@ -868,7 +868,7 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 		podDB = podBucket.Bucket(podID)
 		if podDB == nil {
 			pod.valid = false
-			return errors.Wrapf(define.ErrNoSuchPod, "no pod with ID %s found in DB", pod.ID())
+			return fmt.Errorf("no pod with ID %s found in DB: %w", pod.ID(), define.ErrNoSuchPod)
 		}
 	}
 
@@ -876,17 +876,17 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 	ctrExists := ctrBucket.Bucket(ctrID)
 	if ctrExists == nil {
 		ctr.valid = false
-		return errors.Wrapf(define.ErrNoSuchCtr, "no container with ID %s found in DB", ctr.ID())
+		return fmt.Errorf("no container with ID %s found in DB: %w", ctr.ID(), define.ErrNoSuchCtr)
 	}
 
 	// Compare namespace
 	// We can't remove containers not in our namespace
 	if s.namespace != "" {
 		if s.namespace != ctr.config.Namespace {
-			return errors.Wrapf(define.ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
+			return fmt.Errorf("container %s is in namespace %q, does not match our namespace %q: %w", ctr.ID(), ctr.config.Namespace, s.namespace, define.ErrNSMismatch)
 		}
 		if pod != nil && s.namespace != pod.config.Namespace {
-			return errors.Wrapf(define.ErrNSMismatch, "pod %s is in namespace %q, does not match out namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
+			return fmt.Errorf("pod %s is in namespace %q, does not match out namespace %q: %w", pod.ID(), pod.config.Namespace, s.namespace, define.ErrNSMismatch)
 		}
 	}
 
@@ -899,10 +899,10 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 		} else {
 			ctrInPod := podCtrs.Get(ctrID)
 			if ctrInPod == nil {
-				return errors.Wrapf(define.ErrNoSuchCtr, "container %s is not in pod %s", ctr.ID(), pod.ID())
+				return fmt.Errorf("container %s is not in pod %s: %w", ctr.ID(), pod.ID(), define.ErrNoSuchCtr)
 			}
 			if err := podCtrs.Delete(ctrID); err != nil {
-				return errors.Wrapf(err, "error removing container %s from pod %s", ctr.ID(), pod.ID())
+				return fmt.Errorf("error removing container %s from pod %s: %w", ctr.ID(), pod.ID(), err)
 			}
 		}
 	}
@@ -920,14 +920,14 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 			return err
 		}
 		if len(sessions) > 0 {
-			return errors.Wrapf(define.ErrExecSessionExists, "container %s has active exec sessions: %s", ctr.ID(), strings.Join(sessions, ", "))
+			return fmt.Errorf("container %s has active exec sessions: %s: %w", ctr.ID(), strings.Join(sessions, ", "), define.ErrExecSessionExists)
 		}
 	}
 
 	// Does the container have dependencies?
 	ctrDepsBkt := ctrExists.Bucket(dependenciesBkt)
 	if ctrDepsBkt == nil {
-		return errors.Wrapf(define.ErrInternal, "container %s does not have a dependencies bucket", ctr.ID())
+		return fmt.Errorf("container %s does not have a dependencies bucket: %w", ctr.ID(), define.ErrInternal)
 	}
 	deps := []string{}
 	err = ctrDepsBkt.ForEach(func(id, value []byte) error {
@@ -939,25 +939,25 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 		return err
 	}
 	if len(deps) != 0 {
-		return errors.Wrapf(define.ErrDepExists, "container %s is a dependency of the following containers: %s", ctr.ID(), strings.Join(deps, ", "))
+		return fmt.Errorf("container %s is a dependency of the following containers: %s: %w", ctr.ID(), strings.Join(deps, ", "), define.ErrDepExists)
 	}
 
 	if err := ctrBucket.DeleteBucket(ctrID); err != nil {
-		return errors.Wrapf(define.ErrInternal, "error deleting container %s from DB", ctr.ID())
+		return fmt.Errorf("error deleting container %s from DB: %w", ctr.ID(), define.ErrInternal)
 	}
 
 	if err := idsBucket.Delete(ctrID); err != nil {
-		return errors.Wrapf(err, "error deleting container %s ID in DB", ctr.ID())
+		return fmt.Errorf("error deleting container %s ID in DB: %w", ctr.ID(), err)
 	}
 
 	if err := namesBucket.Delete(ctrName); err != nil {
-		return errors.Wrapf(err, "error deleting container %s name in DB", ctr.ID())
+		return fmt.Errorf("error deleting container %s name in DB: %w", ctr.ID(), err)
 	}
 	if err := nsBucket.Delete(ctrID); err != nil {
-		return errors.Wrapf(err, "error deleting container %s namespace in DB", ctr.ID())
+		return fmt.Errorf("error deleting container %s namespace in DB: %w", ctr.ID(), err)
 	}
 	if err := allCtrsBucket.Delete(ctrID); err != nil {
-		return errors.Wrapf(err, "error deleting container %s from all containers bucket in DB", ctr.ID())
+		return fmt.Errorf("error deleting container %s from all containers bucket in DB: %w", ctr.ID(), err)
 	}
 
 	depCtrs := ctr.Dependencies()
@@ -986,7 +986,7 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 		}
 
 		if err := depCtrDependsBkt.Delete(ctrID); err != nil {
-			return errors.Wrapf(err, "error removing container %s as a dependency of container %s", ctr.ID(), depCtr)
+			return fmt.Errorf("error removing container %s as a dependency of container %s: %w", ctr.ID(), depCtr, err)
 		}
 	}
 
@@ -1001,11 +1001,11 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 
 		ctrDepsBkt := volDB.Bucket(volDependenciesBkt)
 		if ctrDepsBkt == nil {
-			return errors.Wrapf(define.ErrInternal, "volume %s is missing container dependencies bucket, cannot remove container %s from dependencies", vol.Name, ctr.ID())
+			return fmt.Errorf("volume %s is missing container dependencies bucket, cannot remove container %s from dependencies: %w", vol.Name, ctr.ID(), define.ErrInternal)
 		}
 		if depExists := ctrDepsBkt.Get(ctrID); depExists == nil {
 			if err := ctrDepsBkt.Delete(ctrID); err != nil {
-				return errors.Wrapf(err, "error deleting container %s dependency on volume %s", ctr.ID(), vol.Name)
+				return fmt.Errorf("error deleting container %s dependency on volume %s: %w", ctr.ID(), vol.Name, err)
 			}
 		}
 	}
@@ -1062,7 +1062,7 @@ func (s *BoltState) lookupContainerID(idOrName string, ctrBucket, namesBucket, n
 		}
 		if strings.HasPrefix(string(checkID), idOrName) {
 			if exists {
-				return errors.Wrapf(define.ErrCtrExists, "more than one result for container ID %s", idOrName)
+				return fmt.Errorf("more than one result for container ID %s: %w", idOrName, define.ErrCtrExists)
 			}
 			id = checkID
 			exists = true
@@ -1075,9 +1075,9 @@ func (s *BoltState) lookupContainerID(idOrName string, ctrBucket, namesBucket, n
 		return nil, err
 	} else if !exists {
 		if isPod {
-			return nil, errors.Wrapf(define.ErrNoSuchCtr, "%q is a pod, not a container", idOrName)
+			return nil, fmt.Errorf("%q is a pod, not a container: %w", idOrName, define.ErrNoSuchCtr)
 		}
-		return nil, errors.Wrapf(define.ErrNoSuchCtr, "no container with name or ID %q found", idOrName)
+		return nil, fmt.Errorf("no container with name or ID %q found: %w", idOrName, define.ErrNoSuchCtr)
 	}
 	return id, nil
 }

--- a/libpod/boltdb_state_linux.go
+++ b/libpod/boltdb_state_linux.go
@@ -4,8 +4,9 @@
 package libpod
 
 import (
+	"fmt"
+
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -29,7 +30,7 @@ func replaceNetNS(netNSPath string, ctr *Container, newState *ContainerState) er
 				newState.NetNS = ns
 			} else {
 				if ctr.ensureState(define.ContainerStateRunning, define.ContainerStatePaused) {
-					return errors.Wrapf(err, "error joining network namespace of container %s", ctr.ID())
+					return fmt.Errorf("error joining network namespace of container %s: %w", ctr.ID(), err)
 				}
 
 				logrus.Errorf("Joining network namespace for container %s: %v", ctr.ID(), err)

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containers/podman/v4/libpod/lock"
 	"github.com/containers/storage"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -355,14 +354,14 @@ func (c *Container) specFromState() (*spec.Spec, error) {
 		returnSpec = new(spec.Spec)
 		content, err := ioutil.ReadAll(f)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error reading container config")
+			return nil, fmt.Errorf("error reading container config: %w", err)
 		}
 		if err := json.Unmarshal(content, &returnSpec); err != nil {
-			return nil, errors.Wrapf(err, "error unmarshalling container config")
+			return nil, fmt.Errorf("error unmarshalling container config: %w", err)
 		}
 	} else if !os.IsNotExist(err) {
 		// ignore when the file does not exist
-		return nil, errors.Wrapf(err, "error opening container config")
+		return nil, fmt.Errorf("error opening container config: %w", err)
 	}
 
 	return returnSpec, nil
@@ -518,7 +517,7 @@ func (c *Container) PortMappings() ([]types.PortMapping, error) {
 	if len(c.config.NetNsCtr) > 0 {
 		netNsCtr, err := c.runtime.GetContainer(c.config.NetNsCtr)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to look up network namespace for container %s", c.ID())
+			return nil, fmt.Errorf("unable to look up network namespace for container %s: %w", c.ID(), err)
 		}
 		return netNsCtr.PortMappings()
 	}
@@ -705,7 +704,7 @@ func (c *Container) Mounted() (bool, string, error) {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if err := c.syncContainer(); err != nil {
-			return false, "", errors.Wrapf(err, "error updating container %s state", c.ID())
+			return false, "", fmt.Errorf("error updating container %s state: %w", c.ID(), err)
 		}
 	}
 	// We cannot directly return c.state.Mountpoint as it is not guaranteed
@@ -735,7 +734,7 @@ func (c *Container) StartedTime() (time.Time, error) {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if err := c.syncContainer(); err != nil {
-			return time.Time{}, errors.Wrapf(err, "error updating container %s state", c.ID())
+			return time.Time{}, fmt.Errorf("error updating container %s state: %w", c.ID(), err)
 		}
 	}
 	return c.state.StartedTime, nil
@@ -747,7 +746,7 @@ func (c *Container) FinishedTime() (time.Time, error) {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if err := c.syncContainer(); err != nil {
-			return time.Time{}, errors.Wrapf(err, "error updating container %s state", c.ID())
+			return time.Time{}, fmt.Errorf("error updating container %s state: %w", c.ID(), err)
 		}
 	}
 	return c.state.FinishedTime, nil
@@ -762,7 +761,7 @@ func (c *Container) ExitCode() (int32, bool, error) {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if err := c.syncContainer(); err != nil {
-			return 0, false, errors.Wrapf(err, "error updating container %s state", c.ID())
+			return 0, false, fmt.Errorf("error updating container %s state: %w", c.ID(), err)
 		}
 	}
 	return c.state.ExitCode, c.state.Exited, nil
@@ -774,7 +773,7 @@ func (c *Container) OOMKilled() (bool, error) {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if err := c.syncContainer(); err != nil {
-			return false, errors.Wrapf(err, "error updating container %s state", c.ID())
+			return false, fmt.Errorf("error updating container %s state: %w", c.ID(), err)
 		}
 	}
 	return c.state.OOMKilled, nil
@@ -845,7 +844,7 @@ func (c *Container) execSessionNoCopy(id string) (*ExecSession, error) {
 
 	session, ok := c.state.ExecSessions[id]
 	if !ok {
-		return nil, errors.Wrapf(define.ErrNoSuchExecSession, "no exec session with ID %s found in container %s", id, c.ID())
+		return nil, fmt.Errorf("no exec session with ID %s found in container %s: %w", id, c.ID(), define.ErrNoSuchExecSession)
 	}
 
 	return session, nil
@@ -861,7 +860,7 @@ func (c *Container) ExecSession(id string) (*ExecSession, error) {
 
 	returnSession := new(ExecSession)
 	if err := JSONDeepCopy(session, returnSession); err != nil {
-		return nil, errors.Wrapf(err, "error copying contents of container %s exec session %s", c.ID(), session.ID())
+		return nil, fmt.Errorf("error copying contents of container %s exec session %s: %w", c.ID(), session.ID(), err)
 	}
 
 	return returnSession, nil
@@ -921,7 +920,7 @@ func (c *Container) NamespacePath(linuxNS LinuxNS) (string, error) { //nolint:in
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if err := c.syncContainer(); err != nil {
-			return "", errors.Wrapf(err, "error updating container %s state", c.ID())
+			return "", fmt.Errorf("error updating container %s state: %w", c.ID(), err)
 		}
 	}
 
@@ -932,11 +931,11 @@ func (c *Container) NamespacePath(linuxNS LinuxNS) (string, error) { //nolint:in
 // If the container is not running, an error will be returned
 func (c *Container) namespacePath(linuxNS LinuxNS) (string, error) { //nolint:interfacer
 	if c.state.State != define.ContainerStateRunning && c.state.State != define.ContainerStatePaused {
-		return "", errors.Wrapf(define.ErrCtrStopped, "cannot get namespace path unless container %s is running", c.ID())
+		return "", fmt.Errorf("cannot get namespace path unless container %s is running: %w", c.ID(), define.ErrCtrStopped)
 	}
 
 	if linuxNS == InvalidNS {
-		return "", errors.Wrapf(define.ErrInvalidArg, "invalid namespace requested from container %s", c.ID())
+		return "", fmt.Errorf("invalid namespace requested from container %s: %w", c.ID(), define.ErrInvalidArg)
 	}
 
 	return fmt.Sprintf("/proc/%d/ns/%s", c.state.PID, linuxNS.String()), nil
@@ -959,7 +958,7 @@ func (c *Container) CgroupPath() (string, error) {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if err := c.syncContainer(); err != nil {
-			return "", errors.Wrapf(err, "error updating container %s state", c.ID())
+			return "", fmt.Errorf("error updating container %s state: %w", c.ID(), err)
 		}
 	}
 	return c.cGroupPath()
@@ -971,10 +970,10 @@ func (c *Container) CgroupPath() (string, error) {
 // NOTE: only call this when owning the container's lock.
 func (c *Container) cGroupPath() (string, error) {
 	if c.config.NoCgroups || c.config.CgroupsMode == "disabled" {
-		return "", errors.Wrapf(define.ErrNoCgroups, "this container is not creating cgroups")
+		return "", fmt.Errorf("this container is not creating cgroups: %w", define.ErrNoCgroups)
 	}
 	if c.state.State != define.ContainerStateRunning && c.state.State != define.ContainerStatePaused {
-		return "", errors.Wrapf(define.ErrCtrStopped, "cannot get cgroup path unless container %s is running", c.ID())
+		return "", fmt.Errorf("cannot get cgroup path unless container %s is running: %w", c.ID(), define.ErrCtrStopped)
 	}
 
 	// Read /proc/{PID}/cgroup and find the *longest* cgroup entry.  That's
@@ -995,7 +994,7 @@ func (c *Container) cGroupPath() (string, error) {
 		// If the file doesn't exist, it means the container could have been terminated
 		// so report it.
 		if os.IsNotExist(err) {
-			return "", errors.Wrapf(define.ErrCtrStopped, "cannot get cgroup path unless container %s is running", c.ID())
+			return "", fmt.Errorf("cannot get cgroup path unless container %s is running: %w", c.ID(), define.ErrCtrStopped)
 		}
 		return "", err
 	}
@@ -1024,7 +1023,7 @@ func (c *Container) cGroupPath() (string, error) {
 	}
 
 	if len(cgroupPath) == 0 {
-		return "", errors.Errorf("could not find any cgroup in %q", procPath)
+		return "", fmt.Errorf("could not find any cgroup in %q", procPath)
 	}
 
 	cgroupManager := c.CgroupManager()
@@ -1059,7 +1058,7 @@ func (c *Container) RootFsSize() (int64, error) {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if err := c.syncContainer(); err != nil {
-			return -1, errors.Wrapf(err, "error updating container %s state", c.ID())
+			return -1, fmt.Errorf("error updating container %s state: %w", c.ID(), err)
 		}
 	}
 	return c.rootFsSize()
@@ -1071,7 +1070,7 @@ func (c *Container) RWSize() (int64, error) {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		if err := c.syncContainer(); err != nil {
-			return -1, errors.Wrapf(err, "error updating container %s state", c.ID())
+			return -1, fmt.Errorf("error updating container %s state: %w", c.ID(), err)
 		}
 	}
 	return c.rwSize()
@@ -1173,7 +1172,7 @@ func (c *Container) ContainerState() (*ContainerState, error) {
 	}
 	returnConfig := new(ContainerState)
 	if err := JSONDeepCopy(c.state, returnConfig); err != nil {
-		return nil, errors.Wrapf(err, "error copying container %s state", c.ID())
+		return nil, fmt.Errorf("error copying container %s state: %w", c.ID(), err)
 	}
 	return c.state, nil
 }

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/signal"
 	"github.com/containers/storage/pkg/archive"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -39,7 +39,7 @@ func (c *Container) Init(ctx context.Context, recursive bool) error {
 	}
 
 	if !c.ensureState(define.ContainerStateConfigured, define.ContainerStateStopped, define.ContainerStateExited) {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "container %s has already been created in runtime", c.ID())
+		return fmt.Errorf("container %s has already been created in runtime: %w", c.ID(), define.ErrCtrStateInvalid)
 	}
 
 	if !recursive {
@@ -197,7 +197,7 @@ func (c *Container) StopWithTimeout(timeout uint) error {
 	}
 
 	if !c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning, define.ContainerStateStopping) {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "can only stop created or running containers. %s is in state %s", c.ID(), c.state.State.String())
+		return fmt.Errorf("can only stop created or running containers. %s is in state %s: %w", c.ID(), c.state.State.String(), define.ErrCtrStateInvalid)
 	}
 
 	return c.stop(timeout)
@@ -221,7 +221,7 @@ func (c *Container) Kill(signal uint) error {
 		// stop the container and if that is taking too long, a user
 		// may have decided to kill the container after all.
 	default:
-		return errors.Wrapf(define.ErrCtrStateInvalid, "can only kill running containers. %s is in state %s", c.ID(), c.state.State.String())
+		return fmt.Errorf("can only kill running containers. %s is in state %s: %w", c.ID(), c.state.State.String(), define.ErrCtrStateInvalid)
 	}
 
 	// Hardcode all = false, we only use all when removing.
@@ -241,7 +241,7 @@ func (c *Container) Kill(signal uint) error {
 // the duration of its runtime, only using it at the beginning to verify state.
 func (c *Container) Attach(streams *define.AttachStreams, keys string, resize <-chan define.TerminalSize) error {
 	if c.LogDriver() == define.PassthroughLogging {
-		return errors.Wrapf(define.ErrNoLogs, "this container is using the 'passthrough' log driver, cannot attach")
+		return fmt.Errorf("this container is using the 'passthrough' log driver, cannot attach: %w", define.ErrNoLogs)
 	}
 	if !c.batched {
 		c.lock.Lock()
@@ -254,7 +254,7 @@ func (c *Container) Attach(streams *define.AttachStreams, keys string, resize <-
 	}
 
 	if !c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning) {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "can only attach to created or running containers")
+		return fmt.Errorf("can only attach to created or running containers: %w", define.ErrCtrStateInvalid)
 	}
 
 	// HACK: This is really gross, but there isn't a better way without
@@ -320,11 +320,11 @@ func (c *Container) HTTPAttach(r *http.Request, w http.ResponseWriter, streams *
 	}
 
 	if !c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning) {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "can only attach to created or running containers")
+		return fmt.Errorf("can only attach to created or running containers: %w", define.ErrCtrStateInvalid)
 	}
 
 	if !streamAttach && !streamLogs {
-		return errors.Wrapf(define.ErrInvalidArg, "must specify at least one of stream or logs")
+		return fmt.Errorf("must specify at least one of stream or logs: %w", define.ErrInvalidArg)
 	}
 
 	logrus.Infof("Performing HTTP Hijack attach to container %s", c.ID())
@@ -346,7 +346,7 @@ func (c *Container) AttachResize(newSize define.TerminalSize) error {
 	}
 
 	if !c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning) {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "can only resize created or running containers")
+		return fmt.Errorf("can only resize created or running containers: %w", define.ErrCtrStateInvalid)
 	}
 
 	logrus.Infof("Resizing TTY of container %s", c.ID())
@@ -383,20 +383,20 @@ func (c *Container) Unmount(force bool) error {
 	if c.state.Mounted {
 		mounted, err := c.runtime.storageService.MountedContainerImage(c.ID())
 		if err != nil {
-			return errors.Wrapf(err, "can't determine how many times %s is mounted, refusing to unmount", c.ID())
+			return fmt.Errorf("can't determine how many times %s is mounted, refusing to unmount: %w", c.ID(), err)
 		}
 		if mounted == 1 {
 			if c.ensureState(define.ContainerStateRunning, define.ContainerStatePaused) {
-				return errors.Wrapf(define.ErrCtrStateInvalid, "cannot unmount storage for container %s as it is running or paused", c.ID())
+				return fmt.Errorf("cannot unmount storage for container %s as it is running or paused: %w", c.ID(), define.ErrCtrStateInvalid)
 			}
 			execSessions, err := c.getActiveExecSessions()
 			if err != nil {
 				return err
 			}
 			if len(execSessions) != 0 {
-				return errors.Wrapf(define.ErrCtrStateInvalid, "container %s has active exec sessions, refusing to unmount", c.ID())
+				return fmt.Errorf("container %s has active exec sessions, refusing to unmount: %w", c.ID(), define.ErrCtrStateInvalid)
 			}
-			return errors.Wrapf(define.ErrInternal, "can't unmount %s last mount, it is still in use", c.ID())
+			return fmt.Errorf("can't unmount %s last mount, it is still in use: %w", c.ID(), define.ErrInternal)
 		}
 	}
 	defer c.newContainerEvent(events.Unmount)
@@ -415,10 +415,10 @@ func (c *Container) Pause() error {
 	}
 
 	if c.state.State == define.ContainerStatePaused {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "%q is already paused", c.ID())
+		return fmt.Errorf("%q is already paused: %w", c.ID(), define.ErrCtrStateInvalid)
 	}
 	if c.state.State != define.ContainerStateRunning {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "%q is not running, can't pause", c.state.State)
+		return fmt.Errorf("%q is not running, can't pause: %w", c.state.State, define.ErrCtrStateInvalid)
 	}
 	defer c.newContainerEvent(events.Pause)
 	return c.pause()
@@ -436,7 +436,7 @@ func (c *Container) Unpause() error {
 	}
 
 	if c.state.State != define.ContainerStatePaused {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "%q is not paused, can't unpause", c.ID())
+		return fmt.Errorf("%q is not paused, can't unpause: %w", c.ID(), define.ErrCtrStateInvalid)
 	}
 	defer c.newContainerEvent(events.Unpause)
 	return c.unpause()
@@ -455,7 +455,7 @@ func (c *Container) Export(path string) error {
 	}
 
 	if c.state.State == define.ContainerStateRemoving {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "cannot mount container %s as it is being removed", c.ID())
+		return fmt.Errorf("cannot mount container %s as it is being removed: %w", c.ID(), define.ErrCtrStateInvalid)
 	}
 
 	defer c.newContainerEvent(events.Mount)
@@ -666,22 +666,21 @@ func (c *Container) Cleanup(ctx context.Context) error {
 		defer c.lock.Unlock()
 
 		if err := c.syncContainer(); err != nil {
-			switch errors.Cause(err) {
 			// When the container has already been removed, the OCI runtime directory remain.
-			case define.ErrNoSuchCtr, define.ErrCtrRemoved:
+			if errors.Is(err, define.ErrNoSuchCtr) || errors.Is(err, define.ErrCtrRemoved) {
 				if err := c.cleanupRuntime(ctx); err != nil {
-					return errors.Wrapf(err, "error cleaning up container %s from OCI runtime", c.ID())
+					return fmt.Errorf("error cleaning up container %s from OCI runtime: %w", c.ID(), err)
 				}
-			default:
-				logrus.Errorf("Syncing container %s status: %v", c.ID(), err)
+				return nil
 			}
+			logrus.Errorf("Syncing container %s status: %v", c.ID(), err)
 			return err
 		}
 	}
 
 	// Check if state is good
 	if !c.ensureState(define.ContainerStateConfigured, define.ContainerStateCreated, define.ContainerStateStopped, define.ContainerStateStopping, define.ContainerStateExited) {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "container %s is running or paused, refusing to clean up", c.ID())
+		return fmt.Errorf("container %s is running or paused, refusing to clean up: %w", c.ID(), define.ErrCtrStateInvalid)
 	}
 
 	// Handle restart policy.
@@ -703,7 +702,7 @@ func (c *Container) Cleanup(ctx context.Context) error {
 		return err
 	}
 	if len(sessions) > 0 {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "container %s has active exec sessions, refusing to clean up", c.ID())
+		return fmt.Errorf("container %s has active exec sessions, refusing to clean up: %w", c.ID(), define.ErrCtrStateInvalid)
 	}
 
 	defer c.newContainerEvent(events.Cleanup)
@@ -789,7 +788,7 @@ func (c *Container) ReloadNetwork() error {
 	}
 
 	if !c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning) {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "cannot reload network unless container network has been configured")
+		return fmt.Errorf("cannot reload network unless container network has been configured: %w", define.ErrCtrStateInvalid)
 	}
 
 	return c.reloadNetwork()

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/runtime-tools/validate"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/syndtr/gocapability/capability"
 )
@@ -24,15 +24,15 @@ import (
 func (c *Container) inspectLocked(size bool) (*define.InspectContainerData, error) {
 	storeCtr, err := c.runtime.store.Container(c.ID())
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting container from store %q", c.ID())
+		return nil, fmt.Errorf("error getting container from store %q: %w", c.ID(), err)
 	}
 	layer, err := c.runtime.store.Layer(storeCtr.LayerID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error reading information about layer %q", storeCtr.LayerID)
+		return nil, fmt.Errorf("error reading information about layer %q: %w", storeCtr.LayerID, err)
 	}
 	driverData, err := driver.GetDriverData(c.runtime.store, layer.ID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting graph driver info %q", c.ID())
+		return nil, fmt.Errorf("error getting graph driver info %q: %w", c.ID(), err)
 	}
 	return c.getContainerInspectData(size, driverData)
 }
@@ -241,7 +241,7 @@ func (c *Container) GetMounts(namedVolumes []*ContainerNamedVolume, imageVolumes
 		// volume.
 		volFromDB, err := c.runtime.state.Volume(volume.Name)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error looking up volume %s in container %s config", volume.Name, c.ID())
+			return nil, fmt.Errorf("error looking up volume %s in container %s config: %w", volume.Name, c.ID(), err)
 		}
 		mountStruct.Driver = volFromDB.Driver()
 

--- a/libpod/container_log_unsupported.go
+++ b/libpod/container_log_unsupported.go
@@ -5,16 +5,16 @@ package libpod
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/libpod/logs"
-	"github.com/pkg/errors"
 )
 
 func (c *Container) readFromJournal(_ context.Context, _ *logs.LogOptions, _ chan *logs.LogLine, colorID int64) error {
-	return errors.Wrapf(define.ErrOSNotSupported, "Journald logging only enabled with systemd on linux")
+	return fmt.Errorf("journald logging only enabled with systemd on linux: %w", define.ErrOSNotSupported)
 }
 
 func (c *Container) initializeJournal(ctx context.Context) error {
-	return errors.Wrapf(define.ErrOSNotSupported, "Journald logging only enabled with systemd on linux")
+	return fmt.Errorf("journald logging only enabled with systemd on linux: %w", define.ErrOSNotSupported)
 }

--- a/libpod/container_path_resolution.go
+++ b/libpod/container_path_resolution.go
@@ -1,12 +1,12 @@
 package libpod
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -65,7 +65,7 @@ func (c *Container) resolvePath(mountPoint string, containerPath string) (string
 				return "", "", err
 			}
 			if mountPoint == "" {
-				return "", "", errors.Errorf("volume %s is not mounted, cannot copy into it", volume.Name())
+				return "", "", fmt.Errorf("volume %s is not mounted, cannot copy into it", volume.Name())
 			}
 
 			// We found a matching volume for searchPath.  We now

--- a/libpod/container_stat_linux.go
+++ b/libpod/container_stat_linux.go
@@ -4,6 +4,8 @@
 package libpod
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,7 +13,6 @@ import (
 	"github.com/containers/buildah/copier"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/copy"
-	"github.com/pkg/errors"
 )
 
 // statInsideMount stats the specified path *inside* the container's mount and PID
@@ -150,10 +151,10 @@ func secureStat(root string, path string) (*copier.StatForItem, error) {
 	}
 
 	if len(globStats) != 1 {
-		return nil, errors.Errorf("internal error: secureStat: expected 1 item but got %d", len(globStats))
+		return nil, fmt.Errorf("internal error: secureStat: expected 1 item but got %d", len(globStats))
 	}
 	if len(globStats) != 1 {
-		return nil, errors.Errorf("internal error: secureStat: expected 1 result but got %d", len(globStats[0].Results))
+		return nil, fmt.Errorf("internal error: secureStat: expected 1 result but got %d", len(globStats[0].Results))
 	}
 
 	// NOTE: the key in the map differ from `glob` when hitting symlink.
@@ -167,7 +168,7 @@ func secureStat(root string, path string) (*copier.StatForItem, error) {
 		if stat.IsSymlink {
 			target, err := copier.Eval(root, path, copier.EvalOptions{})
 			if err != nil {
-				return nil, errors.Wrap(err, "error evaluating symlink in container")
+				return nil, fmt.Errorf("error evaluating symlink in container: %w", err)
 			}
 			// Need to make sure the symlink is relative to the root!
 			target = strings.TrimPrefix(target, root)

--- a/libpod/container_validate.go
+++ b/libpod/container_validate.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/podman/v4/libpod/define"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 // Validate that the configuration of a container is valid.
@@ -16,17 +15,17 @@ func (c *Container) validate() error {
 
 	// If one of RootfsImageIDor RootfsImageName are set, both must be set.
 	if (imageIDSet || imageNameSet) && !(imageIDSet && imageNameSet) {
-		return errors.Wrapf(define.ErrInvalidArg, "both RootfsImageName and RootfsImageID must be set if either is set")
+		return fmt.Errorf("both RootfsImageName and RootfsImageID must be set if either is set: %w", define.ErrInvalidArg)
 	}
 
 	// Cannot set RootfsImageID and Rootfs at the same time
 	if imageIDSet && rootfsSet {
-		return errors.Wrapf(define.ErrInvalidArg, "cannot set both an image ID and rootfs for a container")
+		return fmt.Errorf("cannot set both an image ID and rootfs for a container: %w", define.ErrInvalidArg)
 	}
 
 	// Must set at least one of RootfsImageID or Rootfs
 	if !(imageIDSet || rootfsSet) {
-		return errors.Wrapf(define.ErrInvalidArg, "must set root filesystem source to either image or rootfs")
+		return fmt.Errorf("must set root filesystem source to either image or rootfs: %w", define.ErrInvalidArg)
 	}
 
 	// A container cannot be marked as an infra and service container at
@@ -38,62 +37,62 @@ func (c *Container) validate() error {
 	// Cannot make a network namespace if we are joining another container's
 	// network namespace
 	if c.config.CreateNetNS && c.config.NetNsCtr != "" {
-		return errors.Wrapf(define.ErrInvalidArg, "cannot both create a network namespace and join another container's network namespace")
+		return fmt.Errorf("cannot both create a network namespace and join another container's network namespace: %w", define.ErrInvalidArg)
 	}
 
 	if c.config.CgroupsMode == cgroupSplit && c.config.CgroupParent != "" {
-		return errors.Wrapf(define.ErrInvalidArg, "cannot specify --cgroup-mode=split with a cgroup-parent")
+		return fmt.Errorf("cannot specify --cgroup-mode=split with a cgroup-parent: %w", define.ErrInvalidArg)
 	}
 
 	// Not creating cgroups has a number of requirements, mostly related to
 	// the PID namespace.
 	if c.config.NoCgroups || c.config.CgroupsMode == "disabled" {
 		if c.config.PIDNsCtr != "" {
-			return errors.Wrapf(define.ErrInvalidArg, "cannot join another container's PID namespace if not creating cgroups")
+			return fmt.Errorf("cannot join another container's PID namespace if not creating cgroups: %w", define.ErrInvalidArg)
 		}
 
 		if c.config.CgroupParent != "" {
-			return errors.Wrapf(define.ErrInvalidArg, "cannot set cgroup parent if not creating cgroups")
+			return fmt.Errorf("cannot set cgroup parent if not creating cgroups: %w", define.ErrInvalidArg)
 		}
 
 		// Ensure we have a PID namespace
 		if c.config.Spec.Linux == nil {
-			return errors.Wrapf(define.ErrInvalidArg, "must provide Linux namespace configuration in OCI spec when using NoCgroups")
+			return fmt.Errorf("must provide Linux namespace configuration in OCI spec when using NoCgroups: %w", define.ErrInvalidArg)
 		}
 		foundPid := false
 		for _, ns := range c.config.Spec.Linux.Namespaces {
 			if ns.Type == spec.PIDNamespace {
 				foundPid = true
 				if ns.Path != "" {
-					return errors.Wrapf(define.ErrInvalidArg, "containers not creating Cgroups must create a private PID namespace - cannot use another")
+					return fmt.Errorf("containers not creating Cgroups must create a private PID namespace - cannot use another: %w", define.ErrInvalidArg)
 				}
 				break
 			}
 		}
 		if !foundPid {
-			return errors.Wrapf(define.ErrInvalidArg, "containers not creating Cgroups must create a private PID namespace")
+			return fmt.Errorf("containers not creating Cgroups must create a private PID namespace: %w", define.ErrInvalidArg)
 		}
 	}
 
 	// Can only set static IP or MAC is creating a network namespace.
 	if !c.config.CreateNetNS && (c.config.StaticIP != nil || c.config.StaticMAC != nil) {
-		return errors.Wrapf(define.ErrInvalidArg, "cannot set static IP or MAC address if not creating a network namespace")
+		return fmt.Errorf("cannot set static IP or MAC address if not creating a network namespace: %w", define.ErrInvalidArg)
 	}
 
 	// Cannot set static IP or MAC if joining >1 CNI network.
 	if len(c.config.Networks) > 1 && (c.config.StaticIP != nil || c.config.StaticMAC != nil) {
-		return errors.Wrapf(define.ErrInvalidArg, "cannot set static IP or MAC address if joining more than one network")
+		return fmt.Errorf("cannot set static IP or MAC address if joining more than one network: %w", define.ErrInvalidArg)
 	}
 
 	// Using image resolv.conf conflicts with various DNS settings.
 	if c.config.UseImageResolvConf &&
 		(len(c.config.DNSSearch) > 0 || len(c.config.DNSServer) > 0 ||
 			len(c.config.DNSOption) > 0) {
-		return errors.Wrapf(define.ErrInvalidArg, "cannot configure DNS options if using image's resolv.conf")
+		return fmt.Errorf("cannot configure DNS options if using image's resolv.conf: %w", define.ErrInvalidArg)
 	}
 
 	if c.config.UseImageHosts && len(c.config.HostAdd) > 0 {
-		return errors.Wrapf(define.ErrInvalidArg, "cannot add to /etc/hosts if using image's /etc/hosts")
+		return fmt.Errorf("cannot add to /etc/hosts if using image's /etc/hosts: %w", define.ErrInvalidArg)
 	}
 
 	// Check named volume, overlay volume and image volume destination conflist
@@ -102,7 +101,7 @@ func (c *Container) validate() error {
 		// Don't check if they already exist.
 		// If they don't we will automatically create them.
 		if _, ok := destinations[vol.Dest]; ok {
-			return errors.Wrapf(define.ErrInvalidArg, "two volumes found with destination %s", vol.Dest)
+			return fmt.Errorf("two volumes found with destination %s: %w", vol.Dest, define.ErrInvalidArg)
 		}
 		destinations[vol.Dest] = true
 	}
@@ -110,7 +109,7 @@ func (c *Container) validate() error {
 		// Don't check if they already exist.
 		// If they don't we will automatically create them.
 		if _, ok := destinations[vol.Dest]; ok {
-			return errors.Wrapf(define.ErrInvalidArg, "two volumes found with destination %s", vol.Dest)
+			return fmt.Errorf("two volumes found with destination %s: %w", vol.Dest, define.ErrInvalidArg)
 		}
 		destinations[vol.Dest] = true
 	}
@@ -118,7 +117,7 @@ func (c *Container) validate() error {
 		// Don't check if they already exist.
 		// If they don't we will automatically create them.
 		if _, ok := destinations[vol.Dest]; ok {
-			return errors.Wrapf(define.ErrInvalidArg, "two volumes found with destination %s", vol.Dest)
+			return fmt.Errorf("two volumes found with destination %s: %w", vol.Dest, define.ErrInvalidArg)
 		}
 		destinations[vol.Dest] = true
 	}
@@ -126,13 +125,13 @@ func (c *Container) validate() error {
 	// If User in the OCI spec is set, require that c.config.User is set for
 	// security reasons (a lot of our code relies on c.config.User).
 	if c.config.User == "" && (c.config.Spec.Process.User.UID != 0 || c.config.Spec.Process.User.GID != 0) {
-		return errors.Wrapf(define.ErrInvalidArg, "please set User explicitly via WithUser() instead of in OCI spec directly")
+		return fmt.Errorf("please set User explicitly via WithUser() instead of in OCI spec directly: %w", define.ErrInvalidArg)
 	}
 
 	// Init-ctrs must be used inside a Pod.  Check if a init container type is
 	// passed and if no pod is passed
 	if len(c.config.InitContainerType) > 0 && len(c.config.Pod) < 1 {
-		return errors.Wrap(define.ErrInvalidArg, "init containers must be created in a pod")
+		return fmt.Errorf("init containers must be created in a pod: %w", define.ErrInvalidArg)
 	}
 	return nil
 }

--- a/libpod/define/containerstate.go
+++ b/libpod/define/containerstate.go
@@ -1,9 +1,8 @@
 package define
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // ContainerStatus represents the current state of a container
@@ -91,7 +90,7 @@ func StringToContainerStatus(status string) (ContainerStatus, error) {
 	case ContainerStateRemoving.String():
 		return ContainerStateRemoving, nil
 	default:
-		return ContainerStateUnknown, errors.Wrapf(ErrInvalidArg, "unknown container state: %s", status)
+		return ContainerStateUnknown, fmt.Errorf("unknown container state: %s: %w", status, ErrInvalidArg)
 	}
 }
 

--- a/libpod/define/exec_codes.go
+++ b/libpod/define/exec_codes.go
@@ -1,9 +1,9 @@
 package define
 
 import (
+	"errors"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,10 +23,10 @@ const (
 // has a predefined exit code associated. If so, it returns that, otherwise it returns
 // the exit code originally stated in libpod.Exec()
 func TranslateExecErrorToExitCode(originalEC int, err error) int {
-	if errors.Cause(err) == ErrOCIRuntimePermissionDenied {
+	if errors.Is(err, ErrOCIRuntimePermissionDenied) {
 		return ExecErrorCodeCannotInvoke
 	}
-	if errors.Cause(err) == ErrOCIRuntimeNotFound {
+	if errors.Is(err, ErrOCIRuntimeNotFound) {
 		return ExecErrorCodeNotFound
 	}
 	return originalEC

--- a/libpod/diff.go
+++ b/libpod/diff.go
@@ -1,10 +1,11 @@
 package libpod
 
 import (
+	"fmt"
+
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/libpod/layers"
 	"github.com/containers/storage/pkg/archive"
-	"github.com/pkg/errors"
 )
 
 var initInodes = map[string]bool{
@@ -76,5 +77,5 @@ func (r *Runtime) getLayerID(id string, diffType define.DiffType) (string, error
 		}
 		lastErr = err
 	}
-	return "", errors.Wrapf(lastErr, "%s not found", id)
+	return "", fmt.Errorf("%s not found: %w", id, lastErr)
 }

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/containers/podman/v4/libpod/events"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -178,7 +177,7 @@ func (r *Runtime) GetLastContainerEvent(ctx context.Context, nameOrID string, co
 		return nil, err
 	}
 	if len(containerEvents) < 1 {
-		return nil, errors.Wrapf(events.ErrEventNotFound, "%s not found", containerEvent.String())
+		return nil, fmt.Errorf("%s not found: %w", containerEvent.String(), events.ErrEventNotFound)
 	}
 	// return the last element in the slice
 	return containerEvents[len(containerEvents)-1], nil
@@ -201,7 +200,7 @@ func (r *Runtime) GetExecDiedEvent(ctx context.Context, nameOrID, execSessionID 
 	// There *should* only be one event maximum.
 	// But... just in case... let's not blow up if there's more than one.
 	if len(containerEvents) < 1 {
-		return nil, errors.Wrapf(events.ErrEventNotFound, "exec died event for session %s (container %s) not found", execSessionID, nameOrID)
+		return nil, fmt.Errorf("exec died event for session %s (container %s) not found: %w", execSessionID, nameOrID, events.ErrEventNotFound)
 	}
 	return containerEvents[len(containerEvents)-1], nil
 }

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -2,9 +2,8 @@ package events
 
 import (
 	"context"
+	"errors"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // EventerType ...

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -2,16 +2,16 @@ package events
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/containers/storage/pkg/stringid"
-	"github.com/pkg/errors"
 )
 
 // ErrNoJournaldLogging indicates that there is no journald logging
 // supported (requires libsystemd)
-var ErrNoJournaldLogging = errors.New("No support for journald logging")
+var ErrNoJournaldLogging = errors.New("no support for journald logging")
 
 // String returns a string representation of EventerType
 func (et EventerType) String() string {
@@ -140,7 +140,7 @@ func StringToType(name string) (Type, error) {
 	case "":
 		return "", ErrEventTypeBlank
 	}
-	return "", errors.Errorf("unknown event type %q", name)
+	return "", fmt.Errorf("unknown event type %q", name)
 }
 
 // StringToStatus converts a string to an Event Status
@@ -225,5 +225,5 @@ func StringToStatus(name string) (Status, error) {
 	case Untag.String():
 		return Untag, nil
 	}
-	return "", errors.Errorf("unknown event status %q", name)
+	return "", fmt.Errorf("unknown event status %q", name)
 }

--- a/libpod/events/events_linux.go
+++ b/libpod/events/events_linux.go
@@ -1,9 +1,9 @@
 package events
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -14,7 +14,7 @@ func NewEventer(options EventerOptions) (Eventer, error) {
 	case strings.ToUpper(Journald.String()):
 		eventer, err := newEventJournalD(options)
 		if err != nil {
-			return nil, errors.Wrapf(err, "eventer creation")
+			return nil, fmt.Errorf("eventer creation: %w", err)
 		}
 		return eventer, nil
 	case strings.ToUpper(LogFile.String()):
@@ -24,6 +24,6 @@ func NewEventer(options EventerOptions) (Eventer, error) {
 	case strings.ToUpper(Memory.String()):
 		return NewMemoryEventer(), nil
 	default:
-		return nil, errors.Errorf("unknown event logger type: %s", strings.ToUpper(options.EventerType))
+		return nil, fmt.Errorf("unknown event logger type: %s", strings.ToUpper(options.EventerType))
 	}
 }

--- a/libpod/events/events_unsupported.go
+++ b/libpod/events/events_unsupported.go
@@ -3,7 +3,7 @@
 
 package events
 
-import "github.com/pkg/errors"
+import "errors"
 
 // NewEventer creates an eventer based on the eventer type
 func NewEventer(options EventerOptions) (Eventer, error) {

--- a/libpod/events/filters.go
+++ b/libpod/events/filters.go
@@ -1,11 +1,11 @@
 package events
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 )
 
 func generateEventFilter(filter, filterValue string) (func(e *Event) bool, error) {
@@ -74,7 +74,7 @@ func generateEventFilter(filter, filterValue string) (func(e *Event) bool, error
 			return found
 		}, nil
 	}
-	return nil, errors.Errorf("%s is an invalid filter", filter)
+	return nil, fmt.Errorf("%s is an invalid filter", filter)
 }
 
 func generateEventSinceOption(timeSince time.Time) func(e *Event) bool {
@@ -92,7 +92,7 @@ func generateEventUntilOption(timeUntil time.Time) func(e *Event) bool {
 func parseFilter(filter string) (string, string, error) {
 	filterSplit := strings.SplitN(filter, "=", 2)
 	if len(filterSplit) != 2 {
-		return "", "", errors.Errorf("%s is an invalid filter", filter)
+		return "", "", fmt.Errorf("%s is an invalid filter", filter)
 	}
 	return filterSplit[0], filterSplit[1], nil
 }
@@ -137,7 +137,7 @@ func generateEventFilters(filters []string, since, until string) (map[string][]E
 	if len(since) > 0 {
 		timeSince, err := util.ParseInputTime(since, true)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to convert since time of %s", since)
+			return nil, fmt.Errorf("unable to convert since time of %s: %w", since, err)
 		}
 		filterFunc := generateEventSinceOption(timeSince)
 		filterMap["since"] = []EventFilter{filterFunc}
@@ -146,7 +146,7 @@ func generateEventFilters(filters []string, since, until string) (map[string][]E
 	if len(until) > 0 {
 		timeUntil, err := util.ParseInputTime(until, false)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to convert until time of %s", until)
+			return nil, fmt.Errorf("unable to convert until time of %s: %w", until, err)
 		}
 		filterFunc := generateEventUntilOption(timeUntil)
 		filterMap["until"] = []EventFilter{filterFunc}

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -6,6 +6,7 @@ package events
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,7 +17,6 @@ import (
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/storage/pkg/lockfile"
 	"github.com/nxadm/tail"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -90,7 +90,7 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 	defer close(options.EventChannel)
 	filterMap, err := generateEventFilters(options.Filters, options.Since, options.Until)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse event filters")
+		return fmt.Errorf("failed to parse event filters: %w", err)
 	}
 	t, err := e.getTail(options)
 	if err != nil {
@@ -136,7 +136,7 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 		case Image, Volume, Pod, System, Container, Network:
 		//	no-op
 		default:
-			return errors.Errorf("event type %s is not valid in %s", event.Type.String(), e.options.LogFilePath)
+			return fmt.Errorf("event type %s is not valid in %s", event.Type.String(), e.options.LogFilePath)
 		}
 		if copy && applyFilters(event, filterMap) {
 			options.EventChannel <- event

--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/pkg/errorhandling"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/systemd"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -21,7 +20,7 @@ func (c *Container) createTimer() error {
 	}
 	podman, err := os.Executable()
 	if err != nil {
-		return errors.Wrapf(err, "failed to get path for podman for a health check timer")
+		return fmt.Errorf("failed to get path for podman for a health check timer: %w", err)
 	}
 
 	var cmd = []string{}
@@ -36,13 +35,13 @@ func (c *Container) createTimer() error {
 
 	conn, err := systemd.ConnectToDBUS()
 	if err != nil {
-		return errors.Wrapf(err, "unable to get systemd connection to add healthchecks")
+		return fmt.Errorf("unable to get systemd connection to add healthchecks: %w", err)
 	}
 	conn.Close()
 	logrus.Debugf("creating systemd-transient files: %s %s", "systemd-run", cmd)
 	systemdRun := exec.Command("systemd-run", cmd...)
 	if output, err := systemdRun.CombinedOutput(); err != nil {
-		return errors.Errorf("%s", output)
+		return fmt.Errorf("%s", output)
 	}
 	return nil
 }
@@ -65,7 +64,7 @@ func (c *Container) startTimer() error {
 	}
 	conn, err := systemd.ConnectToDBUS()
 	if err != nil {
-		return errors.Wrapf(err, "unable to get systemd connection to start healthchecks")
+		return fmt.Errorf("unable to get systemd connection to start healthchecks: %w", err)
 	}
 	defer conn.Close()
 
@@ -89,7 +88,7 @@ func (c *Container) removeTransientFiles(ctx context.Context) error {
 	}
 	conn, err := systemd.ConnectToDBUS()
 	if err != nil {
-		return errors.Wrapf(err, "unable to get systemd connection to remove healthchecks")
+		return fmt.Errorf("unable to get systemd connection to remove healthchecks: %w", err)
 	}
 	defer conn.Close()
 

--- a/libpod/lock/in_memory_locks.go
+++ b/libpod/lock/in_memory_locks.go
@@ -1,9 +1,9 @@
 package lock
 
 import (
+	"errors"
+	"fmt"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 // Mutex holds a single mutex and whether it has been allocated.
@@ -49,7 +49,7 @@ type InMemoryManager struct {
 // of locks.
 func NewInMemoryManager(numLocks uint32) (Manager, error) {
 	if numLocks == 0 {
-		return nil, errors.Errorf("must provide a non-zero number of locks")
+		return nil, errors.New("must provide a non-zero number of locks")
 	}
 
 	manager := new(InMemoryManager)
@@ -78,13 +78,13 @@ func (m *InMemoryManager) AllocateLock() (Locker, error) {
 		}
 	}
 
-	return nil, errors.Errorf("all locks have been allocated")
+	return nil, errors.New("all locks have been allocated")
 }
 
 // RetrieveLock retrieves a lock from the manager.
 func (m *InMemoryManager) RetrieveLock(id uint32) (Locker, error) {
 	if id >= m.numLocks {
-		return nil, errors.Errorf("given lock ID %d is too large - this manager only supports lock indexes up to %d", id, m.numLocks-1)
+		return nil, fmt.Errorf("given lock ID %d is too large - this manager only supports lock indexes up to %d", id, m.numLocks-1)
 	}
 
 	return m.locks[id], nil
@@ -94,11 +94,11 @@ func (m *InMemoryManager) RetrieveLock(id uint32) (Locker, error) {
 // use) and returns it.
 func (m *InMemoryManager) AllocateAndRetrieveLock(id uint32) (Locker, error) {
 	if id >= m.numLocks {
-		return nil, errors.Errorf("given lock ID %d is too large - this manager only supports lock indexes up to %d", id, m.numLocks)
+		return nil, fmt.Errorf("given lock ID %d is too large - this manager only supports lock indexes up to %d", id, m.numLocks)
 	}
 
 	if m.locks[id].allocated {
-		return nil, errors.Errorf("given lock ID %d is already in use, cannot reallocate", id)
+		return nil, fmt.Errorf("given lock ID %d is already in use, cannot reallocate", id)
 	}
 
 	m.locks[id].allocated = true

--- a/libpod/lock/shm/shm_lock.go
+++ b/libpod/lock/shm/shm_lock.go
@@ -11,11 +11,12 @@ package shm
 import "C"
 
 import (
+	"errors"
+	"fmt"
 	"runtime"
 	"syscall"
 	"unsafe"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -40,7 +41,7 @@ type SHMLocks struct {
 // size used by the underlying implementation.
 func CreateSHMLock(path string, numLocks uint32) (*SHMLocks, error) {
 	if numLocks == 0 {
-		return nil, errors.Wrapf(syscall.EINVAL, "number of locks must be greater than 0")
+		return nil, fmt.Errorf("number of locks must be greater than 0: %w", syscall.EINVAL)
 	}
 
 	locks := new(SHMLocks)
@@ -52,7 +53,7 @@ func CreateSHMLock(path string, numLocks uint32) (*SHMLocks, error) {
 	lockStruct := C.setup_lock_shm(cPath, C.uint32_t(numLocks), &errCode)
 	if lockStruct == nil {
 		// We got a null pointer, so something errored
-		return nil, errors.Wrapf(syscall.Errno(-1*errCode), "failed to create %d locks in %s", numLocks, path)
+		return nil, fmt.Errorf("failed to create %d locks in %s: %w", numLocks, path, syscall.Errno(-1*errCode))
 	}
 
 	locks.lockStruct = lockStruct
@@ -69,7 +70,7 @@ func CreateSHMLock(path string, numLocks uint32) (*SHMLocks, error) {
 // segment was created with.
 func OpenSHMLock(path string, numLocks uint32) (*SHMLocks, error) {
 	if numLocks == 0 {
-		return nil, errors.Wrapf(syscall.EINVAL, "number of locks must be greater than 0")
+		return nil, fmt.Errorf("number of locks must be greater than 0: %w", syscall.EINVAL)
 	}
 
 	locks := new(SHMLocks)
@@ -81,7 +82,7 @@ func OpenSHMLock(path string, numLocks uint32) (*SHMLocks, error) {
 	lockStruct := C.open_lock_shm(cPath, C.uint32_t(numLocks), &errCode)
 	if lockStruct == nil {
 		// We got a null pointer, so something errored
-		return nil, errors.Wrapf(syscall.Errno(-1*errCode), "failed to open %d locks in %s", numLocks, path)
+		return nil, fmt.Errorf("failed to open %d locks in %s: %w", numLocks, path, syscall.Errno(-1*errCode))
 	}
 
 	locks.lockStruct = lockStruct
@@ -103,7 +104,7 @@ func (locks *SHMLocks) GetMaxLocks() uint32 {
 // Close() is only intended to be used while testing the locks.
 func (locks *SHMLocks) Close() error {
 	if !locks.valid {
-		return errors.Wrapf(syscall.EINVAL, "locks have already been closed")
+		return fmt.Errorf("locks have already been closed: %w", syscall.EINVAL)
 	}
 
 	locks.valid = false
@@ -124,7 +125,7 @@ func (locks *SHMLocks) Close() error {
 // created will result in an error, and no semaphore will be allocated.
 func (locks *SHMLocks) AllocateSemaphore() (uint32, error) {
 	if !locks.valid {
-		return 0, errors.Wrapf(syscall.EINVAL, "locks have already been closed")
+		return 0, fmt.Errorf("locks have already been closed: %w", syscall.EINVAL)
 	}
 
 	// This returns a U64, so we have the full u32 range available for
@@ -138,7 +139,7 @@ func (locks *SHMLocks) AllocateSemaphore() (uint32, error) {
 			// that there's no room in the SHM inn for this lock, this tends to send normal people
 			// down the path of checking disk-space which is not actually their problem.
 			// Give a clue that it's actually due to num_locks filling up.
-			var errFull = errors.Errorf("allocation failed; exceeded num_locks (%d)", locks.maxLocks)
+			var errFull = fmt.Errorf("allocation failed; exceeded num_locks (%d)", locks.maxLocks)
 			return uint32(retCode), errFull
 		}
 		return uint32(retCode), syscall.Errno(-1 * retCode)
@@ -153,7 +154,7 @@ func (locks *SHMLocks) AllocateSemaphore() (uint32, error) {
 // returned.
 func (locks *SHMLocks) AllocateGivenSemaphore(sem uint32) error {
 	if !locks.valid {
-		return errors.Wrapf(syscall.EINVAL, "locks have already been closed")
+		return fmt.Errorf("locks have already been closed: %w", syscall.EINVAL)
 	}
 
 	retCode := C.allocate_given_semaphore(locks.lockStruct, C.uint32_t(sem))
@@ -169,11 +170,11 @@ func (locks *SHMLocks) AllocateGivenSemaphore(sem uint32) error {
 // The given semaphore must be already allocated, or an error will be returned.
 func (locks *SHMLocks) DeallocateSemaphore(sem uint32) error {
 	if !locks.valid {
-		return errors.Wrapf(syscall.EINVAL, "locks have already been closed")
+		return fmt.Errorf("locks have already been closed: %w", syscall.EINVAL)
 	}
 
 	if sem > locks.maxLocks {
-		return errors.Wrapf(syscall.EINVAL, "given semaphore %d is higher than maximum locks count %d", sem, locks.maxLocks)
+		return fmt.Errorf("given semaphore %d is higher than maximum locks count %d: %w", sem, locks.maxLocks, syscall.EINVAL)
 	}
 
 	retCode := C.deallocate_semaphore(locks.lockStruct, C.uint32_t(sem))
@@ -189,7 +190,7 @@ func (locks *SHMLocks) DeallocateSemaphore(sem uint32) error {
 // other containers and pods.
 func (locks *SHMLocks) DeallocateAllSemaphores() error {
 	if !locks.valid {
-		return errors.Wrapf(syscall.EINVAL, "locks have already been closed")
+		return fmt.Errorf("locks have already been closed: %w", syscall.EINVAL)
 	}
 
 	retCode := C.deallocate_all_semaphores(locks.lockStruct)
@@ -210,11 +211,11 @@ func (locks *SHMLocks) DeallocateAllSemaphores() error {
 // succeed.
 func (locks *SHMLocks) LockSemaphore(sem uint32) error {
 	if !locks.valid {
-		return errors.Wrapf(syscall.EINVAL, "locks have already been closed")
+		return fmt.Errorf("locks have already been closed: %w", syscall.EINVAL)
 	}
 
 	if sem > locks.maxLocks {
-		return errors.Wrapf(syscall.EINVAL, "given semaphore %d is higher than maximum locks count %d", sem, locks.maxLocks)
+		return fmt.Errorf("given semaphore %d is higher than maximum locks count %d: %w", sem, locks.maxLocks, syscall.EINVAL)
 	}
 
 	// For pthread mutexes, we have to guarantee lock and unlock happen in
@@ -238,11 +239,11 @@ func (locks *SHMLocks) LockSemaphore(sem uint32) error {
 // succeed.
 func (locks *SHMLocks) UnlockSemaphore(sem uint32) error {
 	if !locks.valid {
-		return errors.Wrapf(syscall.EINVAL, "locks have already been closed")
+		return fmt.Errorf("locks have already been closed: %w", syscall.EINVAL)
 	}
 
 	if sem > locks.maxLocks {
-		return errors.Wrapf(syscall.EINVAL, "given semaphore %d is higher than maximum locks count %d", sem, locks.maxLocks)
+		return fmt.Errorf("given semaphore %d is higher than maximum locks count %d: %w", sem, locks.maxLocks, syscall.EINVAL)
 	}
 
 	retCode := C.unlock_semaphore(locks.lockStruct, C.uint32_t(sem))

--- a/libpod/lock/shm_lock_manager_linux.go
+++ b/libpod/lock/shm_lock_manager_linux.go
@@ -4,10 +4,10 @@
 package lock
 
 import (
+	"fmt"
 	"syscall"
 
 	"github.com/containers/podman/v4/libpod/lock/shm"
-	"github.com/pkg/errors"
 )
 
 // SHMLockManager manages shared memory locks.
@@ -66,8 +66,8 @@ func (m *SHMLockManager) AllocateAndRetrieveLock(id uint32) (Locker, error) {
 	lock.manager = m
 
 	if id >= m.locks.GetMaxLocks() {
-		return nil, errors.Wrapf(syscall.EINVAL, "lock ID %d is too large - max lock size is %d",
-			id, m.locks.GetMaxLocks()-1)
+		return nil, fmt.Errorf("lock ID %d is too large - max lock size is %d: %w",
+			id, m.locks.GetMaxLocks()-1, syscall.EINVAL)
 	}
 
 	if err := m.locks.AllocateGivenSemaphore(id); err != nil {
@@ -84,8 +84,8 @@ func (m *SHMLockManager) RetrieveLock(id uint32) (Locker, error) {
 	lock.manager = m
 
 	if id >= m.locks.GetMaxLocks() {
-		return nil, errors.Wrapf(syscall.EINVAL, "lock ID %d is too large - max lock size is %d",
-			id, m.locks.GetMaxLocks()-1)
+		return nil, fmt.Errorf("lock ID %d is too large - max lock size is %d: %w",
+			id, m.locks.GetMaxLocks()-1, syscall.EINVAL)
 	}
 
 	return lock, nil

--- a/libpod/logs/reversereader/reversereader.go
+++ b/libpod/logs/reversereader/reversereader.go
@@ -1,10 +1,10 @@
 package reversereader
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 // ReverseReader structure for reading a file backwards
@@ -49,12 +49,12 @@ func NewReverseReader(reader *os.File) (*ReverseReader, error) {
 // then sets the newoff set one pagesize less than the previous read.
 func (r *ReverseReader) Read() (string, error) {
 	if r.offset < 0 {
-		return "", errors.Wrap(io.EOF, "at beginning of file")
+		return "", fmt.Errorf("at beginning of file: %w", io.EOF)
 	}
 	// Read from given offset
 	b := make([]byte, r.readSize)
 	n, err := r.reader.ReadAt(b, r.offset)
-	if err != nil && errors.Cause(err) != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return "", err
 	}
 	if int64(n) < r.readSize {

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -41,7 +42,6 @@ import (
 	pmount "github.com/containers/storage/pkg/mount"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -81,7 +81,7 @@ type ConmonOCIRuntime struct {
 // libpod.
 func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtimeFlags []string, runtimeCfg *config.Config) (OCIRuntime, error) {
 	if name == "" {
-		return nil, errors.Wrapf(define.ErrInvalidArg, "the OCI runtime must be provided a non-empty name")
+		return nil, fmt.Errorf("the OCI runtime must be provided a non-empty name: %w", define.ErrInvalidArg)
 	}
 
 	// Make lookup tables for runtime support
@@ -125,7 +125,7 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 			if os.IsNotExist(err) {
 				continue
 			}
-			return nil, errors.Wrapf(err, "cannot stat OCI runtime %s path", name)
+			return nil, fmt.Errorf("cannot stat OCI runtime %s path: %w", name, err)
 		}
 		if !stat.Mode().IsRegular() {
 			continue
@@ -146,7 +146,7 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 	}
 
 	if !foundPath {
-		return nil, errors.Wrapf(define.ErrInvalidArg, "no valid executable found for OCI runtime %s", name)
+		return nil, fmt.Errorf("no valid executable found for OCI runtime %s: %w", name, define.ErrInvalidArg)
 	}
 
 	runtime.exitsDir = filepath.Join(runtime.tmpDir, "exits")
@@ -155,7 +155,7 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 	if err := os.MkdirAll(runtime.exitsDir, 0750); err != nil {
 		// The directory is allowed to exist
 		if !os.IsExist(err) {
-			return nil, errors.Wrapf(err, "error creating OCI runtime exit files directory")
+			return nil, fmt.Errorf("error creating OCI runtime exit files directory: %w", err)
 		}
 	}
 	return runtime, nil
@@ -231,7 +231,7 @@ func (r *ConmonOCIRuntime) CreateContainer(ctr *Container, restoreOptions *Conta
 					// changes are propagated to the host.
 					err = unix.Mount("/sys", "/sys", "none", unix.MS_REC|unix.MS_SLAVE, "")
 					if err != nil {
-						return 0, errors.Wrapf(err, "cannot make /sys slave")
+						return 0, fmt.Errorf("cannot make /sys slave: %w", err)
 					}
 
 					mounts, err := pmount.GetMounts()
@@ -244,7 +244,7 @@ func (r *ConmonOCIRuntime) CreateContainer(ctr *Container, restoreOptions *Conta
 						}
 						err = unix.Unmount(m.Mountpoint, 0)
 						if err != nil && !os.IsNotExist(err) {
-							return 0, errors.Wrapf(err, "cannot unmount %s", m.Mountpoint)
+							return 0, fmt.Errorf("cannot unmount %s: %w", m.Mountpoint, err)
 						}
 					}
 					return r.createOCIContainer(ctr, restoreOptions)
@@ -282,17 +282,17 @@ func (r *ConmonOCIRuntime) UpdateContainerStatus(ctr *Container) error {
 
 	outPipe, err := cmd.StdoutPipe()
 	if err != nil {
-		return errors.Wrapf(err, "getting stdout pipe")
+		return fmt.Errorf("getting stdout pipe: %w", err)
 	}
 	errPipe, err := cmd.StderrPipe()
 	if err != nil {
-		return errors.Wrapf(err, "getting stderr pipe")
+		return fmt.Errorf("getting stderr pipe: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
 		out, err2 := ioutil.ReadAll(errPipe)
 		if err2 != nil {
-			return errors.Wrapf(err, "error getting container %s state", ctr.ID())
+			return fmt.Errorf("error getting container %s state: %w", ctr.ID(), err)
 		}
 		if strings.Contains(string(out), "does not exist") || strings.Contains(string(out), "No such file") {
 			if err := ctr.removeConmonFiles(); err != nil {
@@ -303,7 +303,7 @@ func (r *ConmonOCIRuntime) UpdateContainerStatus(ctr *Container) error {
 			ctr.state.State = define.ContainerStateExited
 			return nil
 		}
-		return errors.Wrapf(err, "error getting container %s state. stderr/out: %s", ctr.ID(), out)
+		return fmt.Errorf("error getting container %s state. stderr/out: %s: %w", ctr.ID(), out, err)
 	}
 	defer func() {
 		_ = cmd.Wait()
@@ -314,10 +314,10 @@ func (r *ConmonOCIRuntime) UpdateContainerStatus(ctr *Container) error {
 	}
 	out, err := ioutil.ReadAll(outPipe)
 	if err != nil {
-		return errors.Wrapf(err, "error reading stdout: %s", ctr.ID())
+		return fmt.Errorf("error reading stdout: %s: %w", ctr.ID(), err)
 	}
 	if err := json.NewDecoder(bytes.NewBuffer(out)).Decode(state); err != nil {
-		return errors.Wrapf(err, "error decoding container status for container %s", ctr.ID())
+		return fmt.Errorf("error decoding container status for container %s: %w", ctr.ID(), err)
 	}
 	ctr.state.PID = state.Pid
 
@@ -331,8 +331,8 @@ func (r *ConmonOCIRuntime) UpdateContainerStatus(ctr *Container) error {
 	case "stopped":
 		ctr.state.State = define.ContainerStateStopped
 	default:
-		return errors.Wrapf(define.ErrInternal, "unrecognized status returned by runtime for container %s: %s",
-			ctr.ID(), state.Status)
+		return fmt.Errorf("unrecognized status returned by runtime for container %s: %s: %w",
+			ctr.ID(), state.Status, define.ErrInternal)
 	}
 
 	// Only grab exit status if we were not already stopped
@@ -400,7 +400,7 @@ func (r *ConmonOCIRuntime) KillContainer(ctr *Container, signal uint, all bool) 
 		if ctr.ensureState(define.ContainerStateStopped, define.ContainerStateExited) {
 			return define.ErrCtrStateInvalid
 		}
-		return errors.Wrapf(err, "error sending signal to container %s", ctr.ID())
+		return fmt.Errorf("error sending signal to container %s: %w", ctr.ID(), err)
 	}
 
 	return nil
@@ -457,7 +457,7 @@ func (r *ConmonOCIRuntime) StopContainer(ctr *Container, timeout uint, all bool)
 			return nil
 		}
 
-		return errors.Wrapf(err, "error sending SIGKILL to container %s", ctr.ID())
+		return fmt.Errorf("error sending SIGKILL to container %s: %w", ctr.ID(), err)
 	}
 
 	// Give runtime a few seconds to make it happen
@@ -514,7 +514,7 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 
 	if streams != nil {
 		if !streams.Stdin && !streams.Stdout && !streams.Stderr {
-			return errors.Wrapf(define.ErrInvalidArg, "must specify at least one stream to attach to")
+			return fmt.Errorf("must specify at least one stream to attach to: %w", define.ErrInvalidArg)
 		}
 	}
 
@@ -527,7 +527,7 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 	if streamAttach {
 		newConn, err := openUnixSocket(attachSock)
 		if err != nil {
-			return errors.Wrapf(err, "failed to connect to container's attach socket: %v", attachSock)
+			return fmt.Errorf("failed to connect to container's attach socket: %v: %w", attachSock, err)
 		}
 		conn = newConn
 		defer func() {
@@ -562,12 +562,12 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 	// Alright, let's hijack.
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		return errors.Errorf("unable to hijack connection")
+		return fmt.Errorf("unable to hijack connection")
 	}
 
 	httpCon, httpBuf, err := hijacker.Hijack()
 	if err != nil {
-		return errors.Wrapf(err, "error hijacking connection")
+		return fmt.Errorf("error hijacking connection: %w", err)
 	}
 
 	hijackDone <- true
@@ -576,7 +576,7 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 
 	// Force a flush after the header is written.
 	if err := httpBuf.Flush(); err != nil {
-		return errors.Wrapf(err, "error flushing HTTP hijack header")
+		return fmt.Errorf("error flushing HTTP hijack header: %w", err)
 	}
 
 	defer func() {
@@ -722,7 +722,8 @@ func (r *ConmonOCIRuntime) HTTPAttach(ctr *Container, req *http.Request, w http.
 // isRetryable returns whether the error was caused by a blocked syscall or the
 // specified operation on a non blocking file descriptor wasn't ready for completion.
 func isRetryable(err error) bool {
-	if errno, isErrno := errors.Cause(err).(syscall.Errno); isErrno {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
 		return errno == syscall.EINTR || errno == syscall.EAGAIN
 	}
 	return false
@@ -737,11 +738,11 @@ func openControlFile(ctr *Container, parentDir string) (*os.File, error) {
 			return controlFile, nil
 		}
 		if !isRetryable(err) {
-			return nil, errors.Wrapf(err, "could not open ctl file for terminal resize for container %s", ctr.ID())
+			return nil, fmt.Errorf("could not open ctl file for terminal resize for container %s: %w", ctr.ID(), err)
 		}
 		time.Sleep(time.Second / 10)
 	}
-	return nil, errors.Errorf("timeout waiting for %q", controlPath)
+	return nil, fmt.Errorf("timeout waiting for %q", controlPath)
 }
 
 // AttachResize resizes the terminal used by the given container.
@@ -754,7 +755,7 @@ func (r *ConmonOCIRuntime) AttachResize(ctr *Container, newSize define.TerminalS
 
 	logrus.Debugf("Received a resize event for container %s: %+v", ctr.ID(), newSize)
 	if _, err = fmt.Fprintf(controlFile, "%d %d %d\n", 1, newSize.Height, newSize.Width); err != nil {
-		return errors.Wrapf(err, "failed to write to ctl file to resize terminal")
+		return fmt.Errorf("failed to write to ctl file to resize terminal: %w", err)
 	}
 
 	return nil
@@ -862,7 +863,7 @@ func (r *ConmonOCIRuntime) CheckConmonRunning(ctr *Container) (bool, error) {
 		if err == unix.ESRCH {
 			return false, nil
 		}
-		return false, errors.Wrapf(err, "error pinging container %s conmon with signal 0", ctr.ID())
+		return false, fmt.Errorf("error pinging container %s conmon with signal 0: %w", ctr.ID(), err)
 	}
 	return true, nil
 }
@@ -894,7 +895,7 @@ func (r *ConmonOCIRuntime) SupportsKVM() bool {
 // AttachSocketPath is the path to a single container's attach socket.
 func (r *ConmonOCIRuntime) AttachSocketPath(ctr *Container) (string, error) {
 	if ctr == nil {
-		return "", errors.Wrapf(define.ErrInvalidArg, "must provide a valid container to get attach socket path")
+		return "", fmt.Errorf("must provide a valid container to get attach socket path: %w", define.ErrInvalidArg)
 	}
 
 	return filepath.Join(ctr.bundlePath(), "attach"), nil
@@ -903,7 +904,7 @@ func (r *ConmonOCIRuntime) AttachSocketPath(ctr *Container) (string, error) {
 // ExitFilePath is the path to a container's exit file.
 func (r *ConmonOCIRuntime) ExitFilePath(ctr *Container) (string, error) {
 	if ctr == nil {
-		return "", errors.Wrapf(define.ErrInvalidArg, "must provide a valid container to get exit file path")
+		return "", fmt.Errorf("must provide a valid container to get exit file path: %w", define.ErrInvalidArg)
 	}
 	return filepath.Join(r.exitsDir, ctr.ID()), nil
 }
@@ -914,11 +915,11 @@ func (r *ConmonOCIRuntime) RuntimeInfo() (*define.ConmonInfo, *define.OCIRuntime
 	conmonPackage := packageVersion(r.conmonPath)
 	runtimeVersion, err := r.getOCIRuntimeVersion()
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error getting version of OCI runtime %s", r.name)
+		return nil, nil, fmt.Errorf("error getting version of OCI runtime %s: %w", r.name, err)
 	}
 	conmonVersion, err := r.getConmonVersion()
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error getting conmon version")
+		return nil, nil, fmt.Errorf("error getting conmon version: %w", err)
 	}
 
 	conmon := define.ConmonInfo{
@@ -988,7 +989,7 @@ func waitPidStop(pid int, timeout time.Duration) error {
 		return nil
 	case <-time.After(timeout):
 		close(chControl)
-		return errors.Errorf("given PIDs did not die within timeout")
+		return fmt.Errorf("given PIDs did not die within timeout")
 	}
 }
 
@@ -1004,7 +1005,7 @@ func (r *ConmonOCIRuntime) getLogTag(ctr *Container) (string, error) {
 	}
 	tmpl, err := template.New("container").Parse(logTag)
 	if err != nil {
-		return "", errors.Wrapf(err, "template parsing error %s", logTag)
+		return "", fmt.Errorf("template parsing error %s: %w", logTag, err)
 	}
 	var b bytes.Buffer
 	err = tmpl.Execute(&b, data)
@@ -1025,13 +1026,13 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 
 	parentSyncPipe, childSyncPipe, err := newPipe()
 	if err != nil {
-		return 0, errors.Wrapf(err, "error creating socket pair")
+		return 0, fmt.Errorf("error creating socket pair: %w", err)
 	}
 	defer errorhandling.CloseQuiet(parentSyncPipe)
 
 	childStartPipe, parentStartPipe, err := newPipe()
 	if err != nil {
-		return 0, errors.Wrapf(err, "error creating socket pair for start pipe")
+		return 0, fmt.Errorf("error creating socket pair for start pipe: %w", err)
 	}
 
 	defer errorhandling.CloseQuiet(parentStartPipe)
@@ -1202,12 +1203,12 @@ func (r *ConmonOCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Co
 			if havePortMapping {
 				ctr.rootlessPortSyncR, ctr.rootlessPortSyncW, err = os.Pipe()
 				if err != nil {
-					return 0, errors.Wrapf(err, "failed to create rootless port sync pipe")
+					return 0, fmt.Errorf("failed to create rootless port sync pipe: %w", err)
 				}
 			}
 			ctr.rootlessSlirpSyncR, ctr.rootlessSlirpSyncW, err = os.Pipe()
 			if err != nil {
-				return 0, errors.Wrapf(err, "failed to create rootless network sync pipe")
+				return 0, fmt.Errorf("failed to create rootless network sync pipe: %w", err)
 			}
 		} else {
 			if ctr.rootlessSlirpSyncR != nil {
@@ -1544,7 +1545,7 @@ func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, 
 					}
 				}
 			}
-			return -1, errors.Wrapf(ss.err, "container create failed (no logs from conmon)")
+			return -1, fmt.Errorf("container create failed (no logs from conmon): %w", ss.err)
 		}
 		logrus.Debugf("Received: %d", ss.si.Data)
 		if ss.si.Data < 0 {
@@ -1561,11 +1562,11 @@ func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, 
 			if ss.si.Message != "" {
 				return ss.si.Data, getOCIRuntimeError(runtimeName, ss.si.Message)
 			}
-			return ss.si.Data, errors.Wrapf(define.ErrInternal, "container create failed")
+			return ss.si.Data, fmt.Errorf("container create failed: %w", define.ErrInternal)
 		}
 		data = ss.si.Data
 	case <-time.After(define.ContainerCreateTimeout):
-		return -1, errors.Wrapf(define.ErrInternal, "container creation timeout")
+		return -1, fmt.Errorf("container creation timeout: %w", define.ErrInternal)
 	}
 	return data, nil
 }

--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -209,7 +208,7 @@ func (r *MissingRuntime) ExecAttachSocketPath(ctr *Container, sessionID string) 
 // the container, but Conmon should still place an exit file for it.
 func (r *MissingRuntime) ExitFilePath(ctr *Container) (string, error) {
 	if ctr == nil {
-		return "", errors.Wrapf(define.ErrInvalidArg, "must provide a valid container to get exit file path")
+		return "", fmt.Errorf("must provide a valid container to get exit file path: %w", define.ErrInvalidArg)
 	}
 	return filepath.Join(r.exitsDir, ctr.ID()), nil
 }
@@ -227,5 +226,5 @@ func (r *MissingRuntime) RuntimeInfo() (*define.ConmonInfo, *define.OCIRuntimeIn
 
 // Return an error indicating the runtime is missing
 func (r *MissingRuntime) printError() error {
-	return errors.Wrapf(define.ErrOCIRuntimeNotFound, "runtime %s is missing", r.name)
+	return fmt.Errorf("runtime %s is missing: %w", r.name, define.ErrOCIRuntimeNotFound)
 }

--- a/libpod/oci_util.go
+++ b/libpod/oci_util.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -70,7 +69,7 @@ func bindPort(protocol, hostIP string, port uint16, isV6 bool, sctpWarning *bool
 			addr, err = net.ResolveUDPAddr("udp4", fmt.Sprintf("%s:%d", hostIP, port))
 		}
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot resolve the UDP address")
+			return nil, fmt.Errorf("cannot resolve the UDP address: %w", err)
 		}
 
 		proto := "udp4"
@@ -79,11 +78,11 @@ func bindPort(protocol, hostIP string, port uint16, isV6 bool, sctpWarning *bool
 		}
 		server, err := net.ListenUDP(proto, addr)
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot listen on the UDP port")
+			return nil, fmt.Errorf("cannot listen on the UDP port: %w", err)
 		}
 		file, err = server.File()
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot get file for UDP socket")
+			return nil, fmt.Errorf("cannot get file for UDP socket: %w", err)
 		}
 		// close the listener
 		// note that this does not affect the fd, see the godoc for server.File()
@@ -103,7 +102,7 @@ func bindPort(protocol, hostIP string, port uint16, isV6 bool, sctpWarning *bool
 			addr, err = net.ResolveTCPAddr("tcp4", fmt.Sprintf("%s:%d", hostIP, port))
 		}
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot resolve the TCP address")
+			return nil, fmt.Errorf("cannot resolve the TCP address: %w", err)
 		}
 
 		proto := "tcp4"
@@ -112,11 +111,11 @@ func bindPort(protocol, hostIP string, port uint16, isV6 bool, sctpWarning *bool
 		}
 		server, err := net.ListenTCP(proto, addr)
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot listen on the TCP port")
+			return nil, fmt.Errorf("cannot listen on the TCP port: %w", err)
 		}
 		file, err = server.File()
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot get file for TCP socket")
+			return nil, fmt.Errorf("cannot get file for TCP socket: %w", err)
 		}
 		// close the listener
 		// note that this does not affect the fd, see the godoc for server.File()
@@ -144,14 +143,14 @@ func getOCIRuntimeError(name, runtimeMsg string) error {
 		if includeFullOutput {
 			errStr = runtimeMsg
 		}
-		return errors.Wrapf(define.ErrOCIRuntimePermissionDenied, "%s: %s", name, strings.Trim(errStr, "\n"))
+		return fmt.Errorf("%s: %s: %w", name, strings.Trim(errStr, "\n"), define.ErrOCIRuntimePermissionDenied)
 	}
 	if match := regexp.MustCompile("(?i).*executable file not found in.*|.*no such file or directory.*").FindString(runtimeMsg); match != "" {
 		errStr := match
 		if includeFullOutput {
 			errStr = runtimeMsg
 		}
-		return errors.Wrapf(define.ErrOCIRuntimeNotFound, "%s: %s", name, strings.Trim(errStr, "\n"))
+		return fmt.Errorf("%s: %s: %w", name, strings.Trim(errStr, "\n"), define.ErrOCIRuntimeNotFound)
 	}
 	if match := regexp.MustCompile("`/proc/[a-z0-9-].+/attr.*`").FindString(runtimeMsg); match != "" {
 		errStr := match
@@ -159,11 +158,11 @@ func getOCIRuntimeError(name, runtimeMsg string) error {
 			errStr = runtimeMsg
 		}
 		if strings.HasSuffix(match, "/exec`") {
-			return errors.Wrapf(define.ErrSetSecurityAttribute, "%s: %s", name, strings.Trim(errStr, "\n"))
+			return fmt.Errorf("%s: %s: %w", name, strings.Trim(errStr, "\n"), define.ErrSetSecurityAttribute)
 		} else if strings.HasSuffix(match, "/current`") {
-			return errors.Wrapf(define.ErrGetSecurityAttribute, "%s: %s", name, strings.Trim(errStr, "\n"))
+			return fmt.Errorf("%s: %s: %w", name, strings.Trim(errStr, "\n"), define.ErrGetSecurityAttribute)
 		}
-		return errors.Wrapf(define.ErrSecurityAttribute, "%s: %s", name, strings.Trim(errStr, "\n"))
+		return fmt.Errorf("%s: %s: %w", name, strings.Trim(errStr, "\n"), define.ErrSecurityAttribute)
 	}
-	return errors.Wrapf(define.ErrOCIRuntime, "%s: %s", name, strings.Trim(runtimeMsg, "\n"))
+	return fmt.Errorf("%s: %s: %w", name, strings.Trim(runtimeMsg, "\n"), define.ErrOCIRuntime)
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -25,7 +26,6 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -141,7 +141,7 @@ func WithOCIRuntime(runtime string) RuntimeOption {
 		}
 
 		if runtime == "" {
-			return errors.Wrapf(define.ErrInvalidArg, "must provide a valid path")
+			return fmt.Errorf("must provide a valid path: %w", define.ErrInvalidArg)
 		}
 
 		rt.config.Engine.OCIRuntime = runtime
@@ -159,7 +159,7 @@ func WithConmonPath(path string) RuntimeOption {
 		}
 
 		if path == "" {
-			return errors.Wrapf(define.ErrInvalidArg, "must provide a valid path")
+			return fmt.Errorf("must provide a valid path: %w", define.ErrInvalidArg)
 		}
 
 		rt.config.Engine.ConmonPath = []string{path}
@@ -219,8 +219,8 @@ func WithCgroupManager(manager string) RuntimeOption {
 		}
 
 		if manager != config.CgroupfsCgroupsManager && manager != config.SystemdCgroupsManager {
-			return errors.Wrapf(define.ErrInvalidArg, "Cgroup manager must be one of %s and %s",
-				config.CgroupfsCgroupsManager, config.SystemdCgroupsManager)
+			return fmt.Errorf("cgroup manager must be one of %s and %s: %w",
+				config.CgroupfsCgroupsManager, config.SystemdCgroupsManager, define.ErrInvalidArg)
 		}
 
 		rt.config.Engine.CgroupManager = manager
@@ -250,7 +250,7 @@ func WithRegistriesConf(path string) RuntimeOption {
 	logrus.Debugf("Setting custom registries.conf: %q", path)
 	return func(rt *Runtime) error {
 		if _, err := os.Stat(path); err != nil {
-			return errors.Wrap(err, "locating specified registries.conf")
+			return fmt.Errorf("locating specified registries.conf: %w", err)
 		}
 		if rt.imageContext == nil {
 			rt.imageContext = &types.SystemContext{
@@ -272,7 +272,7 @@ func WithHooksDir(hooksDirs ...string) RuntimeOption {
 
 		for _, hooksDir := range hooksDirs {
 			if hooksDir == "" {
-				return errors.Wrap(define.ErrInvalidArg, "empty-string hook directories are not supported")
+				return fmt.Errorf("empty-string hook directories are not supported: %w", define.ErrInvalidArg)
 			}
 		}
 
@@ -494,7 +494,7 @@ func WithMigrateRuntime(requestedRuntime string) RuntimeOption {
 		}
 
 		if requestedRuntime == "" {
-			return errors.Wrapf(define.ErrInvalidArg, "must provide a non-empty name for new runtime")
+			return fmt.Errorf("must provide a non-empty name for new runtime: %w", define.ErrInvalidArg)
 		}
 
 		rt.migrateRuntime = requestedRuntime
@@ -513,7 +513,7 @@ func WithEventsLogger(logger string) RuntimeOption {
 		}
 
 		if !events.IsValidEventer(logger) {
-			return errors.Wrapf(define.ErrInvalidArg, "%q is not a valid events backend", logger)
+			return fmt.Errorf("%q is not a valid events backend: %w", logger, define.ErrInvalidArg)
 		}
 
 		rt.config.Engine.EventsLogger = logger
@@ -622,7 +622,7 @@ func WithSdNotifyMode(mode string) CtrCreateOption {
 
 		// verify values
 		if len(mode) > 0 && !cutil.StringInSlice(strings.ToLower(mode), SdNotifyModeValues) {
-			return errors.Wrapf(define.ErrInvalidArg, "--sdnotify values must be one of %q", strings.Join(SdNotifyModeValues, ", "))
+			return fmt.Errorf("--sdnotify values must be one of %q: %w", strings.Join(SdNotifyModeValues, ", "), define.ErrInvalidArg)
 		}
 
 		ctr.config.SdNotifyMode = mode
@@ -770,9 +770,9 @@ func WithStopSignal(signal syscall.Signal) CtrCreateOption {
 		}
 
 		if signal == 0 {
-			return errors.Wrapf(define.ErrInvalidArg, "stop signal cannot be 0")
+			return fmt.Errorf("stop signal cannot be 0: %w", define.ErrInvalidArg)
 		} else if signal > 64 {
-			return errors.Wrapf(define.ErrInvalidArg, "stop signal cannot be greater than 64 (SIGRTMAX)")
+			return fmt.Errorf("stop signal cannot be greater than 64 (SIGRTMAX): %w", define.ErrInvalidArg)
 		}
 
 		ctr.config.StopSignal = uint(signal)
@@ -1080,11 +1080,11 @@ func WithLogDriver(driver string) CtrCreateOption {
 		}
 		switch driver {
 		case "":
-			return errors.Wrapf(define.ErrInvalidArg, "log driver must be set")
+			return fmt.Errorf("log driver must be set: %w", define.ErrInvalidArg)
 		case define.JournaldLogging, define.KubernetesLogging, define.JSONLogging, define.NoLogging, define.PassthroughLogging:
 			break
 		default:
-			return errors.Wrapf(define.ErrInvalidArg, "invalid log driver")
+			return fmt.Errorf("invalid log driver: %w", define.ErrInvalidArg)
 		}
 
 		ctr.config.LogDriver = driver
@@ -1100,7 +1100,7 @@ func WithLogPath(path string) CtrCreateOption {
 			return define.ErrCtrFinalized
 		}
 		if path == "" {
-			return errors.Wrapf(define.ErrInvalidArg, "log path must be set")
+			return fmt.Errorf("log path must be set: %w", define.ErrInvalidArg)
 		}
 
 		ctr.config.LogPath = path
@@ -1116,7 +1116,7 @@ func WithLogTag(tag string) CtrCreateOption {
 			return define.ErrCtrFinalized
 		}
 		if tag == "" {
-			return errors.Wrapf(define.ErrInvalidArg, "log tag must be set")
+			return fmt.Errorf("log tag must be set: %w", define.ErrInvalidArg)
 		}
 
 		ctr.config.LogTag = tag
@@ -1139,7 +1139,7 @@ func WithCgroupsMode(mode string) CtrCreateOption {
 		case "enabled", "no-conmon", cgroupSplit:
 			ctr.config.CgroupsMode = mode
 		default:
-			return errors.Wrapf(define.ErrInvalidArg, "Invalid cgroup mode %q", mode)
+			return fmt.Errorf("invalid cgroup mode %q: %w", mode, define.ErrInvalidArg)
 		}
 
 		return nil
@@ -1154,7 +1154,7 @@ func WithCgroupParent(parent string) CtrCreateOption {
 		}
 
 		if parent == "" {
-			return errors.Wrapf(define.ErrInvalidArg, "cgroup parent cannot be empty")
+			return fmt.Errorf("cgroup parent cannot be empty: %w", define.ErrInvalidArg)
 		}
 
 		ctr.config.CgroupParent = parent
@@ -1184,7 +1184,7 @@ func WithDNS(dnsServers []string) CtrCreateOption {
 		for _, i := range dnsServers {
 			result := net.ParseIP(i)
 			if result == nil {
-				return errors.Wrapf(define.ErrInvalidArg, "invalid IP address %s", i)
+				return fmt.Errorf("invalid IP address %s: %w", i, define.ErrInvalidArg)
 			}
 			dns = append(dns, result)
 		}
@@ -1201,7 +1201,7 @@ func WithDNSOption(dnsOptions []string) CtrCreateOption {
 			return define.ErrCtrFinalized
 		}
 		if ctr.config.UseImageResolvConf {
-			return errors.Wrapf(define.ErrInvalidArg, "cannot add DNS options if container will not create /etc/resolv.conf")
+			return fmt.Errorf("cannot add DNS options if container will not create /etc/resolv.conf: %w", define.ErrInvalidArg)
 		}
 		ctr.config.DNSOption = append(ctr.config.DNSOption, dnsOptions...)
 		return nil
@@ -1375,7 +1375,7 @@ func WithRestartPolicy(policy string) CtrCreateOption {
 		case define.RestartPolicyNone, define.RestartPolicyNo, define.RestartPolicyOnFailure, define.RestartPolicyAlways, define.RestartPolicyUnlessStopped:
 			ctr.config.RestartPolicy = policy
 		default:
-			return errors.Wrapf(define.ErrInvalidArg, "%q is not a valid restart policy", policy)
+			return fmt.Errorf("%q is not a valid restart policy: %w", policy, define.ErrInvalidArg)
 		}
 
 		return nil
@@ -1407,7 +1407,7 @@ func WithNamedVolumes(volumes []*ContainerNamedVolume) CtrCreateOption {
 		for _, vol := range volumes {
 			mountOpts, err := util.ProcessOptions(vol.Options, false, "")
 			if err != nil {
-				return errors.Wrapf(err, "processing options for named volume %q mounted at %q", vol.Name, vol.Dest)
+				return fmt.Errorf("processing options for named volume %q mounted at %q: %w", vol.Name, vol.Dest, err)
 			}
 
 			ctr.config.NamedVolumes = append(ctr.config.NamedVolumes, &ContainerNamedVolume{
@@ -1720,7 +1720,7 @@ func WithTimezone(path string) CtrCreateOption {
 			}
 			// We don't want to mount a timezone directory
 			if file.IsDir() {
-				return errors.New("Invalid timezone: is a directory")
+				return errors.New("invalid timezone: is a directory")
 			}
 		}
 
@@ -1736,7 +1736,7 @@ func WithUmask(umask string) CtrCreateOption {
 			return define.ErrCtrFinalized
 		}
 		if !define.UmaskRegex.MatchString(umask) {
-			return errors.Wrapf(define.ErrInvalidArg, "Invalid umask string %s", umask)
+			return fmt.Errorf("invalid umask string %s: %w", umask, define.ErrInvalidArg)
 		}
 		ctr.config.Umask = umask
 		return nil
@@ -1809,7 +1809,7 @@ func WithInitCtrType(containerType string) CtrCreateOption {
 			ctr.config.InitContainerType = containerType
 			return nil
 		}
-		return errors.Errorf("%s is invalid init container type", containerType)
+		return fmt.Errorf("%s is invalid init container type", containerType)
 	}
 }
 
@@ -1843,12 +1843,12 @@ func WithInfraConfig(compatibleOptions InfraInherit) CtrCreateOption {
 		}
 		compatMarshal, err := json.Marshal(compatibleOptions)
 		if err != nil {
-			return errors.New("Could not marshal compatible options")
+			return errors.New("could not marshal compatible options")
 		}
 
 		err = json.Unmarshal(compatMarshal, ctr.config)
 		if err != nil {
-			return errors.New("Could not unmarshal compatible options into contrainer config")
+			return errors.New("could not unmarshal compatible options into contrainer config")
 		}
 		return nil
 	}

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/libpod/lock"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 // Pod represents a group of containers that are managed together.
@@ -312,7 +312,7 @@ func (p *Pod) CgroupPath() (string, error) {
 		return "", err
 	}
 	if p.state.InfraContainerID == "" {
-		return "", errors.Wrap(define.ErrNoSuchCtr, "pod has no infra container")
+		return "", fmt.Errorf("pod has no infra container: %w", define.ErrNoSuchCtr)
 	}
 	return p.state.CgroupPath, nil
 }
@@ -386,7 +386,7 @@ func (p *Pod) infraContainer() (*Container, error) {
 		return nil, err
 	}
 	if id == "" {
-		return nil, errors.Wrap(define.ErrNoSuchCtr, "pod has no infra container")
+		return nil, fmt.Errorf("pod has no infra container: %w", define.ErrNoSuchCtr)
 	}
 
 	return p.runtime.state.Container(id)
@@ -426,7 +426,7 @@ func (p *Pod) GetPodStats(previousContainerStats map[string]*define.ContainerSta
 		newStats, err := c.GetContainerStats(previousContainerStats[c.ID()])
 		// If the container wasn't running, don't include it
 		// but also suppress the error
-		if err != nil && errors.Cause(err) != define.ErrCtrStateInvalid {
+		if err != nil && !errors.Is(err, define.ErrCtrStateInvalid) {
 			return nil, err
 		}
 		if err == nil {

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containers/common/pkg/cgroups"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/pkg/parallel"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -32,7 +32,7 @@ func (p *Pod) startInitContainers(ctx context.Context) error {
 			return err
 		}
 		if rc != 0 {
-			return errors.Errorf("init container %s exited with code %d", initCon.ID(), rc)
+			return fmt.Errorf("init container %s exited with code %d", initCon.ID(), rc)
 		}
 		// If the container is a once init container, we need to remove it
 		// after it runs
@@ -42,7 +42,7 @@ func (p *Pod) startInitContainers(ctx context.Context) error {
 			var time *uint
 			if err := p.runtime.removeContainer(ctx, initCon, false, false, true, time); err != nil {
 				icLock.Unlock()
-				return errors.Wrapf(err, "failed to remove once init container %s", initCon.ID())
+				return fmt.Errorf("failed to remove once init container %s: %w", initCon.ID(), err)
 			}
 			// Removing a container this way requires an explicit call to clean up the db
 			if err := p.runtime.state.RemoveContainerFromPod(p, initCon); err != nil {
@@ -92,12 +92,12 @@ func (p *Pod) Start(ctx context.Context) (map[string]error, error) {
 	// Build a dependency graph of containers in the pod
 	graph, err := BuildContainerGraph(allCtrs)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error generating dependency graph for pod %s", p.ID())
+		return nil, fmt.Errorf("error generating dependency graph for pod %s: %w", p.ID(), err)
 	}
 	// If there are no containers without dependencies, we can't start
 	// Error out
 	if len(graph.noDepNodes) == 0 {
-		return nil, errors.Wrapf(define.ErrNoSuchCtr, "no containers in pod %s have no dependencies, cannot start pod", p.ID())
+		return nil, fmt.Errorf("no containers in pod %s have no dependencies, cannot start pod: %w", p.ID(), define.ErrNoSuchCtr)
 	}
 
 	ctrErrors := make(map[string]error)
@@ -109,7 +109,7 @@ func (p *Pod) Start(ctx context.Context) (map[string]error, error) {
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(define.ErrPodPartialFail, "error starting some containers")
+		return ctrErrors, fmt.Errorf("error starting some containers: %w", define.ErrPodPartialFail)
 	}
 	defer p.newPodEvent(events.Start)
 	return nil, nil
@@ -193,7 +193,7 @@ func (p *Pod) stopWithTimeout(ctx context.Context, cleanup bool, timeout int) (m
 	// Get returned error for every container we worked on
 	for id, channel := range ctrErrChan {
 		if err := <-channel; err != nil {
-			if errors.Cause(err) == define.ErrCtrStateInvalid || errors.Cause(err) == define.ErrCtrStopped {
+			if errors.Is(err, define.ErrCtrStateInvalid) || errors.Is(err, define.ErrCtrStopped) {
 				continue
 			}
 			ctrErrors[id] = err
@@ -201,7 +201,7 @@ func (p *Pod) stopWithTimeout(ctx context.Context, cleanup bool, timeout int) (m
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(define.ErrPodPartialFail, "error stopping some containers")
+		return ctrErrors, fmt.Errorf("error stopping some containers: %w", define.ErrPodPartialFail)
 	}
 
 	if err := p.maybeStopServiceContainer(); err != nil {
@@ -297,7 +297,7 @@ func (p *Pod) Cleanup(ctx context.Context) (map[string]error, error) {
 	// Get returned error for every container we worked on
 	for id, channel := range ctrErrChan {
 		if err := <-channel; err != nil {
-			if errors.Cause(err) == define.ErrCtrStateInvalid || errors.Cause(err) == define.ErrCtrStopped {
+			if errors.Is(err, define.ErrCtrStateInvalid) || errors.Is(err, define.ErrCtrStopped) {
 				continue
 			}
 			ctrErrors[id] = err
@@ -305,7 +305,7 @@ func (p *Pod) Cleanup(ctx context.Context) (map[string]error, error) {
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(define.ErrPodPartialFail, "error cleaning up some containers")
+		return ctrErrors, fmt.Errorf("error cleaning up some containers: %w", define.ErrPodPartialFail)
 	}
 
 	if err := p.maybeStopServiceContainer(); err != nil {
@@ -338,10 +338,10 @@ func (p *Pod) Pause(ctx context.Context) (map[string]error, error) {
 	if rootless.IsRootless() {
 		cgroupv2, err := cgroups.IsCgroup2UnifiedMode()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to determine cgroupversion")
+			return nil, fmt.Errorf("failed to determine cgroupversion: %w", err)
 		}
 		if !cgroupv2 {
-			return nil, errors.Wrap(define.ErrNoCgroups, "can not pause pods containing rootless containers with cgroup V1")
+			return nil, fmt.Errorf("can not pause pods containing rootless containers with cgroup V1: %w", define.ErrNoCgroups)
 		}
 	}
 
@@ -368,7 +368,7 @@ func (p *Pod) Pause(ctx context.Context) (map[string]error, error) {
 	// Get returned error for every container we worked on
 	for id, channel := range ctrErrChan {
 		if err := <-channel; err != nil {
-			if errors.Cause(err) == define.ErrCtrStateInvalid || errors.Cause(err) == define.ErrCtrStopped {
+			if errors.Is(err, define.ErrCtrStateInvalid) || errors.Is(err, define.ErrCtrStopped) {
 				continue
 			}
 			ctrErrors[id] = err
@@ -376,7 +376,7 @@ func (p *Pod) Pause(ctx context.Context) (map[string]error, error) {
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(define.ErrPodPartialFail, "error pausing some containers")
+		return ctrErrors, fmt.Errorf("error pausing some containers: %w", define.ErrPodPartialFail)
 	}
 	return nil, nil
 }
@@ -424,7 +424,7 @@ func (p *Pod) Unpause(ctx context.Context) (map[string]error, error) {
 	// Get returned error for every container we worked on
 	for id, channel := range ctrErrChan {
 		if err := <-channel; err != nil {
-			if errors.Cause(err) == define.ErrCtrStateInvalid || errors.Cause(err) == define.ErrCtrStopped {
+			if errors.Is(err, define.ErrCtrStateInvalid) || errors.Is(err, define.ErrCtrStopped) {
 				continue
 			}
 			ctrErrors[id] = err
@@ -432,7 +432,7 @@ func (p *Pod) Unpause(ctx context.Context) (map[string]error, error) {
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(define.ErrPodPartialFail, "error unpausing some containers")
+		return ctrErrors, fmt.Errorf("error unpausing some containers: %w", define.ErrPodPartialFail)
 	}
 	return nil, nil
 }
@@ -470,7 +470,7 @@ func (p *Pod) Restart(ctx context.Context) (map[string]error, error) {
 	// Build a dependency graph of containers in the pod
 	graph, err := BuildContainerGraph(allCtrs)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error generating dependency graph for pod %s", p.ID())
+		return nil, fmt.Errorf("error generating dependency graph for pod %s: %w", p.ID(), err)
 	}
 
 	ctrErrors := make(map[string]error)
@@ -479,7 +479,7 @@ func (p *Pod) Restart(ctx context.Context) (map[string]error, error) {
 	// If there are no containers without dependencies, we can't start
 	// Error out
 	if len(graph.noDepNodes) == 0 {
-		return nil, errors.Wrapf(define.ErrNoSuchCtr, "no containers in pod %s have no dependencies, cannot start pod", p.ID())
+		return nil, fmt.Errorf("no containers in pod %s have no dependencies, cannot start pod: %w", p.ID(), define.ErrNoSuchCtr)
 	}
 
 	// Traverse the graph beginning at nodes with no dependencies
@@ -488,7 +488,7 @@ func (p *Pod) Restart(ctx context.Context) (map[string]error, error) {
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(define.ErrPodPartialFail, "error stopping some containers")
+		return ctrErrors, fmt.Errorf("error stopping some containers: %w", define.ErrPodPartialFail)
 	}
 	p.newPodEvent(events.Stop)
 	p.newPodEvent(events.Start)
@@ -539,7 +539,7 @@ func (p *Pod) Kill(ctx context.Context, signal uint) (map[string]error, error) {
 	// Get returned error for every container we worked on
 	for id, channel := range ctrErrChan {
 		if err := <-channel; err != nil {
-			if errors.Cause(err) == define.ErrCtrStateInvalid || errors.Cause(err) == define.ErrCtrStopped {
+			if errors.Is(err, define.ErrCtrStateInvalid) || errors.Is(err, define.ErrCtrStopped) {
 				continue
 			}
 			ctrErrors[id] = err
@@ -547,7 +547,7 @@ func (p *Pod) Kill(ctx context.Context, signal uint) (map[string]error, error) {
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(define.ErrPodPartialFail, "error killing some containers")
+		return ctrErrors, fmt.Errorf("error killing some containers: %w", define.ErrPodPartialFail)
 	}
 
 	if err := p.maybeStopServiceContainer(); err != nil {

--- a/libpod/pod_internal.go
+++ b/libpod/pod_internal.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/storage/pkg/stringid"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -39,7 +38,7 @@ func (p *Pod) updatePod() error {
 // Save pod state to database
 func (p *Pod) save() error {
 	if err := p.runtime.state.SavePod(p); err != nil {
-		return errors.Wrapf(err, "error saving pod %s state", p.ID())
+		return fmt.Errorf("error saving pod %s state: %w", p.ID(), err)
 	}
 
 	return nil
@@ -61,7 +60,7 @@ func (p *Pod) refresh() error {
 	// Retrieve the pod's lock
 	lock, err := p.runtime.lockManager.AllocateAndRetrieveLock(p.config.LockID)
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving lock %d for pod %s", p.config.LockID, p.ID())
+		return fmt.Errorf("error retrieving lock %d for pod %s: %w", p.config.LockID, p.ID(), err)
 	}
 	p.lock = lock
 
@@ -81,7 +80,7 @@ func (p *Pod) refresh() error {
 				logrus.Debugf("setting pod cgroup to %s", p.state.CgroupPath)
 			}
 		default:
-			return errors.Wrapf(define.ErrInvalidArg, "unknown cgroups manager %s specified", p.runtime.config.Engine.CgroupManager)
+			return fmt.Errorf("unknown cgroups manager %s specified: %w", p.runtime.config.Engine.CgroupManager, define.ErrInvalidArg)
 		}
 	}
 

--- a/libpod/service.go
+++ b/libpod/service.go
@@ -2,10 +2,10 @@ package libpod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -29,7 +29,7 @@ func (p *Pod) hasServiceContainer() bool {
 func (p *Pod) serviceContainer() (*Container, error) {
 	id := p.config.ServiceContainerID
 	if id == "" {
-		return nil, errors.Wrap(define.ErrNoSuchCtr, "pod has no service container")
+		return nil, fmt.Errorf("pod has no service container: %w", define.ErrNoSuchCtr)
 	}
 	return p.runtime.state.Container(id)
 }

--- a/libpod/shutdown/handler.go
+++ b/libpod/shutdown/handler.go
@@ -1,18 +1,18 @@
 package shutdown
 
 import (
+	"errors"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
 	logrusImport "github.com/sirupsen/logrus"
 )
 
 var (
-	ErrHandlerExists error = errors.New("handler with given name already exists")
+	ErrHandlerExists = errors.New("handler with given name already exists")
 )
 
 var (

--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -4,6 +4,7 @@
 package libpod
 
 import (
+	"fmt"
 	"math"
 	"strings"
 	"syscall"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/containers/common/pkg/cgroups"
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/pkg/errors"
 )
 
 // GetContainerStats gets the running stats for a given container.
@@ -25,7 +25,7 @@ func (c *Container) GetContainerStats(previousStats *define.ContainerStats) (*de
 	stats.Name = c.Name()
 
 	if c.config.NoCgroups {
-		return nil, errors.Wrapf(define.ErrNoCgroups, "cannot run top on container %s as it did not create a cgroup", c.ID())
+		return nil, fmt.Errorf("cannot run top on container %s as it did not create a cgroup: %w", c.ID(), define.ErrNoCgroups)
 	}
 
 	if !c.batched {
@@ -55,13 +55,13 @@ func (c *Container) GetContainerStats(previousStats *define.ContainerStats) (*de
 	}
 	cgroup, err := cgroups.Load(cgroupPath)
 	if err != nil {
-		return stats, errors.Wrapf(err, "unable to load cgroup at %s", cgroupPath)
+		return stats, fmt.Errorf("unable to load cgroup at %s: %w", cgroupPath, err)
 	}
 
 	// Ubuntu does not have swap memory in cgroups because swap is often not enabled.
 	cgroupStats, err := cgroup.Stat()
 	if err != nil {
-		return stats, errors.Wrapf(err, "unable to obtain cgroup stats")
+		return stats, fmt.Errorf("unable to obtain cgroup stats: %w", err)
 	}
 	conState := c.state.State
 	netStats, err := getContainerNetIO(c)

--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	istorage "github.com/containers/image/v5/storage"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -184,7 +184,7 @@ func (r *storageService) DeleteContainer(idOrName string) error {
 	}
 	err = r.store.DeleteContainer(container.ID)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrNotAContainer || errors.Cause(err) == storage.ErrContainerUnknown {
+		if errors.Is(err, storage.ErrNotAContainer) || errors.Is(err, storage.ErrContainerUnknown) {
 			logrus.Infof("Storage for container %s already removed", container.ID)
 		} else {
 			logrus.Debugf("Failed to delete container %q: %v", container.ID, err)
@@ -218,7 +218,7 @@ func (r *storageService) GetContainerMetadata(idOrName string) (RuntimeContainer
 func (r *storageService) MountContainerImage(idOrName string) (string, error) {
 	container, err := r.store.Container(idOrName)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrContainerUnknown {
+		if errors.Is(err, storage.ErrContainerUnknown) {
 			return "", define.ErrNoSuchCtr
 		}
 		return "", err
@@ -281,7 +281,7 @@ func (r *storageService) MountedContainerImage(idOrName string) (int, error) {
 func (r *storageService) GetMountpoint(id string) (string, error) {
 	container, err := r.store.Container(id)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrContainerUnknown {
+		if errors.Is(err, storage.ErrContainerUnknown) {
 			return "", define.ErrNoSuchCtr
 		}
 		return "", err
@@ -297,7 +297,7 @@ func (r *storageService) GetMountpoint(id string) (string, error) {
 func (r *storageService) GetWorkDir(id string) (string, error) {
 	container, err := r.store.Container(id)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrContainerUnknown {
+		if errors.Is(err, storage.ErrContainerUnknown) {
 			return "", define.ErrNoSuchCtr
 		}
 		return "", err
@@ -308,7 +308,7 @@ func (r *storageService) GetWorkDir(id string) (string, error) {
 func (r *storageService) GetRunDir(id string) (string, error) {
 	container, err := r.store.Container(id)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrContainerUnknown {
+		if errors.Is(err, storage.ErrContainerUnknown) {
 			return "", define.ErrNoSuchCtr
 		}
 		return "", err

--- a/libpod/util_linux.go
+++ b/libpod/util_linux.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/pkg/rootless"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -30,7 +29,7 @@ func systemdSliceFromPath(parent, name string, resources *spec.LinuxResources) (
 	logrus.Debugf("Created cgroup path %s for parent %s and name %s", cgroupPath, parent, name)
 
 	if err := makeSystemdCgroup(cgroupPath, resources); err != nil {
-		return "", errors.Wrapf(err, "error creating cgroup %s", cgroupPath)
+		return "", fmt.Errorf("error creating cgroup %s: %w", cgroupPath, err)
 	}
 
 	logrus.Debugf("Created cgroup %s", cgroupPath)
@@ -95,7 +94,7 @@ func assembleSystemdCgroupName(baseSlice, newSlice string) (string, error) {
 	const sliceSuffix = ".slice"
 
 	if !strings.HasSuffix(baseSlice, sliceSuffix) {
-		return "", errors.Wrapf(define.ErrInvalidArg, "cannot assemble cgroup path with base %q - must end in .slice", baseSlice)
+		return "", fmt.Errorf("cannot assemble cgroup path with base %q - must end in .slice: %w", baseSlice, define.ErrInvalidArg)
 	}
 
 	noSlice := strings.TrimSuffix(baseSlice, sliceSuffix)
@@ -113,17 +112,17 @@ var lvpReleaseLabel = label.ReleaseLabel
 func LabelVolumePath(path string) error {
 	_, mountLabel, err := lvpInitLabels([]string{})
 	if err != nil {
-		return errors.Wrapf(err, "error getting default mountlabels")
+		return fmt.Errorf("error getting default mountlabels: %w", err)
 	}
 	if err := lvpReleaseLabel(mountLabel); err != nil {
-		return errors.Wrapf(err, "error releasing label %q", mountLabel)
+		return fmt.Errorf("error releasing label %q: %w", mountLabel, err)
 	}
 
 	if err := lvpRelabel(path, mountLabel, true); err != nil {
 		if err == syscall.ENOTSUP {
 			logrus.Debugf("Labeling not supported on %q", path)
 		} else {
-			return errors.Wrapf(err, "error setting selinux label for %s to %q as shared", path, mountLabel)
+			return fmt.Errorf("error setting selinux label for %s to %q as shared: %w", path, mountLabel, err)
 		}
 	}
 	return nil

--- a/libpod/volume_inspect.go
+++ b/libpod/volume_inspect.go
@@ -1,9 +1,10 @@
 package libpod
 
 import (
+	"fmt"
+
 	"github.com/containers/podman/v4/libpod/define"
 	pluginapi "github.com/docker/go-plugins-helpers/volume"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -29,7 +30,7 @@ func (v *Volume) Inspect() (*define.InspectVolumeData, error) {
 		data.Mountpoint = v.state.MountPoint
 
 		if v.plugin == nil {
-			return nil, errors.Wrapf(define.ErrMissingPlugin, "volume %s uses volume plugin %s but it is not available, cannot inspect", v.Name(), v.config.Driver)
+			return nil, fmt.Errorf("volume %s uses volume plugin %s but it is not available, cannot inspect: %w", v.Name(), v.config.Driver, define.ErrMissingPlugin)
 		}
 
 		// Retrieve status for the volume.
@@ -38,7 +39,7 @@ func (v *Volume) Inspect() (*define.InspectVolumeData, error) {
 		req.Name = v.Name()
 		resp, err := v.plugin.GetVolume(req)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error retrieving volume %s information from plugin %s", v.Name(), v.Driver())
+			return nil, fmt.Errorf("error retrieving volume %s information from plugin %s: %w", v.Name(), v.Driver(), err)
 		}
 		if resp != nil {
 			data.Status = resp.Status

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -1,11 +1,11 @@
 package libpod
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/pkg/errors"
 )
 
 // Creates a new volume
@@ -90,7 +90,7 @@ func (v *Volume) save() error {
 func (v *Volume) refresh() error {
 	lock, err := v.runtime.lockManager.AllocateAndRetrieveLock(v.config.LockID)
 	if err != nil {
-		return errors.Wrapf(err, "acquiring lock %d for volume %s", v.config.LockID, v.Name())
+		return fmt.Errorf("acquiring lock %d for volume %s: %w", v.config.LockID, v.Name(), err)
 	}
 	v.lock = lock
 

--- a/pkg/api/handlers/compat/containers_archive.go
+++ b/pkg/api/handlers/compat/containers_archive.go
@@ -2,9 +2,12 @@ package compat
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
+
+	"errors"
 
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/libpod/define"
@@ -14,7 +17,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -28,7 +30,7 @@ func Archive(w http.ResponseWriter, r *http.Request) {
 	case http.MethodHead, http.MethodGet:
 		handleHeadAndGet(w, r, decoder, runtime)
 	default:
-		utils.Error(w, http.StatusNotImplemented, errors.Errorf("unsupported method: %v", r.Method))
+		utils.Error(w, http.StatusNotImplemented, fmt.Errorf("unsupported method: %v", r.Method))
 	}
 }
 
@@ -39,7 +41,7 @@ func handleHeadAndGet(w http.ResponseWriter, r *http.Request, decoder *schema.De
 
 	err := decoder.Decode(&query, r.URL.Query())
 	if err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrap(err, "couldn't decode the query"))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("couldn't decode the query: %w", err))
 		return
 	}
 
@@ -65,7 +67,7 @@ func handleHeadAndGet(w http.ResponseWriter, r *http.Request, decoder *schema.De
 		w.Header().Add(copy.XDockerContainerPathStatHeader, statHeader)
 	}
 
-	if errors.Cause(err) == define.ErrNoSuchCtr || errors.Cause(err) == copy.ErrENOENT {
+	if errors.Is(err, define.ErrNoSuchCtr) || errors.Is(err, copy.ErrENOENT) {
 		// 404 is returned for an absent container and path.  The
 		// clients must deal with it accordingly.
 		utils.Error(w, http.StatusNotFound, err)
@@ -105,14 +107,14 @@ func handlePut(w http.ResponseWriter, r *http.Request, decoder *schema.Decoder, 
 
 	err := decoder.Decode(&query, r.URL.Query())
 	if err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrap(err, "couldn't decode the query"))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("couldn't decode the query: %w", err))
 		return
 	}
 
 	var rename map[string]string
 	if query.Rename != "" {
 		if err := json.Unmarshal([]byte(query.Rename), &rename); err != nil {
-			utils.Error(w, http.StatusBadRequest, errors.Wrap(err, "couldn't decode the query field 'rename'"))
+			utils.Error(w, http.StatusBadRequest, fmt.Errorf("couldn't decode the query field 'rename': %w", err))
 			return
 		}
 	}
@@ -128,10 +130,10 @@ func handlePut(w http.ResponseWriter, r *http.Request, decoder *schema.Decoder, 
 		})
 	if err != nil {
 		switch {
-		case errors.Cause(err) == define.ErrNoSuchCtr || os.IsNotExist(err):
+		case errors.Is(err, define.ErrNoSuchCtr) || os.IsNotExist(err):
 			// 404 is returned for an absent container and path.  The
 			// clients must deal with it accordingly.
-			utils.Error(w, http.StatusNotFound, errors.Wrap(err, "the container doesn't exists"))
+			utils.Error(w, http.StatusNotFound, fmt.Errorf("the container doesn't exists: %w", err))
 		case strings.Contains(err.Error(), "copier: put: error creating file"):
 			// Not the best test but need to break this out for compatibility
 			// See vendor/github.com/containers/buildah/copier/copier.go:1585

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -2,6 +2,7 @@ package compat
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -26,7 +27,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 func CreateContainer(w http.ResponseWriter, r *http.Request) {
@@ -38,14 +38,14 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
 	// compatible configuration
 	body := handlers.CreateContainerConfig{}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("decode(): %w", err))
 		return
 	}
 
@@ -53,37 +53,37 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	body.Name = query.Name
 
 	if len(body.HostConfig.Links) > 0 {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(utils.ErrLinkNotSupport, "bad parameter"))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("bad parameter: %w", utils.ErrLinkNotSupport))
 		return
 	}
 	rtc, err := runtime.GetConfig()
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to get runtime config"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to get runtime config: %w", err))
 		return
 	}
 
 	imageName, err := utils.NormalizeToDockerHub(r, body.Config.Image)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("error normalizing image: %w", err))
 		return
 	}
 	body.Config.Image = imageName
 
 	newImage, resolvedName, err := runtime.LibimageRuntime().LookupImage(body.Config.Image, nil)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrImageUnknown {
-			utils.Error(w, http.StatusNotFound, errors.Wrap(err, "No such image"))
+		if errors.Is(err, storage.ErrImageUnknown) {
+			utils.Error(w, http.StatusNotFound, fmt.Errorf("no such image: %w", err))
 			return
 		}
 
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error looking up image"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("error looking up image: %w", err))
 		return
 	}
 
 	// Take body structure and convert to cliopts
 	cliOpts, args, err := cliOpts(body, rtc)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "make cli opts()"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("make cli opts(): %w", err))
 		return
 	}
 
@@ -100,7 +100,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 
 	sg := specgen.NewSpecGenerator(imgNameOrID, cliOpts.RootFS)
 	if err := specgenutil.FillOutSpecGen(sg, cliOpts, args); err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "fill out specgen"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("fill out specgen: %w", err))
 		return
 	}
 	// moby always create the working directory
@@ -109,7 +109,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	ic := abi.ContainerEngine{Libpod: runtime}
 	report, err := ic.ContainerCreate(r.Context(), sg)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "container create"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("container create: %w", err))
 		return
 	}
 	createResponse := entities.ContainerCreateResponse{
@@ -300,7 +300,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 				if len(endpoint.IPAddress) > 0 {
 					staticIP := net.ParseIP(endpoint.IPAddress)
 					if staticIP == nil {
-						return nil, nil, errors.Errorf("failed to parse the ip address %q", endpoint.IPAddress)
+						return nil, nil, fmt.Errorf("failed to parse the ip address %q", endpoint.IPAddress)
 					}
 					netOpts.StaticIPs = append(netOpts.StaticIPs, staticIP)
 				}
@@ -310,7 +310,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 					if len(endpoint.IPAMConfig.IPv4Address) > 0 {
 						staticIP := net.ParseIP(endpoint.IPAMConfig.IPv4Address)
 						if staticIP == nil {
-							return nil, nil, errors.Errorf("failed to parse the ipv4 address %q", endpoint.IPAMConfig.IPv4Address)
+							return nil, nil, fmt.Errorf("failed to parse the ipv4 address %q", endpoint.IPAMConfig.IPv4Address)
 						}
 						netOpts.StaticIPs = append(netOpts.StaticIPs, staticIP)
 					}
@@ -318,7 +318,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 					if len(endpoint.IPAMConfig.IPv6Address) > 0 {
 						staticIP := net.ParseIP(endpoint.IPAMConfig.IPv6Address)
 						if staticIP == nil {
-							return nil, nil, errors.Errorf("failed to parse the ipv6 address %q", endpoint.IPAMConfig.IPv6Address)
+							return nil, nil, fmt.Errorf("failed to parse the ipv6 address %q", endpoint.IPAMConfig.IPv6Address)
 						}
 						netOpts.StaticIPs = append(netOpts.StaticIPs, staticIP)
 					}
@@ -327,7 +327,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 				if len(endpoint.MacAddress) > 0 {
 					staticMac, err := net.ParseMAC(endpoint.MacAddress)
 					if err != nil {
-						return nil, nil, errors.Errorf("failed to parse the mac address %q", endpoint.MacAddress)
+						return nil, nil, fmt.Errorf("failed to parse the mac address %q", endpoint.MacAddress)
 					}
 					netOpts.StaticMAC = types.HardwareAddr(staticMac)
 				}
@@ -433,7 +433,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 	}
 	if cc.HostConfig.Resources.NanoCPUs > 0 {
 		if cliOpts.CPUPeriod != 0 || cliOpts.CPUQuota != 0 {
-			return nil, nil, errors.Errorf("NanoCpus conflicts with CpuPeriod and CpuQuota")
+			return nil, nil, fmt.Errorf("NanoCpus conflicts with CpuPeriod and CpuQuota")
 		}
 		cliOpts.CPUPeriod = 100000
 		cliOpts.CPUQuota = cc.HostConfig.Resources.NanoCPUs / 10000
@@ -479,7 +479,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 		}
 		if err := os.MkdirAll(vol, 0o755); err != nil {
 			if !os.IsExist(err) {
-				return nil, nil, errors.Wrapf(err, "error making volume mountpoint for volume %s", vol)
+				return nil, nil, fmt.Errorf("error making volume mountpoint for volume %s: %w", vol, err)
 			}
 		}
 	}

--- a/pkg/api/handlers/compat/containers_restart.go
+++ b/pkg/api/handlers/compat/containers_restart.go
@@ -1,6 +1,8 @@
 package compat
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
@@ -10,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 func RestartContainer(w http.ResponseWriter, r *http.Request) {
@@ -29,7 +30,7 @@ func RestartContainer(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -44,7 +45,7 @@ func RestartContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	report, err := containerEngine.ContainerRestart(r.Context(), []string{name}, options)
 	if err != nil {
-		if errors.Cause(err) == define.ErrNoSuchCtr {
+		if errors.Is(err, define.ErrNoSuchCtr) {
 			utils.ContainerNotFound(w, name, err)
 			return
 		}

--- a/pkg/api/handlers/compat/containers_stop.go
+++ b/pkg/api/handlers/compat/containers_stop.go
@@ -1,6 +1,8 @@
 package compat
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
@@ -10,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 func StopContainer(w http.ResponseWriter, r *http.Request) {
@@ -29,7 +30,7 @@ func StopContainer(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -63,7 +64,7 @@ func StopContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	report, err := containerEngine.ContainerStop(r.Context(), []string{name}, options)
 	if err != nil {
-		if errors.Cause(err) == define.ErrNoSuchCtr {
+		if errors.Is(err, define.ErrNoSuchCtr) {
 			utils.ContainerNotFound(w, name, err)
 			return
 		}

--- a/pkg/api/handlers/compat/images_remove.go
+++ b/pkg/api/handlers/compat/images_remove.go
@@ -1,6 +1,8 @@
 package compat
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
@@ -10,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	"github.com/containers/storage"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 func RemoveImage(w http.ResponseWriter, r *http.Request) {
@@ -25,7 +26,7 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 	if _, found := r.URL.Query()["noprune"]; found {
@@ -36,7 +37,7 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, name)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("error normalizing image: %w", err))
 		return
 	}
 
@@ -48,12 +49,12 @@ func RemoveImage(w http.ResponseWriter, r *http.Request) {
 	report, rmerrors := imageEngine.Remove(r.Context(), []string{possiblyNormalizedName}, options)
 	if len(rmerrors) > 0 && rmerrors[0] != nil {
 		err := rmerrors[0]
-		if errors.Cause(err) == storage.ErrImageUnknown {
-			utils.ImageNotFound(w, name, errors.Wrapf(err, "failed to find image %s", name))
+		if errors.Is(err, storage.ErrImageUnknown) {
+			utils.ImageNotFound(w, name, fmt.Errorf("failed to find image %s: %w", name, err))
 			return
 		}
-		if errors.Cause(err) == storage.ErrImageUsedByContainer {
-			utils.Error(w, http.StatusConflict, errors.Wrapf(err, "image %s is in use", name))
+		if errors.Is(err, storage.ErrImageUsedByContainer) {
+			utils.Error(w, http.StatusConflict, fmt.Errorf("image %s is in use: %w", name, err))
 			return
 		}
 		utils.Error(w, http.StatusInternalServerError, err)

--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -2,6 +2,7 @@ package compat
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -19,7 +20,6 @@ import (
 
 	dockerNetwork "github.com/docker/docker/api/types/network"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,7 +36,7 @@ func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -133,7 +133,7 @@ func ListNetworks(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -167,7 +167,7 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 	)
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	if err := json.NewDecoder(r.Body).Decode(&networkCreate); err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("Decode(): %w", err))
 		return
 	}
 
@@ -227,7 +227,7 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 				var err error
 				subnet, err := nettypes.ParseCIDR(conf.Subnet)
 				if err != nil {
-					utils.InternalServerError(w, errors.Wrap(err, "failed to parse subnet"))
+					utils.InternalServerError(w, fmt.Errorf("failed to parse subnet: %w", err))
 					return
 				}
 				s.Subnet = subnet
@@ -235,7 +235,7 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 			if len(conf.Gateway) > 0 {
 				gw := net.ParseIP(conf.Gateway)
 				if gw == nil {
-					utils.InternalServerError(w, errors.Errorf("failed to parse gateway ip %s", conf.Gateway))
+					utils.InternalServerError(w, fmt.Errorf("failed to parse gateway ip %s", conf.Gateway))
 					return
 				}
 				s.Gateway = gw
@@ -243,17 +243,17 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 			if len(conf.IPRange) > 0 {
 				_, net, err := net.ParseCIDR(conf.IPRange)
 				if err != nil {
-					utils.InternalServerError(w, errors.Wrap(err, "failed to parse ip range"))
+					utils.InternalServerError(w, fmt.Errorf("failed to parse ip range: %w", err))
 					return
 				}
 				startIP, err := netutil.FirstIPInSubnet(net)
 				if err != nil {
-					utils.InternalServerError(w, errors.Wrap(err, "failed to get first ip in range"))
+					utils.InternalServerError(w, fmt.Errorf("failed to get first ip in range: %w", err))
 					return
 				}
 				lastIP, err := netutil.LastIPInSubnet(net)
 				if err != nil {
-					utils.InternalServerError(w, errors.Wrap(err, "failed to get last ip in range"))
+					utils.InternalServerError(w, fmt.Errorf("failed to get last ip in range: %w", err))
 					return
 				}
 				s.LeaseRange = &nettypes.LeaseRange{
@@ -296,7 +296,7 @@ func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -312,12 +312,12 @@ func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(reports) == 0 {
-		utils.Error(w, http.StatusInternalServerError, errors.Errorf("internal error"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("internal error"))
 		return
 	}
 	report := reports[0]
 	if report.Err != nil {
-		if errors.Cause(report.Err) == define.ErrNoSuchNetwork {
+		if errors.Is(report.Err, define.ErrNoSuchNetwork) {
 			utils.Error(w, http.StatusNotFound, define.ErrNoSuchNetwork)
 			return
 		}
@@ -334,7 +334,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 
 	var netConnect types.NetworkConnect
 	if err := json.NewDecoder(r.Body).Decode(&netConnect); err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("Decode(): %w", err))
 		return
 	}
 
@@ -351,7 +351,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 			staticIP := net.ParseIP(netConnect.EndpointConfig.IPAddress)
 			if staticIP == nil {
 				utils.Error(w, http.StatusInternalServerError,
-					errors.Errorf("failed to parse the ip address %q", netConnect.EndpointConfig.IPAddress))
+					fmt.Errorf("failed to parse the ip address %q", netConnect.EndpointConfig.IPAddress))
 				return
 			}
 			netOpts.StaticIPs = append(netOpts.StaticIPs, staticIP)
@@ -363,7 +363,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 				staticIP := net.ParseIP(netConnect.EndpointConfig.IPAMConfig.IPv4Address)
 				if staticIP == nil {
 					utils.Error(w, http.StatusInternalServerError,
-						errors.Errorf("failed to parse the ipv4 address %q", netConnect.EndpointConfig.IPAMConfig.IPv4Address))
+						fmt.Errorf("failed to parse the ipv4 address %q", netConnect.EndpointConfig.IPAMConfig.IPv4Address))
 					return
 				}
 				netOpts.StaticIPs = append(netOpts.StaticIPs, staticIP)
@@ -373,7 +373,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 				staticIP := net.ParseIP(netConnect.EndpointConfig.IPAMConfig.IPv6Address)
 				if staticIP == nil {
 					utils.Error(w, http.StatusInternalServerError,
-						errors.Errorf("failed to parse the ipv6 address %q", netConnect.EndpointConfig.IPAMConfig.IPv6Address))
+						fmt.Errorf("failed to parse the ipv6 address %q", netConnect.EndpointConfig.IPAMConfig.IPv6Address))
 					return
 				}
 				netOpts.StaticIPs = append(netOpts.StaticIPs, staticIP)
@@ -384,7 +384,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 			staticMac, err := net.ParseMAC(netConnect.EndpointConfig.MacAddress)
 			if err != nil {
 				utils.Error(w, http.StatusInternalServerError,
-					errors.Errorf("failed to parse the mac address %q", netConnect.EndpointConfig.IPAMConfig.IPv6Address))
+					fmt.Errorf("failed to parse the mac address %q", netConnect.EndpointConfig.IPAMConfig.IPv6Address))
 				return
 			}
 			netOpts.StaticMAC = nettypes.HardwareAddr(staticMac)
@@ -392,11 +392,11 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 	}
 	err := runtime.ConnectContainerToNetwork(netConnect.Container, name, netOpts)
 	if err != nil {
-		if errors.Cause(err) == define.ErrNoSuchCtr {
+		if errors.Is(err, define.ErrNoSuchCtr) {
 			utils.ContainerNotFound(w, netConnect.Container, err)
 			return
 		}
-		if errors.Cause(err) == define.ErrNoSuchNetwork {
+		if errors.Is(err, define.ErrNoSuchNetwork) {
 			utils.Error(w, http.StatusNotFound, err)
 			return
 		}
@@ -412,18 +412,18 @@ func Disconnect(w http.ResponseWriter, r *http.Request) {
 
 	var netDisconnect types.NetworkDisconnect
 	if err := json.NewDecoder(r.Body).Decode(&netDisconnect); err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("Decode(): %w", err))
 		return
 	}
 
 	name := utils.GetName(r)
 	err := runtime.DisconnectContainerFromNetwork(netDisconnect.Container, name, netDisconnect.Force)
 	if err != nil {
-		if errors.Cause(err) == define.ErrNoSuchCtr {
+		if errors.Is(err, define.ErrNoSuchCtr) {
 			utils.Error(w, http.StatusNotFound, err)
 			return
 		}
-		if errors.Cause(err) == define.ErrNoSuchNetwork {
+		if errors.Is(err, define.ErrNoSuchNetwork) {
 			utils.Error(w, http.StatusNotFound, err)
 			return
 		}
@@ -438,7 +438,7 @@ func Prune(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("Decode(): %w", err))
 		return
 	}
 

--- a/pkg/api/handlers/compat/resize.go
+++ b/pkg/api/handlers/compat/resize.go
@@ -1,6 +1,7 @@
 package compat
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -11,7 +12,6 @@ import (
 	api "github.com/containers/podman/v4/pkg/api/types"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 func ResizeTTY(w http.ResponseWriter, r *http.Request) {
@@ -28,7 +28,7 @@ func ResizeTTY(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -47,8 +47,8 @@ func ResizeTTY(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := ctnr.AttachResize(sz); err != nil {
-			if errors.Cause(err) != define.ErrCtrStateInvalid {
-				utils.InternalServerError(w, errors.Wrapf(err, "cannot resize container"))
+			if !errors.Is(err, define.ErrCtrStateInvalid) {
+				utils.InternalServerError(w, fmt.Errorf("cannot resize container: %w", err))
 			} else {
 				utils.Error(w, http.StatusConflict, err)
 			}
@@ -65,15 +65,15 @@ func ResizeTTY(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if state, err := ctnr.State(); err != nil {
-			utils.InternalServerError(w, errors.Wrapf(err, "cannot obtain session container state"))
+			utils.InternalServerError(w, fmt.Errorf("cannot obtain session container state: %w", err))
 			return
 		} else if state != define.ContainerStateRunning && !query.IgnoreNotRunning {
 			utils.Error(w, http.StatusConflict, fmt.Errorf("container %q in wrong state %q", name, state.String()))
 			return
 		}
 		if err := ctnr.ExecResize(name, sz); err != nil {
-			if errors.Cause(err) != define.ErrExecSessionStateInvalid || !query.IgnoreNotRunning {
-				utils.InternalServerError(w, errors.Wrapf(err, "cannot resize session"))
+			if !errors.Is(err, define.ErrExecSessionStateInvalid) || !query.IgnoreNotRunning {
+				utils.InternalServerError(w, fmt.Errorf("cannot resize session: %w", err))
 				return
 			}
 		}

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -29,7 +30,6 @@ import (
 	utils2 "github.com/containers/podman/v4/utils"
 	"github.com/containers/storage"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 // Commit
@@ -50,11 +50,11 @@ func ImageExists(w http.ResponseWriter, r *http.Request) {
 	ir := abi.ImageEngine{Libpod: runtime}
 	report, err := ir.Exists(r.Context(), name)
 	if err != nil {
-		utils.Error(w, http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
+		utils.Error(w, http.StatusNotFound, fmt.Errorf("failed to find image %s: %w", name, err))
 		return
 	}
 	if !report.Value {
-		utils.Error(w, http.StatusNotFound, errors.Errorf("failed to find image %s", name))
+		utils.Error(w, http.StatusNotFound, fmt.Errorf("failed to find image %s", name))
 		return
 	}
 	utils.WriteResponse(w, http.StatusNoContent, "")
@@ -70,18 +70,18 @@ func ImageTree(w http.ResponseWriter, r *http.Request) {
 		WhatRequires: false,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 	ir := abi.ImageEngine{Libpod: runtime}
 	options := entities.ImageTreeOptions{WhatRequires: query.WhatRequires}
 	report, err := ir.Tree(r.Context(), name, options)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrImageUnknown {
-			utils.Error(w, http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
+		if errors.Is(err, storage.ErrImageUnknown) {
+			utils.Error(w, http.StatusNotFound, fmt.Errorf("failed to find image %s: %w", name, err))
 			return
 		}
-		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to generate image tree for %s", name))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to generate image tree for %s: %w", name, err))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, report)
@@ -91,13 +91,13 @@ func GetImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	newImage, err := utils.GetImage(r, name)
 	if err != nil {
-		utils.Error(w, http.StatusNotFound, errors.Wrapf(err, "failed to find image %s", name))
+		utils.Error(w, http.StatusNotFound, fmt.Errorf("failed to find image %s: %w", name, err))
 		return
 	}
 	options := &libimage.InspectOptions{WithParent: true, WithSize: true}
 	inspect, err := newImage.Inspect(r.Context(), options)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed in inspect image %s", inspect.ID))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed in inspect image %s: %w", inspect.ID, err))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, inspect)
@@ -117,15 +117,13 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError,
-			errors.
-				Wrapf(err, "failed to decode filter parameters for %s", r.URL.String()))
+			fmt.Errorf("failed to decode filter parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusInternalServerError,
-			errors.
-				Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+			fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -174,7 +172,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+			fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 	name := utils.GetName(r)
@@ -188,23 +186,23 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 	case define.OCIArchive, define.V2s2Archive:
 		tmpfile, err := ioutil.TempFile("", "api.tar")
 		if err != nil {
-			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 			return
 		}
 		output = tmpfile.Name()
 		if err := tmpfile.Close(); err != nil {
-			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
+			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to close tempfile: %w", err))
 			return
 		}
 	case define.OCIManifestDir, define.V2s2ManifestDir:
 		tmpdir, err := ioutil.TempDir("", "save")
 		if err != nil {
-			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempdir"))
+			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempdir: %w", err))
 			return
 		}
 		output = tmpdir
 	default:
-		utils.Error(w, http.StatusInternalServerError, errors.Errorf("unknown format %q", query.Format))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unknown format %q", query.Format))
 		return
 	}
 
@@ -233,7 +231,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 	}
 	rdr, err := os.Open(output)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to read the exported tarfile: %w", err))
 		return
 	}
 	defer rdr.Close()
@@ -254,20 +252,20 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
 	// References are mandatory!
 	if len(query.References) == 0 {
-		utils.Error(w, http.StatusBadRequest, errors.New("No references"))
+		utils.Error(w, http.StatusBadRequest, errors.New("no references"))
 		return
 	}
 
 	// Format is mandatory! Currently, we only support multi-image docker
 	// archives.
 	if len(query.References) > 1 && query.Format != define.V2s2Archive {
-		utils.Error(w, http.StatusInternalServerError, errors.Errorf("multi-image archives must use format of %s", define.V2s2Archive))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("multi-image archives must use format of %s", define.V2s2Archive))
 		return
 	}
 
@@ -285,23 +283,23 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 	case define.V2s2Archive, define.OCIArchive:
 		tmpfile, err := ioutil.TempFile("", "api.tar")
 		if err != nil {
-			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 			return
 		}
 		output = tmpfile.Name()
 		if err := tmpfile.Close(); err != nil {
-			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
+			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to close tempfile: %w", err))
 			return
 		}
 	case define.OCIManifestDir, define.V2s2ManifestDir:
 		tmpdir, err := ioutil.TempDir("", "save")
 		if err != nil {
-			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tmpdir"))
+			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tmpdir: %w", err))
 			return
 		}
 		output = tmpdir
 	default:
-		utils.Error(w, http.StatusInternalServerError, errors.Errorf("unsupported format %q", query.Format))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unsupported format %q", query.Format))
 		return
 	}
 	defer os.RemoveAll(output)
@@ -323,7 +321,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 
 	rdr, err := os.Open(output)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to read the exported tarfile: %w", err))
 		return
 	}
 	defer rdr.Close()
@@ -335,7 +333,7 @@ func ImagesLoad(w http.ResponseWriter, r *http.Request) {
 
 	tmpfile, err := ioutil.TempFile("", "libpod-images-load.tar")
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 		return
 	}
 	defer os.Remove(tmpfile.Name())
@@ -344,7 +342,7 @@ func ImagesLoad(w http.ResponseWriter, r *http.Request) {
 	tmpfile.Close()
 
 	if err != nil && err != io.EOF {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to write archive to temporary file"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to write archive to temporary file: %w", err))
 		return
 	}
 
@@ -353,7 +351,7 @@ func ImagesLoad(w http.ResponseWriter, r *http.Request) {
 	loadOptions := entities.ImageLoadOptions{Input: tmpfile.Name()}
 	loadReport, err := imageEngine.Load(r.Context(), loadOptions)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to load image"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to load image: %w", err))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, loadReport)
@@ -375,7 +373,7 @@ func ImagesImport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -384,14 +382,14 @@ func ImagesImport(w http.ResponseWriter, r *http.Request) {
 	if len(query.URL) == 0 {
 		tmpfile, err := ioutil.TempFile("", "libpod-images-import.tar")
 		if err != nil {
-			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 			return
 		}
 		defer os.Remove(tmpfile.Name())
 		defer tmpfile.Close()
 
 		if _, err := io.Copy(tmpfile, r.Body); err != nil && err != io.EOF {
-			utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to write archive to temporary file"))
+			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to write archive to temporary file: %w", err))
 			return
 		}
 
@@ -411,7 +409,7 @@ func ImagesImport(w http.ResponseWriter, r *http.Request) {
 	}
 	report, err := imageEngine.Import(r.Context(), importOptions)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to import tarball"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to import tarball: %w", err))
 		return
 	}
 
@@ -433,7 +431,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		// This is where you can override the golang default value for one of fields
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -479,7 +477,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 	if err := imageEngine.Push(context.Background(), source, destination, options); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "error pushing image %q", destination))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("error pushing image %q: %w", destination, err))
 		return
 	}
 
@@ -509,12 +507,12 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 	rtc, err := runtime.GetConfig()
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to get runtime config"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to get runtime config: %w", err))
 		return
 	}
 	sc := runtime.SystemContext()
@@ -532,7 +530,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	case "docker":
 		mimeType = manifest.DockerV2Schema2MediaType
 	default:
-		utils.InternalServerError(w, errors.Errorf("unrecognized image format %q", query.Format))
+		utils.InternalServerError(w, fmt.Errorf("unrecognized image format %q", query.Format))
 		return
 	}
 	options.CommitOptions = buildah.CommitOptions{
@@ -561,7 +559,7 @@ func CommitContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	commitImage, err := ctr.Commit(r.Context(), destImage, options)
 	if err != nil && !strings.Contains(err.Error(), "is not running") {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "CommitFailure"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("CommitFailure: %w", err))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, entities.IDResponse{ID: commitImage.ID()})
@@ -600,8 +598,8 @@ func UntagImage(w http.ResponseWriter, r *http.Request) {
 
 	name := utils.GetName(r)
 	if err := imageEngine.Untag(r.Context(), name, tags, opts); err != nil {
-		if errors.Cause(err) == storage.ErrImageUnknown {
-			utils.ImageNotFound(w, name, errors.Wrapf(err, "failed to find image %s", name))
+		if errors.Is(err, storage.ErrImageUnknown) {
+			utils.ImageNotFound(w, name, fmt.Errorf("failed to find image %s: %w", name, err))
 		} else {
 			utils.Error(w, http.StatusInternalServerError, err)
 		}
@@ -623,7 +621,7 @@ func ImagesBatchRemove(w http.ResponseWriter, r *http.Request) {
 	}{}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -647,7 +645,7 @@ func ImagesRemove(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -684,7 +682,7 @@ func ImageScp(w http.ResponseWriter, r *http.Request) {
 		// This is where you can override the golang default value for one of fields
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -697,7 +695,7 @@ func ImageScp(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if source != nil || dest != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(define.ErrInvalidArg, "cannot use the user transfer function on the remote client"))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("cannot use the user transfer function on the remote client: %w", define.ErrInvalidArg))
 		return
 	}
 

--- a/pkg/domain/infra/abi/containers_runlabel.go
+++ b/pkg/domain/infra/abi/containers_runlabel.go
@@ -2,6 +2,7 @@ package abi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,7 +15,6 @@ import (
 	envLib "github.com/containers/podman/v4/pkg/env"
 	"github.com/containers/podman/v4/utils"
 	"github.com/google/shlex"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -40,7 +40,7 @@ func (ic *ContainerEngine) ContainerRunlabel(ctx context.Context, label string, 
 	}
 
 	if len(pulledImages) != 1 {
-		return errors.Errorf("internal error: expected an image to be pulled (or an error)")
+		return errors.New("internal error: expected an image to be pulled (or an error)")
 	}
 
 	// Extract the runlabel from the image.
@@ -57,7 +57,7 @@ func (ic *ContainerEngine) ContainerRunlabel(ctx context.Context, label string, 
 		}
 	}
 	if runlabel == "" {
-		return errors.Errorf("cannot find the value of label: %s in image: %s", label, imageRef)
+		return fmt.Errorf("cannot find the value of label: %s in image: %s", label, imageRef)
 	}
 
 	cmd, env, err := generateRunlabelCommand(runlabel, pulledImages[0], imageRef, args, options)
@@ -86,7 +86,7 @@ func (ic *ContainerEngine) ContainerRunlabel(ctx context.Context, label string, 
 				name := cmd[i+1]
 				ctr, err := ic.Libpod.LookupContainer(name)
 				if err != nil {
-					if errors.Cause(err) != define.ErrNoSuchCtr {
+					if !errors.Is(err, define.ErrNoSuchCtr) {
 						logrus.Debugf("Error occurred searching for container %s: %v", name, err)
 						return err
 					}

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -2,6 +2,7 @@ package abi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"io/ioutil"
@@ -34,7 +35,6 @@ import (
 	dockerRef "github.com/docker/distribution/reference"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -128,14 +128,14 @@ func (ir *ImageEngine) History(ctx context.Context, nameOrID string, opts entiti
 
 func (ir *ImageEngine) Mount(ctx context.Context, nameOrIDs []string, opts entities.ImageMountOptions) ([]*entities.ImageMountReport, error) {
 	if opts.All && len(nameOrIDs) > 0 {
-		return nil, errors.Errorf("cannot mix --all with images")
+		return nil, errors.New("cannot mix --all with images")
 	}
 
 	if os.Geteuid() != 0 {
 		if driver := ir.Libpod.StorageConfig().GraphDriverName; driver != "vfs" {
 			// Do not allow to mount a graphdriver that is not vfs if we are creating the userns as part
 			// of the mount command.
-			return nil, errors.Errorf("cannot mount using driver %s in rootless mode", driver)
+			return nil, fmt.Errorf("cannot mount using driver %s in rootless mode", driver)
 		}
 
 		became, ret, err := rootless.BecomeRootInUserNS("")
@@ -194,7 +194,7 @@ func (ir *ImageEngine) Mount(ctx context.Context, nameOrIDs []string, opts entit
 
 func (ir *ImageEngine) Unmount(ctx context.Context, nameOrIDs []string, options entities.ImageUnmountOptions) ([]*entities.ImageUnmountReport, error) {
 	if options.All && len(nameOrIDs) > 0 {
-		return nil, errors.Errorf("cannot mix --all with images")
+		return nil, errors.New("cannot mix --all with images")
 	}
 
 	listImagesOptions := &libimage.ListImagesOptions{}
@@ -292,7 +292,7 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 	case "v2s2", "docker":
 		manifestType = manifest.DockerV2Schema2MediaType
 	default:
-		return errors.Errorf("unknown format %q. Choose on of the supported formats: 'oci', 'v2s1', or 'v2s2'", options.Format)
+		return fmt.Errorf("unknown format %q. Choose on of the supported formats: 'oci', 'v2s1', or 'v2s2'", options.Format)
 	}
 
 	pushOptions := &libimage.PushOptions{}
@@ -523,12 +523,12 @@ func removeErrorsToExitCode(rmErrors []error) int {
 	}
 
 	for _, e := range rmErrors {
-		switch errors.Cause(e) {
-		case storage.ErrImageUnknown, storage.ErrLayerUnknown:
+		//nolint:gocritic
+		if errors.Is(e, storage.ErrImageUnknown) || errors.Is(e, storage.ErrLayerUnknown) {
 			noSuchImageErrors = true
-		case storage.ErrImageUsedByContainer:
+		} else if errors.Is(e, storage.ErrImageUsedByContainer) {
 			inUseErrors = true
-		default:
+		} else {
 			otherErrors = true
 		}
 	}
@@ -590,11 +590,11 @@ func (ir *ImageEngine) Shutdown(_ context.Context) {
 func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entities.SignOptions) (*entities.SignReport, error) {
 	mech, err := signature.NewGPGSigningMechanism()
 	if err != nil {
-		return nil, errors.Wrap(err, "error initializing GPG")
+		return nil, fmt.Errorf("error initializing GPG: %w", err)
 	}
 	defer mech.Close()
 	if err := mech.SupportsSigning(); err != nil {
-		return nil, errors.Wrap(err, "signing is not supported")
+		return nil, fmt.Errorf("signing is not supported: %w", err)
 	}
 	sc := ir.Libpod.SystemContext()
 	sc.DockerCertPath = options.CertDir
@@ -604,11 +604,11 @@ func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entitie
 		err = func() error {
 			srcRef, err := alltransports.ParseImageName(signimage)
 			if err != nil {
-				return errors.Wrapf(err, "error parsing image name")
+				return fmt.Errorf("error parsing image name: %w", err)
 			}
 			rawSource, err := srcRef.NewImageSource(ctx, sc)
 			if err != nil {
-				return errors.Wrapf(err, "error getting image source")
+				return fmt.Errorf("error getting image source: %w", err)
 			}
 			defer func() {
 				if err = rawSource.Close(); err != nil {
@@ -617,17 +617,17 @@ func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entitie
 			}()
 			topManifestBlob, manifestType, err := rawSource.GetManifest(ctx, nil)
 			if err != nil {
-				return errors.Wrapf(err, "error getting manifest blob")
+				return fmt.Errorf("error getting manifest blob: %w", err)
 			}
 			dockerReference := rawSource.Reference().DockerReference()
 			if dockerReference == nil {
-				return errors.Errorf("cannot determine canonical Docker reference for destination %s", transports.ImageName(rawSource.Reference()))
+				return fmt.Errorf("cannot determine canonical Docker reference for destination %s", transports.ImageName(rawSource.Reference()))
 			}
 			var sigStoreDir string
 			if options.Directory != "" {
 				repo := reference.Path(dockerReference)
 				if path.Clean(repo) != repo { // Coverage: This should not be reachable because /./ and /../ components are not valid in docker references
-					return errors.Errorf("Unexpected path elements in Docker reference %s for signature storage", dockerReference.String())
+					return fmt.Errorf("unexpected path elements in Docker reference %s for signature storage", dockerReference.String())
 				}
 				sigStoreDir = filepath.Join(options.Directory, repo)
 			} else {
@@ -647,11 +647,11 @@ func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entitie
 
 			if options.All {
 				if !manifest.MIMETypeIsMultiImage(manifestType) {
-					return errors.Errorf("%s is not a multi-architecture image (manifest type %s)", signimage, manifestType)
+					return fmt.Errorf("%s is not a multi-architecture image (manifest type %s)", signimage, manifestType)
 				}
 				list, err := manifest.ListFromBlob(topManifestBlob, manifestType)
 				if err != nil {
-					return errors.Wrapf(err, "Error parsing manifest list %q", string(topManifestBlob))
+					return fmt.Errorf("error parsing manifest list %q: %w", string(topManifestBlob), err)
 				}
 				instanceDigests := list.Instances()
 				for _, instanceDigest := range instanceDigests {
@@ -661,13 +661,13 @@ func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entitie
 						return err
 					}
 					if err = putSignature(man, mech, sigStoreDir, instanceDigest, dockerReference, options); err != nil {
-						return errors.Wrapf(err, "error storing signature for %s, %v", dockerReference.String(), instanceDigest)
+						return fmt.Errorf("error storing signature for %s, %v: %w", dockerReference.String(), instanceDigest, err)
 					}
 				}
 				return nil
 			}
 			if err = putSignature(topManifestBlob, mech, sigStoreDir, manifestDigest, dockerReference, options); err != nil {
-				return errors.Wrapf(err, "error storing signature for %s, %v", dockerReference.String(), manifestDigest)
+				return fmt.Errorf("error storing signature for %s, %v: %w", dockerReference.String(), manifestDigest, err)
 			}
 			return nil
 		}()
@@ -694,7 +694,7 @@ func (ir *ImageEngine) Scp(ctx context.Context, src, dst string, parentFlags []s
 
 func Transfer(ctx context.Context, source entities.ImageScpOptions, dest entities.ImageScpOptions, parentFlags []string) error {
 	if source.User == "" {
-		return errors.Wrapf(define.ErrInvalidArg, "you must define a user when transferring from root to rootless storage")
+		return fmt.Errorf("you must define a user when transferring from root to rootless storage: %w", define.ErrInvalidArg)
 	}
 	podman, err := os.Executable()
 	if err != nil {
@@ -881,7 +881,7 @@ func getSigFilename(sigStoreDirPath string) (string, error) {
 
 func localPathFromURI(url *url.URL) (string, error) {
 	if url.Scheme != "file" {
-		return "", errors.Errorf("writing to %s is not supported. Use a supported scheme", url.String())
+		return "", fmt.Errorf("writing to %s is not supported. Use a supported scheme", url.String())
 	}
 	return url.Path, nil
 }

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
+
+	"errors"
 
 	"github.com/containers/common/libimage"
 	cp "github.com/containers/image/v5/copy"
@@ -17,7 +20,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,7 +48,7 @@ func (ir *ImageEngine) ManifestCreate(ctx context.Context, name string, images [
 func (ir *ImageEngine) ManifestExists(ctx context.Context, name string) (*entities.BoolReport, error) {
 	_, err := ir.Libpod.LibimageRuntime().LookupManifestList(name)
 	if err != nil {
-		if errors.Cause(err) == storage.ErrImageUnknown {
+		if errors.Is(err, storage.ErrImageUnknown) {
 			return &entities.BoolReport{Value: false}, nil
 		}
 		return nil, err
@@ -63,15 +65,13 @@ func (ir *ImageEngine) ManifestInspect(ctx context.Context, name string) ([]byte
 
 	manifestList, err := ir.Libpod.LibimageRuntime().LookupManifestList(name)
 	if err != nil {
-		switch errors.Cause(err) {
-		// Do a remote inspect if there's no local image or if the
-		// local image is not a manifest list.
-		case storage.ErrImageUnknown, libimage.ErrNotAManifestList:
+		if errors.Is(err, storage.ErrImageUnknown) || errors.Is(err, libimage.ErrNotAManifestList) {
+			// Do a remote inspect if there's no local image or if the
+			// local image is not a manifest list.
 			return ir.remoteManifestInspect(ctx, name)
-
-		default:
-			return nil, err
 		}
+
+		return nil, err
 	}
 
 	schema2List, err := manifestList.Inspect()
@@ -86,7 +86,7 @@ func (ir *ImageEngine) ManifestInspect(ctx context.Context, name string) ([]byte
 
 	var b bytes.Buffer
 	if err := json.Indent(&b, rawSchema2List, "", "    "); err != nil {
-		return nil, errors.Wrapf(err, "error rendering manifest %s for display", name)
+		return nil, fmt.Errorf("error rendering manifest %s for display: %w", name, err)
 	}
 	return b.Bytes(), nil
 }
@@ -113,8 +113,7 @@ func (ir *ImageEngine) remoteManifestInspect(ctx context.Context, name string) (
 			// FIXME should we use multierror package instead?
 
 			// we want the new line here so ignore the linter
-			//nolint:revive
-			latestErr = errors.Wrapf(latestErr, "tried %v\n", e)
+			latestErr = fmt.Errorf("tried %v\n: %w", e, latestErr)
 		}
 	}
 
@@ -125,14 +124,14 @@ func (ir *ImageEngine) remoteManifestInspect(ctx context.Context, name string) (
 		}
 		src, err := ref.NewImageSource(ctx, sys)
 		if err != nil {
-			appendErr(errors.Wrapf(err, "reading image %q", transports.ImageName(ref)))
+			appendErr(fmt.Errorf("reading image %q: %w", transports.ImageName(ref), err))
 			continue
 		}
 		defer src.Close()
 
 		manifestBytes, manifestType, err := src.GetManifest(ctx, nil)
 		if err != nil {
-			appendErr(errors.Wrapf(err, "loading manifest %q", transports.ImageName(ref)))
+			appendErr(fmt.Errorf("loading manifest %q: %w", transports.ImageName(ref), err))
 			continue
 		}
 
@@ -150,7 +149,7 @@ func (ir *ImageEngine) remoteManifestInspect(ctx context.Context, name string) (
 		logrus.Warnf("The manifest type %s is not a manifest list but a single image.", manType)
 		schema2Manifest, err := manifest.Schema2FromManifest(result)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing manifest blob %q as a %q", string(result), manType)
+			return nil, fmt.Errorf("error parsing manifest blob %q as a %q: %w", string(result), manType, err)
 		}
 		if result, err = schema2Manifest.Serialize(); err != nil {
 			return nil, err
@@ -158,7 +157,7 @@ func (ir *ImageEngine) remoteManifestInspect(ctx context.Context, name string) (
 	default:
 		listBlob, err := manifest.ListFromBlob(result, manType)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing manifest blob %q as a %q", string(result), manType)
+			return nil, fmt.Errorf("error parsing manifest blob %q as a %q: %w", string(result), manType, err)
 		}
 		list, err := listBlob.ConvertToMIMEType(manifest.DockerV2ListMediaType)
 		if err != nil {
@@ -170,7 +169,7 @@ func (ir *ImageEngine) remoteManifestInspect(ctx context.Context, name string) (
 	}
 
 	if err = json.Indent(&b, result, "", "    "); err != nil {
-		return nil, errors.Wrapf(err, "error rendering manifest %s for display", name)
+		return nil, fmt.Errorf("error rendering manifest %s for display: %w", name, err)
 	}
 	return b.Bytes(), nil
 }
@@ -213,7 +212,7 @@ func (ir *ImageEngine) ManifestAdd(ctx context.Context, name string, images []st
 			for _, annotationSpec := range opts.Annotation {
 				spec := strings.SplitN(annotationSpec, "=", 2)
 				if len(spec) != 2 {
-					return "", errors.Errorf("no value given for annotation %q", spec[0])
+					return "", fmt.Errorf("no value given for annotation %q", spec[0])
 				}
 				annotations[spec[0]] = spec[1]
 			}
@@ -231,7 +230,7 @@ func (ir *ImageEngine) ManifestAdd(ctx context.Context, name string, images []st
 func (ir *ImageEngine) ManifestAnnotate(ctx context.Context, name, image string, opts entities.ManifestAnnotateOptions) (string, error) {
 	instanceDigest, err := digest.Parse(image)
 	if err != nil {
-		return "", errors.Errorf(`invalid image digest "%s": %v`, image, err)
+		return "", fmt.Errorf(`invalid image digest "%s": %v`, image, err)
 	}
 
 	manifestList, err := ir.Libpod.LibimageRuntime().LookupManifestList(name)
@@ -251,7 +250,7 @@ func (ir *ImageEngine) ManifestAnnotate(ctx context.Context, name, image string,
 		for _, annotationSpec := range opts.Annotation {
 			spec := strings.SplitN(annotationSpec, "=", 2)
 			if len(spec) != 2 {
-				return "", errors.Errorf("no value given for annotation %q", spec[0])
+				return "", fmt.Errorf("no value given for annotation %q", spec[0])
 			}
 			annotations[spec[0]] = spec[1]
 		}
@@ -269,7 +268,7 @@ func (ir *ImageEngine) ManifestAnnotate(ctx context.Context, name, image string,
 func (ir *ImageEngine) ManifestRemoveDigest(ctx context.Context, name, image string) (string, error) {
 	instanceDigest, err := digest.Parse(image)
 	if err != nil {
-		return "", errors.Errorf(`invalid image digest "%s": %v`, image, err)
+		return "", fmt.Errorf(`invalid image digest "%s": %v`, image, err)
 	}
 
 	manifestList, err := ir.Libpod.LibimageRuntime().LookupManifestList(name)
@@ -293,7 +292,7 @@ func (ir *ImageEngine) ManifestRm(ctx context.Context, names []string) (report *
 func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination string, opts entities.ImagePushOptions) (string, error) {
 	manifestList, err := ir.Libpod.LibimageRuntime().LookupManifestList(name)
 	if err != nil {
-		return "", errors.Wrapf(err, "error retrieving local image from image name %s", name)
+		return "", fmt.Errorf("error retrieving local image from image name %s: %w", name, err)
 	}
 
 	var manifestType string
@@ -304,7 +303,7 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 		case "v2s2", "docker":
 			manifestType = manifest.DockerV2Schema2MediaType
 		default:
-			return "", errors.Errorf("unknown format %q. Choose one of the supported formats: 'oci' or 'v2s2'", opts.Format)
+			return "", fmt.Errorf("unknown format %q. Choose one of the supported formats: 'oci' or 'v2s2'", opts.Format)
 		}
 	}
 
@@ -333,7 +332,7 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 
 	if opts.Rm {
 		if _, rmErrors := ir.Libpod.LibimageRuntime().RemoveImages(ctx, []string{manifestList.ID()}, nil); len(rmErrors) > 0 {
-			return "", errors.Wrap(rmErrors[0], "error removing manifest after push")
+			return "", fmt.Errorf("error removing manifest after push: %w", rmErrors[0])
 		}
 	}
 

--- a/pkg/domain/infra/abi/pods.go
+++ b/pkg/domain/infra/abi/pods.go
@@ -2,6 +2,8 @@ package abi
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -12,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/pkg/signal"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/specgen/generate"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -49,7 +50,7 @@ func getPodsByContext(all, latest bool, pods []string, runtime *libpod.Runtime) 
 
 func (ic *ContainerEngine) PodExists(ctx context.Context, nameOrID string) (*entities.BoolReport, error) {
 	_, err := ic.Libpod.LookupPod(nameOrID)
-	if err != nil && errors.Cause(err) != define.ErrNoSuchPod {
+	if err != nil && !errors.Is(err, define.ErrNoSuchPod) {
 		return nil, err
 	}
 	return &entities.BoolReport{Value: err == nil}, nil
@@ -69,14 +70,14 @@ func (ic *ContainerEngine) PodKill(ctx context.Context, namesOrIds []string, opt
 	for _, p := range pods {
 		report := entities.PodKillReport{Id: p.ID()}
 		conErrs, err := p.Kill(ctx, uint(sig))
-		if err != nil && errors.Cause(err) != define.ErrPodPartialFail {
+		if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
 			report.Errs = []error{err}
 			reports = append(reports, &report)
 			continue
 		}
 		if len(conErrs) > 0 {
 			for id, err := range conErrs {
-				report.Errs = append(report.Errs, errors.Wrapf(err, "error killing container %s", id))
+				report.Errs = append(report.Errs, fmt.Errorf("error killing container %s: %w", id, err))
 			}
 			reports = append(reports, &report)
 			continue
@@ -110,7 +111,7 @@ func (ic *ContainerEngine) PodLogs(ctx context.Context, nameOrID string, options
 			}
 		}
 		if !ctrFound {
-			return errors.Wrapf(define.ErrNoSuchCtr, "container %s is not in pod %s", options.ContainerName, nameOrID)
+			return fmt.Errorf("container %s is not in pod %s: %w", options.ContainerName, nameOrID, define.ErrNoSuchCtr)
 		}
 	} else {
 		// No container name specified select all containers
@@ -135,13 +136,13 @@ func (ic *ContainerEngine) PodPause(ctx context.Context, namesOrIds []string, op
 	for _, p := range pods {
 		report := entities.PodPauseReport{Id: p.ID()}
 		errs, err := p.Pause(ctx)
-		if err != nil && errors.Cause(err) != define.ErrPodPartialFail {
+		if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
 			report.Errs = []error{err}
 			continue
 		}
 		if len(errs) > 0 {
 			for id, v := range errs {
-				report.Errs = append(report.Errs, errors.Wrapf(v, "error pausing container %s", id))
+				report.Errs = append(report.Errs, fmt.Errorf("error pausing container %s: %w", id, v))
 			}
 			reports = append(reports, &report)
 			continue
@@ -160,13 +161,13 @@ func (ic *ContainerEngine) PodUnpause(ctx context.Context, namesOrIds []string, 
 	for _, p := range pods {
 		report := entities.PodUnpauseReport{Id: p.ID()}
 		errs, err := p.Unpause(ctx)
-		if err != nil && errors.Cause(err) != define.ErrPodPartialFail {
+		if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
 			report.Errs = []error{err}
 			continue
 		}
 		if len(errs) > 0 {
 			for id, v := range errs {
-				report.Errs = append(report.Errs, errors.Wrapf(v, "error unpausing container %s", id))
+				report.Errs = append(report.Errs, fmt.Errorf("error unpausing container %s: %w", id, v))
 			}
 			reports = append(reports, &report)
 			continue
@@ -179,19 +180,19 @@ func (ic *ContainerEngine) PodUnpause(ctx context.Context, namesOrIds []string, 
 func (ic *ContainerEngine) PodStop(ctx context.Context, namesOrIds []string, options entities.PodStopOptions) ([]*entities.PodStopReport, error) {
 	reports := []*entities.PodStopReport{}
 	pods, err := getPodsByContext(options.All, options.Latest, namesOrIds, ic.Libpod)
-	if err != nil && !(options.Ignore && errors.Cause(err) == define.ErrNoSuchPod) {
+	if err != nil && !(options.Ignore && errors.Is(err, define.ErrNoSuchPod)) {
 		return nil, err
 	}
 	for _, p := range pods {
 		report := entities.PodStopReport{Id: p.ID()}
 		errs, err := p.StopWithTimeout(ctx, false, options.Timeout)
-		if err != nil && errors.Cause(err) != define.ErrPodPartialFail {
+		if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
 			report.Errs = []error{err}
 			continue
 		}
 		if len(errs) > 0 {
 			for id, v := range errs {
-				report.Errs = append(report.Errs, errors.Wrapf(v, "error stopping container %s", id))
+				report.Errs = append(report.Errs, fmt.Errorf("error stopping container %s: %w", id, v))
 			}
 			reports = append(reports, &report)
 			continue
@@ -210,14 +211,14 @@ func (ic *ContainerEngine) PodRestart(ctx context.Context, namesOrIds []string, 
 	for _, p := range pods {
 		report := entities.PodRestartReport{Id: p.ID()}
 		errs, err := p.Restart(ctx)
-		if err != nil && errors.Cause(err) != define.ErrPodPartialFail {
+		if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
 			report.Errs = []error{err}
 			reports = append(reports, &report)
 			continue
 		}
 		if len(errs) > 0 {
 			for id, v := range errs {
-				report.Errs = append(report.Errs, errors.Wrapf(v, "error restarting container %s", id))
+				report.Errs = append(report.Errs, fmt.Errorf("error restarting container %s: %w", id, v))
 			}
 			reports = append(reports, &report)
 			continue
@@ -237,14 +238,14 @@ func (ic *ContainerEngine) PodStart(ctx context.Context, namesOrIds []string, op
 	for _, p := range pods {
 		report := entities.PodStartReport{Id: p.ID()}
 		errs, err := p.Start(ctx)
-		if err != nil && errors.Cause(err) != define.ErrPodPartialFail {
+		if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
 			report.Errs = []error{err}
 			reports = append(reports, &report)
 			continue
 		}
 		if len(errs) > 0 {
 			for id, v := range errs {
-				report.Errs = append(report.Errs, errors.Wrapf(v, "error starting container %s", id))
+				report.Errs = append(report.Errs, fmt.Errorf("error starting container %s: %w", id, v))
 			}
 			reports = append(reports, &report)
 			continue
@@ -256,7 +257,7 @@ func (ic *ContainerEngine) PodStart(ctx context.Context, namesOrIds []string, op
 
 func (ic *ContainerEngine) PodRm(ctx context.Context, namesOrIds []string, options entities.PodRmOptions) ([]*entities.PodRmReport, error) {
 	pods, err := getPodsByContext(options.All, options.Latest, namesOrIds, ic.Libpod)
-	if err != nil && !(options.Ignore && errors.Cause(err) == define.ErrNoSuchPod) {
+	if err != nil && !(options.Ignore && errors.Is(err, define.ErrNoSuchPod)) {
 		return nil, err
 	}
 	reports := make([]*entities.PodRmReport, 0, len(pods))
@@ -393,7 +394,7 @@ func (ic *ContainerEngine) PodTop(ctx context.Context, options entities.PodTopOp
 		pod, err = ic.Libpod.LookupPod(options.NameOrID)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to look up requested container")
+		return nil, fmt.Errorf("unable to look up requested container: %w", err)
 	}
 
 	// Run Top.
@@ -505,7 +506,7 @@ func (ic *ContainerEngine) PodInspect(ctx context.Context, options entities.PodI
 		pod, err = ic.Libpod.LookupPod(options.NameOrID)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to look up requested container")
+		return nil, fmt.Errorf("unable to look up requested container: %w", err)
 	}
 	inspect, err := pod.Inspect()
 	if err != nil {

--- a/pkg/domain/infra/abi/terminal/sigproxy_linux.go
+++ b/pkg/domain/infra/abi/terminal/sigproxy_linux.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"errors"
 	"os"
 	"syscall"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/libpod/shutdown"
 	"github.com/containers/podman/v4/pkg/signal"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -39,7 +39,7 @@ func ProxySignals(ctr *libpod.Container) {
 			}
 
 			if err := ctr.Kill(uint(s.(syscall.Signal))); err != nil {
-				if errors.Cause(err) == define.ErrCtrStateInvalid {
+				if errors.Is(err, define.ErrCtrStateInvalid) {
 					logrus.Infof("Ceasing signal forwarding to container %s as it has stopped", ctr.ID())
 				} else {
 					logrus.Errorf("forwarding signal %d to container %s: %v", s, ctr.ID(), err)

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -2,6 +2,8 @@ package abi
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/libpod/define"
@@ -9,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
 	"github.com/containers/podman/v4/pkg/domain/filters"
 	"github.com/containers/podman/v4/pkg/domain/infra/abi/parse"
-	"github.com/pkg/errors"
 )
 
 func (ic *ContainerEngine) VolumeCreate(ctx context.Context, opts entities.VolumeCreateOptions) (*entities.IDOrNameResponse, error) {
@@ -91,11 +92,11 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 		for _, v := range namesOrIds {
 			vol, err := ic.Libpod.LookupVolume(v)
 			if err != nil {
-				if errors.Cause(err) == define.ErrNoSuchVolume {
-					errs = append(errs, errors.Errorf("no such volume %s", v))
+				if errors.Is(err, define.ErrNoSuchVolume) {
+					errs = append(errs, fmt.Errorf("no such volume %s", v))
 					continue
 				} else {
-					return nil, nil, errors.Wrapf(err, "error inspecting volume %s", v)
+					return nil, nil, fmt.Errorf("error inspecting volume %s: %w", v, err)
 				}
 			}
 			vols = append(vols, vol)

--- a/pkg/domain/infra/tunnel/pods.go
+++ b/pkg/domain/infra/tunnel/pods.go
@@ -2,12 +2,12 @@ package tunnel
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/bindings/pods"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 )
 
 func (ic *ContainerEngine) PodExists(ctx context.Context, nameOrID string) (*entities.BoolReport, error) {
@@ -97,7 +97,7 @@ func (ic *ContainerEngine) PodUnpause(ctx context.Context, namesOrIds []string, 
 func (ic *ContainerEngine) PodStop(ctx context.Context, namesOrIds []string, opts entities.PodStopOptions) ([]*entities.PodStopReport, error) {
 	timeout := -1
 	foundPods, err := getPodsByContext(ic.ClientCtx, opts.All, namesOrIds)
-	if err != nil && !(opts.Ignore && errors.Cause(err) == define.ErrNoSuchPod) {
+	if err != nil && !(opts.Ignore && errors.Is(err, define.ErrNoSuchPod)) {
 		return nil, err
 	}
 	if opts.Timeout != -1 {
@@ -164,7 +164,7 @@ func (ic *ContainerEngine) PodStart(ctx context.Context, namesOrIds []string, op
 
 func (ic *ContainerEngine) PodRm(ctx context.Context, namesOrIds []string, opts entities.PodRmOptions) ([]*entities.PodRmReport, error) {
 	foundPods, err := getPodsByContext(ic.ClientCtx, opts.All, namesOrIds)
-	if err != nil && !(opts.Ignore && errors.Cause(err) == define.ErrNoSuchPod) {
+	if err != nil && !(opts.Ignore && errors.Is(err, define.ErrNoSuchPod)) {
 		return nil, err
 	}
 	reports := make([]*entities.PodRmReport, 0, len(foundPods))

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"io/ioutil"
@@ -30,7 +31,6 @@ import (
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/digitalocean/go-qemu/qmp"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -434,12 +434,12 @@ func (v *MachineVM) Set(_ string, opts machine.SetOptions) ([]error, error) {
 		if v.Name != machine.DefaultMachineName {
 			suffix = " " + v.Name
 		}
-		return setErrors, errors.Errorf("cannot change settings while the vm is running, run 'podman machine stop%s' first", suffix)
+		return setErrors, fmt.Errorf("cannot change settings while the vm is running, run 'podman machine stop%s' first", suffix)
 	}
 
 	if opts.Rootful != nil && v.Rootful != *opts.Rootful {
 		if err := v.setRootful(*opts.Rootful); err != nil {
-			setErrors = append(setErrors, errors.Wrapf(err, "failed to set rootful option"))
+			setErrors = append(setErrors, fmt.Errorf("failed to set rootful option: %w", err))
 		} else {
 			v.Rootful = *opts.Rootful
 		}
@@ -457,7 +457,7 @@ func (v *MachineVM) Set(_ string, opts machine.SetOptions) ([]error, error) {
 
 	if opts.DiskSize != nil && v.DiskSize != *opts.DiskSize {
 		if err := v.resizeDisk(*opts.DiskSize, v.DiskSize); err != nil {
-			setErrors = append(setErrors, errors.Wrapf(err, "failed to resize disk"))
+			setErrors = append(setErrors, fmt.Errorf("failed to resize disk: %w", err))
 		} else {
 			v.DiskSize = *opts.DiskSize
 		}
@@ -514,7 +514,7 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 
 	forwardSock, forwardState, err := v.startHostNetworking()
 	if err != nil {
-		return errors.Errorf("unable to start host networking: %q", err)
+		return fmt.Errorf("unable to start host networking: %q", err)
 	}
 
 	rtPath, err := getRuntimeDir()
@@ -593,7 +593,7 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		}
 		_, err = os.StartProcess(cmd[0], cmd, attr)
 		if err != nil {
-			return errors.Wrapf(err, "unable to execute %q", cmd)
+			return fmt.Errorf("unable to execute %q: %w", cmd, err)
 		}
 	}
 	fmt.Println("Waiting for VM ...")
@@ -700,7 +700,7 @@ func (v *MachineVM) checkStatus(monitor *qmp.SocketMonitor) (machine.Status, err
 	}
 	b, err := monitor.Run(input)
 	if err != nil {
-		if errors.Cause(err) == os.ErrNotExist {
+		if errors.Is(err, os.ErrNotExist) {
 			return machine.Stopped, nil
 		}
 		return "", err
@@ -879,7 +879,7 @@ func (v *MachineVM) Remove(_ string, opts machine.RemoveOptions) (string, func()
 	}
 	if state == machine.Running {
 		if !opts.Force {
-			return "", nil, errors.Errorf("running vm %q cannot be destroyed", v.Name)
+			return "", nil, fmt.Errorf("running vm %q cannot be destroyed", v.Name)
 		}
 		err := v.Stop(v.Name, machine.StopOptions{})
 		if err != nil {
@@ -1001,7 +1001,7 @@ func (v *MachineVM) SSH(_ string, opts machine.SSHOptions) error {
 		return err
 	}
 	if state != machine.Running {
-		return errors.Errorf("vm %q is not running", v.Name)
+		return fmt.Errorf("vm %q is not running", v.Name)
 	}
 
 	username := opts.Username
@@ -1165,7 +1165,7 @@ func (p *Provider) IsValidVMName(name string) (bool, error) {
 func (p *Provider) CheckExclusiveActiveVM() (bool, string, error) {
 	vms, err := getVMInfos()
 	if err != nil {
-		return false, "", errors.Wrap(err, "error checking VM active")
+		return false, "", fmt.Errorf("error checking VM active: %w", err)
 	}
 	for _, vm := range vms {
 		if vm.Running || vm.Starting {
@@ -1217,7 +1217,7 @@ func (v *MachineVM) startHostNetworking() (string, apiForwardingState, error) {
 		fmt.Println(cmd)
 	}
 	_, err = os.StartProcess(cmd[0], cmd, attr)
-	return forwardSock, state, errors.Wrapf(err, "unable to execute: %q", cmd)
+	return forwardSock, state, fmt.Errorf("unable to execute: %q: %w", cmd, err)
 }
 
 func (v *MachineVM) setupAPIForwarding(cmd []string) ([]string, string, apiForwardingState) {
@@ -1486,7 +1486,7 @@ func (v *MachineVM) update() error {
 	b, err := v.ConfigPath.Read()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return errors.Wrap(machine.ErrNoSuchVM, v.Name)
+			return fmt.Errorf("%v: %w", v.Name, machine.ErrNoSuchVM)
 		}
 		return err
 	}
@@ -1562,7 +1562,7 @@ func (v *MachineVM) resizeDisk(diskSize uint64, oldSize uint64) error {
 	// only if the virtualdisk size is less than
 	// the given disk size
 	if diskSize < oldSize {
-		return errors.Errorf("new disk size must be larger than current disk size: %vGB", oldSize)
+		return fmt.Errorf("new disk size must be larger than current disk size: %vGB", oldSize)
 	}
 
 	// Find the qemu executable
@@ -1578,7 +1578,7 @@ func (v *MachineVM) resizeDisk(diskSize uint64, oldSize uint64) error {
 	resize.Stdout = os.Stdout
 	resize.Stderr = os.Stderr
 	if err := resize.Run(); err != nil {
-		return errors.Errorf("resizing image: %q", err)
+		return fmt.Errorf("resizing image: %q", err)
 	}
 
 	return nil

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -560,7 +560,7 @@ var _ = Describe("Podman create", func() {
 		session = podmanTest.Podman([]string{"create", "--umask", "9999", "--name", "bad", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(ContainSubstring("Invalid umask"))
+		Expect(session.ErrorToString()).To(ContainSubstring("invalid umask"))
 	})
 
 	It("create container in pod with IP should fail", func() {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1659,7 +1659,7 @@ USER mail`, BB)
 		session = podmanTest.Podman([]string{"run", "--umask", "9999", "--rm", ALPINE, "sh", "-c", "umask"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
-		Expect(session.ErrorToString()).To(ContainSubstring("Invalid umask"))
+		Expect(session.ErrorToString()).To(ContainSubstring("invalid umask"))
 	})
 
 	It("podman run makes workdir from image", func() {


### PR DESCRIPTION
We now use the golang error wrapping format specifier `%w` instead of the deprecated github.com/pkg/errors package.


#### Does this PR introduce a user-facing change?


```release-note
NONE
```

It's a huge one, but the libpod/pkg `errors.Cause` chain is somehow interconnected.