### PR TITLE
hack/test/utils: switch to golang native error wrapping

### DIFF
--- a/hack/podman-registry-go/registry.go
+++ b/hack/podman-registry-go/registry.go
@@ -1,10 +1,10 @@
 package registry
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/containers/podman/v4/utils"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -57,7 +57,7 @@ func StartWithOptions(options *Options) (*Registry, error) {
 	// Start a registry.
 	out, err := utils.ExecCmd(binary, args...)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error running %q: %s", binary, out)
+		return nil, fmt.Errorf("error running %q: %s: %w", binary, out, err)
 	}
 
 	// Parse the output.
@@ -68,7 +68,7 @@ func StartWithOptions(options *Options) (*Registry, error) {
 		}
 		spl := strings.Split(s, "=")
 		if len(spl) != 2 {
-			return nil, errors.Errorf("unexpected output format %q: want 'PODMAN_...=...'", s)
+			return nil, fmt.Errorf("unexpected output format %q: want 'PODMAN_...=...'", s)
 		}
 		key := spl[0]
 		val := strings.TrimSuffix(strings.TrimPrefix(spl[1], "\""), "\"")
@@ -88,16 +88,16 @@ func StartWithOptions(options *Options) (*Registry, error) {
 
 	// Extra sanity check.
 	if registry.Image == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, ImageKey)
+		return nil, fmt.Errorf("unexpected output %q: %q missing", out, ImageKey)
 	}
 	if registry.User == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, UserKey)
+		return nil, fmt.Errorf("unexpected output %q: %q missing", out, UserKey)
 	}
 	if registry.Password == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, PassKey)
+		return nil, fmt.Errorf("unexpected output %q: %q missing", out, PassKey)
 	}
 	if registry.Port == "" {
-		return nil, errors.Errorf("unexpected output %q: %q missing", out, PortKey)
+		return nil, fmt.Errorf("unexpected output %q: %q missing", out, PortKey)
 	}
 
 	registry.running = true
@@ -112,7 +112,7 @@ func (r *Registry) Stop() error {
 		return nil
 	}
 	if _, err := utils.ExecCmd(binary, "-P", r.Port, "stop"); err != nil {
-		return errors.Wrapf(err, "error stopping registry (%v) with %q", *r, binary)
+		return fmt.Errorf("error stopping registry (%v) with %q: %w", *r, binary, err)
 	}
 	r.running = false
 	return nil

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -30,7 +31,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -618,14 +618,14 @@ func (p *PodmanTestIntegration) RunHealthCheck(cid string) error {
 				restart := p.Podman([]string{"restart", cid})
 				restart.WaitWithDefaultTimeout()
 				if restart.ExitCode() != 0 {
-					return errors.Errorf("unable to restart %s", cid)
+					return fmt.Errorf("unable to restart %s", cid)
 				}
 			}
 		}
 		fmt.Printf("Waiting for %s to pass healthcheck\n", cid)
 		time.Sleep(1 * time.Second)
 	}
-	return errors.Errorf("unable to detect %s as running", cid)
+	return fmt.Errorf("unable to detect %s as running", cid)
 }
 
 func (p *PodmanTestIntegration) CreateSeccompJSON(in []byte) (string, error) {

--- a/utils/ports.go
+++ b/utils/ports.go
@@ -1,26 +1,25 @@
 package utils
 
 import (
+	"fmt"
 	"net"
 	"strconv"
-
-	"github.com/pkg/errors"
 )
 
 // Find a random, open port on the host.
 func GetRandomPort() (int, error) {
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to get free TCP port")
+		return 0, fmt.Errorf("unable to get free TCP port: %w", err)
 	}
 	defer l.Close()
 	_, randomPort, err := net.SplitHostPort(l.Addr().String())
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to determine free port")
+		return 0, fmt.Errorf("unable to determine free port: %w", err)
 	}
 	rp, err := strconv.Atoi(randomPort)
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to convert random port to int")
+		return 0, fmt.Errorf("unable to convert random port to int: %w", err)
 	}
 	return rp, nil
 }

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/podman/v4/pkg/rootless"
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/godbus/dbus/v5"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -77,7 +76,7 @@ func getCgroupProcess(procFile string, allowRoot bool) (string, error) {
 		line := scanner.Text()
 		parts := strings.SplitN(line, ":", 3)
 		if len(parts) != 3 {
-			return "", errors.Errorf("cannot parse cgroup line %q", line)
+			return "", fmt.Errorf("cannot parse cgroup line %q", line)
 		}
 		if strings.HasPrefix(line, "0::") {
 			cgroup = line[3:]
@@ -88,7 +87,7 @@ func getCgroupProcess(procFile string, allowRoot bool) (string, error) {
 		}
 	}
 	if len(cgroup) == 0 || (!allowRoot && cgroup == "/") {
-		return "", errors.Errorf("could not find cgroup mount in %q", procFile)
+		return "", fmt.Errorf("could not find cgroup mount in %q", procFile)
 	}
 	return cgroup, nil
 }
@@ -133,7 +132,7 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 		line := scanner.Text()
 		parts := strings.SplitN(line, ":", 3)
 		if len(parts) != 3 {
-			return errors.Errorf("cannot parse cgroup line %q", line)
+			return fmt.Errorf("cannot parse cgroup line %q", line)
 		}
 
 		// root cgroup, skip it

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -3,7 +3,7 @@
 
 package utils
 
-import "github.com/pkg/errors"
+import "errors"
 
 func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 	return errors.New("not implemented for windows")


### PR DESCRIPTION
We now use the golang error wrapping format specifier `%w` instead of the deprecated github.com/pkg/errors package.


```release-note
None
```
