### PR TITLE
Sync: handle exit file

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -761,19 +761,8 @@ func (c *Container) Sync() error {
 		defer c.lock.Unlock()
 	}
 
-	// If runtime knows about the container, update its status in runtime
-	// And then save back to disk
-	if c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning, define.ContainerStatePaused, define.ContainerStateStopped, define.ContainerStateStopping) {
-		oldState := c.state.State
-		if err := c.ociRuntime.UpdateContainerStatus(c); err != nil {
-			return err
-		}
-		// Only save back to DB if state changed
-		if c.state.State != oldState {
-			if err := c.save(); err != nil {
-				return err
-			}
-		}
+	if err := c.syncContainer(); err != nil {
+		return err
 	}
 
 	defer c.newContainerEvent(events.Sync)

--- a/test/system/130-kill.bats
+++ b/test/system/130-kill.bats
@@ -130,4 +130,14 @@ load helpers
     is "$output" $cname
 }
 
+@test "podman kill - concurrent stop" {
+    # 14761 - concurrent kill/stop must record the exit code
+    random_name=$(random_string 10)
+    run_podman run -d --replace --name=$random_name alpine sh -c "trap 'echo Received SIGTERM, ignoring' SIGTERM; echo READY; while :; do sleep 0.2; done"
+    $PODMAN stop -t 1 $random_name &
+    run_podman kill $random_name
+    run_podman wait $random_name
+    run_podman rm -f $random_name
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Make sure `Sync()` handles state transitions and exit codes correctly.
The function was only being called when batching which could render
containers in an unusable state when running concurrently with other
state-altering functions/commands since the state must be re-read from
the database before acting upon it.

Fixes: #14761
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

No release notes needed as it's fixing a bug that hasn't been released yet.
```release-note
None
```
