### PR TITLE
e2e tests: cleanup: capitalize CONSTANTS

### DIFF
--- a/test/e2e/benchmarks_test.go
+++ b/test/e2e/benchmarks_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Podman Benchmark Suite", func() {
 	Measure("Podman Benchmark Suite", func(b Benchmarker) {
 
 		registryOptions := &podmanRegistry.Options{
-			Image: "docker-archive:" + imageTarPath(registry),
+			Image: "docker-archive:" + imageTarPath(REGISTRY_IMAGE),
 		}
 
 		for i := range allBenchmarks {

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -339,7 +339,7 @@ var _ = Describe("Podman checkpoint", func() {
 	It("podman checkpoint container with established tcp connections", func() {
 		// Broken on Ubuntu.
 		SkipIfNotFedora()
-		localRunString := getRunString([]string{redis})
+		localRunString := getRunString([]string{REDIS_IMAGE})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -1052,7 +1052,7 @@ var _ = Describe("Podman checkpoint", func() {
 	It("podman checkpoint and restore container with different port mappings", func() {
 		randomPort, err := utils.GetRandomPort()
 		Expect(err).ShouldNot(HaveOccurred())
-		localRunString := getRunString([]string{"-p", fmt.Sprintf("%d:6379", randomPort), "--rm", redis})
+		localRunString := getRunString([]string{"-p", fmt.Sprintf("%d:6379", randomPort), "--rm", REDIS_IMAGE})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -1360,11 +1360,11 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint and restore containers with --print-stats", func() {
-		session1 := podmanTest.Podman(getRunString([]string{redis}))
+		session1 := podmanTest.Podman(getRunString([]string{REDIS_IMAGE}))
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))
 
-		session2 := podmanTest.Podman(getRunString([]string{redis, "top"}))
+		session2 := podmanTest.Podman(getRunString([]string{REDIS_IMAGE, "top"}))
 		session2.WaitWithDefaultTimeout()
 		Expect(session2).Should(Exit(0))
 

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -362,7 +362,7 @@ var _ = Describe("Podman commit", func() {
 		Expect(images[0].Config.ExposedPorts).To(HaveKey("80/tcp"))
 
 		name = "testcon2"
-		s = podmanTest.Podman([]string{"run", "--name", name, "-d", nginx})
+		s = podmanTest.Podman([]string{"run", "--name", name, "-d", NGINX_IMAGE})
 		s.WaitWithDefaultTimeout()
 		Expect(s).Should(Exit(0))
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -36,10 +36,10 @@ import (
 
 var (
 	//lint:ignore ST1003
-	PODMAN_BINARY      string                        //nolint:revive,stylecheck
-	INTEGRATION_ROOT   string                        //nolint:revive,stylecheck
-	CGROUP_MANAGER     = "systemd"                   //nolint:revive,stylecheck
-	RESTORE_IMAGES     = []string{ALPINE, BB, nginx} //nolint:revive,stylecheck
+	PODMAN_BINARY      string                              //nolint:revive,stylecheck
+	INTEGRATION_ROOT   string                              //nolint:revive,stylecheck
+	CGROUP_MANAGER     = "systemd"                         //nolint:revive,stylecheck
+	RESTORE_IMAGES     = []string{ALPINE, BB, NGINX_IMAGE} //nolint:revive,stylecheck
 	defaultWaitTimeout = 90
 	CGROUPSV2, _       = cgroups.IsCgroup2UnifiedMode()
 )
@@ -115,7 +115,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	podman := PodmanTestSetup("/tmp")
 
 	// Pull cirros but don't put it into the cache
-	pullImages := []string{cirros, fedoraToolbox, volumeTest}
+	pullImages := []string{CIRROS_IMAGE, fedoraToolbox, volumeTest}
 	pullImages = append(pullImages, CACHE_IMAGES...)
 	for _, image := range pullImages {
 		podman.createArtifact(image)
@@ -464,7 +464,7 @@ func (p *PodmanTestIntegration) RunNginxWithHealthCheck(name string) (*PodmanSes
 		podmanArgs = append(podmanArgs, "--name", name)
 	}
 	// curl without -f exits 0 even if http code >= 400!
-	podmanArgs = append(podmanArgs, "-dt", "-P", "--health-cmd", "curl -f http://localhost/", nginx)
+	podmanArgs = append(podmanArgs, "-dt", "-P", "--health-cmd", "curl -f http://localhost/", NGINX_IMAGE)
 	session := p.Podman(podmanArgs)
 	session.WaitWithDefaultTimeout()
 	return session, session.OutputToString()

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -1,7 +1,7 @@
 package integration
 
 var (
-	redis             = "quay.io/libpod/redis:alpine"
+	REDIS_IMAGE       = "quay.io/libpod/redis:alpine" //nolint:revive,stylecheck
 	fedoraMinimal     = "registry.fedoraproject.org/fedora-minimal:34"
 	ALPINE            = "quay.io/libpod/alpine:latest"
 	ALPINELISTTAG     = "quay.io/libpod/alpine:3.10.2"
@@ -10,9 +10,9 @@ var (
 	ALPINEAMD64ID     = "961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4"
 	ALPINEARM64DIGEST = "quay.io/libpod/alpine@sha256:f270dcd11e64b85919c3bab66886e59d677cf657528ac0e4805d3c71e458e525"
 	ALPINEARM64ID     = "915beeae46751fc564998c79e73a1026542e945ca4f73dc841d09ccc6c2c0672"
-	infra             = "k8s.gcr.io/pause:3.2"
+	INFRA_IMAGE       = "k8s.gcr.io/pause:3.2" //nolint:revive,stylecheck
 	BB                = "quay.io/libpod/busybox:latest"
-	healthcheck       = "quay.io/libpod/alpine_healthcheck:latest"
+	HEALTHCHECK_IMAGE = "quay.io/libpod/alpine_healthcheck:latest" //nolint:revive,stylecheck
 	ImageCacheDir     = "/tmp/podman/imagecachedir"
 	fedoraToolbox     = "registry.fedoraproject.org/fedora-toolbox:36"
 	volumeTest        = "quay.io/libpod/volume-plugin-test-img:20220623"

--- a/test/e2e/config_amd64.go
+++ b/test/e2e/config_amd64.go
@@ -1,16 +1,16 @@
 package integration
 
 var (
-	STORAGE_FS               = "vfs"                                                                                                                         //nolint:revive,stylecheck
-	STORAGE_OPTIONS          = "--storage-driver vfs"                                                                                                        //nolint:revive,stylecheck
-	ROOTLESS_STORAGE_FS      = "vfs"                                                                                                                         //nolint:revive,stylecheck
-	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"                                                                                                        //nolint:revive,stylecheck
-	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, registry, infra, labels, healthcheck, UBI_INIT, UBI_MINIMAL, fedoraToolbox} //nolint:revive,stylecheck
-	nginx                    = "quay.io/libpod/alpine_nginx:latest"
-	BB_GLIBC                 = "docker.io/library/busybox:glibc" //nolint:revive,stylecheck
-	registry                 = "quay.io/libpod/registry:2.6"
-	labels                   = "quay.io/libpod/alpine_labels:latest"
-	UBI_MINIMAL              = "registry.access.redhat.com/ubi8-minimal" //nolint:revive,stylecheck
-	UBI_INIT                 = "registry.access.redhat.com/ubi8-init"    //nolint:revive,stylecheck
-	cirros                   = "quay.io/libpod/cirros:latest"
+	STORAGE_FS               = "vfs"                                                                                                                                                             //nolint:revive,stylecheck
+	STORAGE_OPTIONS          = "--storage-driver vfs"                                                                                                                                            //nolint:revive,stylecheck
+	ROOTLESS_STORAGE_FS      = "vfs"                                                                                                                                                             //nolint:revive,stylecheck
+	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"                                                                                                                                            //nolint:revive,stylecheck
+	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, REGISTRY_IMAGE, INFRA_IMAGE, LABELS_IMAGE, HEALTHCHECK_IMAGE, UBI_INIT, UBI_MINIMAL, fedoraToolbox} //nolint:revive,stylecheck
+	NGINX_IMAGE              = "quay.io/libpod/alpine_nginx:latest"                                                                                                                              //nolint:revive,stylecheck
+	BB_GLIBC                 = "docker.io/library/busybox:glibc"                                                                                                                                 //nolint:revive,stylecheck
+	REGISTRY_IMAGE           = "quay.io/libpod/registry:2.6"                                                                                                                                     //nolint:revive,stylecheck
+	LABELS_IMAGE             = "quay.io/libpod/alpine_labels:latest"                                                                                                                             //nolint:revive,stylecheck
+	UBI_MINIMAL              = "registry.access.redhat.com/ubi8-minimal"                                                                                                                         //nolint:revive,stylecheck
+	UBI_INIT                 = "registry.access.redhat.com/ubi8-init"                                                                                                                            //nolint:revive,stylecheck
+	CIRROS_IMAGE             = "quay.io/libpod/cirros:latest"                                                                                                                                    //nolint:revive,stylecheck
 )

--- a/test/e2e/config_ppc64le.go
+++ b/test/e2e/config_ppc64le.go
@@ -5,9 +5,9 @@ var (
 	STORAGE_OPTIONS          = "--storage-driver overlay"
 	ROOTLESS_STORAGE_FS      = "vfs"
 	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"
-	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, infra, labels}
-	nginx                    = "quay.io/libpod/alpine_nginx-ppc64le:latest"
+	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, NGINX_IMAGE, REDIS_IMAGE, INFRA_IMAGE, LABELS_IMAGE}
+	NGINX_IMAGE              = "quay.io/libpod/alpine_nginx-ppc64le:latest"
 	BB_GLIBC                 = "docker.io/ppc64le/busybox:glibc"
-	labels                   = "quay.io/libpod/alpine_labels-ppc64le:latest"
-	registry                 string
+	LABELS_IMAGE             = "quay.io/libpod/alpine_labels-ppc64le:latest"
+	REGISTRY_IMAGE           string
 )

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Podman container inspect", func() {
 
 	It("podman inspect shows exposed ports on image", func() {
 		name := "testcon"
-		session := podmanTest.Podman([]string{"run", "-d", "--expose", "8989", "--name", name, nginx})
+		session := podmanTest.Podman([]string{"run", "-d", "--expose", "8989", "--name", name, NGINX_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Podman create", func() {
 
 		lock := GetPortLock("5000")
 		defer lock.Unlock()
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5000:5000", registry, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5000:5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -273,7 +273,7 @@ var _ = Describe("Podman create", func() {
 
 	It("podman run entrypoint and cmd test", func() {
 		name := "test101"
-		create := podmanTest.Podman([]string{"create", "--name", name, redis})
+		create := podmanTest.Podman([]string{"create", "--name", name, REDIS_IMAGE})
 		create.WaitWithDefaultTimeout()
 		Expect(create).Should(Exit(0))
 

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Podman generate systemd", func() {
 	})
 
 	It("podman generate systemd", func() {
-		n := podmanTest.Podman([]string{"run", "--name", "nginx", "-dt", nginx})
+		n := podmanTest.Podman([]string{"run", "--name", "nginx", "-dt", NGINX_IMAGE})
 		n.WaitWithDefaultTimeout()
 		Expect(n).Should(Exit(0))
 
@@ -124,7 +124,7 @@ var _ = Describe("Podman generate systemd", func() {
 	})
 
 	It("podman generate systemd --files --name", func() {
-		n := podmanTest.Podman([]string{"run", "--name", "nginx", "-dt", nginx})
+		n := podmanTest.Podman([]string{"run", "--name", "nginx", "-dt", NGINX_IMAGE})
 		n.WaitWithDefaultTimeout()
 		Expect(n).Should(Exit(0))
 
@@ -139,7 +139,7 @@ var _ = Describe("Podman generate systemd", func() {
 	})
 
 	It("podman generate systemd with timeout", func() {
-		n := podmanTest.Podman([]string{"run", "--name", "nginx", "-dt", nginx})
+		n := podmanTest.Podman([]string{"run", "--name", "nginx", "-dt", NGINX_IMAGE})
 		n.WaitWithDefaultTimeout()
 		Expect(n).Should(Exit(0))
 
@@ -159,7 +159,7 @@ var _ = Describe("Podman generate systemd", func() {
 	})
 
 	It("podman generate systemd with user-defined dependencies", func() {
-		n := podmanTest.Podman([]string{"run", "--name", "nginx", "-dt", nginx})
+		n := podmanTest.Podman([]string{"run", "--name", "nginx", "-dt", NGINX_IMAGE})
 		n.WaitWithDefaultTimeout()
 		Expect(n).Should(Exit(0))
 

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	})
 
 	It("podman disable healthcheck with --no-healthcheck on valid container", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--no-healthcheck", "--name", "hc", healthcheck})
+		session := podmanTest.Podman([]string{"run", "-dt", "--no-healthcheck", "--name", "hc", HEALTHCHECK_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
@@ -54,7 +54,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	})
 
 	It("podman disable healthcheck with --no-healthcheck must not show starting on status", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--no-healthcheck", "--name", "hc", healthcheck})
+		session := podmanTest.Podman([]string{"run", "-dt", "--no-healthcheck", "--name", "hc", HEALTHCHECK_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		hc := podmanTest.Podman([]string{"container", "inspect", "--format", "{{.State.Health.Status}}", "hc"})
@@ -98,7 +98,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	})
 
 	It("podman disable healthcheck with --health-cmd=none on valid container", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "none", "--name", "hc", healthcheck})
+		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "none", "--name", "hc", HEALTHCHECK_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
@@ -108,7 +108,7 @@ var _ = Describe("Podman healthcheck run", func() {
 
 	It("podman healthcheck on valid container", func() {
 		Skip("Extremely consistent flake - re-enable on debugging")
-		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", healthcheck})
+		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", HEALTHCHECK_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -143,7 +143,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	})
 
 	It("podman healthcheck on stopped container", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", healthcheck, "ls"})
+		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", HEALTHCHECK_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -182,8 +182,8 @@ var _ = Describe("Podman inspect", func() {
 	})
 
 	It("podman inspect shows healthcheck on docker image", func() {
-		podmanTest.AddImageToRWStore(healthcheck)
-		session := podmanTest.Podman([]string{"inspect", "--format=json", healthcheck})
+		podmanTest.AddImageToRWStore(HEALTHCHECK_IMAGE)
+		session := podmanTest.Podman([]string{"inspect", "--format=json", HEALTHCHECK_IMAGE})
 		session.WaitWithDefaultTimeout()
 		imageData := session.InspectImageJSON()
 		Expect(imageData[0].HealthCheck.Timeout).To(BeNumerically("==", 3000000000))

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -295,7 +295,7 @@ var _ = Describe("Podman manifest", func() {
 
 	It("authenticated push", func() {
 		registryOptions := &podmanRegistry.Options{
-			Image: "docker-archive:" + imageTarPath(registry),
+			Image: "docker-archive:" + imageTarPath(REGISTRY_IMAGE),
 		}
 		registry, err := podmanRegistry.StartWithOptions(registryOptions)
 		Expect(err).To(BeNil())

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -507,14 +507,14 @@ var _ = Describe("Podman network", func() {
 			interval *= 2
 		}
 
-		top := podmanTest.Podman([]string{"run", "-dt", "--name=web", "--network=" + netName, "--network-alias=web1", "--network-alias=web2", nginx})
+		top := podmanTest.Podman([]string{"run", "-dt", "--name=web", "--network=" + netName, "--network-alias=web1", "--network-alias=web2", NGINX_IMAGE})
 		top.WaitWithDefaultTimeout()
 		Expect(top).Should(Exit(0))
 		interval = 250 * time.Millisecond
 		// Wait for the nginx service to be running
 		for i := 0; i < 6; i++ {
 			// Test curl against the container's name
-			c1 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, nginx, "curl", "web"})
+			c1 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, NGINX_IMAGE, "curl", "web"})
 			c1.WaitWithDefaultTimeout()
 			worked = c1.ExitCode() == 0
 			if worked {
@@ -527,12 +527,12 @@ var _ = Describe("Podman network", func() {
 
 		// Nginx is now running so no need to do a loop
 		// Test against the first alias
-		c2 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, nginx, "curl", "web1"})
+		c2 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, NGINX_IMAGE, "curl", "web1"})
 		c2.WaitWithDefaultTimeout()
 		Expect(c2).Should(Exit(0))
 
 		// Test against the second alias
-		c3 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, nginx, "curl", "web2"})
+		c3 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, NGINX_IMAGE, "curl", "web2"})
 		c3.WaitWithDefaultTimeout()
 		Expect(c3).Should(Exit(0))
 	})
@@ -558,14 +558,14 @@ var _ = Describe("Podman network", func() {
 			interval *= 2
 		}
 
-		top := podmanTest.Podman([]string{"run", "-dt", "--name=web", "--network=" + netName, "--network-alias=web1", "--network-alias=web2", nginx})
+		top := podmanTest.Podman([]string{"run", "-dt", "--name=web", "--network=" + netName, "--network-alias=web1", "--network-alias=web2", NGINX_IMAGE})
 		top.WaitWithDefaultTimeout()
 		Expect(top).Should(Exit(0))
 		interval = 250 * time.Millisecond
 		// Wait for the nginx service to be running
 		for i := 0; i < 6; i++ {
 			// Test curl against the container's name
-			c1 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, nginx, "curl", "web"})
+			c1 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, NGINX_IMAGE, "curl", "web"})
 			c1.WaitWithDefaultTimeout()
 			worked = c1.ExitCode() == 0
 			if worked {
@@ -578,12 +578,12 @@ var _ = Describe("Podman network", func() {
 
 		// Nginx is now running so no need to do a loop
 		// Test against the first alias
-		c2 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, nginx, "curl", "web1"})
+		c2 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, NGINX_IMAGE, "curl", "web1"})
 		c2.WaitWithDefaultTimeout()
 		Expect(c2).Should(Exit(0))
 
 		// Test against the second alias
-		c3 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, nginx, "curl", "web2"})
+		c3 := podmanTest.Podman([]string{"run", "--dns-search", "dns.podman", "--network=" + netName, NGINX_IMAGE, "curl", "web2"})
 		c3.WaitWithDefaultTimeout()
 		Expect(c3).Should(Exit(0))
 	})

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -273,7 +273,7 @@ var _ = Describe("Podman pause", func() {
 	It("Pause a bunch of running containers", func() {
 		for i := 0; i < 3; i++ {
 			name := fmt.Sprintf("test%d", i)
-			run := podmanTest.Podman([]string{"run", "-dt", "--name", name, nginx})
+			run := podmanTest.Podman([]string{"run", "-dt", "--name", name, NGINX_IMAGE})
 			run.WaitWithDefaultTimeout()
 			Expect(run).Should(Exit(0))
 
@@ -300,7 +300,7 @@ var _ = Describe("Podman pause", func() {
 	It("Unpause a bunch of running containers", func() {
 		for i := 0; i < 3; i++ {
 			name := fmt.Sprintf("test%d", i)
-			run := podmanTest.Podman([]string{"run", "-dt", "--name", name, nginx})
+			run := podmanTest.Podman([]string{"run", "-dt", "--name", name, NGINX_IMAGE})
 			run.WaitWithDefaultTimeout()
 			Expect(run).Should(Exit(0))
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -1512,7 +1512,7 @@ var _ = Describe("Podman play kube", func() {
 
 	// If you do not supply command or args for a Container, the defaults defined in the Docker image are used.
 	It("podman play kube test correct args and cmd when not specified", func() {
-		pod := getPod(withCtr(getCtr(withImage(registry), withCmd(nil), withArg(nil))))
+		pod := getPod(withCtr(getCtr(withImage(REGISTRY_IMAGE), withCmd(nil), withArg(nil))))
 		err := generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())
 
@@ -1536,7 +1536,7 @@ var _ = Describe("Podman play kube", func() {
 	// If you supply a command but no args for a Container, only the supplied command is used.
 	// The default EntryPoint and the default Cmd defined in the Docker image are ignored.
 	It("podman play kube test correct command with only set command in yaml file", func() {
-		pod := getPod(withCtr(getCtr(withImage(registry), withCmd([]string{"echo", "hello"}), withArg(nil))))
+		pod := getPod(withCtr(getCtr(withImage(REGISTRY_IMAGE), withCmd([]string{"echo", "hello"}), withArg(nil))))
 		err := generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())
 
@@ -1587,7 +1587,7 @@ var _ = Describe("Podman play kube", func() {
 
 	// If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
 	It("podman play kube test correct command with only set args in yaml file", func() {
-		pod := getPod(withCtr(getCtr(withImage(registry), withCmd(nil), withArg([]string{"echo", "hello"}))))
+		pod := getPod(withCtr(getCtr(withImage(REGISTRY_IMAGE), withCmd(nil), withArg([]string{"echo", "hello"}))))
 		err := generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())
 
@@ -1611,7 +1611,7 @@ var _ = Describe("Podman play kube", func() {
 	// the default Entrypoint and the default Cmd defined in the Docker image are ignored.
 	// Your command is run with your args.
 	It("podman play kube test correct command with both set args and cmd in yaml file", func() {
-		pod := getPod(withCtr(getCtr(withImage(registry), withCmd([]string{"echo"}), withArg([]string{"hello"}))))
+		pod := getPod(withCtr(getCtr(withImage(REGISTRY_IMAGE), withCmd([]string{"echo"}), withArg([]string{"hello"}))))
 		err := generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())
 
@@ -3705,7 +3705,7 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 
 		blockVolume := getHostPathVolume("BlockDevice", devicePath)
 
-		pod := getPod(withVolume(blockVolume), withCtr(getCtr(withImage(registry), withCmd(nil), withArg(nil), withVolumeMount(devicePath, false))))
+		pod := getPod(withVolume(blockVolume), withCtr(getCtr(withImage(REGISTRY_IMAGE), withCmd(nil), withArg(nil), withVolumeMount(devicePath, false))))
 		err = generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())
 
@@ -3744,7 +3744,7 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 
 		charVolume := getHostPathVolume("CharDevice", devicePath)
 
-		pod := getPod(withVolume(charVolume), withCtr(getCtr(withImage(registry), withCmd(nil), withArg(nil), withVolumeMount(devicePath, false))))
+		pod := getPod(withVolume(charVolume), withCtr(getCtr(withImage(REGISTRY_IMAGE), withCmd(nil), withArg(nil), withVolumeMount(devicePath, false))))
 		err = generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())
 
@@ -3772,7 +3772,7 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 
 		blockVolume := getHostPathVolume("BlockDevice", devicePath)
 
-		pod := getPod(withVolume(blockVolume), withCtr(getCtr(withImage(registry), withCmd(nil), withArg(nil), withVolumeMount(devicePath, false))))
+		pod := getPod(withVolume(blockVolume), withCtr(getCtr(withImage(REGISTRY_IMAGE), withCmd(nil), withArg(nil), withVolumeMount(devicePath, false))))
 		err = generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())
 
@@ -3798,7 +3798,7 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 
 		charVolume := getHostPathVolume("BlockDevice", devicePath)
 
-		pod := getPod(withVolume(charVolume), withCtr(getCtr(withImage(registry), withCmd(nil), withArg(nil), withVolumeMount(devicePath, false))))
+		pod := getPod(withVolume(charVolume), withCtr(getCtr(withImage(REGISTRY_IMAGE), withCmd(nil), withArg(nil), withVolumeMount(devicePath, false))))
 		err = generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())
 
@@ -3823,7 +3823,7 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 
 		charVolume := getHostPathVolume("CharDevice", devicePath)
 
-		pod := getPod(withVolume(charVolume), withCtr(getCtr(withImage(registry), withCmd(nil), withArg(nil), withVolumeMount(devicePath, false))))
+		pod := getPod(withVolume(charVolume), withCtr(getCtr(withImage(REGISTRY_IMAGE), withCmd(nil), withArg(nil), withVolumeMount(devicePath, false))))
 		err = generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())
 

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Podman pod create", func() {
 		Expect(session).Should(Exit(0))
 		pod := session.OutputToString()
 
-		webserver := podmanTest.Podman([]string{"run", "--pod", pod, "-dt", nginx})
+		webserver := podmanTest.Podman([]string{"run", "--pod", pod, "-dt", NGINX_IMAGE})
 		webserver.WaitWithDefaultTimeout()
 		Expect(webserver).Should(Exit(0))
 
@@ -114,7 +114,7 @@ var _ = Describe("Podman pod create", func() {
 		Expect(session).Should(Exit(0))
 		pod := session.OutputToString()
 
-		webserver := podmanTest.Podman([]string{"run", "--pod", pod, "-dt", nginx})
+		webserver := podmanTest.Podman([]string{"run", "--pod", pod, "-dt", NGINX_IMAGE})
 		webserver.WaitWithDefaultTimeout()
 		Expect(webserver).Should(Exit(0))
 		Expect(ncz(port)).To(BeTrue())
@@ -128,7 +128,7 @@ var _ = Describe("Podman pod create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		webserver := podmanTest.Podman([]string{"run", "--pod-id-file", file, "-dt", nginx})
+		webserver := podmanTest.Podman([]string{"run", "--pod-id-file", file, "-dt", NGINX_IMAGE})
 		webserver.WaitWithDefaultTimeout()
 		Expect(webserver).Should(Exit(0))
 		Expect(ncz(port)).To(BeTrue())

--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Podman pod create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"run", "-d", "--pod", podID, nginx})
+		session = podmanTest.Podman([]string{"run", "-d", "--pod", podID, NGINX_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -237,11 +237,11 @@ var _ = Describe("Podman pod create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"run", "-d", "--pod", podID, nginx})
+		session = podmanTest.Podman([]string{"run", "-d", "--pod", podID, NGINX_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"run", "--pod", podID, "--network", "bridge", nginx, "curl", "-f", "localhost"})
+		session = podmanTest.Podman([]string{"run", "--pod", podID, "--network", "bridge", NGINX_IMAGE, "curl", "-f", "localhost"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
 	})

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Podman pull", func() {
 	It("podman pull from docker-archive", func() {
 		SkipIfRemote("podman-remote does not support pulling from docker-archive")
 
-		podmanTest.AddImageToRWStore(cirros)
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 		tarfn := filepath.Join(podmanTest.TempDir, "cirros.tar")
 		session := podmanTest.Podman([]string{"save", "-o", tarfn, "cirros"})
 		session.WaitWithDefaultTimeout()
@@ -319,7 +319,7 @@ var _ = Describe("Podman pull", func() {
 	It("podman pull from oci-archive", func() {
 		SkipIfRemote("podman-remote does not support pulling from oci-archive")
 
-		podmanTest.AddImageToRWStore(cirros)
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 		tarfn := filepath.Join(podmanTest.TempDir, "oci-cirrus.tar")
 		session := podmanTest.Podman([]string{"save", "--format", "oci-archive", "-o", tarfn, "cirros"})
 		session.WaitWithDefaultTimeout()
@@ -339,7 +339,7 @@ var _ = Describe("Podman pull", func() {
 	It("podman pull from local directory", func() {
 		SkipIfRemote("podman-remote does not support pulling from local directory")
 
-		podmanTest.AddImageToRWStore(cirros)
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 		dirpath := filepath.Join(podmanTest.TempDir, "cirros")
 		err = os.MkdirAll(dirpath, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
@@ -363,7 +363,7 @@ var _ = Describe("Podman pull", func() {
 	It("podman pull from local OCI directory", func() {
 		SkipIfRemote("podman-remote does not support pulling from OCI directory")
 
-		podmanTest.AddImageToRWStore(cirros)
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 		dirpath := filepath.Join(podmanTest.TempDir, "cirros")
 		err = os.MkdirAll(dirpath, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -100,12 +100,12 @@ var _ = Describe("Podman push", func() {
 			Skip("No registry image for ppc64le")
 		}
 		if rootless.IsRootless() {
-			err := podmanTest.RestoreArtifact(registry)
+			err := podmanTest.RestoreArtifact(REGISTRY_IMAGE)
 			Expect(err).ToNot(HaveOccurred())
 		}
 		lock := GetPortLock("5000")
 		defer lock.Unlock()
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5000:5000", registry, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5000:5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -156,7 +156,7 @@ var _ = Describe("Podman push", func() {
 		}
 		lock := GetPortLock("5000")
 		defer lock.Unlock()
-		session := podmanTest.Podman([]string{"run", "--entrypoint", "htpasswd", registry, "-Bbn", "podmantest", "test"})
+		session := podmanTest.Podman([]string{"run", "--entrypoint", "htpasswd", REGISTRY_IMAGE, "-Bbn", "podmantest", "test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -173,7 +173,7 @@ var _ = Describe("Podman push", func() {
 			strings.Join([]string{authPath, "/auth"}, ":"), "-e", "REGISTRY_AUTH=htpasswd", "-e",
 			"REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm", "-e", "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd",
 			"-v", strings.Join([]string{certPath, "/certs"}, ":"), "-e", "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt",
-			"-e", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key", registry})
+			"-e", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key", REGISTRY_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi with short name", func() {
-		podmanTest.AddImageToRWStore(cirros)
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 		session := podmanTest.Podman([]string{"rmi", "cirros"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -58,7 +58,7 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi all images", func() {
-		podmanTest.AddImageToRWStore(nginx)
+		podmanTest.AddImageToRWStore(NGINX_IMAGE)
 		session := podmanTest.Podman([]string{"rmi", "-a"})
 		session.WaitWithDefaultTimeout()
 		images := podmanTest.Podman([]string{"images"})
@@ -68,7 +68,7 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi all images forcibly with short options", func() {
-		podmanTest.AddImageToRWStore(nginx)
+		podmanTest.AddImageToRWStore(NGINX_IMAGE)
 		session := podmanTest.Podman([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -76,12 +76,12 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi tagged image", func() {
-		podmanTest.AddImageToRWStore(cirros)
-		setup := podmanTest.Podman([]string{"images", "-q", cirros})
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
+		setup := podmanTest.Podman([]string{"images", "-q", CIRROS_IMAGE})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(Exit(0))
 
-		session := podmanTest.Podman([]string{"tag", cirros, "foo:bar", "foo"})
+		session := podmanTest.Podman([]string{"tag", CIRROS_IMAGE, "foo:bar", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -93,8 +93,8 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi image with tags by ID cannot be done without force", func() {
-		podmanTest.AddImageToRWStore(cirros)
-		setup := podmanTest.Podman([]string{"images", "-q", cirros})
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
+		setup := podmanTest.Podman([]string{"images", "-q", CIRROS_IMAGE})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(Exit(0))
 		cirrosID := setup.OutputToString()
@@ -116,8 +116,8 @@ var _ = Describe("Podman rmi", func() {
 
 	It("podman rmi image that is a parent of another image", func() {
 		Skip("I need help with this one. i don't understand what is going on")
-		podmanTest.AddImageToRWStore(cirros)
-		session := podmanTest.Podman([]string{"run", "--name", "c_test", cirros, "true"})
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
+		session := podmanTest.Podman([]string{"run", "--name", "c_test", CIRROS_IMAGE, "true"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -129,7 +129,7 @@ var _ = Describe("Podman rmi", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"rmi", cirros})
+		session = podmanTest.Podman([]string{"rmi", CIRROS_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -183,12 +183,12 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi with cached images", func() {
-		podmanTest.AddImageToRWStore(cirros)
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 		dockerfile := fmt.Sprintf(`FROM %s
 		RUN mkdir hello
 		RUN touch test.txt
 		ENV foo=bar
-		`, cirros)
+		`, CIRROS_IMAGE)
 		podmanTest.BuildImage(dockerfile, "test", "true")
 
 		dockerfile = fmt.Sprintf(`FROM %s
@@ -196,7 +196,7 @@ var _ = Describe("Podman rmi", func() {
 		RUN touch test.txt
 		RUN mkdir blah
 		ENV foo=bar
-		`, cirros)
+		`, CIRROS_IMAGE)
 
 		podmanTest.BuildImage(dockerfile, "test2", "true")
 
@@ -225,7 +225,7 @@ var _ = Describe("Podman rmi", func() {
 
 		podmanTest.BuildImage(dockerfile, "test3", "true")
 
-		session = podmanTest.Podman([]string{"rmi", cirros})
+		session = podmanTest.Podman([]string{"rmi", CIRROS_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -250,7 +250,7 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi -a with parent|child images", func() {
-		podmanTest.AddImageToRWStore(cirros)
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 		dockerfile := fmt.Sprintf(`FROM %s AS base
 RUN touch /1
 ENV LOCAL=/1
@@ -258,7 +258,7 @@ RUN find $LOCAL
 FROM base
 RUN find $LOCAL
 
-`, cirros)
+`, CIRROS_IMAGE)
 		podmanTest.BuildImage(dockerfile, "test", "true")
 		session := podmanTest.Podman([]string{"rmi", "-a"})
 		session.WaitWithDefaultTimeout()
@@ -285,7 +285,7 @@ RUN find $LOCAL
 		// a race, we may not hit the condition a 100 percent of times
 		// but ocal reproducers hit it all the time.
 
-		podmanTest.AddImageToRWStore(cirros)
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 		var wg sync.WaitGroup
 
 		buildAndRemove := func(i int) {
@@ -293,7 +293,7 @@ RUN find $LOCAL
 			defer wg.Done()
 			imageName := fmt.Sprintf("rmtest:%d", i)
 			containerfile := fmt.Sprintf(`FROM %s
-RUN touch %s`, cirros, imageName)
+RUN touch %s`, CIRROS_IMAGE, imageName)
 
 			podmanTest.BuildImage(containerfile, imageName, "false")
 			session := podmanTest.Podman([]string{"rmi", "-f", imageName})

--- a/test/e2e/run_aardvark_test.go
+++ b/test/e2e/run_aardvark_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Podman run networking", func() {
 		defer podmanTest.removeNetwork(netName)
 		Expect(session).Should(Exit(0))
 
-		ctrID := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netName, nginx})
+		ctrID := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netName, NGINX_IMAGE})
 		ctrID.WaitWithDefaultTimeout()
 		Expect(ctrID).Should(Exit(0))
 		cid := ctrID.OutputToString()
@@ -72,7 +72,7 @@ var _ = Describe("Podman run networking", func() {
 		defer podmanTest.removeNetwork(netName)
 		Expect(session).Should(Exit(0))
 
-		ctr1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netName, nginx})
+		ctr1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netName, NGINX_IMAGE})
 		ctr1.WaitWithDefaultTimeout()
 		Expect(ctr1).Should(Exit(0))
 		cid1 := ctr1.OutputToString()
@@ -83,7 +83,7 @@ var _ = Describe("Podman run networking", func() {
 		cip1 := ctrIP1.OutputToString()
 		Expect(cip1).To(MatchRegexp(IPRegex))
 
-		ctr2 := podmanTest.Podman([]string{"run", "-dt", "--name", "atwo", "--network", netName, nginx})
+		ctr2 := podmanTest.Podman([]string{"run", "-dt", "--name", "atwo", "--network", netName, NGINX_IMAGE})
 		ctr2.WaitWithDefaultTimeout()
 		Expect(ctr2).Should(Exit(0))
 		cid2 := ctr2.OutputToString()
@@ -123,7 +123,7 @@ var _ = Describe("Podman run networking", func() {
 		defer podmanTest.removeNetwork(netName)
 		Expect(session).Should(Exit(0))
 
-		ctr1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netName, "--network-alias", "alias_a1,alias_1a", nginx})
+		ctr1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netName, "--network-alias", "alias_a1,alias_1a", NGINX_IMAGE})
 		ctr1.WaitWithDefaultTimeout()
 		Expect(ctr1).Should(Exit(0))
 
@@ -133,7 +133,7 @@ var _ = Describe("Podman run networking", func() {
 		cip1 := ctrIP1.OutputToString()
 		Expect(cip1).To(MatchRegexp(IPRegex))
 
-		ctr2 := podmanTest.Podman([]string{"run", "-dt", "--name", "atwo", "--network", netName, "--network-alias", "alias_a2,alias_2a", nginx})
+		ctr2 := podmanTest.Podman([]string{"run", "-dt", "--name", "atwo", "--network", netName, "--network-alias", "alias_a2,alias_2a", NGINX_IMAGE})
 		ctr2.WaitWithDefaultTimeout()
 		Expect(ctr2).Should(Exit(0))
 
@@ -170,11 +170,11 @@ var _ = Describe("Podman run networking", func() {
 		defer podmanTest.removeNetwork(netNameB)
 		Expect(sessionB).Should(Exit(0))
 
-		ctrA1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netNameA, nginx})
+		ctrA1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netNameA, NGINX_IMAGE})
 		ctrA1.WaitWithDefaultTimeout()
 		cidA1 := ctrA1.OutputToString()
 
-		ctrB1 := podmanTest.Podman([]string{"run", "-dt", "--name", "bone", "--network", netNameB, nginx})
+		ctrB1 := podmanTest.Podman([]string{"run", "-dt", "--name", "bone", "--network", netNameB, NGINX_IMAGE})
 		ctrB1.WaitWithDefaultTimeout()
 		cidB1 := ctrB1.OutputToString()
 
@@ -214,7 +214,7 @@ var _ = Describe("Podman run networking", func() {
 		defer podmanTest.removeNetwork(netNameB)
 		Expect(sessionB).Should(Exit(0))
 
-		ctrA1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netNameA, nginx})
+		ctrA1 := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netNameA, NGINX_IMAGE})
 		ctrA1.WaitWithDefaultTimeout()
 		cidA1 := ctrA1.OutputToString()
 
@@ -224,7 +224,7 @@ var _ = Describe("Podman run networking", func() {
 		cipA1 := ctrIPA1.OutputToString()
 		Expect(cipA1).To(MatchRegexp(IPRegex))
 
-		ctrB1 := podmanTest.Podman([]string{"run", "-dt", "--name", "bone", "--network", netNameB, nginx})
+		ctrB1 := podmanTest.Podman([]string{"run", "-dt", "--name", "bone", "--network", netNameB, NGINX_IMAGE})
 		ctrB1.WaitWithDefaultTimeout()
 		cidB1 := ctrB1.OutputToString()
 
@@ -234,7 +234,7 @@ var _ = Describe("Podman run networking", func() {
 		cipB1 := ctrIPB1.OutputToString()
 		Expect(cipB1).To(MatchRegexp(IPRegex))
 
-		ctrA2B2 := podmanTest.Podman([]string{"run", "-dt", "--name", "atwobtwo", "--network", netNameA, "--network", netNameB, nginx})
+		ctrA2B2 := podmanTest.Podman([]string{"run", "-dt", "--name", "atwobtwo", "--network", netNameA, "--network", netNameB, NGINX_IMAGE})
 		ctrA2B2.WaitWithDefaultTimeout()
 		cidA2B2 := ctrA2B2.OutputToString()
 
@@ -278,11 +278,11 @@ var _ = Describe("Podman run networking", func() {
 		defer podmanTest.removeNetwork(netNameC)
 		Expect(sessionC).Should(Exit(0))
 
-		ctrA := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netNameA, nginx})
+		ctrA := podmanTest.Podman([]string{"run", "-dt", "--name", "aone", "--network", netNameA, NGINX_IMAGE})
 		ctrA.WaitWithDefaultTimeout()
 		Expect(ctrA).Should(Exit(0))
 
-		ctrC := podmanTest.Podman([]string{"run", "-dt", "--name", "cone", "--network", netNameC, nginx})
+		ctrC := podmanTest.Podman([]string{"run", "-dt", "--name", "cone", "--network", netNameC, NGINX_IMAGE})
 		ctrC.WaitWithDefaultTimeout()
 		Expect(ctrC).Should(Exit(0))
 

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -513,7 +513,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 	})
 
 	It("podman run network expose ports in image metadata", func() {
-		session := podmanTest.Podman([]string{"create", "--name", "test", "-t", "-P", nginx})
+		session := podmanTest.Podman([]string{"create", "--name", "test", "-t", "-P", NGINX_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		results := podmanTest.Podman([]string{"inspect", "test"})

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 
 	It("Podman run two containers with the same IP", func() {
 		ip := GetRandomIPAddress()
-		result := podmanTest.Podman([]string{"run", "-d", "--name", "nginx", "--ip", ip, nginx})
+		result := podmanTest.Podman([]string{"run", "-d", "--name", "nginx", "--ip", ip, NGINX_IMAGE})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run a container based on a complex local image name", func() {
-		imageName := strings.TrimPrefix(nginx, "quay.io/")
+		imageName := strings.TrimPrefix(NGINX_IMAGE, "quay.io/")
 		session := podmanTest.Podman([]string{"run", imageName, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ErrorToString()).ToNot(ContainSubstring("Trying to pull"))
@@ -141,10 +141,10 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run a container based on on a short name with localhost", func() {
-		tag := podmanTest.Podman([]string{"tag", nginx, "localhost/libpod/alpine_nginx:latest"})
+		tag := podmanTest.Podman([]string{"tag", NGINX_IMAGE, "localhost/libpod/alpine_nginx:latest"})
 		tag.WaitWithDefaultTimeout()
 
-		rmi := podmanTest.Podman([]string{"rmi", nginx})
+		rmi := podmanTest.Podman([]string{"rmi", NGINX_IMAGE})
 		rmi.WaitWithDefaultTimeout()
 
 		session := podmanTest.Podman([]string{"run", "libpod/alpine_nginx:latest", "ls"})
@@ -154,10 +154,10 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman container run a container based on on a short name with localhost", func() {
-		tag := podmanTest.Podman([]string{"image", "tag", nginx, "localhost/libpod/alpine_nginx:latest"})
+		tag := podmanTest.Podman([]string{"image", "tag", NGINX_IMAGE, "localhost/libpod/alpine_nginx:latest"})
 		tag.WaitWithDefaultTimeout()
 
-		rmi := podmanTest.Podman([]string{"image", "rm", nginx})
+		rmi := podmanTest.Podman([]string{"image", "rm", NGINX_IMAGE})
 		rmi.WaitWithDefaultTimeout()
 
 		session := podmanTest.Podman([]string{"container", "run", "libpod/alpine_nginx:latest", "ls"})
@@ -198,7 +198,7 @@ var _ = Describe("Podman run", func() {
 
 		lock := GetPortLock("5000")
 		defer lock.Unlock()
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5000:5000", registry, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5000:5000", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -1041,7 +1041,7 @@ echo -n %s >%s
 	})
 
 	It("podman run with built-in volume image", func() {
-		session := podmanTest.Podman([]string{"run", "--rm", redis, "ls"})
+		session := podmanTest.Podman([]string{"run", "--rm", REDIS_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -1144,7 +1144,7 @@ USER mail`, BB)
 	})
 
 	It("podman run --volumes-from flag with built-in volumes", func() {
-		session := podmanTest.Podman([]string{"create", redis, "sh"})
+		session := podmanTest.Podman([]string{"create", REDIS_IMAGE, "sh"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		ctrID := session.OutputToString()
@@ -1701,24 +1701,24 @@ WORKDIR /madethis`, BB)
 	})
 
 	It("podman run container with --pull missing and only pull once", func() {
-		session := podmanTest.Podman([]string{"run", "--pull", "missing", cirros, "ls"})
+		session := podmanTest.Podman([]string{"run", "--pull", "missing", CIRROS_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.ErrorToString()).To(ContainSubstring("Trying to pull"))
 
-		session = podmanTest.Podman([]string{"run", "--pull", "missing", cirros, "ls"})
+		session = podmanTest.Podman([]string{"run", "--pull", "missing", CIRROS_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.ErrorToString()).ToNot(ContainSubstring("Trying to pull"))
 	})
 
 	It("podman run container with --pull missing should pull image multiple times", func() {
-		session := podmanTest.Podman([]string{"run", "--pull", "always", cirros, "ls"})
+		session := podmanTest.Podman([]string{"run", "--pull", "always", CIRROS_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.ErrorToString()).To(ContainSubstring("Trying to pull"))
 
-		session = podmanTest.Podman([]string{"run", "--pull", "always", cirros, "ls"})
+		session = podmanTest.Podman([]string{"run", "--pull", "always", CIRROS_IMAGE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.ErrorToString()).To(ContainSubstring("Trying to pull"))

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman run with conflict between image volume and user mount succeeds", func() {
-		err = podmanTest.RestoreArtifact(redis)
+		err = podmanTest.RestoreArtifact(REDIS_IMAGE)
 		Expect(err).ToNot(HaveOccurred())
 		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
 		err := os.Mkdir(mountPath, 0755)
@@ -160,7 +160,7 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(err).To(BeNil(), "os.Create(testfile)")
 		f.Close()
 		Expect(err).To(BeNil())
-		session := podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:/data", mountPath), redis, "ls", "/data/test1"})
+		session := podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:/data", mountPath), REDIS_IMAGE, "ls", "/data/test1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})
@@ -592,7 +592,7 @@ RUN sh -c "cd /etc/apk && ln -s ../../testfile"`, ALPINE)
 	})
 
 	It("podman run image volume is not noexec", func() {
-		session := podmanTest.Podman([]string{"run", "--rm", redis, "grep", "/data", "/proc/self/mountinfo"})
+		session := podmanTest.Podman([]string{"run", "--rm", REDIS_IMAGE, "grep", "/data", "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(Not(ContainSubstring("noexec")))

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Podman save", func() {
 		defer os.Setenv("GNUPGHOME", origGNUPGHOME)
 
 		port := 5000
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", strings.Join([]string{strconv.Itoa(port), strconv.Itoa(port)}, ":"), "quay.io/libpod/registry:2.6"})
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", strings.Join([]string{strconv.Itoa(port), strconv.Itoa(port)}, ":"), REGISTRY_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		if !WaitContainerReady(podmanTest, "registry", "listening on", 20, 1) {

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -206,7 +206,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		port := GetPort()
 		fakereg := podmanTest.Podman([]string{"run", "-d", "--name", "registry",
 			"-p", fmt.Sprintf("%d:5000", port),
-			registry, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+			REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		fakereg.WaitWithDefaultTimeout()
 		Expect(fakereg).Should(Exit(0))
 
@@ -231,7 +231,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		}
 		port := GetPort()
 		registry := podmanTest.Podman([]string{"run", "-d", "--name", "registry3",
-			"-p", fmt.Sprintf("%d:5000", port), registry,
+			"-p", fmt.Sprintf("%d:5000", port), REGISTRY_IMAGE,
 			"/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		registry.WaitWithDefaultTimeout()
 		Expect(registry).Should(Exit(0))
@@ -268,7 +268,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		port := GetPort()
 		ep := endpoint{Port: fmt.Sprintf("%d", port), Host: "localhost"}
 		registry := podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%d:5000", port),
-			"--name", "registry4", registry, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+			"--name", "registry4", REGISTRY_IMAGE, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		registry.WaitWithDefaultTimeout()
 		Expect(registry).Should(Exit(0))
 
@@ -313,7 +313,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		port := GetPort()
 		ep := endpoint{Port: fmt.Sprintf("%d", port), Host: "localhost"}
 		registry := podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%d:5000", port),
-			"--name", "registry5", registry})
+			"--name", "registry5", REGISTRY_IMAGE})
 		registry.WaitWithDefaultTimeout()
 		Expect(registry).Should(Exit(0))
 
@@ -353,7 +353,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		port := GetPort()
 		ep := endpoint{Port: fmt.Sprintf("%d", port), Host: "localhost"}
 		registry := podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%d:5000", port),
-			"--name", "registry6", registry})
+			"--name", "registry6", REGISTRY_IMAGE})
 		registry.WaitWithDefaultTimeout()
 		Expect(registry).Should(Exit(0))
 
@@ -401,7 +401,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		ep3 := endpoint{Port: fmt.Sprintf("%d", port3), Host: "localhost"}
 
 		registryLocal := podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%d", port1),
-			"--name", "registry7", registry})
+			"--name", "registry7", REGISTRY_IMAGE})
 		registryLocal.WaitWithDefaultTimeout()
 		Expect(registryLocal).Should(Exit(0))
 
@@ -409,7 +409,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 			Fail("Cannot start docker registry on port %s", port1)
 		}
 
-		registryLocal = podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%d:5000", port2), "--name", "registry8", registry})
+		registryLocal = podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%d:5000", port2), "--name", "registry8", REGISTRY_IMAGE})
 		registryLocal.WaitWithDefaultTimeout()
 		Expect(registryLocal).Should(Exit(0))
 

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -60,7 +60,7 @@ WantedBy=default.target
 			Expect(stop).Should(Exit(0))
 		}()
 
-		create := podmanTest.Podman([]string{"create", "--name", "redis", redis})
+		create := podmanTest.Podman([]string{"create", "--name", "redis", REDIS_IMAGE})
 		create.WaitWithDefaultTimeout()
 		Expect(create).Should(Exit(0))
 

--- a/test/e2e/tree_test.go
+++ b/test/e2e/tree_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Podman image tree", func() {
 
 	It("podman image tree", func() {
 		SkipIfRemote("podman-image-tree is not supported for remote clients")
-		podmanTest.AddImageToRWStore(cirros)
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 		dockerfile := `FROM quay.io/libpod/cirros:latest
 RUN mkdir hello
 RUN touch test.txt

--- a/test/e2e/untag_test.go
+++ b/test/e2e/untag_test.go
@@ -33,8 +33,8 @@ var _ = Describe("Podman untag", func() {
 	})
 
 	It("podman untag all", func() {
-		podmanTest.AddImageToRWStore(cirros)
-		tags := []string{cirros, "registry.com/foo:bar", "localhost/foo:bar"}
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
+		tags := []string{CIRROS_IMAGE, "registry.com/foo:bar", "localhost/foo:bar"}
 
 		cmd := []string{"tag"}
 		cmd = append(cmd, tags...)
@@ -50,7 +50,7 @@ var _ = Describe("Podman untag", func() {
 		}
 
 		// No arguments -> remove all tags.
-		session = podmanTest.Podman([]string{"untag", cirros})
+		session = podmanTest.Podman([]string{"untag", CIRROS_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
@@ -63,7 +63,7 @@ var _ = Describe("Podman untag", func() {
 	})
 
 	It("podman tag/untag - tag normalization", func() {
-		podmanTest.AddImageToRWStore(cirros)
+		podmanTest.AddImageToRWStore(CIRROS_IMAGE)
 
 		tests := []struct {
 			tag, normalized string
@@ -77,7 +77,7 @@ var _ = Describe("Podman untag", func() {
 		// Make sure that the user input is normalized correctly for
 		// `podman tag` and `podman untag`.
 		for _, tt := range tests {
-			session := podmanTest.Podman([]string{"tag", cirros, tt.tag})
+			session := podmanTest.Podman([]string{"tag", CIRROS_IMAGE, tt.tag})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
 
@@ -85,7 +85,7 @@ var _ = Describe("Podman untag", func() {
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
 
-			session = podmanTest.Podman([]string{"untag", cirros, tt.tag})
+			session = podmanTest.Podman([]string{"untag", CIRROS_IMAGE, tt.tag})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
 


### PR DESCRIPTION
A number of standard image names were lower-case, leading to
confusion in code such as:

    registry := podman(... , "-n", "registry", registry, ...)
    ^--- variable                              ^---- constant

Fix a number of those to be capitalized and with _IMAGE suffix:

    registry := podman(...,                    REGISTRY_IMAGE

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```