### PR TITLE
golangci install: explicitly set BINDIR

### DIFF
--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -9,14 +9,17 @@ function install() {
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$VERSION
 }
 
-BIN="./bin/golangci-lint"
+# Undocumented behavior: golangci-lint installer requires $BINDIR in env,
+# will default to ./bin but we can't rely on that.
+export BINDIR="./bin"
+BIN="$BINDIR/golangci-lint"
 if [ ! -x "$BIN" ]; then
 	install
 else
     # Prints its own file name as part of --version output
     $BIN --version | grep "$VERSION"
     if [ $? -eq 0 ]; then
-        echo "Using existing $(dirname $BIN)/$($BIN --version)"
+        echo "Using existing $BINDIR/$($BIN --version)"
     else
         install
     fi


### PR DESCRIPTION
The golangci installer (which is curl pipe sh, ewww) installs
into $BINDIR, which it gets from the caller's environment.
Make sure we set it explicitly.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```