### PR TITLE
pkg: switch to golang native error wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20211214071223-8958f93039ab
 	github.com/opencontainers/runtime-tools v0.9.1-0.20220110225228-7e2d60f1e41f
 	github.com/opencontainers/selinux v1.10.1
-	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/rootless-containers/rootlesskit v1.0.1
 	github.com/sirupsen/logrus v1.8.1

--- a/pkg/api/handlers/compat/auth.go
+++ b/pkg/api/handlers/compat/auth.go
@@ -3,6 +3,7 @@ package compat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	api "github.com/containers/podman/v4/pkg/api/types"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	docker "github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 )
 
 func stripAddressOfScheme(address string) string {
@@ -28,7 +28,7 @@ func Auth(w http.ResponseWriter, r *http.Request) {
 	var authConfig docker.AuthConfig
 	err := json.NewDecoder(r.Body).Decode(&authConfig)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse request"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to parse request: %w", err))
 		return
 	}
 

--- a/pkg/api/handlers/compat/changes.go
+++ b/pkg/api/handlers/compat/changes.go
@@ -1,6 +1,7 @@
 package compat
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
@@ -8,7 +9,6 @@ import (
 	"github.com/containers/podman/v4/pkg/api/handlers/utils"
 	api "github.com/containers/podman/v4/pkg/api/types"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 func Changes(w http.ResponseWriter, r *http.Request) {
@@ -20,7 +20,7 @@ func Changes(w http.ResponseWriter, r *http.Request) {
 		DiffType string `schema:"diffType"`
 	}{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 	var diffType define.DiffType
@@ -32,7 +32,7 @@ func Changes(w http.ResponseWriter, r *http.Request) {
 	case "image":
 		diffType = define.DiffImage
 	default:
-		utils.Error(w, http.StatusBadRequest, errors.Errorf("invalid diffType value %q", query.DiffType))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("invalid diffType value %q", query.DiffType))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_attach.go
+++ b/pkg/api/handlers/compat/containers_attach.go
@@ -1,6 +1,8 @@
 package compat
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
@@ -9,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/pkg/api/server/idle"
 	api "github.com/containers/podman/v4/pkg/api/types"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -60,13 +61,13 @@ func AttachContainer(w http.ResponseWriter, r *http.Request) {
 		streams = nil
 	}
 	if useStreams && !streams.Stdout && !streams.Stderr && !streams.Stdin {
-		utils.Error(w, http.StatusBadRequest, errors.Errorf("at least one of stdin, stdout, stderr must be true"))
+		utils.Error(w, http.StatusBadRequest, errors.New("at least one of stdin, stdout, stderr must be true"))
 		return
 	}
 
 	// At least one of these must be set
 	if !query.Stream && !query.Logs {
-		utils.Error(w, http.StatusBadRequest, errors.Errorf("at least one of Logs or Stream must be set"))
+		utils.Error(w, http.StatusBadRequest, errors.New("at least one of Logs or Stream must be set"))
 		return
 	}
 
@@ -85,16 +86,16 @@ func AttachContainer(w http.ResponseWriter, r *http.Request) {
 	// For Docker compatibility, we need to re-initialize containers in these states.
 	if state == define.ContainerStateConfigured || state == define.ContainerStateExited || state == define.ContainerStateStopped {
 		if err := ctr.Init(r.Context(), ctr.PodID() != ""); err != nil {
-			utils.Error(w, http.StatusConflict, errors.Wrapf(err, "error preparing container %s for attach", ctr.ID()))
+			utils.Error(w, http.StatusConflict, fmt.Errorf("error preparing container %s for attach: %w", ctr.ID(), err))
 			return
 		}
 	} else if !(state == define.ContainerStateCreated || state == define.ContainerStateRunning) {
-		utils.InternalServerError(w, errors.Wrapf(define.ErrCtrStateInvalid, "can only attach to created or running containers - currently in state %s", state.String()))
+		utils.InternalServerError(w, fmt.Errorf("can only attach to created or running containers - currently in state %s: %w", state.String(), define.ErrCtrStateInvalid))
 		return
 	}
 
 	logErr := func(e error) {
-		logrus.Error(errors.Wrapf(e, "error attaching to container %s", ctr.ID()))
+		logrus.Errorf("Error attaching to container %s: %v", ctr.ID(), e)
 	}
 
 	// Perform HTTP attach.

--- a/pkg/api/handlers/compat/containers_export.go
+++ b/pkg/api/handlers/compat/containers_export.go
@@ -1,6 +1,7 @@
 package compat
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -8,7 +9,6 @@ import (
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/pkg/api/handlers/utils"
 	api "github.com/containers/podman/v4/pkg/api/types"
-	"github.com/pkg/errors"
 )
 
 func ExportContainer(w http.ResponseWriter, r *http.Request) {
@@ -21,21 +21,21 @@ func ExportContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	tmpfile, err := ioutil.TempFile("", "api.tar")
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to create tempfile"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 		return
 	}
 	defer os.Remove(tmpfile.Name())
 	if err := tmpfile.Close(); err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "unable to close tempfile"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to close tempfile: %w", err))
 		return
 	}
 	if err := con.Export(tmpfile.Name()); err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to save image"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to save image: %w", err))
 		return
 	}
 	rdr, err := os.Open(tmpfile.Name())
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "failed to read the exported tarfile"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to read the exported tarfile: %w", err))
 		return
 	}
 	defer rdr.Close()

--- a/pkg/api/handlers/compat/containers_logs.go
+++ b/pkg/api/handlers/compat/containers_logs.go
@@ -16,7 +16,6 @@ import (
 	api "github.com/containers/podman/v4/pkg/api/types"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -36,13 +35,13 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 		Tail: "all",
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
 	if !(query.Stdout || query.Stderr) {
 		msg := fmt.Sprintf("%s: you must choose at least one stream", http.StatusText(http.StatusBadRequest))
-		utils.Error(w, http.StatusBadRequest, errors.Errorf("%s for %s", msg, r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("%s for %s", msg, r.URL.String()))
 		return
 	}
 
@@ -96,7 +95,7 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 
 	logChannel := make(chan *logs.LogLine, tail+1)
 	if err := runtime.Log(r.Context(), []*libpod.Container{ctnr}, options, logChannel); err != nil {
-		utils.InternalServerError(w, errors.Wrapf(err, "failed to obtain logs for Container '%s'", name))
+		utils.InternalServerError(w, fmt.Errorf("failed to obtain logs for Container '%s': %w", name, err))
 		return
 	}
 	go func() {
@@ -114,7 +113,7 @@ func LogsFromContainer(w http.ResponseWriter, r *http.Request) {
 	if !utils.IsLibpodRequest(r) {
 		inspectData, err := ctnr.Inspect(false)
 		if err != nil {
-			utils.InternalServerError(w, errors.Wrapf(err, "failed to obtain logs for Container '%s'", name))
+			utils.InternalServerError(w, fmt.Errorf("failed to obtain logs for Container '%s': %w", name, err))
 			return
 		}
 		writeHeader = !inspectData.Config.Tty

--- a/pkg/api/handlers/compat/containers_prune.go
+++ b/pkg/api/handlers/compat/containers_prune.go
@@ -2,6 +2,8 @@ package compat
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
@@ -11,14 +13,13 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
 	"github.com/containers/podman/v4/pkg/domain/filters"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 )
 
 func PruneContainers(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	filtersMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_stats.go
+++ b/pkg/api/handlers/compat/containers_stats.go
@@ -2,6 +2,7 @@ package compat
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	docker "github.com/docker/docker/api/types"
 	"github.com/gorilla/schema"
 	runccgroups "github.com/opencontainers/runc/libcontainer/cgroups"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -30,7 +30,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		Stream: true,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 	if query.Stream && query.OneShot { // mismatch. one-shot can only be passed with stream=false
@@ -47,7 +47,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 
 	stats, err := ctnr.GetContainerStats(nil)
 	if err != nil {
-		utils.InternalServerError(w, errors.Wrapf(err, "failed to obtain Container %s stats", name))
+		utils.InternalServerError(w, fmt.Errorf("failed to obtain Container %s stats: %w", name, err))
 		return
 	}
 

--- a/pkg/api/handlers/compat/containers_top.go
+++ b/pkg/api/handlers/compat/containers_top.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/pkg/api/handlers/utils"
 	api "github.com/containers/podman/v4/pkg/api/types"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,7 +32,7 @@ func TopContainer(w http.ResponseWriter, r *http.Request) {
 		PsArgs: psArgs,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 

--- a/pkg/api/handlers/compat/events.go
+++ b/pkg/api/handlers/compat/events.go
@@ -1,6 +1,7 @@
 package compat
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
@@ -11,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/gorilla/schema"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -34,7 +34,7 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 		Stream: true,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -44,7 +44,7 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 
 	libpodFilters, err := util.FiltersFromRequest(r)
 	if err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 	eventChannel := make(chan *events.Event)

--- a/pkg/api/handlers/compat/images_history.go
+++ b/pkg/api/handlers/compat/images_history.go
@@ -1,13 +1,13 @@
 package compat
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/pkg/api/handlers"
 	"github.com/containers/podman/v4/pkg/api/handlers/utils"
 	api "github.com/containers/podman/v4/pkg/api/types"
-	"github.com/pkg/errors"
 )
 
 func HistoryImage(w http.ResponseWriter, r *http.Request) {
@@ -16,13 +16,13 @@ func HistoryImage(w http.ResponseWriter, r *http.Request) {
 
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, name)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("error normalizing image: %w", err))
 		return
 	}
 
 	newImage, _, err := runtime.LibimageRuntime().LookupImage(possiblyNormalizedName, nil)
 	if err != nil {
-		utils.ImageNotFound(w, possiblyNormalizedName, errors.Wrapf(err, "failed to find image %s", possiblyNormalizedName))
+		utils.ImageNotFound(w, possiblyNormalizedName, fmt.Errorf("failed to find image %s: %w", possiblyNormalizedName, err))
 		return
 	}
 	history, err := newImage.History(r.Context())

--- a/pkg/api/handlers/compat/images_prune.go
+++ b/pkg/api/handlers/compat/images_prune.go
@@ -2,6 +2,7 @@ package compat
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 )
 
 func PruneImages(w http.ResponseWriter, r *http.Request) {
@@ -22,7 +22,7 @@ func PruneImages(w http.ResponseWriter, r *http.Request) {
 
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 

--- a/pkg/api/handlers/compat/images_search.go
+++ b/pkg/api/handlers/compat/images_search.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	"github.com/containers/storage"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 func SearchImages(w http.ResponseWriter, r *http.Request) {
@@ -30,7 +29,7 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 

--- a/pkg/api/handlers/compat/images_tag.go
+++ b/pkg/api/handlers/compat/images_tag.go
@@ -1,6 +1,7 @@
 package compat
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/pkg/api/handlers/utils"
 	api "github.com/containers/podman/v4/pkg/api/types"
-	"github.com/pkg/errors"
 )
 
 func TagImage(w http.ResponseWriter, r *http.Request) {
@@ -17,7 +17,7 @@ func TagImage(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	possiblyNormalizedName, err := utils.NormalizeToDockerHub(r, name)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("error normalizing image: %w", err))
 		return
 	}
 
@@ -25,7 +25,7 @@ func TagImage(w http.ResponseWriter, r *http.Request) {
 	lookupOptions := &libimage.LookupImageOptions{ManifestList: true}
 	newImage, _, err := runtime.LibimageRuntime().LookupImage(possiblyNormalizedName, lookupOptions)
 	if err != nil {
-		utils.ImageNotFound(w, name, errors.Wrapf(err, "failed to find image %s", name))
+		utils.ImageNotFound(w, name, fmt.Errorf("failed to find image %s: %w", name, err))
 		return
 	}
 
@@ -42,7 +42,7 @@ func TagImage(w http.ResponseWriter, r *http.Request) {
 
 	possiblyNormalizedTag, err := utils.NormalizeToDockerHub(r, tagName)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error normalizing image"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("error normalizing image: %w", err))
 		return
 	}
 

--- a/pkg/api/handlers/compat/info.go
+++ b/pkg/api/handlers/compat/info.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -33,18 +32,18 @@ func GetInfo(w http.ResponseWriter, r *http.Request) {
 
 	infoData, err := runtime.Info()
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain system memory info"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to obtain system memory info: %w", err))
 		return
 	}
 
 	configInfo, err := runtime.GetConfig()
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain runtime config"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to obtain runtime config: %w", err))
 		return
 	}
 	versionInfo, err := define.GetVersion()
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain podman versions"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to obtain podman versions: %w", err))
 		return
 	}
 	stateInfo := getContainersState(runtime)

--- a/pkg/api/handlers/compat/version.go
+++ b/pkg/api/handlers/compat/version.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/entities/types"
 	"github.com/containers/podman/v4/version"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -28,7 +27,7 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 
 	info, err := runtime.Info()
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrapf(err, "failed to obtain system memory info"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to obtain system memory info: %w", err))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/specgen/generate"
 	"github.com/containers/podman/v4/pkg/specgenutil"
-	"github.com/pkg/errors"
 )
 
 // CreateContainer takes a specgenerator and makes a container. It returns
@@ -34,7 +34,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&sg); err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("decode(): %w", err))
 		return
 	}
 	if sg.Passwd == nil {

--- a/pkg/api/handlers/libpod/containers_stats.go
+++ b/pkg/api/handlers/libpod/containers_stats.go
@@ -2,6 +2,8 @@ package libpod
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/containers/common/pkg/cgroups"
@@ -12,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -24,8 +25,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 	if rootless.IsRootless() {
 		// if so, then verify cgroup v2 available (more expensive check)
 		if isV2, _ := cgroups.IsCgroup2UnifiedMode(); !isV2 {
-			msg := "Container stats resource only available for cgroup v2"
-			utils.Error(w, http.StatusConflict, errors.New(msg))
+			utils.Error(w, http.StatusConflict, errors.New("container stats resource only available for cgroup v2"))
 			return
 		}
 	}
@@ -39,7 +39,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		Interval: 5,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/generate.go
+++ b/pkg/api/handlers/libpod/generate.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 func GenerateSystemd(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +37,7 @@ func GenerateSystemd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -76,7 +76,7 @@ func GenerateSystemd(w http.ResponseWriter, r *http.Request) {
 
 	report, err := containerEngine.GenerateSystemd(r.Context(), utils.GetName(r), options)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error generating systemd units"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("error generating systemd units: %w", err))
 		return
 	}
 
@@ -94,7 +94,7 @@ func GenerateKube(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -102,7 +102,7 @@ func GenerateKube(w http.ResponseWriter, r *http.Request) {
 	options := entities.GenerateKubeOptions{Service: query.Service}
 	report, err := containerEngine.GenerateKube(r.Context(), query.Names, options)
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error generating YAML"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("error generating YAML: %w", err))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -3,6 +3,8 @@ package libpod
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/containers/common/libimage"
@@ -15,7 +17,6 @@ import (
 	"github.com/containers/podman/v4/pkg/channel"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -41,7 +42,7 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -24,7 +25,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/schema"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 func ManifestCreate(w http.ResponseWriter, r *http.Request) {
@@ -45,7 +45,7 @@ func ManifestCreate(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+			fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -54,7 +54,7 @@ func ManifestCreate(w http.ResponseWriter, r *http.Request) {
 		n, err := url.QueryUnescape(name)
 		if err != nil {
 			utils.Error(w, http.StatusBadRequest,
-				errors.Wrapf(err, "failed to parse name parameter %q", name))
+				fmt.Errorf("failed to parse name parameter %q: %w", name, err))
 			return
 		}
 		query.Name = n
@@ -62,7 +62,7 @@ func ManifestCreate(w http.ResponseWriter, r *http.Request) {
 
 	if _, err := reference.ParseNormalizedNamed(query.Name); err != nil {
 		utils.Error(w, http.StatusBadRequest,
-			errors.Wrapf(err, "invalid image name %s", query.Name))
+			fmt.Errorf("invalid image name %s: %w", query.Name, err))
 		return
 	}
 
@@ -94,7 +94,7 @@ func ManifestCreate(w http.ResponseWriter, r *http.Request) {
 
 	body := new(entities.ManifestModifyOptions)
 	if err := json.Unmarshal(buffer, body); err != nil {
-		utils.InternalServerError(w, errors.Wrap(err, "Decode()"))
+		utils.InternalServerError(w, fmt.Errorf("Decode(): %w", err))
 		return
 	}
 
@@ -166,7 +166,7 @@ func ManifestAddV3(w http.ResponseWriter, r *http.Request) {
 		TLSVerify bool `schema:"tlsVerify"`
 	}{}
 	if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("Decode(): %w", err))
 		return
 	}
 
@@ -220,7 +220,7 @@ func ManifestRemoveDigestV3(w http.ResponseWriter, r *http.Request) {
 	name := utils.GetName(r)
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+			fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 	manifestList, err := runtime.LibimageRuntime().LookupManifestList(name)
@@ -256,7 +256,7 @@ func ManifestPushV3(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+			fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 	if err := utils.IsRegistryReference(query.Destination); err != nil {
@@ -292,7 +292,7 @@ func ManifestPushV3(w http.ResponseWriter, r *http.Request) {
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 	digest, err := imageEngine.ManifestPush(context.Background(), source, query.Destination, options)
 	if err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "error pushing image %q", query.Destination))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("error pushing image %q: %w", query.Destination, err))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, entities.IDResponse{ID: digest})
@@ -313,7 +313,7 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+			fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -325,7 +325,7 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 
 	authconf, authfile, err := auth.GetCredentials(r)
 	if err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse registry header for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse registry header for %s: %w", r.URL.String(), err))
 		return
 	}
 	defer auth.RemoveAuthfile(authfile)
@@ -351,7 +351,7 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 	source := utils.GetName(r)
 	digest, err := imageEngine.ManifestPush(context.Background(), source, destination, options)
 	if err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "error pushing image %q", destination))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("error pushing image %q: %w", destination, err))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, entities.IDResponse{ID: digest})
@@ -364,7 +364,7 @@ func ManifestModify(w http.ResponseWriter, r *http.Request) {
 
 	body := new(entities.ManifestModifyOptions)
 	if err := json.NewDecoder(r.Body).Decode(body); err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("Decode(): %w", err))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/play.go
+++ b/pkg/api/handlers/libpod/play.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 func PlayKube(w http.ResponseWriter, r *http.Request) {
@@ -34,7 +34,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 
@@ -42,7 +42,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	for _, ipString := range query.StaticIPs {
 		ip := net.ParseIP(ipString)
 		if ip == nil {
-			utils.Error(w, http.StatusBadRequest, errors.Errorf("Invalid IP address %s", ipString))
+			utils.Error(w, http.StatusBadRequest, fmt.Errorf("invalid IP address %s", ipString))
 			return
 		}
 		staticIPs = append(staticIPs, ip)
@@ -103,7 +103,7 @@ func PlayKube(w http.ResponseWriter, r *http.Request) {
 	report, err := containerEngine.PlayKube(r.Context(), r.Body, options)
 	_ = r.Body.Close()
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error playing YAML file"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("error playing YAML file: %w", err))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, report)
@@ -116,7 +116,7 @@ func PlayKubeDown(w http.ResponseWriter, r *http.Request) {
 	report, err := containerEngine.PlayKubeDown(r.Context(), r.Body, *options)
 	_ = r.Body.Close()
 	if err != nil {
-		utils.Error(w, http.StatusInternalServerError, errors.Wrap(err, "error tearing down YAML file"))
+		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("error tearing down YAML file: %w", err))
 		return
 	}
 	utils.WriteResponse(w, http.StatusOK, report)

--- a/pkg/api/handlers/libpod/secrets.go
+++ b/pkg/api/handlers/libpod/secrets.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
@@ -9,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 func CreateSecret(w http.ResponseWriter, r *http.Request) {
@@ -27,7 +27,7 @@ func CreateSecret(w http.ResponseWriter, r *http.Request) {
 	}
 	opts := entities.SecretCreateOptions{}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, http.StatusBadRequest, errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 

--- a/pkg/api/handlers/libpod/swagger_spec.go
+++ b/pkg/api/handlers/libpod/swagger_spec.go
@@ -1,11 +1,12 @@
 package libpod
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"os"
 
 	"github.com/containers/podman/v4/pkg/api/handlers/utils"
-	"github.com/pkg/errors"
 )
 
 // DefaultPodmanSwaggerSpec provides the default path to the podman swagger spec file
@@ -18,7 +19,7 @@ func ServeSwagger(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, err := os.Stat(path); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			utils.InternalServerError(w, errors.Errorf("swagger spec %q does not exist", path))
+			utils.InternalServerError(w, fmt.Errorf("swagger spec %q does not exist", path))
 			return
 		}
 		utils.InternalServerError(w, err)

--- a/pkg/api/handlers/libpod/system.go
+++ b/pkg/api/handlers/libpod/system.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/containers/podman/v4/libpod"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/infra/abi"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/gorilla/schema"
-	"github.com/pkg/errors"
 )
 
 // SystemPrune removes unused data
@@ -25,13 +25,13 @@ func SystemPrune(w http.ResponseWriter, r *http.Request) {
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+			fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 	filterMap, err := util.PrepareFilters(r)
 	if err != nil {
 		utils.Error(w, http.StatusBadRequest,
-			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+			fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
 		return
 	}
 

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/containers/common/libimage"
@@ -10,7 +11,6 @@ import (
 	dockerContainer "github.com/docker/docker/api/types/container"
 	dockerNetwork "github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
-	"github.com/pkg/errors"
 )
 
 type AuthConfig struct {
@@ -237,17 +237,17 @@ func portsToPortSet(input map[string]struct{}) (nat.PortSet, error) {
 		case "tcp", "":
 			p, err := nat.NewPort("tcp", port)
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to create tcp port from %s", k)
+				return nil, fmt.Errorf("unable to create tcp port from %s: %w", k, err)
 			}
 			ports[p] = struct{}{}
 		case "udp":
 			p, err := nat.NewPort("udp", port)
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to create tcp port from %s", k)
+				return nil, fmt.Errorf("unable to create tcp port from %s: %w", k, err)
 			}
 			ports[p] = struct{}{}
 		default:
-			return nil, errors.Errorf("invalid port proto %q in %q", proto, k)
+			return nil, fmt.Errorf("invalid port proto %q in %q", proto, k)
 		}
 	}
 	return ports, nil

--- a/pkg/api/handlers/utils/handler.go
+++ b/pkg/api/handlers/utils/handler.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/version"
 	"github.com/gorilla/mux"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -42,11 +42,11 @@ func SupportedVersion(r *http.Request, condition string) (semver.Version, error)
 	}
 	safeVal, err := url.PathUnescape(val)
 	if err != nil {
-		return version, errors.Wrapf(err, "unable to unescape given API version: %q", val)
+		return version, fmt.Errorf("unable to unescape given API version: %q: %w", val, err)
 	}
 	version, err = semver.ParseTolerant(safeVal)
 	if err != nil {
-		return version, errors.Wrapf(err, "unable to parse given API version: %q from %q", safeVal, val)
+		return version, fmt.Errorf("unable to parse given API version: %q from %q: %w", safeVal, val, err)
 	}
 
 	inRange, err := semver.ParseRange(condition)
@@ -178,7 +178,7 @@ func GetVar(r *http.Request, k string) string {
 	val := mux.Vars(r)[k]
 	safeVal, err := url.PathUnescape(val)
 	if err != nil {
-		logrus.Error(errors.Wrapf(err, "failed to unescape mux key %s, value %s", k, val))
+		logrus.Error(fmt.Errorf("failed to unescape mux key %s, value %s: %w", k, val, err))
 		return val
 	}
 	return safeVal

--- a/pkg/api/server/listener_api.go
+++ b/pkg/api/server/listener_api.go
@@ -1,11 +1,10 @@
 package server
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 // ListenUnix follows stdlib net.Listen() API, providing a unix listener for given path
@@ -14,18 +13,18 @@ func ListenUnix(network string, path string) (net.Listener, error) {
 	// set up custom listener for API server
 	err := os.MkdirAll(filepath.Dir(path), 0770)
 	if err != nil {
-		return nil, errors.Wrapf(err, "api.ListenUnix() failed to create %s", filepath.Dir(path))
+		return nil, fmt.Errorf("api.ListenUnix() failed to create %s: %w", filepath.Dir(path), err)
 	}
 	os.Remove(path)
 
 	listener, err := net.Listen(network, path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "api.ListenUnix() failed to create net.Listen(%s, %s)", network, path)
+		return nil, fmt.Errorf("api.ListenUnix() failed to create net.Listen(%s, %s): %w", network, path, err)
 	}
 
 	_, err = os.Stat(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "net.Listen(%s, %s) failed to report the failure to create socket", network, path)
+		return nil, fmt.Errorf("net.Listen(%s, %s) failed to report the failure to create socket: %w", network, path, err)
 	}
 
 	return listener, nil

--- a/pkg/bindings/containers/archive.go
+++ b/pkg/bindings/containers/archive.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -9,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/pkg/bindings"
 	"github.com/containers/podman/v4/pkg/copy"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 )
 
 // Stat checks if the specified path is on the container.  Note that the stat

--- a/pkg/bindings/containers/attach.go
+++ b/pkg/bindings/containers/attach.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -18,7 +19,6 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/bindings"
 	"github.com/moby/term"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	terminal "golang.org/x/term"
 )
@@ -75,7 +75,7 @@ func Attach(ctx context.Context, nameOrID string, stdin io.Reader, stdout io.Wri
 
 		detachKeysInBytes, err = term.ToBytes(options.GetDetachKeys())
 		if err != nil {
-			return errors.Wrapf(err, "invalid detach keys")
+			return fmt.Errorf("invalid detach keys: %w", err)
 		}
 	}
 	if isSet.stdin {
@@ -261,7 +261,7 @@ func DemuxHeader(r io.Reader, buffer []byte) (fd, sz int, err error) {
 
 	fd = int(buffer[0])
 	if fd < 0 || fd > 3 {
-		err = errors.Wrapf(ErrLostSync, fmt.Sprintf(`channel "%d" found, 0-3 supported`, fd))
+		err = fmt.Errorf(`channel "%d" found, 0-3 supported: %w`, fd, ErrLostSync)
 		return
 	}
 

--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -2,6 +2,8 @@ package containers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -12,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/pkg/bindings"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -447,7 +448,7 @@ func ContainerInit(ctx context.Context, nameOrID string, options *InitOptions) e
 	defer response.Body.Close()
 
 	if response.StatusCode == http.StatusNotModified {
-		return errors.Wrapf(define.ErrCtrStateInvalid, "container %s has already been created in runtime", nameOrID)
+		return fmt.Errorf("container %s has already been created in runtime: %w", nameOrID, define.ErrCtrStateInvalid)
 	}
 	return response.Process(nil)
 }

--- a/pkg/bindings/containers/exec.go
+++ b/pkg/bindings/containers/exec.go
@@ -3,6 +3,8 @@ package containers
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -11,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/pkg/bindings"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,12 +28,12 @@ func ExecCreate(ctx context.Context, nameOrID string, config *handlers.ExecCreat
 	}
 
 	if config == nil {
-		return "", errors.Errorf("must provide a configuration for exec session")
+		return "", errors.New("must provide a configuration for exec session")
 	}
 
 	requestJSON, err := json.Marshal(config)
 	if err != nil {
-		return "", errors.Wrapf(err, "error marshalling exec config to JSON")
+		return "", fmt.Errorf("error marshalling exec config to JSON: %w", err)
 	}
 	jsonReader := strings.NewReader(string(requestJSON))
 

--- a/pkg/bindings/containers/logs.go
+++ b/pkg/bindings/containers/logs.go
@@ -2,13 +2,13 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 
 	"github.com/containers/podman/v4/pkg/bindings"
-	"github.com/pkg/errors"
 )
 
 // Logs obtains a container's logs given the options provided.  The logs are then sent to the

--- a/pkg/bindings/errors.go
+++ b/pkg/bindings/errors.go
@@ -2,10 +2,11 @@ package bindings
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/containers/podman/v4/pkg/errorhandling"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -30,7 +31,7 @@ func (h APIResponse) Process(unmarshalInto interface{}) error {
 func (h APIResponse) ProcessWithError(unmarshalInto interface{}, unmarshalErrorInto interface{}) error {
 	data, err := ioutil.ReadAll(h.Response.Body)
 	if err != nil {
-		return errors.Wrap(err, "unable to process API response")
+		return fmt.Errorf("unable to process API response: %w", err)
 	}
 	if h.IsSuccess() || h.IsRedirection() {
 		if unmarshalInto != nil {

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -2,6 +2,7 @@ package images
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,7 +15,6 @@ import (
 	"github.com/containers/podman/v4/pkg/bindings"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
-	"github.com/pkg/errors"
 )
 
 // Exists a lightweight way to determine if an image exists in local storage.  It returns a

--- a/pkg/bindings/images/pull.go
+++ b/pkg/bindings/images/pull.go
@@ -3,6 +3,7 @@ package images
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,7 +16,6 @@ import (
 	"github.com/containers/podman/v4/pkg/bindings"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/errorhandling"
-	"github.com/pkg/errors"
 )
 
 // Pull is the binding for libpod's v2 endpoints for pulling images.  Note that
@@ -91,7 +91,7 @@ func Pull(ctx context.Context, rawImage string, options *PullOptions) ([]string,
 			images = report.Images
 		case report.ID != "":
 		default:
-			return images, errors.Errorf("failed to parse pull results stream, unexpected input: %v", report)
+			return images, fmt.Errorf("failed to parse pull results stream, unexpected input: %v", report)
 		}
 	}
 	return images, errorhandling.JoinErrors(pullErrors)

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -2,6 +2,8 @@ package manifests
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -15,7 +17,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/errorhandling"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 // Create creates a manifest for the given name.  Optional images to be associated with
@@ -219,13 +220,13 @@ func Modify(ctx context.Context, name string, images []string, options *ModifyOp
 
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to process API response")
+		return "", fmt.Errorf("unable to process API response: %w", err)
 	}
 
 	if response.IsSuccess() || response.IsRedirection() {
 		var report entities.ManifestModifyReport
 		if err = jsoniter.Unmarshal(data, &report); err != nil {
-			return "", errors.Wrap(err, "unable to decode API response")
+			return "", fmt.Errorf("unable to decode API response: %w", err)
 		}
 
 		err = errorhandling.JoinErrors(report.Errors)
@@ -244,7 +245,7 @@ func Modify(ctx context.Context, name string, images []string, options *ModifyOp
 		ResponseCode: response.StatusCode,
 	}
 	if err = jsoniter.Unmarshal(data, &errModel); err != nil {
-		return "", errors.Wrap(err, "unable to decode API response")
+		return "", fmt.Errorf("unable to decode API response: %w", err)
 	}
 	return "", &errModel
 }

--- a/pkg/bindings/system/system.go
+++ b/pkg/bindings/system/system.go
@@ -3,6 +3,7 @@ package system
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/bindings"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -37,7 +37,7 @@ func Events(ctx context.Context, eventChan chan entities.Event, cancelChan chan 
 		go func() {
 			<-cancelChan
 			err = response.Body.Close()
-			logrus.Error(errors.Wrap(err, "unable to close event response body"))
+			logrus.Errorf("Unable to close event response body: %v", err)
 		}()
 	}
 
@@ -56,7 +56,7 @@ func Events(ctx context.Context, eventChan chan entities.Event, cancelChan chan 
 	case errors.Is(err, io.EOF):
 		return nil
 	default:
-		return errors.Wrap(err, "unable to decode event response")
+		return fmt.Errorf("unable to decode event response: %w", err)
 	}
 }
 

--- a/pkg/bindings/test/common_test.go
+++ b/pkg/bindings/test/common_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega/gexec"
-	"github.com/pkg/errors"
 )
 
 type testImage struct {
@@ -127,7 +126,7 @@ func (b *bindingTest) runPodman(command []string) *gexec.Session {
 	fmt.Printf("Running: %s %s\n", podmanBinary, strings.Join(cmd, " "))
 	session, err := gexec.Start(c, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 	if err != nil {
-		panic(errors.Errorf("unable to run podman command: %q", cmd))
+		panic(fmt.Errorf("unable to run podman command: %q", cmd))
 	}
 	return session
 }

--- a/pkg/channel/writer.go
+++ b/pkg/channel/writer.go
@@ -1,10 +1,9 @@
 package channel
 
 import (
+	"errors"
 	"io"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 // WriteCloser is an io.WriteCloser that that proxies Write() calls to a channel

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -2,6 +2,8 @@ package checkpoint
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -16,7 +18,6 @@ import (
 	"github.com/containers/podman/v4/pkg/specgen/generate"
 	"github.com/containers/podman/v4/pkg/specgenutil"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -65,7 +66,7 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 
 	// This should not happen as checkpoints with these options are not exported.
 	if len(ctrConfig.Dependencies) > 0 {
-		return nil, errors.Errorf("Cannot import checkpoints of containers with dependencies")
+		return nil, errors.New("cannot import checkpoints of containers with dependencies")
 	}
 
 	// Volumes included in the checkpoint should not exist
@@ -76,7 +77,7 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 				return nil, err
 			}
 			if exists {
-				return nil, errors.Errorf("volume with name %s already exists. Use --ignore-volumes to not restore content of volumes", vol.Name)
+				return nil, fmt.Errorf("volume with name %s already exists. Use --ignore-volumes to not restore content of volumes", vol.Name)
 			}
 		}
 	}
@@ -106,11 +107,11 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 	if restoreOptions.Pod != "" {
 		// Restoring into a Pod requires much newer versions of CRIU
 		if !criu.CheckForCriu(criu.PodCriuVersion) {
-			return nil, errors.Errorf("restoring containers into pods requires at least CRIU %d", criu.PodCriuVersion)
+			return nil, fmt.Errorf("restoring containers into pods requires at least CRIU %d", criu.PodCriuVersion)
 		}
 		// The runtime also has to support it
 		if !crutils.CRRuntimeSupportsPodCheckpointRestore(runtime.GetOCIRuntimePath()) {
-			return nil, errors.Errorf("runtime %s does not support pod restore", runtime.GetOCIRuntimePath())
+			return nil, fmt.Errorf("runtime %s does not support pod restore", runtime.GetOCIRuntimePath())
 		}
 		// Restoring into an existing Pod
 		ctrConfig.Pod = restoreOptions.Pod
@@ -120,12 +121,12 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 		// Let's make sure we a restoring into a pod with the same shared namespaces.
 		pod, err := runtime.LookupPod(ctrConfig.Pod)
 		if err != nil {
-			return nil, errors.Wrapf(err, "pod %q cannot be retrieved", ctrConfig.Pod)
+			return nil, fmt.Errorf("pod %q cannot be retrieved: %w", ctrConfig.Pod, err)
 		}
 
 		infraContainer, err := pod.InfraContainer()
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot retrieve infra container from pod %q", ctrConfig.Pod)
+			return nil, fmt.Errorf("cannot retrieve infra container from pod %q: %w", ctrConfig.Pod, err)
 		}
 
 		// If a namespaces was shared (!= "") it needs to be set to the new infrastructure container
@@ -133,14 +134,14 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 		// container we abort.
 		if ctrConfig.IPCNsCtr != "" {
 			if !pod.SharesIPC() {
-				return nil, errors.Errorf("pod %s does not share the IPC namespace", ctrConfig.Pod)
+				return nil, fmt.Errorf("pod %s does not share the IPC namespace", ctrConfig.Pod)
 			}
 			ctrConfig.IPCNsCtr = infraContainer.ID()
 		}
 
 		if ctrConfig.NetNsCtr != "" {
 			if !pod.SharesNet() {
-				return nil, errors.Errorf("pod %s does not share the network namespace", ctrConfig.Pod)
+				return nil, fmt.Errorf("pod %s does not share the network namespace", ctrConfig.Pod)
 			}
 			ctrConfig.NetNsCtr = infraContainer.ID()
 			for net, opts := range ctrConfig.Networks {
@@ -154,21 +155,21 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 
 		if ctrConfig.PIDNsCtr != "" {
 			if !pod.SharesPID() {
-				return nil, errors.Errorf("pod %s does not share the PID namespace", ctrConfig.Pod)
+				return nil, fmt.Errorf("pod %s does not share the PID namespace", ctrConfig.Pod)
 			}
 			ctrConfig.PIDNsCtr = infraContainer.ID()
 		}
 
 		if ctrConfig.UTSNsCtr != "" {
 			if !pod.SharesUTS() {
-				return nil, errors.Errorf("pod %s does not share the UTS namespace", ctrConfig.Pod)
+				return nil, fmt.Errorf("pod %s does not share the UTS namespace", ctrConfig.Pod)
 			}
 			ctrConfig.UTSNsCtr = infraContainer.ID()
 		}
 
 		if ctrConfig.CgroupNsCtr != "" {
 			if !pod.SharesCgroup() {
-				return nil, errors.Errorf("pod %s does not share the cgroup namespace", ctrConfig.Pod)
+				return nil, fmt.Errorf("pod %s does not share the cgroup namespace", ctrConfig.Pod)
 			}
 			ctrConfig.CgroupNsCtr = infraContainer.ID()
 		}
@@ -180,7 +181,7 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 		// Fix parent cgroup
 		cgroupPath, err := pod.CgroupPath()
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot retrieve cgroup path from pod %q", ctrConfig.Pod)
+			return nil, fmt.Errorf("cannot retrieve cgroup path from pod %q: %w", ctrConfig.Pod, err)
 		}
 		ctrConfig.CgroupParent = cgroupPath
 
@@ -228,14 +229,14 @@ func CRImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, restoreOpt
 	containerConfig := container.Config()
 	ctrName := ctrConfig.Name
 	if containerConfig.Name != ctrName {
-		return nil, errors.Errorf("Name of restored container (%s) does not match requested name (%s)", containerConfig.Name, ctrName)
+		return nil, fmt.Errorf("name of restored container (%s) does not match requested name (%s)", containerConfig.Name, ctrName)
 	}
 
 	if !newName {
 		// Only check ID for a restore with the same name.
 		// Using -n to request a new name for the restored container, will also create a new ID
 		if containerConfig.ID != ctrID {
-			return nil, errors.Errorf("ID of restored container (%s) does not match requested ID (%s)", containerConfig.ID, ctrID)
+			return nil, fmt.Errorf("ID of restored container (%s) does not match requested ID (%s)", containerConfig.ID, ctrID)
 		}
 	}
 

--- a/pkg/copy/fileinfo.go
+++ b/pkg/copy/fileinfo.go
@@ -3,13 +3,14 @@ package copy
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/pkg/errors"
 )
 
 // XDockerContainerPathStatHeader is the *key* in http headers pointing to the
@@ -18,7 +19,7 @@ const XDockerContainerPathStatHeader = "X-Docker-Container-Path-Stat"
 
 // ErrENOENT mimics the stdlib's ErrENOENT and can be used to implement custom logic
 // while preserving the user-visible error message.
-var ErrENOENT = errors.New("No such file or directory")
+var ErrENOENT = errors.New("no such file or directory")
 
 // FileInfo describes a file or directory and is returned by
 // (*CopyItem).Stat().
@@ -29,7 +30,7 @@ type FileInfo = define.FileInfo
 func EncodeFileInfo(info *FileInfo) (string, error) {
 	buf, err := json.Marshal(&info)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to serialize file stats")
+		return "", fmt.Errorf("failed to serialize file stats: %w", err)
 	}
 	return base64.URLEncoding.EncodeToString(buf), nil
 }

--- a/pkg/copy/parse.go
+++ b/pkg/copy/parse.go
@@ -1,9 +1,8 @@
 package copy
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // ParseSourceAndDestination parses the source and destination input into a
@@ -19,7 +18,7 @@ func ParseSourceAndDestination(source, destination string) (string, string, stri
 	destContainer, destPath := parseUserInput(destination)
 
 	if len(sourcePath) == 0 || len(destPath) == 0 {
-		return "", "", "", "", errors.Errorf("invalid arguments %q, %q: you must specify paths", source, destination)
+		return "", "", "", "", fmt.Errorf("invalid arguments %q, %q: you must specify paths", source, destination)
 	}
 
 	return sourceContainer, sourcePath, destContainer, destPath, nil

--- a/pkg/domain/entities/container_ps.go
+++ b/pkg/domain/entities/container_ps.go
@@ -1,13 +1,13 @@
 package entities
 
 import (
+	"errors"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/podman/v4/pkg/ps/define"
-	"github.com/pkg/errors"
 )
 
 // ListContainer describes a container suitable for listing
@@ -166,7 +166,7 @@ func SortPsOutput(sortBy string, psOutput SortListContainers) (SortListContainer
 	case "pod":
 		sort.Sort(psSortedPod{psOutput})
 	default:
-		return nil, errors.Errorf("invalid option for --sort, options are: command, created, id, image, names, runningfor, size, or status")
+		return nil, errors.New("invalid option for --sort, options are: command, created, id, image, names, runningfor, size, or status")
 	}
 	return psOutput, nil
 }

--- a/pkg/domain/filters/pods.go
+++ b/pkg/domain/filters/pods.go
@@ -1,6 +1,8 @@
 package filters
 
 import (
+	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -8,7 +10,6 @@ import (
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 )
 
 // GeneratePodFilterFunc takes a filter and filtervalue (key, value)
@@ -59,7 +60,7 @@ func GeneratePodFilterFunc(filter string, filterValues []string, r *libpod.Runti
 	case "ctr-status":
 		for _, filterValue := range filterValues {
 			if !cutil.StringInSlice(filterValue, []string{"created", "running", "paused", "stopped", "exited", "unknown"}) {
-				return nil, errors.Errorf("%s is not a valid status", filterValue)
+				return nil, fmt.Errorf("%s is not a valid status", filterValue)
 			}
 		}
 		return func(p *libpod.Pod) bool {
@@ -96,7 +97,7 @@ func GeneratePodFilterFunc(filter string, filterValues []string, r *libpod.Runti
 	case "status":
 		for _, filterValue := range filterValues {
 			if !cutil.StringInSlice(filterValue, []string{"stopped", "running", "paused", "exited", "dead", "created", "degraded"}) {
-				return nil, errors.Errorf("%s is not a valid pod status", filterValue)
+				return nil, fmt.Errorf("%s is not a valid pod status", filterValue)
 			}
 		}
 		return func(p *libpod.Pod) bool {
@@ -158,5 +159,5 @@ func GeneratePodFilterFunc(filter string, filterValues []string, r *libpod.Runti
 			return false
 		}, nil
 	}
-	return nil, errors.Errorf("%s is an invalid filter", filter)
+	return nil, fmt.Errorf("%s is an invalid filter", filter)
 }

--- a/pkg/domain/filters/volumes.go
+++ b/pkg/domain/filters/volumes.go
@@ -1,13 +1,13 @@
 package filters
 
 import (
+	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
 
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 )
 
 func GenerateVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, error) {
@@ -72,7 +72,7 @@ func GenerateVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, error) {
 					// invert the result of IsDangling.
 					invert = true
 				default:
-					return nil, errors.Errorf("%q is not a valid value for the \"dangling\" filter - must be true or false", danglingVal)
+					return nil, fmt.Errorf("%q is not a valid value for the \"dangling\" filter - must be true or false", danglingVal)
 				}
 				vf = append(vf, func(v *libpod.Volume) bool {
 					dangling, err := v.IsDangling()
@@ -85,7 +85,7 @@ func GenerateVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, error) {
 					return dangling
 				})
 			default:
-				return nil, errors.Errorf("%q is an invalid volume filter", filter)
+				return nil, fmt.Errorf("%q is an invalid volume filter", filter)
 			}
 		}
 	}
@@ -109,7 +109,7 @@ func GeneratePruneVolumeFilters(filters url.Values) ([]libpod.VolumeFilter, erro
 				}
 				vf = append(vf, f)
 			default:
-				return nil, errors.Errorf("%q is an invalid volume filter", filter)
+				return nil, fmt.Errorf("%q is an invalid volume filter", filter)
 			}
 		}
 	}

--- a/pkg/domain/infra/abi/images_list.go
+++ b/pkg/domain/infra/abi/images_list.go
@@ -2,10 +2,10 @@ package abi
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containers/common/libimage"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 )
 
 func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions) ([]*entities.ImageSummary, error) {
@@ -28,11 +28,11 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 	for _, img := range images {
 		repoDigests, err := img.RepoDigests()
 		if err != nil {
-			return nil, errors.Wrapf(err, "getting repoDigests from image %q", img.ID())
+			return nil, fmt.Errorf("getting repoDigests from image %q: %w", img.ID(), err)
 		}
 		isDangling, err := img.IsDangling(ctx)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error checking if image %q is dangling", img.ID())
+			return nil, fmt.Errorf("error checking if image %q is dangling: %w", img.ID(), err)
 		}
 
 		e := entities.ImageSummary{
@@ -49,18 +49,18 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 		}
 		e.Labels, err = img.Labels(ctx)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error retrieving label for image %q: you may need to remove the image to resolve the error", img.ID())
+			return nil, fmt.Errorf("error retrieving label for image %q: you may need to remove the image to resolve the error: %w", img.ID(), err)
 		}
 
 		ctnrs, err := img.Containers()
 		if err != nil {
-			return nil, errors.Wrapf(err, "error retrieving containers for image %q: you may need to remove the image to resolve the error", img.ID())
+			return nil, fmt.Errorf("error retrieving containers for image %q: you may need to remove the image to resolve the error: %w", img.ID(), err)
 		}
 		e.Containers = len(ctnrs)
 
 		sz, err := img.Size()
 		if err != nil {
-			return nil, errors.Wrapf(err, "error retrieving size of image %q: you may need to remove the image to resolve the error", img.ID())
+			return nil, fmt.Errorf("error retrieving size of image %q: you may need to remove the image to resolve the error: %w", img.ID(), err)
 		}
 		e.Size = sz
 		// This is good enough for now, but has to be
@@ -69,7 +69,7 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 
 		parent, err := img.Parent(ctx)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error retrieving parent of image %q: you may need to remove the image to resolve the error", img.ID())
+			return nil, fmt.Errorf("error retrieving parent of image %q: you may need to remove the image to resolve the error: %w", img.ID(), err)
 		}
 		if parent != nil {
 			e.ParentId = parent.ID()

--- a/pkg/domain/infra/abi/parse/parse.go
+++ b/pkg/domain/infra/abi/parse/parse.go
@@ -1,13 +1,13 @@
 package parse
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/libpod/define"
 	units "github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -32,7 +32,7 @@ func VolumeOptions(opts map[string]string) ([]libpod.VolumeCreateOption, error) 
 				case "size":
 					size, err := units.FromHumanSize(splitO[1])
 					if err != nil {
-						return nil, errors.Wrapf(err, "cannot convert size %s to integer", splitO[1])
+						return nil, fmt.Errorf("cannot convert size %s to integer: %w", splitO[1], err)
 					}
 					libpodOptions = append(libpodOptions, libpod.WithVolumeSize(uint64(size)))
 					finalVal = append(finalVal, o)
@@ -41,7 +41,7 @@ func VolumeOptions(opts map[string]string) ([]libpod.VolumeCreateOption, error) 
 				case "inodes":
 					inodes, err := strconv.ParseUint(splitO[1], 10, 64)
 					if err != nil {
-						return nil, errors.Wrapf(err, "cannot convert inodes %s to integer", splitO[1])
+						return nil, fmt.Errorf("cannot convert inodes %s to integer: %w", splitO[1], err)
 					}
 					libpodOptions = append(libpodOptions, libpod.WithVolumeInodes(inodes))
 					finalVal = append(finalVal, o)
@@ -49,11 +49,11 @@ func VolumeOptions(opts map[string]string) ([]libpod.VolumeCreateOption, error) 
 					volumeOptions["INODES"] = splitO[1]
 				case "uid":
 					if len(splitO) != 2 {
-						return nil, errors.Wrapf(define.ErrInvalidArg, "uid option must provide a UID")
+						return nil, fmt.Errorf("uid option must provide a UID: %w", define.ErrInvalidArg)
 					}
 					intUID, err := strconv.Atoi(splitO[1])
 					if err != nil {
-						return nil, errors.Wrapf(err, "cannot convert UID %s to integer", splitO[1])
+						return nil, fmt.Errorf("cannot convert UID %s to integer: %w", splitO[1], err)
 					}
 					logrus.Debugf("Removing uid= from options and adding WithVolumeUID for UID %d", intUID)
 					libpodOptions = append(libpodOptions, libpod.WithVolumeUID(intUID), libpod.WithVolumeNoChown())
@@ -62,11 +62,11 @@ func VolumeOptions(opts map[string]string) ([]libpod.VolumeCreateOption, error) 
 					volumeOptions["UID"] = splitO[1]
 				case "gid":
 					if len(splitO) != 2 {
-						return nil, errors.Wrapf(define.ErrInvalidArg, "gid option must provide a GID")
+						return nil, fmt.Errorf("gid option must provide a GID: %w", define.ErrInvalidArg)
 					}
 					intGID, err := strconv.Atoi(splitO[1])
 					if err != nil {
-						return nil, errors.Wrapf(err, "cannot convert GID %s to integer", splitO[1])
+						return nil, fmt.Errorf("cannot convert GID %s to integer: %w", splitO[1], err)
 					}
 					logrus.Debugf("Removing gid= from options and adding WithVolumeGID for GID %d", intGID)
 					libpodOptions = append(libpodOptions, libpod.WithVolumeGID(intGID), libpod.WithVolumeNoChown())
@@ -80,11 +80,11 @@ func VolumeOptions(opts map[string]string) ([]libpod.VolumeCreateOption, error) 
 					volumeOptions["NOQUOTA"] = "true"
 				case "timeout":
 					if len(splitO) != 2 {
-						return nil, errors.Wrapf(define.ErrInvalidArg, "timeout option must provide a valid timeout in seconds")
+						return nil, fmt.Errorf("timeout option must provide a valid timeout in seconds: %w", define.ErrInvalidArg)
 					}
 					intTimeout, err := strconv.Atoi(splitO[1])
 					if err != nil {
-						return nil, errors.Wrapf(err, "cannot convert Timeout %s to an integer", splitO[1])
+						return nil, fmt.Errorf("cannot convert Timeout %s to an integer: %w", splitO[1], err)
 					}
 					logrus.Debugf("Removing timeout from options and adding WithTimeout for Timeout %d", intTimeout)
 					libpodOptions = append(libpodOptions, libpod.WithVolumeDriverTimeout(intTimeout))

--- a/pkg/domain/infra/abi/pods_stats.go
+++ b/pkg/domain/infra/abi/pods_stats.go
@@ -2,6 +2,7 @@ package abi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containers/common/pkg/cgroups"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/utils"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 )
 
 // PodStats implements printing stats about pods.
@@ -28,7 +28,7 @@ func (ic *ContainerEngine) PodStats(ctx context.Context, namesOrIds []string, op
 	// Get the (running) pods and convert them to the entities format.
 	pods, err := getPodsByContext(options.All, options.Latest, namesOrIds, ic.Libpod)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get list of pods")
+		return nil, fmt.Errorf("unable to get list of pods: %w", err)
 	}
 	return ic.podsToStatsReport(pods)
 }

--- a/pkg/domain/infra/abi/terminal/terminal.go
+++ b/pkg/domain/infra/abi/terminal/terminal.go
@@ -2,13 +2,13 @@ package terminal
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 
 	"github.com/containers/common/pkg/resize"
 	lsignal "github.com/containers/podman/v4/pkg/signal"
 	"github.com/moby/term"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -89,7 +89,7 @@ func handleTerminalAttach(ctx context.Context, resize chan resize.TerminalSize) 
 	if err != nil {
 		// allow caller to not have to do any cleaning up if we error here
 		cancel()
-		return nil, nil, errors.Wrapf(err, "unable to save terminal state")
+		return nil, nil, fmt.Errorf("unable to save terminal state: %w", err)
 	}
 
 	logrus.SetFormatter(&RawTtyFormatter{})

--- a/pkg/domain/infra/abi/terminal/terminal_linux.go
+++ b/pkg/domain/infra/abi/terminal/terminal_linux.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/common/pkg/resize"
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/libpod/define"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/term"
 )
@@ -104,7 +103,7 @@ func StartAttachCtr(ctx context.Context, ctr *libpod.Container, stdout, stderr, 
 
 	err = <-attachChan
 	if err != nil {
-		return errors.Wrapf(err, "error attaching to container %s", ctr.ID())
+		return fmt.Errorf("error attaching to container %s: %w", ctr.ID(), err)
 	}
 
 	return nil

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -5,6 +5,7 @@ package infra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -18,7 +19,6 @@ import (
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/types"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
 )
@@ -316,7 +316,7 @@ func ParseIDMapping(mode namespaces.UsernsMode, uidMapSlice, gidMapSlice []strin
 
 		uids, gids, err := rootless.GetConfiguredMappings()
 		if err != nil {
-			return nil, errors.Wrapf(err, "cannot read mappings")
+			return nil, fmt.Errorf("cannot read mappings: %w", err)
 		}
 		maxUID, maxGID := 0, 0
 		for _, u := range uids {

--- a/pkg/domain/infra/tunnel/auto-update.go
+++ b/pkg/domain/infra/tunnel/auto-update.go
@@ -2,9 +2,9 @@ package tunnel
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 )
 
 func (ic *ContainerEngine) AutoUpdate(ctx context.Context, options entities.AutoUpdateOptions) ([]*entities.AutoUpdateReport, []error) {

--- a/pkg/domain/infra/tunnel/events.go
+++ b/pkg/domain/infra/tunnel/events.go
@@ -2,13 +2,12 @@ package tunnel
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/containers/podman/v4/libpod/events"
 	"github.com/containers/podman/v4/pkg/bindings/system"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-
-	"github.com/pkg/errors"
 )
 
 func (ic *ContainerEngine) Events(ctx context.Context, opts entities.EventsOptions) error {
@@ -17,7 +16,7 @@ func (ic *ContainerEngine) Events(ctx context.Context, opts entities.EventsOptio
 		for _, filter := range opts.Filter {
 			split := strings.Split(filter, "=")
 			if len(split) < 2 {
-				return errors.Errorf("invalid filter %q", filter)
+				return fmt.Errorf("invalid filter %q", filter)
 			}
 			filters[split[0]] = append(filters[split[0]], strings.Join(split[1:], "="))
 		}
@@ -56,7 +55,7 @@ func (ic *ContainerEngine) GetLastContainerEvent(ctx context.Context, nameOrID s
 				return nil, err
 			}
 			if len(containerEvents) < 1 {
-				return nil, errors.Wrapf(events.ErrEventNotFound, "%s not found", containerEvent.String())
+				return nil, fmt.Errorf("%s not found: %w", containerEvent.String(), events.ErrEventNotFound)
 			}
 			// return the last element in the slice
 			return containerEvents[len(containerEvents)-1], nil

--- a/pkg/domain/infra/tunnel/helpers.go
+++ b/pkg/domain/infra/tunnel/helpers.go
@@ -2,13 +2,14 @@ package tunnel
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/bindings/containers"
 	"github.com/containers/podman/v4/pkg/bindings/pods"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/errorhandling"
-	"github.com/pkg/errors"
 )
 
 // FIXME: the `ignore` parameter is very likely wrong here as it should rather
@@ -69,7 +70,7 @@ func getContainersAndInputByContext(contextWithConnection context.Context, all, 
 		}
 
 		if !found && !ignore {
-			return nil, nil, errors.Wrapf(define.ErrNoSuchCtr, "unable to find container %q", nameOrID)
+			return nil, nil, fmt.Errorf("unable to find container %q: %w", nameOrID, define.ErrNoSuchCtr)
 		}
 	}
 	return filtered, rawInputs, nil
@@ -102,7 +103,7 @@ func getPodsByContext(contextWithConnection context.Context, all bool, namesOrID
 		inspectData, err := pods.Inspect(contextWithConnection, nameOrID, nil)
 		if err != nil {
 			if errorhandling.Contains(err, define.ErrNoSuchPod) {
-				return nil, errors.Wrapf(define.ErrNoSuchPod, "unable to find pod %q", nameOrID)
+				return nil, fmt.Errorf("unable to find pod %q: %w", nameOrID, define.ErrNoSuchPod)
 			}
 			return nil, err
 		}
@@ -120,7 +121,7 @@ func getPodsByContext(contextWithConnection context.Context, all bool, namesOrID
 		}
 
 		if !found {
-			return nil, errors.Wrapf(define.ErrNoSuchPod, "unable to find pod %q", nameOrID)
+			return nil, fmt.Errorf("unable to find pod %q: %w", nameOrID, define.ErrNoSuchPod)
 		}
 	}
 	return filtered, nil

--- a/pkg/domain/infra/tunnel/network.go
+++ b/pkg/domain/infra/tunnel/network.go
@@ -2,13 +2,14 @@ package tunnel
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/containers/common/libnetwork/types"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/bindings/network"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/errorhandling"
-	"github.com/pkg/errors"
 )
 
 func (ic *ContainerEngine) NetworkList(ctx context.Context, opts entities.NetworkListOptions) ([]types.Network, error) {
@@ -30,7 +31,7 @@ func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []stri
 				return nil, nil, err
 			}
 			if errModel.ResponseCode == 404 {
-				errs = append(errs, errors.Wrapf(define.ErrNoSuchNetwork, "network %s", name))
+				errs = append(errs, fmt.Errorf("network %s: %w", name, define.ErrNoSuchNetwork))
 				continue
 			}
 			return nil, nil, err

--- a/pkg/domain/infra/tunnel/secrets.go
+++ b/pkg/domain/infra/tunnel/secrets.go
@@ -2,12 +2,12 @@ package tunnel
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/containers/podman/v4/pkg/bindings/secrets"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/errorhandling"
-	"github.com/pkg/errors"
 )
 
 func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader io.Reader, options entities.SecretCreateOptions) (*entities.SecretCreateReport, error) {
@@ -33,7 +33,7 @@ func (ic *ContainerEngine) SecretInspect(ctx context.Context, nameOrIDs []string
 				return nil, nil, err
 			}
 			if errModel.ResponseCode == 404 {
-				errs = append(errs, errors.Errorf("no such secret %q", name))
+				errs = append(errs, fmt.Errorf("no such secret %q", name))
 				continue
 			}
 			return nil, nil, err
@@ -73,7 +73,7 @@ func (ic *ContainerEngine) SecretRm(ctx context.Context, nameOrIDs []string, opt
 			}
 			if errModel.ResponseCode == 404 {
 				allRm = append(allRm, &entities.SecretRmReport{
-					Err: errors.Errorf("no secret with name or id %q: no such secret ", name),
+					Err: fmt.Errorf("no secret with name or id %q: no such secret ", name),
 					ID:  "",
 				})
 				continue

--- a/pkg/domain/infra/tunnel/volumes.go
+++ b/pkg/domain/infra/tunnel/volumes.go
@@ -2,12 +2,13 @@ package tunnel
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/containers/podman/v4/pkg/bindings/volumes"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/entities/reports"
 	"github.com/containers/podman/v4/pkg/errorhandling"
-	"github.com/pkg/errors"
 )
 
 func (ic *ContainerEngine) VolumeCreate(ctx context.Context, opts entities.VolumeCreateOptions) (*entities.IDOrNameResponse, error) {
@@ -64,7 +65,7 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 				return nil, nil, err
 			}
 			if errModel.ResponseCode == 404 {
-				errs = append(errs, errors.Errorf("no such volume %q", id))
+				errs = append(errs, fmt.Errorf("no such volume %q", id))
 				continue
 			}
 			return nil, nil, err

--- a/pkg/domain/utils/secrets_filters.go
+++ b/pkg/domain/utils/secrets_filters.go
@@ -1,11 +1,11 @@
 package utils
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/containers/common/pkg/secrets"
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 )
 
 func IfPassesSecretsFilter(s secrets.Secret, filters map[string][]string) (bool, error) {
@@ -17,7 +17,7 @@ func IfPassesSecretsFilter(s secrets.Secret, filters map[string][]string) (bool,
 		case "id":
 			result = util.StringMatchRegexSlice(s.ID, filterValues)
 		default:
-			return false, errors.Errorf("invalid filter %q", key)
+			return false, fmt.Errorf("invalid filter %q", key)
 		}
 	}
 	return result, nil

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const whiteSpaces = " \t"
@@ -56,7 +54,7 @@ func ParseFile(path string) (_ map[string]string, err error) {
 	env := make(map[string]string)
 	defer func() {
 		if err != nil {
-			err = errors.Wrapf(err, "error parsing env file %q", path)
+			err = fmt.Errorf("error parsing env file %q: %w", path, err)
 		}
 	}()
 
@@ -85,12 +83,12 @@ func parseEnv(env map[string]string, line string) error {
 
 	// catch invalid variables such as "=" or "=A"
 	if data[0] == "" {
-		return errors.Errorf("invalid environment variable: %q", line)
+		return fmt.Errorf("invalid environment variable: %q", line)
 	}
 	// trim the front of a variable, but nothing else
 	name := strings.TrimLeft(data[0], whiteSpaces)
 	if strings.ContainsAny(name, whiteSpaces) {
-		return errors.Errorf("name %q has white spaces, poorly formatted name", name)
+		return fmt.Errorf("name %q has white spaces, poorly formatted name", name)
 	}
 
 	if len(data) > 1 {

--- a/pkg/hooks/1.0.0/hook.go
+++ b/pkg/hooks/1.0.0/hook.go
@@ -3,12 +3,12 @@ package hook
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
 
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 // Version is the hook configuration version defined in this package.
@@ -50,16 +50,16 @@ func (hook *Hook) Validate(extensionStages []string) (err error) {
 
 	for key, value := range hook.When.Annotations {
 		if _, err = regexp.Compile(key); err != nil {
-			return errors.Wrapf(err, "invalid annotation key %q", key)
+			return fmt.Errorf("invalid annotation key %q: %w", key, err)
 		}
 		if _, err = regexp.Compile(value); err != nil {
-			return errors.Wrapf(err, "invalid annotation value %q", value)
+			return fmt.Errorf("invalid annotation value %q: %w", value, err)
 		}
 	}
 
 	for _, command := range hook.When.Commands {
 		if _, err = regexp.Compile(command); err != nil {
-			return errors.Wrapf(err, "invalid command %q", command)
+			return fmt.Errorf("invalid command %q: %w", command, err)
 		}
 	}
 

--- a/pkg/hooks/1.0.0/when.go
+++ b/pkg/hooks/1.0.0/when.go
@@ -1,10 +1,11 @@
 package hook
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 // When holds hook-injection conditions.
@@ -52,12 +53,12 @@ func (when *When) Match(config *rspec.Spec, annotations map[string]string, hasBi
 		for key, value := range annotations {
 			match, err = regexp.MatchString(keyPattern, key)
 			if err != nil {
-				return false, errors.Wrap(err, "annotation key")
+				return false, fmt.Errorf("annotation key: %w", err)
 			}
 			if match {
 				match, err = regexp.MatchString(valuePattern, value)
 				if err != nil {
-					return false, errors.Wrap(err, "annotation value")
+					return false, fmt.Errorf("annotation value: %w", err)
 				}
 				if match {
 					break
@@ -82,7 +83,7 @@ func (when *When) Match(config *rspec.Spec, annotations map[string]string, hasBi
 		for _, cmdPattern := range when.Commands {
 			match, err := regexp.MatchString(cmdPattern, command)
 			if err != nil {
-				return false, errors.Wrap(err, "command")
+				return false, fmt.Errorf("command: %w", err)
 			}
 			if match {
 				return true, nil

--- a/pkg/hooks/exec/exec.go
+++ b/pkg/hooks/exec/exec.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,7 +45,7 @@ func Run(ctx context.Context, hook *rspec.Hook, state []byte, stdout io.Writer, 
 	go func() {
 		err := cmd.Wait()
 		if err != nil {
-			err = errors.Wrapf(err, "executing %v", cmd.Args)
+			err = fmt.Errorf("executing %v: %w", cmd.Args, err)
 		}
 		exit <- err
 	}()

--- a/pkg/hooks/exec/runtimeconfigfilter.go
+++ b/pkg/hooks/exec/runtimeconfigfilter.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/sirupsen/logrus"
 )
@@ -43,7 +43,7 @@ func RuntimeConfigFilter(ctx context.Context, hooks []spec.Hook, config *spec.Sp
 		err = json.Unmarshal(data, &newConfig)
 		if err != nil {
 			logrus.Debugf("invalid JSON from config-filter hook %d:\n%s", i, string(data))
-			return nil, errors.Wrapf(err, "unmarshal output from config-filter hook %d", i)
+			return nil, fmt.Errorf("unmarshal output from config-filter hook %d: %w", i, err)
 		}
 
 		if !reflect.DeepEqual(config, &newConfig) {

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -11,7 +11,6 @@ import (
 
 	current "github.com/containers/podman/v4/pkg/hooks/1.0.0"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -105,7 +104,7 @@ func (m *Manager) Hooks(config *rspec.Spec, annotations map[string]string, hasBi
 	for _, namedHook := range hooks {
 		match, err := namedHook.hook.When.Match(config, annotations, hasBindMounts)
 		if err != nil {
-			return extensionStageHooks, errors.Wrapf(err, "matching hook %q", namedHook.name)
+			return extensionStageHooks, fmt.Errorf("matching hook %q: %w", namedHook.name, err)
 		}
 		if match {
 			logrus.Debugf("hook %s matched; adding to stages %v", namedHook.name, namedHook.hook.Stages)

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -4,7 +4,7 @@
 package machine
 
 import (
-	errors2 "errors"
+	"errors"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/containers/storage/pkg/homedir"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -256,11 +255,11 @@ func (m *VMFile) GetPath() string {
 // the actual path
 func (m *VMFile) Delete() error {
 	if m.Symlink != nil {
-		if err := os.Remove(*m.Symlink); err != nil && !errors2.Is(err, os.ErrNotExist) {
+		if err := os.Remove(*m.Symlink); err != nil && !errors.Is(err, os.ErrNotExist) {
 			logrus.Errorf("unable to remove symlink %q", *m.Symlink)
 		}
 	}
-	if err := os.Remove(m.Path); err != nil && !errors2.Is(err, os.ErrNotExist) {
+	if err := os.Remove(m.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	return nil
@@ -274,14 +273,14 @@ func (m *VMFile) Read() ([]byte, error) {
 // NewMachineFile is a constructor for VMFile
 func NewMachineFile(path string, symlink *string) (*VMFile, error) {
 	if len(path) < 1 {
-		return nil, errors2.New("invalid machine file path")
+		return nil, errors.New("invalid machine file path")
 	}
 	if symlink != nil && len(*symlink) < 1 {
-		return nil, errors2.New("invalid symlink path")
+		return nil, errors.New("invalid symlink path")
 	}
 	mf := VMFile{Path: path}
 	if symlink != nil && len(path) > maxSocketPathLength {
-		if err := mf.makeSymlink(symlink); err != nil && !errors2.Is(err, os.ErrExist) {
+		if err := mf.makeSymlink(symlink); err != nil && !errors.Is(err, os.ErrExist) {
 			return nil, err
 		}
 	}
@@ -297,7 +296,7 @@ func (m *VMFile) makeSymlink(symlink *string) error {
 	}
 	sl := filepath.Join(homeDir, ".podman", *symlink)
 	// make the symlink dir and throw away if it already exists
-	if err := os.MkdirAll(filepath.Dir(sl), 0700); err != nil && !errors2.Is(err, os.ErrNotExist) {
+	if err := os.MkdirAll(filepath.Dir(sl), 0700); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	m.Symlink = &sl

--- a/pkg/machine/connection.go
+++ b/pkg/machine/connection.go
@@ -4,10 +4,10 @@
 package machine
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/containers/common/pkg/config"
-	"github.com/pkg/errors"
 )
 
 func AddConnection(uri fmt.Stringer, name, identity string, isDefault bool) error {
@@ -72,7 +72,7 @@ func RemoveConnection(name string) error {
 	if _, ok := cfg.Engine.ServiceDestinations[name]; ok {
 		delete(cfg.Engine.ServiceDestinations, name)
 	} else {
-		return errors.Errorf("unable to find connection named %q", name)
+		return fmt.Errorf("unable to find connection named %q", name)
 	}
 	return cfg.Write()
 }

--- a/pkg/machine/fcos.go
+++ b/pkg/machine/fcos.go
@@ -17,7 +17,6 @@ import (
 	"github.com/coreos/stream-metadata-go/fedoracoreos"
 	"github.com/coreos/stream-metadata-go/release"
 	"github.com/coreos/stream-metadata-go/stream"
-	"github.com/pkg/errors"
 
 	digest "github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
@@ -156,7 +155,7 @@ func GetFCOSDownload(imageStream string) (*FcosDownloadInfo, error) {
 	case "stable":
 		streamType = fedoracoreos.StreamStable
 	default:
-		return nil, errors.Errorf("invalid stream %s: valid streams are `testing` and `stable`", imageStream)
+		return nil, fmt.Errorf("invalid stream %s: valid streams are `testing` and `stable`", imageStream)
 	}
 	streamurl := getStreamURL(streamType)
 	resp, err := http.Get(streamurl.String())

--- a/pkg/machine/fedora.go
+++ b/pkg/machine/fedora.go
@@ -4,6 +4,7 @@
 package machine
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -107,12 +107,12 @@ func getFedoraDownload(releaseStream string) (string, *url.URL, int64, error) {
 	newLocation := rawURL + file
 	downloadURL, err := url.Parse(newLocation)
 	if err != nil {
-		return "", nil, -1, errors.Wrapf(err, "invalid URL generated from discovered Fedora file: %s", newLocation)
+		return "", nil, -1, fmt.Errorf("invalid URL generated from discovered Fedora file: %s: %w", newLocation, err)
 	}
 
 	resp, err := http.Head(newLocation)
 	if err != nil {
-		return "", nil, -1, errors.Wrapf(err, "head request failed: %s", newLocation)
+		return "", nil, -1, fmt.Errorf("head request failed: %s: %w", newLocation, err)
 	}
 	_ = resp.Body.Close()
 

--- a/pkg/machine/keys.go
+++ b/pkg/machine/keys.go
@@ -4,6 +4,7 @@
 package machine
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/parallel/parallel.go
+++ b/pkg/parallel/parallel.go
@@ -2,9 +2,10 @@ package parallel
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 )
@@ -59,7 +60,7 @@ func Enqueue(ctx context.Context, fn func() error) <-chan error {
 		defer close(retChan)
 
 		if err := jobControl.Acquire(ctx, 1); err != nil {
-			retChan <- errors.Wrapf(err, "error acquiring job control semaphore")
+			retChan <- fmt.Errorf("error acquiring job control semaphore: %w", err)
 			return
 		}
 

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -4,10 +4,10 @@
 package rootless
 
 import (
+	"errors"
 	"os"
 
 	"github.com/containers/storage/pkg/idtools"
-	"github.com/pkg/errors"
 )
 
 // IsRootless returns whether the user is rootless

--- a/pkg/seccomp/seccomp.go
+++ b/pkg/seccomp/seccomp.go
@@ -1,9 +1,8 @@
 package seccomp
 
 import (
+	"fmt"
 	"sort"
-
-	"github.com/pkg/errors"
 )
 
 // ContainerImageLabel is the key of the image annotation embedding a seccomp
@@ -50,5 +49,5 @@ func LookupPolicy(s string) (Policy, error) {
 	}
 	sort.Strings(keys)
 
-	return -1, errors.Errorf("invalid seccomp policy %q: valid policies are %+q", s, keys)
+	return -1, fmt.Errorf("invalid seccomp policy %q: valid policies are %+q", s, keys)
 }

--- a/pkg/specgen/config_unsupported.go
+++ b/pkg/specgen/config_unsupported.go
@@ -4,9 +4,10 @@
 package specgen
 
 import (
+	"errors"
+
 	"github.com/containers/common/libimage"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 func (s *SpecGenerator) getSeccompConfig(configSpec *spec.Spec, img *libimage.Image) (*spec.LinuxSeccomp, error) {

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/pkg/util"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -46,7 +45,7 @@ func DevicesFromPath(g *generate.Generator, devicePath string) error {
 		}
 		if len(devs) > 2 {
 			if devmode != "" {
-				return errors.Wrapf(unix.EINVAL, "invalid device specification %s", devicePath)
+				return fmt.Errorf("invalid device specification %s: %w", devicePath, unix.EINVAL)
 			}
 			devmode = devs[2]
 		}
@@ -60,7 +59,7 @@ func DevicesFromPath(g *generate.Generator, devicePath string) error {
 					device = fmt.Sprintf("%s:%s", device, devmode)
 				}
 				if err := addDevice(g, device); err != nil {
-					return errors.Wrapf(err, "failed to add %s device", dpath)
+					return fmt.Errorf("failed to add %s device: %w", dpath, err)
 				}
 			}
 			return nil
@@ -68,7 +67,7 @@ func DevicesFromPath(g *generate.Generator, devicePath string) error {
 			return err
 		}
 		if !found {
-			return errors.Wrapf(unix.EINVAL, "no devices found in %s", devicePath)
+			return fmt.Errorf("no devices found in %s: %w", devicePath, unix.EINVAL)
 		}
 		return nil
 	}
@@ -131,7 +130,7 @@ func addDevice(g *generate.Generator, device string) error {
 	}
 	dev, err := util.DeviceFromPath(src)
 	if err != nil {
-		return errors.Wrapf(err, "%s is not a valid device", src)
+		return fmt.Errorf("%s is not a valid device: %w", src, err)
 	}
 	if rootless.IsRootless() {
 		if _, err := os.Stat(src); err != nil {

--- a/pkg/specgen/generate/config_linux_cgo.go
+++ b/pkg/specgen/generate/config_linux_cgo.go
@@ -5,6 +5,8 @@ package generate
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/containers/common/libimage"
@@ -12,7 +14,6 @@ import (
 	"github.com/containers/podman/v4/pkg/seccomp"
 	"github.com/containers/podman/v4/pkg/specgen"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -39,7 +40,7 @@ func getSeccompConfig(s *specgen.SpecGenerator, configSpec *spec.Spec, img *libi
 		logrus.Debug("Loading seccomp profile from the security config")
 		seccompConfig, err = goSeccomp.LoadProfile(imagePolicy, configSpec)
 		if err != nil {
-			return nil, errors.Wrap(err, "loading seccomp profile failed")
+			return nil, fmt.Errorf("loading seccomp profile failed: %w", err)
 		}
 		return seccompConfig, nil
 	}
@@ -48,17 +49,17 @@ func getSeccompConfig(s *specgen.SpecGenerator, configSpec *spec.Spec, img *libi
 		logrus.Debugf("Loading seccomp profile from %q", s.SeccompProfilePath)
 		seccompProfile, err := ioutil.ReadFile(s.SeccompProfilePath)
 		if err != nil {
-			return nil, errors.Wrap(err, "opening seccomp profile failed")
+			return nil, fmt.Errorf("opening seccomp profile failed: %w", err)
 		}
 		seccompConfig, err = goSeccomp.LoadProfile(string(seccompProfile), configSpec)
 		if err != nil {
-			return nil, errors.Wrapf(err, "loading seccomp profile (%s) failed", s.SeccompProfilePath)
+			return nil, fmt.Errorf("loading seccomp profile (%s) failed: %w", s.SeccompProfilePath, err)
 		}
 	} else {
 		logrus.Debug("Loading default seccomp profile")
 		seccompConfig, err = goSeccomp.GetDefaultProfile(configSpec)
 		if err != nil {
-			return nil, errors.Wrapf(err, "loading seccomp profile (%s) failed", s.SeccompProfilePath)
+			return nil, fmt.Errorf("loading seccomp profile (%s) failed: %w", s.SeccompProfilePath, err)
 		}
 	}
 

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -17,7 +18,6 @@ import (
 	"github.com/containers/podman/v4/pkg/signal"
 	"github.com/containers/podman/v4/pkg/specgen"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -115,7 +115,7 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 	// Get Default Environment from containers.conf
 	defaultEnvs, err := envLib.ParseSlice(rtc.GetDefaultEnvEx(s.EnvHost, s.HTTPProxy))
 	if err != nil {
-		return nil, errors.Wrap(err, "error parsing fields in containers.conf")
+		return nil, fmt.Errorf("error parsing fields in containers.conf: %w", err)
 	}
 	var envs map[string]string
 
@@ -125,7 +125,7 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 		// already, overriding the default environments
 		envs, err = envLib.ParseSlice(inspectData.Config.Env)
 		if err != nil {
-			return nil, errors.Wrap(err, "Env fields from image failed to parse")
+			return nil, fmt.Errorf("env fields from image failed to parse: %w", err)
 		}
 		defaultEnvs = envLib.Join(envLib.DefaultEnvVariables(), envLib.Join(defaultEnvs, envs))
 	}
@@ -141,7 +141,7 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 	// any case.
 	osEnv, err := envLib.ParseSlice(os.Environ())
 	if err != nil {
-		return nil, errors.Wrap(err, "error parsing host environment variables")
+		return nil, fmt.Errorf("error parsing host environment variables: %w", err)
 	}
 	// Caller Specified defaults
 	if s.EnvHost {

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -3,6 +3,7 @@ package kube
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -29,7 +30,6 @@ import (
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/go-units"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -146,7 +146,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	// pod name should be non-empty for Deployment objects to be able to create
 	// multiple pods having containers with unique names
 	if len(opts.PodName) < 1 {
-		return nil, errors.Errorf("got empty pod name on container creation when playing kube")
+		return nil, errors.New("got empty pod name on container creation when playing kube")
 	}
 
 	s.Name = fmt.Sprintf("%s-%s", opts.PodName, opts.Container.Name)
@@ -163,7 +163,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	for _, o := range opts.LogOptions {
 		split := strings.SplitN(o, "=", 2)
 		if len(split) < 2 {
-			return nil, errors.Errorf("invalid log option %q", o)
+			return nil, fmt.Errorf("invalid log option %q", o)
 		}
 		switch strings.ToLower(split[0]) {
 		case "driver":
@@ -179,7 +179,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		default:
 			switch len(split[1]) {
 			case 0:
-				return nil, errors.Wrapf(define.ErrInvalidArg, "invalid log option")
+				return nil, fmt.Errorf("invalid log option: %w", define.ErrInvalidArg)
 			default:
 				// tags for journald only
 				if s.LogConfiguration.Driver == "" || s.LogConfiguration.Driver == define.JournaldLogging {
@@ -196,7 +196,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	setupSecurityContext(s, opts.Container.SecurityContext, opts.PodSecurityContext)
 	err := setupLivenessProbe(s, opts.Container, opts.RestartPolicy)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to configure livenessProbe")
+		return nil, fmt.Errorf("failed to configure livenessProbe: %w", err)
 	}
 
 	// Since we prefix the container name with pod name to work-around the uniqueness requirement,
@@ -207,7 +207,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	s.ResourceLimits = &spec.LinuxResources{}
 	milliCPU, err := quantityToInt64(opts.Container.Resources.Limits.Cpu())
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to set CPU quota")
+		return nil, fmt.Errorf("failed to set CPU quota: %w", err)
 	}
 	if milliCPU > 0 {
 		period, quota := util.CoresToPeriodAndQuota(float64(milliCPU))
@@ -219,12 +219,12 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 
 	limit, err := quantityToInt64(opts.Container.Resources.Limits.Memory())
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to set memory limit")
+		return nil, fmt.Errorf("failed to set memory limit: %w", err)
 	}
 
 	memoryRes, err := quantityToInt64(opts.Container.Resources.Requests.Memory())
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to set memory reservation")
+		return nil, fmt.Errorf("failed to set memory reservation: %w", err)
 	}
 
 	if limit > 0 || memoryRes > 0 {
@@ -337,7 +337,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	for _, volume := range opts.Container.VolumeMounts {
 		volumeSource, exists := opts.Volumes[volume.Name]
 		if !exists {
-			return nil, errors.Errorf("Volume mount %s specified for container but not configured in volumes", volume.Name)
+			return nil, fmt.Errorf("volume mount %s specified for container but not configured in volumes", volume.Name)
 		}
 		// Skip if the volume is optional. This means that a configmap for a configmap volume was not found but it was
 		// optional so we can move on without throwing an error
@@ -399,7 +399,7 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 			}
 			s.Devices = append(s.Devices, device)
 		default:
-			return nil, errors.Errorf("Unsupported volume source type")
+			return nil, errors.New("unsupported volume source type")
 		}
 	}
 
@@ -432,21 +432,21 @@ func parseMountPath(mountPath string, readOnly bool, propagationMode *v1.MountPr
 	options := []string{}
 	splitVol := strings.Split(mountPath, ":")
 	if len(splitVol) > 2 {
-		return "", options, errors.Errorf("%q incorrect volume format, should be ctr-dir[:option]", mountPath)
+		return "", options, fmt.Errorf("%q incorrect volume format, should be ctr-dir[:option]", mountPath)
 	}
 	dest := splitVol[0]
 	if len(splitVol) > 1 {
 		options = strings.Split(splitVol[1], ",")
 	}
 	if err := parse.ValidateVolumeCtrDir(dest); err != nil {
-		return "", options, errors.Wrapf(err, "parsing MountPath")
+		return "", options, fmt.Errorf("parsing MountPath: %w", err)
 	}
 	if readOnly {
 		options = append(options, "ro")
 	}
 	opts, err := parse.ValidateVolumeOpts(options)
 	if err != nil {
-		return "", opts, errors.Wrapf(err, "parsing MountOptions")
+		return "", opts, fmt.Errorf("parsing MountOptions: %w", err)
 	}
 	if propagationMode != nil {
 		switch *propagationMode {
@@ -457,7 +457,7 @@ func parseMountPath(mountPath string, readOnly bool, propagationMode *v1.MountPr
 		case v1.MountPropagationBidirectional:
 			opts = append(opts, "rshared")
 		default:
-			return "", opts, errors.Errorf("unknown propagation mode %q", *propagationMode)
+			return "", opts, fmt.Errorf("unknown propagation mode %q", *propagationMode)
 		}
 	}
 	return dest, opts, nil
@@ -504,7 +504,7 @@ func setupLivenessProbe(s *specgen.SpecGenerator, containerYAML v1.Container, re
 func makeHealthCheck(inCmd string, interval int32, retries int32, timeout int32, startPeriod int32) (*manifest.Schema2HealthConfig, error) {
 	// Every healthcheck requires a command
 	if len(inCmd) == 0 {
-		return nil, errors.New("Must define a healthcheck command for all healthchecks")
+		return nil, errors.New("must define a healthcheck command for all healthchecks")
 	}
 
 	// first try to parse option value as JSON array of strings...
@@ -630,7 +630,7 @@ func quantityToInt64(quantity *resource.Quantity) (int64, error) {
 		return i, nil
 	}
 
-	return 0, errors.Errorf("Quantity cannot be represented as int64: %v", quantity)
+	return 0, fmt.Errorf("quantity cannot be represented as int64: %v", quantity)
 }
 
 // read a k8s secret in JSON format from the secret manager
@@ -642,7 +642,7 @@ func k8sSecretFromSecretManager(name string, secretsManager *secrets.SecretsMana
 
 	var secrets map[string][]byte
 	if err := json.Unmarshal(jsonSecret, &secrets); err != nil {
-		return nil, errors.Errorf("Secret %v is not valid JSON: %v", name, err)
+		return nil, fmt.Errorf("secret %v is not valid JSON: %v", name, err)
 	}
 	return secrets, nil
 }
@@ -653,7 +653,7 @@ func envVarsFrom(envFrom v1.EnvFromSource, opts *CtrSpecGenOptions) (map[string]
 
 	if envFrom.ConfigMapRef != nil {
 		cmRef := envFrom.ConfigMapRef
-		err := errors.Errorf("Configmap %v not found", cmRef.Name)
+		err := fmt.Errorf("configmap %v not found", cmRef.Name)
 
 		for _, c := range opts.ConfigMaps {
 			if cmRef.Name == c.Name {
@@ -689,14 +689,14 @@ func envVarValue(env v1.EnvVar, opts *CtrSpecGenOptions) (*string, error) {
 	if env.ValueFrom != nil {
 		if env.ValueFrom.ConfigMapKeyRef != nil {
 			cmKeyRef := env.ValueFrom.ConfigMapKeyRef
-			err := errors.Errorf("Cannot set env %v: configmap %v not found", env.Name, cmKeyRef.Name)
+			err := fmt.Errorf("cannot set env %v: configmap %v not found", env.Name, cmKeyRef.Name)
 
 			for _, c := range opts.ConfigMaps {
 				if cmKeyRef.Name == c.Name {
 					if value, ok := c.Data[cmKeyRef.Key]; ok {
 						return &value, nil
 					}
-					err = errors.Errorf("Cannot set env %v: key %s not found in configmap %v", env.Name, cmKeyRef.Key, cmKeyRef.Name)
+					err = fmt.Errorf("cannot set env %v: key %s not found in configmap %v", env.Name, cmKeyRef.Key, cmKeyRef.Name)
 					break
 				}
 			}
@@ -714,10 +714,10 @@ func envVarValue(env v1.EnvVar, opts *CtrSpecGenOptions) (*string, error) {
 					value := string(val)
 					return &value, nil
 				}
-				err = errors.Errorf("Secret %v has not %v key", secKeyRef.Name, secKeyRef.Key)
+				err = fmt.Errorf("secret %v has not %v key", secKeyRef.Name, secKeyRef.Key)
 			}
 			if secKeyRef.Optional == nil || !*secKeyRef.Optional {
-				return nil, errors.Errorf("Cannot set env %v: %v", env.Name, err)
+				return nil, fmt.Errorf("cannot set env %v: %v", env.Name, err)
 			}
 			return nil, nil
 		}
@@ -761,8 +761,8 @@ func envVarValueFieldRef(env v1.EnvVar, opts *CtrSpecGenOptions) (*string, error
 		return &annotationValue, nil
 	}
 
-	return nil, errors.Errorf(
-		"Can not set env %v. Reason: fieldPath %v is either not valid or not supported",
+	return nil, fmt.Errorf(
+		"can not set env %v. Reason: fieldPath %v is either not valid or not supported",
 		env.Name, fieldPath,
 	)
 }
@@ -796,15 +796,15 @@ func envVarValueResourceFieldRef(env v1.EnvVar, opts *CtrSpecGenOptions) (*strin
 		value = resources.Requests.Cpu()
 		isValidDivisor = isCPUDivisor(divisor)
 	default:
-		return nil, errors.Errorf(
-			"Can not set env %v. Reason: resource %v is either not valid or not supported",
+		return nil, fmt.Errorf(
+			"can not set env %v. Reason: resource %v is either not valid or not supported",
 			env.Name, resourceName,
 		)
 	}
 
 	if !isValidDivisor {
-		return nil, errors.Errorf(
-			"Can not set env %s. Reason: divisor value %s is not valid",
+		return nil, fmt.Errorf(
+			"can not set env %s. Reason: divisor value %s is not valid",
 			env.Name, divisor.String(),
 		)
 	}

--- a/pkg/specgen/generate/kube/seccomp.go
+++ b/pkg/specgen/generate/kube/seccomp.go
@@ -1,12 +1,12 @@
 package kube
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/containers/podman/v4/libpod"
 	v1 "github.com/containers/podman/v4/pkg/k8s.io/api/core/v1"
-	"github.com/pkg/errors"
 )
 
 // KubeSeccompPaths holds information about a pod YAML's seccomp configuration
@@ -42,7 +42,7 @@ func InitializeSeccompPaths(annotations map[string]string, profileRoot string) (
 				// this could be caused by a user inputting either of
 				// container.seccomp.security.alpha.kubernetes.io{,/}
 				// both of which are invalid
-				return nil, errors.Errorf("Invalid seccomp path: %s", prefixAndCtr[0])
+				return nil, fmt.Errorf("invalid seccomp path: %s", prefixAndCtr[0])
 			}
 
 			path, err := verifySeccompPath(seccomp, profileRoot)
@@ -80,6 +80,6 @@ func verifySeccompPath(path string, profileRoot string) (string, error) {
 		if parts[0] == "localhost" {
 			return filepath.Join(profileRoot, parts[1]), nil
 		}
-		return "", errors.Errorf("invalid seccomp path: %s", path)
+		return "", fmt.Errorf("invalid seccomp path: %s", path)
 	}
 }

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path"
 	"strings"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/containers/podman/v4/pkg/specgen"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -117,7 +117,7 @@ func makeCommand(s *specgen.SpecGenerator, imageData *libimage.ImageData, rtc *c
 	finalCommand = append(finalCommand, command...)
 
 	if len(finalCommand) == 0 {
-		return nil, errors.Errorf("no command or entrypoint provided, and no CMD or ENTRYPOINT from image")
+		return nil, fmt.Errorf("no command or entrypoint provided, and no CMD or ENTRYPOINT from image")
 	}
 
 	if s.Init {
@@ -126,7 +126,7 @@ func makeCommand(s *specgen.SpecGenerator, imageData *libimage.ImageData, rtc *c
 			initPath = rtc.Engine.InitPath
 		}
 		if initPath == "" {
-			return nil, errors.Errorf("no path to init binary found but container requested an init")
+			return nil, fmt.Errorf("no path to init binary found but container requested an init")
 		}
 		finalCommand = append([]string{define.ContainerInitPath, "--"}, finalCommand...)
 	}
@@ -348,7 +348,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	for k, v := range s.WeightDevice {
 		statT := unix.Stat_t{}
 		if err := unix.Stat(k, &statT); err != nil {
-			return nil, errors.Wrapf(err, "failed to inspect '%s' in --blkio-weight-device", k)
+			return nil, fmt.Errorf("failed to inspect '%s' in --blkio-weight-device: %w", k, err)
 		}
 		g.AddLinuxResourcesBlockIOWeightDevice((int64(unix.Major(uint64(statT.Rdev)))), (int64(unix.Minor(uint64(statT.Rdev)))), *v.Weight) //nolint: unconvert
 	}

--- a/pkg/specgen/generate/pod_create.go
+++ b/pkg/specgen/generate/pod_create.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/specgenutil"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -155,7 +154,7 @@ func MapSpec(p *specgen.PodSpecGenerator) (*specgen.SpecGenerator, error) {
 		if len(p.InfraContainerSpec.PortMappings) > 0 ||
 			len(p.InfraContainerSpec.Networks) > 0 ||
 			p.InfraContainerSpec.NetNS.NSMode == specgen.NoNetwork {
-			return nil, errors.Wrapf(define.ErrInvalidArg, "cannot set host network if network-related configuration is specified")
+			return nil, fmt.Errorf("cannot set host network if network-related configuration is specified: %w", define.ErrInvalidArg)
 		}
 		p.InfraContainerSpec.NetNS.NSMode = specgen.Host
 	case specgen.Slirp:
@@ -169,11 +168,11 @@ func MapSpec(p *specgen.PodSpecGenerator) (*specgen.SpecGenerator, error) {
 		if len(p.InfraContainerSpec.PortMappings) > 0 ||
 			len(p.InfraContainerSpec.Networks) > 0 ||
 			p.InfraContainerSpec.NetNS.NSMode == specgen.Host {
-			return nil, errors.Wrapf(define.ErrInvalidArg, "cannot disable pod network if network-related configuration is specified")
+			return nil, fmt.Errorf("cannot disable pod network if network-related configuration is specified: %w", define.ErrInvalidArg)
 		}
 		p.InfraContainerSpec.NetNS.NSMode = specgen.NoNetwork
 	default:
-		return nil, errors.Errorf("pods presently do not support network mode %s", p.NetNS.NSMode)
+		return nil, fmt.Errorf("pods presently do not support network mode %s", p.NetNS.NSMode)
 	}
 
 	if len(p.InfraCommand) > 0 {

--- a/pkg/specgen/generate/ports.go
+++ b/pkg/specgen/generate/ports.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/common/pkg/util"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/specgenutil"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,7 +45,7 @@ func joinTwoPortsToRangePortIfPossible(ports *[]types.PortMapping, allHostPorts,
 		// if both host port ranges overlap and the container port range did not match
 		// we have to error because we cannot assign the same host port to more than one container port
 		if previousPort.HostPort+previousPort.Range-1 > port.HostPort {
-			return nil, errors.Errorf("conflicting port mappings for host port %d (protocol %s)", port.HostPort, port.Protocol)
+			return nil, fmt.Errorf("conflicting port mappings for host port %d (protocol %s)", port.HostPort, port.Protocol)
 		}
 	}
 	// we could not join the ports so we append the old one to the list
@@ -127,7 +126,7 @@ outer:
 		rangePort = fmt.Sprintf("with range %d ", port.Range)
 	}
 
-	return port, errors.Errorf("failed to find an open port to expose container port %d %son the host", port.ContainerPort, rangePort)
+	return port, fmt.Errorf("failed to find an open port to expose container port %d %son the host", port.ContainerPort, rangePort)
 }
 
 // Parse port maps to port mappings.
@@ -163,7 +162,7 @@ func ParsePortMapping(portMappings []types.PortMapping, exposePorts map[uint16][
 		}
 		if port.HostIP != "" {
 			if ip := net.ParseIP(port.HostIP); ip == nil {
-				return nil, errors.Errorf("invalid IP address %q in port mapping", port.HostIP)
+				return nil, fmt.Errorf("invalid IP address %q in port mapping", port.HostIP)
 			}
 		}
 
@@ -174,14 +173,14 @@ func ParsePortMapping(portMappings []types.PortMapping, exposePorts map[uint16][
 		}
 		containerPort := port.ContainerPort
 		if containerPort == 0 {
-			return nil, errors.Errorf("container port number must be non-0")
+			return nil, fmt.Errorf("container port number must be non-0")
 		}
 		hostPort := port.HostPort
 		if uint32(portRange-1)+uint32(containerPort) > 65535 {
-			return nil, errors.Errorf("container port range exceeds maximum allowable port number")
+			return nil, fmt.Errorf("container port range exceeds maximum allowable port number")
 		}
 		if uint32(portRange-1)+uint32(hostPort) > 65535 {
-			return nil, errors.Errorf("host port range exceeds maximum allowable port number")
+			return nil, fmt.Errorf("host port range exceeds maximum allowable port number")
 		}
 
 		hostProtoMap, ok := portMap[port.HostIP]
@@ -351,11 +350,11 @@ func createPortMappings(s *specgen.SpecGenerator, imageData *libimage.ImageData)
 	for _, expose := range []map[uint16]string{expose, s.Expose} {
 		for port, proto := range expose {
 			if port == 0 {
-				return nil, nil, errors.Errorf("cannot expose 0 as it is not a valid port number")
+				return nil, nil, fmt.Errorf("cannot expose 0 as it is not a valid port number")
 			}
 			protocols, err := checkProtocol(proto, false)
 			if err != nil {
-				return nil, nil, errors.Wrapf(err, "error validating protocols for exposed port %d", port)
+				return nil, nil, fmt.Errorf("error validating protocols for exposed port %d: %w", port, err)
 			}
 			toExpose[port] = appendProtocolsNoDuplicates(toExpose[port], protocols)
 		}
@@ -387,11 +386,11 @@ func checkProtocol(protocol string, allowSCTP bool) ([]string, error) {
 			protocols[protoUDP] = struct{}{}
 		case protoSCTP:
 			if !allowSCTP {
-				return nil, errors.Errorf("protocol SCTP is not allowed for exposed ports")
+				return nil, fmt.Errorf("protocol SCTP is not allowed for exposed ports")
 			}
 			protocols[protoSCTP] = struct{}{}
 		default:
-			return nil, errors.Errorf("unrecognized protocol %q in port mapping", p)
+			return nil, fmt.Errorf("unrecognized protocol %q in port mapping", p)
 		}
 	}
 
@@ -402,7 +401,7 @@ func checkProtocol(protocol string, allowSCTP bool) ([]string, error) {
 
 	// This shouldn't be possible, but check anyways
 	if len(finalProto) == 0 {
-		return nil, errors.Errorf("no valid protocols specified for port mapping")
+		return nil, fmt.Errorf("no valid protocols specified for port mapping")
 	}
 
 	return finalProto, nil
@@ -415,7 +414,7 @@ func GenExposedPorts(exposedPorts map[string]struct{}) (map[uint16]string, error
 	}
 	toReturn, err := specgenutil.CreateExpose(expose)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to convert image EXPOSE")
+		return nil, fmt.Errorf("unable to convert image EXPOSE: %w", err)
 	}
 	return toReturn, nil
 }

--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -2,6 +2,7 @@ package generate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -16,11 +17,10 @@ import (
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/util"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-var errDuplicateDest = errors.Errorf("duplicate mount destination")
+var errDuplicateDest = errors.New("duplicate mount destination")
 
 // Produce final mounts and named volumes for a container
 func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runtime, rtc *config.Config, img *libimage.Image) ([]spec.Mount, []*specgen.NamedVolume, []*specgen.OverlayVolume, error) {
@@ -63,7 +63,7 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 		}
 		cleanDestination := filepath.Clean(m.Destination)
 		if _, ok := unifiedMounts[cleanDestination]; ok {
-			return nil, nil, nil, errors.Wrapf(errDuplicateDest, "conflict in specified mounts - multiple mounts at %q", cleanDestination)
+			return nil, nil, nil, fmt.Errorf("conflict in specified mounts - multiple mounts at %q: %w", cleanDestination, errDuplicateDest)
 		}
 		unifiedMounts[cleanDestination] = m
 	}
@@ -84,7 +84,7 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 		}
 		cleanDestination := filepath.Clean(v.Dest)
 		if _, ok := unifiedVolumes[cleanDestination]; ok {
-			return nil, nil, nil, errors.Wrapf(errDuplicateDest, "conflict in specified volumes - multiple volumes at %q", cleanDestination)
+			return nil, nil, nil, fmt.Errorf("conflict in specified volumes - multiple volumes at %q: %w", cleanDestination, errDuplicateDest)
 		}
 		unifiedVolumes[cleanDestination] = v
 	}
@@ -105,7 +105,7 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 		}
 		cleanDestination := filepath.Clean(v.Destination)
 		if _, ok := unifiedOverlays[cleanDestination]; ok {
-			return nil, nil, nil, errors.Wrapf(errDuplicateDest, "conflict in specified volumes - multiple volumes at %q", cleanDestination)
+			return nil, nil, nil, fmt.Errorf("conflict in specified volumes - multiple volumes at %q: %w", cleanDestination, errDuplicateDest)
 		}
 		unifiedOverlays[cleanDestination] = v
 	}
@@ -131,7 +131,7 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 			return nil, nil, nil, err
 		}
 		if _, ok := unifiedMounts[initMount.Destination]; ok {
-			return nil, nil, nil, errors.Wrapf(errDuplicateDest, "conflict with mount added by --init to %q", initMount.Destination)
+			return nil, nil, nil, fmt.Errorf("conflict with mount added by --init to %q: %w", initMount.Destination, errDuplicateDest)
 		}
 		unifiedMounts[initMount.Destination] = initMount
 	}
@@ -161,12 +161,12 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 	// Check for conflicts between named volumes and mounts
 	for dest := range baseMounts {
 		if _, ok := baseVolumes[dest]; ok {
-			return nil, nil, nil, errors.Wrapf(errDuplicateDest, "conflict at mount destination %v", dest)
+			return nil, nil, nil, fmt.Errorf("conflict at mount destination %v: %w", dest, errDuplicateDest)
 		}
 	}
 	for dest := range baseVolumes {
 		if _, ok := baseMounts[dest]; ok {
-			return nil, nil, nil, errors.Wrapf(errDuplicateDest, "conflict at mount destination %v", dest)
+			return nil, nil, nil, fmt.Errorf("conflict at mount destination %v: %w", dest, errDuplicateDest)
 		}
 	}
 	// Final step: maps to arrays
@@ -175,7 +175,7 @@ func finalizeMounts(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Ru
 		if mount.Type == define.TypeBind {
 			absSrc, err := filepath.Abs(mount.Source)
 			if err != nil {
-				return nil, nil, nil, errors.Wrapf(err, "error getting absolute path of %s", mount.Source)
+				return nil, nil, nil, fmt.Errorf("error getting absolute path of %s: %w", mount.Source, err)
 			}
 			mount.Source = absSrc
 		}
@@ -208,7 +208,7 @@ func getImageVolumes(ctx context.Context, img *libimage.Image, s *specgen.SpecGe
 
 	inspect, err := img.Inspect(ctx, nil)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error inspecting image to get image volumes")
+		return nil, nil, fmt.Errorf("error inspecting image to get image volumes: %w", err)
 	}
 	for volume := range inspect.Config.Volumes {
 		logrus.Debugf("Image has volume at %q", volume)
@@ -252,16 +252,16 @@ func getVolumesFrom(volumesFrom []string, runtime *libpod.Runtime) (map[string]s
 				switch opt {
 				case "z":
 					if setZ {
-						return nil, nil, errors.Errorf("cannot set :z more than once in mount options")
+						return nil, nil, errors.New("cannot set :z more than once in mount options")
 					}
 					setZ = true
 				case "ro", "rw":
 					if setRORW {
-						return nil, nil, errors.Errorf("cannot set ro or rw options more than once")
+						return nil, nil, errors.New("cannot set ro or rw options more than once")
 					}
 					setRORW = true
 				default:
-					return nil, nil, errors.Errorf("invalid option %q specified - volumes from another container can only use z,ro,rw options", opt)
+					return nil, nil, fmt.Errorf("invalid option %q specified - volumes from another container can only use z,ro,rw options", opt)
 				}
 			}
 			options = splitOpts
@@ -269,7 +269,7 @@ func getVolumesFrom(volumesFrom []string, runtime *libpod.Runtime) (map[string]s
 
 		ctr, err := runtime.LookupContainer(splitVol[0])
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "error looking up container %q for volumes-from", splitVol[0])
+			return nil, nil, fmt.Errorf("error looking up container %q for volumes-from: %w", splitVol[0], err)
 		}
 
 		logrus.Debugf("Adding volumes from container %s", ctr.ID())
@@ -290,7 +290,7 @@ func getVolumesFrom(volumesFrom []string, runtime *libpod.Runtime) (map[string]s
 		// and append them in if we can find them.
 		spec := ctr.Spec()
 		if spec == nil {
-			return nil, nil, errors.Errorf("retrieving container %s spec for volumes-from", ctr.ID())
+			return nil, nil, fmt.Errorf("retrieving container %s spec for volumes-from", ctr.ID())
 		}
 		for _, mnt := range spec.Mounts {
 			if mnt.Type != define.TypeBind {
@@ -364,16 +364,16 @@ func addContainerInitBinary(s *specgen.SpecGenerator, path string) (spec.Mount, 
 	}
 
 	if path == "" {
-		return mount, fmt.Errorf("please specify a path to the container-init binary")
+		return mount, errors.New("please specify a path to the container-init binary")
 	}
 	if !s.PidNS.IsPrivate() {
-		return mount, fmt.Errorf("cannot add init binary as PID 1 (PID namespace isn't private)")
+		return mount, errors.New("cannot add init binary as PID 1 (PID namespace isn't private)")
 	}
 	if s.Systemd == "always" {
-		return mount, fmt.Errorf("cannot use container-init binary with systemd=always")
+		return mount, errors.New("cannot use container-init binary with systemd=always")
 	}
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return mount, errors.Wrap(err, "container-init binary not found on the host")
+		return mount, fmt.Errorf("container-init binary not found on the host: %w", err)
 	}
 	return mount, nil
 }

--- a/pkg/specgen/generate/validate.go
+++ b/pkg/specgen/generate/validate.go
@@ -1,6 +1,8 @@
 package generate
 
 import (
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -9,7 +11,6 @@ import (
 	"github.com/containers/common/pkg/sysinfo"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/utils"
-	"github.com/pkg/errors"
 )
 
 // Verify resource limits are sanely set when running on cgroup v1.
@@ -23,7 +24,7 @@ func verifyContainerResourcesCgroupV1(s *specgen.SpecGenerator) ([]string, error
 	}
 
 	if s.ResourceLimits.Unified != nil {
-		return nil, errors.New("Cannot use --cgroup-conf without cgroup v2")
+		return nil, errors.New("cannot use --cgroup-conf without cgroup v2")
 	}
 
 	// Memory checks
@@ -49,7 +50,7 @@ func verifyContainerResourcesCgroupV1(s *specgen.SpecGenerator) ([]string, error
 				warnings = append(warnings, "Your kernel does not support memory swappiness capabilities, or the cgroup is not mounted. Memory swappiness discarded.")
 				memory.Swappiness = nil
 			} else if *memory.Swappiness > 100 {
-				return warnings, errors.Errorf("invalid value: %v, valid memory swappiness range is 0-100", *memory.Swappiness)
+				return warnings, fmt.Errorf("invalid value: %v, valid memory swappiness range is 0-100", *memory.Swappiness)
 			}
 		}
 		if memory.Reservation != nil && !sysInfo.MemoryReservation {
@@ -104,18 +105,18 @@ func verifyContainerResourcesCgroupV1(s *specgen.SpecGenerator) ([]string, error
 
 		cpusAvailable, err := sysInfo.IsCpusetCpusAvailable(cpu.Cpus)
 		if err != nil {
-			return warnings, errors.Errorf("invalid value %s for cpuset cpus", cpu.Cpus)
+			return warnings, fmt.Errorf("invalid value %s for cpuset cpus", cpu.Cpus)
 		}
 		if !cpusAvailable {
-			return warnings, errors.Errorf("requested CPUs are not available - requested %s, available: %s", cpu.Cpus, sysInfo.Cpus)
+			return warnings, fmt.Errorf("requested CPUs are not available - requested %s, available: %s", cpu.Cpus, sysInfo.Cpus)
 		}
 
 		memsAvailable, err := sysInfo.IsCpusetMemsAvailable(cpu.Mems)
 		if err != nil {
-			return warnings, errors.Errorf("invalid value %s for cpuset mems", cpu.Mems)
+			return warnings, fmt.Errorf("invalid value %s for cpuset mems", cpu.Mems)
 		}
 		if !memsAvailable {
-			return warnings, errors.Errorf("requested memory nodes are not available - requested %s, available: %s", cpu.Mems, sysInfo.Mems)
+			return warnings, fmt.Errorf("requested memory nodes are not available - requested %s, available: %s", cpu.Mems, sysInfo.Mems)
 		}
 	}
 

--- a/pkg/specgen/pod_validate.go
+++ b/pkg/specgen/pod_validate.go
@@ -1,8 +1,10 @@
 package specgen
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/containers/podman/v4/pkg/util"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -13,7 +15,7 @@ var (
 )
 
 func exclusivePodOptions(opt1, opt2 string) error {
-	return errors.Wrapf(ErrInvalidPodSpecConfig, "%s and %s are mutually exclusive pod options", opt1, opt2)
+	return fmt.Errorf("%s and %s are mutually exclusive pod options: %w", opt1, opt2, ErrInvalidPodSpecConfig)
 }
 
 // Validate verifies the input is valid

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -1,6 +1,7 @@
 package specgen
 
 import (
+	"errors"
 	"net"
 	"strings"
 	"syscall"
@@ -10,7 +11,6 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/storage/types"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 //  LogConfig describes the logging characteristics for a container
@@ -571,10 +571,10 @@ type Secret struct {
 var (
 	// ErrNoStaticIPRootless is used when a rootless user requests to assign a static IP address
 	// to a pod or container
-	ErrNoStaticIPRootless error = errors.New("rootless containers and pods cannot be assigned static IP addresses")
+	ErrNoStaticIPRootless = errors.New("rootless containers and pods cannot be assigned static IP addresses")
 	// ErrNoStaticMACRootless is used when a rootless user requests to assign a static MAC address
 	// to a pod or container
-	ErrNoStaticMACRootless error = errors.New("rootless containers and pods cannot be assigned static MAC addresses")
+	ErrNoStaticMACRootless = errors.New("rootless containers and pods cannot be assigned static MAC addresses")
 )
 
 // NewSpecGenerator returns a SpecGenerator struct given one of two mandatory inputs

--- a/pkg/specgen/winpath.go
+++ b/pkg/specgen/winpath.go
@@ -1,11 +1,10 @@
 package specgen
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"unicode"
-
-	"github.com/pkg/errors"
 )
 
 func isHostWinPath(path string) bool {

--- a/pkg/specgenutil/createparse.go
+++ b/pkg/specgenutil/createparse.go
@@ -1,9 +1,10 @@
 package specgenutil
 
 import (
+	"errors"
+
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/pkg/errors"
 )
 
 // validate determines if the flags and values given by the user are valid. things checked
@@ -11,7 +12,7 @@ import (
 func validate(c *entities.ContainerCreateOptions) error {
 	var ()
 	if c.Rm && (c.Restart != "" && c.Restart != "no" && c.Restart != "on-failure") {
-		return errors.Errorf(`the --rm option conflicts with --restart, when the restartPolicy is not "" and "no"`)
+		return errors.New(`the --rm option conflicts with --restart, when the restartPolicy is not "" and "no"`)
 	}
 
 	if _, err := config.ParsePullPolicy(c.Pull); err != nil {

--- a/pkg/specgenutil/ports.go
+++ b/pkg/specgenutil/ports.go
@@ -1,8 +1,9 @@
 package specgenutil
 
 import (
+	"fmt"
+
 	"github.com/docker/go-connections/nat"
-	"github.com/pkg/errors"
 )
 
 func verifyExpose(expose []string) error {
@@ -15,7 +16,7 @@ func verifyExpose(expose []string) error {
 		// if expose a port, the start and end port are the same
 		_, _, err := nat.ParsePortRange(port)
 		if err != nil {
-			return errors.Wrapf(err, "invalid range format for --expose: %s", expose)
+			return fmt.Errorf("invalid range format for --expose: %s: %w", expose, err)
 		}
 	}
 	return nil

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -2,6 +2,7 @@ package specgenutil
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -22,7 +23,6 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/go-units"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 func getCPULimits(c *entities.ContainerCreateOptions) *specs.LinuxCPU {
@@ -78,7 +78,7 @@ func getIOLimits(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions) (
 	if b := c.BlkIOWeight; len(b) > 0 {
 		u, err := strconv.ParseUint(b, 10, 16)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid value for blkio-weight")
+			return nil, fmt.Errorf("invalid value for blkio-weight: %w", err)
 		}
 		nu := uint16(u)
 		io.Weight = &nu
@@ -143,7 +143,7 @@ func getMemoryLimits(c *entities.ContainerCreateOptions) (*specs.LinuxMemory, er
 	if m := c.Memory; len(m) > 0 {
 		ml, err := units.RAMInBytes(m)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid value for memory")
+			return nil, fmt.Errorf("invalid value for memory: %w", err)
 		}
 		LimitToSwap(memory, c.MemorySwap, ml)
 		hasLimits = true
@@ -151,7 +151,7 @@ func getMemoryLimits(c *entities.ContainerCreateOptions) (*specs.LinuxMemory, er
 	if m := c.MemoryReservation; len(m) > 0 {
 		mr, err := units.RAMInBytes(m)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid value for memory")
+			return nil, fmt.Errorf("invalid value for memory: %w", err)
 		}
 		memory.Reservation = &mr
 		hasLimits = true
@@ -164,7 +164,7 @@ func getMemoryLimits(c *entities.ContainerCreateOptions) (*specs.LinuxMemory, er
 			ms, err = units.RAMInBytes(m)
 			memory.Swap = &ms
 			if err != nil {
-				return nil, errors.Wrapf(err, "invalid value for memory")
+				return nil, fmt.Errorf("invalid value for memory: %w", err)
 			}
 			hasLimits = true
 		}
@@ -248,7 +248,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 
 	if len(c.HealthCmd) > 0 {
 		if c.NoHealthCheck {
-			return errors.New("Cannot specify both --no-healthcheck and --health-cmd")
+			return errors.New("cannot specify both --no-healthcheck and --health-cmd")
 		}
 		s.HealthConfig, err = makeHealthCheckFromCli(c.HealthCmd, c.HealthInterval, c.HealthRetries, c.HealthTimeout, c.HealthStartPeriod)
 		if err != nil {
@@ -318,7 +318,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 
 	if len(c.PodIDFile) > 0 {
 		if len(s.Pod) > 0 {
-			return errors.New("Cannot specify both --pod and --pod-id-file")
+			return errors.New("cannot specify both --pod and --pod-id-file")
 		}
 		podID, err := ReadPodIDFile(c.PodIDFile)
 		if err != nil {
@@ -357,7 +357,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	// any case.
 	osEnv, err := envLib.ParseSlice(os.Environ())
 	if err != nil {
-		return errors.Wrap(err, "error parsing host environment variables")
+		return fmt.Errorf("error parsing host environment variables: %w", err)
 	}
 
 	if !s.EnvHost {
@@ -390,7 +390,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	// LABEL VARIABLES
 	labels, err := parse.GetAllLabels(c.LabelFile, c.Label)
 	if err != nil {
-		return errors.Wrapf(err, "unable to process labels")
+		return fmt.Errorf("unable to process labels: %w", err)
 	}
 
 	if systemdUnit, exists := osEnv[systemdDefine.EnvVariable]; exists {
@@ -414,7 +414,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	for _, annotation := range c.Annotation {
 		splitAnnotation := strings.SplitN(annotation, "=", 2)
 		if len(splitAnnotation) < 2 {
-			return errors.Errorf("Annotations must be formatted KEY=VALUE")
+			return errors.New("annotations must be formatted KEY=VALUE")
 		}
 		annotations[splitAnnotation[0]] = splitAnnotation[1]
 	}
@@ -427,7 +427,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		for _, opt := range c.StorageOpts {
 			split := strings.SplitN(opt, "=", 2)
 			if len(split) != 2 {
-				return errors.Errorf("storage-opt must be formatted KEY=VALUE")
+				return errors.New("storage-opt must be formatted KEY=VALUE")
 			}
 			opts[split[0]] = split[1]
 		}
@@ -459,7 +459,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	if c.ShmSize != "" {
 		var m opts.MemBytes
 		if err := m.Set(c.ShmSize); err != nil {
-			return errors.Wrapf(err, "unable to translate --shm-size")
+			return fmt.Errorf("unable to translate --shm-size: %w", err)
 		}
 		val := m.Value()
 		s.ShmSize = &val
@@ -531,7 +531,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	for _, unified := range c.CgroupConf {
 		splitUnified := strings.SplitN(unified, "=", 2)
 		if len(splitUnified) < 2 {
-			return errors.Errorf("--cgroup-conf must be formatted KEY=VALUE")
+			return errors.New("--cgroup-conf must be formatted KEY=VALUE")
 		}
 		unifieds[splitUnified[0]] = splitUnified[1]
 	}
@@ -608,7 +608,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	for _, ctl := range c.Sysctl {
 		splitCtl := strings.SplitN(ctl, "=", 2)
 		if len(splitCtl) < 2 {
-			return errors.Errorf("invalid sysctl value %q", ctl)
+			return fmt.Errorf("invalid sysctl value %q", ctl)
 		}
 		sysmap[splitCtl[0]] = splitCtl[1]
 	}
@@ -731,7 +731,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 		}
 		ul, err := units.ParseUlimit(u)
 		if err != nil {
-			return errors.Wrapf(err, "ulimit option %q requires name=SOFT:HARD, failed to be parsed", u)
+			return fmt.Errorf("ulimit option %q requires name=SOFT:HARD, failed to be parsed: %w", u, err)
 		}
 		rl := specs.POSIXRlimit{
 			Type: ul.Name,
@@ -745,7 +745,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	for _, o := range c.LogOptions {
 		split := strings.SplitN(o, "=", 2)
 		if len(split) < 2 {
-			return errors.Errorf("invalid log option %q", o)
+			return fmt.Errorf("invalid log option %q", o)
 		}
 		switch strings.ToLower(split[0]) {
 		case "driver":
@@ -782,19 +782,19 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 			// No retries specified
 		case 2:
 			if strings.ToLower(splitRestart[0]) != "on-failure" {
-				return errors.Errorf("restart policy retries can only be specified with on-failure restart policy")
+				return errors.New("restart policy retries can only be specified with on-failure restart policy")
 			}
 			retries, err := strconv.Atoi(splitRestart[1])
 			if err != nil {
-				return errors.Wrapf(err, "error parsing restart policy retry count")
+				return fmt.Errorf("error parsing restart policy retry count: %w", err)
 			}
 			if retries < 0 {
-				return errors.Errorf("must specify restart policy retry count as a number greater than 0")
+				return errors.New("must specify restart policy retry count as a number greater than 0")
 			}
 			var retriesUint = uint(retries)
 			s.RestartRetries = &retriesUint
 		default:
-			return errors.Errorf("invalid restart policy: may specify retries at most once")
+			return errors.New("invalid restart policy: may specify retries at most once")
 		}
 		s.RestartPolicy = splitRestart[0]
 	}
@@ -869,7 +869,7 @@ func makeHealthCheckFromCli(inCmd, interval string, retries uint, timeout, start
 	}
 	// Every healthcheck requires a command
 	if len(cmdArr) == 0 {
-		return nil, errors.New("Must define a healthcheck command for all healthchecks")
+		return nil, errors.New("must define a healthcheck command for all healthchecks")
 	}
 
 	var concat string
@@ -902,7 +902,7 @@ func makeHealthCheckFromCli(inCmd, interval string, retries uint, timeout, start
 	}
 	intervalDuration, err := time.ParseDuration(interval)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid healthcheck-interval")
+		return nil, fmt.Errorf("invalid healthcheck-interval: %w", err)
 	}
 
 	hc.Interval = intervalDuration
@@ -913,7 +913,7 @@ func makeHealthCheckFromCli(inCmd, interval string, retries uint, timeout, start
 	hc.Retries = int(retries)
 	timeoutDuration, err := time.ParseDuration(timeout)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid healthcheck-timeout")
+		return nil, fmt.Errorf("invalid healthcheck-timeout: %w", err)
 	}
 	if timeoutDuration < time.Duration(1) {
 		return nil, errors.New("healthcheck-timeout must be at least 1 second")
@@ -922,7 +922,7 @@ func makeHealthCheckFromCli(inCmd, interval string, retries uint, timeout, start
 
 	startPeriodDuration, err := time.ParseDuration(startPeriod)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid healthcheck-start-period")
+		return nil, fmt.Errorf("invalid healthcheck-start-period: %w", err)
 	}
 	if startPeriodDuration < time.Duration(0) {
 		return nil, errors.New("healthcheck-start-period must be 0 seconds or greater")
@@ -1035,17 +1035,17 @@ func parseSecrets(secrets []string) ([]specgen.Secret, map[string]string, error)
 		for _, val := range split {
 			kv := strings.SplitN(val, "=", 2)
 			if len(kv) < 2 {
-				return nil, nil, errors.Wrapf(secretParseError, "option %s must be in form option=value", val)
+				return nil, nil, fmt.Errorf("option %s must be in form option=value: %w", val, secretParseError)
 			}
 			switch kv[0] {
 			case "source":
 				source = kv[1]
 			case "type":
 				if secretType != "" {
-					return nil, nil, errors.Wrap(secretParseError, "cannot set more than one secret type")
+					return nil, nil, fmt.Errorf("cannot set more than one secret type: %w", secretParseError)
 				}
 				if kv[1] != "mount" && kv[1] != "env" {
-					return nil, nil, errors.Wrapf(secretParseError, "type %s is invalid", kv[1])
+					return nil, nil, fmt.Errorf("type %s is invalid: %w", kv[1], secretParseError)
 				}
 				secretType = kv[1]
 			case "target":
@@ -1054,26 +1054,26 @@ func parseSecrets(secrets []string) ([]specgen.Secret, map[string]string, error)
 				mountOnly = true
 				mode64, err := strconv.ParseUint(kv[1], 8, 32)
 				if err != nil {
-					return nil, nil, errors.Wrapf(secretParseError, "mode %s invalid", kv[1])
+					return nil, nil, fmt.Errorf("mode %s invalid: %w", kv[1], secretParseError)
 				}
 				mode = uint32(mode64)
 			case "uid", "UID":
 				mountOnly = true
 				uid64, err := strconv.ParseUint(kv[1], 10, 32)
 				if err != nil {
-					return nil, nil, errors.Wrapf(secretParseError, "UID %s invalid", kv[1])
+					return nil, nil, fmt.Errorf("UID %s invalid: %w", kv[1], secretParseError)
 				}
 				uid = uint32(uid64)
 			case "gid", "GID":
 				mountOnly = true
 				gid64, err := strconv.ParseUint(kv[1], 10, 32)
 				if err != nil {
-					return nil, nil, errors.Wrapf(secretParseError, "GID %s invalid", kv[1])
+					return nil, nil, fmt.Errorf("GID %s invalid: %w", kv[1], secretParseError)
 				}
 				gid = uint32(gid64)
 
 			default:
-				return nil, nil, errors.Wrapf(secretParseError, "option %s invalid", val)
+				return nil, nil, fmt.Errorf("option %s invalid: %w", val, secretParseError)
 			}
 		}
 
@@ -1081,7 +1081,7 @@ func parseSecrets(secrets []string) ([]specgen.Secret, map[string]string, error)
 			secretType = "mount"
 		}
 		if source == "" {
-			return nil, nil, errors.Wrapf(secretParseError, "no source found %s", val)
+			return nil, nil, fmt.Errorf("no source found %s: %w", val, secretParseError)
 		}
 		if secretType == "mount" {
 			mountSecret := specgen.Secret{
@@ -1095,7 +1095,7 @@ func parseSecrets(secrets []string) ([]specgen.Secret, map[string]string, error)
 		}
 		if secretType == "env" {
 			if mountOnly {
-				return nil, nil, errors.Wrap(secretParseError, "UID, GID, Mode options cannot be set with secret type env")
+				return nil, nil, fmt.Errorf("UID, GID, Mode options cannot be set with secret type env: %w", secretParseError)
 			}
 			if target == "" {
 				target = source

--- a/pkg/systemd/generate/common.go
+++ b/pkg/systemd/generate/common.go
@@ -1,11 +1,11 @@
 package generate
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/containers/podman/v4/pkg/systemd/define"
-	"github.com/pkg/errors"
 )
 
 // minTimeoutStopSec is the minimal stop timeout for generated systemd units.
@@ -20,7 +20,7 @@ func validateRestartPolicy(restart string) error {
 			return nil
 		}
 	}
-	return errors.Errorf("%s is not a valid restart policy", restart)
+	return fmt.Errorf("%s is not a valid restart policy", restart)
 }
 
 const headerTemplate = `# {{{{.ServiceName}}}}{{{{- if (eq .IdentifySpecifier true) }}}}@{{{{- end}}}}.service

--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -2,6 +2,7 @@ package generate
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -14,7 +15,6 @@ import (
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/systemd/define"
 	"github.com/containers/podman/v4/version"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
@@ -186,14 +186,14 @@ func generateContainerInfo(ctr *libpod.Container, options entities.GenerateSyste
 	config := ctr.Config()
 	conmonPidFile := config.ConmonPidFile
 	if conmonPidFile == "" {
-		return nil, errors.Errorf("conmon PID file path is empty, try to recreate the container with --conmon-pidfile flag")
+		return nil, errors.New("conmon PID file path is empty, try to recreate the container with --conmon-pidfile flag")
 	}
 
 	createCommand := []string{}
 	if config.CreateCommand != nil {
 		createCommand = config.CreateCommand
 	} else if options.New {
-		return nil, errors.Errorf("cannot use --new on container %q: no create command found: only works on containers created directly with podman but not via REST API", ctr.ID())
+		return nil, fmt.Errorf("cannot use --new on container %q: no create command found: only works on containers created directly with podman but not via REST API", ctr.ID())
 	}
 
 	nameOrID, serviceName := containerServiceName(ctr, options)
@@ -204,7 +204,7 @@ func generateContainerInfo(ctr *libpod.Container, options entities.GenerateSyste
 	} else {
 		runRoot = ctr.Runtime().RunRoot()
 		if runRoot == "" {
-			return nil, errors.Errorf("could not look up container's runroot: got empty string")
+			return nil, errors.New("could not look up container's runroot: got empty string")
 		}
 	}
 
@@ -350,7 +350,7 @@ func executeContainerTemplate(info *containerInfo, options entities.GenerateSyst
 			}
 		}
 		if index == 0 {
-			return "", errors.Errorf("container's create command is too short or invalid: %v", info.CreateCommand)
+			return "", fmt.Errorf("container's create command is too short or invalid: %v", info.CreateCommand)
 		}
 		// We're hard-coding the first five arguments and append the
 		// CreateCommand with a stripped command and subcommand.
@@ -520,7 +520,7 @@ func executeContainerTemplate(info *containerInfo, options entities.GenerateSyst
 	// template execution.
 	templ, err := template.New("container_template").Delims("{{{{", "}}}}").Parse(containerTemplate)
 	if err != nil {
-		return "", errors.Wrap(err, "error parsing systemd service template")
+		return "", fmt.Errorf("error parsing systemd service template: %w", err)
 	}
 
 	var buf bytes.Buffer
@@ -531,7 +531,7 @@ func executeContainerTemplate(info *containerInfo, options entities.GenerateSyst
 	// Now parse the generated template (i.e., buf) and execute it.
 	templ, err = template.New("container_template").Delims("{{{{", "}}}}").Parse(buf.String())
 	if err != nil {
-		return "", errors.Wrap(err, "error parsing systemd service template")
+		return "", fmt.Errorf("error parsing systemd service template: %w", err)
 	}
 
 	buf = bytes.Buffer{}

--- a/pkg/util/filters.go
+++ b/pkg/util/filters.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -9,14 +10,13 @@ import (
 	"time"
 
 	"github.com/containers/podman/v4/pkg/timetype"
-	"github.com/pkg/errors"
 )
 
 // ComputeUntilTimestamp extracts until timestamp from filters
 func ComputeUntilTimestamp(filterValues []string) (time.Time, error) {
 	invalid := time.Time{}
 	if len(filterValues) != 1 {
-		return invalid, errors.Errorf("specify exactly one timestamp for until")
+		return invalid, errors.New("specify exactly one timestamp for until")
 	}
 	ts, err := timetype.GetTimestamp(filterValues[0], time.Now())
 	if err != nil {

--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -1,16 +1,16 @@
 package util
 
 import (
+	"errors"
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 var (
 	// ErrBadMntOption indicates that an invalid mount option was passed.
-	ErrBadMntOption = errors.Errorf("invalid mount option")
+	ErrBadMntOption = errors.New("invalid mount option")
 	// ErrDupeMntOption indicates that a duplicate mount option was passed.
-	ErrDupeMntOption = errors.Errorf("duplicate mount option passed")
+	ErrDupeMntOption = errors.New("duplicate mount option passed")
 )
 
 type defaultMountOptions struct {
@@ -47,7 +47,7 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 
 		if strings.HasPrefix(splitOpt[0], "idmap") {
 			if foundIdmap {
-				return nil, errors.Wrapf(ErrDupeMntOption, "the 'idmap' option can only be set once")
+				return nil, fmt.Errorf("the 'idmap' option can only be set once: %w", ErrDupeMntOption)
 			}
 			foundIdmap = true
 			newOptions = append(newOptions, opt)
@@ -57,7 +57,7 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 		switch splitOpt[0] {
 		case "copy", "nocopy":
 			if foundCopy {
-				return nil, errors.Wrapf(ErrDupeMntOption, "only one of 'nocopy' and 'copy' can be used")
+				return nil, fmt.Errorf("only one of 'nocopy' and 'copy' can be used: %w", ErrDupeMntOption)
 			}
 			foundCopy = true
 		case "O":
@@ -67,51 +67,51 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 			newOptions = append(newOptions, opt)
 		case "exec", "noexec":
 			if foundExec {
-				return nil, errors.Wrapf(ErrDupeMntOption, "only one of 'noexec' and 'exec' can be used")
+				return nil, fmt.Errorf("only one of 'noexec' and 'exec' can be used: %w", ErrDupeMntOption)
 			}
 			foundExec = true
 		case "suid", "nosuid":
 			if foundSuid {
-				return nil, errors.Wrapf(ErrDupeMntOption, "only one of 'nosuid' and 'suid' can be used")
+				return nil, fmt.Errorf("only one of 'nosuid' and 'suid' can be used: %w", ErrDupeMntOption)
 			}
 			foundSuid = true
 		case "nodev", "dev":
 			if foundDev {
-				return nil, errors.Wrapf(ErrDupeMntOption, "only one of 'nodev' and 'dev' can be used")
+				return nil, fmt.Errorf("only one of 'nodev' and 'dev' can be used: %w", ErrDupeMntOption)
 			}
 			foundDev = true
 		case "rw", "ro":
 			if foundWrite {
-				return nil, errors.Wrapf(ErrDupeMntOption, "only one of 'rw' and 'ro' can be used")
+				return nil, fmt.Errorf("only one of 'rw' and 'ro' can be used: %w", ErrDupeMntOption)
 			}
 			foundWrite = true
 		case "private", "rprivate", "slave", "rslave", "shared", "rshared", "unbindable", "runbindable":
 			if foundProp {
-				return nil, errors.Wrapf(ErrDupeMntOption, "only one root propagation mode can be used")
+				return nil, fmt.Errorf("only one root propagation mode can be used: %w", ErrDupeMntOption)
 			}
 			foundProp = true
 		case "size":
 			if !isTmpfs {
-				return nil, errors.Wrapf(ErrBadMntOption, "the 'size' option is only allowed with tmpfs mounts")
+				return nil, fmt.Errorf("the 'size' option is only allowed with tmpfs mounts: %w", ErrBadMntOption)
 			}
 			if foundSize {
-				return nil, errors.Wrapf(ErrDupeMntOption, "only one tmpfs size can be specified")
+				return nil, fmt.Errorf("only one tmpfs size can be specified: %w", ErrDupeMntOption)
 			}
 			foundSize = true
 		case "mode":
 			if !isTmpfs {
-				return nil, errors.Wrapf(ErrBadMntOption, "the 'mode' option is only allowed with tmpfs mounts")
+				return nil, fmt.Errorf("the 'mode' option is only allowed with tmpfs mounts: %w", ErrBadMntOption)
 			}
 			if foundMode {
-				return nil, errors.Wrapf(ErrDupeMntOption, "only one tmpfs mode can be specified")
+				return nil, fmt.Errorf("only one tmpfs mode can be specified: %w", ErrDupeMntOption)
 			}
 			foundMode = true
 		case "tmpcopyup":
 			if !isTmpfs {
-				return nil, errors.Wrapf(ErrBadMntOption, "the 'tmpcopyup' option is only allowed with tmpfs mounts")
+				return nil, fmt.Errorf("the 'tmpcopyup' option is only allowed with tmpfs mounts: %w", ErrBadMntOption)
 			}
 			if foundCopyUp {
-				return nil, errors.Wrapf(ErrDupeMntOption, "the 'tmpcopyup' or 'notmpcopyup' option can only be set once")
+				return nil, fmt.Errorf("the 'tmpcopyup' or 'notmpcopyup' option can only be set once: %w", ErrDupeMntOption)
 			}
 			foundCopyUp = true
 		case "consistency":
@@ -120,37 +120,37 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 			continue
 		case "notmpcopyup":
 			if !isTmpfs {
-				return nil, errors.Wrapf(ErrBadMntOption, "the 'notmpcopyup' option is only allowed with tmpfs mounts")
+				return nil, fmt.Errorf("the 'notmpcopyup' option is only allowed with tmpfs mounts: %w", ErrBadMntOption)
 			}
 			if foundCopyUp {
-				return nil, errors.Wrapf(ErrDupeMntOption, "the 'tmpcopyup' or 'notmpcopyup' option can only be set once")
+				return nil, fmt.Errorf("the 'tmpcopyup' or 'notmpcopyup' option can only be set once: %w", ErrDupeMntOption)
 			}
 			foundCopyUp = true
 			// do not propagate notmpcopyup to the OCI runtime
 			continue
 		case "bind", "rbind":
 			if isTmpfs {
-				return nil, errors.Wrapf(ErrBadMntOption, "the 'bind' and 'rbind' options are not allowed with tmpfs mounts")
+				return nil, fmt.Errorf("the 'bind' and 'rbind' options are not allowed with tmpfs mounts: %w", ErrBadMntOption)
 			}
 			if foundBind {
-				return nil, errors.Wrapf(ErrDupeMntOption, "only one of 'rbind' and 'bind' can be used")
+				return nil, fmt.Errorf("only one of 'rbind' and 'bind' can be used: %w", ErrDupeMntOption)
 			}
 			foundBind = true
 		case "z", "Z":
 			if isTmpfs {
-				return nil, errors.Wrapf(ErrBadMntOption, "the 'z' and 'Z' options are not allowed with tmpfs mounts")
+				return nil, fmt.Errorf("the 'z' and 'Z' options are not allowed with tmpfs mounts: %w", ErrBadMntOption)
 			}
 			if foundZ {
-				return nil, errors.Wrapf(ErrDupeMntOption, "only one of 'z' and 'Z' can be used")
+				return nil, fmt.Errorf("only one of 'z' and 'Z' can be used: %w", ErrDupeMntOption)
 			}
 			foundZ = true
 		case "U":
 			if foundU {
-				return nil, errors.Wrapf(ErrDupeMntOption, "the 'U' option can only be set once")
+				return nil, fmt.Errorf("the 'U' option can only be set once: %w", ErrDupeMntOption)
 			}
 			foundU = true
 		default:
-			return nil, errors.Wrapf(ErrBadMntOption, "unknown mount option %q", opt)
+			return nil, fmt.Errorf("unknown mount option %q: %w", opt, ErrBadMntOption)
 		}
 		newOptions = append(newOptions, opt)
 	}
@@ -187,11 +187,11 @@ func ProcessOptions(options []string, isTmpfs bool, sourcePath string) ([]string
 func ParseDriverOpts(option string) (string, string, error) {
 	token := strings.SplitN(option, "=", 2)
 	if len(token) != 2 {
-		return "", "", errors.Wrapf(ErrBadMntOption, "cannot parse driver opts")
+		return "", "", fmt.Errorf("cannot parse driver opts: %w", ErrBadMntOption)
 	}
 	opt := strings.SplitN(token[1], "=", 2)
 	if len(opt) != 2 {
-		return "", "", errors.Wrapf(ErrBadMntOption, "cannot parse driver opts")
+		return "", "", fmt.Errorf("cannot parse driver opts: %w", ErrBadMntOption)
 	}
 	return opt[0], opt[1], nil
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"math"
@@ -27,7 +28,6 @@ import (
 	stypes "github.com/containers/storage/types"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/term"
 )
@@ -68,7 +68,7 @@ func ParseRegistryCreds(creds string) (*types.DockerAuthConfig, error) {
 		fmt.Print("Password: ")
 		termPassword, err := term.ReadPassword(0)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not read password from terminal")
+			return nil, fmt.Errorf("could not read password from terminal: %w", err)
 		}
 		password = string(termPassword)
 	}
@@ -129,7 +129,7 @@ func GetImageConfig(changes []string) (ImageConfig, error) {
 		if len(split) != 2 {
 			split = strings.SplitN(change, "=", 2)
 			if len(split) != 2 {
-				return ImageConfig{}, errors.Errorf("invalid change %q - must be formatted as KEY VALUE", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - must be formatted as KEY VALUE", change)
 			}
 		}
 
@@ -139,7 +139,7 @@ func GetImageConfig(changes []string) (ImageConfig, error) {
 		case "USER":
 			// Assume literal contents are the user.
 			if value == "" {
-				return ImageConfig{}, errors.Errorf("invalid change %q - must provide a value to USER", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - must provide a value to USER", change)
 			}
 			config.User = value
 		case "EXPOSE":
@@ -148,14 +148,14 @@ func GetImageConfig(changes []string) (ImageConfig, error) {
 			// Protocol must be "tcp" or "udp"
 			splitPort := strings.Split(value, "/")
 			if len(splitPort) > 2 {
-				return ImageConfig{}, errors.Errorf("invalid change %q - EXPOSE port must be formatted as PORT[/PROTO]", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - EXPOSE port must be formatted as PORT[/PROTO]", change)
 			}
 			portNum, err := strconv.Atoi(splitPort[0])
 			if err != nil {
-				return ImageConfig{}, errors.Wrapf(err, "invalid change %q - EXPOSE port must be an integer", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - EXPOSE port must be an integer: %w", change, err)
 			}
 			if portNum > 65535 || portNum <= 0 {
-				return ImageConfig{}, errors.Errorf("invalid change %q - EXPOSE port must be a valid port number", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - EXPOSE port must be a valid port number", change)
 			}
 			proto := "tcp"
 			if len(splitPort) > 1 {
@@ -164,7 +164,7 @@ func GetImageConfig(changes []string) (ImageConfig, error) {
 				case "tcp", "udp":
 					proto = testProto
 				default:
-					return ImageConfig{}, errors.Errorf("invalid change %q - EXPOSE protocol must be TCP or UDP", change)
+					return ImageConfig{}, fmt.Errorf("invalid change %q - EXPOSE protocol must be TCP or UDP", change)
 				}
 			}
 			if config.ExposedPorts == nil {
@@ -188,7 +188,7 @@ func GetImageConfig(changes []string) (ImageConfig, error) {
 			key = splitEnv[0]
 			// We do need a key
 			if key == "" {
-				return ImageConfig{}, errors.Errorf("invalid change %q - ENV must have at least one argument", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - ENV must have at least one argument", change)
 			}
 			// Perfectly valid to not have a value
 			if len(splitEnv) == 2 {
@@ -250,11 +250,11 @@ func GetImageConfig(changes []string) (ImageConfig, error) {
 				testUnmarshal = strings.Split(value, " ")
 			}
 			if len(testUnmarshal) == 0 {
-				return ImageConfig{}, errors.Errorf("invalid change %q - must provide at least one argument to VOLUME", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - must provide at least one argument to VOLUME", change)
 			}
 			for _, vol := range testUnmarshal {
 				if vol == "" {
-					return ImageConfig{}, errors.Errorf("invalid change %q - VOLUME paths must not be empty", change)
+					return ImageConfig{}, fmt.Errorf("invalid change %q - VOLUME paths must not be empty", change)
 				}
 				if config.Volumes == nil {
 					config.Volumes = make(map[string]struct{})
@@ -268,7 +268,7 @@ func GetImageConfig(changes []string) (ImageConfig, error) {
 			// WORKDIR c results in /A/b/c
 			// Just need to check it's not empty...
 			if value == "" {
-				return ImageConfig{}, errors.Errorf("invalid change %q - must provide a non-empty WORKDIR", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - must provide a non-empty WORKDIR", change)
 			}
 			config.WorkingDir = filepath.Join(config.WorkingDir, value)
 		case "LABEL":
@@ -285,7 +285,7 @@ func GetImageConfig(changes []string) (ImageConfig, error) {
 			splitLabel := strings.SplitN(value, "=", 2)
 			// Unlike ENV, LABEL must have a value
 			if len(splitLabel) != 2 {
-				return ImageConfig{}, errors.Errorf("invalid change %q - LABEL must be formatted key=value", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - LABEL must be formatted key=value", change)
 			}
 			key = splitLabel[0]
 			val = splitLabel[1]
@@ -298,7 +298,7 @@ func GetImageConfig(changes []string) (ImageConfig, error) {
 			}
 			// Check key after we strip quotations
 			if key == "" {
-				return ImageConfig{}, errors.Errorf("invalid change %q - LABEL must have a non-empty key", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - LABEL must have a non-empty key", change)
 			}
 			if config.Labels == nil {
 				config.Labels = make(map[string]string)
@@ -308,17 +308,17 @@ func GetImageConfig(changes []string) (ImageConfig, error) {
 			// Check the provided signal for validity.
 			killSignal, err := ParseSignal(value)
 			if err != nil {
-				return ImageConfig{}, errors.Wrapf(err, "invalid change %q - KILLSIGNAL must be given a valid signal", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - KILLSIGNAL must be given a valid signal: %w", change, err)
 			}
 			config.StopSignal = fmt.Sprintf("%d", killSignal)
 		case "ONBUILD":
 			// Onbuild always appends.
 			if value == "" {
-				return ImageConfig{}, errors.Errorf("invalid change %q - ONBUILD must be given an argument", change)
+				return ImageConfig{}, fmt.Errorf("invalid change %q - ONBUILD must be given an argument", change)
 			}
 			config.OnBuild = append(config.OnBuild, value)
 		default:
-			return ImageConfig{}, errors.Errorf("invalid change %q - invalid instruction %s", change, outerKey)
+			return ImageConfig{}, fmt.Errorf("invalid change %q - invalid instruction %s", change, outerKey)
 		}
 	}
 
@@ -336,7 +336,7 @@ func ParseSignal(rawSignal string) (syscall.Signal, error) {
 	}
 	// 64 is SIGRTMAX; wish we could get this from a standard Go library
 	if sig < 1 || sig > 64 {
-		return -1, errors.Errorf("valid signals are 1 through 64")
+		return -1, errors.New("valid signals are 1 through 64")
 	}
 	return sig, nil
 }
@@ -362,10 +362,10 @@ func GetKeepIDMapping() (*stypes.IDMappingOptions, int, int, error) {
 
 	uids, gids, err := rootless.GetConfiguredMappings()
 	if err != nil {
-		return nil, -1, -1, errors.Wrapf(err, "cannot read mappings")
+		return nil, -1, -1, fmt.Errorf("cannot read mappings: %w", err)
 	}
 	if len(uids) == 0 || len(gids) == 0 {
-		return nil, -1, -1, errors.Wrapf(err, "keep-id requires additional UIDs or GIDs defined in /etc/subuid and /etc/subgid to function correctly")
+		return nil, -1, -1, fmt.Errorf("keep-id requires additional UIDs or GIDs defined in /etc/subuid and /etc/subgid to function correctly: %w", err)
 	}
 	maxUID, maxGID := 0, 0
 	for _, u := range uids {
@@ -403,10 +403,10 @@ func GetNoMapMapping() (*stypes.IDMappingOptions, int, int, error) {
 	}
 	uids, gids, err := rootless.GetConfiguredMappings()
 	if err != nil {
-		return nil, -1, -1, errors.Wrapf(err, "cannot read mappings")
+		return nil, -1, -1, fmt.Errorf("cannot read mappings: %w", err)
 	}
 	if len(uids) == 0 || len(gids) == 0 {
-		return nil, -1, -1, errors.Wrapf(err, "nomap requires additional UIDs or GIDs defined in /etc/subuid and /etc/subgid to function correctly")
+		return nil, -1, -1, fmt.Errorf("nomap requires additional UIDs or GIDs defined in /etc/subuid and /etc/subgid to function correctly: %w", err)
 	}
 	options.UIDMap, options.GIDMap = nil, nil
 	uid, gid := 0, 0
@@ -566,7 +566,7 @@ func ParseInputTime(inputTime string, since bool) (time.Time, error) {
 	// input might be a duration
 	duration, err := time.ParseDuration(inputTime)
 	if err != nil {
-		return time.Time{}, errors.Errorf("unable to interpret time value")
+		return time.Time{}, errors.New("unable to interpret time value")
 	}
 	if since {
 		return time.Now().Add(-duration), nil
@@ -607,7 +607,7 @@ func HomeDir() (string, error) {
 	if home == "" {
 		usr, err := user.LookupId(fmt.Sprintf("%d", rootless.GetRootlessUID()))
 		if err != nil {
-			return "", errors.Wrapf(err, "unable to resolve HOME directory")
+			return "", fmt.Errorf("unable to resolve HOME directory: %w", err)
 		}
 		home = usr.HomeDir
 	}
@@ -645,12 +645,12 @@ func ValidateSysctls(strSlice []string) (map[string]string, error) {
 		foundMatch := false
 		arr := strings.Split(val, "=")
 		if len(arr) < 2 {
-			return nil, errors.Errorf("%s is invalid, sysctl values must be in the form of KEY=VALUE", val)
+			return nil, fmt.Errorf("%s is invalid, sysctl values must be in the form of KEY=VALUE", val)
 		}
 
 		trimmed := fmt.Sprintf("%s=%s", strings.TrimSpace(arr[0]), strings.TrimSpace(arr[1]))
 		if trimmed != val {
-			return nil, errors.Errorf("'%s' is invalid, extra spaces found", val)
+			return nil, fmt.Errorf("'%s' is invalid, extra spaces found", val)
 		}
 
 		if validSysctlMap[arr[0]] {
@@ -666,7 +666,7 @@ func ValidateSysctls(strSlice []string) (map[string]string, error) {
 			}
 		}
 		if !foundMatch {
-			return nil, errors.Errorf("sysctl '%s' is not allowed", arr[0])
+			return nil, fmt.Errorf("sysctl '%s' is not allowed", arr[0])
 		}
 	}
 	return sysctl, nil
@@ -680,9 +680,9 @@ func CreateCidFile(cidfile string, id string) error {
 	cidFile, err := OpenExclusiveFile(cidfile)
 	if err != nil {
 		if os.IsExist(err) {
-			return errors.Errorf("container id file exists. Ensure another container is not using it or delete %s", cidfile)
+			return fmt.Errorf("container id file exists. Ensure another container is not using it or delete %s", cidfile)
 		}
-		return errors.Errorf("opening cidfile %s", cidfile)
+		return fmt.Errorf("opening cidfile %s", cidfile)
 	}
 	if _, err = cidFile.WriteString(id); err != nil {
 		logrus.Error(err)

--- a/pkg/util/utils_darwin.go
+++ b/pkg/util/utils_darwin.go
@@ -4,7 +4,7 @@
 package util
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 func GetContainerPidInformationDescriptors() ([]string, error) {

--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"github.com/containers/psgo"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -53,7 +53,7 @@ func FindDeviceNodes() (map[string]string, error) {
 		// We are a device node. Get major/minor.
 		sysstat, ok := info.Sys().(*syscall.Stat_t)
 		if !ok {
-			return errors.Errorf("Could not convert stat output for use")
+			return errors.New("could not convert stat output for use")
 		}
 		// We must typeconvert sysstat.Rdev from uint64->int to avoid constant overflow
 		rdev := int(sysstat.Rdev)

--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -7,13 +7,13 @@ package util
 //  should work to take darwin from this
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
 
 	"github.com/containers/podman/v4/pkg/rootless"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -51,12 +51,12 @@ func GetRuntimeDir() (string, error) {
 		if runtimeDir == "" {
 			home := os.Getenv("HOME")
 			if home == "" {
-				rootlessRuntimeDirError = fmt.Errorf("neither XDG_RUNTIME_DIR nor HOME was set non-empty")
+				rootlessRuntimeDirError = errors.New("neither XDG_RUNTIME_DIR nor HOME was set non-empty")
 				return
 			}
 			resolvedHome, err := filepath.EvalSymlinks(home)
 			if err != nil {
-				rootlessRuntimeDirError = errors.Wrapf(err, "cannot resolve %s", home)
+				rootlessRuntimeDirError = fmt.Errorf("cannot resolve %s: %w", home, err)
 				return
 			}
 			runtimeDir = filepath.Join(resolvedHome, "rundir")
@@ -80,7 +80,7 @@ func GetRootlessConfigHomeDir() (string, error) {
 			home := os.Getenv("HOME")
 			resolvedHome, err := filepath.EvalSymlinks(home)
 			if err != nil {
-				rootlessConfigHomeDirError = errors.Wrapf(err, "cannot resolve %s", home)
+				rootlessConfigHomeDirError = fmt.Errorf("cannot resolve %s: %w", home, err)
 				return
 			}
 			tmpDir := filepath.Join(resolvedHome, ".config")
@@ -115,7 +115,7 @@ func GetRootlessPauseProcessPidPath() (string, error) {
 // files.
 func GetRootlessPauseProcessPidPathGivenDir(libpodTmpDir string) (string, error) {
 	if libpodTmpDir == "" {
-		return "", errors.Errorf("must provide non-empty temporary directory")
+		return "", errors.New("must provide non-empty temporary directory")
 	}
 	return filepath.Join(libpodTmpDir, "pause.pid"), nil
 }

--- a/pkg/util/utils_unsupported.go
+++ b/pkg/util/utils_unsupported.go
@@ -3,11 +3,9 @@
 
 package util
 
-import (
-	"github.com/pkg/errors"
-)
+import "errors"
 
 // FindDeviceNodes is not implemented anywhere except Linux.
 func FindDeviceNodes() (map[string]string, error) {
-	return nil, errors.Errorf("not supported on non-Linux OSes")
+	return nil, errors.New("not supported on non-Linux OSes")
 }

--- a/pkg/util/utils_windows.go
+++ b/pkg/util/utils_windows.go
@@ -4,35 +4,36 @@
 package util
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
 
 	"github.com/containers/storage/pkg/homedir"
-	"github.com/pkg/errors"
 )
 
 var errNotImplemented = errors.New("not yet implemented")
 
 // IsCgroup2UnifiedMode returns whether we are running in cgroup 2 unified mode.
 func IsCgroup2UnifiedMode() (bool, error) {
-	return false, errors.Wrap(errNotImplemented, "IsCgroup2Unified")
+	return false, fmt.Errorf("IsCgroup2Unified: %w", errNotImplemented)
 }
 
 // GetContainerPidInformationDescriptors returns a string slice of all supported
 // format descriptors of GetContainerPidInformation.
 func GetContainerPidInformationDescriptors() ([]string, error) {
-	return nil, errors.Wrap(errNotImplemented, "GetContainerPidInformationDescriptors")
+	return nil, fmt.Errorf("GetContainerPidInformationDescriptors: %w", errNotImplemented)
 }
 
 // GetRootlessPauseProcessPidPath returns the path to the file that holds the pid for
 // the pause process
 func GetRootlessPauseProcessPidPath() (string, error) {
-	return "", errors.Wrap(errNotImplemented, "GetRootlessPauseProcessPidPath")
+	return "", fmt.Errorf("GetRootlessPauseProcessPidPath: %w", errNotImplemented)
 }
 
 // GetRootlessPauseProcessPidPath returns the path to the file that holds the pid for
 // the pause process
 func GetRootlessPauseProcessPidPathGivenDir(unused string) (string, error) {
-	return "", errors.Wrap(errNotImplemented, "GetRootlessPauseProcessPidPath")
+	return "", fmt.Errorf("GetRootlessPauseProcessPidPath: %w", errNotImplemented)
 }
 
 // GetRuntimeDir returns the runtime directory

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -66,7 +66,7 @@ load helpers
 
     # Container (parent) path does not exist.
     run_podman 125 cp $srcdir/hostfile0 cpcontainer:/IdoNotExist/
-    is "$output" 'Error: "/IdoNotExist/" could not be found on container cpcontainer: No such file or directory' \
+    is "$output" 'Error: "/IdoNotExist/" could not be found on container cpcontainer: no such file or directory' \
        "copy into nonexistent path in container"
 
     run_podman kill cpcontainer
@@ -794,7 +794,7 @@ ${randomcontent[1]}" "$description"
     is "$output" "" "output from podman cp 1"
 
     run_podman 125 cp --pause=false $srcdir/$rand_filename2 cpcontainer:/tmp/d2/x/
-    is "$output" 'Error: "/tmp/d2/x/" could not be found on container cpcontainer: No such file or directory' "cp will not create nonexistent destination directory"
+    is "$output" 'Error: "/tmp/d2/x/" could not be found on container cpcontainer: no such file or directory' "cp will not create nonexistent destination directory"
 
     run_podman cp --pause=false $srcdir/$rand_filename3 cpcontainer:/tmp/d3/x
     is "$output" "" "output from podman cp 3"

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -332,7 +332,7 @@ EOF
 @test "podman pod create --share" {
     local pod_name="$(random_string 10 | tr A-Z a-z)"
     run_podman 125 pod create --share bogus --name $pod_name
-    is "$output" ".*Invalid kernel namespace to share: bogus. Options are: cgroup, ipc, net, pid, uts or none" \
+    is "$output" ".*invalid kernel namespace to share: bogus. Options are: cgroup, ipc, net, pid, uts or none" \
        "pod test for bogus --share option"
     run_podman pod create --share ipc --name $pod_name
     run_podman pod inspect $pod_name --format "{{.SharedNamespaces}}"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -595,7 +595,6 @@ github.com/openshift/imagebuilder/strslice
 github.com/ostreedev/ostree-go/pkg/glibobject
 github.com/ostreedev/ostree-go/pkg/otbuiltin
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit


### PR DESCRIPTION
We now use the golang error wrapping format specifier `%w` instead of the deprecated github.com/pkg/errors package.

Fixes https://github.com/containers/podman/issues/14784

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
