### PR TITLE
Update play kube docs

### DIFF
--- a/docs/play_kube_support.md
+++ b/docs/play_kube_support.md
@@ -150,3 +150,26 @@ Note: **N/A** means that the option cannot be supported in a single-node Podman 
 | selector           |         |
 | resources.limits   |         |
 | resources.requests | ✅      |
+
+## ConfigMap Fields
+
+| Field      | Support |
+|------------|---------|
+| binaryData |         |
+| data       | ✅      |
+| immutable  |         |
+
+## Deployment Fields
+
+| Field                                 | Support |
+|---------------------------------------|---------|
+| replicas                              | ✅      |
+| selector                              | ✅      |
+| template                              | ✅      |
+| minReadySeconds                       |         |
+| strategy.type                         |         |
+| strategy.rollingUpdate.maxSurge       |         |
+| strategy.rollingUpdate.maxUnavailable |         |
+| revisionHistoryLimit                  |         |
+| progressDeadlineSeconds               |         |
+| paused                                |         |


### PR DESCRIPTION
Update play kube docs with supported fields for
configMap and deployment kinds.

Fixes https://github.com/containers/podman/pull/14318

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update supported kube fields for configMap and deployment kind in play kube docs

```
