### PR TITLE
manifest_test: safer registry setup and teardown

### DIFF
--- a/hack/podman-registry
+++ b/hack/podman-registry
@@ -122,6 +122,25 @@ function must_pass() {
     fi
 }
 
+###################
+#  wait_for_port  #  Returns once port is available on localhost
+###################
+function wait_for_port() {
+    local port=$1                      # Numeric port
+
+    local host=127.0.0.1
+    local _timeout=5
+
+    # Wait
+    while [ $_timeout -gt 0 ]; do
+        { exec {unused_fd}<> /dev/tcp/$host/$port; } &>/dev/null && return
+        sleep 1
+        _timeout=$(( $_timeout - 1 ))
+    done
+
+    die "Timed out waiting for port $port"
+}
+
 # END   helper functions
 ###############################################################################
 # BEGIN action processing
@@ -130,7 +149,7 @@ function do_start() {
     # If called without a port, assign a random one in the 5xxx range
     if [ -z "${PODMAN_REGISTRY_PORT}" ]; then
         for port in $(shuf -i 5000-5999);do
-            if ! { exec 3<> /dev/tcp/127.0.0.1/$port; } &>/dev/null; then
+            if ! { exec {unused_fd}<> /dev/tcp/127.0.0.1/$port; } &>/dev/null; then
                 PODMAN_REGISTRY_PORT=$port
                 break
             fi
@@ -202,6 +221,9 @@ function do_start() {
               -e "REGISTRY_HTTP_TLS_CERTIFICATE=/auth/domain.crt"       \
               -e "REGISTRY_HTTP_TLS_KEY=/auth/domain.key"               \
               registry:2.6
+
+    # Confirm that registry started and port is active
+    wait_for_port $PODMAN_REGISTRY_PORT
 
     # Dump settings. Our caller will use these to access the registry.
     for v in IMAGE PORT USER PASS; do

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -76,3 +76,8 @@ func (p *PodmanTestIntegration) StopRemoteService() {}
 // We don't support running API service when local
 func (p *PodmanTestIntegration) StartRemoteService() {
 }
+
+// Just a stub for compiling with `!remote`.
+func getRemoteOptions(p *PodmanTestIntegration, args []string) []string {
+	return nil
+}


### PR DESCRIPTION
manifest_test:authenticated_push() is the final test left to
fix before merging #14397. The reason it's failing _seems_ to be
that podman is running with a mix of netavark and CNI, and
that _seems_ to be because this test invokes hack/podman-registry
which invokes plain podman without whatever options used in e2e.

Starting a registry directly from the test is insane: there is
no reusable code for doing that (see login_logout_test.go and
push_test.go. Yeesh.)

Solution: set $PODMAN, by inspecting the podmanTest object
which includes both a path and a list of options. podman-registry
will invoke that. (It will also override --root and --runroot.
This is the desired behavior).

Also: add cleanup. If auth-push test fails, stop the registry.

Also: add a sanity check to podman-registry script, have it
wait for the registry port to activate. Die if it doesn't.
That could've saved us a nice bit of debugging time.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```