### PR TITLE
pkg/machine/e2e: do not import from cmd/podman

### DIFF
--- a/pkg/domain/entities/machine.go
+++ b/pkg/domain/entities/machine.go
@@ -1,0 +1,18 @@
+package entities
+
+type ListReporter struct {
+	Name           string
+	Default        bool
+	Created        string
+	Running        bool
+	Starting       bool
+	LastUp         string
+	Stream         string
+	VMType         string
+	CPUs           uint64
+	Memory         string
+	DiskSize       string
+	Port           int
+	RemoteUsername string
+	IdentityPath   string
+}

--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/containers/common/pkg/util"
-	"github.com/containers/podman/v4/cmd/podman/machine"
+	"github.com/containers/podman/v4/pkg/domain/entities"
 	jsoniter "github.com/json-iterator/go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -134,7 +134,7 @@ var _ = Describe("podman machine list", func() {
 		Expect(err).To(BeNil())
 		Expect(listSession2).To(Exit(0))
 
-		var listResponse []*machine.ListReporter
+		var listResponse []*entities.ListReporter
 		err = jsoniter.Unmarshal(listSession.Bytes(), &listResponse)
 		Expect(err).To(BeNil())
 

--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"strings"
+	"time"
 
 	"github.com/containers/common/pkg/util"
 	"github.com/containers/podman/v4/cmd/podman/machine"
@@ -87,7 +88,7 @@ var _ = Describe("podman machine list", func() {
 		startSession, err := mb.setCmd(s).runWithoutWait()
 		Expect(err).To(BeNil())
 		l := new(listMachine)
-		for { // needs to be infinite because we need to check if running when inspect returns to avoid race conditions.
+		for i := 0; i < 30; i++ {
 			listSession, err := mb.setCmd(l).run()
 			Expect(listSession).To(Exit(0))
 			Expect(err).To(BeNil())
@@ -96,6 +97,7 @@ var _ = Describe("podman machine list", func() {
 			} else {
 				break
 			}
+			time.Sleep(3 * time.Second)
 		}
 		Expect(startSession).To(Exit(0))
 		listSession, err := mb.setCmd(l).run()

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -138,8 +138,10 @@ func (p *Provider) NewMachine(opts machine.InitOptions) (machine.VM, error) {
 	cmd = append(cmd, []string{
 		"-device", "virtio-serial",
 		// qemu needs to establish the long name; other connections can use the symlink'd
-		"-chardev", "socket,path=" + vm.ReadySocket.Path + ",server=on,wait=off,id=" + vm.Name + "_ready",
-		"-device", "virtserialport,chardev=" + vm.Name + "_ready" + ",name=org.fedoraproject.port.0",
+		// Note both id and chardev start with an extra "a" becuase qemu requires that it
+		// starts with an letter but users can also use numbers
+		"-chardev", "socket,path=" + vm.ReadySocket.Path + ",server=on,wait=off,id=a" + vm.Name + "_ready",
+		"-device", "virtserialport,chardev=a" + vm.Name + "_ready" + ",name=org.fedoraproject.port.0",
 		"-pidfile", vm.VMPidFilePath.GetPath()}...)
 	vm.CmdLine = cmd
 	return vm, nil

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -5,6 +5,7 @@ package qemu
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -138,7 +139,7 @@ func (p *Provider) NewMachine(opts machine.InitOptions) (machine.VM, error) {
 	cmd = append(cmd, []string{
 		"-device", "virtio-serial",
 		// qemu needs to establish the long name; other connections can use the symlink'd
-		// Note both id and chardev start with an extra "a" becuase qemu requires that it
+		// Note both id and chardev start with an extra "a" because qemu requires that it
 		// starts with an letter but users can also use numbers
 		"-chardev", "socket,path=" + vm.ReadySocket.Path + ",server=on,wait=off,id=a" + vm.Name + "_ready",
 		"-device", "virtserialport,chardev=a" + vm.Name + "_ready" + ",name=org.fedoraproject.port.0",
@@ -573,15 +574,25 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 	files := []*os.File{dnr, dnw, dnw, fd}
 	attr.Files = files
 	logrus.Debug(v.CmdLine)
-	cmd := v.CmdLine
+	cmdLine := v.CmdLine
 
 	// Disable graphic window when not in debug mode
 	// Done in start, so we're not suck with the debug level we used on init
 	if !logrus.IsLevelEnabled(logrus.DebugLevel) {
-		cmd = append(cmd, "-display", "none")
+		cmdLine = append(cmdLine, "-display", "none")
 	}
 
-	_, err = os.StartProcess(v.CmdLine[0], cmd, attr)
+	stderrBuf := &bytes.Buffer{}
+
+	cmd := &exec.Cmd{
+		Args:       cmdLine,
+		Path:       cmdLine[0],
+		Stdin:      dnr,
+		Stdout:     dnw,
+		Stderr:     stderrBuf,
+		ExtraFiles: []*os.File{fd},
+	}
+	err = cmd.Start()
 	if err != nil {
 		// check if qemu was not found
 		if !errors.Is(err, os.ErrNotExist) {
@@ -592,15 +603,17 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		if err != nil {
 			return err
 		}
-		cmd[0], err = cfg.FindHelperBinary(QemuCommand, true)
+		cmdLine[0], err = cfg.FindHelperBinary(QemuCommand, true)
 		if err != nil {
 			return err
 		}
-		_, err = os.StartProcess(cmd[0], cmd, attr)
+		cmd.Path = cmdLine[0]
+		err = cmd.Start()
 		if err != nil {
 			return fmt.Errorf("unable to execute %q: %w", cmd, err)
 		}
 	}
+	defer cmd.Process.Release() //nolint:errcheck
 	fmt.Println("Waiting for VM ...")
 	socketPath, err := getRuntimeDir()
 	if err != nil {
@@ -614,6 +627,16 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		conn, err = net.Dial("unix", filepath.Join(socketPath, "podman", v.Name+"_ready.sock"))
 		if err == nil {
 			break
+		}
+		// check if qemu is still alive
+		var status syscall.WaitStatus
+		pid, err := syscall.Wait4(cmd.Process.Pid, &status, syscall.WNOHANG, nil)
+		if err != nil {
+			return fmt.Errorf("failed to read qemu process status: %w", err)
+		}
+		if pid > 0 {
+			// child exited
+			return fmt.Errorf("qemu exited unexpectedly with exit code %d, stderr: %s", status.ExitStatus(), stderrBuf.String())
 		}
 		time.Sleep(wait)
 		wait++


### PR DESCRIPTION
machine test: fix endless loop in test

The problem is that this could loop forever as long as podman start doe
snot exit (which could happen due bugs). Also since there no timeout
between the machine list calls the test is using the full cpu and this
causes the system to slow down making the machine start command even
slower. IMO it is enough to only check the status every three seconds.

pkg/machine/e2e: do not import from cmd/podman

It should be avoided to import cmd/podman/... packages from outside of
cmd/podman. This can lead in weird hard to debug import paths but also
can have negative consequences when imported in unit tests. In this case
it will set XDG_CONFIG_HOME and thus the machine tests this dir over the
tmp HOME env variable which is set at a later point. This caused machine
files to be leaked into the actual users home dir.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where podman machine start failed to start the qemu VM when the machine name starts with a number. 
```
