### PR TITLE
[v4.1] Backport fix for Windows machine init failure when ran in System32 

### DIFF
--- a/pkg/machine/keys.go
+++ b/pkg/machine/keys.go
@@ -59,7 +59,16 @@ func generatekeysPrefix(dir string, file string, passThru bool, prefix ...string
 	args := append([]string{}, prefix[1:]...)
 	args = append(args, sshCommand...)
 	args = append(args, file)
-	cmd := exec.Command(prefix[0], args...)
+
+	binary, err := exec.LookPath(prefix[0])
+	if err != nil {
+		return err
+	}
+	binary, err = filepath.Abs(binary)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(binary, args...)
 	cmd.Dir = dir
 	if passThru {
 		cmd.Stdin = os.Stdin


### PR DESCRIPTION
Backports fix to #14416 (#14570) since it's being hit by a number of users

[NO NEW TESTS NEEDED]

```release-note
Fixes ssh keygen failure when `machine init` is run from C:\Windows\System32 on Windows
```
