### PR TITLE
resource limits for pods

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -56,22 +56,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
-		blkioWeightFlagName := "blkio-weight"
-		createFlags.StringVar(
-			&cf.BlkIOWeight,
-			blkioWeightFlagName, "",
-			"Block IO weight (relative weight) accepts a weight value between 10 and 1000.",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(blkioWeightFlagName, completion.AutocompleteNone)
-
-		blkioWeightDeviceFlagName := "blkio-weight-device"
-		createFlags.StringSliceVar(
-			&cf.BlkIOWeightDevice,
-			blkioWeightDeviceFlagName, []string{},
-			"Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`)",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(blkioWeightDeviceFlagName, completion.AutocompleteDefault)
-
 		capAddFlagName := "cap-add"
 		createFlags.StringSliceVar(
 			&cf.CapAdd,
@@ -126,14 +110,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			"Limit read rate (IO per second) from a device (e.g. --device-read-iops=/dev/sda:1000)",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(deviceReadIopsFlagName, completion.AutocompleteDefault)
-
-		deviceWriteBpsFlagName := "device-write-bps"
-		createFlags.StringSliceVar(
-			&cf.DeviceWriteBPs,
-			deviceWriteBpsFlagName, []string{},
-			"Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(deviceWriteBpsFlagName, completion.AutocompleteDefault)
 
 		deviceWriteIopsFlagName := "device-write-iops"
 		createFlags.StringSliceVar(
@@ -783,14 +759,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(deviceFlagName, completion.AutocompleteDefault)
 
-		deviceReadBpsFlagName := "device-read-bps"
-		createFlags.StringSliceVar(
-			&cf.DeviceReadBPs,
-			deviceReadBpsFlagName, []string{},
-			"Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(deviceReadBpsFlagName, completion.AutocompleteDefault)
-
 		volumesFromFlagName := "volumes-from"
 		createFlags.StringArrayVar(
 			&cf.VolumesFrom,
@@ -848,22 +816,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(cpuRtRuntimeFlagName, completion.AutocompleteNone)
 
-		cpuSharesFlagName := "cpu-shares"
-		createFlags.Uint64VarP(
-			&cf.CPUShares,
-			cpuSharesFlagName, "c", 0,
-			"CPU shares (relative weight)",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(cpuSharesFlagName, completion.AutocompleteNone)
-
-		cpusetMemsFlagName := "cpuset-mems"
-		createFlags.StringVar(
-			&cf.CPUSetMems,
-			cpusetMemsFlagName, "",
-			"Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(cpusetMemsFlagName, completion.AutocompleteNone)
-
 		memoryReservationFlagName := "memory-reservation"
 		createFlags.StringVar(
 			&cf.MemoryReservation,
@@ -871,14 +823,6 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			"Memory soft limit "+sizeWithUnitFormat,
 		)
 		_ = cmd.RegisterFlagCompletionFunc(memoryReservationFlagName, completion.AutocompleteNone)
-
-		memorySwapFlagName := "memory-swap"
-		createFlags.StringVar(
-			&cf.MemorySwap,
-			memorySwapFlagName, "",
-			"Swap limit equal to memory plus swap: '-1' to enable unlimited swap",
-		)
-		_ = cmd.RegisterFlagCompletionFunc(memorySwapFlagName, completion.AutocompleteNone)
 
 		memorySwappinessFlagName := "memory-swappiness"
 		createFlags.Int64Var(
@@ -913,4 +857,60 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		"Memory limit "+sizeWithUnitFormat,
 	)
 	_ = cmd.RegisterFlagCompletionFunc(memoryFlagName, completion.AutocompleteNone)
+
+	cpuSharesFlagName := "cpu-shares"
+	createFlags.Uint64VarP(
+		&cf.CPUShares,
+		cpuSharesFlagName, "c", 0,
+		"CPU shares (relative weight)",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(cpuSharesFlagName, completion.AutocompleteNone)
+
+	cpusetMemsFlagName := "cpuset-mems"
+	createFlags.StringVar(
+		&cf.CPUSetMems,
+		cpusetMemsFlagName, "",
+		"Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(cpusetMemsFlagName, completion.AutocompleteNone)
+
+	memorySwapFlagName := "memory-swap"
+	createFlags.StringVar(
+		&cf.MemorySwap,
+		memorySwapFlagName, "",
+		"Swap limit equal to memory plus swap: '-1' to enable unlimited swap",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(memorySwapFlagName, completion.AutocompleteNone)
+
+	deviceReadBpsFlagName := "device-read-bps"
+	createFlags.StringSliceVar(
+		&cf.DeviceReadBPs,
+		deviceReadBpsFlagName, []string{},
+		"Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(deviceReadBpsFlagName, completion.AutocompleteDefault)
+
+	deviceWriteBpsFlagName := "device-write-bps"
+	createFlags.StringSliceVar(
+		&cf.DeviceWriteBPs,
+		deviceWriteBpsFlagName, []string{},
+		"Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(deviceWriteBpsFlagName, completion.AutocompleteDefault)
+
+	blkioWeightFlagName := "blkio-weight"
+	createFlags.StringVar(
+		&cf.BlkIOWeight,
+		blkioWeightFlagName, "",
+		"Block IO weight (relative weight) accepts a weight value between 10 and 1000.",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(blkioWeightFlagName, completion.AutocompleteNone)
+
+	blkioWeightDeviceFlagName := "blkio-weight-device"
+	createFlags.StringSliceVar(
+		&cf.BlkIOWeightDevice,
+		blkioWeightDeviceFlagName, []string{},
+		"Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`)",
+	)
+	_ = cmd.RegisterFlagCompletionFunc(blkioWeightDeviceFlagName, completion.AutocompleteDefault)
 }

--- a/docs/source/markdown/podman-container-clone.1.md
+++ b/docs/source/markdown/podman-container-clone.1.md
@@ -11,6 +11,14 @@ podman\-container\-clone - Creates a copy of an existing container
 
 ## OPTIONS
 
+#### **--blkio-weight**=*weight*
+
+Block IO weight (relative weight) accepts a weight value between 10 and 1000.
+
+#### **--blkio-weight-device**=*weight*
+
+Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`).
+
 #### **--cpu-period**=*limit*
 
 Set the CPU period for the Completely Fair Scheduler (CFS), which is a
@@ -125,6 +133,14 @@ If none are specified, the original container's CPU memory nodes are used.
 #### **--destroy**
 
 Remove the original container that we are cloning once used to mimic the configuration.
+
+#### **--device-read-bps**=*path*
+
+Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb).
+
+#### **--device-write-bps**=*path*
+
+Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
 
 #### **--force**, **-f**
 

--- a/docs/source/markdown/podman-pod-clone.1.md
+++ b/docs/source/markdown/podman-pod-clone.1.md
@@ -11,9 +11,54 @@ podman\-pod\-clone - Creates a copy of an existing pod
 
 ## OPTIONS
 
+#### **--blkio-weight**=*weight*
+
+Block IO weight (relative weight) accepts a weight value between 10 and 1000.
+
+#### **--blkio-weight-device**=*weight*
+
+Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`).
+
 #### **--cgroup-parent**=*path*
 
 Path to cgroups under which the cgroup for the pod will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
+
+#### **--cpu-shares**, **-c**=*shares*
+
+CPU shares (relative weight)
+
+By default, all containers get the same proportion of CPU cycles. This proportion
+can be modified by changing the container's CPU share weighting relative
+to the weighting of all other running containers.
+
+To modify the proportion from the default of 1024, use the **--cpu-shares**
+flag to set the weighting to 2 or higher.
+
+The proportion will only apply when CPU-intensive processes are running.
+When tasks in one container are idle, other containers can use the
+left-over CPU time. The actual amount of CPU time will vary depending on
+the number of containers running on the system.
+
+For example, consider three containers, one has a cpu-share of 1024 and
+two others have a cpu-share setting of 512. When processes in all three
+containers attempt to use 100% of CPU, the first container would receive
+50% of the total CPU time. If you add a fourth container with a cpu-share
+of 1024, the first container only gets 33% of the CPU. The remaining containers
+receive 16.5%, 16.5% and 33% of the CPU.
+
+On a multi-core system, the shares of CPU time are distributed over all CPU
+cores. Even if a container is limited to less than 100% of CPU time, it can
+use 100% of each individual CPU core.
+
+For example, consider a system with more than three cores. If you start one
+container **{C0}** with **-c=512** running one process, and another container
+**{C1}** with **-c=1024** running two processes, this can result in the following
+division of CPU shares:
+
+PID    container	CPU	CPU share
+100    {C0}		0	100% of CPU0
+101    {C1}		1	100% of CPU1
+102    {C1}		2	100% of CPU2
 
 #### **--cpus**
 
@@ -22,6 +67,15 @@ Set a number of CPUs for the pod that overrides the original pods CPU limits. If
 #### **--cpuset-cpus**
 
 CPUs in which to allow execution (0-3, 0,1). If none are specified, the original pod's CPUset is used.
+
+
+#### **--cpuset-mems**=*nodes*
+
+Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
+
+If there are four memory nodes on the system (0-3), use `--cpuset-mems=0,1`
+then processes in the container will only use memory from the first
+two memory nodes.
 
 #### **--destroy**
 
@@ -47,6 +101,10 @@ device. The devices that Podman will load modules for when necessary are:
 #### **--device-read-bps**=*path*
 
 Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb).
+
+#### **--device-write-bps**=*path*
+
+Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
 
 #### **--gidmap**=*pod_gid:host_gid:amount*
 
@@ -89,6 +147,17 @@ supports swap memory, then the **-m** memory setting can be larger than physical
 RAM. If a limit of 0 is specified (not using **-m**), the container's memory is
 not limited. The actual limit may be rounded up to a multiple of the operating
 system's page size (the value would be very large, that's millions of trillions).
+
+#### **--memory-swap**=*limit*
+
+A limit value equal to memory plus swap. Must be used with the  **-m**
+(**--memory**) flag. The swap `LIMIT` should always be larger than **-m**
+(**--memory**) value. By default, the swap `LIMIT` will be set to double
+the value of --memory.
+
+The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
+`k` (kibibytes), `m` (mebibytes), or `g` (gibibytes). If you don't specify a
+unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
 #### **--name**, **-n**
 

--- a/libpod/define/pod_inspect.go
+++ b/libpod/define/pod_inspect.go
@@ -57,20 +57,32 @@ type InspectPodData struct {
 	CPUPeriod uint64 `json:"cpu_period,omitempty"`
 	// CPUQuota contains the CPU quota of the pod
 	CPUQuota int64 `json:"cpu_quota,omitempty"`
+	// CPUShares contains the cpu shares for the pod
+	CPUShares uint64 `json:"cpu_shares,omitempty"`
 	// CPUSetCPUs contains linux specific CPU data for the pod
 	CPUSetCPUs string `json:"cpuset_cpus,omitempty"`
+	// CPUSetMems contains linux specific CPU data for the pod
+	CPUSetMems string `json:"cpuset_mems,omitempty"`
 	// Mounts contains volume related information for the pod
 	Mounts []InspectMount `json:"mounts,omitempty"`
 	// Devices contains the specified host devices
 	Devices []InspectDevice `json:"devices,omitempty"`
 	// BlkioDeviceReadBps contains the Read/Access limit for the pod's devices
 	BlkioDeviceReadBps []InspectBlkioThrottleDevice `json:"device_read_bps,omitempty"`
+	// BlkioDeviceReadBps contains the Read/Access limit for the pod's devices
+	BlkioDeviceWriteBps []InspectBlkioThrottleDevice `json:"device_write_bps,omitempty"`
 	// VolumesFrom contains the containers that the pod inherits mounts from
 	VolumesFrom []string `json:"volumes_from,omitempty"`
 	// SecurityOpt contains the specified security labels and related SELinux information
 	SecurityOpts []string `json:"security_opt,omitempty"`
 	// MemoryLimit contains the specified cgroup memory limit for the pod
 	MemoryLimit uint64 `json:"memory_limit,omitempty"`
+	// MemorySwap contains the specified memory swap limit for the pod
+	MemorySwap uint64 `json:"memory_swap,omitempty"`
+	// BlkioWeight contains the blkio weight limit for the pod
+	BlkioWeight uint64 `json:"blkio_weight,omitempty"`
+	// BlkioWeightDevice contains the blkio weight device limits for the pod
+	BlkioWeightDevice []InspectBlkioWeightDevice `json:"blkio_weight_device,omitempty"`
 }
 
 // InspectPodInfraConfig contains the configuration of the pod's infra

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -2145,6 +2145,18 @@ func WithServiceContainer(id string) PodCreateOption {
 	}
 }
 
+// WithPodResources sets resource limits to be applied to the pod's cgroup
+// these will be inherited by all containers unless overridden.
+func WithPodResources(resources specs.LinuxResources) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return define.ErrPodFinalized
+		}
+		pod.config.ResourceLimits = resources
+		return nil
+	}
+}
+
 // WithVolatile sets the volatile flag for the container storage.
 // The option can potentially cause data loss when used on a container that must survive a machine reboot.
 func WithVolatile() CtrCreateOption {

--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -80,7 +80,7 @@ func (r *Runtime) NewPod(ctx context.Context, p specgen.PodSpecGenerator, option
 						p.InfraContainerSpec.CgroupParent = pod.state.CgroupPath
 						// cgroupfs + rootless = permission denied when creating the cgroup.
 						if !rootless.IsRootless() {
-							res, err := GetLimits(p.InfraContainerSpec.ResourceLimits)
+							res, err := GetLimits(p.ResourceLimits)
 							if err != nil {
 								return nil, err
 							}
@@ -113,7 +113,7 @@ func (r *Runtime) NewPod(ctx context.Context, p specgen.PodSpecGenerator, option
 			// If we are set to use pod cgroups, set the cgroup parent that
 			// all containers in the pod will share
 			if pod.config.UsePodCgroup {
-				cgroupPath, err := systemdSliceFromPath(pod.config.CgroupParent, fmt.Sprintf("libpod_pod_%s", pod.ID()), p.InfraContainerSpec.ResourceLimits)
+				cgroupPath, err := systemdSliceFromPath(pod.config.CgroupParent, fmt.Sprintf("libpod_pod_%s", pod.ID()), p.ResourceLimits)
 				if err != nil {
 					return nil, fmt.Errorf("unable to create pod cgroup for pod %s: %w", pod.ID(), err)
 				}

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -55,9 +55,6 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		}
 	}
 
-	if err := FinishThrottleDevices(s); err != nil {
-		return nil, nil, nil, err
-	}
 	// Set defaults for unset namespaces
 	if s.PidNS.IsDefault() {
 		defaultNS, err := GetDefaultNamespaceMode("pid", rtc, pod)

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -2,12 +2,17 @@
 
 load helpers
 
+LOOPDEVICE=
+
 # This is a long ugly way to clean up pods and remove the pause image
 function teardown() {
     run_podman pod rm -f -t 0 -a
     run_podman rm -f -t 0 -a
     run_podman rmi --ignore $(pause_image)
     basic_teardown
+    if [[ -n "$LOOPDEVICE" ]]; then
+        losetup -d $LOOPDEVICE
+    fi
 }
 
 
@@ -474,31 +479,57 @@ spec:
 
 @test "pod resource limits" {
     skip_if_remote "resource limits only implemented on non-remote"
-    if is_rootless; then
+    if is_rootless || ! is_cgroupsv2; then
         skip "only meaningful for rootful"
     fi
 
-    local name1="resources1"
-    run_podman --cgroup-manager=systemd pod create --name=$name1 --cpus=5 --memory=10m
-    run_podman --cgroup-manager=systemd pod start $name1
-    run_podman pod inspect --format '{{.CgroupPath}}' $name1
-    local path1="$output"
-    local actual1=$(< /sys/fs/cgroup/$path1/cpu.max)
-    is "$actual1" "500000 100000" "resource limits set properly"
-    local actual2=$(< /sys/fs/cgroup/$path1/memory.max)
-    is "$actual2" "10485760" "resource limits set properly"
-    run_podman pod --cgroup-manager=systemd rm -f $name1
+    # create loopback device
+    lofile=${PODMAN_TMPDIR}/disk.img
+    fallocate -l 1k  ${lofile}
+    LOOPDEVICE=$(losetup --show -f $lofile)
 
-    local name2="resources2"
-    run_podman --cgroup-manager=cgroupfs pod create --cpus=5 --memory=10m --name=$name2
-    run_podman --cgroup-manager=cgroupfs pod start $name2
-    run_podman pod inspect --format '{{.CgroupPath}}' $name2
-    local path2="$output"
-    local actual2=$(< /sys/fs/cgroup/$path2/cpu.max)
-    is "$actual2" "500000 100000" "resource limits set properly"
-    local actual2=$(< /sys/fs/cgroup/$path2/memory.max)
-    is "$actual2" "10485760" "resource limits set properly"
-    run_podman --cgroup-manager=cgroupfs pod rm $name2
+    # tr needed because losetup seems to use %2d
+    lomajmin=$(losetup -l --noheadings --output MAJ:MIN $LOOPDEVICE | tr -d ' ')
+    run grep -w bfq /sys/block/$(basename ${LOOPDEVICE})/queue/scheduler
+    if [ $status -ne 0 ]; then
+        skip "BFQ scheduler is not supported on the system"
+        if [ -f ${lofile} ]; then
+            run_podman '?' rm -t 0 --all --force --ignore
+
+            while read path dev; do
+                if [[ "$path" == "$lofile" ]]; then
+                    losetup -d $dev
+                fi
+            done < <(losetup -l --noheadings --output BACK-FILE,NAME)
+            rm ${lofile}
+        fi
+    fi
+    echo bfq > /sys/block/$(basename ${LOOPDEVICE})/queue/scheduler
+
+    expected_limits="
+cpu.max         | 500000 100000
+memory.max      | 5242880
+memory.swap.max | 1068498944
+io.max          | $lomajmin rbps=1048576 wbps=1048576 riops=max wiops=max
+"
+
+    for cgm in systemd cgroupfs; do
+        local name=resources-$cgm
+        run_podman --cgroup-manager=$cgm pod create --name=$name --cpus=5 --memory=5m --memory-swap=1g --cpu-shares=1000 --cpuset-cpus=0 --cpuset-mems=0 --device-read-bps=${LOOPDEVICE}:1mb --device-write-bps=${LOOPDEVICE}:1mb --blkio-weight-device=${LOOPDEVICE}:123 --blkio-weight=50
+        run_podman --cgroup-manager=$cgm pod start $name
+        run_podman pod inspect --format '{{.CgroupPath}}' $name
+        local cgroup_path="$output"
+
+        while read unit expect; do
+            local actual=$(< /sys/fs/cgroup/$cgroup_path/$unit)
+            is "$actual" "$expect" "resource limit under $cgm: $unit"
+        done < <(parse_table "$expected_limits")
+        run_podman --cgroup-manager=$cgm pod rm -f $name
+    done
+
+    # Clean up, and prevent duplicate cleanup in teardown
+    losetup -d $LOOPDEVICE
+    LOOPDEVICE=
 }
 
 @test "podman pod ps doesn't race with pod rm" {


### PR DESCRIPTION
added the following flags and handling for podman pod create

--memory-swap
--cpuset-mems
--device-read-bps
--device-write-bps
--blkio-weight
--blkio-weight-device
--cpu-shares

given the new backend for systemd in c/common, all of these can now be exposed to pod create.
most of the heavy lifting (nearly all) is done within c/common. However, some rewiring needed to be done here
as well!

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
expose resource limts flags: 

--memory-swap
--cpuset-mems
--device-read-bps
--device-write-bps
--blkio-weight
--blkio-weight-device 
--cpu-shares

to podman pod create
```
