### PR TITLE
podman machine: do not commit proxies into config file

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -240,20 +240,6 @@ func (p *Provider) LoadVMByName(name string) (machine.VM, error) {
 		return nil, err
 	}
 
-	// It is here for providing the ability to propagate
-	// proxy settings (e.g. HTTP_PROXY and others) on a start
-	// and avoid a need of re-creating/re-initiating a VM
-	if proxyOpts := machine.GetProxyVariables(); len(proxyOpts) > 0 {
-		proxyStr := "name=opt/com.coreos/environment,string="
-		var proxies string
-		for k, v := range proxyOpts {
-			proxies = fmt.Sprintf("%s%s=\"%s\"|", proxies, k, v)
-		}
-		proxyStr = fmt.Sprintf("%s%s", proxyStr, base64.StdEncoding.EncodeToString([]byte(proxies)))
-		vm.CmdLine = append(vm.CmdLine, "-fw_cfg", proxyStr)
-	}
-
-	logrus.Debug(vm.CmdLine)
 	return vm, nil
 }
 
@@ -573,14 +559,28 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 	attr := new(os.ProcAttr)
 	files := []*os.File{dnr, dnw, dnw, fd}
 	attr.Files = files
-	logrus.Debug(v.CmdLine)
 	cmdLine := v.CmdLine
+
+	// It is here for providing the ability to propagate
+	// proxy settings (e.g. HTTP_PROXY and others) on a start
+	// and avoid a need of re-creating/re-initiating a VM
+	if proxyOpts := machine.GetProxyVariables(); len(proxyOpts) > 0 {
+		proxyStr := "name=opt/com.coreos/environment,string="
+		var proxies string
+		for k, v := range proxyOpts {
+			proxies = fmt.Sprintf("%s%s=\"%s\"|", proxies, k, v)
+		}
+		proxyStr = fmt.Sprintf("%s%s", proxyStr, base64.StdEncoding.EncodeToString([]byte(proxies)))
+		cmdLine = append(cmdLine, "-fw_cfg", proxyStr)
+	}
 
 	// Disable graphic window when not in debug mode
 	// Done in start, so we're not suck with the debug level we used on init
 	if !logrus.IsLevelEnabled(logrus.DebugLevel) {
 		cmdLine = append(cmdLine, "-display", "none")
 	}
+
+	logrus.Debugf("qemu cmd: %v", cmdLine)
 
 	stderrBuf := &bytes.Buffer{}
 


### PR DESCRIPTION
qemu fails when the same `fw_cfg` options is used more than once.
Since the current logic always adds a new option on each machine load
this will fail on the second start.

We can fix this by checking if the option is already set and replace but
I think it is easier to just not commit the option in the config and add
it dynamically on start. User that hit this bug have to recreate the
machine.

Fixes #14636
Fixes #14837

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where podman machine with proxy variables could not be started more than once.
```
