### PR TITLE
Fix machine test for list

### DIFF
--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -135,7 +135,7 @@ var _ = Describe("podman machine list", func() {
 		Expect(listSession2).To(Exit(0))
 
 		var listResponse []*entities.ListReporter
-		err = jsoniter.Unmarshal(listSession.Bytes(), &listResponse)
+		err = jsoniter.Unmarshal(listSession2.Bytes(), &listResponse)
 		Expect(err).To(BeNil())
 
 		// table format includes the header


### PR DESCRIPTION
Fix last machine test
    
The list --format json test case had a typo like error.

[NO NEW TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```
