### PR TITLE
fix wrong log message on Trace level

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -133,7 +133,7 @@ func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtime
 			continue
 		}
 		foundPath = true
-		logrus.Tracef("found runtime %q", runtime.path)
+		logrus.Tracef("found runtime %q", path)
 		runtime.path = path
 		break
 	}


### PR DESCRIPTION
[NO NEW TESTS NEEDED]

Empty path to runtime binary was printed instead of a real path.

Before fix:
TRAC[0000] found runtime ""
TRAC[0000] found runtime ""

After:
TRAC[0000] found runtime "/usr/bin/crun"
TRAC[0000] found runtime "/usr/bin/runc"

Signed-off-by: Mikhail Khachayants <khachayants@arrival.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

```release-note
None
```
