### PR TITLE
[CI:DOCS] CI: sanity check for desired runtime

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -167,14 +167,18 @@ build_task:
               VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
               # ID for re-use of build output
+              CI_DESIRED_RUNTIME: crun
         - env: &priorfedora_envvars
               DISTRO_NV: ${PRIOR_FEDORA_NAME}
               VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
               CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
+              CI_DESIRED_RUNTIME: crun
         - env: &ubuntu_envvars
               DISTRO_NV: ${UBUNTU_NAME}
               VM_IMAGE_NAME: ${UBUNTU_CACHE_IMAGE_NAME}
               CTR_FQIN: ${UBUNTU_CONTAINER_FQIN}
+              # FIXME 2022-07-12: change to runc once #14833 is fixed!
+              CI_DESIRED_RUNTIME: crun
     env:
         TEST_FLAVOR: build
     clone_script: *full_clone

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -236,6 +236,16 @@ function _run_build() {
     make clean
     make vendor
     make podman-release  # includes podman, podman-remote, and docs
+
+    # Last-minute confirmation that we're testing the desired runtime.
+    # This Can't Possibly Fail™ in regular CI; only when updating VMs.
+    # $CI_DESIRED_RUNTIME must be defined in .cirrus.yml.
+    req_env_vars CI_DESIRED_RUNTIME
+    runtime=$(bin/podman info --format '{{.Host.OCIRuntime.Name}}')
+    # shellcheck disable=SC2154
+    if [[ "$runtime" != "$CI_DESIRED_RUNTIME" ]]; then
+        die "Built podman is using '$runtime'; this CI environment requires $CI_DESIRED_RUNTIME"
+    fi
 }
 
 function _run_altbuild() {


### PR DESCRIPTION
We're still not testing runc in CI (#14833), and it may be weeks
or months before we can, due to criu/glibc nightmare, but one day
we'll be back on track, then later on we'll update VMs again,
and screw it up, and lose runc, and not notice, and RHEL will
break, and oh noes headless chicken again, repeat repeat.

We can do better. Use .cirrus.yml to explicitly define which
VMs should use which runtimes, and enforce it early in the
CI build step. This should never fail (uh huh) in a PR,
only in one of the update-VM PRs.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```