### PR TITLE
[CI:DOCS] man pages: replace -c with --cpu-shares

### DIFF
--- a/docs/source/markdown/podman-container-clone.1.md
+++ b/docs/source/markdown/podman-container-clone.1.md
@@ -89,14 +89,15 @@ cores. Even if a container is limited to less than 100% of CPU time, it can
 use 100% of each individual CPU core.
 
 For example, consider a system with more than three cores.
-container **{C0}** is started with **-c=512** running one process, and another container
-**{C1}** with **-c=1024** running two processes, this can result in the following
-division of CPU shares:
+If the container _C0_ is started with **--cpu-shares=512** running one process,
+and another container _C1_ with **--cpu-shares=1024** running two processes,
+this can result in the following division of CPU shares:
 
-PID    container	CPU	CPU share
-100    {C0}		0	100% of CPU0
-101    {C1}		1	100% of CPU1
-102    {C1}		2	100% of CPU2
+| PID  |  container  | CPU     | CPU share    |
+| ---- | ----------- | ------- | ------------ |
+| 100  |  C0         | 0       | 100% of CPU0 |
+| 101  |  C1         | 1       | 100% of CPU1 |
+| 102  |  C1         | 2       | 100% of CPU2 |
 
 If none are specified, the original container's CPU shares are used.
 

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -229,8 +229,8 @@ cores. Even if a container is limited to less than 100% of CPU time, it can
 use 100% of each individual CPU core.
 
 For example, consider a system with more than three cores. If you start one
-container **{C0}** with **-c=512** running one process, and another container
-**{C1}** with **-c=1024** running two processes, this can result in the following
+container **{C0}** with **--cpu-shares=512** running one process, and another container
+**{C1}** with **--cpu-shares=1024** running two processes, this can result in the following
 division of CPU shares:
 
 PID    container	CPU	CPU share

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -228,15 +228,16 @@ On a multi-core system, the shares of CPU time are distributed over all CPU
 cores. Even if a container is limited to less than 100% of CPU time, it can
 use 100% of each individual CPU core.
 
-For example, consider a system with more than three cores. If you start one
-container **{C0}** with **--cpu-shares=512** running one process, and another container
-**{C1}** with **--cpu-shares=1024** running two processes, this can result in the following
-division of CPU shares:
+For example, consider a system with more than three cores.
+If the container _C0_ is started with **--cpu-shares=512** running one process,
+and another container _C1_ with **--cpu-shares=1024** running two processes,
+this can result in the following division of CPU shares:
 
-PID    container	CPU	CPU share
-100    {C0}		0	100% of CPU0
-101    {C1}		1	100% of CPU1
-102    {C1}		2	100% of CPU2
+| PID  |  container  | CPU     | CPU share    |
+| ---- | ----------- | ------- | ------------ |
+| 100  |  C0         | 0       | 100% of CPU0 |
+| 101  |  C1         | 1       | 100% of CPU1 |
+| 102  |  C1         | 2       | 100% of CPU2 |
 
 #### **--cpus**=*number*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -244,16 +244,16 @@ On a multi-core system, the shares of CPU time are distributed over all CPU
 cores. Even if a container is limited to less than 100% of CPU time, it can
 use 100% of each individual CPU core.
 
-For example, consider a system with more than three cores. If you start one
-container **{C0}** with **--cpu-shares=512** running one process, and another container
-**{C1}** with **--cpu-shares=1024** running two processes, this can result in the following
-division of CPU shares:
+For example, consider a system with more than three cores.
+If the container _C0_ is started with **--cpu-shares=512** running one process,
+and another container _C1_ with **--cpu-shares=1024** running two processes,
+this can result in the following division of CPU shares:
 
 | PID  |  container  | CPU     | CPU share    |
 | ---- | ----------- | ------- | ------------ |
-| 100  |  {C0}       | 0       | 100% of CPU0 |
-| 101  |  {C1}       | 1       | 100% of CPU1 |
-| 102  |  {C1}       | 2       | 100% of CPU2 |
+| 100  |  C0         | 0       | 100% of CPU0 |
+| 101  |  C1         | 1       | 100% of CPU1 |
+| 102  |  C1         | 2       | 100% of CPU2 |
 
 #### **--cpus**=*number*
 


### PR DESCRIPTION
These three man pages have some similar text.




https://github.com/containers/podman/blob/edbfbfcda18f57c89a9657ba453c51977a7796a9/docs/source/markdown/podman-run.1.md?plain=1#L247-L256



https://github.com/containers/podman/blob/edbfbfcda18f57c89a9657ba453c51977a7796a9/docs/source/markdown/podman-create.1.md?plain=1#L231-L239

https://github.com/containers/podman/blob/edbfbfcda18f57c89a9657ba453c51977a7796a9/docs/source/markdown/podman-container-clone.1.md?plain=1#L91-L99


 I assume podman-run.1.md is the correct one (i.e. using __--cpu-shares=__ instead of __-c=__)

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
