### PR TITLE
Docker uses "-c" to mean "--cpu-shares" in create and run

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -849,9 +849,9 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		_ = cmd.RegisterFlagCompletionFunc(cpuRtRuntimeFlagName, completion.AutocompleteNone)
 
 		cpuSharesFlagName := "cpu-shares"
-		createFlags.Uint64Var(
+		createFlags.Uint64VarP(
 			&cf.CPUShares,
-			cpuSharesFlagName, 0,
+			cpuSharesFlagName, "c", 0,
 			"CPU shares (relative weight)",
 		)
 		_ = cmd.RegisterFlagCompletionFunc(cpuSharesFlagName, completion.AutocompleteNone)

--- a/docs/source/markdown/podman-container-clone.1.md
+++ b/docs/source/markdown/podman-container-clone.1.md
@@ -61,7 +61,7 @@ The sum of all runtimes across containers cannot exceed the amount allotted to t
 
 This option is not supported on cgroups V2 systems.
 
-#### **--cpu-shares**=*shares*
+#### **--cpu-shares**, **-c**=*shares*
 
 CPU shares (relative weight)
 

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -201,7 +201,7 @@ The sum of all runtimes across containers cannot exceed the amount allotted to t
 
 This flag is not supported on cgroups V2 systems.
 
-#### **--cpu-shares**=*shares*
+#### **--cpu-shares**, **-c**=*shares*
 
 CPU shares (relative weight)
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -220,7 +220,7 @@ The sum of all runtimes across containers cannot exceed the amount allotted to t
 
 This flag is not supported on cgroups V2 systems.
 
-#### **--cpu-shares**=*shares*
+#### **--cpu-shares**, **-c**=*shares*
 
 CPU shares (relative weight).
 

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Podman run cpu", func() {
 			Expect(result).Should(Exit(0))
 			Expect(result.OutputToString()).To(Equal("10000"))
 		} else {
-			result := podmanTest.Podman([]string{"run", "--rm", "--cpu-shares=2", ALPINE, "cat", "/sys/fs/cgroup/cpu/cpu.shares"})
+			result := podmanTest.Podman([]string{"run", "--rm", "-c", "2", ALPINE, "cat", "/sys/fs/cgroup/cpu/cpu.shares"})
 			result.WaitWithDefaultTimeout()
 			Expect(result).Should(Exit(0))
 			Expect(result.OutputToString()).To(Equal("2"))


### PR DESCRIPTION
Add support for -c as an alias for --cpu-shares to be compatible with
Docker.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add support for -c as an alias for --cpu-shares to be compatible with Docker.
```
