### PR TITLE
WIP: [CI:DOCS] Refactor common options in man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,12 @@ BUILDTAGS_CROSS ?= containers_image_openpgp exclude_graphdriver_btrfs exclude_gr
 CONTAINER_RUNTIME := $(shell command -v podman 2> /dev/null || echo docker)
 OCI_RUNTIME ?= ""
 
-MANPAGES_MD ?= $(wildcard docs/source/markdown/*.md)
-MANPAGES ?= $(MANPAGES_MD:%.md=%)
-MANPAGES_DEST ?= $(subst markdown,man, $(subst source,build,$(MANPAGES)))
+MANPAGES_SOURCE_DIR = docs/source/markdown
+MANPAGES_MD_IN ?= $(wildcard $(MANPAGES_SOURCE_DIR)/*.md.in)
+MANPAGES_MD_GENERATED ?= $(MANPAGES_MD_IN:%.md.in=%.md)
+MANPAGES_MD = $(wildcard $(MANPAGES_SOURCE_DIR)/*.md)
+MANPAGES = $(MANPAGES_MD:%.md=%)
+MANPAGES_DEST = $(subst markdown,man, $(subst source,build,$(MANPAGES)))
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 ZSHINSTALLDIR=${PREFIX}/share/zsh/site-functions
@@ -416,17 +419,24 @@ completions: podman podman-remote
 pkg/api/swagger.yaml:
 	make -C pkg/api
 
+$(MANPAGES_MD_GENERATED): %.md: %.md.in $(MANPAGES_SOURCE_DIR)/options/*.md
+	hack/markdown-preprocess $<
+
 $(MANPAGES): %: %.md .install.md2man docdir
 
-### sed is used to filter http/s links as well as relative links
-### replaces "\" at the end of a line with two spaces
-### this ensures that manpages are renderd correctly
-
-	@$(SED) -e 's/\((podman[^)]*\.md\(#.*\)\?)\)//g' \
-	 -e 's/\[\(podman[^]]*\)\]/\1/g' \
-		 -e 's/\[\([^]]*\)](http[^)]\+)/\1/g' \
-	 -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g' \
-	 -e 's/\\$$/  /g' $<  | \
+# This does a bunch of filtering needed for man pages:
+#  1. Strip markdown link targets like '[podman(1)](podman.1.md)'
+#     to just '[podman(1)]', because man pages have no link mechanism;
+#  2. Then remove the brackets: '[podman(1)]' -> 'podman(1)';
+#  3. Then do the same for all other markdown links,
+#     like '[cgroups(7)](https://.....)'  -> just 'cgroups(7)';
+#  4. Remove HTML-ish stuff like '<sup>..</sup>' and '<a>..</a>'
+#  5. Replace "\" (backslash) at EOL with two spaces (no idea why)
+	@$(SED) -e 's/\((podman[^)]*\.md\(#.*\)\?)\)//g'    \
+	       -e 's/\[\(podman[^]]*\)\]/\1/g'              \
+	       -e 's/\[\([^]]*\)](http[^)]\+)/\1/g'         \
+	       -e 's;<\(/\)\?\(a\|a\s\+[^>]*\|sup\)>;;g'    \
+	       -e 's/\\$$/  /g' $<                         |\
 	$(GOMD2MAN) -in /dev/stdin -out $(subst source/markdown,build/man,$@)
 
 .PHONY: docdir
@@ -434,7 +444,7 @@ docdir:
 	mkdir -p docs/build/man
 
 .PHONY: docs
-docs: $(MANPAGES) ## Generate documentation
+docs: $(MANPAGES_MD_GENERATED) $(MANPAGES) ## Generate documentation
 
 # docs/remote-docs.sh requires a locally executable 'podman-remote' binary
 # in addition to the target-architecture binary (if different). That's

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,7 +13,8 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 clean:
-	rm -fr build/
+	$(RM) -fr build
+	cd source/markdown && $(RM) -f $$(<.gitignore)
 
 .PHONY: help Makefile
 

--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -1,0 +1,8 @@
+podman-build.1.md
+podman-container-clone.1.md
+podman-create.1.md
+podman-exec.1.md
+podman-pod-clone.1.md
+podman-pod-create.1.md
+podman-pull.1.md
+podman-run.1.md

--- a/docs/source/markdown/options/add-host.md
+++ b/docs/source/markdown/options/add-host.md
@@ -1,0 +1,6 @@
+#### **--add-host**=*host:ip*
+
+Add a custom host-to-IP mapping (host:ip)
+
+Add a line to /etc/hosts. The format is hostname:ip. The **--add-host**
+option can be set multiple times. Conflicts with the **--no-hosts** option.

--- a/docs/source/markdown/options/blkio-weight-device.md
+++ b/docs/source/markdown/options/blkio-weight-device.md
@@ -1,0 +1,3 @@
+#### **--blkio-weight-device**=*device:weight*
+
+Block IO relative device weight.

--- a/docs/source/markdown/options/blkio-weight.md
+++ b/docs/source/markdown/options/blkio-weight.md
@@ -1,0 +1,3 @@
+#### **--blkio-weight**=*weight*
+
+Block IO relative weight. The _weight_ is a value between **10** and **1000**.

--- a/docs/source/markdown/options/cap-add.md
+++ b/docs/source/markdown/options/cap-add.md
@@ -1,0 +1,3 @@
+#### **--cap-add**=*capability*
+
+Add Linux capabilities.

--- a/docs/source/markdown/options/cap-drop.md
+++ b/docs/source/markdown/options/cap-drop.md
@@ -1,0 +1,3 @@
+#### **--cap-drop**=*capability*
+
+Drop Linux capabilities.

--- a/docs/source/markdown/options/cgroup-conf.md
+++ b/docs/source/markdown/options/cgroup-conf.md
@@ -1,0 +1,3 @@
+#### **--cgroup-conf**=*KEY=VALUE*
+
+When running on cgroup v2, specify the cgroup file to write to and its value. For example **--cgroup-conf=memory.high=1073741824** sets the memory.high limit to 1GB.

--- a/docs/source/markdown/options/cgroupns.md
+++ b/docs/source/markdown/options/cgroupns.md
@@ -1,0 +1,10 @@
+#### **--cgroupns**=*mode*
+
+Set the cgroup namespace mode for the container.
+
+- **host**: use the host's cgroup namespace inside the container.
+- **container:<NAME|ID>**: join the namespace of the specified container.
+- **private**: create a new cgroup namespace.
+- **ns:<PATH>**: join the namespace at the specified path.
+
+If the host uses cgroups v1, the default is set to **host**. On cgroups v2, the default is **private**.

--- a/docs/source/markdown/options/cgroups.md
+++ b/docs/source/markdown/options/cgroups.md
@@ -1,0 +1,10 @@
+#### **--cgroups**=*how*
+
+Determines whether the container will create CGroups.
+
+Default is **enabled**.
+
+The **enabled** option will create a new cgroup under the cgroup-parent.
+The **disabled** option will force the container to not create CGroups, and thus conflicts with CGroup options (**--cgroupns** and **--cgroup-parent**).
+The **no-conmon** option disables a new CGroup only for the **conmon** process.
+The **split** option splits the current CGroup in two sub-cgroups: one for conmon and one for the container payload. It is not possible to set **--cgroup-parent** with **split**.

--- a/docs/source/markdown/options/chrootdirs.md
+++ b/docs/source/markdown/options/chrootdirs.md
@@ -1,0 +1,5 @@
+#### **--chrootdirs**=*path*
+
+Path to a directory inside the container that should be treated as a `chroot` directory.
+Any Podman managed file (e.g., /etc/resolv.conf, /etc/hosts, etc/hostname) that is mounted into the root directory will be mounted into that location as well.
+Multiple directories should be separated with a comma.

--- a/docs/source/markdown/options/conmon-pidfile.md
+++ b/docs/source/markdown/options/conmon-pidfile.md
@@ -1,0 +1,4 @@
+#### **--conmon-pidfile**=*file*
+
+Write the pid of the **conmon** process to a file. As **conmon** runs in a separate process than Podman, this is necessary when using systemd to restart Podman containers.
+(This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/options/cpu-period.md
+++ b/docs/source/markdown/options/cpu-period.md
@@ -1,0 +1,10 @@
+#### **--cpu-period**=*limit*
+
+Set the CPU period for the Completely Fair Scheduler (CFS), which is a
+duration in microseconds. Once the container's CPU quota is used up, it will
+not be scheduled to run until the current period ends. Defaults to 100000
+microseconds.
+
+On some systems, changing the CPU limits may not be allowed for non-root
+users. For more details, see
+https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error

--- a/docs/source/markdown/options/cpu-quota.md
+++ b/docs/source/markdown/options/cpu-quota.md
@@ -1,0 +1,12 @@
+#### **--cpu-quota**=*limit*
+
+Limit the CPU Completely Fair Scheduler (CFS) quota.
+
+Limit the container's CPU usage. By default, containers run with the full
+CPU resource. The limit is a number in microseconds. If a number is provided,
+the container will be allowed to use that much CPU time until the CPU period
+ends (controllable via **--cpu-period**).
+
+On some systems, changing the CPU limits may not be allowed for non-root
+users. For more details, see
+https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error

--- a/docs/source/markdown/options/cpu-rt-period.md
+++ b/docs/source/markdown/options/cpu-rt-period.md
@@ -1,0 +1,7 @@
+#### **--cpu-rt-period**=*microseconds*
+
+Limit the CPU real-time period in microseconds.
+
+Limit the container's Real Time CPU usage. This option tells the kernel to restrict the container's Real Time CPU usage to the period specified.
+
+This option is not supported on cgroups V2 systems.

--- a/docs/source/markdown/options/cpu-rt-runtime.md
+++ b/docs/source/markdown/options/cpu-rt-runtime.md
@@ -1,0 +1,10 @@
+#### **--cpu-rt-runtime**=*microseconds*
+
+Limit the CPU real-time runtime in microseconds.
+
+Limit the containers Real Time CPU usage. This option tells the kernel to limit the amount of time in a given CPU period Real Time tasks may consume. Ex:
+Period of 1,000,000us and Runtime of 950,000us means that this container could consume 95% of available CPU and leave the remaining 5% to normal priority tasks.
+
+The sum of all runtimes across containers cannot exceed the amount allotted to the parent cgroup.
+
+This option is not supported on cgroups V2 systems.

--- a/docs/source/markdown/options/cpu-shares.md
+++ b/docs/source/markdown/options/cpu-shares.md
@@ -1,0 +1,36 @@
+#### **--cpu-shares**, **-c**=*shares*
+
+CPU shares (relative weight)
+
+By default, all containers get the same proportion of CPU cycles. This proportion
+can be modified by changing the container's CPU share weighting relative
+to the weighting of all other running containers.
+
+To modify the proportion from the default of 1024, use the **--cpu-shares**
+flag to set the weighting to 2 or higher.
+
+The proportion will only apply when CPU-intensive processes are running.
+When tasks in one container are idle, other containers can use the
+left-over CPU time. The actual amount of CPU time will vary depending on
+the number of containers running on the system.
+
+For example, consider three containers, one has a cpu-share of 1024 and
+two others have a cpu-share setting of 512. When processes in all three
+containers attempt to use 100% of CPU, the first container would receive
+50% of the total CPU time. If you add a fourth container with a cpu-share
+of 1024, the first container only gets 33% of the CPU. The remaining containers
+receive 16.5%, 16.5% and 33% of the CPU.
+
+On a multi-core system, the shares of CPU time are distributed over all CPU
+cores. Even if a container is limited to less than 100% of CPU time, it can
+use 100% of each individual CPU core.
+
+For example, consider a system with more than three cores. If you start one
+container **{C0}** with **-c=512** running one process, and another container
+**{C1}** with **-c=1024** running two processes, this can result in the following
+division of CPU shares:
+
+PID    container	CPU	CPU share
+100    {C0}		0	100% of CPU0
+101    {C1}		1	100% of CPU1
+102    {C1}		2	100% of CPU2

--- a/docs/source/markdown/options/cpuset-mems.md
+++ b/docs/source/markdown/options/cpuset-mems.md
@@ -1,0 +1,7 @@
+#### **--cpuset-mems**=*nodes*
+
+Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
+
+If there are four memory nodes on the system (0-3), use `--cpuset-mems=0,1`
+then processes in the container will only use memory from the first
+two memory nodes.

--- a/docs/source/markdown/options/device-read-bps.md
+++ b/docs/source/markdown/options/device-read-bps.md
@@ -1,0 +1,3 @@
+#### **--device-read-bps**=*path:rate*
+
+Limit read rate (in bytes per second) from a device (e.g., **--device-read-bps=/dev/sda:1mb**).

--- a/docs/source/markdown/options/device-read-iops.md
+++ b/docs/source/markdown/options/device-read-iops.md
@@ -1,0 +1,3 @@
+#### **--device-read-iops**=*path:rate*
+
+Limit read rate (in IO operations per second) from a device (e.g., **--device-read-iops=/dev/sda:1000**).

--- a/docs/source/markdown/options/device-write-bps.md
+++ b/docs/source/markdown/options/device-write-bps.md
@@ -1,0 +1,3 @@
+#### **--device-write-bps**=*path:rate*
+
+Limit write rate (in bytes per second) to a device (e.g., **--device-write-bps=/dev/sda:1mb**).

--- a/docs/source/markdown/options/device-write-iops.md
+++ b/docs/source/markdown/options/device-write-iops.md
@@ -1,0 +1,3 @@
+#### **--device-write-iops**=*path:rate*
+
+Limit write rate (in IO operations per second) to a device (e.g., **--device-write-iops=/dev/sda:1000**).

--- a/docs/source/markdown/options/device.container.md
+++ b/docs/source/markdown/options/device.container.md
@@ -1,0 +1,18 @@
+#### **--device**=*host-device[:container-device][:permissions]*
+
+Add a host device to the <POD-OR-CONTAINER>. Optional *permissions* parameter
+can be used to specify device permissions by combining
+**r** for read, **w** for write, and **m** for **mknod**(2).
+
+Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
+
+Note: if _host_device_ is a symbolic link then it will be resolved first.
+The <POD-OR-CONTAINER> will only store the major and minor numbers of the host device.
+
+Note: if the user only has access rights via a group, accessing the device
+from inside a rootless container will fail. Use the `--group-add keep-groups`
+flag to pass the user's supplementary group access into the container.
+
+Podman may load kernel modules required for using the specified
+device. The devices that Podman will load modules for when necessary are:
+/dev/fuse.

--- a/docs/source/markdown/options/device.pod.md
+++ b/docs/source/markdown/options/device.pod.md
@@ -1,0 +1,16 @@
+#### **--device**=*host-device[:container-device][:permissions]*
+
+Add a host device to the <POD-OR-CONTAINER>. Optional *permissions* parameter
+can be used to specify device permissions by combining
+**r** for read, **w** for write, and **m** for **mknod**(2).
+
+Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
+
+Note: if _host_device_ is a symbolic link then it will be resolved first.
+The <POD-OR-CONTAINER> will only store the major and minor numbers of the host device.
+
+Note: the pod implements devices by storing the initial configuration passed by the user and recreating the device on each container added to the pod.
+
+Podman may load kernel modules required for using the specified
+device. The devices that Podman will load modules for when necessary are:
+/dev/fuse.

--- a/docs/source/markdown/options/dns-opt.md
+++ b/docs/source/markdown/options/dns-opt.md
@@ -1,0 +1,3 @@
+#### **--dns-opt**=*option*
+
+Set custom DNS options. Invalid if using **--dns-opt** with **--network** that is set to **none** or **container:**_id_.

--- a/docs/source/markdown/options/dns.md
+++ b/docs/source/markdown/options/dns.md
@@ -1,0 +1,11 @@
+#### **--dns**=*ipaddr*
+
+Set custom DNS servers. Invalid if using **--dns** with **--network** that is set to **none** or **container:**_id_.
+
+This option can be used to override the DNS
+configuration passed to the container. Typically this is necessary when the
+host DNS configuration is invalid for the container (e.g., **127.0.0.1**). When this
+is the case the **--dns** flag is necessary for every run.
+
+The special value **none** can be specified to disable creation of _/etc/resolv.conf_ in the container by Podman.
+The _/etc/resolv.conf_ file in the image will be used without changes.

--- a/docs/source/markdown/options/entrypoint.md
+++ b/docs/source/markdown/options/entrypoint.md
@@ -1,0 +1,17 @@
+#### **--entrypoint**=*"command"* | *'["command", "arg1", ...]'*
+
+Overwrite the default ENTRYPOINT of the image.
+
+This option allows you to overwrite the default entrypoint of the image.
+
+The ENTRYPOINT of an image is similar to a COMMAND
+because it specifies what executable to run when the container starts, but it is
+(purposely) more difficult to override. The ENTRYPOINT gives a container its
+default nature or behavior, so that when you set an ENTRYPOINT you can run the
+container as if it were that binary, complete with default options, and you can
+pass in more options via the COMMAND. But, sometimes an operator may want to run
+something else inside the container, so you can override the default ENTRYPOINT
+at runtime by using a **--entrypoint** and a string to specify the new
+ENTRYPOINT.
+
+You need to specify multi option commands in the form of a json string.

--- a/docs/source/markdown/options/env-file.md
+++ b/docs/source/markdown/options/env-file.md
@@ -1,0 +1,3 @@
+#### **--env-file**=*file*
+
+Read in a line delimited file of environment variables.

--- a/docs/source/markdown/options/env-host.md
+++ b/docs/source/markdown/options/env-host.md
@@ -1,0 +1,3 @@
+#### **--env-host**
+
+Use host environment inside of the container. See **Environment** note below for precedence. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/options/expose.md
+++ b/docs/source/markdown/options/expose.md
@@ -1,0 +1,4 @@
+#### **--expose**=*port*
+
+Expose a port, or a range of ports (e.g. **--expose=3300-3310**) to set up port redirection
+on the host system.

--- a/docs/source/markdown/options/group-add.md
+++ b/docs/source/markdown/options/group-add.md
@@ -1,0 +1,11 @@
+#### **--group-add**=*group* | *keep-groups*
+
+Assign additional groups to the primary user running within the container process.
+
+- `keep-groups` is a special flag that tells Podman to keep the supplementary group access.
+
+Allows container to use the user's supplementary group access. If file systems or
+devices are only accessible by the rootless user's group, this flag tells the OCI
+runtime to pass the group access into the container. Currently only available
+with the `crun` OCI runtime. Note: `keep-groups` is exclusive, you cannot add any other groups
+with this flag. (Not available for remote commands, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/options/health-cmd.md
+++ b/docs/source/markdown/options/health-cmd.md
@@ -1,0 +1,8 @@
+#### **--health-cmd**=*"command"* | *'["command", "arg1", ...]'*
+
+Set or alter a healthcheck command for a container. The command is a command to be executed inside your
+container that determines your container health. The command is required for other healthcheck options
+to be applied. A value of **none** disables existing healthchecks.
+
+Multiple options can be passed in the form of a JSON array; otherwise, the command will be interpreted
+as an argument to `/bin/sh -c`.

--- a/docs/source/markdown/options/health-interval.md
+++ b/docs/source/markdown/options/health-interval.md
@@ -1,0 +1,3 @@
+#### **--health-interval**=*interval*
+
+Set an interval for the healthchecks. An _interval_ of **disable** results in no automatic timer setup. The default is **30s**.

--- a/docs/source/markdown/options/health-retries.md
+++ b/docs/source/markdown/options/health-retries.md
@@ -1,0 +1,3 @@
+#### **--health-retries**=*retries*
+
+The number of retries allowed before a healthcheck is considered to be unhealthy. The default value is **3**.

--- a/docs/source/markdown/options/health-start-period.md
+++ b/docs/source/markdown/options/health-start-period.md
@@ -1,0 +1,4 @@
+#### **--health-start-period**=*period*
+
+The initialization time needed for a container to bootstrap. The value can be expressed in time format like
+**2m3s**. The default value is **0s**.

--- a/docs/source/markdown/options/health-timeout.md
+++ b/docs/source/markdown/options/health-timeout.md
@@ -1,0 +1,4 @@
+#### **--health-timeout**=*timeout*
+
+The maximum time allowed to complete the healthcheck before an interval is considered failed. Like start-period, the
+value can be expressed in a time format such as **1m22s**. The default value is **30s**.

--- a/docs/source/markdown/options/hostname.container.md
+++ b/docs/source/markdown/options/hostname.container.md
@@ -1,0 +1,5 @@
+#### **--hostname**, **-h**=*name*
+
+Container host name
+
+Sets the container host name that is available inside the container. Can only be used with a private UTS namespace `--uts=private` (default). If `--pod` is specified and the pod shares the UTS namespace (default) the pod's hostname will be used.

--- a/docs/source/markdown/options/hostname.pod.md
+++ b/docs/source/markdown/options/hostname.pod.md
@@ -1,0 +1,3 @@
+#### **--hostname**=*name*
+
+Set a hostname to the pod.

--- a/docs/source/markdown/options/hostuser.md
+++ b/docs/source/markdown/options/hostuser.md
@@ -1,0 +1,4 @@
+#### **--hostuser**=*name*
+
+Add a user account to /etc/passwd from the host to the container. The Username
+or UID must exist on the host system.

--- a/docs/source/markdown/options/http-proxy.md
+++ b/docs/source/markdown/options/http-proxy.md
@@ -1,0 +1,14 @@
+#### **--http-proxy**
+
+By default proxy environment variables are passed into the container if set
+for the Podman process. This can be disabled by setting the value to **false**.
+The environment variables passed in include **http_proxy**,
+**https_proxy**, **ftp_proxy**, **no_proxy**, and also the upper case versions of
+those. This option is only needed when the host system must use a proxy but
+the container should not use any proxy. Proxy environment variables specified
+for the container in any other way will override the values that would have
+been passed through from the host. (Other ways to specify the proxy for the
+container include passing the values with the **--env** flag, or hard coding the
+proxy environment at container build time.) (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+
+Defaults to **true**.

--- a/docs/source/markdown/options/image-volume.md
+++ b/docs/source/markdown/options/image-volume.md
@@ -1,0 +1,8 @@
+#### **--image-volume**=**bind** | *tmpfs* | *ignore*
+
+Tells Podman how to handle the builtin image volumes. Default is **bind**.
+
+- **bind**: An anonymous named volume will be created and mounted into the container.
+- **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
+content that disappears when the container is stopped.
+- **ignore**: All volumes are just ignored and no action is taken.

--- a/docs/source/markdown/options/infra-command.md
+++ b/docs/source/markdown/options/infra-command.md
@@ -1,0 +1,3 @@
+#### **--infra-command**=*command*
+
+The command that will be run to start the infra container. Default: "/pause".

--- a/docs/source/markdown/options/infra-conmon-pidfile.md
+++ b/docs/source/markdown/options/infra-conmon-pidfile.md
@@ -1,0 +1,3 @@
+#### **--infra-conmon-pidfile**=*file*
+
+Write the pid of the infra container's **conmon** process to a file. As **conmon** runs in a separate process than Podman, this is necessary when using systemd to manage Podman containers and pods.

--- a/docs/source/markdown/options/infra-name.md
+++ b/docs/source/markdown/options/infra-name.md
@@ -1,0 +1,3 @@
+#### **--infra-name**=*name*
+
+The name that will be used for the pod's infra container.

--- a/docs/source/markdown/options/init-path.md
+++ b/docs/source/markdown/options/init-path.md
@@ -1,0 +1,3 @@
+#### **--init-path**=*path*
+
+Path to the container-init binary.

--- a/docs/source/markdown/options/init.md
+++ b/docs/source/markdown/options/init.md
@@ -1,0 +1,5 @@
+#### **--init**
+
+Run an init inside the container that forwards signals and reaps processes.
+The container-init binary is mounted at `/run/podman-init`.
+Mounting over `/run` will hence break container execution.

--- a/docs/source/markdown/options/ipc.md
+++ b/docs/source/markdown/options/ipc.md
@@ -1,0 +1,12 @@
+#### **--ipc**=*ipc*
+
+Set the IPC namespace mode for a container. The default is to create
+a private IPC namespace.
+
+- "": Use Podman's default, defined in containers.conf.
+- **container:**_id_: reuses another container's shared memory, semaphores, and message queues
+- **host**: use the host's shared memory, semaphores, and message queues inside the container. Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+- **none**:  private IPC namespace, with /dev/shm not mounted.
+- **ns:**_path_: path to an IPC namespace to join.
+- **private**: private IPC namespace.
+= **shareable**: private IPC namespace with a possibility to share it with other containers.

--- a/docs/source/markdown/options/link-local-ip.md
+++ b/docs/source/markdown/options/link-local-ip.md
@@ -1,0 +1,3 @@
+#### **--link-local-ip**=*ip*
+
+Not implemented.

--- a/docs/source/markdown/options/memory-swappiness.md
+++ b/docs/source/markdown/options/memory-swappiness.md
@@ -1,0 +1,5 @@
+#### **--memory-swappiness**=*number*
+
+Tune a container's memory swappiness behavior. Accepts an integer between *0* and *100*.
+
+This flag is not supported on cgroups V2 systems.

--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -1,0 +1,77 @@
+#### **--mount**=*type=TYPE,TYPE-SPECIFIC-OPTION[,...]*
+
+Attach a filesystem mount to the container
+
+Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and **devpts**. <sup>[[1]](#Footnote1)</sup>
+
+       e.g.
+
+       type=bind,source=/path/on/host,destination=/path/in/container
+
+       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
+
+       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
+
+       type=volume,source=vol1,destination=/path/in/container,ro=true
+
+       type=tmpfs,tmpfs-size=512M,destination=/path/in/container
+
+       type=image,source=fedora,destination=/fedora-image,rw=true
+
+       type=devpts,destination=/dev/pts
+
+       Common Options:
+
+	      · src, source: mount source spec for bind and volume. Mandatory for bind.
+
+	      · dst, destination, target: mount destination spec.
+
+       Options specific to volume:
+
+	      · ro, readonly: true or false (default).
+
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
+	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
+
+       Options specific to image:
+
+	      · rw, readwrite: true or false (default).
+
+       Options specific to bind:
+
+	      · ro, readonly: true or false (default).
+
+	      · bind-propagation: shared, slave, private, unbindable, rshared, rslave, runbindable, or rprivate(default). See also mount(2).
+
+	      . bind-nonrecursive: do not set up a recursive bind mount. By default it is recursive.
+
+	      . relabel: shared, private.
+
+	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
+
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
+       Options specific to tmpfs:
+
+	      · ro, readonly: true or false (default).
+
+	      · tmpfs-size: Size of the tmpfs mount in bytes. Unlimited by default in Linux.
+
+	      · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
+
+	      · tmpcopyup: Enable copyup from the image directory at the same location to the tmpfs. Used by default.
+
+	      · notmpcopyup: Disable copying files from the image to the tmpfs.
+
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
+       Options specific to devpts:
+
+	      · uid: UID of the file owner (default 0).
+
+	      · gid: GID of the file owner (default 0).
+
+	      · mode: permission mask for the file (default 600).
+
+	      · max: maximum number of PTYs (default 1048576).

--- a/docs/source/markdown/options/network-alias.md
+++ b/docs/source/markdown/options/network-alias.md
@@ -1,0 +1,8 @@
+#### **--network-alias**=*alias*
+
+Add a network-scoped alias for the <POD-OR-CONTAINER>, setting the alias for all networks that the container joins. To set a
+name only for a specific network, use the alias option as described under the **--network** option.
+If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <name>`),
+these aliases can be used for name resolution on the given network. This option can be specified multiple times.
+NOTE: When using CNI a <POD-OR-CONTAINER> will only have access to aliases on the first network that it joins. This limitation does
+not exist with netavark/aardvark-dns.

--- a/docs/source/markdown/options/no-healthcheck.md
+++ b/docs/source/markdown/options/no-healthcheck.md
@@ -1,0 +1,3 @@
+#### **--no-healthcheck**
+
+Disable any defined healthchecks for container.

--- a/docs/source/markdown/options/oom-kill-disable.md
+++ b/docs/source/markdown/options/oom-kill-disable.md
@@ -1,0 +1,5 @@
+#### **--oom-kill-disable**
+
+Whether to disable OOM Killer for the container or not.
+
+This flag is not supported on cgroups V2 systems.

--- a/docs/source/markdown/options/oom-score-adj.md
+++ b/docs/source/markdown/options/oom-score-adj.md
@@ -1,0 +1,3 @@
+#### **--oom-score-adj**=*num*
+
+Tune the host's OOM preferences for containers (accepts values from **-1000** to **1000**).

--- a/docs/source/markdown/options/os.md
+++ b/docs/source/markdown/options/os.md
@@ -1,0 +1,3 @@
+#### **--os**=*OS*
+
+Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.

--- a/docs/source/markdown/options/passwd-entry.md
+++ b/docs/source/markdown/options/passwd-entry.md
@@ -1,0 +1,5 @@
+#### **--passwd-entry**=*ENTRY*
+
+Customize the entry that is written to the `/etc/passwd` file within the container when `--passwd` is used.
+
+The variables $USERNAME, $UID, $GID, $NAME, $HOME are automatically replaced with their value at runtime.

--- a/docs/source/markdown/options/personality.md
+++ b/docs/source/markdown/options/personality.md
@@ -1,0 +1,3 @@
+#### **--personality**=*persona*
+
+Personality sets the execution domain via Linux personality(2).

--- a/docs/source/markdown/options/pidfile.md
+++ b/docs/source/markdown/options/pidfile.md
@@ -1,0 +1,9 @@
+#### **--pidfile**=*path*
+
+When the pidfile location is specified, the container process' PID will be written to the pidfile. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+If the pidfile option is not specified, the container process' PID will be written to /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
+
+After the container is started, the location for the pidfile can be discovered with the following `podman inspect` command:
+
+    $ podman inspect --format '{{ .PidFile }}' $CID
+    /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile

--- a/docs/source/markdown/options/pids-limit.md
+++ b/docs/source/markdown/options/pids-limit.md
@@ -1,0 +1,3 @@
+#### **--pids-limit**=*limit*
+
+Tune the container's pids limit. Set to **-1** to have unlimited pids for the container. The default is **4096** on systems that support "pids" cgroup controller.

--- a/docs/source/markdown/options/pod-id-file.container.md
+++ b/docs/source/markdown/options/pod-id-file.container.md
@@ -1,0 +1,4 @@
+#### **--pod-id-file**=*path*
+
+Run container in an existing pod and read the pod's ID from the specified file.
+If a container is run within a pod, and the pod has an infra-container, the infra-container will be started before the container is.

--- a/docs/source/markdown/options/preserve-fds.md
+++ b/docs/source/markdown/options/preserve-fds.md
@@ -1,0 +1,5 @@
+#### **--preserve-fds**=*N*
+
+Pass down to the process N additional file descriptors (in addition to 0, 1, 2).
+The total FDs will be 3+N. (This option is not available with the remote
+Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/options/privileged.md
+++ b/docs/source/markdown/options/privileged.md
@@ -1,0 +1,14 @@
+#### **--privileged**
+
+Give extended privileges to this container. The default is *false*.
+
+By default, Podman containers are unprivileged (*=false*) and cannot, for
+example, modify parts of the operating system. This is because by default a
+container is only allowed limited access to devices. A "privileged" container
+is given the same access to devices as the user launching the container.
+
+A privileged container turns off the security features that isolate the
+container from the host. Dropped Capabilities, limited devices, read-only mount
+points, Apparmor/SELinux separation, and Seccomp filters are all disabled.
+
+Rootless containers cannot have more privileges than the account that launched them.

--- a/docs/source/markdown/options/publish-all.md
+++ b/docs/source/markdown/options/publish-all.md
@@ -1,0 +1,12 @@
+#### **--publish-all**, **-P**
+
+Publish all exposed ports to random ports on the host interfaces. The default is **false**.
+
+When set to **true**, publish all exposed ports to the host interfaces. The
+default is **false**. If the operator uses **-P** (or **-p**) then Podman will make the
+exposed port accessible on the host and the ports will be available to any
+client that can reach the host.
+
+When using this option, Podman will bind any exposed port to a random port on the host
+within an ephemeral port range defined by `/proc/sys/net/ipv4/ip_local_port_range`.
+To find the mapping between the host ports and the exposed ports, use **podman port**.

--- a/docs/source/markdown/options/read-only-tmpfs.md
+++ b/docs/source/markdown/options/read-only-tmpfs.md
@@ -1,0 +1,3 @@
+#### **--read-only-tmpfs**
+
+If container is running in **--read-only** mode, then mount a read-write tmpfs on _/run_, _/tmp_, and _/var/tmp_. The default is **true**.

--- a/docs/source/markdown/options/read-only.md
+++ b/docs/source/markdown/options/read-only.md
@@ -1,0 +1,7 @@
+#### **--read-only**
+
+Mount the container's root filesystem as read-only.
+
+By default a container will have its root filesystem writable allowing processes
+to write files anywhere. By specifying the **--read-only** flag, the container will have
+its root filesystem mounted as read-only prohibiting any writes.

--- a/docs/source/markdown/options/replace.md
+++ b/docs/source/markdown/options/replace.md
@@ -1,0 +1,3 @@
+#### **--replace**
+
+If another <POD-OR-CONTAINER> with the same name already exists, replace and remove it. The default is **false**.

--- a/docs/source/markdown/options/restart.md
+++ b/docs/source/markdown/options/restart.md
@@ -1,0 +1,15 @@
+#### **--restart**=*policy*
+
+Restart policy to follow when containers exit.
+Restart policy will not take effect if a container is stopped via the **podman kill** or **podman stop** commands.
+
+Valid _policy_ values are:
+
+- `no`                       : Do not restart containers on exit
+- `on-failure[:max_retries]` : Restart containers when they exit with a non-zero exit code, retrying indefinitely or until the optional *max_retries* count is hit
+- `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
+- `unless-stopped`           : Identical to **always**
+
+Please note that restart will not restart containers after a system reboot.
+If this functionality is required in your environment, you can invoke Podman from a **systemd.unit**(5) file, or create an init script for whichever init system is in use.
+To generate systemd unit files, please see **podman generate systemd**.

--- a/docs/source/markdown/options/rootfs.md
+++ b/docs/source/markdown/options/rootfs.md
@@ -1,0 +1,19 @@
+#### **--rootfs**
+
+If specified, the first argument refers to an exploded container on the file system.
+
+This is useful to run a container without requiring any image management, the rootfs
+of the container is assumed to be managed externally.
+
+  `Overlay Rootfs Mounts`
+
+   The `:O` flag tells Podman to mount the directory from the rootfs path as
+storage using the `overlay file system`. The container processes
+can modify content within the mount point which is stored in the
+container storage in a separate directory. In overlay terms, the source
+directory will be the lower, and the container storage directory will be the
+upper. Modifications to the mount point are destroyed when the container
+finishes executing, similar to a tmpfs mount point being unmounted.
+
+Note: on **SELinux** systems, the rootfs needs the correct label, which is by default
+**unconfined_u:object_r:container_file_t**.

--- a/docs/source/markdown/options/sdnotify.md
+++ b/docs/source/markdown/options/sdnotify.md
@@ -1,0 +1,10 @@
+#### **--sdnotify**=**container** | *conmon* | *ignore*
+
+Determines how to use the NOTIFY_SOCKET, as passed with systemd and Type=notify.
+
+Default is **container**, which means allow the OCI runtime to proxy the socket into the
+container to receive ready notification. Podman will set the MAINPID to conmon's pid.
+The **conmon** option sets MAINPID to conmon's pid, and sends READY when the container
+has started. The socket is never passed to the runtime or the container.
+The **ignore** option removes NOTIFY_SOCKET from the environment for itself and child processes,
+for the case where some other process above Podman uses NOTIFY_SOCKET and Podman should not use it.

--- a/docs/source/markdown/options/seccomp-policy.md
+++ b/docs/source/markdown/options/seccomp-policy.md
@@ -1,0 +1,5 @@
+#### **--seccomp-policy**=*policy*
+
+Specify the policy to select the seccomp profile. If set to *image*, Podman will look for a "io.containers.seccomp.profile" label in the container-image config and use its value as a seccomp profile. Otherwise, Podman will follow the *default* policy by applying the default profile unless specified otherwise via *--security-opt seccomp* as described below.
+
+Note that this feature is experimental and may change in the future.

--- a/docs/source/markdown/options/secret.md
+++ b/docs/source/markdown/options/secret.md
@@ -1,0 +1,22 @@
+#### **--secret**=*secret[,opt=opt ...]*
+
+Give the container access to a secret. Can be specified multiple times.
+
+A secret is a blob of sensitive data which a container needs at runtime but
+should not be stored in the image or in source control, such as usernames and passwords,
+TLS certificates and keys, SSH keys or other important generic strings or binary content (up to 500 kb in size).
+
+When secrets are specified as type `mount`, the secrets are copied and mounted into the container when a container is created.
+When secrets are specified as type `env`, the secret will be set as an environment variable within the container.
+Secrets are written in the container at the time of container creation, and modifying the secret using `podman secret` commands
+after the container is created will not affect the secret inside the container.
+
+Secrets and its storage are managed using the `podman secret` command.
+
+Secret Options
+
+- `type=mount|env`    : How the secret will be exposed to the container. Default mount.
+- `target=target`     : Target of secret. Defaults to secret name.
+- `uid=0`             : UID of secret. Defaults to 0. Mount secret type only.
+- `gid=0`             : GID of secret. Defaults to 0. Mount secret type only.
+- `mode=0`            : Mode of secret. Defaults to 0444. Mount secret type only.

--- a/docs/source/markdown/options/shm-size.md
+++ b/docs/source/markdown/options/shm-size.md
@@ -1,0 +1,5 @@
+#### **--shm-size**=*size*
+
+Size of `/dev/shm`. The format is `<number><unit>`.
+If the unit is omitted, the system uses bytes. If the size is omitted, the system uses `64m`.
+When size is `0`, there is no limit on the amount of memory used for IPC by the <POD-OR-CONTAINER>. This option conflicts with **--ipc=host** when running containers.

--- a/docs/source/markdown/options/stop-signal.md
+++ b/docs/source/markdown/options/stop-signal.md
@@ -1,0 +1,3 @@
+#### **--stop-signal**=*signal*
+
+Signal to stop a container. Default is **SIGTERM**.

--- a/docs/source/markdown/options/systemd.md
+++ b/docs/source/markdown/options/systemd.md
@@ -1,0 +1,29 @@
+#### **--systemd**=*true* | *false* | *always*
+
+Run container in systemd mode. The default is *true*.
+
+The value *always* enforces the systemd mode is enforced without
+looking at the executable name. Otherwise, if set to true and the
+command you are running inside the container is **systemd**, **/usr/sbin/init**,
+**/sbin/init** or **/usr/local/sbin/init**.
+
+Running the container in systemd mode causes the following changes:
+
+* Podman mounts tmpfs file systems on the following directories
+  * _/run_
+  * _/run/lock_
+  * _/tmp_
+  * _/sys/fs/cgroup/systemd_
+  * _/var/lib/journal_
+* Podman sets the default stop signal to **SIGRTMIN+3**.
+* Podman sets **container_uuid** environment variable in the container to the
+first 32 characters of the container id.
+
+This allows systemd to run in a confined container without any modifications.
+
+Note: on `SELinux` systems, systemd attempts to write to the cgroup
+file system. Containers writing to the cgroup file system are denied by default.
+The `container_manage_cgroup` boolean must be enabled for this to be allowed on an SELinux separated system.
+```
+setsebool -P container_manage_cgroup true
+```

--- a/docs/source/markdown/options/timeout.md
+++ b/docs/source/markdown/options/timeout.md
@@ -1,0 +1,5 @@
+#### **--timeout**=*seconds*
+
+Maximum time a container is allowed to run before conmon sends it the kill
+signal.  By default containers will run until they exit or are stopped by
+`podman stop`.

--- a/docs/source/markdown/options/tmpfs.md
+++ b/docs/source/markdown/options/tmpfs.md
@@ -1,0 +1,14 @@
+#### **--tmpfs**=*fs*
+
+Create a tmpfs mount.
+
+Mount a temporary filesystem (**tmpfs**) mount into a container, for example:
+
+```
+$ podman <SUBCOMMAND> -d --tmpfs /tmp:rw,size=787448k,mode=1777 my_image
+```
+
+This command mounts a **tmpfs** at _/tmp_ within the container. The supported mount
+options are the same as the Linux default mount flags. If you do not specify
+any options, the system uses the following options:
+**rw,noexec,nosuid,nodev**.

--- a/docs/source/markdown/options/tz.md
+++ b/docs/source/markdown/options/tz.md
@@ -1,0 +1,4 @@
+#### **--tz**=*timezone*
+
+Set timezone in container. This flag takes area-based timezones, GMT time, as well as `local`, which sets the timezone in the container to match the host machine. See `/usr/share/zoneinfo/` for valid timezones.
+Remote connections use local containers.conf for defaults

--- a/docs/source/markdown/options/ulimit.md
+++ b/docs/source/markdown/options/ulimit.md
@@ -1,0 +1,3 @@
+#### **--ulimit**=*option*
+
+Ulimit options. Use **host** to copy the current configuration from the host.

--- a/docs/source/markdown/options/umask.md
+++ b/docs/source/markdown/options/umask.md
@@ -1,0 +1,4 @@
+#### **--umask**=*umask*
+
+Set the umask inside the container. Defaults to `0022`.
+Remote connections use local containers.conf for defaults

--- a/docs/source/markdown/options/unsetenv-all.md
+++ b/docs/source/markdown/options/unsetenv-all.md
@@ -1,0 +1,5 @@
+#### **--unsetenv-all**
+
+Unset all default environment variables for the container. Default environment
+variables include variables provided natively by Podman, environment variables
+configured by the image, and environment variables from containers.conf.

--- a/docs/source/markdown/options/unsetenv.md
+++ b/docs/source/markdown/options/unsetenv.md
@@ -1,0 +1,5 @@
+#### **--unsetenv**=*env*
+
+Unset default environment variables for the container. Default environment
+variables include variables provided natively by Podman, environment variables
+configured by the image, and environment variables from containers.conf.

--- a/docs/source/markdown/options/workdir.md
+++ b/docs/source/markdown/options/workdir.md
@@ -1,0 +1,7 @@
+#### **--workdir**, **-w**=*dir*
+
+Working directory inside the container.
+
+The default working directory for running binaries within a container is the root directory (**/**).
+The image developer can set a different default with the WORKDIR instruction. The operator
+can override the working directory by using the **-w** option.

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -47,12 +47,7 @@ command to see these containers. External containers can be removed with the
 
 ## OPTIONS
 
-#### **--add-host**=*host*
-
-Add a custom host-to-IP mapping (host:ip)
-
-Add a line to /etc/hosts. The format is hostname:ip. The **--add-host** option
-can be set multiple times. Conflicts with the --no-hosts option.
+@@option add-host
 
 #### **--all-platforms**
 
@@ -171,80 +166,17 @@ Thus, compressing the data before sending it is irrelevant to Podman. (This opti
 
 Set additional flags to pass to the C Preprocessor cpp(1). Containerfiles ending with a ".in" suffix will be preprocessed via cpp(1). This option can be used to pass additional flags to cpp.Note: You can also set default CPPFLAGS by setting the BUILDAH_CPPFLAGS environment variable (e.g., export BUILDAH_CPPFLAGS="-DDEBUG").
 
-#### **--cpu-period**=*limit*
+@@option cpu-period
 
-Set the CPU period for the Completely Fair Scheduler (CFS), which is a
-duration in microseconds. Once the container's CPU quota is used up, it will
-not be scheduled to run until the current period ends. Defaults to 100000
-microseconds.
+@@option cpu-quota
 
-On some systems, changing the CPU limits may not be allowed for non-root
-users. For more details, see
-https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
-
-#### **--cpu-quota**=*limit*
-
-Limit the CPU Completely Fair Scheduler (CFS) quota.
-
-Limit the container's CPU usage. By default, containers run with the full
-CPU resource. The limit is a number in microseconds. If you provide a number,
-the container will be allowed to use that much CPU time until the CPU period
-ends (controllable via **--cpu-period**).
-
-On some systems, changing the CPU limits may not be allowed for non-root
-users. For more details, see
-https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
-
-#### **--cpu-shares**, **-c**=*shares*
-
-CPU shares (relative weight)
-
-By default, all containers get the same proportion of CPU cycles. This
-proportion can be modified by changing the container's CPU share weighting
-relative to the weighting of all other running containers.
-
-To modify the proportion from the default of 1024, use the **--cpu-shares**
-option to set the weighting to 2 or higher.
-
-The proportion will only apply when CPU-intensive processes are running.
-When tasks in one container are idle, other containers can use the
-left-over CPU time. The actual amount of CPU time will vary depending on
-the number of containers running on the system.
-
-For example, consider three containers, one has a cpu-share of 1024 and
-two others have a cpu-share setting of 512. When processes in all three
-containers attempt to use 100% of CPU, the first container would receive
-50% of the total CPU time. If you add a fourth container with a cpu-share
-of 1024, the first container only gets 33% of the CPU. The remaining containers
-receive 16.5%, 16.5% and 33% of the CPU.
-
-On a multi-core system, the shares of CPU time are distributed over all CPU
-cores. Even if a container is limited to less than 100% of CPU time, it can
-use 100% of each individual CPU core.
-
-For example, consider a system with more than three cores. If you start one
-container **{C0}** with **-c=512** running one process, and another container
-**{C1}** with **-c=1024** running two processes, this can result in the
-following
-division of CPU shares:
-
-    PID    container	CPU	CPU share
-    100    {C0}		0	100% of CPU0
-    101    {C1}		1	100% of CPU1
-    102    {C1}		2	100% of CPU2
+@@option cpu-shares
 
 #### **--cpuset-cpus**=*num*
 
   CPUs in which to allow execution (0-3, 0,1)
 
-#### **--cpuset-mems**=*nodes*
-
-Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on
-NUMA systems.
-
-If you have four memory nodes on your system (0-3), use `--cpuset-mems=0,1`
-then processes in your container will only use memory from the first
-two memory nodes.
+@@option cpuset-mems
 
 #### **--creds**=*creds*
 
@@ -262,12 +194,12 @@ omitted otherwise.
 #### **--device**=*host-device[:container-device][:permissions]*
 
 Add a host device to the container. Optional *permissions* parameter
-can be used to specify device permissions, it is combination of
+can be used to specify device permissions by combining
 **r** for read, **w** for write, and **m** for **mknod**(2).
 
 Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
 
-Note: if *host-device* is a symbolic link then it will be resolved first.
+Note: if _host_device_ is a symbolic link then it will be resolved first.
 The container will only store the major and minor numbers of the host device.
 
 Note: if the user only has access rights via a group, accessing the device
@@ -633,13 +565,7 @@ container
 - `seccomp=profile.json` :  White listed syscalls seccomp Json file to be used
 as a seccomp filter
 
-#### **--shm-size**=*size*
-
-Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater
-than `0`.
-Unit is optional and can be `b` (bytes), `k` (kibibytes), `m`(mebibytes), or
-`g` (gibibytes). If you omit the unit, the system uses bytes. If you omit the
-size entirely, the system uses `64m`.
+@@option shm-size
 
 #### **--sign-by**=*fingerprint*
 

--- a/docs/source/markdown/podman-container-clone.1.md.in
+++ b/docs/source/markdown/podman-container-clone.1.md.in
@@ -11,101 +11,25 @@ podman\-container\-clone - Creates a copy of an existing container
 
 ## OPTIONS
 
-#### **--blkio-weight**=*weight*
+@@option blkio-weight
 
-Block IO weight (relative weight) accepts a weight value between 10 and 1000.
+@@option blkio-weight-device
 
-#### **--blkio-weight-device**=*weight*
-
-Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`).
-
-#### **--cpu-period**=*limit*
-
-Set the CPU period for the Completely Fair Scheduler (CFS), which is a
-duration in microseconds. Once the container's CPU quota is used up, it will
-not be scheduled to run until the current period ends. Defaults to 100000
-microseconds.
-
-On some systems, changing the CPU limits may not be allowed for non-root
-users. For more details, see
-https://github.com/containers/podman/blob/master/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
+@@option cpu-period
 
 If none is specified, the original container's cpu period is used
 
-#### **--cpu-quota**=*limit*
-
-Limit the CPU Completely Fair Scheduler (CFS) quota.
-
-Limit the container's CPU usage. By default, containers run with the full
-CPU resource. The limit is a number in microseconds. If a number is provided,
-the container will be allowed to use that much CPU time until the CPU period
-ends (controllable via **--cpu-period**).
-
-On some systems, changing the CPU limits may not be allowed for non-root
-users. For more details, see
-https://github.com/containers/podman/blob/master/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
+@@option cpu-quota
 
 If none is specified, the original container's CPU quota are used.
 
-#### **--cpu-rt-period**=*microseconds*
-
-Limit the CPU real-time period in microseconds
-
-Limit the container's Real Time CPU usage. This option tells the kernel to restrict the container's Real Time CPU usage to the period specified.
-
-This option is not supported on cgroups V2 systems.
+@@option cpu-rt-period
 
 If none is specified, the original container's CPU runtime period is used.
 
+@@option cpu-rt-runtime
 
-#### **--cpu-rt-runtime**=*microseconds*
-
-Limit the CPU real-time runtime in microseconds.
-
-Limit the containers Real Time CPU usage. This option tells the kernel to limit the amount of time in a given CPU period Real Time tasks may consume. Ex:
-Period of 1,000,000us and Runtime of 950,000us means that this container could consume 95% of available CPU and leave the remaining 5% to normal priority tasks.
-
-The sum of all runtimes across containers cannot exceed the amount allotted to the parent cgroup.
-
-This option is not supported on cgroups V2 systems.
-
-#### **--cpu-shares**, **-c**=*shares*
-
-CPU shares (relative weight)
-
-By default, all containers get the same proportion of CPU cycles. This proportion
-can be modified by changing the container's CPU share weighting relative
-to the weighting of all other running containers.
-
-To modify the proportion from the default of 1024, use the **--cpu-shares**
-option to set the weighting to 2 or higher.
-
-The proportion will only apply when CPU-intensive processes are running.
-When tasks in one container are idle, other containers can use the
-left-over CPU time. The actual amount of CPU time will vary depending on
-the number of containers running on the system.
-
-For example, consider three containers, one has a cpu-share of 1024 and
-two others have a cpu-share setting of 512. When processes in all three
-containers attempt to use 100% of CPU, the first container would receive
-50% of the total CPU time. If a fourth container is added with a cpu-share
-of 1024, the first container only gets 33% of the CPU. The remaining containers
-receive 16.5%, 16.5% and 33% of the CPU.
-
-On a multi-core system, the shares of CPU time are distributed over all CPU
-cores. Even if a container is limited to less than 100% of CPU time, it can
-use 100% of each individual CPU core.
-
-For example, consider a system with more than three cores.
-If the container _C0_ is started with **--cpu-shares=512** running one process,
-and another container _C1_ with **--cpu-shares=1024** running two processes,
-this can result in the following division of CPU shares:
-
-| PID  |  container  | CPU     | CPU share    |
-| ---- | ----------- | ------- | ------------ |
-| 100  |  C0         | 0       | 100% of CPU0 |
-| 101  |  C1         | 1       | 100% of CPU1 |
-| 102  |  C1         | 2       | 100% of CPU2 |
+@@option cpu-shares
 
 If none are specified, the original container's CPU shares are used.
 
@@ -120,13 +44,7 @@ for **--cpu-period** and **--cpu-quota**, so only **--cpus** or either both the 
 
 CPUs in which to allow execution (0-3, 0,1). If none are specified, the original container's CPUset is used.
 
-#### **--cpuset-mems**=*nodes*
-
-Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
-
-If there are four memory nodes on the system (0-3), use `--cpuset-mems=0,1`
-then processes in the container will only use memory from the first
-two memory nodes.
+@@option cpuset-mems
 
 If none are specified, the original container's CPU memory nodes are used.
 
@@ -134,13 +52,9 @@ If none are specified, the original container's CPU memory nodes are used.
 
 Remove the original container that we are cloning once used to mimic the configuration.
 
-#### **--device-read-bps**=*path*
+@@option device-read-bps
 
-Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb).
-
-#### **--device-write-bps**=*path*
-
-Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
+@@option device-write-bps
 
 #### **--force**, **-f**
 
@@ -179,11 +93,7 @@ The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kibibytes), `m` (mebibytes), or `g` (gibibytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
-#### **--memory-swappiness**=*number*
-
-Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
-
-This flag is not supported on cgroups V2 systems.
+@@option memory-swappiness
 
 #### **--name**
 

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -66,12 +66,7 @@ and specified with a _tag_.
 
 ## OPTIONS
 
-#### **--add-host**=*host*
-
-Add a custom host-to-IP mapping (host:ip)
-
-Add a line to /etc/hosts. The format is hostname:ip. The **--add-host**
-option can be set multiple times.
+@@option add-host
 
 #### **--annotation**=*key=value*
 
@@ -99,145 +94,41 @@ Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
 
-#### **--blkio-weight**=*weight*
+@@option blkio-weight
 
-Block IO weight (relative weight) accepts a weight value between 10 and 1000.
+@@option blkio-weight-device
 
-#### **--blkio-weight-device**=*weight*
+@@option cap-add
 
-Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`).
+@@option cap-drop
 
-#### **--cap-add**=*capability*
-
-Add Linux capabilities
-
-#### **--cap-drop**=*capability*
-
-Drop Linux capabilities
-
-#### **--cgroup-conf**=*KEY=VALUE*
-
-When running on cgroup v2, specify the cgroup file to write to and its value. For example **--cgroup-conf=memory.high=1073741824** sets the memory.high limit to 1GB.
+@@option cgroup-conf
 
 #### **--cgroup-parent**=*path*
 
 Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
-#### **--cgroupns**=*mode*
+@@option cgroupns
 
-Set the cgroup namespace mode for the container.
-    **`host`**: use the host's cgroup namespace inside the container.
-    **`container:<NAME|ID>`**: join the namespace of the specified container.
-    **`ns:<PATH>`**: join the namespace at the specified path.
-    **`private`**: create a new cgroup namespace.
+@@option cgroups
 
-If the host uses cgroups v1, the default is set to **host**. On cgroups v2 the default is **private**.
-
-#### **--cgroups**=*mode*
-
-Determines whether the container will create CGroups.
-Valid values are *enabled*, *disabled*, *no-conmon*, *split*, with the default being *enabled*.
-
-The *enabled* option will create a new cgroup under the cgroup-parent.
-The *disabled* option will force the container to not create CGroups, and thus conflicts with CGroup options (**--cgroupns** and **--cgroup-parent**).
-The *no-conmon* option disables a new CGroup only for the conmon process.
-The *split* option splits the current cgroup in two sub-cgroups: one for conmon and one for the container payload. It is not possible to set *--cgroup-parent* with *split*.
-
-#### **--chrootdirs**=*path*
-
-Path to a directory inside the container that should be treated as a `chroot` directory.
-Any Podman managed file (e.g., /etc/resolv.conf, /etc/hosts, etc/hostname) that is mounted into the root directory will be mounted into that location as well.
-Multiple directories should be separated with a comma.
+@@option chrootdirs
 
 #### **--cidfile**=*id*
 
 Write the container ID to the file
 
-#### **--conmon-pidfile**=*path*
+@@option conmon-pidfile
 
-Write the pid of the `conmon` process to a file. `conmon` runs in a separate process than Podman, so this is necessary when using systemd to restart Podman containers.
-(This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option cpu-period
 
-#### **--cpu-period**=*limit*
+@@option cpu-quota
 
-Set the CPU period for the Completely Fair Scheduler (CFS), which is a
-duration in microseconds. Once the container's CPU quota is used up, it will
-not be scheduled to run until the current period ends. Defaults to 100000
-microseconds.
+@@option cpu-rt-period
 
-On some systems, changing the CPU limits may not be allowed for non-root
-users. For more details, see
-https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
+@@option cpu-rt-runtime
 
-#### **--cpu-quota**=*limit*
-
-Limit the CPU Completely Fair Scheduler (CFS) quota.
-
-Limit the container's CPU usage. By default, containers run with the full
-CPU resource. The limit is a number in microseconds. If you provide a number,
-the container will be allowed to use that much CPU time until the CPU period
-ends (controllable via **--cpu-period**).
-
-On some systems, changing the CPU limits may not be allowed for non-root
-users. For more details, see
-https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
-
-#### **--cpu-rt-period**=*microseconds*
-
-Limit the CPU real-time period in microseconds
-
-Limit the container's Real Time CPU usage. This flag tell the kernel to restrict the container's Real Time CPU usage to the period you specify.
-
-This flag is not supported on cgroups V2 systems.
-
-#### **--cpu-rt-runtime**=*microseconds*
-
-Limit the CPU real-time runtime in microseconds
-
-Limit the containers Real Time CPU usage. This flag tells the kernel to limit the amount of time in a given CPU period Real Time tasks may consume. Ex:
-Period of 1,000,000us and Runtime of 950,000us means that this container could consume 95% of available CPU and leave the remaining 5% to normal priority tasks.
-
-The sum of all runtimes across containers cannot exceed the amount allotted to the parent cgroup.
-
-This flag is not supported on cgroups V2 systems.
-
-#### **--cpu-shares**, **-c**=*shares*
-
-CPU shares (relative weight)
-
-By default, all containers get the same proportion of CPU cycles. This proportion
-can be modified by changing the container's CPU share weighting relative
-to the weighting of all other running containers.
-
-To modify the proportion from the default of 1024, use the **--cpu-shares**
-flag to set the weighting to 2 or higher.
-
-The proportion will only apply when CPU-intensive processes are running.
-When tasks in one container are idle, other containers can use the
-left-over CPU time. The actual amount of CPU time will vary depending on
-the number of containers running on the system.
-
-For example, consider three containers, one has a cpu-share of 1024 and
-two others have a cpu-share setting of 512. When processes in all three
-containers attempt to use 100% of CPU, the first container would receive
-50% of the total CPU time. If you add a fourth container with a cpu-share
-of 1024, the first container only gets 33% of the CPU. The remaining containers
-receive 16.5%, 16.5% and 33% of the CPU.
-
-On a multi-core system, the shares of CPU time are distributed over all CPU
-cores. Even if a container is limited to less than 100% of CPU time, it can
-use 100% of each individual CPU core.
-
-For example, consider a system with more than three cores.
-If the container _C0_ is started with **--cpu-shares=512** running one process,
-and another container _C1_ with **--cpu-shares=1024** running two processes,
-this can result in the following division of CPU shares:
-
-| PID  |  container  | CPU     | CPU share    |
-| ---- | ----------- | ------- | ------------ |
-| 100  |  C0         | 0       | 100% of CPU0 |
-| 101  |  C1         | 1       | 100% of CPU1 |
-| 102  |  C1         | 2       | 100% of CPU2 |
+@@option cpu-shares
 
 #### **--cpus**=*number*
 
@@ -253,32 +144,9 @@ https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-con
 
 CPUs in which to allow execution (0-3, 0,1)
 
-#### **--cpuset-mems**=*nodes*
+@@option cpuset-mems
 
-Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
-
-If you have four memory nodes on your system (0-3), use `--cpuset-mems=0,1`
-then processes in your container will only use memory from the first
-two memory nodes.
-
-#### **--device**=*host-device[:container-device][:permissions]*
-
-Add a host device to the container. Optional *permissions* parameter
-can be used to specify device permissions, it is combination of
-**r** for read, **w** for write, and **m** for **mknod**(2).
-
-Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
-
-Note: if *host-device* is a symbolic link then it will be resolved first.
-The container will only store the major and minor numbers of the host device.
-
-Note: if the user only has access rights via a group, accessing the device
-from inside a rootless container will fail. Use the `--group-add keep-groups`
-flag to pass the user's supplementary group access into the container.
-
-Podman may load kernel modules required for using the specified
-device. The devices that podman will load modules when necessary are:
-/dev/fuse.
+@@option device.container
 
 #### **--device-cgroup-rule**=*"type major:minor mode"*
 
@@ -287,21 +155,13 @@ Add a rule to the cgroup allowed devices list. The rule is expected to be in the
        - major and minor: either a number, or * for all;
        - mode: a composition of r (read), w (write), and m (mknod(2)).
 
-#### **--device-read-bps**=*path*
+@@option device-read-bps
 
-Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)
+@@option device-read-iops
 
-#### **--device-read-iops**=*path*
+@@option device-write-bps
 
-Limit read rate (IO per second) from a device (e.g. --device-read-iops=/dev/sda:1000)
-
-#### **--device-write-bps**=*path*
-
-Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
-
-#### **--device-write-iops**=*path*
-
-Limit write rate (IO per second) to a device (e.g. --device-write-iops=/dev/sda:1000)
+@@option device-write-iops
 
 #### **--disable-content-trust**
 
@@ -309,42 +169,15 @@ This is a Docker specific option to disable image verification to a Docker
 registry and is not supported by Podman. This flag is a NOOP and provided
 solely for scripting compatibility.
 
-#### **--dns**=*dns*
+@@option dns
 
-Set custom DNS servers. Invalid if using **--dns** and **--network** that is set to 'none' or `container:<name|id>`.
-
-This option can be used to override the DNS
-configuration passed to the container. Typically this is necessary when the
-host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this
-is the case the **--dns** flag is necessary for every run.
-
-The special value **none** can be specified to disable creation of **/etc/resolv.conf** in the container by Podman.
-The **/etc/resolv.conf** file in the image will be used without changes.
-
-#### **--dns-opt**=*option*
-
-Set custom DNS options. Invalid if using **--dns-opt** and **--network** that is set to 'none' or `container:<name|id>`.
+@@option dns-opt
 
 #### **--dns-search**=*domain*
 
 Set custom DNS search domains. Invalid if using **--dns-search** and **--network** that is set to 'none' or `container:<name|id>`. (Use --dns-search=. if you don't wish to set the search domain)
 
-#### **--entrypoint**=*"command"* | *'["command", "arg1", ...]'*
-
-Overwrite the default ENTRYPOINT of the image
-
-This option allows you to overwrite the default entrypoint of the image.
-The ENTRYPOINT of an image is similar to a COMMAND
-because it specifies what executable to run when the container starts, but it is
-(purposely) more difficult to override. The ENTRYPOINT gives a container its
-default nature or behavior, so that when you set an ENTRYPOINT you can run the
-container as if it were that binary, complete with default options, and you can
-pass in more options via the COMMAND. But, sometimes an operator may want to run
-something else inside the container, so you can override the default ENTRYPOINT
-at runtime by using a **--entrypoint** and a string to specify the new
-ENTRYPOINT.
-
-You need to specify multi option commands in the form of a json string.
+@@option entrypoint
 
 #### **--env**, **-e**=*env*
 
@@ -354,18 +187,12 @@ This option allows arbitrary environment variables that are available for the pr
 
 See [**Environment**](#environment) note below for precedence and examples.
 
-#### **--env-file**=*file*
+@@option env-file
+See **Environment** note below for precedence.
 
-Read in a line delimited file of environment variables. See **Environment** note below for precedence.
+@@option env-host
 
-#### **--env-host**
-
-Use host environment inside of the container. See **Environment** note below for precedence. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
-
-#### **--expose**=*port*
-
-Expose a port, or a range of ports (e.g. --expose=3300-3310) to set up port redirection
-on the host system.
+@@option expose
 
 #### **--gidmap**=*container_gid:host_gid:amount*
 
@@ -376,94 +203,31 @@ __--uidmap__ maps host UIDs to container UIDs. For details see __--uidmap__.
 
 Note: the **--gidmap** flag cannot be called in conjunction with the **--pod** flag as a gidmap cannot be set on the container level when in a pod.
 
-#### **--group-add**=*group* | *keep-groups*
+@@option group-add
 
-Assign additional groups to the primary user running within the container process.
+@@option health-cmd
 
-- `keep-groups` is a special flag that tells Podman to keep the supplementary group access.
+@@option health-interval
 
-Allows container to use the user's supplementary group access. If file systems or
-devices are only accessible by the rootless user's group, this flag tells the OCI
-runtime to pass the group access into the container. Currently only available
-with the `crun` OCI runtime. Note: `keep-groups` is exclusive, you cannot add any other groups
-with this flag. (Not available for remote commands, including Mac and Windows (excluding WSL2) machines)
+@@option health-retries
 
-#### **--health-cmd**=*"command"* | *'["command", "arg1", ...]'*
+@@option health-start-period
 
-Set or alter a healthcheck command for a container. The command is a command to be executed inside your
-container that determines your container health. The command is required for other healthcheck options
-to be applied. A value of `none` disables existing healthchecks.
-
-Multiple options can be passed in the form of a JSON array; otherwise, the command will be interpreted
-as an argument to `/bin/sh -c`.
-
-#### **--health-interval**=*interval*
-
-Set an interval for the healthchecks (a value of `disable` results in no automatic timer setup) (default "30s")
-
-#### **--health-retries**=*retries*
-
-The number of retries allowed before a healthcheck is considered to be unhealthy. The default value is `3`.
-
-#### **--health-start-period**=*period*
-
-The initialization time needed for a container to bootstrap. The value can be expressed in time format like
-`2m3s`. The default value is `0s`
-
-#### **--health-timeout**=*timeout*
-
-The maximum time allowed to complete the healthcheck before an interval is considered failed. Like start-period, the
-value can be expressed in a time format such as `1m22s`. The default value is `30s`.
+@@option health-timeout
 
 #### **--help**
 
 Print usage statement
 
-#### **--hostname**, **-h**=*name*
+@@option hostname.container
 
-Container host name
+@@option hostuser
 
-Sets the container host name that is available inside the container. Can only be used with a private UTS namespace `--uts=private` (default). If `--pod` is specified and the pod shares the UTS namespace (default) the pod's hostname will be used.
+@@option http-proxy
 
-#### **--hostuser**=*name*
+@@option image-volume
 
-Add a user account to /etc/passwd from the host to the container. The Username
-or UID must exist on the host system.
-
-#### **--http-proxy**
-
-By default proxy environment variables are passed into the container if set
-for the Podman process. This can be disabled by setting the `--http-proxy`
-option to `false`. The environment variables passed in include `http_proxy`,
-`https_proxy`, `ftp_proxy`, `no_proxy`, and also the upper case versions of
-those. This option is only needed when the host system must use a proxy but
-the container should not use any proxy. Proxy environment variables specified
-for the container in any other way will override the values that would have
-been passed through from the host. (Other ways to specify the proxy for the
-container include passing the values with the `--env` flag, or hard coding the
-proxy environment at container build time.)  (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
-
-For example, to disable passing these environment variables from host to
-container:
-
-`--http-proxy=false`
-
-Defaults to `true`
-
-#### **--image-volume**=**bind** | *tmpfs* | *ignore*
-
-Tells Podman how to handle the builtin image volumes. Default is **bind**.
-
-- **bind**: An anonymous named volume will be created and mounted into the container.
-- **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
-content that disappears when the container is stopped.
-- **ignore**: All volumes are just ignored and no action is taken.
-
-#### **--init**
-
-Run an init inside the container that forwards signals and reaps processes.
-The container-init binary is mounted at `/run/podman-init`.
-Mounting over `/run` will hence break container execution.
+@@option init
 
 #### **--init-ctr**=*type*
 
@@ -480,9 +244,7 @@ Init containers are only run on pod `start`.  Restarting a pod will not execute 
 containers should they be present.  Furthermore, init containers can only be created in a
 pod when that pod is not running.
 
-#### **--init-path**=*path*
-
-Path to the container-init binary.
+@@option init-path
 
 #### **--interactive**, **-i**
 
@@ -507,18 +269,7 @@ The address must be within the network's IPv6 address pool.
 To specify multiple static IPv6 addresses per container, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
 
 
-#### **--ipc**=*ipc*
-
-Set the IPC namespace mode for a container. The default is to create
-a private IPC namespace.
-
-- "": Use Podman's default, defined in containers.conf.
-- **container:**_id_: reuses another container's shared memory, semaphores, and message queues
-- **host**: use the host's shared memory, semaphores, and message queues inside the container. Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
-- **none**:  private IPC namespace, with /dev/shm not mounted.
-- **ns:**_path_: path to an IPC namespace to join.
-- **private**: private IPC namespace.
-= **shareable**: private IPC namespace with a possibility to share it with other containers.
+@@option ipc
 
 #### **--label**, **-l**=*label*
 
@@ -528,9 +279,7 @@ Add metadata to a container (e.g., --label com.example.key=value)
 
 Read in a line delimited file of labels
 
-#### **--link-local-ip**=*ip*
-
-Not implemented
+@@option link-local-ip
 
 #### **--log-driver**=*driver*
 
@@ -607,87 +356,11 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
 #### **--memory-swappiness**=*number*
 
-Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
+Tune a container's memory swappiness behavior. Accepts an integer between *0* and *100*.
 
 This flag is not supported on cgroups V2 systems.
 
-#### **--mount**=*type=TYPE,TYPE-SPECIFIC-OPTION[,...]*
-
-Attach a filesystem mount to the container
-
-Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and **devpts**. <sup>[[1]](#Footnote1)</sup>
-
-       e.g.
-
-       type=bind,source=/path/on/host,destination=/path/in/container
-
-       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
-
-       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
-
-       type=volume,source=vol1,destination=/path/in/container,ro=true
-
-       type=tmpfs,tmpfs-size=512M,destination=/path/in/container
-
-       type=image,source=fedora,destination=/fedora-image,rw=true
-
-       type=devpts,destination=/dev/pts
-
-       Common Options:
-
-	      · src, source: mount source spec for bind and volume. Mandatory for bind.
-
-	      · dst, destination, target: mount destination spec.
-
-       Options specific to volume:
-
-	      · ro, readonly: true or false (default).
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
-
-       Options specific to image:
-
-	      · rw, readwrite: true or false (default).
-
-       Options specific to bind:
-
-	      · ro, readonly: true or false (default).
-
-	      · bind-propagation: shared, slave, private, unbindable, rshared, rslave, runbindable, or rprivate(default). See also mount(2).
-
-	      . bind-nonrecursive: do not set up a recursive bind mount. By default it is recursive.
-
-	      . relabel: shared, private.
-
-	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-       Options specific to tmpfs:
-
-	      · ro, readonly: true or false (default).
-
-	      · tmpfs-size: Size of the tmpfs mount in bytes. Unlimited by default in Linux.
-
-	      · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
-
-	      · tmpcopyup: Enable copyup from the image directory at the same location to the tmpfs. Used by default.
-
-	      · notmpcopyup: Disable copying files from the image to the tmpfs.
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-       Options specific to devpts:
-
-	      · uid: UID of the file owner (default 0).
-
-	      · gid: GID of the file owner (default 0).
-
-	      · mode: permission mask for the file (default 600).
-
-	      · max: maximum number of PTYs (default 1048576).
+@@option mount
 
 #### **--name**=*name*
 
@@ -736,18 +409,9 @@ Valid _mode_ values are:
   Note: Rootlesskit changes the source IP address of incoming packets to an IP address in the container network namespace, usually `10.0.2.100`. If your application requires the real source IP address, e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for rootless containers when connected to user-defined networks.
   - **port_handler=slirp4netns**: Use the slirp4netns port forwarding, it is slower than rootlesskit but preserves the correct source IP address. This port handler cannot be used for user-defined networks.
 
-#### **--network-alias**=*alias*
+@@option network-alias
 
-Add a network-scoped alias for the container, setting the alias for all networks that the container joins. To set a
-name only for a specific network, use the alias option as described under the **--network** option.
-If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <name>`),
-these aliases can be used for name resolution on the given network. This option can be specified multiple times.
-NOTE: When using CNI a container will only have access to aliases on the first network that it joins. This limitation does
-not exist with netavark/aardvark-dns.
-
-#### **--no-healthcheck**
-
-Disable any defined healthchecks for container.
+@@option no-healthcheck
 
 #### **--no-hosts**
 
@@ -756,28 +420,15 @@ By default, Podman will manage _/etc/hosts_, adding the container's own IP addre
 **--no-hosts** disables this, and the image's _/etc/hosts_ will be preserved unmodified.
 This option conflicts with **--add-host**.
 
-#### **--oom-kill-disable**
+@@option oom-kill-disable
 
-Whether to disable OOM Killer for the container or not.
+@@option oom-score-adj
 
-This flag is not supported on cgroups V2 systems.
+@@option os
 
-#### **--oom-score-adj**=*num*
+@@option passwd-entry
 
-Tune the host's OOM preferences for containers (accepts -1000 to 1000)
-
-#### **--os**=*OS*
-Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
-
-#### **--passwd-entry**=*ENTRY*
-
-Customize the entry that is written to the `/etc/passwd` file within the container when `--passwd` is used.
-
-The variables $USERNAME, $UID, $GID, $NAME, $HOME are automatically replaced with their value at runtime.
-
-#### **--personality**=*persona*
-
-Personality sets the execution domain via Linux personality(2).
+@@option personality
 
 #### **--pid**=*pid*
 
@@ -788,19 +439,11 @@ Default is to create a private PID namespace for the container
 - `ns`: join the specified PID namespace
 - `private`: create a new namespace for the container (default)
 
-#### **--pidfile**=*path*
-
-When the pidfile location is specified, the container process' PID will be written to the pidfile. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
-If the pidfile option is not specified, the container process' PID will be written to /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
-
-After the container is started, the location for the pidfile can be discovered with the following `podman inspect` command:
-
-    $ podman inspect --format '{{ .PidFile }}' $CID
-    /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile
+@@option pidfile
 
 #### **--pids-limit**=*limit*
 
-Tune the container's pids limit. Set `-1` to have unlimited pids for the container. (default "4096" on systems that support PIDS cgroups).
+Tune the container's pids limit. Set to **-1** to have unlimited pids for the container. The default is **4096** on systems that support "pids" cgroup controller.
 
 #### **--platform**=*OS/ARCH*
 
@@ -812,25 +455,9 @@ The `--platform` option can be used to override the current architecture and ope
 Run container in an existing pod. If you want Podman to make the pod for you, preference the pod name with `new:`.
 To make a pod with more granular options, use the `podman pod create` command before creating a container.
 
-#### **--pod-id-file**=*path*
+@@option pod-id-file.container
 
-Run container in an existing pod and read the pod's ID from the specified file. If a container is run within a pod, and the pod has an infra-container, the infra-container will be started before the container is.
-
-#### **--privileged**
-
-Give extended privileges to this container. The default is *false*.
-
-By default, Podman containers are
-“unprivileged” (=false) and cannot, for example, modify parts of the operating system.
-This is because by default a container is not allowed to access any devices.
-A “privileged” container is given access to all devices.
-
-When the operator executes a privileged container, Podman enables access
-to all devices on the host, turns off graphdriver mount options, as well as
-turning off most of the security measures protecting the host from the
-container.
-
-Rootless containers cannot have more privileges than the account that launched them.
+@@option privileged
 
 #### **--publish**, **-p**=*[[ip:][hostPort]:]containerPort[/protocol]*
 
@@ -860,17 +487,7 @@ associated ports. If one container binds to a port, no other container can use t
 within the pod while it is in use. Containers in the pod can also communicate over localhost
 by having one container bind to localhost in the pod, and another connect to that port.
 
-#### **--publish-all**, **-P**
-
-Publish all exposed ports to random ports on the host interfaces. The default is *false*.
-
-When set to true publish all exposed ports to the host interfaces. The
-default is false. If the operator uses -P (or -p) then Podman will make the
-exposed port accessible on the host and the ports will be available to any
-client that can reach the host. When using -P, Podman will bind any exposed
-port to a random port on the host within an *ephemeral port range* defined by
-`/proc/sys/net/ipv4/ip_local_port_range`. To find the mapping between the host
-ports and the exposed ports, use `podman port`.
+@@option publish-all
 
 #### **--pull**=*policy*
 
@@ -885,21 +502,11 @@ Pull image policy. The default is **missing**.
 
 Suppress output information when pulling images
 
-#### **--read-only**
+@@option read-only
 
-Mount the container's root filesystem as read-only.
+@@option read-only-tmpfs
 
-By default a container will have its root filesystem writable allowing processes
-to write files anywhere. By specifying the `--read-only` flag the container will have
-its root filesystem mounted as read-only prohibiting any writes.
-
-#### **--read-only-tmpfs**
-
-If container is running in --read-only mode, then mount a read-write tmpfs on /run, /tmp, and /var/tmp. The default is *true*
-
-#### **--replace**
-
-If another container with the same name already exists, replace and remove it. The default is **false**.
+@@option replace
 
 #### **--requires**=*container*
 
@@ -907,82 +514,19 @@ Specify one or more requirements.
 A requirement is a dependency container that will be started before this container.
 Containers can be specified by name or ID, with multiple containers being separated by commas.
 
-#### **--restart**=*policy*
-
-Restart policy to follow when containers exit.
-Restart policy will not take effect if a container is stopped via the `podman kill` or `podman stop` commands.
-
-Valid values are:
-
-- `no`                       : Do not restart containers on exit
-- `on-failure[:max_retries]` : Restart containers when they exit with a non-0 exit code, retrying indefinitely or until the optional max_retries count is hit
-- `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
-- `unless-stopped`           : Identical to **always**
-
-Please note that restart will not restart containers after a system reboot.
-If this functionality is required in your environment, you can invoke Podman from a systemd unit file, or create an init script for whichever init system is in use.
-To generate systemd unit files, please see *podman generate systemd*
+@@option restart
 
 #### **--rm**
 
 Automatically remove the container when it exits. The default is *false*.
 
-#### **--rootfs**
+@@option rootfs
 
-If specified, the first argument refers to an exploded container on the file system.
+@@option sdnotify
 
-This is useful to run a container without requiring any image management, the rootfs
-of the container is assumed to be managed externally.
+@@option seccomp-policy
 
-  `Overlay Rootfs Mounts`
-
-   The `:O` flag tells Podman to mount the directory from the rootfs path as
-storage using the `overlay file system`. The container processes
-can modify content within the mount point which is stored in the
-container storage in a separate directory. In overlay terms, the source
-directory will be the lower, and the container storage directory will be the
-upper. Modifications to the mount point are destroyed when the container
-finishes executing, similar to a tmpfs mount point being unmounted.
-
-#### **--sdnotify**=**container** | *conmon* | *ignore*
-
-Determines how to use the NOTIFY_SOCKET, as passed with systemd and Type=notify.
-
-Default is **container**, which means allow the OCI runtime to proxy the socket into the
-container to receive ready notification. Podman will set the MAINPID to conmon's pid.
-The **conmon** option sets MAINPID to conmon's pid, and sends READY when the container
-has started. The socket is never passed to the runtime or the container.
-The **ignore** option removes NOTIFY_SOCKET from the environment for itself and child processes,
-for the case where some other process above Podman uses NOTIFY_SOCKET and Podman should not use it.
-
-#### **--seccomp-policy**=*policy*
-
-Specify the policy to select the seccomp profile. If set to *image*, Podman will look for a "io.containers.seccomp.profile" label in the container-image config and use its value as a seccomp profile. Otherwise, Podman will follow the *default* policy by applying the default profile unless specified otherwise via *--security-opt seccomp* as described below.
-
-Note that this feature is experimental and may change in the future.
-
-#### **--secret**=*secret[,opt=opt ...]*
-
-Give the container access to a secret. Can be specified multiple times.
-
-A secret is a blob of sensitive data which a container needs at runtime but
-should not be stored in the image or in source control, such as usernames and passwords,
-TLS certificates and keys, SSH keys or other important generic strings or binary content (up to 500 kb in size).
-
-When secrets are specified as type `mount`, the secrets are copied and mounted into the container when a container is created.
-When secrets are specified as type `env`, the secret will be set as an environment variable within the container.
-Secrets are written in the container at the time of container creation, and modifying the secret using `podman secret` commands
-after the container is created will not affect the secret inside the container.
-
-Secrets and its storage are managed using the `podman secret` command.
-
-Secret Options
-
-- `type=mount|env`    : How the secret will be exposed to the container. Default mount.
-- `target=target`     : Target of secret. Defaults to secret name.
-- `uid=0`             : UID of secret. Defaults to 0. Mount secret type only.
-- `gid=0`             : GID of secret. Defaults to 0. Mount secret type only.
-- `mode=0`            : Mode of secret. Defaults to 0444. Mount secret type only.
+@@option secret
 
 #### **--security-opt**=*option*
 
@@ -1017,15 +561,9 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
 
-#### **--shm-size**=*size*
+@@option shm-size
 
-Size of `/dev/shm` (format: `<number>[<unit>]`, where unit = b (bytes), k (kibibytes), m (mebibytes), or g (gibibytes))
-If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
-When size is `0`, there is no limit on the amount of memory used for IPC by the container.
-
-#### **--stop-signal**=*SIGTERM*
-
-Signal to stop a container. Default is SIGTERM.
+@@option stop-signal
 
 #### **--stop-timeout**=*seconds*
 
@@ -1056,57 +594,15 @@ Network Namespace - current sysctls allowed:
 
 Note: if you use the --network=host option these sysctls will not be allowed.
 
-#### **--systemd**=*true* | *false* | *always*
+@@option systemd
 
-Run container in systemd mode. The default is *true*.
-
-The value *always* enforces the systemd mode is enforced without
-looking at the executable name. Otherwise, if set to true and the
-command you are running inside the container is **systemd**, **/usr/sbin/init**,
-**/sbin/init** or **/usr/local/sbin/init**.
-
-Running the container in systemd mode causes the following changes:
-
-* Podman mounts tmpfs file systems on the following directories
-  * _/run_
-  * _/run/lock_
-  * _/tmp_
-  * _/sys/fs/cgroup/systemd_
-  * _/var/lib/journal_
-* Podman sets the default stop signal to **SIGRTMIN+3**.
-* Podman sets **container_uuid** environment variable in the container to the
-first 32 characters of the container id.
-
-This allows systemd to run in a confined container without any modifications.
-
-Note: On `SELinux` systems, systemd attempts to write to the cgroup
-file system. Containers writing to the cgroup file system are denied by default.
-The `container_manage_cgroup` boolean must be enabled for this to be allowed on an SELinux separated system.
-
-`setsebool -P container_manage_cgroup true`
-
-#### **--timeout**=*seconds*
-
-Maximum time a container is allowed to run before conmon sends it the kill
-signal.  By default containers will run until they exit or are stopped by
-`podman stop`.
+@@option timeout
 
 #### **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true, then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified, TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
-#### **--tmpfs**=*fs*
-
-Create a tmpfs mount
-
-Mount a temporary filesystem (`tmpfs`) mount into a container, for example:
-
-$ podman create -d --tmpfs /tmp:rw,size=787448k,mode=1777 my_image
-
-This command mounts a `tmpfs` at `/tmp` within the container. The supported mount
-options are the same as the Linux default `mount` flags. If you do not specify
-any options, the systems uses the following options:
-`rw,noexec,nosuid,nodev`.
+@@option tmpfs
 
 #### **--tty**, **-t**
 
@@ -1119,10 +615,7 @@ interactive shell. The default is false.
 Note: The **-t** option is incompatible with a redirection of the Podman client
 standard input.
 
-#### **--tz**=*timezone*
-
-Set timezone in container. This flag takes area-based timezones, GMT time, as well as `local`, which sets the timezone in the container to match the host machine. See `/usr/share/zoneinfo/` for valid timezones.
-Remote connections use local containers.conf for defaults
+@@option tz
 
 #### **--uidmap**=*container_uid:from_uid:amount*
 
@@ -1202,28 +695,13 @@ container UID by running `podman create --uidmap $container_uid:0:1 --user $cont
 
 Note: the **--uidmap** flag cannot be called in conjunction with the **--pod** flag as a uidmap cannot be set on the container level when in a pod.
 
-#### **--ulimit**=*option*
+@@option ulimit
 
-Ulimit options
+@@option umask
 
-You can pass `host` to copy the current configuration from the host.
+@@option unsetenv
 
-#### **--umask**=*umask*
-
-Set the umask inside the container. Defaults to `0022`.
-Remote connections use local containers.conf for defaults
-
-#### **--unsetenv**=*env*
-
-Unset default environment variables for the container. Default environment
-variables include variables provided natively by Podman, environment variables
-configured by the image, and environment variables from containers.conf.
-
-#### **--unsetenv-all**
-
-Unset all default environment variables for the container. Default environment
-variables include variables provided natively by Podman, environment variables
-configured by the image, and environment variables from containers.conf.
+@@option unsetenv-all
 
 #### **--user**, **-u**=*user*
 
@@ -1492,13 +970,7 @@ If the location of the volume from the source container overlaps with
 data residing on a target container, then the volume hides
 that data on the target.
 
-#### **--workdir**, **-w**=*dir*
-
-Working directory inside the container
-
-The default working directory for running binaries within a container is the root directory (/).
-The image developer can set a different default with the WORKDIR instruction. The operator
-can override the working directory by using the **-w** option.
+@@option workdir
 
 ## EXAMPLES
 

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -27,9 +27,7 @@ Set environment variables.
 
 This option allows arbitrary environment variables that are available for the process to be launched inside of the container. If an environment variable is specified without a value, Podman will check the host environment for a value and set the variable only if it is set on the host. As a special case, if an environment variable ending in __*__ is specified without a value, Podman will search the host environment for variables starting with the prefix and will add those variables to the container.
 
-#### **--env-file**=*file*
-
-Read in a line delimited file of environment variables.
+@@option env-file
 
 #### **--interactive**, **-i**
 
@@ -40,25 +38,9 @@ When set to true, keep stdin open even if not attached. The default is *false*.
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--preserve-fds**=*N*
+@@option preserve-fds
 
-Pass down to the process N additional file descriptors (in addition to 0, 1, 2).  The total FDs will be 3+N.
-
-#### **--privileged**
-
-Give extended privileges to this container. The default is *false*.
-
-By default, Podman containers are
-"unprivileged" and cannot, for example, modify parts of the operating system.
-This is because by default a container is only allowed limited access to devices.
-A "privileged" container is given the same access to devices as the user launching the container.
-
-A privileged container turns off the security features that isolate the
-container from the host. Dropped Capabilities, limited devices, read/only mount
-points, Apparmor/SELinux separation, and Seccomp filters are all disabled.
-
-Rootless containers cannot have more privileges than the account that launched them.
-
+@@option privileged
 
 #### **--tty**, **-t**
 
@@ -70,13 +52,7 @@ Sets the username or UID used and optionally the groupname or GID for the specif
 The following examples are all valid:
 --user [user | user:group | uid | uid:gid | user:gid | uid:group ]
 
-#### **--workdir**, **-w**=*path*
-
-Working directory inside the container
-
-The default working directory for running binaries within a container is the root directory (/).
-The image developer can set a different default with the WORKDIR instruction, which can be overridden
-when creating the container.
+@@option workdir
 
 ## Exit Status
 

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -11,54 +11,15 @@ podman\-pod\-clone - Creates a copy of an existing pod
 
 ## OPTIONS
 
-#### **--blkio-weight**=*weight*
+@@option blkio-weight
 
-Block IO weight (relative weight) accepts a weight value between 10 and 1000.
-
-#### **--blkio-weight-device**=*weight*
-
-Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`).
+@@option blkio-weight-device
 
 #### **--cgroup-parent**=*path*
 
 Path to cgroups under which the cgroup for the pod will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
-#### **--cpu-shares**, **-c**=*shares*
-
-CPU shares (relative weight)
-
-By default, all containers get the same proportion of CPU cycles. This proportion
-can be modified by changing the container's CPU share weighting relative
-to the weighting of all other running containers.
-
-To modify the proportion from the default of 1024, use the **--cpu-shares**
-flag to set the weighting to 2 or higher.
-
-The proportion will only apply when CPU-intensive processes are running.
-When tasks in one container are idle, other containers can use the
-left-over CPU time. The actual amount of CPU time will vary depending on
-the number of containers running on the system.
-
-For example, consider three containers, one has a cpu-share of 1024 and
-two others have a cpu-share setting of 512. When processes in all three
-containers attempt to use 100% of CPU, the first container would receive
-50% of the total CPU time. If you add a fourth container with a cpu-share
-of 1024, the first container only gets 33% of the CPU. The remaining containers
-receive 16.5%, 16.5% and 33% of the CPU.
-
-On a multi-core system, the shares of CPU time are distributed over all CPU
-cores. Even if a container is limited to less than 100% of CPU time, it can
-use 100% of each individual CPU core.
-
-For example, consider a system with more than three cores. If you start one
-container **{C0}** with **-c=512** running one process, and another container
-**{C1}** with **-c=1024** running two processes, this can result in the following
-division of CPU shares:
-
-PID    container	CPU	CPU share
-100    {C0}		0	100% of CPU0
-101    {C1}		1	100% of CPU1
-102    {C1}		2	100% of CPU2
+@@option cpu-shares
 
 #### **--cpus**
 
@@ -69,42 +30,17 @@ Set a number of CPUs for the pod that overrides the original pods CPU limits. If
 CPUs in which to allow execution (0-3, 0,1). If none are specified, the original pod's CPUset is used.
 
 
-#### **--cpuset-mems**=*nodes*
-
-Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
-
-If there are four memory nodes on the system (0-3), use `--cpuset-mems=0,1`
-then processes in the container will only use memory from the first
-two memory nodes.
+@@option cpuset-mems
 
 #### **--destroy**
 
 Remove the original pod that we are cloning once used to mimic the configuration.
 
-#### **--device**=*host-device[:container-device][:permissions]*
+@@option device.pod
 
-Add a host device to the pod. Optional *permissions* parameter
-can be used to specify device permissions. It is a combination of
-**r** for read, **w** for write, and **m** for **mknod**(2).
+@@option device-read-bps
 
-Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
-
-Note: if _host_device_ is a symbolic link then it will be resolved first.
-The pod will only store the major and minor numbers of the host device.
-
-Note: the pod implements devices by storing the initial configuration passed by the user and recreating the device on each container added to the pod.
-
-Podman may load kernel modules required for using the specified
-device. The devices that Podman will load modules for when necessary are:
-/dev/fuse.
-
-#### **--device-read-bps**=*path*
-
-Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb).
-
-#### **--device-write-bps**=*path*
-
-Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
+@@option device-write-bps
 
 #### **--gidmap**=*pod_gid:host_gid:amount*
 
@@ -114,21 +50,13 @@ GID map for the user namespace. Using this flag will run all containers in the p
 
 Print usage statement.
 
-#### **--hostname**=*name*
+@@option hostname.pod
 
-Set a hostname to the pod.
+@@option infra-command
 
-#### **--infra-command**=*command*
+@@option infra-conmon-pidfile
 
-The command that will be run to start the infra container. Default: "/pause".
-
-#### **--infra-conmon-pidfile**=*file*
-
-Write the pid of the infra container's **conmon** process to a file. As **conmon** runs in a separate process than Podman, this is necessary when using systemd to manage Podman containers and pods.
-
-#### **--infra-name**=*name*
-
-The name that will be used for the pod's infra container.
+@@option infra-name
 
 #### **--label**, **-l**=*label*
 
@@ -203,11 +131,7 @@ Note: Labeling can be disabled for all pods/containers by setting label=false in
 
 Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
 
-#### **--shm-size**=*size*
-
-Size of `/dev/shm` (format: `<number>[<unit>]`, where unit = b (bytes), k (kibibytes), m (mebibytes), or g (gibibytes))
-If the unit is omitted, the system uses bytes. If the size is omitted, the system uses `64m`.
-When size is `0`, there is no limit on the amount of memory used for IPC by the pod. This option conflicts with **--ipc=host** when running containers.
+@@option shm-size
 
 #### **--start**
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -28,62 +28,18 @@ which by default, is the cgroup parent for all containers joining the pod. Conta
 
 ## OPTIONS
 
-#### **--add-host**=*host:ip*
-
-Add a custom host-to-IP mapping (host:ip)
-
-Add a line to /etc/hosts. The format is hostname:ip. The **--add-host**
-option can be set multiple times.
+@@option add-host
 The /etc/hosts file is shared between all containers in the pod.
 
-#### **--blkio-weight**=*weight*
+@@option blkio-weight
 
-Block IO weight (relative weight) accepts a weight value between 10 and 1000.
-
-#### **--blkio-weight-device**=*weight*
-
-Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`).
+@@option blkio-weight-device
 
 #### **--cgroup-parent**=*path*
 
 Path to cgroups under which the cgroup for the pod will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
-#### **--cpu-shares**, **-c**=*shares*
-
-CPU shares (relative weight)
-
-By default, all containers get the same proportion of CPU cycles. This proportion
-can be modified by changing the container's CPU share weighting relative
-to the weighting of all other running containers.
-
-To modify the proportion from the default of 1024, use the **--cpu-shares**
-flag to set the weighting to 2 or higher.
-
-The proportion will only apply when CPU-intensive processes are running.
-When tasks in one container are idle, other containers can use the
-left-over CPU time. The actual amount of CPU time will vary depending on
-the number of containers running on the system.
-
-For example, consider three containers, one has a cpu-share of 1024 and
-two others have a cpu-share setting of 512. When processes in all three
-containers attempt to use 100% of CPU, the first container would receive
-50% of the total CPU time. If you add a fourth container with a cpu-share
-of 1024, the first container only gets 33% of the CPU. The remaining containers
-receive 16.5%, 16.5% and 33% of the CPU.
-
-On a multi-core system, the shares of CPU time are distributed over all CPU
-cores. Even if a container is limited to less than 100% of CPU time, it can
-use 100% of each individual CPU core.
-
-For example, consider a system with more than three cores. If you start one
-container **{C0}** with **-c=512** running one process, and another container
-**{C1}** with **-c=1024** running two processes, this can result in the following
-division of CPU shares:
-
-PID    container	CPU	CPU share
-100    {C0}		0	100% of CPU0
-101    {C1}		1	100% of CPU1
-102    {C1}		2	100% of CPU2
+@@option cpu-shares
 
 #### **--cpus**=*amount*
 
@@ -100,38 +56,13 @@ Examples of the List Format:
 0-4,9           # bits 0, 1, 2, 3, 4, and 9 set
 0-2,7,12-14     # bits 0, 1, 2, 7, 12, 13, and 14 set
 
-#### **--cpuset-mems**=*nodes*
+@@option cpuset-mems
 
-Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
+@@option device.pod
 
-If there are four memory nodes on the system (0-3), use `--cpuset-mems=0,1`
-then processes in the container will only use memory from the first
-two memory nodes.
+@@option device-read-bps
 
-#### **--device**=_host-device_[**:**_container-device_][**:**_permissions_]
-
-Add a host device to the pod. Optional *permissions* parameter
-can be used to specify device permissions. It is a combination of
-**r** for read, **w** for write, and **m** for **mknod**(2).
-
-Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
-
-Note: if *host-device* is a symbolic link then it will be resolved first.
-The pod will only store the major and minor numbers of the host device.
-
-Note: the pod implements devices by storing the initial configuration passed by the user and recreating the device on each container added to the pod.
-
-Podman may load kernel modules required for using the specified
-device. The devices that Podman will load modules for when necessary are:
-/dev/fuse.
-
-#### **--device-read-bps**=*path*
-
-Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)
-
-#### **--device-write-bps**=*path*
-
-Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
+@@option device-write-bps
 
 #### **--dns**=*ipaddr*
 
@@ -162,29 +93,21 @@ GID map for the user namespace. Using this flag will run the container with user
 
 Print usage statement.
 
-#### **--hostname**=*name*
-
-Set a hostname to the pod
+@@option hostname.pod
 
 #### **--infra**
 
 Create an infra container and associate it with the pod. An infra container is a lightweight container used to coordinate the shared kernel namespace of a pod. Default: true.
 
-#### **--infra-command**=*command*
+@@option infra-command
 
-The command that will be run to start the infra container. Default: "/pause".
-
-#### **--infra-conmon-pidfile**=*file*
-
-Write the pid of the infra container's **conmon** process to a file. As **conmon** runs in a separate process than Podman, this is necessary when using systemd to manage Podman containers and pods.
+@@option infra-conmon-pidfile
 
 #### **--infra-image**=*image*
 
 The custom image that will be used for the infra container.  Unless specified, Podman builds a custom local image which does not require pulling down an image.
 
-#### **--infra-name**=*name*
-
-The name that will be used for the pod's infra container.
+@@option infra-name
 
 #### **--ip**=*ip*
 
@@ -282,14 +205,7 @@ Valid _mode_ values are:
   Note: Rootlesskit changes the source IP address of incoming packets to an IP address in the container network namespace, usually `10.0.2.100`. If your application requires the real source IP address, e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for rootless containers when connected to user-defined networks.
   - **port_handler=slirp4netns**: Use the slirp4netns port forwarding, it is slower than rootlesskit but preserves the correct source IP address. This port handler cannot be used for user-defined networks.
 
-#### **--network-alias**=*alias*
-
-Add a network-scoped alias for the pod, setting the alias for all networks that the container joins. To set a
-name only for a specific network, use the alias option as described under the **--network** option.
-If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <name>`),
-these aliases can be used for name resolution on the given network. This option can be specified multiple times.
-NOTE: When using CNI a pod will only have access to aliases on the first network that it joins. This limitation does
-not exist with netavark/aardvark-dns.
+@@option network-alias
 
 #### **--no-hosts**
 
@@ -335,9 +251,7 @@ but only by the pod itself.
 
 **Note:** This cannot be modified once the pod is created.
 
-#### **--replace**
-
-If another pod with the same name already exists, replace and remove it.  The default is **false**.
+@@option replace
 
 #### **--security-opt**=*option*
 
@@ -381,11 +295,7 @@ This boolean determines whether or not all containers entering the pod will use 
 
 Note: This options conflict with **--share=cgroup** since that would set the pod as the cgroup parent but enter the container into the same cgroupNS as the infra container.
 
-#### **--shm-size**=*size*
-
-Size of `/dev/shm` (format: `<number>[<unit>]`, where unit = b (bytes), k (kibibytes), m (mebibytes), or g (gibibytes))
-If the unit is omitted, the system uses bytes. If the size is omitted, the system uses `64m`.
-When size is `0`, there is no limit on the amount of memory used for IPC by the pod. This option conflicts with **--ipc=host** when running containers.
+@@option shm-size
 
 #### **--subgidname**=*name*
 

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -81,9 +81,7 @@ solely for scripting compatibility.
 
 Print the usage statement.
 
-#### **--os**=*OS*
-
-Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
+@@option os
 
 #### **--platform**=*OS/ARCH*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -83,12 +83,8 @@ and specified with a _tag_.
     $ podman run oci-archive:/tmp/fedora echo hello
 
 ## OPTIONS
-#### **--add-host**=*host:ip*
 
-Add a custom host-to-IP mapping (host:ip)
-
-Add a line to /etc/hosts. The format is hostname:ip. The **--add-host**
-option can be set multiple times.
+@@option add-host
 
 #### **--annotation**=*key=value*
 
@@ -116,144 +112,41 @@ Path to the authentication file. Default is *${XDG_RUNTIME_DIR}/containers/auth.
 Note: You can also override the default path of the authentication file by setting the **REGISTRY_AUTH_FILE**
 environment variable.
 
-#### **--blkio-weight**=*weight*
+@@option blkio-weight
 
-Block IO relative weight. The _weight_ is a value between **10** and **1000**.
+@@option blkio-weight-device
 
-#### **--blkio-weight-device**=*device:weight*
+@@option cap-add
 
-Block IO relative device weight.
+@@option cap-drop
 
-#### **--cap-add**=*capability*
-
-Add Linux capabilities.
-
-#### **--cap-drop**=*capability*
-
-Drop Linux capabilities.
-
-#### **--cgroup-conf**=*KEY=VALUE*
-
-When running on cgroup v2, specify the cgroup file to write to and its value. For example **--cgroup-conf=memory.high=1073741824** sets the memory.high limit to 1GB.
+@@option cgroup-conf
 
 #### **--cgroup-parent**=*path*
 
 Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
-#### **--cgroupns**=*mode*
+@@option cgroupns
 
-Set the cgroup namespace mode for the container.
+@@option cgroups
 
-- **host**: use the host's cgroup namespace inside the container.
-- **container:**_id_: join the namespace of the specified container.
-- **private**: create a new cgroup namespace.
-- **ns:**_path_: join the namespace at the specified path.
-
-If the host uses cgroups v1, the default is set to **host**. On cgroups v2, the default is **private**.
-
-#### **--cgroups**=*how*
-
-Determines whether the container will create CGroups.
-
-Default is **enabled**.
-
-The **enabled** option will create a new cgroup under the cgroup-parent.
-The **disabled** option will force the container to not create CGroups, and thus conflicts with CGroup options (**--cgroupns** and **--cgroup-parent**).
-The **no-conmon** option disables a new CGroup only for the **conmon** process.
-The **split** option splits the current CGroup in two sub-cgroups: one for conmon and one for the container payload. It is not possible to set **--cgroup-parent** with **split**.
-
-#### **--chrootdirs**=*path*
-
-Path to a directory inside the container that should be treated as a `chroot` directory.
-Any Podman managed file (e.g., /etc/resolv.conf, /etc/hosts, etc/hostname) that is mounted into the root directory will be mounted into that location as well.
-Multiple directories should be separated with a comma.
+@@option chrootdirs
 
 #### **--cidfile**=*file*
 
 Write the container ID to *file*.
 
-#### **--conmon-pidfile**=*file*
+@@option conmon-pidfile
 
-Write the pid of the **conmon** process to a file. As **conmon** runs in a separate process than Podman, this is necessary when using systemd to restart Podman containers.
-(This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option cpu-period
 
-#### **--cpu-period**=*limit*
+@@option cpu-quota
 
-Set the CPU period for the Completely Fair Scheduler (CFS), which is a
-duration in microseconds. Once the container's CPU quota is used up, it will
-not be scheduled to run until the current period ends. Defaults to 100000
-microseconds.
+@@option cpu-rt-period
 
-On some systems, changing the CPU limits may not be allowed for non-root
-users. For more details, see
-https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
+@@option cpu-rt-runtime
 
-#### **--cpu-quota**=*limit*
-
-Limit the CPU Completely Fair Scheduler (CFS) quota.
-
-Limit the container's CPU usage. By default, containers run with the full
-CPU resource. The limit is a number in microseconds. If you provide a number,
-the container will be allowed to use that much CPU time until the CPU period
-ends (controllable via **--cpu-period**).
-
-On some systems, changing the CPU limits may not be allowed for non-root
-users. For more details, see
-https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
-
-#### **--cpu-rt-period**=*microseconds*
-
-Limit the CPU real-time period in microseconds.
-
-Limit the container's Real Time CPU usage. This flag tell the kernel to restrict the container's Real Time CPU usage to the period you specify.
-
-This flag is not supported on cgroups V2 systems.
-
-#### **--cpu-rt-runtime**=*microseconds*
-
-Limit the CPU real-time runtime in microseconds.
-
-Limit the containers Real Time CPU usage. This flag tells the kernel to limit the amount of time in a given CPU period Real Time tasks may consume. Ex:
-Period of 1,000,000us and Runtime of 950,000us means that this container could consume 95% of available CPU and leave the remaining 5% to normal priority tasks.
-
-The sum of all runtimes across containers cannot exceed the amount allotted to the parent cgroup.
-
-This flag is not supported on cgroups V2 systems.
-
-#### **--cpu-shares**, **-c**=*shares*
-
-CPU shares (relative weight).
-
-By default, all containers get the same proportion of CPU cycles. This proportion
-can be modified by changing the container's CPU share weighting relative
-to the combined weight of all the running containers. Default weight is **1024**.
-
-The proportion will only apply when CPU-intensive processes are running.
-When tasks in one container are idle, other containers can use the
-left-over CPU time. The actual amount of CPU time will vary depending on
-the number of containers running on the system.
-
-For example, consider three containers, one has a cpu-share of 1024 and
-two others have a cpu-share setting of 512. When processes in all three
-containers attempt to use 100% of CPU, the first container would receive
-50% of the total CPU time. If you add a fourth container with a cpu-share
-of 1024, the first container only gets 33% of the CPU. The remaining containers
-receive 16.5%, 16.5% and 33% of the CPU.
-
-On a multi-core system, the shares of CPU time are distributed over all CPU
-cores. Even if a container is limited to less than 100% of CPU time, it can
-use 100% of each individual CPU core.
-
-For example, consider a system with more than three cores.
-If the container _C0_ is started with **--cpu-shares=512** running one process,
-and another container _C1_ with **--cpu-shares=1024** running two processes,
-this can result in the following division of CPU shares:
-
-| PID  |  container  | CPU     | CPU share    |
-| ---- | ----------- | ------- | ------------ |
-| 100  |  C0         | 0       | 100% of CPU0 |
-| 101  |  C1         | 1       | 100% of CPU1 |
-| 102  |  C1         | 2       | 100% of CPU2 |
+@@option cpu-shares
 
 #### **--cpus**=*number*
 
@@ -271,12 +164,7 @@ CPUs in which to allow execution. Can be specified as a comma-separated list
 (e.g. **0,1**), as a range (e.g. **0-3**), or any combination thereof
 (e.g. **0-3,7,11-15**).
 
-#### **--cpuset-mems**=*nodes*
-
-Memory nodes (MEMs) in which to allow execution. Only effective on NUMA systems.
-
-For example, if you have four memory nodes (0-3) on your system, use **--cpuset-mems=0,1**
-to only use memory from the first two memory nodes.
+@@option cpuset-mems
 
 #### **--detach**, **-d**
 
@@ -297,44 +185,19 @@ Specify the key sequence for detaching a container. Format is a single character
 
 This option can also be set in **containers.conf**(5) file.
 
-#### **--device**=*host-device[:container-device][:permissions]*
-
-Add a host device to the container. Optional *permissions* parameter
-can be used to specify device permissions by combining
-**r** for read, **w** for write, and **m** for **mknod**(2).
-
-Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
-
-Note: if _host_device_ is a symbolic link then it will be resolved first.
-The container will only store the major and minor numbers of the host device.
-
-Note: if the user only has access rights via a group, accessing the device
-from inside a rootless container will fail. Use the `--group-add keep-groups`
-flag to pass the user's supplementary group access into the container.
-
-Podman may load kernel modules required for using the specified
-device. The devices that Podman will load modules when necessary are:
-/dev/fuse.
+@@option device.container
 
 #### **--device-cgroup-rule**=*rule*
 
 Add a rule to the cgroup allowed devices list
 
-#### **--device-read-bps**=*path:rate*
+@@option device-read-bps
 
-Limit read rate (in bytes per second) from a device (e.g. **--device-read-bps=/dev/sda:1mb**).
+@@option device-read-iops
 
-#### **--device-read-iops**=*path:rate*
+@@option device-write-bps
 
-Limit read rate (in IO operations per second) from a device (e.g. **--device-read-iops=/dev/sda:1000**).
-
-#### **--device-write-bps**=*path:rate*
-
-Limit write rate (in bytes per second) to a device (e.g. **--device-write-bps=/dev/sda:1mb**).
-
-#### **--device-write-iops**=*path:rate*
-
-Limit write rate (in IO operations per second) to a device (e.g. **--device-write-iops=/dev/sda:1000**).
+@@option device-write-iops
 
 #### **--disable-content-trust**
 
@@ -342,44 +205,16 @@ This is a Docker specific option to disable image verification to a Docker
 registry and is not supported by Podman. This flag is a NOOP and provided
 solely for scripting compatibility.
 
-#### **--dns**=*ipaddr*
+@@option dns
 
-Set custom DNS servers. Invalid if using **--dns** with **--network** that is set to **none** or **container:**_id_.
-
-This option can be used to override the DNS
-configuration passed to the container. Typically this is necessary when the
-host DNS configuration is invalid for the container (e.g., **127.0.0.1**). When this
-is the case the **--dns** flag is necessary for every run.
-
-The special value **none** can be specified to disable creation of _/etc/resolv.conf_ in the container by Podman.
-The _/etc/resolv.conf_ file in the image will be used without changes.
-
-#### **--dns-opt**=*option*
-
-Set custom DNS options. Invalid if using **--dns-opt** with **--network** that is set to **none** or **container:**_id_.
+@@option dns-opt
 
 #### **--dns-search**=*domain*
 
 Set custom DNS search domains. Invalid if using **--dns-search** and **--network** that is set to **none** or **container:**_id_.
 Use **--dns-search=.** if you don't wish to set the search domain.
 
-#### **--entrypoint**=*"command"* | *'["command", "arg1", ...]'*
-
-Overwrite the default ENTRYPOINT of the image.
-
-This option allows you to overwrite the default entrypoint of the image.
-
-The ENTRYPOINT of an image is similar to a COMMAND
-because it specifies what executable to run when the container starts, but it is
-(purposely) more difficult to override. The ENTRYPOINT gives a container its
-default nature or behavior, so that when you set an ENTRYPOINT you can run the
-container as if it were that binary, complete with default options, and you can
-pass in more options via the COMMAND. But, sometimes an operator may want to run
-something else inside the container, so you can override the default ENTRYPOINT
-at runtime by using a **--entrypoint** and a string to specify the new
-ENTRYPOINT.
-
-You need to specify multi option commands in the form of a json string.
+@@option entrypoint
 
 #### **--env**, **-e**=*env*
 
@@ -389,18 +224,12 @@ This option allows arbitrary environment variables that are available for the pr
 
 See [**Environment**](#environment) note below for precedence and examples.
 
-#### **--env-file**=*file*
+@@option env-file
+See **Environment** note below for precedence.
 
-Read in a line delimited file of environment variables. See **Environment** note below for precedence.
+@@option env-host
 
-#### **--env-host**
-
-Use host environment inside of the container. See **Environment** note below for precedence. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
-
-#### **--expose**=*port*
-
-Expose a port, or a range of ports (e.g. **--expose=3300-3310**) to set up port redirection
-on the host system.
+@@option expose
 
 #### **--gidmap**=*container_gid:host_gid:amount*
 
@@ -411,93 +240,33 @@ __--uidmap__ maps host UIDs to container UIDs. For details see __--uidmap__.
 
 Note: the **--gidmap** flag cannot be called in conjunction with the **--pod** flag as a gidmap cannot be set on the container level when in a pod.
 
-#### **--group-add**=*group* | *keep-groups*
+@@option group-add
 
-Assign additional groups to the primary user running within the container process.
+@@option health-cmd
 
-- `keep-groups` is a special flag that tells Podman to keep the supplementary group access.
+@@option health-interval
 
-Allows container to use the user's supplementary group access. If file systems or
-devices are only accessible by the rootless user's group, this flag tells the OCI
-runtime to pass the group access into the container. Currently only available
-with the `crun` OCI runtime. Note: `keep-groups` is exclusive, you cannot add any other groups
-with this flag. (Not available for remote commands, including Mac and Windows (excluding WSL2) machines)
+@@option health-retries
 
-#### **--health-cmd**=*"command"* | *'["command", "arg1", ...]'*
+@@option health-start-period
 
-Set or alter a healthcheck command for a container. The command is a command to be executed inside your
-container that determines your container health. The command is required for other healthcheck options
-to be applied. A value of **none** disables existing healthchecks.
-
-Multiple options can be passed in the form of a JSON array; otherwise, the command will be interpreted
-as an argument to **/bin/sh -c**.
-
-#### **--health-interval**=*interval*
-
-Set an interval for the healthchecks. An _interval_ of **disable** results in no automatic timer setup. The default is **30s**.
-
-#### **--health-retries**=*retries*
-
-The number of retries allowed before a healthcheck is considered to be unhealthy. The default value is **3**.
-
-#### **--health-start-period**=*period*
-
-The initialization time needed for a container to bootstrap. The value can be expressed in time format like
-**2m3s**. The default value is **0s**.
-
-#### **--health-timeout**=*timeout*
-
-The maximum time allowed to complete the healthcheck before an interval is considered failed. Like start-period, the
-value can be expressed in a time format such as **1m22s**. The default value is **30s**.
+@@option health-timeout
 
 #### **--help**
 
 Print usage statement
 
-#### **--hostname**, **-h**=*name*
+@@option hostname.container
 
-Container host name
+@@option hostuser
 
-Sets the container host name that is available inside the container. Can only be used with a private UTS namespace `--uts=private` (default). If `--pod` is specified and the pod shares the UTS namespace (default) the pod's hostname will be used.
+@@option http-proxy
 
-#### **--hostuser**=*name*
+@@option image-volume
 
-Add a user account to /etc/passwd from the host to the container. The Username
-or UID must exist on the host system.
+@@option init
 
-#### **--http-proxy**
-
-By default proxy environment variables are passed into the container if set
-for the Podman process. This can be disabled by setting the value to **false**.
-The environment variables passed in include **http_proxy**,
-**https_proxy**, **ftp_proxy**, **no_proxy**, and also the upper case versions of
-those. This option is only needed when the host system must use a proxy but
-the container should not use any proxy. Proxy environment variables specified
-for the container in any other way will override the values that would have
-been passed through from the host. (Other ways to specify the proxy for the
-container include passing the values with the **--env** flag, or hard coding the
-proxy environment at container build time.) (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
-
-Defaults to **true**.
-
-#### **--image-volume**=**bind** | *tmpfs* | *ignore*
-
-Tells Podman how to handle the builtin image volumes. Default is **bind**.
-
-- **bind**: An anonymous named volume will be created and mounted into the container.
-- **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
-content that disappears when the container is stopped.
-- **ignore**: All volumes are just ignored and no action is taken.
-
-#### **--init**
-
-Run an init inside the container that forwards signals and reaps processes.
-The container-init binary is mounted at `/run/podman-init`.
-Mounting over `/run` will hence break container execution.
-
-#### **--init-path**=*path*
-
-Path to the container-init binary.
+@@option init-path
 
 #### **--interactive**, **-i**
 
@@ -521,18 +290,7 @@ The address must be within the network's IPv6 address pool.
 
 To specify multiple static IPv6 addresses per container, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
 
-#### **--ipc**=*mode*
-
-Set the IPC namespace mode for a container. The default is to create
-a private IPC namespace.
-
-- "": Use Podman's default, defined in containers.conf.
-- **container:**_id_: reuses another container shared memory, semaphores and message queues
-- **host**: use the host shared memory,semaphores and message queues inside the container. Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
-- **none**:  private IPC namespace, with /dev/shm not mounted.
-- **ns:**_path_: path to an IPC namespace to join.
-- **private**: private IPC namespace.
-= **shareable**: private IPC namespace with a possibility to share it with  other containers.
+@@option ipc
 
 #### **--label**, **-l**=*key=value*
 
@@ -542,9 +300,7 @@ Add metadata to a container.
 
 Read in a line-delimited file of labels.
 
-#### **--link-local-ip**=*ip*
-
-Not implemented.
+@@option link-local-ip
 
 #### **--log-driver**=*driver*
 
@@ -621,89 +377,9 @@ the value of **--memory**.
 
 Set _number_ to **-1** to enable unlimited swap.
 
-#### **--memory-swappiness**=*number*
+@@option memory-swappiness
 
-Tune a container's memory swappiness behavior. Accepts an integer between *0* and *100*.
-
-This flag is not supported on cgroups V2 systems.
-
-#### **--mount**=*type=TYPE,TYPE-SPECIFIC-OPTION[,...]*
-
-Attach a filesystem mount to the container
-
-Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and **devpts**. <sup>[[1]](#Footnote1)</sup>
-
-       e.g.
-
-       type=bind,source=/path/on/host,destination=/path/in/container
-
-       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
-
-       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
-
-       type=volume,source=vol1,destination=/path/in/container,ro=true
-
-       type=tmpfs,tmpfs-size=512M,destination=/path/in/container
-
-       type=image,source=fedora,destination=/fedora-image,rw=true
-
-       type=devpts,destination=/dev/pts
-
-       Common Options:
-
-	      · src, source: mount source spec for bind and volume. Mandatory for bind.
-
-	      · dst, destination, target: mount destination spec.
-
-       Options specific to volume:
-
-	      · ro, readonly: true or false (default).
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
-
-       Options specific to image:
-
-	      · rw, readwrite: true or false (default).
-
-       Options specific to bind:
-
-	      · ro, readonly: true or false (default).
-
-	      · bind-propagation: shared, slave, private, unbindable, rshared, rslave, runbindable, or rprivate(default). See also mount(2).
-
-	      . bind-nonrecursive: do not set up a recursive bind mount. By default it is recursive.
-
-	      . relabel: shared, private.
-
-	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-       Options specific to tmpfs:
-
-	      · ro, readonly: true or false (default).
-
-	      · tmpfs-size: Size of the tmpfs mount in bytes. Unlimited by default in Linux.
-
-	      · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
-
-	      · tmpcopyup: Enable copyup from the image directory at the same location to the tmpfs. Used by default.
-
-	      · notmpcopyup: Disable copying files from the image to the tmpfs.
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-       Options specific to devpts:
-
-	      · uid: UID of the file owner (default 0).
-
-	      · gid: GID of the file owner (default 0).
-
-	      · mode: permission mask for the file (default 600).
-
-	      · max: maximum number of PTYs (default 1048576).
+@@option mount
 
 #### **--name**=*name*
 
@@ -753,18 +429,9 @@ Valid _mode_ values are:
   Note: Rootlesskit changes the source IP address of incoming packets to an IP address in the container network namespace, usually `10.0.2.100`. If your application requires the real source IP address, e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for rootless containers when connected to user-defined networks.
   - **port_handler=slirp4netns**: Use the slirp4netns port forwarding, it is slower than rootlesskit but preserves the correct source IP address. This port handler cannot be used for user-defined networks.
 
-#### **--network-alias**=*alias*
+@@option network-alias
 
-Add a network-scoped alias for the container, setting the alias for all networks that the container joins. To set a
-name only for a specific network, use the alias option as described under the **--network** option.
-If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <name>`),
-these aliases can be used for name resolution on the given network. This option can be specified multiple times.
-NOTE: When using CNI a container will only have access to aliases on the first network that it joins. This limitation does
-not exist with netavark/aardvark-dns.
-
-#### **--no-healthcheck**
-
-Disable any defined healthchecks for container.
+@@option no-healthcheck
 
 #### **--no-hosts**
 
@@ -773,33 +440,20 @@ By default, Podman will manage _/etc/hosts_, adding the container's own IP addre
 **--no-hosts** disables this, and the image's _/etc/hosts_ will be preserved unmodified.
 This option conflicts with **--add-host**.
 
-#### **--oom-kill-disable**
+@@option oom-kill-disable
 
-Whether to disable OOM Killer for the container or not.
+@@option oom-score-adj
 
-This flag is not supported on cgroups V2 systems.
-
-#### **--oom-score-adj**=*num*
-
-Tune the host's OOM preferences for containers (accepts values from **-1000** to **1000**).
-
-#### **--os**=*OS*
-Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
+@@option os
 
 #### **--passwd**
 
 Allow Podman to add entries to /etc/passwd and /etc/group when used in conjunction with the --user option.
 This is used to override the Podman provided user setup in favor of entrypoint configurations such as libnss-extrausers.
 
-#### **--passwd-entry**=*ENTRY*
+@@option passwd-entry
 
-Customize the entry that is written to the `/etc/passwd` file within the container when `--passwd` is used.
-
-The variables $USERNAME, $UID, $GID, $NAME, $HOME are automatically replaced with their value at runtime.
-
-#### **--personality**=*persona*
-
-Personality sets the execution domain via Linux personality(2).
+@@option personality
 
 #### **--pid**=*mode*
 
@@ -811,19 +465,9 @@ The default is to create a private PID namespace for the container.
 - **private**: create a new namespace for the container (default)
 - **ns:**_path_: join the specified PID namespace.
 
-#### **--pidfile**=*path*
+@@option pidfile
 
-When the pidfile location is specified, the container process' PID will be written to the pidfile. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
-If the pidfile option is not specified, the container process' PID will be written to /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
-
-After the container is started, the location for the pidfile can be discovered with the following `podman inspect` command:
-
-    $ podman inspect --format '{{ .PidFile }}' $CID
-    /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile
-
-#### **--pids-limit**=*limit*
-
-Tune the container's pids limit. Set to **-1** to have unlimited pids for the container. The default is **4096** on systems that support "pids" cgroup controller.
+@@option pids-limit
 
 #### **--platform**=*OS/ARCH*
 
@@ -836,30 +480,11 @@ Run container in an existing pod. If you want Podman to make the pod for you, pr
 To make a pod with more granular options, use the **podman pod create** command before creating a container.
 If a container is run with a pod, and the pod has an infra-container, the infra-container will be started before the container is.
 
-#### **--pod-id-file**=*path*
+@@option pod-id-file.container
 
-Run container in an existing pod and read the pod's ID from the specified file.
-If a container is run within a pod, and the pod has an infra-container, the infra-container will be started before the container is.
+@@option preserve-fds
 
-#### **--preserve-fds**=*N*
-
-Pass down to the process N additional file descriptors (in addition to 0, 1, 2).
-The total FDs will be 3+N. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
-
-#### **--privileged**
-
-Give extended privileges to this container. The default is **false**.
-
-By default, Podman containers are unprivileged (**=false**) and cannot, for
-example, modify parts of the operating system. This is because by default a
-container is only allowed limited access to devices. A "privileged" container
-is given the same access to devices as the user launching the container.
-
-A privileged container turns off the security features that isolate the
-container from the host. Dropped Capabilities, limited devices, read-only mount
-points, Apparmor/SELinux separation, and Seccomp filters are all disabled.
-
-Rootless containers cannot have more privileges than the account that launched them.
+@@option privileged
 
 #### **--publish**, **-p**=*[[ip:][hostPort]:]containerPort[/protocol]*
 
@@ -889,18 +514,7 @@ associated ports. If one container binds to a port, no other container can use t
 within the pod while it is in use. Containers in the pod can also communicate over localhost
 by having one container bind to localhost in the pod, and another connect to that port.
 
-#### **--publish-all**, **-P**
-
-Publish all exposed ports to random ports on the host interfaces. The default is **false**.
-
-When set to **true**, publish all exposed ports to the host interfaces. The
-default is **false**. If the operator uses **-P** (or **-p**) then Podman will make the
-exposed port accessible on the host and the ports will be available to any
-client that can reach the host.
-
-When using this option, Podman will bind any exposed port to a random port on the host
-within an ephemeral port range defined by */proc/sys/net/ipv4/ip_local_port_range*.
-To find the mapping between the host ports and the exposed ports, use **podman port**.
+@@option publish-all
 
 #### **--pull**=*policy*
 
@@ -915,21 +529,11 @@ Pull image policy. The default is **missing**.
 
 Suppress output information when pulling images
 
-#### **--read-only**
+@@option read-only
 
-Mount the container's root filesystem as read-only.
+@@option read-only-tmpfs
 
-By default a container will have its root filesystem writable allowing processes
-to write files anywhere. By specifying the **--read-only** flag, the container will have
-its root filesystem mounted as read-only prohibiting any writes.
-
-#### **--read-only-tmpfs**
-
-If container is running in **--read-only** mode, then mount a read-write tmpfs on _/run_, _/tmp_, and _/var/tmp_. The default is **true**.
-
-#### **--replace**
-
-If another container with the same name already exists, replace and remove it. The default is **false**.
+@@option replace
 
 #### **--requires**=*container*
 
@@ -937,21 +541,7 @@ Specify one or more requirements.
 A requirement is a dependency container that will be started before this container.
 Containers can be specified by name or ID, with multiple containers being separated by commas.
 
-#### **--restart**=*policy*
-
-Restart policy to follow when containers exit.
-Restart policy will not take effect if a container is stopped via the **podman kill** or **podman stop** commands.
-
-Valid _policy_ values are:
-
-- `no`                       : Do not restart containers on exit
-- `on-failure[:max_retries]` : Restart containers when they exit with a non-zero exit code, retrying indefinitely or until the optional *max_retries* count is hit
-- `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
-- `unless-stopped`           : Identical to **always**
-
-Please note that restart will not restart containers after a system reboot.
-If this functionality is required in your environment, you can invoke Podman from a **systemd.unit**(5) file, or create an init script for whichever init system is in use.
-To generate systemd unit files, please see **podman generate systemd**.
+@@option restart
 
 #### **--rm**
 
@@ -962,65 +552,13 @@ Automatically remove the container when it exits. The default is **false**.
 After exit of the container, remove the image unless another
 container is using it. The default is *false*.
 
-#### **--rootfs**
+@@option rootfs
 
-If specified, the first argument refers to an exploded container on the file system.
+@@option sdnotify
 
-This is useful to run a container without requiring any image management, the rootfs
-of the container is assumed to be managed externally.
+@@option seccomp-policy
 
-  `Overlay Rootfs Mounts`
-
-   The `:O` flag tells Podman to mount the directory from the rootfs path as
-storage using the `overlay file system`. The container processes
-can modify content within the mount point which is stored in the
-container storage in a separate directory. In overlay terms, the source
-directory will be the lower, and the container storage directory will be the
-upper. Modifications to the mount point are destroyed when the container
-finishes executing, similar to a tmpfs mount point being unmounted.
-
-Note: On **SELinux** systems, the rootfs needs the correct label, which is by default
-**unconfined_u:object_r:container_file_t**.
-
-#### **--sdnotify**=**container** | *conmon* | *ignore*
-
-Determines how to use the NOTIFY_SOCKET, as passed with systemd and Type=notify.
-
-Default is **container**, which means allow the OCI runtime to proxy the socket into the
-container to receive ready notification. Podman will set the MAINPID to conmon's pid.
-The **conmon** option sets MAINPID to conmon's pid, and sends READY when the container
-has started. The socket is never passed to the runtime or the container.
-The **ignore** option removes NOTIFY_SOCKET from the environment for itself and child processes,
-for the case where some other process above Podman uses NOTIFY_SOCKET and Podman should not use it.
-
-#### **--seccomp-policy**=*policy*
-
-Specify the policy to select the seccomp profile. If set to *image*, Podman will look for a "io.containers.seccomp.profile" label in the container-image config and use its value as a seccomp profile. Otherwise, Podman will follow the *default* policy by applying the default profile unless specified otherwise via *--security-opt seccomp* as described below.
-
-Note that this feature is experimental and may change in the future.
-
-#### **--secret**=*secret[,opt=opt ...]*
-
-Give the container access to a secret. Can be specified multiple times.
-
-A secret is a blob of sensitive data which a container needs at runtime but
-should not be stored in the image or in source control, such as usernames and passwords,
-TLS certificates and keys, SSH keys or other important generic strings or binary content (up to 500 kb in size).
-
-When secrets are specified as type `mount`, the secrets are copied and mounted into the container when a container is created.
-When secrets are specified as type `env`, the secret will be set as an environment variable within the container.
-Secrets are written in the container at the time of container creation, and modifying the secret using `podman secret` commands
-after the container is created will not affect the secret inside the container.
-
-Secrets and its storage are managed using the `podman secret` command.
-
-Secret Options
-
-- `type=mount|env`    : How the secret will be exposed to the container. Default mount.
-- `target=target`     : Target of secret. Defaults to secret name.
-- `uid=0`             : UID of secret. Defaults to 0. Mount secret type only.
-- `gid=0`             : GID of secret. Defaults to 0. Mount secret type only.
-- `mode=0`            : Mode of secret. Defaults to 0444. Mount secret type only.
+@@option secret
 
 #### **--security-opt**=*option*
 
@@ -1054,19 +592,13 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 Note: Labeling can be disabled for all containers by setting **label=false** in the **containers.conf**(5) file.
 
-#### **--shm-size**=*number[unit]*
-
-Size of _/dev/shm_. A _unit_ can be **b** (bytes), **k** (kibibytes), **m** (mebibytes), or **g** (gibibytes).
-If you omit the unit, the system uses bytes. If you omit the size entirely, the default is **64m**.
-When _size_ is **0**, there is no limit on the amount of memory used for IPC by the container.
+@@option shm-size
 
 #### **--sig-proxy**
 
 Sets whether the signals sent to the **podman run** command are proxied to the container process. SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is **true**.
 
-#### **--stop-signal**=*signal*
-
-Signal to stop a container. Default is **SIGTERM**.
+@@option stop-signal
 
 #### **--stop-timeout**=*seconds*
 
@@ -1109,60 +641,15 @@ For the network namespace, the following sysctls are allowed:
 
 Note: if you use the **--network=host** option, these sysctls will not be allowed.
 
-#### **--systemd**=*true* | *false* | *always*
+@@option systemd
 
-Run container in systemd mode. The default is **true**.
-
-The value *always* enforces the systemd mode is enforced without
-looking at the executable name. Otherwise, if set to true and the
-command you are running inside the container is **systemd**, **/usr/sbin/init**,
-**/sbin/init** or **/usr/local/sbin/init**.
-
-Running the container in systemd mode causes the following changes:
-
-* Podman mounts tmpfs file systems on the following directories
-  * _/run_
-  * _/run/lock_
-  * _/tmp_
-  * _/sys/fs/cgroup/systemd_
-  * _/var/lib/journal_
-* Podman sets the default stop signal to **SIGRTMIN+3**.
-* Podman sets **container_uuid** environment variable in the container to the
-first 32 characters of the container id.
-
-This allows systemd to run in a confined container without any modifications.
-
-Note that on **SELinux** systems, systemd attempts to write to the cgroup
-file system. Containers writing to the cgroup file system are denied by default.
-The **container_manage_cgroup** boolean must be enabled for this to be allowed on an SELinux separated system.
-```
-setsebool -P container_manage_cgroup true
-```
-
-#### **--timeout**=*seconds*
-
-Maximum time a container is allowed to run before conmon sends it the kill
-signal.  By default containers will run until they exit or are stopped by
-`podman stop`.
+@@option timeout
 
 #### **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true, then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified, TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
-#### **--tmpfs**=*fs*
-
-Create a tmpfs mount.
-
-Mount a temporary filesystem (**tmpfs**) mount into a container, for example:
-
-```
-$ podman run -d --tmpfs /tmp:rw,size=787448k,mode=1777 my_image
-```
-
-This command mounts a **tmpfs** at _/tmp_ within the container. The supported mount
-options are the same as the Linux default mount flags. If you do not specify
-any options, the system uses the following options:
-**rw,noexec,nosuid,nodev**.
+@@option tmpfs
 
 #### **--tty**, **-t**
 
@@ -1178,10 +665,7 @@ interactive shell. The default is **false**.
 echo "asdf" | podman run --rm -i someimage /bin/cat
 ```
 
-#### **--tz**=*timezone*
-
-Set timezone in container. This flag takes area-based timezones, GMT time, as well as `local`, which sets the timezone in the container to match the host machine. See `/usr/share/zoneinfo/` for valid timezones.
-Remote connections use local containers.conf for defaults
+@@option tz
 
 #### **--uidmap**=*container_uid:from_uid:amount*
 
@@ -1263,26 +747,13 @@ container UID by running `podman run --uidmap $container_uid:0:1 --user $contain
 
 Note: the **--uidmap** flag cannot be called in conjunction with the **--pod** flag as a uidmap cannot be set on the container level when in a pod.
 
-#### **--ulimit**=*option*
+@@option ulimit
 
-Ulimit options. You can use **host** to copy the current configuration from the host.
+@@option umask
 
-#### **--umask**=*umask*
+@@option unsetenv
 
-Set the umask inside the container. Defaults to `0022`.
-Remote connections use local containers.conf for defaults
-
-#### **--unsetenv**=*env*
-
-Unset default environment variables for the container. Default environment
-variables include variables provided natively by Podman, environment variables
-configured by the image, and environment variables from containers.conf.
-
-#### **--unsetenv-all**
-
-Unset all default environment variables for the container. Default environment
-variables include variables provided natively by Podman, environment variables
-configured by the image, and environment variables from containers.conf.
+@@option unsetenv-all
 
 #### **--user**, **-u**=*user[:group]*
 
@@ -1555,13 +1026,7 @@ If the location of the volume from the source container overlaps with
 data residing on a target container, then the volume hides
 that data on the target.
 
-#### **--workdir**, **-w**=*dir*
-
-Working directory inside the container.
-
-The default working directory for running binaries within a container is the root directory (**/**).
-The image developer can set a different default with the WORKDIR instruction. The operator
-can override the working directory by using the **-w** option.
+@@option workdir
 
 ## Exit Status
 

--- a/hack/markdown-preprocess
+++ b/hack/markdown-preprocess
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+#
+# markdown-preprocess - filter *.md.in files, convert to .md
+#
+
+import glob
+import os
+import sys
+
+def main():
+    try:
+        os.chdir("docs/source/markdown")
+    except FileNotFoundError:
+        raise Exception("Please invoke me from the base repo dir")
+
+    # If called with args, process only those files
+    infiles = [ os.path.basename(x) for x in sys.argv[1:] ]
+    if len(infiles) == 0:
+        # Called without args: process all *.md.in files
+        infiles = glob.glob('*.md.in')
+    for infile in infiles:
+        process(infile)
+
+def process(infile):
+    # Some options are the same between containers and pods; determine
+    # which description to use from the name of the source man page.
+    pod_or_container = 'container'
+    if '-pod-' in infile:
+        pod_or_container = 'pod'
+
+    # Sometimes a man page includes the subcommand.
+    subcommand = infile.removeprefix("podman-").removesuffix(".1.md.in").replace("-", " ")
+
+    # foo.md.in -> foo.md -- but always write to a tmpfile
+    outfile = os.path.splitext(infile)[0]
+    outfile_tmp = outfile + '.tmp.' + str(os.getpid())
+
+#    print("got here: ",infile, " -> ", outfile)
+
+    with open(infile, 'r') as fh_in, open(outfile_tmp, 'w') as fh_out:
+        for line in fh_in:
+            # '@@option foo' -> include file options/foo.md
+            if line.startswith('@@option '):
+                _, optionname = line.strip().split(" ")
+                optionfile = os.path.join("options", optionname + '.md')
+                fh_out.write("[//]: # (BEGIN included file " + optionfile + ")\n")
+                with open(optionfile, 'r') as fh_optfile:
+                    for opt_line in fh_optfile:
+                        opt_line = opt_line.replace('<POD-OR-CONTAINER>', pod_or_container)
+                        opt_line = opt_line.replace('<SUBCOMMAND>', subcommand)
+                        fh_out.write(opt_line)
+                fh_out.write("[//]: # (END   included file " + optionfile + ")\n")
+            else:
+                fh_out.write(line)
+
+    os.chmod(outfile_tmp, 0o444)
+    os.rename(outfile_tmp, outfile)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Many options are common to multiple commands and man pages,
e.g., podman run and create have countless identical options.
To date, those have been documented via copy/pasting, and
(shudder) maintaining, across multiple .md files.

Solution: add an 'include' mechanism such that multiple
md source files can fetch from a common file documenting
an option.

See discussion #13435

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
Consolidated descriptions of common options across man pages
```