### PR TITLE
Add missing -l equivalent option for --log-level

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -455,7 +455,7 @@ func rootFlags(cmd *cobra.Command, opts *entities.PodmanConfig) {
 	pFlags.BoolVar(&dummyHelp, "help", false, "Help for podman")
 
 	logLevelFlagName := "log-level"
-	pFlags.StringVar(&logLevel, logLevelFlagName, logLevel, fmt.Sprintf("Log messages above specified level (%s)", strings.Join(common.LogLevels, ", ")))
+	pFlags.StringVarP(&logLevel, logLevelFlagName, "l", logLevel, fmt.Sprintf("Log messages above specified level (%s)", strings.Join(common.LogLevels, ", ")))
 	_ = rootCmd.RegisterFlagCompletionFunc(logLevelFlagName, common.AutocompleteLogLevel)
 
 	// Only create these flags for ABI connections

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -78,7 +78,7 @@ Identity value resolution precedence:
  - `containers.conf`
 Remote connections use local containers.conf for default.
 
-#### **--log-level**=*level*
+#### **--log-level**, "**-l**"=*level*
 
 Log messages at and above specified level: debug, info, warn, error, fatal or panic (default: "warn")
 

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -173,10 +173,10 @@ See 'podman version --help'" "podman version --remote"
     is "$output" 'Log Level "telepathic" is not supported.*'
     run_podman --log-level=trace   info
     run_podman --log-level=debug   info
-    run_podman --log-level=info    info
+    run_podman --l=info    info
     run_podman --log-level=warn    info
     run_podman --log-level=warning info
-    run_podman --log-level=error   info
+    run_podman --l error   info
     run_podman --log-level=fatal   info
     run_podman --log-level=panic   info
 }


### PR DESCRIPTION
Needed for Docker compatibility.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman now supports -l as a shorthand option for --log-level

```
