### PR TITLE
Cirrus: Trigger podman-machine task by label

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -588,11 +588,14 @@ rootless_integration_test_task:
 podman_machine_task:
     name: *std_name_fmt
     alias: podman_machine
+    # Required_pr_labels does not apply to non-PRs.
+    # Do not run on tags, branches, [CI:BUILD], or [CI:DOCS].
     only_if: *not_tag_branch_build_docs
-    # Manually-triggered task: This is "expensive" to run.
+    # This task costs about $4 per attempt to execute.
+    # Only run it if a magic PR label is present.
     # DO NOT ADD THIS TASK AS DEPENDENCY FOR `success_task`
-    # it will cause 'success' to block.
-    trigger_type: manual
+    # it will cause an infinate-block / never completing build.
+    required_pr_labels: test_podman_machine
     depends_on:
         - build
         - local_integration_test
@@ -879,8 +882,8 @@ success_task:
         - remote_integration_test
         - container_integration_test
         - rootless_integration_test
-        # Manually triggered task. If made automatic, remove bypass
-        # in contrib/cirrus/cirrus_yaml_test.py for this task.
+        # Label triggered task. If made automatic, remove line below
+        # AND bypass in contrib/cirrus/cirrus_yaml_test.py for this name.
         # - podman_machine
         - local_system_test
         - remote_system_test


### PR DESCRIPTION
Instead of requiring developers to search for a magic button, make the
task trigger at the time a special PR label is added.  Update comments
accordingly.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
