### PR TITLE
"podman pod pause" return error if cgroups v1 rootless container

### DIFF
--- a/cmd/podman/containers/pause.go
+++ b/cmd/podman/containers/pause.go
@@ -5,12 +5,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/containers/common/pkg/cgroups"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -65,12 +63,6 @@ func pause(cmd *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
-	if rootless.IsRootless() && !registry.IsRemote() {
-		cgroupv2, _ := cgroups.IsCgroup2UnifiedMode()
-		if !cgroupv2 {
-			return errors.New("pause is not supported for cgroupv1 rootless containers")
-		}
-	}
 
 	if len(args) < 1 && !pauseOpts.All {
 		return errors.New("you must provide at least one container name or id")

--- a/pkg/domain/infra/abi/pods.go
+++ b/pkg/domain/infra/abi/pods.go
@@ -138,6 +138,7 @@ func (ic *ContainerEngine) PodPause(ctx context.Context, namesOrIds []string, op
 		errs, err := p.Pause(ctx)
 		if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
 			report.Errs = []error{err}
+			reports = append(reports, &report)
 			continue
 		}
 		if len(errs) > 0 {
@@ -171,6 +172,7 @@ func (ic *ContainerEngine) PodUnpause(ctx context.Context, namesOrIds []string, 
 		errs, err := p.Unpause(ctx)
 		if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
 			report.Errs = []error{err}
+			reports = append(reports, &report)
 			continue
 		}
 		if len(errs) > 0 {
@@ -196,6 +198,7 @@ func (ic *ContainerEngine) PodStop(ctx context.Context, namesOrIds []string, opt
 		errs, err := p.StopWithTimeout(ctx, false, options.Timeout)
 		if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
 			report.Errs = []error{err}
+			reports = append(reports, &report)
 			continue
 		}
 		if len(errs) > 0 {


### PR DESCRIPTION
`podman pod pause` doesn't work for cgroups v1 rootless container
as `podman pause` does.

[NO NEW TESTS NEEDED]

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
