### PR TITLE
[wip] Podman push --all-tags option

### DIFF
--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -73,8 +73,8 @@ func init() {
 func pushFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
-	// For now default All flag to true, for pushing of manifest lists
-	pushOptions.All = true
+	flags.BoolVarP(&pushOptions.All, "all-tags", "a", false, "Push all tagged images in the repository")
+
 	authfileFlagName := "authfile"
 	flags.StringVar(&pushOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = cmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)

--- a/docs/source/markdown/podman-push.1.md
+++ b/docs/source/markdown/podman-push.1.md
@@ -47,6 +47,10 @@ $ podman push myimage oci-archive:/tmp/myimage
 
 ## OPTIONS
 
+#### **--all-tags**, **-a**
+
+Push all tags for a given image to the repository. When using this flag, do not specify a tag for the DESTINATION.
+
 #### **--authfile**=*path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
@@ -120,6 +124,10 @@ This example pushes the image specified by the imageID to a local directory in o
 This example pushes the image specified by the imageID to a container registry named registry.example.com
 
  `# podman push imageID docker://registry.example.com/repository:tag`
+
+This example pushes all tags for the image specified by the imageID to a container registry named registry.example.com
+
+`# podman push --all-tags imageID docker://registry.example.com/repository`
 
 This example pushes the image specified by the imageID to a container registry named registry.example.com and saves the digest in the specified digestfile.
 

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -305,6 +305,7 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 	pushOptions.RemoveSignatures = options.RemoveSignatures
 	pushOptions.SignBy = options.SignBy
 	pushOptions.InsecureSkipTLSVerify = options.SkipTLSVerify
+	pushOptions.AllTags = options.All
 
 	compressionFormat := options.CompressionFormat
 	if compressionFormat == "" {

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -117,14 +117,18 @@ var _ = Describe("Podman push", func() {
 		push.WaitWithDefaultTimeout()
 		Expect(push).Should(Exit(0))
 
+		pushA := podmanTest.Podman([]string{"push", "-q", "-a", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
+		pushA.WaitWithDefaultTimeout()
+		Expect(pushA).Should(Exit(0))
+
 		SkipIfRemote("Remote does not support --digestfile")
 		// Test --digestfile option
-		push2 := podmanTest.Podman([]string{"push", "--tls-verify=false", "--digestfile=/tmp/digestfile.txt", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
-		push2.WaitWithDefaultTimeout()
+		pushD := podmanTest.Podman([]string{"push", "--tls-verify=false", "--digestfile=/tmp/digestfile.txt", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
+		pushD.WaitWithDefaultTimeout()
 		fi, err := os.Lstat("/tmp/digestfile.txt")
 		Expect(err).To(BeNil())
 		Expect(fi.Name()).To(Equal("digestfile.txt"))
-		Expect(push2).Should(Exit(0))
+		Expect(pushD).Should(Exit(0))
 	})
 
 	It("podman push to local registry with authorization", func() {


### PR DESCRIPTION
Task for #14917

Podman will now push all tags for a given image
when -a or --all-tags is specified.

Signed-off-by: Brian Yarbrough<bcynmelk+git@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds option to push all tags for a given image. When doing so, do not specify a tag after the destination.
```
