### PR TITLE
Machine init: create .ssh dir if not exist

### DIFF
--- a/pkg/machine/keys.go
+++ b/pkg/machine/keys.go
@@ -21,6 +21,9 @@ var sshCommand = []string{"ssh-keygen", "-N", "", "-t", "ed25519", "-f"}
 // CreateSSHKeys makes a priv and pub ssh key for interacting
 // the a VM.
 func CreateSSHKeys(writeLocation string) (string, error) {
+	if err := os.MkdirAll(filepath.Dir(writeLocation), 0700); err != nil {
+		return "", err
+	}
 	if err := generatekeys(writeLocation); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
When initing a machine, we generate ssh keys in `$HOME/.ssh`. If there
is not .ssh dir, we should create it, so the init does not fail.

[NO NEW TESTS NEEDED]
Since we need to create the .ssh directory during the tests to configure ssh config, we can't test when there is not .ssh dir.

Closes: https://github.com/containers/podman/issues/14572

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where `podman machine init` would fail if there is no `$HOME/.ssh` dir
```
