### PR TITLE
[CI:DOCS] document isolate option for network create

### DIFF
--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -73,8 +73,9 @@ Set driver specific options.
 
 All drivers accept the `mtu` option. The `mtu` option sets the Maximum Transmission Unit (MTU) and takes an integer value.
 
-Additionally the `bridge` driver supports the following option:
+Additionally the `bridge` driver supports the following options:
 - `vlan`: This option assign VLAN tag and enables vlan\_filtering. Defaults to none.
+- `isolate`: This option isolates networks by blocking traffic between those that have this option enabled.
 
 The `macvlan` and `ipvlan` driver support the following options:
 - `parent`: The host device which should be used for the macvlan interface. Defaults to the default route interface.


### PR DESCRIPTION
[CI-DOCS]

document the podman network create -o=isolate which allows networks to cut themselves off
from external connections.

Signed-off-by: Charlie Doern <cdoern@redhat.com>

resolves #5805

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
document isolate option for network create
```
