### PR TITLE
When removing objects specifying --force,podman should exit with 0

### DIFF
--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -126,6 +126,9 @@ func removeContainers(namesOrIDs []string, rmOptions entities.RmOptions, setExit
 	var errs utils.OutputErrors
 	responses, err := registry.ContainerEngine().ContainerRm(context.Background(), namesOrIDs, rmOptions)
 	if err != nil {
+		if rmOptions.Force && strings.Contains(err.Error(), define.ErrNoSuchCtr.Error()) {
+			return nil
+		}
 		if setExit {
 			setExitCode(err)
 		}
@@ -135,6 +138,9 @@ func removeContainers(namesOrIDs []string, rmOptions entities.RmOptions, setExit
 		if r.Err != nil {
 			if errors.Is(r.Err, define.ErrWillDeadlock) {
 				logrus.Errorf("Potential deadlock detected - please run 'podman system renumber' to resolve")
+			}
+			if rmOptions.Force && strings.Contains(r.Err.Error(), define.ErrNoSuchCtr.Error()) {
+				continue
 			}
 			if setExit {
 				setExitCode(r.Err)

--- a/cmd/podman/networks/rm.go
+++ b/cmd/podman/networks/rm.go
@@ -63,6 +63,9 @@ func networkRm(cmd *cobra.Command, args []string) error {
 	}
 	responses, err := registry.ContainerEngine().NetworkRm(registry.Context(), args, networkRmOptions)
 	if err != nil {
+		if networkRmOptions.Force && strings.Contains(err.Error(), define.ErrNoSuchNetwork.Error()) {
+			return nil
+		}
 		setExitCode(err)
 		return err
 	}
@@ -70,6 +73,9 @@ func networkRm(cmd *cobra.Command, args []string) error {
 		if r.Err == nil {
 			fmt.Println(r.Name)
 		} else {
+			if networkRmOptions.Force && strings.Contains(r.Err.Error(), define.ErrNoSuchNetwork.Error()) {
+				continue
+			}
 			setExitCode(r.Err)
 			errs = append(errs, r.Err)
 		}

--- a/cmd/podman/volumes/rm.go
+++ b/cmd/podman/volumes/rm.go
@@ -65,6 +65,9 @@ func rm(cmd *cobra.Command, args []string) error {
 	}
 	responses, err := registry.ContainerEngine().VolumeRm(context.Background(), args, rmOptions)
 	if err != nil {
+		if rmOptions.Force && strings.Contains(err.Error(), define.ErrNoSuchVolume.Error()) {
+			return nil
+		}
 		setExitCode(err)
 		return err
 	}
@@ -72,6 +75,9 @@ func rm(cmd *cobra.Command, args []string) error {
 		if r.Err == nil {
 			fmt.Println(r.Id)
 		} else {
+			if rmOptions.Force && strings.Contains(r.Err.Error(), define.ErrNoSuchVolume.Error()) {
+				continue
+			}
 			setExitCode(r.Err)
 			errs = append(errs, r.Err)
 		}

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -317,4 +317,11 @@ Deleted: $pauseID"
     is "$output" ""
 }
 
+@test "podman image rm --force bogus" {
+    run_podman 1 image rm bogus
+    is "$output" "Error: bogus: image not known" "Should print error"
+    run_podman image rm --force bogus
+    is "$output" "" "Should print no output"
+}
+
 # vim: filetype=sh

--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -96,4 +96,11 @@ load helpers
     run_podman 137 run --name $rand $IMAGE sleep 30
 }
 
+@test "podman container rm --force bogus" {
+    run_podman 1 container rm bogus
+    is "$output" "Error: no container with name or ID \"bogus\" found: no such container" "Should print error"
+    run_podman container rm --force bogus
+    is "$output" "" "Should print no output"
+}
+
 # vim: filetype=sh

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -473,4 +473,11 @@ EOF
     run_podman image rm --force localhost/volume_image
 }
 
+@test "podman volume rm --force bogus" {
+    run_podman 1 volume rm bogus
+    is "$output" "Error: no volume with name \"bogus\" found: no such volume" "Should print error"
+    run_podman volume rm --force bogus
+    is "$output" "" "Should print no output"
+}
+
 # vim: filetype=sh

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -547,4 +547,11 @@ io.max          | $lomajmin rbps=1048576 wbps=1048576 riops=max wiops=max
     wait
 }
 
+@test "podman pod rm --force bogus" {
+    run_podman 1 pod rm bogus
+    is "$output" "Error: .*bogus.*: no such pod" "Should print error"
+    run_podman pod rm --force bogus
+    is "$output" "" "Should print no output"
+}
+
 # vim: filetype=sh

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -260,7 +260,7 @@ load helpers
 
     run_podman rm -t 0 -f $cid
     run_podman network rm $mynetname
-    run_podman 1 network rm -f $mynetname
+    run_podman 1 network rm $mynetname
 }
 
 @test "podman network reload" {
@@ -758,6 +758,13 @@ EOF
         is "${lines[1]}" "0\:0" "/etc/resolv.conf owned by root"
         is "${lines[2]}" "0\:0" "/etc/hosts owned by root"
     done
+}
+
+@test "podman network rm --force bogus" {
+    run_podman 1 network rm bogus
+    is "$output" "Error: unable to find network with name or ID bogus: network not found" "Should print error"
+    run_podman network rm --force bogus
+    is "$output" "" "Should print no output"
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
This Patch will cause podman COMMAND rm --force bogus exit with 0.

This is how Docker works, so Podman should follow this to allow existing
scripts to convert from Docker to Podman.

Fixes: https://github.com/containers/podman/issues/14612

Signed-off-by: wufan <1991849113@qq.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman COMMAND rm -f BOGUS: Command will now exit with 0 if the only error is OBJECT does not exist.

```
