### PR TITLE
Add pause/unpause --latest, --cidfile, --filter

### DIFF
--- a/cmd/podman/containers/pause.go
+++ b/cmd/podman/containers/pause.go
@@ -2,61 +2,88 @@ package containers
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"io/ioutil"
+	"strings"
 
+	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/utils"
+	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var (
 	pauseDescription = `Pauses one or more running containers.  The container name or ID can be used.`
 	pauseCommand     = &cobra.Command{
-		Use:               "pause [options] CONTAINER [CONTAINER...]",
-		Short:             "Pause all the processes in one or more containers",
-		Long:              pauseDescription,
-		RunE:              pause,
+		Use:   "pause [options] CONTAINER [CONTAINER...]",
+		Short: "Pause all the processes in one or more containers",
+		Long:  pauseDescription,
+		RunE:  pause,
+		Args: func(cmd *cobra.Command, args []string) error {
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "cidfile")
+		},
 		ValidArgsFunction: common.AutocompleteContainersRunning,
 		Example: `podman pause mywebserver
   podman pause 860a4b23
-  podman pause -a`,
+  podman pause --all`,
 	}
 
 	containerPauseCommand = &cobra.Command{
-		Use:               pauseCommand.Use,
-		Short:             pauseCommand.Short,
-		Long:              pauseCommand.Long,
-		RunE:              pauseCommand.RunE,
+		Use:   pauseCommand.Use,
+		Short: pauseCommand.Short,
+		Long:  pauseCommand.Long,
+		RunE:  pauseCommand.RunE,
+		Args: func(cmd *cobra.Command, args []string) error {
+			return validate.CheckAllLatestAndIDFile(cmd, args, false, "cidfile")
+		},
 		ValidArgsFunction: pauseCommand.ValidArgsFunction,
 		Example: `podman container pause mywebserver
   podman container pause 860a4b23
-  podman container pause -a`,
+  podman container pause --all`,
 	}
-
-	pauseOpts = entities.PauseUnPauseOptions{}
 )
 
-func pauseFlags(flags *pflag.FlagSet) {
+var (
+	pauseOpts = entities.PauseUnPauseOptions{
+		Filters: make(map[string][]string),
+	}
+	pauseCidFiles = []string{}
+)
+
+func pauseFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
 	flags.BoolVarP(&pauseOpts.All, "all", "a", false, "Pause all running containers")
+
+	cidfileFlagName := "cidfile"
+	flags.StringArrayVar(&pauseCidFiles, cidfileFlagName, nil, "Read the container ID from the file")
+	_ = cmd.RegisterFlagCompletionFunc(cidfileFlagName, completion.AutocompleteDefault)
+
+	filterFlagName := "filter"
+	flags.StringSliceVarP(&filters, filterFlagName, "f", []string{}, "Filter output based on conditions given")
+	_ = cmd.RegisterFlagCompletionFunc(filterFlagName, common.AutocompletePsFilters)
+
+	if registry.IsRemote() {
+		_ = flags.MarkHidden("cidfile")
+	}
 }
 
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: pauseCommand,
 	})
-	flags := pauseCommand.Flags()
-	pauseFlags(flags)
+	pauseFlags(pauseCommand)
+	validate.AddLatestFlag(pauseCommand, &pauseOpts.Latest)
 
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: containerPauseCommand,
 		Parent:  containerCmd,
 	})
-	containerPauseFlags := containerPauseCommand.Flags()
-	pauseFlags(containerPauseFlags)
+	pauseFlags(containerPauseCommand)
+	validate.AddLatestFlag(containerPauseCommand, &pauseOpts.Latest)
 }
 
 func pause(cmd *cobra.Command, args []string) error {
@@ -64,16 +91,30 @@ func pause(cmd *cobra.Command, args []string) error {
 		errs utils.OutputErrors
 	)
 
-	if len(args) < 1 && !pauseOpts.All {
-		return errors.New("you must provide at least one container name or id")
+	for _, cidFile := range pauseCidFiles {
+		content, err := ioutil.ReadFile(cidFile)
+		if err != nil {
+			return fmt.Errorf("error reading CIDFile: %w", err)
+		}
+		id := strings.Split(string(content), "\n")[0]
+		args = append(args, id)
 	}
+
+	for _, f := range filters {
+		split := strings.SplitN(f, "=", 2)
+		if len(split) < 2 {
+			return fmt.Errorf("invalid filter %q", f)
+		}
+		pauseOpts.Filters[split[0]] = append(pauseOpts.Filters[split[0]], split[1])
+	}
+
 	responses, err := registry.ContainerEngine().ContainerPause(context.Background(), args, pauseOpts)
 	if err != nil {
 		return err
 	}
 	for _, r := range responses {
 		if r.Err == nil {
-			fmt.Println(r.Id)
+			fmt.Println(r.RawInput)
 		} else {
 			errs = append(errs, r.Err)
 		}

--- a/docs/source/markdown/podman-pause.1.md
+++ b/docs/source/markdown/podman-pause.1.md
@@ -17,21 +17,65 @@ Pauses all the processes in one or more containers.  You may use container IDs o
 
 Pause all running containers.
 
+#### **--cidfile**
+
+Read container ID from the specified file and pause the container.  Can be specified multiple times.
+
+#### **--filter**, **-f**=*filter*
+
+Filter what containers pause.
+Multiple filters can be given with multiple uses of the --filter flag.
+Filters with the same key work inclusive with the only exception being
+`label` which is exclusive. Filters with different keys always work exclusive.
+
+Valid filters are listed below:
+
+| **Filter**      | **Description**                                                                  |
+| --------------- | -------------------------------------------------------------------------------- |
+| id              | [ID] Container's ID (accepts regex)                                              |
+| name            | [Name] Container's name (accepts regex)                                          |
+| label           | [Key] or [Key=Value] Label assigned to a container                               |
+| exited          | [Int] Container's exit code                                                      |
+| status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
+| ancestor        | [ImageName] Image or descendant used to create container                         |
+| before          | [ID] or [Name] Containers created before this container                          |
+| since           | [ID] or [Name] Containers created since this container                           |
+| volume          | [VolumeName] or [MountpointDestination] Volume mounted in container              |
+| health          | [Status] healthy or unhealthy                                                    |
+| pod             | [Pod] name or full or partial ID of pod                                          |
+| network         | [Network] name or full ID of network                                             |
+
+#### **--latest**, **-l**
+
+Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+
 ## EXAMPLE
 
-Pause a container named 'mywebserver'
+Pause container named 'mywebserver'
 ```
 podman pause mywebserver
 ```
 
-Pause a container by partial container ID.
+Pause container by partial container ID.
 ```
 podman pause 860a4b23
 ```
 
 Pause all **running** containers.
 ```
-podman pause -a
+podman pause --all
+```
+
+Pause container using ID specified in a given files.
+```
+podman pause --cidfile /home/user/cidfile-1
+podman pause --cidfile /home/user/cidfile-1 --cidfile ./cidfile-2
+```
+
+Pause the latest container created by Podman.
+```
+podman pause --latest
 ```
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-unpause.1.md
+++ b/docs/source/markdown/podman-unpause.1.md
@@ -17,21 +17,65 @@ Unpauses the processes in one or more containers.  You may use container IDs or 
 
 Unpause all paused containers.
 
+#### **--cidfile**
+
+Read container ID from the specified file and unpause the container.  Can be specified multiple times.
+
+#### **--filter**, **-f**=*filter*
+
+Filter what containers unpause.
+Multiple filters can be given with multiple uses of the --filter flag.
+Filters with the same key work inclusive with the only exception being
+`label` which is exclusive. Filters with different keys always work exclusive.
+
+Valid filters are listed below:
+
+| **Filter**      | **Description**                                                                  |
+| --------------- | -------------------------------------------------------------------------------- |
+| id              | [ID] Container's ID (accepts regex)                                              |
+| name            | [Name] Container's name (accepts regex)                                          |
+| label           | [Key] or [Key=Value] Label assigned to a container                               |
+| exited          | [Int] Container's exit code                                                      |
+| status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
+| ancestor        | [ImageName] Image or descendant used to create container                         |
+| before          | [ID] or [Name] Containers created before this container                          |
+| since           | [ID] or [Name] Containers created since this container                           |
+| volume          | [VolumeName] or [MountpointDestination] Volume mounted in container              |
+| health          | [Status] healthy or unhealthy                                                    |
+| pod             | [Pod] name or full or partial ID of pod                                          |
+| network         | [Network] name or full ID of network                                             |
+
+#### **--latest**, **-l**
+
+Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
+to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+
 ## EXAMPLE
 
-Unpause a container called 'mywebserver'
+Unpause container called 'mywebserver'
 ```
 podman unpause mywebserver
 ```
 
-Unpause a container by a partial container ID.
+Unpause container by a partial container ID.
 ```
 podman unpause 860a4b23
 ```
 
 Unpause all **paused** containers.
 ```
-podman unpause -a
+podman unpause --all
+```
+
+Unpause container using ID specified in a given files.
+```
+podman unpause --cidfile /home/user/cidfile-1
+podman unpause --cidfile /home/user/cidfile-1 --cidfile ./cidfile-2
+```
+
+Unpause the latest container created by Podman.
+```
+podman unpause --latest
 ```
 
 ## SEE ALSO

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -71,12 +71,15 @@ type StringSliceReport struct {
 }
 
 type PauseUnPauseOptions struct {
-	All bool
+	Filters map[string][]string
+	All     bool
+	Latest  bool
 }
 
 type PauseUnpauseReport struct {
-	Err error
-	Id  string //nolint:revive,stylecheck
+	Err      error
+	Id       string //nolint:revive,stylecheck
+	RawInput string
 }
 
 type StopOptions struct {


### PR DESCRIPTION
--latest  : pause/unpause the latest container.
--filter  : pause/unpause the filtered container.
--cidfile : Read container ID from the specified file and pause/unpause the container.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
User can use podman pause/unpause --latest, --cidfile, --filter option.
```
