### PR TITLE
Compat API: unify pull/push and add missing progress info

### DIFF
--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -156,6 +156,7 @@ loop: // break out of for/select infinite loop
 					Current: int64(e.Offset),
 					Total:   e.Artifact.Size,
 				}
+				report.ProgressMessage = report.Progress.String()
 			case types.ProgressEventSkipped:
 				report.Status = "Layer already exists"
 			case types.ProgressEventDone:


### PR DESCRIPTION
Progress bar in JSONMessage is missing compared to docker output both in
pull and push. Additionaly, pull was not using JSONMessage while push
was using this type.
[NO NEW TESTS NEEDED]

Signed-off-by: Jakub Guzik <jguzik@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Compat REST API: image push and pull have now progress bars
```
