### PR TITLE
Bump VMs, to Ubuntu 2204 with cgroups v1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,11 +29,11 @@ env:
     ####
     FEDORA_NAME: "fedora-36"
     #PRIOR_FEDORA_NAME: "fedora-35"
-    UBUNTU_NAME: "ubuntu-2110"
+    UBUNTU_NAME: "ubuntu-2204"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c6211193021923328"
-    FEDORA_AMI_ID: "ami-06a41d8a81ab56afa"
+    IMAGE_SUFFIX: "c6013173500215296"
+    FEDORA_AMI_ID: "ami-0f116746f31965e41"
     # Complete image names
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     #PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
@@ -178,8 +178,7 @@ build_task:
               DISTRO_NV: ${UBUNTU_NAME}
               VM_IMAGE_NAME: ${UBUNTU_CACHE_IMAGE_NAME}
               CTR_FQIN: ${UBUNTU_CONTAINER_FQIN}
-              # FIXME 2022-07-12: change to runc once #14833 is fixed!
-              CI_DESIRED_RUNTIME: crun
+              CI_DESIRED_RUNTIME: runc
     env:
         TEST_FLAVOR: build
     clone_script: *full_clone
@@ -550,6 +549,7 @@ container_integration_test_task:
               _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
               VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+              CI_DESIRED_RUNTIME: crun
               #- env:
               #DISTRO_NV: ${PRIOR_FEDORA_NAME}
               #_BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
@@ -667,6 +667,7 @@ rootless_remote_system_test_task:
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
               # ID for re-use of build output
               _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+              CI_DESIRED_RUNTIME: crun
     <<: *local_system_test_task
     alias: rootless_remote_system_test
     depends_on:

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -246,6 +246,7 @@ function _run_build() {
     if [[ "$runtime" != "$CI_DESIRED_RUNTIME" ]]; then
         die "Built podman is using '$runtime'; this CI environment requires $CI_DESIRED_RUNTIME"
     fi
+    msg "Built podman is using expected runtime='$runtime'"
 }
 
 function _run_altbuild() {

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -524,6 +524,8 @@ subdir**`
 	// See https://github.com/containers/podman/issues/13535
 	It("Remote build .containerignore filtering embedded directory (#13535)", func() {
 		SkipIfNotRemote("Testing remote .containerignore file filtering")
+		Skip("FIXME: #15014: test times out in 'dd' on f36.")
+
 		podmanTest.RestartRemoteService()
 
 		// Switch to temp dir and restore it afterwards
@@ -552,7 +554,7 @@ subdir**`
 		Expect(ioutil.WriteFile(filepath.Join(subdirPath, "extra"), contents.Bytes(), 0644)).
 			ToNot(HaveOccurred())
 		randomFile := filepath.Join(subdirPath, "randomFile")
-		dd := exec.Command("dd", "if=/dev/random", "of="+randomFile, "bs=1G", "count=1")
+		dd := exec.Command("dd", "if=/dev/urandom", "of="+randomFile, "bs=1G", "count=1")
 		ddSession, err := Start(dd, GinkgoWriter, GinkgoWriter)
 		Expect(err).ToNot(HaveOccurred())
 		Eventually(ddSession, "10s", "1s").Should(Exit(0))

--- a/test/e2e/checkpoint_image_test.go
+++ b/test/e2e/checkpoint_image_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint --create-image with running container", func() {
+		SkipIfContainerized("FIXME: #15015. All checkpoint tests hang when containerized.")
 		// Container image must be lowercase
 		checkpointImage := "alpine-checkpoint-" + strings.ToLower(RandomString(6))
 		containerName := "alpine-container-" + RandomString(6)
@@ -163,7 +164,8 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
-	It("podman restore multiple containers from single checkpint image", func() {
+	It("podman restore multiple containers from single checkpoint image", func() {
+		SkipIfContainerized("FIXME: #15015. All checkpoint tests hang when containerized.")
 		// Container image must be lowercase
 		checkpointImage := "alpine-checkpoint-" + strings.ToLower(RandomString(6))
 		containerName := "alpine-container-" + RandomString(6)
@@ -225,7 +227,8 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
-	It("podman restore multiple containers from multiple checkpint images", func() {
+	It("podman restore multiple containers from multiple checkpoint images", func() {
+		SkipIfContainerized("FIXME: #15015. All checkpoint tests hang when containerized.")
 		// Container image must be lowercase
 		checkpointImage1 := "alpine-checkpoint-" + strings.ToLower(RandomString(6))
 		checkpointImage2 := "alpine-checkpoint-" + strings.ToLower(RandomString(6))

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -57,6 +57,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 	BeforeEach(func() {
 		SkipIfRootless("checkpoint not supported in rootless mode")
+		SkipIfContainerized("FIXME: #15015. All checkpoint tests hang when containerized.")
 		tempdir, err = CreateTempDirInTempDir()
 		Expect(err).To(BeNil())
 
@@ -1128,6 +1129,10 @@ var _ = Describe("Podman checkpoint", func() {
 		share := share // copy into local scope, for use inside function
 
 		It(testName, func() {
+			if podmanTest.Host.Distribution == "ubuntu" && IsRemote() {
+				Skip("FIXME: #15018. Cannot restore --pod under cgroupsV1 and remote")
+			}
+
 			if !criu.CheckForCriu(criu.PodCriuVersion) {
 				Skip("CRIU is missing or too old.")
 			}

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -152,4 +152,19 @@ var _ = Describe("Podman Info", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("memory"))
 		Expect(session.OutputToString()).To(ContainSubstring("pids"))
 	})
+
+	It("Podman info: check desired runtime", func() {
+		// defined in .cirrus.yml
+		want := os.Getenv("CI_DESIRED_RUNTIME")
+		if want == "" {
+			if os.Getenv("CIRRUS_CI") == "" {
+				Skip("CI_DESIRED_RUNTIME is not set--this is OK because we're not running under Cirrus")
+			}
+			Fail("CIRRUS_CI is set, but CI_DESIRED_RUNTIME is not! See #14912")
+		}
+		session := podmanTest.Podman([]string{"info", "--format", "{{.Host.OCIRuntime.Name}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(Exit(0))
+		Expect(session.OutputToString()).To(Equal(want))
+	})
 })

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -129,6 +129,7 @@ var _ = Describe("Podman kill", func() {
 	})
 
 	It("podman kill paused container", func() {
+		SkipIfRootlessCgroupsV1("pause is not supported for cgroupv1 rootless")
 		ctrName := "testctr"
 		session := podmanTest.RunTopContainer(ctrName)
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -293,6 +293,9 @@ var _ = Describe("Podman manifest", func() {
 	})
 
 	It("authenticated push", func() {
+		if podmanTest.Host.Distribution == "ubuntu" && IsRemote() {
+			Skip("FIXME: #15017. Registry times out.")
+		}
 		registryOptions := &podmanRegistry.Options{
 			Image: "docker-archive:" + imageTarPath(REGISTRY_IMAGE),
 		}

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -71,6 +71,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network disconnect", func() {
+		SkipIfRootlessCgroupsV1("stats not supported under rootless CgroupsV1")
 		netName := "aliasTest" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
@@ -180,6 +181,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network connect", func() {
+		SkipIfRootlessCgroupsV1("stats not supported under rootless CgroupsV1")
 		netName := "aliasTest" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -1051,6 +1051,7 @@ ENTRYPOINT ["sleep","99999"]
 
 	It("podman pod create --share-parent test", func() {
 		SkipIfRootlessCgroupsV1("rootless cannot use cgroups with cgroupsv1")
+		SkipIfCgroupV1("FIXME: #15013: CgroupMode shows 'host' instead of CID under Cgroups V1.")
 		podCreate := podmanTest.Podman([]string{"pod", "create", "--share-parent=false"})
 		podCreate.WaitWithDefaultTimeout()
 		Expect(podCreate).Should(Exit(0))

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -91,7 +91,8 @@ var _ = Describe("Podman run", func() {
 		if exitCode == 0 {
 			Expect(session.OutputToString()).To(ContainSubstring("aarch64"))
 		} else {
-			Expect(session.ErrorToString()).To(ContainSubstring("Exec format error"))
+			// crun says 'Exec', runc says 'exec'. Handle either.
+			Expect(session.ErrorToString()).To(ContainSubstring("xec format error"))
 		}
 	})
 
@@ -714,6 +715,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-read-bps test", func() {
+		SkipIfCgroupV1("FIXME: #15035 - bps broken")
 		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-read-bps not supported on cgroupv1 for rootless users")
 
@@ -733,6 +735,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-write-bps test", func() {
+		SkipIfCgroupV1("FIXME: #15035 - bps broken")
 		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-write-bps not supported on cgroupv1 for rootless users")
 
@@ -751,6 +754,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-read-iops test", func() {
+		SkipIfCgroupV1("FIXME: #15035 - bps broken")
 		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-read-iops not supported on cgroupv1 for rootless users")
 		var session *PodmanSessionIntegration
@@ -769,6 +773,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-write-iops test", func() {
+		SkipIfCgroupV1("FIXME: #15035 - bps broken")
 		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-write-iops not supported on cgroupv1 for rootless users")
 		var session *PodmanSessionIntegration

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -70,6 +70,7 @@ echo $rand        |   0 | $rand
 }
 
 @test "podman run - uidmapping has no /sys/kernel mounts" {
+    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
     skip_if_rootless "cannot umount as rootless"
     skip_if_remote "TODO Fix this for remote case"
 
@@ -805,6 +806,7 @@ EOF
 
 # rhbz#1902979 : podman run fails to update /etc/hosts when --uidmap is provided
 @test "podman run update /etc/hosts" {
+    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
     HOST=$(random_string 25)
     run_podman run --uidmap 0:10001:10002 --rm --hostname ${HOST} $IMAGE grep ${HOST} /etc/hosts
     is "${lines[0]}" ".*${HOST}.*"

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -149,16 +149,16 @@ EOF
 
     # By default, volumes are mounted exec, but we have manually added the
     # noexec option. This should fail.
-    # ARGH. Unfortunately, runc (used for cgroups v1) produces a different error
+    # ARGH. Unfortunately, runc (used for cgroups v1) has different exit status
     local expect_rc=126
-    local expect_msg='.* OCI permission denied.*'
     if [[ $(podman_runtime) = "runc" ]]; then
         expect_rc=1
-        expect_msg='.* exec user process caused.*permission denied'
     fi
 
     run_podman ${expect_rc} run --rm --volume $myvolume:/vol:noexec,z $IMAGE /vol/myscript
-    is "$output" "$expect_msg" "run on volume, noexec"
+    # crun and runc emit different messages, and even runc is inconsistent
+    # with itself (output changed some time in 2022?). Deal with all.
+    assert "$output" =~ 'exec.* permission denied' "run on volume, noexec"
 
     # With the default, it should pass
     run_podman run --rm -v $myvolume:/vol:z $IMAGE /vol/myscript

--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -30,6 +30,7 @@ function _require_crun() {
 }
 
 @test "podman --group-add without keep-groups while in a userns" {
+    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
     skip_if_rootless "chroot is not allowed in rootless mode"
     skip_if_remote "--group-add keep-groups not supported in remote mode"
     run chroot --groups 1234,5678 / ${PODMAN} run --rm --uidmap 0:200000:5000 --group-add 457 $IMAGE id
@@ -37,6 +38,7 @@ function _require_crun() {
 }
 
 @test "rootful pod with custom ID mapping" {
+    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
     skip_if_rootless "does not work rootless - rootful feature"
     random_pod_name=$(random_string 30)
     run_podman pod create --uidmap 0:200000:5000 --name=$random_pod_name

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -479,9 +479,8 @@ spec:
 
 @test "pod resource limits" {
     skip_if_remote "resource limits only implemented on non-remote"
-    if is_rootless || ! is_cgroupsv2; then
-        skip "only meaningful for rootful"
-    fi
+    skip_if_rootless "resource limits only work with root"
+    skip_if_cgroupsv1 "resource limits only meaningful on cgroups V2"
 
     # create loopback device
     lofile=${PODMAN_TMPDIR}/disk.img

--- a/test/system/251-system-service.bats
+++ b/test/system/251-system-service.bats
@@ -17,6 +17,10 @@ function teardown() {
 
 @test "podman-system-service containers survive service stop" {
     skip_if_remote "podman system service unavailable over remote"
+    local runtime=$(podman_runtime)
+    if [[ "$runtime" != "crun" ]]; then
+        skip "survival code only implemented in crun; you're using $runtime"
+    fi
 
     port=$(random_free_port)
     URL=tcp://127.0.0.1:$port

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -7,6 +7,7 @@
 load helpers
 
 @test "podman container storage is not accessible by unprivileged users" {
+    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
     skip_if_rootless "test meaningless without suid"
     skip_if_remote
 

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -84,6 +84,7 @@ load helpers
 
 # Issue #5466 - port-forwarding doesn't work with this option and -d
 @test "podman networking: port with --userns=keep-id for rootless or --uidmap=* for rootful" {
+    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
     for cidr in "" "$(random_rfc1918_subnet).0/24"; do
         myport=$(random_free_port 52000-52999)
         if [[ -z $cidr ]]; then
@@ -744,6 +745,7 @@ EOF
 }
 
 @test "podman run /etc/* permissions" {
+    skip_if_cgroupsv1 "FIXME: #15025: run --uidmap fails on cgroups v1"
     userns="--userns=keep-id"
     if ! is_rootless; then
         userns="--uidmap=0:1111111:65536 --gidmap=0:1111111:65536"

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -367,8 +367,8 @@ func (s *PodmanSession) WaitWithDefaultTimeout() {
 func (s *PodmanSession) WaitWithTimeout(timeout int) {
 	Eventually(s, timeout).Should(Exit(), func() string {
 		// in case of timeouts show output
-		return fmt.Sprintf("command %v timed out\nSTDOUT: %s\nSTDERR: %s",
-			s.Command.Args, string(s.Out.Contents()), string(s.Err.Contents()))
+		return fmt.Sprintf("command timed out after %ds: %v\nSTDOUT: %s\nSTDERR: %s",
+			timeout, s.Command.Args, string(s.Out.Contents()), string(s.Err.Contents()))
 	})
 	os.Stdout.Sync()
 	os.Stderr.Sync()


### PR DESCRIPTION

...and enable the at-test-time confirmation, the one that
double-checks that if CI requests runc we actually use runc.
This exposed a nasty surprise in our setup: there are steps to
define $OCI_RUNTIME, but that's actually a total fakeout!
OCI_RUNTIME is used only in e2e tests, it has no effect
whatsoever on actual podman itself as invoked via command
line such as in system tests. Solution: use containers.conf
 
Given how fragile all this runtime stuff is, I've also added
new tests (e2e and system) that will check $CI_DESIRED_RUNTIME.
 
Image source: https://github.com/containers/automation_images/pull/146
 
Since we haven't actually been testing with runc, we need
to fix a few tests:
 
  - handle an error-message change (make it work in both crun and runc)
  - skip one system test, "survive service stop", that doesn't
    work with runc and I don't think we care.
 
...and skip a bunch, filing issues for each:
 
  - #15013 pod create --share-parent
  - #15014 timeout in dd
  - #15015 checkpoint tests time out under $CONTAINER
  - #15017 networking timeout with registry
  - #15018 restore --pod gripes about missing --pod
  - #15025 run --uidmap broken
  - #15027 pod inspect cgrouppath broken
  - ...and a bunch more ("podman pause") that probably don't
    even merit filing an issue.
 
Also, use /dev/urandom in one test (was: /dev/random) because
the test is timing out and /dev/urandom does not block. (But
the test is still timing out anyway, even with this change)
 
Also, as part of the VM switch we are now using go 1.18 (up
from 1.17) and this broke the gitlab tests. Thanks to @Luap99
for a quick fix.
 
Also, slight tweak to #15021: include the timeout value, and
reword message so command string is at end.
 
Also, fixed a misspelling in a test name.
 
Fixes: #14833 

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
We are now testing with runc again. Golang has been updated from 17 to 18.
```