### PR TITLE
add "podman kube down" command

### DIFF
--- a/cmd/podman/kube/down.go
+++ b/cmd/podman/kube/down.go
@@ -1,0 +1,39 @@
+package pods
+
+import (
+	"github.com/containers/podman/v4/cmd/podman/common"
+	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/spf13/cobra"
+)
+
+var (
+	downDescription = `Reads in a structured file of Kubernetes YAML.
+
+  Removes pods that have been based on the Kubernetes kind described in the YAML.`
+
+	downCmd = &cobra.Command{
+		Use:               "down KUBEFILE|-",
+		Short:             "Remove pods based on Kubernetes YAML.",
+		Long:              downDescription,
+		RunE:              down,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: common.AutocompleteDefaultOneArg,
+		Example: `podman kube down nginx.yml
+   cat nginx.yml | podman kube down -`,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: downCmd,
+		Parent:  kubeCmd,
+	})
+}
+
+func down(cmd *cobra.Command, args []string) error {
+	reader, err := readerFromArg(args[0])
+	if err != nil {
+		return err
+	}
+	return teardown(reader)
+}

--- a/docs/source/markdown/podman-kube-down.1.md
+++ b/docs/source/markdown/podman-kube-down.1.md
@@ -1,0 +1,43 @@
+% podman-kube-down(1)
+
+## NAME
+podman-kube-down - Remove containers and pods based on Kubernetes YAML
+
+## SYNOPSIS
+**podman kube down** *file.yml|-*
+
+## DESCRIPTION
+**podman kube down** reads a specified Kubernetes YAML file, tearing down pods that were created by the `podman kube play` command via the same Kubernetes YAML file. Any volumes that were created by the previous `podman kube play` command remain intact. If the YAML file is specified as `-`, `podman kube down` reads the YAML from stdin.
+
+## EXAMPLES
+
+Example YAML file `demo.yml`:
+```
+apiVersion: v1
+kind: Pod
+metadata:
+...
+spec:
+  containers:
+  - command:
+    - top
+    - name: container
+      value: podman
+    image: foobar
+...
+```
+
+Remove the pod and containers as described in the `demo.yml` file
+```
+$ podman kube down demo.yml
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+```
+
+Remove the pod and containers as described in the`demo.yml` file YAML sent to stdin
+```
+$ cat demo.yml | podman kube play -
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+```
+
+## SEE ALSO
+**[podman(1)](podman.1.md)**, **[podman-kube(1)](podman-kube.1.md)**, **[podman-kube-play(1)](podman-kube-play.1.md)**, **[podman-generate-kube(1)](podman-generate-kube.1.md)**, **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**

--- a/docs/source/markdown/podman-kube-play.1.md
+++ b/docs/source/markdown/podman-kube-play.1.md
@@ -1,7 +1,7 @@
 % podman-kube-play(1)
 
 ## NAME
-podman-kube-play - Create containers, pods or volumes based on Kubernetes YAML
+podman-kube-play - Create containers, pods and volumes based on Kubernetes YAML
 
 ## SYNOPSIS
 **podman kube play** [*options*] *file.yml|-*
@@ -29,6 +29,9 @@ Note: *hostPath* volume types created by kube play will be given an SELinux shar
 Note: If the `:latest` tag is used, Podman will attempt to pull the image from a registry. If the image was built locally with Podman or Buildah, it will have `localhost` as the domain, in that case, Podman will use the image from the local store even if it has the `:latest` tag.
 
 Note: The command `podman play kube` is an alias of `podman kube play`, and will perform the same function.
+
+Note: The command `podman kube down` can be used to stop and remove pods or containers based on the same Kubernetes YAML used
+by `podman kube play` to create them.
 
 `Kubernetes PersistentVolumeClaims`
 
@@ -144,11 +147,6 @@ Use *path* as the build context directory for each image. Requires --build optio
 The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
-
-#### **--down**
-
-Tears down the pods that were created by a previous run of `kube play`.  The pods are stopped and then
-removed.  Any volumes created are left intact.
 
 #### **--help**, **-h**
 
@@ -325,7 +323,7 @@ $ podman kube play demo.yml --network net1:ip=10.89.1.5 --network net2:ip=10.89.
 Please take into account that networks must be created first using podman-network-create(1).
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-kube(1)](podman-kube.1.md)**, **[podman-network-create(1)](podman-network-create.1.md)**, **[podman-generate-kube(1)](podman-generate-kube.1.md)**, **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**
+**[podman(1)](podman.1.md)**, **[podman-kube(1)](podman-kube.1.md)**, **[podman-kube-down(1)](podman-kube-down.1.md)**, **[podman-network-create(1)](podman-network-create.1.md)**, **[podman-generate-kube(1)](podman-generate-kube.1.md)**, **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**
 
 ## HISTORY
 December 2018, Originally compiled by Brent Baude (bbaude at redhat dot com)

--- a/docs/source/markdown/podman-kube.1.md
+++ b/docs/source/markdown/podman-kube.1.md
@@ -14,7 +14,8 @@ file input.  Containers will be automatically started.
 
 | Command  | Man Page                                            | Description                                                                  |
 | -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
-| play     | [podman-kube-play(1)](podman-kube-play.1.md)        | Create containers, pods or volumes based on Kubernetes YAML.                         |
+| down     | [podman-kube-down(1)](podman-kube-down.1.md)        | Remove containers and pods based on Kubernetes YAML.                          |
+| play     | [podman-kube-play(1)](podman-kube-play.1.md)        | Create containers, pods and volumes based on Kubernetes YAML.                 |
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-container(1)](podman-container.1.md)**, **[podman-generate(1)](podman-generate.1.md)**, **[podman-kube-play(1)](podman-kube-play.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-container(1)](podman-container.1.md)**, **[podman-generate(1)](podman-generate.1.md)**, **[podman-kube-play(1)](podman-kube-play.1.md)**, **[podman-kube-down(1)](podman-kube-down.1.md)**

--- a/test/system/700-play.bats
+++ b/test/system/700-play.bats
@@ -182,8 +182,11 @@ EOF
     run_podman container inspect --format "{{.HostConfig.NetworkMode}}" $infraID
     is "$output" "none" "network mode none is set for the container"
 
-    run_podman stop -a -t 0
-    run_podman pod rm -t 0 -f test_pod
+    run_podman kube down - < $PODMAN_TMPDIR/test.yaml
+    run_podman 125 inspect test_pod-test
+    is "$output" ".*Error: inspecting object: no such object: \"test_pod-test\""
+    run_podman pod rm -a
+    run_podman rm -a
 }
 
 @test "podman play with user from image" {
@@ -325,7 +328,6 @@ spec:
     - name: TERM
       value: xterm
     - name: container
-
       value: podman
     image: quay.io/libpod/userimage
     name: test
@@ -353,6 +355,9 @@ status: {}
     run_podman inspect --format "{{.HostConfig.LogConfig.Type}}" test_pod-test
     is "$output" "$default_driver" "play kube uses default log driver"
 
-    run_podman stop -a -t 0
-    run_podman pod rm -t 0 -f test_pod
+    run_podman kube down $PODMAN_TMPDIR/test.yaml
+    run_podman 125 inspect test_pod-test
+    is "$output" ".*Error: inspecting object: no such object: \"test_pod-test\""
+    run_podman pod rm -a
+    run_podman rm -a
 }


### PR DESCRIPTION
The "podman kube down" reads in a structured file of
Kubernetes YAML and removes pods based on the Kubernetes kind described in the YAML,
similiar to "podman play kube --down". Users will still be able to use
"podman play kube --down" and "podman kube play --down" to
perform the same function.

Signed-off-by: Niall Crowe <nicrowe@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Introduces "podman kube down" which removes pods created by "podman kube play/play kube".
The "--down" flag for "podman kube play --down" can still be used and is now hidden. 
```
