### PR TITLE
Update init ctr default for play kube

### DIFF
--- a/docs/source/markdown/podman-kube-play.1.md
+++ b/docs/source/markdown/podman-kube-play.1.md
@@ -22,7 +22,7 @@ Currently, the supported Kubernetes kinds are:
 
 Only two volume types are supported by kube play, the *hostPath* and *persistentVolumeClaim* volume types. For the *hostPath* volume type, only the  *default (empty)*, *DirectoryOrCreate*, *Directory*, *FileOrCreate*, *File*, *Socket*, *CharDevice* and *BlockDevice* subtypes are supported. Podman interprets the value of *hostPath* *path* as a file path when it contains at least one forward slash, otherwise Podman treats the value as the name of a named volume. When using a *persistentVolumeClaim*, the value for *claimName* is the name for the Podman named volume.
 
-Note: When playing a kube YAML with init containers, the init container will be created with init type value `always`.
+Note: When playing a kube YAML with init containers, the init container will be created with init type value `once`. To change the default type, use the `io.podman.annotations.init.container.type` annotation to set the type to `always`.
 
 Note: *hostPath* volume types created by kube play will be given an SELinux shared label (z), bind mounts are not relabeled (use `chcon -t container_file_t -R <directory>`).
 

--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -135,6 +135,11 @@ const (
 	// creating a checkpoint image to specify the name of host distribution on
 	// which the checkpoint was created.
 	CheckpointAnnotationDistributionName = "io.podman.annotations.checkpoint.distribution.name"
+
+	// InitContainerType is used by play kube when playing a kube yaml to specify the type
+	// of the init container.
+	InitContainerType = "io.podman.annotations.init.container.type"
+
 	// MaxKubeAnnotation is the max length of annotations allowed by Kubernetes.
 	MaxKubeAnnotation = 63
 )

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -507,13 +507,17 @@ func (ic *ContainerEngine) playKubePod(ctx context.Context, podName string, podY
 		for k, v := range podSpec.PodSpecGen.Labels { // add podYAML labels
 			labels[k] = v
 		}
+		initCtrType := annotations[define.InitContainerType]
+		if initCtrType == "" {
+			initCtrType = define.OneShotInitContainer
+		}
 
 		specgenOpts := kube.CtrSpecGenOptions{
 			Annotations:        annotations,
 			ConfigMaps:         configMaps,
 			Container:          initCtr,
 			Image:              pulledImage,
-			InitContainerType:  define.AlwaysInitContainer,
+			InitContainerType:  initCtrType,
 			Labels:             labels,
 			LogDriver:          options.LogDriver,
 			LogOptions:         options.LogOptions,


### PR DESCRIPTION
Update the init container type default to once instead
of always to match k8s behavior.
Add a new annotation that can be used to change the init
ctr type in the kube yaml.

Fixes https://github.com/containers/podman/issues/14877

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a new annotation to allow users to define the init container type in a kube yaml for podman play kube. Change the default init container type to `once`.
```
