### PR TITLE
libpod: create /etc/passwd if missing

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -2886,23 +2886,6 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 		}
 	}
 
-	// Next, check if the container even has a /etc/passwd or /etc/group.
-	// If it doesn't we don't want to create them ourselves.
-	if needPasswd {
-		exists, err := c.checkFileExistsInRootfs("/etc/passwd")
-		if err != nil {
-			return "", "", err
-		}
-		needPasswd = exists
-	}
-	if needGroup {
-		exists, err := c.checkFileExistsInRootfs("/etc/group")
-		if err != nil {
-			return "", "", err
-		}
-		needGroup = exists
-	}
-
 	// If we don't need a /etc/passwd or /etc/group at this point we can
 	// just return.
 	if !needPasswd && !needGroup {
@@ -2947,7 +2930,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 				return "", "", fmt.Errorf("error looking up location of container %s /etc/passwd: %w", c.ID(), err)
 			}
 
-			f, err := os.OpenFile(containerPasswd, os.O_APPEND|os.O_WRONLY, 0600)
+			f, err := os.OpenFile(containerPasswd, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 			if err != nil {
 				return "", "", fmt.Errorf("container %s: %w", c.ID(), err)
 			}
@@ -2993,7 +2976,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 				return "", "", fmt.Errorf("error looking up location of container %s /etc/group: %w", c.ID(), err)
 			}
 
-			f, err := os.OpenFile(containerGroup, os.O_APPEND|os.O_WRONLY, 0600)
+			f, err := os.OpenFile(containerGroup, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 			if err != nil {
 				return "", "", fmt.Errorf("container %s: %w", c.ID(), err)
 			}
@@ -3110,26 +3093,6 @@ func (c *Container) copyTimezoneFile(zonePath string) (string, error) {
 
 func (c *Container) cleanupOverlayMounts() error {
 	return overlay.CleanupContent(c.config.StaticDir)
-}
-
-// Check if a file exists at the given path in the container's root filesystem.
-// Container must already be mounted for this to be used.
-func (c *Container) checkFileExistsInRootfs(file string) (bool, error) {
-	checkPath, err := securejoin.SecureJoin(c.state.Mountpoint, file)
-	if err != nil {
-		return false, fmt.Errorf("cannot create path to container %s file %q: %w", c.ID(), file, err)
-	}
-	stat, err := os.Stat(checkPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("container %s: %w", c.ID(), err)
-	}
-	if stat.IsDir() {
-		return false, nil
-	}
-	return true, nil
 }
 
 // Creates and mounts an empty dir to mount secrets into, if it does not already exist

--- a/test/e2e/run_passwd_test.go
+++ b/test/e2e/run_passwd_test.go
@@ -66,10 +66,15 @@ RUN rm -f /etc/passwd /etc/shadow /etc/group
 USER 1000`, ALPINE)
 		imgName := "testimg"
 		podmanTest.BuildImage(dockerfile, imgName, "false")
-		session := podmanTest.Podman([]string{"run", "--rm", imgName, "ls", "/etc/"})
+		session := podmanTest.Podman([]string{"run", "--passwd=false", "--rm", imgName, "ls", "/etc/"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(Not(ContainSubstring("passwd")))
+
+		// test that the /etc/passwd file is created
+		session = podmanTest.Podman([]string{"run", "--rm", "--user", "0:0", imgName, "ls", "/etc/passwd"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
 	})
 
 	It("podman run with no user specified does not change --group specified", func() {


### PR DESCRIPTION
create the /etc/passwd file is it is missing in the image.

Closes: https://github.com/containers/podman/issues/14966

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
If it is needed, create automatically the /etc/passwd file when it is missing in the image
```
