### PR TITLE
enable linter for pkg/machine/e2e

### DIFF
--- a/cmd/podman/machine/info.go
+++ b/cmd/podman/machine/info.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/libpod/define"
+	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/machine"
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
@@ -40,26 +41,6 @@ var (
 	inFormat string
 )
 
-// Info contains info on the machine host and version info
-type Info struct {
-	Host    *HostInfo      `json:"Host"`
-	Version define.Version `json:"Version"`
-}
-
-// HostInfo contains info on the machine host
-type HostInfo struct {
-	Arch             string `json:"Arch"`
-	CurrentMachine   string `json:"CurrentMachine"`
-	DefaultMachine   string `json:"DefaultMachine"`
-	EventsDir        string `json:"EventsDir"`
-	MachineConfigDir string `json:"MachineConfigDir"`
-	MachineImageDir  string `json:"MachineImageDir"`
-	MachineState     string `json:"MachineState"`
-	NumberOfMachines int    `json:"NumberOfMachines"`
-	OS               string `json:"OS"`
-	VMType           string `json:"VMType"`
-}
-
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: infoCmd,
@@ -69,11 +50,11 @@ func init() {
 	flags := infoCmd.Flags()
 	formatFlagName := "format"
 	flags.StringVarP(&inFormat, formatFlagName, "f", "", "Change the output format to JSON or a Go template")
-	_ = infoCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&define.Info{}))
+	_ = infoCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.MachineInfo{}))
 }
 
 func info(cmd *cobra.Command, args []string) error {
-	info := Info{}
+	info := entities.MachineInfo{}
 	version, err := define.GetVersion()
 	if err != nil {
 		return fmt.Errorf("error getting version info %w", err)
@@ -112,8 +93,8 @@ func info(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func hostInfo() (*HostInfo, error) {
-	host := HostInfo{}
+func hostInfo() (*entities.MachineHostInfo, error) {
+	host := entities.MachineHostInfo{}
 
 	host.Arch = runtime.GOARCH
 	host.OS = runtime.GOOS

--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -80,6 +80,11 @@ func ssh(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	vm, err = provider.LoadVMByName(vmName)
+	if err != nil {
+		return fmt.Errorf("vm %s not found: %w", vmName, err)
+	}
+
 	if !validVM && sshOpts.Username == "" {
 		sshOpts.Username, err = remoteConnectionUsername()
 		if err != nil {
@@ -87,10 +92,6 @@ func ssh(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	vm, err = provider.LoadVMByName(vmName)
-	if err != nil {
-		return fmt.Errorf("vm %s not found: %w", vmName, err)
-	}
 	err = vm.SSH(vmName, sshOpts)
 	return utils.HandleOSExecError(err)
 }

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -9,9 +9,9 @@ BUILD_TAGS[abi]="${BUILD_TAGS[default]},systemd"
 BUILD_TAGS[tunnel]="${BUILD_TAGS[default]},remote"
 
 declare -A SKIP_DIRS
-SKIP_DIRS[abi]="pkg/machine/e2e"
+SKIP_DIRS[abi]=""
 # TODO: add "remote" build tag to pkg/api
-SKIP_DIRS[tunnel]="pkg/api,pkg/machine/e2e"
+SKIP_DIRS[tunnel]="pkg/api"
 
 [[ $1 == run ]] && shift
 

--- a/pkg/domain/entities/machine.go
+++ b/pkg/domain/entities/machine.go
@@ -1,5 +1,7 @@
 package entities
 
+import "github.com/containers/podman/v4/libpod/define"
+
 type ListReporter struct {
 	Name           string
 	Default        bool
@@ -15,4 +17,24 @@ type ListReporter struct {
 	Port           int
 	RemoteUsername string
 	IdentityPath   string
+}
+
+// MachineInfo contains info on the machine host and version info
+type MachineInfo struct {
+	Host    *MachineHostInfo `json:"Host"`
+	Version define.Version   `json:"Version"`
+}
+
+// MachineHostInfo contains info on the machine host
+type MachineHostInfo struct {
+	Arch             string `json:"Arch"`
+	CurrentMachine   string `json:"CurrentMachine"`
+	DefaultMachine   string `json:"DefaultMachine"`
+	EventsDir        string `json:"EventsDir"`
+	MachineConfigDir string `json:"MachineConfigDir"`
+	MachineImageDir  string `json:"MachineImageDir"`
+	MachineState     string `json:"MachineState"`
+	NumberOfMachines int    `json:"NumberOfMachines"`
+	OS               string `json:"OS"`
+	VMType           string `json:"VMType"`
 }

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -20,7 +20,7 @@ var _ = Describe("run basic podman commands", func() {
 	})
 
 	It("Basic ops", func() {
-		name := randomString(12)
+		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()
 		Expect(err).To(BeNil())

--- a/pkg/machine/e2e/config_basic_test.go
+++ b/pkg/machine/e2e/config_basic_test.go
@@ -1,8 +1,7 @@
-package e2e
+package e2e_test
 
 type basicMachine struct {
 	args []string
-	cmd  []string
 }
 
 func (s basicMachine) buildCmd(m *machineTestBuilder) []string {

--- a/pkg/machine/e2e/config_info_test.go
+++ b/pkg/machine/e2e/config_info_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 type infoMachine struct {
 	format string

--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	"strconv"
@@ -25,7 +25,7 @@ type initMachine struct {
 	memory       *uint
 	now          bool
 	timezone     string
-	rootful      bool
+	rootful      bool //nolint:unused,structcheck
 	volumes      []string
 
 	cmd []string
@@ -71,7 +71,7 @@ func (i *initMachine) withDiskSize(size uint) *initMachine {
 	return i
 }
 
-func (i *initMachine) withIgnitionPath(path string) *initMachine {
+func (i *initMachine) withIgnitionPath(path string) *initMachine { //nolint:unused
 	i.ignitionPath = path
 	return i
 }

--- a/pkg/machine/e2e/config_inspect_test.go
+++ b/pkg/machine/e2e/config_inspect_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 type inspectMachine struct {
 	/*

--- a/pkg/machine/e2e/config_list_test.go
+++ b/pkg/machine/e2e/config_list_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 type listMachine struct {
 	/*

--- a/pkg/machine/e2e/config_rm_test.go
+++ b/pkg/machine/e2e/config_rm_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 type rmMachine struct {
 	/*
@@ -40,17 +40,17 @@ func (i *rmMachine) withForce() *rmMachine {
 	return i
 }
 
-func (i *rmMachine) withSaveIgnition() *rmMachine {
+func (i *rmMachine) withSaveIgnition() *rmMachine { //nolint:unused
 	i.saveIgnition = true
 	return i
 }
 
-func (i *rmMachine) withSaveImage() *rmMachine {
+func (i *rmMachine) withSaveImage() *rmMachine { //nolint:unused
 	i.saveImage = true
 	return i
 }
 
-func (i *rmMachine) withSaveKeys() *rmMachine {
+func (i *rmMachine) withSaveKeys() *rmMachine { //nolint:unused
 	i.saveKeys = true
 	return i
 }

--- a/pkg/machine/e2e/config_set_test.go
+++ b/pkg/machine/e2e/config_set_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	"strconv"

--- a/pkg/machine/e2e/config_ssh_test.go
+++ b/pkg/machine/e2e/config_ssh_test.go
@@ -1,14 +1,12 @@
-package e2e
+package e2e_test
 
 type sshMachine struct {
 	/*
 		--username string   Username to use when ssh-ing into the VM.
 	*/
 
-	username   string
+	username   string //nolint:unused
 	sshCommand []string
-
-	cmd []string
 }
 
 func (s sshMachine) buildCmd(m *machineTestBuilder) []string {
@@ -22,7 +20,7 @@ func (s sshMachine) buildCmd(m *machineTestBuilder) []string {
 	return cmd
 }
 
-func (s *sshMachine) withUsername(name string) *sshMachine {
+func (s *sshMachine) withUsername(name string) *sshMachine { //nolint:unused
 	s.username = name
 	return s
 }

--- a/pkg/machine/e2e/config_start_test.go
+++ b/pkg/machine/e2e/config_start_test.go
@@ -1,10 +1,9 @@
-package e2e
+package e2e_test
 
 type startMachine struct {
 	/*
 		No command line args other than a machine vm name (also not required)
 	*/
-	cmd []string
 }
 
 func (s startMachine) buildCmd(m *machineTestBuilder) []string {

--- a/pkg/machine/e2e/config_stop_test.go
+++ b/pkg/machine/e2e/config_stop_test.go
@@ -1,10 +1,9 @@
-package e2e
+package e2e_test
 
 type stopMachine struct {
 	/*
 		No command line args other than a machine vm name (also not required)
 	*/
-	cmd []string
 }
 
 func (s stopMachine) buildCmd(m *machineTestBuilder) []string {

--- a/pkg/machine/e2e/config_test.go
+++ b/pkg/machine/e2e/config_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	"encoding/json"
@@ -10,13 +10,11 @@ import (
 	"time"
 
 	"github.com/containers/podman/v4/pkg/machine"
-	"github.com/containers/podman/v4/pkg/machine/qemu"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/storage/pkg/stringid"
-	. "github.com/onsi/ginkgo" //nolint:golint,stylecheck
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
-	. "github.com/onsi/gomega/gexec" //nolint:golint,stylecheck
+	. "github.com/onsi/gomega/gexec"
 )
 
 var originalHomeDir = os.Getenv("HOME")
@@ -36,7 +34,7 @@ type MachineTestBuilder interface {
 	run() (*machineSession, error)
 }
 type machineSession struct {
-	*gexec.Session
+	*Session
 }
 
 type machineTestBuilder struct {
@@ -46,10 +44,6 @@ type machineTestBuilder struct {
 	names        []string
 	podmanBinary string
 	timeout      time.Duration
-}
-type qemuMachineInspectInfo struct {
-	State machine.Status
-	VM    qemu.MachineVM
 }
 
 // waitWithTimeout waits for a command to complete for a given
@@ -121,7 +115,7 @@ func (m *machineTestBuilder) setCmd(mc machineCommand) *machineTestBuilder {
 	// If no name for the machine exists, we set a random name.
 	if !util.StringInSlice(m.name, m.names) {
 		if len(m.name) < 1 {
-			m.name = randomString(12)
+			m.name = randomString()
 		}
 		m.names = append(m.names, m.name)
 	}
@@ -136,10 +130,10 @@ func (m *machineTestBuilder) setTimeout(timeout time.Duration) *machineTestBuild
 
 // toQemuInspectInfo is only for inspecting qemu machines.  Other providers will need
 // to make their own.
-func (mb *machineTestBuilder) toQemuInspectInfo() ([]machine.InspectInfo, int, error) {
+func (m *machineTestBuilder) toQemuInspectInfo() ([]machine.InspectInfo, int, error) {
 	args := []string{"machine", "inspect"}
-	args = append(args, mb.names...)
-	session, err := runWrapper(mb.podmanBinary, args, defaultTimeout, true)
+	args = append(args, m.names...)
+	session, err := runWrapper(m.podmanBinary, args, defaultTimeout, true)
 	if err != nil {
 		return nil, -1, err
 	}
@@ -175,9 +169,7 @@ func runWrapper(podmanBinary string, cmdArgs []string, timeout time.Duration, wa
 	return &ms, nil
 }
 
-func (m *machineTestBuilder) init() {}
-
 // randomString returns a string of given length composed of random characters
-func randomString(n int) string {
+func randomString() string {
 	return stringid.GenerateRandomID()[0:12]
 }

--- a/pkg/machine/e2e/info_test.go
+++ b/pkg/machine/e2e/info_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	"github.com/containers/podman/v4/cmd/podman/machine"

--- a/pkg/machine/e2e/info_test.go
+++ b/pkg/machine/e2e/info_test.go
@@ -1,7 +1,7 @@
 package e2e_test
 
 import (
-	"github.com/containers/podman/v4/cmd/podman/machine"
+	"github.com/containers/podman/v4/pkg/domain/entities"
 	jsoniter "github.com/json-iterator/go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -51,7 +51,7 @@ var _ = Describe("podman machine info", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(infoSession).Should(Exit(0))
 
-		infoReport := &machine.Info{}
+		infoReport := &entities.MachineInfo{}
 		err = jsoniter.Unmarshal(infoSession.Bytes(), infoReport)
 		Expect(err).To(BeNil())
 	})

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -108,7 +108,7 @@ var _ = Describe("podman machine init", func() {
 		switch runtime.GOOS {
 		// os's handle memory differently
 		case "linux":
-			Expect(memorySession.outputToString()).To(ContainSubstring("3821"))
+			Expect(memorySession.outputToString()).To(ContainSubstring("3822"))
 		case "darwin":
 			Expect(memorySession.outputToString()).To(ContainSubstring("3824"))
 		default:

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	"io/ioutil"
@@ -78,7 +78,7 @@ var _ = Describe("podman machine init", func() {
 	})
 
 	It("machine init with cpus, disk size, memory, timezone", func() {
-		name := randomString(12)
+		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withCPUs(2).withDiskSize(102).withMemory(4000).withTimezone("Pacific/Honolulu")).run()
 		Expect(err).To(BeNil())
@@ -130,7 +130,7 @@ var _ = Describe("podman machine init", func() {
 		mount := tmpDir + ":/testmountdir"
 		defer os.RemoveAll(tmpDir)
 
-		name := randomString(12)
+		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withVolume(mount)).run()
 		Expect(err).To(BeNil())

--- a/pkg/machine/e2e/inspect_test.go
+++ b/pkg/machine/e2e/inspect_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	"strings"
@@ -52,15 +52,15 @@ var _ = Describe("podman machine stop", func() {
 	})
 
 	It("inspect with go format", func() {
-		name := randomString(12)
+		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
 		Expect(session).To(Exit(0))
 
 		// regular inspect should
-		inspectJson := new(inspectMachine)
-		inspectSession, err := mb.setName(name).setCmd(inspectJson).run()
+		inspectJSON := new(inspectMachine)
+		inspectSession, err := mb.setName(name).setCmd(inspectJSON).run()
 		Expect(err).To(BeNil())
 		Expect(inspectSession).To(Exit(0))
 

--- a/pkg/machine/e2e/list_test.go
+++ b/pkg/machine/e2e/list_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	"strings"
@@ -45,8 +45,8 @@ var _ = Describe("podman machine list", func() {
 
 	It("list machines with quiet or noheading", func() {
 		// Random names for machines to test list
-		name1 := randomString(12)
-		name2 := randomString(12)
+		name1 := randomString()
+		name2 := randomString()
 
 		list := new(listMachine)
 		firstList, err := mb.setCmd(list.withQuiet()).run()
@@ -109,7 +109,7 @@ var _ = Describe("podman machine list", func() {
 
 	It("list with --format", func() {
 		// Random names for machines to test list
-		name1 := randomString(12)
+		name1 := randomString()
 
 		i := new(initMachine)
 		session, err := mb.setName(name1).setCmd(i.withImagePath(mb.imagePath)).run()

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	"fmt"

--- a/pkg/machine/e2e/rm_test.go
+++ b/pkg/machine/e2e/rm_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	"runtime"
@@ -22,7 +22,7 @@ var _ = Describe("podman machine set", func() {
 	})
 
 	It("set machine cpus, disk, memory", func() {
-		name := randomString(12)
+		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
@@ -75,7 +75,7 @@ var _ = Describe("podman machine set", func() {
 	})
 
 	It("no settings should change if no flags", func() {
-		name := randomString(12)
+		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())

--- a/pkg/machine/e2e/set_test.go
+++ b/pkg/machine/e2e/set_test.go
@@ -62,7 +62,7 @@ var _ = Describe("podman machine set", func() {
 		switch runtime.GOOS {
 		// it seems macos and linux handle memory differently
 		case "linux":
-			Expect(memorySession.outputToString()).To(ContainSubstring("3821"))
+			Expect(memorySession.outputToString()).To(ContainSubstring("3822"))
 		case "darwin":
 			Expect(memorySession.outputToString()).To(ContainSubstring("3824"))
 		default:

--- a/pkg/machine/e2e/ssh_test.go
+++ b/pkg/machine/e2e/ssh_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -20,17 +20,17 @@ var _ = Describe("podman machine ssh", func() {
 	})
 
 	It("bad machine name", func() {
-		name := randomString(12)
+		name := randomString()
 		ssh := sshMachine{}
 		session, err := mb.setName(name).setCmd(ssh).run()
 		Expect(err).To(BeNil())
 		Expect(session).To(Exit(125))
 		// TODO seems like stderr is not being returned; re-enabled when fixed
-		//Expect(session.outputToString()).To(ContainSubstring("not exist"))
+		// Expect(session.outputToString()).To(ContainSubstring("not exist"))
 	})
 
 	It("ssh to non-running machine", func() {
-		name := randomString(12)
+		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath)).run()
 		Expect(err).To(BeNil())
@@ -40,12 +40,12 @@ var _ = Describe("podman machine ssh", func() {
 		sshSession, err := mb.setName(name).setCmd(ssh).run()
 		Expect(err).To(BeNil())
 		// TODO seems like stderr is not being returned; re-enabled when fixed
-		//Expect(sshSession.outputToString()).To(ContainSubstring("is not running"))
+		// Expect(sshSession.outputToString()).To(ContainSubstring("is not running"))
 		Expect(sshSession).To(Exit(125))
 	})
 
 	It("ssh to running machine and check os-type", func() {
-		name := randomString(12)
+		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()
 		Expect(err).To(BeNil())

--- a/pkg/machine/e2e/ssh_test.go
+++ b/pkg/machine/e2e/ssh_test.go
@@ -25,8 +25,7 @@ var _ = Describe("podman machine ssh", func() {
 		session, err := mb.setName(name).setCmd(ssh).run()
 		Expect(err).To(BeNil())
 		Expect(session).To(Exit(125))
-		// TODO seems like stderr is not being returned; re-enabled when fixed
-		// Expect(session.outputToString()).To(ContainSubstring("not exist"))
+		Expect(session.errorToString()).To(ContainSubstring("not exist"))
 	})
 
 	It("ssh to non-running machine", func() {
@@ -39,8 +38,7 @@ var _ = Describe("podman machine ssh", func() {
 		ssh := sshMachine{}
 		sshSession, err := mb.setName(name).setCmd(ssh).run()
 		Expect(err).To(BeNil())
-		// TODO seems like stderr is not being returned; re-enabled when fixed
-		// Expect(sshSession.outputToString()).To(ContainSubstring("is not running"))
+		Expect(sshSession.errorToString()).To(ContainSubstring("is not running"))
 		Expect(sshSession).To(Exit(125))
 	})
 

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	"github.com/containers/podman/v4/pkg/machine"

--- a/pkg/machine/e2e/stop_test.go
+++ b/pkg/machine/e2e/stop_test.go
@@ -1,4 +1,4 @@
-package e2e
+package e2e_test
 
 import (
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
Rename all files to _test.go and rename the package to e2e_test. This
makes the linter less strict about things like dot imports.

Add some unused nolint directives to silence some warnings, these can be
used to find untested options so someone could add tests for them.

Fixes #14996

This also contains some more fixes for the machine tests, see the commits.
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
