### PR TITLE
compat api: allow default bridge name for networks

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -23,6 +23,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func normalizeNetworkName(rt *libpod.Runtime, name string) (string, bool) {
+	if name == nettypes.BridgeNetworkDriver {
+		return rt.Network().DefaultNetworkName(), true
+	}
+	return name, false
+}
+
 func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 
@@ -44,13 +51,13 @@ func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, http.StatusBadRequest, define.ErrInvalidArg)
 		return
 	}
-	name := utils.GetName(r)
+	name, changed := normalizeNetworkName(runtime, utils.GetName(r))
 	net, err := runtime.Network().NetworkInspect(name)
 	if err != nil {
 		utils.NetworkNotFound(w, name, err)
 		return
 	}
-	report, err := convertLibpodNetworktoDockerNetwork(runtime, net)
+	report, err := convertLibpodNetworktoDockerNetwork(runtime, &net, changed)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
@@ -58,7 +65,7 @@ func InspectNetwork(w http.ResponseWriter, r *http.Request) {
 	utils.WriteResponse(w, http.StatusOK, report)
 }
 
-func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, network nettypes.Network) (*types.NetworkResource, error) {
+func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, network *nettypes.Network, changeDefaultName bool) (*types.NetworkResource, error) {
 	cons, err := runtime.GetAllContainers()
 	if err != nil {
 		return nil, err
@@ -107,11 +114,15 @@ func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, network nettyp
 		Config:  ipamConfigs,
 	}
 
+	name := network.Name
+	if changeDefaultName && name == runtime.Network().DefaultNetworkName() {
+		name = nettypes.BridgeNetworkDriver
+	}
 	report := types.NetworkResource{
-		Name:   network.Name,
-		ID:     network.ID,
-		Driver: network.Driver,
-		// TODO add Created: ,
+		Name:       name,
+		ID:         network.ID,
+		Driver:     network.Driver,
+		Created:    network.Created,
 		Internal:   network.Internal,
 		EnableIPv6: network.IPv6Enabled,
 		Labels:     network.Labels,
@@ -149,7 +160,7 @@ func ListNetworks(w http.ResponseWriter, r *http.Request) {
 	}
 	reports := make([]*types.NetworkResource, 0, len(nets))
 	for _, net := range nets {
-		report, err := convertLibpodNetworktoDockerNetwork(runtime, net)
+		report, err := convertLibpodNetworktoDockerNetwork(runtime, &net, true)
 		if err != nil {
 			utils.InternalServerError(w, err)
 			return
@@ -305,7 +316,7 @@ func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 		Timeout: query.Timeout,
 	}
 
-	name := utils.GetName(r)
+	name, _ := normalizeNetworkName(runtime, utils.GetName(r))
 	reports, err := ic.NetworkRm(r.Context(), []string{name}, options)
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, err)
@@ -340,7 +351,7 @@ func Connect(w http.ResponseWriter, r *http.Request) {
 
 	netOpts := nettypes.PerNetworkOptions{}
 
-	name := utils.GetName(r)
+	name, _ := normalizeNetworkName(runtime, utils.GetName(r))
 	if netConnect.EndpointConfig != nil {
 		if netConnect.EndpointConfig.Aliases != nil {
 			netOpts.Aliases = netConnect.EndpointConfig.Aliases
@@ -416,7 +427,7 @@ func Disconnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	name := utils.GetName(r)
+	name, _ := normalizeNetworkName(runtime, utils.GetName(r))
 	err := runtime.DisconnectContainerFromNetwork(netDisconnect.Container, name, netDisconnect.Force)
 	if err != nil {
 		if errors.Is(err, define.ErrNoSuchCtr) {

--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -193,27 +193,22 @@ func CreateNetwork(w http.ResponseWriter, r *http.Request) {
 
 	network.Options = make(map[string]string)
 
-	// TODO: we should consider making this constants in c/common/libnetwork/types
+	// dockers bridge networks are always isolated from each other
+	if network.Driver == nettypes.BridgeNetworkDriver {
+		network.Options[nettypes.IsolateOption] = "true"
+	}
+
 	for opt, optVal := range networkCreate.Options {
 		switch opt {
-		case "mtu":
+		case nettypes.MTUOption:
 			fallthrough
 		case "com.docker.network.driver.mtu":
-			if network.Driver == nettypes.BridgeNetworkDriver {
-				network.Options["mtu"] = optVal
-			}
-		case "icc":
-			fallthrough
-		case "com.docker.network.bridge.enable_icc":
-			// TODO: needs to be implemented
-			if network.Driver == nettypes.BridgeNetworkDriver {
-				responseWarning = "com.docker.network.bridge.enable_icc is not currently implemented"
-			}
+			network.Options[nettypes.MTUOption] = optVal
 		case "com.docker.network.bridge.name":
 			if network.Driver == nettypes.BridgeNetworkDriver {
 				network.NetworkInterface = optVal
 			}
-		case "mode":
+		case nettypes.ModeOption:
 			if network.Driver == nettypes.MacVLANNetworkDriver || network.Driver == nettypes.IPVLANNetworkDriver {
 				network.Options[opt] = optVal
 			}

--- a/test/apiv2/35-networks.at
+++ b/test/apiv2/35-networks.at
@@ -84,11 +84,23 @@ t GET networks?filters='{"dangling":["true","0"]}' 500 \
 t GET networks?filters='{"name":["doesnotexists"]}' 200 \
   "[]"
 
+# check default name in list endpoint
+t GET networks 200 \
+  .[].Name~.*bridge.*
+
 # network inspect docker
 t GET networks/$network1_id 200 \
   .Name=network1 \
   .Id=$network1_id \
   .Scope=local
+
+# inspect default bridge network
+t GET networks/bridge 200 \
+  .Name=bridge
+
+# inspect default bridge network with real podman name should return real name
+t GET networks/podman 200 \
+  .Name=podman
 
 # network create docker
 t POST networks/create Name=net3\ IPAM='{"Config":[]}' 201

--- a/test/compose/test-compose
+++ b/test/compose/test-compose
@@ -212,7 +212,6 @@ function start_service() {
     rm -f $DOCKER_SOCK
     mkdir --mode 0755 $WORKDIR/{root,runroot,cni}
     chcon --reference=/var/lib/containers $WORKDIR/root
-    cp /etc/cni/net.d/*podman*conflist $WORKDIR/cni/
 
     $PODMAN_BIN \
         --log-level debug \


### PR DESCRIPTION
Docker uses "bridge" as default network name so some tools expect this
to work with network list or inspect. To fix this we change "bridge" to
the podman default ("podman") name.

Fixes #14983

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The network endpoints for the docker compat API will now correctly use "bridge" as default network name.
Networks created via the docker compat API are now always isolated from each other (e.g. network1 cannot connect to network2) to match the docker behaviour. 
```
