### PR TITLE
e2e: show command and output when a timeout happens

### DIFF
--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -365,7 +365,11 @@ func (s *PodmanSession) WaitWithDefaultTimeout() {
 
 // WaitWithTimeout waits for process finished with DefaultWaitTimeout
 func (s *PodmanSession) WaitWithTimeout(timeout int) {
-	Eventually(s, timeout).Should(Exit())
+	Eventually(s, timeout).Should(Exit(), func() string {
+		// in case of timeouts show output
+		return fmt.Sprintf("command %v timed out\nSTDOUT: %s\nSTDERR: %s",
+			s.Command.Args, string(s.Out.Contents()), string(s.Err.Contents()))
+	})
 	os.Stdout.Sync()
 	os.Stderr.Sync()
 	fmt.Println("output:", s.OutputToString())


### PR DESCRIPTION
To make debugging easier we should see the command and its output when a
failure happens.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
