### PR TITLE
remote push: show copy progress

### DIFF
--- a/pkg/api/handlers/libpod/images_push.go
+++ b/pkg/api/handlers/libpod/images_push.go
@@ -1,0 +1,144 @@
+package libpod
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/containers/image/v5/types"
+	"github.com/containers/podman/v4/libpod"
+	"github.com/containers/podman/v4/pkg/api/handlers/utils"
+	api "github.com/containers/podman/v4/pkg/api/types"
+	"github.com/containers/podman/v4/pkg/auth"
+	"github.com/containers/podman/v4/pkg/channel"
+	"github.com/containers/podman/v4/pkg/domain/entities"
+	"github.com/containers/podman/v4/pkg/domain/infra/abi"
+	"github.com/gorilla/schema"
+	"github.com/sirupsen/logrus"
+)
+
+// PushImage is the handler for the compat http endpoint for pushing images.
+func PushImage(w http.ResponseWriter, r *http.Request) {
+	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
+
+	query := struct {
+		All              bool   `schema:"all"`
+		Destination      string `schema:"destination"`
+		Format           string `schema:"format"`
+		RemoveSignatures bool   `schema:"removeSignatures"`
+		TLSVerify        bool   `schema:"tlsVerify"`
+		Quiet            bool   `schema:"quiet"`
+	}{
+		// #14971: older versions did not sent *any* data, so we need
+		//         to be quiet by default to remain backwards compatible
+		Quiet: true,
+	}
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		utils.Error(w, http.StatusBadRequest, fmt.Errorf("failed to parse parameters for %s: %w", r.URL.String(), err))
+		return
+	}
+
+	source := strings.TrimSuffix(utils.GetName(r), "/push") // GetName returns the entire path
+	if _, err := utils.ParseStorageReference(source); err != nil {
+		utils.Error(w, http.StatusBadRequest, err)
+		return
+	}
+
+	destination := query.Destination
+	if destination == "" {
+		destination = source
+	}
+
+	if err := utils.IsRegistryReference(destination); err != nil {
+		utils.Error(w, http.StatusBadRequest, err)
+		return
+	}
+
+	authconf, authfile, err := auth.GetCredentials(r)
+	if err != nil {
+		utils.Error(w, http.StatusBadRequest, err)
+		return
+	}
+	defer auth.RemoveAuthfile(authfile)
+
+	var username, password string
+	if authconf != nil {
+		username = authconf.Username
+		password = authconf.Password
+	}
+	options := entities.ImagePushOptions{
+		All:              query.All,
+		Authfile:         authfile,
+		Format:           query.Format,
+		Password:         password,
+		Quiet:            true,
+		RemoveSignatures: query.RemoveSignatures,
+		Username:         username,
+	}
+
+	if _, found := r.URL.Query()["tlsVerify"]; found {
+		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)
+	}
+
+	imageEngine := abi.ImageEngine{Libpod: runtime}
+
+	// Let's keep thing simple when running in quiet mode and push directly.
+	if query.Quiet {
+		if err := imageEngine.Push(context.Background(), source, destination, options); err != nil {
+			utils.Error(w, http.StatusBadRequest, fmt.Errorf("error pushing image %q: %w", destination, err))
+			return
+		}
+		utils.WriteResponse(w, http.StatusOK, "")
+		return
+	}
+
+	writer := channel.NewWriter(make(chan []byte))
+	defer writer.Close()
+	options.Writer = writer
+
+	pushCtx, pushCancel := context.WithCancel(r.Context())
+	var pushError error
+	go func() {
+		defer pushCancel()
+		pushError = imageEngine.Push(pushCtx, source, destination, options)
+	}()
+
+	flush := func() {
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	flush()
+
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(true)
+	for {
+		var report entities.ImagePushReport
+		select {
+		case s := <-writer.Chan():
+			report.Stream = string(s)
+			if err := enc.Encode(report); err != nil {
+				logrus.Warnf("Failed to encode json: %v", err)
+			}
+			flush()
+		case <-pushCtx.Done():
+			if pushError != nil {
+				report.Error = pushError.Error()
+				if err := enc.Encode(report); err != nil {
+					logrus.Warnf("Failed to encode json: %v", err)
+				}
+			}
+			flush()
+			return
+		case <-r.Context().Done():
+			// Client has closed connection
+			return
+		}
+	}
+}

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -730,6 +730,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//    description: Require TLS verification.
 	//    type: boolean
 	//    default: true
+	//  - in: query
+	//    name: quiet
+	//    description: "silences extra stream data on push"
+	//    type: boolean
+	//    default: true
 	//  - in: header
 	//    name: X-Registry-Auth
 	//    type: string

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -267,46 +267,6 @@ func Import(ctx context.Context, r io.Reader, options *ImportOptions) (*entities
 	return &report, response.Process(&report)
 }
 
-// Push is the binding for libpod's v2 endpoints for push images.  Note that
-// `source` must be a referring to an image in the remote's container storage.
-// The destination must be a reference to a registry (i.e., of docker transport
-// or be normalized to one).  Other transports are rejected as they do not make
-// sense in a remote context.
-func Push(ctx context.Context, source string, destination string, options *PushOptions) error {
-	if options == nil {
-		options = new(PushOptions)
-	}
-	conn, err := bindings.GetClient(ctx)
-	if err != nil {
-		return err
-	}
-	header, err := auth.MakeXRegistryAuthHeader(&imageTypes.SystemContext{AuthFilePath: options.GetAuthfile()}, options.GetUsername(), options.GetPassword())
-	if err != nil {
-		return err
-	}
-
-	params, err := options.ToParams()
-	if err != nil {
-		return err
-	}
-	// SkipTLSVerify is special.  We need to delete the param added by
-	// toparams and change the key and flip the bool
-	if options.SkipTLSVerify != nil {
-		params.Del("SkipTLSVerify")
-		params.Set("tlsVerify", strconv.FormatBool(!options.GetSkipTLSVerify()))
-	}
-	params.Set("destination", destination)
-
-	path := fmt.Sprintf("/images/%s/push", source)
-	response, err := conn.DoRequest(ctx, nil, http.MethodPost, path, params, header)
-	if err != nil {
-		return err
-	}
-	defer response.Body.Close()
-
-	return response.Process(err)
-}
-
 // Search is the binding for libpod's v2 endpoints for Search images.
 func Search(ctx context.Context, term string, options *SearchOptions) ([]entities.ImageSearchReport, error) {
 	if options == nil {

--- a/pkg/bindings/images/push.go
+++ b/pkg/bindings/images/push.go
@@ -1,0 +1,96 @@
+package images
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+
+	imageTypes "github.com/containers/image/v5/types"
+	"github.com/containers/podman/v4/pkg/auth"
+	"github.com/containers/podman/v4/pkg/bindings"
+	"github.com/containers/podman/v4/pkg/domain/entities"
+)
+
+// Push is the binding for libpod's endpoints for push images.  Note that
+// `source` must be a referring to an image in the remote's container storage.
+// The destination must be a reference to a registry (i.e., of docker transport
+// or be normalized to one).  Other transports are rejected as they do not make
+// sense in a remote context.
+func Push(ctx context.Context, source string, destination string, options *PushOptions) error {
+	if options == nil {
+		options = new(PushOptions)
+	}
+	conn, err := bindings.GetClient(ctx)
+	if err != nil {
+		return err
+	}
+	header, err := auth.MakeXRegistryAuthHeader(&imageTypes.SystemContext{AuthFilePath: options.GetAuthfile()}, options.GetUsername(), options.GetPassword())
+	if err != nil {
+		return err
+	}
+
+	params, err := options.ToParams()
+	if err != nil {
+		return err
+	}
+	// SkipTLSVerify is special.  We need to delete the param added by
+	// toparams and change the key and flip the bool
+	if options.SkipTLSVerify != nil {
+		params.Del("SkipTLSVerify")
+		params.Set("tlsVerify", strconv.FormatBool(!options.GetSkipTLSVerify()))
+	}
+	params.Set("destination", destination)
+
+	path := fmt.Sprintf("/images/%s/push", source)
+	response, err := conn.DoRequest(ctx, nil, http.MethodPost, path, params, header)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if !response.IsSuccess() {
+		return response.Process(err)
+	}
+
+	// Historically push writes status to stderr
+	writer := io.Writer(os.Stderr)
+	if options.GetQuiet() {
+		writer = ioutil.Discard
+	}
+
+	dec := json.NewDecoder(response.Body)
+	for {
+		var report entities.ImagePushReport
+		if err := dec.Decode(&report); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+
+		select {
+		case <-response.Request.Context().Done():
+			break
+		default:
+			// non-blocking select
+		}
+
+		switch {
+		case report.Stream != "":
+			fmt.Fprint(writer, report.Stream)
+		case report.Error != "":
+			// There can only be one error.
+			return errors.New(report.Error)
+		default:
+			return fmt.Errorf("failed to parse push results stream, unexpected input: %v", report)
+		}
+	}
+
+	return nil
+}

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -133,6 +133,8 @@ type PushOptions struct {
 	RemoveSignatures *bool
 	// Username for authenticating against the registry.
 	Username *string
+	// Quiet can be specified to suppress progress when pushing.
+	Quiet *bool
 }
 
 //go:generate go run ../generator/generator.go SearchOptions

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -136,3 +136,18 @@ func (o *PushOptions) GetUsername() string {
 	}
 	return *o.Username
 }
+
+// WithQuiet set field Quiet to given value
+func (o *PushOptions) WithQuiet(value bool) *PushOptions {
+	o.Quiet = &value
+	return o
+}
+
+// GetQuiet returns value of field Quiet
+func (o *PushOptions) GetQuiet() bool {
+	if o.Quiet == nil {
+		var z bool
+		return z
+	}
+	return *o.Quiet
+}

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -1,6 +1,7 @@
 package entities
 
 import (
+	"io"
 	"net/url"
 	"time"
 
@@ -192,8 +193,7 @@ type ImagePushOptions struct {
 	// image. Default is manifest type of source, with fallbacks.
 	// Ignored for remote calls.
 	Format string
-	// Quiet can be specified to suppress pull progress when pulling.  Ignored
-	// for remote calls.
+	// Quiet can be specified to suppress push progress when pushing.
 	Quiet bool
 	// Rm indicates whether to remove the manifest list if push succeeds
 	Rm bool
@@ -211,6 +211,17 @@ type ImagePushOptions struct {
 	Progress chan types.ProgressProperties
 	// CompressionFormat is the format to use for the compression of the blobs
 	CompressionFormat string
+	// Writer is used to display copy information including progress bars.
+	Writer io.Writer
+}
+
+// ImagePushReport is the response from pushing an image.
+// Currently only used in the remote API.
+type ImagePushReport struct {
+	// Stream used to provide push progress
+	Stream string `json:"stream,omitempty"`
+	// Error contains text of errors from pushing
+	Error string `json:"error,omitempty"`
 }
 
 // ImageSearchOptions are the arguments for searching images.

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -305,6 +305,7 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 	pushOptions.RemoveSignatures = options.RemoveSignatures
 	pushOptions.SignBy = options.SignBy
 	pushOptions.InsecureSkipTLSVerify = options.SkipTLSVerify
+	pushOptions.Writer = options.Writer
 
 	compressionFormat := options.CompressionFormat
 	if compressionFormat == "" {
@@ -322,7 +323,7 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 		pushOptions.CompressionFormat = &algo
 	}
 
-	if !options.Quiet {
+	if !options.Quiet && pushOptions.Writer == nil {
 		pushOptions.Writer = os.Stderr
 	}
 

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -240,7 +240,7 @@ func (ir *ImageEngine) Import(ctx context.Context, opts entities.ImageImportOpti
 
 func (ir *ImageEngine) Push(ctx context.Context, source string, destination string, opts entities.ImagePushOptions) error {
 	options := new(images.PushOptions)
-	options.WithAll(opts.All).WithCompress(opts.Compress).WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithFormat(opts.Format).WithRemoveSignatures(opts.RemoveSignatures)
+	options.WithAll(opts.All).WithCompress(opts.Compress).WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithFormat(opts.Format).WithRemoveSignatures(opts.RemoveSignatures).WithQuiet(opts.Quiet)
 
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {


### PR DESCRIPTION
`podman-remote push` has shown absolutely no progress at all. Fix that
by doing essentially the same as the remote-pull code does.

The get-free-out-of-jail-card for backwards compatibility is to let the
`quiet` parameter default to true.  Since the --quioet flag wasn't
working before either, older Podman clients do not set it.

Also add regression tests to make sure we won't regress again.

Fixes: #14971
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where `podman-remote push` would not print any progress.
```

@containers/podman-maintainers PTAL
@mheon a v4.2 candidate
