### PR TITLE
[CI:DOCS] Cirrus: Add prominent gitlab warning

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -334,6 +334,9 @@ function _run_release() {
 }
 
 
+# ***WARNING*** ***WARNING*** ***WARNING*** ***WARNING***
+#    Please see gitlab comment in setup_environment.sh
+# ***WARNING*** ***WARNING*** ***WARNING*** ***WARNING***
 function _run_gitlab() {
     rootless_uid=$(id -u)
     systemctl enable --now --user podman.socket

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -321,12 +321,29 @@ case "$TEST_FLAVOR" in
         install_test_configs
         ;;
     gitlab)
-        # This only runs on Ubuntu for now
+        # ***WARNING*** ***WARNING*** ***WARNING*** ***WARNING***
+        # This sets up a special ubuntu environment exclusively for
+        # running the upstream gitlab-runner unit tests through
+        # podman as a drop-in replacement for the Docker daemon.
+        # Test and setup information can be found here:
+        # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/27270#note_499585550
+        #
+        # Unless you know what you're doing, and/or are in contact
+        # with the upstream gitlab-runner developers/community,
+        # please don't make changes willy-nilly to this setup.
+        # It's designed to follow upstream gitlab-runner development
+        # and alert us if any podman change breaks their foundation.
+        #
+        # That said, if this task does break in strange ways or requires
+        # updates you're unsure of.  Please consult with the upstream
+        # community through an issue near the one linked above.  If
+        # an extended period of breakage is expected, please un-comment
+        # the related `allow_failures: $CI == $CI` line in `.cirrus.yml`.
+        # ***WARNING*** ***WARNING*** ***WARNING*** ***WARNING***
+
         if [[ "$OS_RELEASE_ID" != "ubuntu" ]]; then
             die "This test only runs on Ubuntu due to sheer laziness"
         fi
-
-        # Ref: https://gitlab.com/gitlab-org/gitlab-runner/-/issues/27270#note_499585550
 
         remove_packaged_podman_files
         make install PREFIX=/usr ETCDIR=/etc


### PR DESCRIPTION
It was not obvious enough in the scripts how much of a snowflake this
environment is.  Fix that with lots of capitalized words and asterisks.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
