### PR TITLE
Fix: manifest push --rm removes a correct manifest list

### DIFF
--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -331,7 +331,8 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 	}
 
 	if opts.Rm {
-		if _, rmErrors := ir.Libpod.LibimageRuntime().RemoveImages(ctx, []string{manifestList.ID()}, nil); len(rmErrors) > 0 {
+		rmOpts := &libimage.RemoveImagesOptions{LookupManifest: true}
+		if _, rmErrors := ir.Libpod.LibimageRuntime().RemoveImages(ctx, []string{manifestList.ID()}, rmOpts); len(rmErrors) > 0 {
 			return "", fmt.Errorf("error removing manifest after push: %w", rmErrors[0])
 		}
 	}

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -110,5 +110,15 @@ func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination strin
 		}
 	}
 	digest, err := manifests.Push(ir.ClientCtx, name, destination, options)
+	if err != nil {
+		return "", fmt.Errorf("error adding to manifest list %s: %w", name, err)
+	}
+
+	if opts.Rm {
+		if _, rmErrors := ir.Remove(ctx, []string{name}, entities.ImageRemoveOptions{LookupManifest: true}); len(rmErrors) > 0 {
+			return "", fmt.Errorf("error removing manifest after push: %w", rmErrors[0])
+		}
+	}
+
 	return digest, err
 }


### PR DESCRIPTION
This bug is reproduced when we execute the following command:

1. `podman manifest add <manifest list> <images exist on local storage>`
2. `podman manifest push --rm <manifest list> dir:<directory>`

If pushing succeeds, it is expected to remove only a manifest list.
However, manifest list remains on local storage and images are removed.

This commit fixes `podman manifest push --rm` to remove only a manifest list.

Fixes: https://github.com/containers/podman/issues/15033

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
We can use "podman manifest push --rm" to remove the correct manifest list.
```
