### PR TITLE
fix container create/run throttle devices

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -494,10 +494,10 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 	if s.ResourceLimits == nil {
 		s.ResourceLimits = &spec.LinuxResources{}
 	}
-	if s.ResourceLimits.BlockIO == nil {
-		s.ResourceLimits.BlockIO = &spec.LinuxBlockIO{}
-	}
 	if bps := s.ThrottleReadBpsDevice; len(bps) > 0 {
+		if s.ResourceLimits.BlockIO == nil {
+			s.ResourceLimits.BlockIO = &spec.LinuxBlockIO{}
+		}
 		for k, v := range bps {
 			statT := unix.Stat_t{}
 			if err := unix.Stat(k, &statT); err != nil {
@@ -512,6 +512,9 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 		}
 	}
 	if bps := s.ThrottleWriteBpsDevice; len(bps) > 0 {
+		if s.ResourceLimits.BlockIO == nil {
+			s.ResourceLimits.BlockIO = &spec.LinuxBlockIO{}
+		}
 		for k, v := range bps {
 			statT := unix.Stat_t{}
 			if err := unix.Stat(k, &statT); err != nil {
@@ -523,6 +526,9 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 		}
 	}
 	if iops := s.ThrottleReadIOPSDevice; len(iops) > 0 {
+		if s.ResourceLimits.BlockIO == nil {
+			s.ResourceLimits.BlockIO = &spec.LinuxBlockIO{}
+		}
 		for k, v := range iops {
 			statT := unix.Stat_t{}
 			if err := unix.Stat(k, &statT); err != nil {
@@ -534,6 +540,9 @@ func FinishThrottleDevices(s *specgen.SpecGenerator) error {
 		}
 	}
 	if iops := s.ThrottleWriteIOPSDevice; len(iops) > 0 {
+		if s.ResourceLimits.BlockIO == nil {
+			s.ResourceLimits.BlockIO = &spec.LinuxBlockIO{}
+		}
 		for k, v := range iops {
 			statT := unix.Stat_t{}
 			if err := unix.Stat(k, &statT); err != nil {

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -55,6 +55,10 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		}
 	}
 
+	if err := FinishThrottleDevices(s); err != nil {
+		return nil, nil, nil, err
+	}
+
 	// Set defaults for unset namespaces
 	if s.PidNS.IsDefault() {
 		defaultNS, err := GetDefaultNamespaceMode("pid", rtc, pod)

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -77,11 +77,11 @@ func getIOLimits(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions) (
 	if s.ResourceLimits == nil {
 		s.ResourceLimits = &specs.LinuxResources{}
 	}
-	if s.ResourceLimits.BlockIO == nil {
-		s.ResourceLimits.BlockIO = &specs.LinuxBlockIO{}
-	}
 	hasLimits := false
 	if b := c.BlkIOWeight; len(b) > 0 {
+		if s.ResourceLimits.BlockIO == nil {
+			s.ResourceLimits.BlockIO = &specs.LinuxBlockIO{}
+		}
 		u, err := strconv.ParseUint(b, 10, 16)
 		if err != nil {
 			return nil, fmt.Errorf("invalid value for blkio-weight: %w", err)
@@ -103,7 +103,6 @@ func getIOLimits(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions) (
 		if s.ThrottleReadBpsDevice, err = parseThrottleBPSDevices(bps); err != nil {
 			return nil, err
 		}
-
 		hasLimits = true
 	}
 
@@ -131,8 +130,6 @@ func getIOLimits(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions) (
 	if !hasLimits {
 		return nil, nil
 	}
-	io = s.ResourceLimits.BlockIO
-
 	return io, nil
 }
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -715,7 +715,6 @@ USER bin`, BB)
 	})
 
 	It("podman run device-read-bps test", func() {
-		SkipIfCgroupV1("FIXME: #15035 - bps broken")
 		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-read-bps not supported on cgroupv1 for rootless users")
 
@@ -735,7 +734,6 @@ USER bin`, BB)
 	})
 
 	It("podman run device-write-bps test", func() {
-		SkipIfCgroupV1("FIXME: #15035 - bps broken")
 		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-write-bps not supported on cgroupv1 for rootless users")
 
@@ -754,7 +752,6 @@ USER bin`, BB)
 	})
 
 	It("podman run device-read-iops test", func() {
-		SkipIfCgroupV1("FIXME: #15035 - bps broken")
 		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-read-iops not supported on cgroupv1 for rootless users")
 		var session *PodmanSessionIntegration
@@ -773,7 +770,6 @@ USER bin`, BB)
 	})
 
 	It("podman run device-write-iops test", func() {
-		SkipIfCgroupV1("FIXME: #15035 - bps broken")
 		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
 		SkipIfRootlessCgroupsV1("Setting device-write-iops not supported on cgroupv1 for rootless users")
 		var session *PodmanSessionIntegration


### PR DESCRIPTION
pod resource limits introduced a regression where `FinishThrottleDevices` was not called for create/run

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
