### PR TITLE
[CI:DOCS] docs: remove CNI word where it is not applicable

### DIFF
--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	networkCreateDescription = `create CNI networks for containers and pods`
+	networkCreateDescription = `create networks for containers and pods`
 	networkCreateCommand     = &cobra.Command{
 		Use:               "create [options] [NAME]",
 		Short:             "network create",

--- a/cmd/podman/networks/inspect.go
+++ b/cmd/podman/networks/inspect.go
@@ -13,8 +13,8 @@ var (
 	networkinspectDescription = `Inspect network`
 	networkinspectCommand     = &cobra.Command{
 		Use:               "inspect [options] NETWORK [NETWORK...]",
-		Short:             "Displays the raw CNI network configuration for one or more networks.",
-		Long:              networkinspectDescription,
+		Long:              "Displays the network configuration for one or more networks.",
+		Short:             networkinspectDescription,
 		RunE:              networkInspect,
 		Example:           `podman network inspect podman`,
 		Args:              cobra.MinimumNArgs(1),

--- a/commands-demo.md
+++ b/commands-demo.md
@@ -45,13 +45,13 @@
 | [podman-logout(1)](https://podman.readthedocs.io/en/latest/markdown/podman-logout.1.html)                             | Logout of a container registry                                             |
 | [podman-logs(1)](https://podman.readthedocs.io/en/latest/markdown/podman-logs.1.html)                                 | Display the logs of one or more containers                                 |
 | [podman-mount(1)](https://podman.readthedocs.io/en/latest/markdown/podman-mount.1.html)                               | Mount a working container's root filesystem                                |
-| [podman-network(1)](https://podman.readthedocs.io/en/latest/network.html)                                             | Manage Podman CNI networks                                                 |
-| [podman-network-create(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-create.1.html)             | Create a CNI network                                                       |
-| [podman-network-connect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-connect.1.html)           | Connect a container to a CNI network                                       |
-| [podman-network-disconnect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-disconnect.1.html)             | Disconnect a container from a CNI network                                  |
-| [podman-network-inspect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-inspect.1.html)           | Displays the raw CNI network configuration for one or more networks        |
-| [podman-network-ls(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-ls.1.html)                     | Display a summary of CNI networks                                          |
-| [podman-network-rm(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-rm.1.html)                     | Remove one or more CNI networks                                            |
+| [podman-network(1)](https://podman.readthedocs.io/en/latest/network.html)                                             | Manage Podman networks                                                 |
+| [podman-network-create(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-create.1.html)             | Create a network                                                       |
+| [podman-network-connect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-connect.1.html)           | Connect a container to a network                                       |
+| [podman-network-disconnect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-disconnect.1.html)             | Disconnect a container from a network                                  |
+| [podman-network-inspect(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-inspect.1.html)           | Displays the network configuration for one or more networks        |
+| [podman-network-ls(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-ls.1.html)                     | Display a summary of networks                                          |
+| [podman-network-rm(1)](https://podman.readthedocs.io/en/latest/markdown/podman-network-rm.1.html)                     | Remove one or more networks                                            |
 | [podman-pause(1)](https://podman.readthedocs.io/en/latest/markdown/podman-pause.1.html)                               | Pause one or more running containers                                       | [![...](/docs/source/markdown/play.png)](https://podman.io/asciinema/podman/pause_unpause/)        | [Here](https://github.com/containers/Demos/blob/master/podman_cli/podman_pause_unpause.sh) |
 | [podman-play(1)](https://podman.readthedocs.io/en/latest/play.html)                                                   | Play a pod                                                                 |
 | [podman-play-kube(1)](https://podman.readthedocs.io/en/latest/markdown/podman-play-kube.1.html)                       | Create pods and containers based on Kubernetes YAML                        |

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -738,9 +738,12 @@ Valid _mode_ values are:
 
 #### **--network-alias**=*alias*
 
-Add a network-scoped alias for the container, setting the alias for all networks that the container joins. To set a name only for a specific network, use the alias option as described under the **--network** option.
-Network aliases work only with the bridge networking mode. This option can be specified multiple times.
-NOTE: A container will only have access to aliases on the first network that it joins. This is a limitation that will be removed in a later release.
+Add a network-scoped alias for the container, setting the alias for all networks that the container joins. To set a
+name only for a specific network, use the alias option as described under the **--network** option.
+If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <name>`),
+these aliases can be used for name resolution on the given network. This option can be specified multiple times.
+NOTE: When using CNI a container will only have access to aliases on the first network that it joins. This limitation does
+not exist with netavark/aardvark-dns.
 
 #### **--no-healthcheck**
 

--- a/docs/source/markdown/podman-kube-play.1.md
+++ b/docs/source/markdown/podman-kube-play.1.md
@@ -322,7 +322,7 @@ $ podman kube play demo.yml --network net1:ip=10.89.1.5 --network net2:ip=10.89.
 52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
 ```
 
-Please take into account that CNI networks must be created first using podman-network-create(1).
+Please take into account that networks must be created first using podman-network-create(1).
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-kube(1)](podman-kube.1.md)**, **[podman-network-create(1)](podman-network-create.1.md)**, **[podman-generate-kube(1)](podman-generate-kube.1.md)**, **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**

--- a/docs/source/markdown/podman-network-connect.1.md
+++ b/docs/source/markdown/podman-network-connect.1.md
@@ -12,10 +12,10 @@ Once connected, the container can communicate with other containers in the same 
 
 ## OPTIONS
 #### **--alias**=*name*
-Add network-scoped alias for the container.  If the network is using the `dnsname` CNI plugin, these aliases
-can be used for name resolution on the given network.  Multiple *--alias* options may be specified as input.
-NOTE: A container will only have access to aliases on the first network that it joins.  This is a limitation
-that will be removed in a later release.
+Add network-scoped alias for the container. If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <NAME>`),
+these aliases can be used for name resolution on the given network.  Multiple *--alias* options may be specified as input.
+NOTE: When using CNI a container will only have access to aliases on the first network that it joins. This limitation does
+not exist with netavark/aardvark-dns.
 
 #### **--ip**=*address*
 Set a static ipv4 address for this container on this network.
@@ -44,7 +44,7 @@ podman network connect --ip 10.89.1.13 test web
 ```
 
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-network(1)](podman-network.1.md)**, **[podman-network-disconnect(1)](podman-network-disconnect.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-network(1)](podman-network.1.md)**, **[podman-network-inspect(1)](podman-network-inspect.1.md)**, **[podman-network-disconnect(1)](podman-network-disconnect.1.md)**
 
 ## HISTORY
 November 2020, Originally compiled by Brent Baude <bbaude@redhat.com>

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -7,11 +7,9 @@ podman\-network-create - Create a Podman network
 **podman network create**  [*options*] [*name*]
 
 ## DESCRIPTION
-Create a CNI-network configuration for use with Podman. By default, Podman creates a bridge connection.
+Create a network configuration for use with Podman. By default, Podman creates a bridge connection.
 A *Macvlan* connection can be created with the *-d macvlan* option. A parent device for macvlan can
-be designated with the *-o parent=`<device>`* option. In the case of *Macvlan* connections, the
-CNI *dhcp* plugin needs to be activated or the container image must have a DHCP client to interact
-with the host network's DHCP server.
+be designated with the *-o parent=`<device>`* option.
 
 If no options are provided, Podman will assign a free subnet and name for your network.
 
@@ -54,7 +52,7 @@ The argument order of the **--subnet**, **--gateway** and **--ip-range** options
 Set the ipam driver (IP Address Management Driver) for the network. When unset podman will choose an
 ipam driver automatically based on the network driver. Valid values are:
  - `host-local`: IP addresses are assigned locally.
- - `dhcp`: IP addresses are assigned from a dhcp server on your network. This driver is not yet supported with netavark.
+ - `dhcp`: IP addresses are assigned from a dhcp server on your network. This driver is not yet supported with netavark. For CNI the *dhcp* plugin needs to be activated before.
  - `none`: No ip addresses are assigned to the interfaces.
 
 You can see the driver in the **podman network inspect** output under the `ipam_options` field.
@@ -94,7 +92,7 @@ This is useful to set a static ipv4 and ipv6 subnet.
 Create a network with no options.
 ```
 $ podman network create
-cni-podman2
+podman2
 ```
 
 Create a network named *newnet* that uses *192.5.0.0/16* for its subnet.
@@ -118,7 +116,7 @@ newnet
 Create a network that uses a *192.168.55.0/24** subnet and has an IP address range of *192.168.55.129 - 192.168.55.254*.
 ```
 $ podman network create --subnet 192.168.55.0/24 --ip-range 192.168.55.128/25
-cni-podman5
+podman5
 ```
 
 Create a network with a static ipv4 and ipv6 subnet and set a gateway.

--- a/docs/source/markdown/podman-network-inspect.1.md
+++ b/docs/source/markdown/podman-network-inspect.1.md
@@ -1,13 +1,13 @@
 % podman-network-inspect(1)
 
 ## NAME
-podman\-network\-inspect - Displays the raw network configuration for one or more networks
+podman\-network\-inspect - Displays the network configuration for one or more networks
 
 ## SYNOPSIS
 **podman network inspect** [*options*] *network* [*network* ...]
 
 ## DESCRIPTION
-Display the raw (JSON format) network configuration.
+Display the (JSON format) network configuration.
 
 ## OPTIONS
 #### **--format**, **-f**=*format*
@@ -40,7 +40,7 @@ $ podman network inspect podman
         "name": "podman",
         "id": "2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9",
         "driver": "bridge",
-        "network_interface": "cni-podman0",
+        "network_interface": "podman0",
         "created": "2021-06-03T12:04:33.088567413+02:00",
         "subnets": [
             {

--- a/docs/source/markdown/podman-network-ls.1.md
+++ b/docs/source/markdown/podman-network-ls.1.md
@@ -77,8 +77,8 @@ Display networks
 $ podman network ls
 NETWORK ID    NAME         DRIVER
 88a7120ee19d  podman       bridge
-6dd508dbf8cd  cni-podman6  bridge
-8e35c2cd3bf6  cni-podman5  macvlan
+6dd508dbf8cd  podman6  bridge
+8e35c2cd3bf6  podman5  macvlan
 ```
 
 Display only network names
@@ -101,7 +101,7 @@ List networks with their subnets
 ```
 $ podman network ls --format "{{.Name}}: {{range .Subnets}}{{.Subnet}} {{end}}"
 podman: 10.88.0.0/16
-cni-podman3: 10.89.30.0/24 fde4:f86f:4aab:e68f::/64
+podman3: 10.89.30.0/24 fde4:f86f:4aab:e68f::/64
 macvlan:
 ```
 

--- a/docs/source/markdown/podman-network-rm.1.md
+++ b/docs/source/markdown/podman-network-rm.1.md
@@ -21,11 +21,11 @@ Seconds to wait before forcibly stopping the running containers that are using t
 
 ## EXAMPLE
 
-Delete the `cni-podman9` network
+Delete the `podman9` network
 
 ```
-# podman network rm cni-podman9
-Deleted: cni-podman9
+# podman network rm podman9
+Deleted: podman9
 ```
 
 Delete the `fred` network and all containers associated with the network.

--- a/docs/source/markdown/podman-network.1.md
+++ b/docs/source/markdown/podman-network.1.md
@@ -27,7 +27,7 @@ so networks have to be created again after a backend change.
 | create     | [podman-network-create(1)](podman-network-create.1.md)         | Create a Podman network                                         |
 | disconnect | [podman-network-disconnect(1)](podman-network-disconnect.1.md) | Disconnect a container from a network                           |
 | exists     | [podman-network-exists(1)](podman-network-exists.1.md)         | Check if the given network exists                               |
-| inspect    | [podman-network-inspect(1)](podman-network-inspect.1.md)       | Displays the raw network configuration for one or more networks |
+| inspect    | [podman-network-inspect(1)](podman-network-inspect.1.md)       | Displays the network configuration for one or more networks     |
 | ls         | [podman-network-ls(1)](podman-network-ls.1.md)                 | Display a summary of networks                                   |
 | prune      | [podman-network-prune(1)](podman-network-prune.1.md)           | Remove all unused networks                                      |
 | reload     | [podman-network-reload(1)](podman-network-reload.1.md)         | Reload network configuration for containers                     |

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -284,9 +284,12 @@ Valid _mode_ values are:
 
 #### **--network-alias**=*alias*
 
-Add a network-scoped alias for the pod, setting the alias for all networks that the pod joins. To set a name only for a specific network, use the alias option as described under the **--network** option.
-Network aliases work only with the bridge networking mode. This option can be specified multiple times.
-NOTE: A container will only have access to aliases on the first network that it joins. This is a limitation that will be removed in a later release.
+Add a network-scoped alias for the pod, setting the alias for all networks that the container joins. To set a
+name only for a specific network, use the alias option as described under the **--network** option.
+If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <name>`),
+these aliases can be used for name resolution on the given network. This option can be specified multiple times.
+NOTE: When using CNI a pod will only have access to aliases on the first network that it joins. This limitation does
+not exist with netavark/aardvark-dns.
 
 #### **--no-hosts**
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -755,9 +755,12 @@ Valid _mode_ values are:
 
 #### **--network-alias**=*alias*
 
-Add a network-scoped alias for the container, setting the alias for all networks that the container joins. To set a name only for a specific network, use the alias option as described under the **--network** option.
-Network aliases work only with the bridge networking mode. This option can be specified multiple times.
-NOTE: A container will only have access to aliases on the first network that it joins. This is a limitation that will be removed in a later release.
+Add a network-scoped alias for the container, setting the alias for all networks that the container joins. To set a
+name only for a specific network, use the alias option as described under the **--network** option.
+If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <name>`),
+these aliases can be used for name resolution on the given network. This option can be specified multiple times.
+NOTE: When using CNI a container will only have access to aliases on the first network that it joins. This limitation does
+not exist with netavark/aardvark-dns.
 
 #### **--no-healthcheck**
 

--- a/docs/tutorials/basic_networking.md
+++ b/docs/tutorials/basic_networking.md
@@ -32,7 +32,7 @@ port mapping.  Depending on the firewall implementation, we have observed firewa
 ports being opened automatically due to running a container with a port mapping (for
 example).  If container traffic does not seem to work properly, check the firewall
 and allow traffic on ports the container is using. A common problem is that
-reloading the firewall deletes the cni iptables rules resulting in a loss of
+reloading the firewall deletes the cni/netavark iptables rules resulting in a loss of
 network connectivity for rootful containers. Podman v3 provides the podman
 network reload command to restore this without having to restart the container.
 
@@ -83,7 +83,7 @@ users.  But as of Podman version 4.0, rootless users can also use netavark.
 The user experience of rootless netavark is very akin to a rootful netavark, except that
 there is no default network configuration provided.  You simply need to create a
 network, and the one will be created as a bridge network. If you would like to switch from
-CNI networking to netvaark, you must issue the `podman system reset --force` command.
+CNI networking to netavark, you must issue the `podman system reset --force` command.
 This will delete all of your images, containers, and custom networks.
 
 ```
@@ -177,7 +177,7 @@ address, you should continue to use CNI instead of netavark.
 
 ```
 $ sudo podman network create -d macvlan -o parent=eth0 webnetwork
-/etc/cni/net.d/webnetwork.conflist
+webnetwork
 ```
 The next step is to ensure that the DHCP CNI plugin is running.  This plugin facilitates
 the DHCP lease from the network.


### PR DESCRIPTION
Most network commands/features work with both netavark and CNI. When
we added added netavark most docs were not vetted and thus still use CNI
network, it should just say network.

Fixes #14990

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
