### PR TITLE
API: libpod/create use correct default umask

### DIFF
--- a/pkg/api/handlers/libpod/containers_create.go
+++ b/pkg/api/handlers/libpod/containers_create.go
@@ -31,6 +31,9 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		ContainerNetworkConfig: specgen.ContainerNetworkConfig{
 			UseImageHosts: conf.Containers.NoHosts,
 		},
+		ContainerSecurityConfig: specgen.ContainerSecurityConfig{
+			Umask: conf.Containers.Umask,
+		},
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&sg); err != nil {

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -123,7 +123,8 @@ t GET    libpod/containers/${cid}/json 200 \
   .Id=$cid \
   .State.Status~\\\(exited\\\|stopped\\\) \
   .State.Running=false \
-  .State.ExitCode=0
+  .State.ExitCode=0 \
+  .Config.Umask=0022 # regression check for #15036
 t DELETE libpod/containers/$cid 200 .[0].Id=$cid
 
 CNAME=myfoo


### PR DESCRIPTION
Make sure containers created via API have the correct umask from
containers.conf set.

Fixes #15036

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Containers created via the libpod API now use the correct umask from containers.conf.
```
