### PR TITLE
integration test: fix network backend option with remote

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -856,12 +856,8 @@ func (p *PodmanTestIntegration) makeOptions(args []string, noEvents, noCache boo
 		eventsType = "none"
 	}
 
-	podmanOptions := strings.Split(fmt.Sprintf("%s--root %s --runroot %s --runtime %s --conmon %s --network-config-dir %s --cgroup-manager %s --tmpdir %s --events-backend %s",
-		debug, p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, p.NetworkConfigDir, p.CgroupManager, p.TmpDir, eventsType), " ")
-
-	if !p.RemoteTest {
-		podmanOptions = append(podmanOptions, "--network-backend", p.NetworkBackend.ToString())
-	}
+	podmanOptions := strings.Split(fmt.Sprintf("%s--root %s --runroot %s --runtime %s --conmon %s --network-config-dir %s --network-backend %s --cgroup-manager %s --tmpdir %s --events-backend %s",
+		debug, p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, p.NetworkConfigDir, p.NetworkBackend.ToString(), p.CgroupManager, p.TmpDir, eventsType), " ")
 
 	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
 	if !noCache {

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -136,11 +136,8 @@ func (p *PodmanTestIntegration) StopRemoteService() {
 // MakeOptions assembles all the podman main options
 func getRemoteOptions(p *PodmanTestIntegration, args []string) []string {
 	networkDir := p.NetworkConfigDir
-	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --network-config-dir %s --cgroup-manager %s",
-		p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, networkDir, p.CgroupManager), " ")
-	if p.NetworkBackend.ToString() == "netavark" {
-		podmanOptions = append(podmanOptions, "--network-backend", "netavark")
-	}
+	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --network-config-dir %s --network-backend %s --cgroup-manager %s",
+		p.Root, p.RunRoot, p.OCIRuntime, p.ConmonBinary, networkDir, p.NetworkBackend.ToString(), p.CgroupManager), " ")
 	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
 	podmanOptions = append(podmanOptions, args...)
 	return podmanOptions

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -293,9 +293,6 @@ var _ = Describe("Podman manifest", func() {
 	})
 
 	It("authenticated push", func() {
-		if podmanTest.Host.Distribution == "ubuntu" && IsRemote() {
-			Skip("FIXME: #15017. Registry times out.")
-		}
 		registryOptions := &podmanRegistry.Options{
 			Image: "docker-archive:" + imageTarPath(REGISTRY_IMAGE),
 		}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -110,9 +110,6 @@ func (p *PodmanTest) PodmanAsUserBase(args []string, uid, gid uint32, cwd string
 	}
 	runCmd := wrapper
 	runCmd = append(runCmd, podmanBinary)
-	if !p.RemoteTest && p.NetworkBackend == Netavark {
-		runCmd = append(runCmd, []string{"--network-backend", "netavark"}...)
-	}
 
 	if env == nil {
 		fmt.Printf("Running: %s %s\n", strings.Join(runCmd, " "), strings.Join(podmanOptions, " "))


### PR DESCRIPTION
I honestly do not understand all this extra option parsing here but
there is really no reason to exclude  the option for remote, all the
other global options are also set there.

This fixes a problem with mixed cni/netavark use because the option was
unset.

Fixes #15017

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
