### PR TITLE
Set TLSVerify=true by default for API endpoints

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -140,6 +140,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		Registry:      "docker.io",
 		Rm:            true,
 		ShmSize:       64 * 1024 * 1024,
+		TLSVerify:     true,
 	}
 
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)

--- a/pkg/api/handlers/compat/images_search.go
+++ b/pkg/api/handlers/compat/images_search.go
@@ -26,6 +26,7 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 		ListTags  bool                `json:"listTags"`
 	}{
 		// This is where you can override the golang default value for one of fields
+		TLSVerify: true,
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {

--- a/pkg/api/handlers/libpod/images_push.go
+++ b/pkg/api/handlers/libpod/images_push.go
@@ -32,6 +32,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		TLSVerify        bool   `schema:"tlsVerify"`
 		Quiet            bool   `schema:"quiet"`
 	}{
+		TLSVerify: true,
 		// #14971: older versions did not sent *any* data, so we need
 		//         to be quiet by default to remain backwards compatible
 		Quiet: true,

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -310,6 +310,7 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 		TLSVerify bool `schema:"tlsVerify"`
 	}{
 		// Add defaults here once needed.
+		TLSVerify: true,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusBadRequest,

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -192,8 +192,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: tlsVerify
 	//    type: boolean
-	//    default: false
-	//    description: skip TLS verification for registries
+	//    default: true
+	//    description: Require HTTPS and verify signatures when contacting registries.
 	//  - in: query
 	//    name: listTags
 	//    type: boolean
@@ -1120,8 +1120,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: tlsVerify
 	//    type: boolean
-	//    default: false
-	//    description: skip TLS verification for registries
+	//    default: true
+	//    description: Require HTTPS and verify signatures when contacting registries.
 	//  - in: query
 	//    name: listTags
 	//    type: boolean

--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -69,12 +69,12 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//    name: all
 	//    description: push all images
 	//    type: boolean
-	//    default: false
+	//    default: true
 	//  - in: query
 	//    name: tlsVerify
 	//    type: boolean
-	//    default: false
-	//    description: skip TLS verification for registries
+	//    default: true
+	//    description: Require HTTPS and verify signatures when contacting registries.
 	// responses:
 	//   200:
 	//     schema:
@@ -195,8 +195,8 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: tlsVerify
 	//    type: boolean
-	//    default: false
-	//    description: skip TLS verification for registries
+	//    default: true
+	//    description: Require HTTPS and verify signatures when contacting registries.
 	//  - in: body
 	//    name: options
 	//    description: options for mutating a manifest

--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -28,7 +28,10 @@ t GET libpod/images/$IMAGE/json 200 \
   .RepoTags[1]=localhost:$REGISTRY_PORT/myrepo:mytag
 
 # Push to local registry...
-t POST "images/localhost:$REGISTRY_PORT/myrepo/push?tlsVerify=false&tag=mytag" 200
+t POST "images/localhost:$REGISTRY_PORT/myrepo/push?tag=mytag" 200 \
+  .error~".*x509: certificate signed by unknown authority"
+t POST "images/localhost:$REGISTRY_PORT/myrepo/push?tlsVerify=false&tag=mytag" 200 \
+  .error~null
 
 # ...and check output. We can't use our built-in checks because this output
 # is a sequence of JSON objects, i.e., individual ones, not in a JSON array.

--- a/test/apiv2/15-manifest.at
+++ b/test/apiv2/15-manifest.at
@@ -31,6 +31,8 @@ t POST /v3.4.0/libpod/manifests/$id_abc/add images="[\"containers-storage:$id_ab
 t PUT /v4.0.0/libpod/manifests/$id_xyz operation='update' images="[\"containers-storage:$id_xyz_image\"]" 200
 
 t POST "/v3.4.0/libpod/manifests/abc:latest/push?destination=localhost:$REGISTRY_PORT%2Fabc:latest&tlsVerify=false&all=true" 200
+t POST "/v4.0.0/libpod/manifests/xyz:latest/registry/localhost:$REGISTRY_PORT%2Fxyz:latest?all=true" 400 \
+  .cause='x509: certificate signed by unknown authority'
 t POST "/v4.0.0/libpod/manifests/xyz:latest/registry/localhost:$REGISTRY_PORT%2Fxyz:latest?tlsVerify=false&all=true" 200
 
 # /v3.x cannot delete a manifest list


### PR DESCRIPTION
Option defaults in API must be the same as in CLI.

```
% podman image push --help
% podman image pull --help
% podman manifest push --help
% podman image search --help
```

All of these CLI commands them have --tls-verify=true by default:
```
--tls-verify  require HTTPS and verify certificates when accessing the registry (default true)
```

As for `podman image build`, it doesn't have any means to control
`tlsVerify` parameter but it must be true by default.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none

```
