### PR TITLE
Semiperiodoc cleanup of obsolete FIXMEs

### DIFF
--- a/pkg/bindings/test/images_test.go
+++ b/pkg/bindings/test/images_test.go
@@ -120,8 +120,6 @@ var _ = Describe("Podman images", func() {
 		// deleting hence image cannot be deleted until the container is deleted.
 		_, errs = images.Remove(bt.conn, []string{alpine.shortName}, nil)
 		code, _ = bindings.CheckResponseCode(errs[0])
-		// FIXME FIXME FIXME: #12441: another invalid error
-		// FIXME FIXME FIXME: this time msg="Image used by SHA: ..."
 		Expect(code).To(BeNumerically("==", -1))
 
 		// Removing the image "alpine" where force = true

--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -163,7 +163,7 @@ skip "does not work under podman" \
 # which we could and perhaps should fix in the buildah repo via:
 #    - ... ${TESTSDIR}/bud/layers-squash/Dockerfile.hardlinks
 #    + ... -f Dockerfile.hardlinks ${TESTSDIR}/bud/layers-squash
-skip "FIXME FIXME FIXME: argument-order incompatible with podman" \
+skip "argument-order incompatible with podman" \
      "bud-squash-hardlinks"
 
 # Fails with "Error: context must be a directory: /path/to/Dockerfile"
@@ -231,7 +231,7 @@ skip_if_remote "FIXME FIXME FIXME: does this test make sense in remote?" \
 ###############################################################################
 # BEGIN tests which are skipped due to actual podman or podman-remote bugs.
 
-skip_if_remote "Podman #12838: different error messages" \
+skip_if_remote "different error messages between podman & podman-remote" \
                "bud with .dockerignore #2"
 
 # These two tests, new in 2022-01, invoke podman (create, export) in ways

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -1457,11 +1457,6 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint and restore container with --file-locks", func() {
-		if !strings.Contains(podmanTest.OCIRuntime, "runc") {
-			// TODO: Enable test for crun when this feature has been released
-			// https://github.com/containers/crun/pull/783
-			Skip("FIXME: requires crun >= 1.4")
-		}
 		localRunString := getRunString([]string{"--name", "test_name", ALPINE, "flock", "test.lock", "sleep", "100"})
 		session := podmanTest.Podman(localRunString)
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -535,7 +535,8 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 	It("podman containers.conf cgroups=disabled", func() {
 		if !strings.Contains(podmanTest.OCIRuntime, "crun") {
-			Skip("FIXME: requires crun")
+			// Assume this will never be fixed in runc
+			Skip("NoCgroups requires crun")
 		}
 
 		conffile := filepath.Join(podmanTest.TempDir, "container.conf")

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -715,8 +715,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-read-bps test", func() {
-		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
-		SkipIfRootlessCgroupsV1("Setting device-read-bps not supported on cgroupv1 for rootless users")
+		SkipIfRootless("Setting device-read-bps not supported for rootless users")
 
 		var session *PodmanSessionIntegration
 
@@ -734,8 +733,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-write-bps test", func() {
-		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
-		SkipIfRootlessCgroupsV1("Setting device-write-bps not supported on cgroupv1 for rootless users")
+		SkipIfRootless("Setting device-write-bps not supported for rootless users")
 
 		var session *PodmanSessionIntegration
 
@@ -752,8 +750,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-read-iops test", func() {
-		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
-		SkipIfRootlessCgroupsV1("Setting device-read-iops not supported on cgroupv1 for rootless users")
+		SkipIfRootless("Setting device-read-iops not supported for rootless users")
 		var session *PodmanSessionIntegration
 
 		if CGROUPSV2 {
@@ -770,8 +767,7 @@ USER bin`, BB)
 	})
 
 	It("podman run device-write-iops test", func() {
-		SkipIfRootless("FIXME: requested cgroup controller `io` is not available")
-		SkipIfRootlessCgroupsV1("Setting device-write-iops not supported on cgroupv1 for rootless users")
+		SkipIfRootless("Setting device-write-iops not supported for rootless users")
 		var session *PodmanSessionIntegration
 
 		if CGROUPSV2 {
@@ -1239,6 +1235,7 @@ USER mail`, BB)
 	})
 
 	It("podman run --mount type=bind,bind-nonrecursive", func() {
+		// crun: mount `/` to `/host`: Invalid argument
 		SkipIfRootless("FIXME: rootless users are not allowed to mount bind-nonrecursive (Could this be a Kernel bug?")
 		session := podmanTest.Podman([]string{"run", "--mount", "type=bind,bind-nonrecursive,slave,src=/,target=/host", fedoraMinimal, "findmnt", "-nR", "/host"})
 		session.WaitWithDefaultTimeout()

--- a/test/system/520-checkpoint.bats
+++ b/test/system/520-checkpoint.bats
@@ -12,7 +12,7 @@ function setup() {
     # could run to see if it's fixed, but it's way too complicated. Since
     # integration tests also skip checkpoint tests on Ubuntu, do the same here.
     if is_ubuntu; then
-        skip "FIXME: checkpointing broken in Ubuntu 2004, 2104, 2110, ..."
+        skip "FIXME: checkpointing broken in Ubuntu 2004, 2104, 2110, 2204, ..."
     fi
 
     # None of these tests work rootless....


### PR DESCRIPTION
Some refer to issues that are closed. Some, I have no idea if
they're fixed or not, we'll find out in CI.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
Increase test coverage by removing outdated skips
```
