### PR TITLE
pod create --share none should not create infra

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -134,6 +134,12 @@ func create(cmd *cobra.Command, args []string) error {
 		imageName = infraImage
 	}
 	img := imageName
+
+	if !cmd.Flag("infra").Changed && (share == "none" || share == "") {
+		// we do not want an infra container when not sharing namespaces
+		createOptions.Infra = false
+	}
+
 	if !createOptions.Infra {
 		if cmd.Flag("no-hosts").Changed {
 			return fmt.Errorf("cannot specify --no-hosts without an infra container")

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -373,7 +373,7 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 #### **--share**=*namespace*
 
-A comma-separated list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared. The namespaces to choose from are cgroup, ipc, net, pid, uts. If the option is prefixed with a "+" then the namespace is appended to the default list, otherwise it replaces the default list. Defaults matches Kubernetes default (ipc, net, uts)
+A comma-separated list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared and the infra container will not be created unless expiclity specified via **--infra=true**. The namespaces to choose from are cgroup, ipc, net, pid, uts. If the option is prefixed with a "+" then the namespace is appended to the default list, otherwise it replaces the default list. Defaults matches Kubernetes default (ipc, net, uts)
 
 #### **--share-parent**
 

--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -435,4 +435,20 @@ var _ = Describe("Podman pod create", func() {
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring(hostname))
 	})
+
+	tests := []string{"", "none"}
+	for _, test := range tests {
+		test := test
+		It("podman pod create --share="+test+" should not create an infra ctr", func() {
+			session := podmanTest.Podman([]string{"pod", "create", "--share", test})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(0))
+
+			session = podmanTest.Podman([]string{"pod", "inspect", "--format", "{{.NumContainers}}", session.OutputToString()})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(0))
+			Expect(session.OutputToString()).Should((Equal("0")))
+		})
+	}
+
 })


### PR DESCRIPTION
for podman pod create, when we are not sharing any namespaces there is no point for the infra container.
This is especially true since resources have also been decoupled from the container recently.

handle this on the cmd level so that we can still create infra if set explicitly

resolves #15048

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
when using podman pod create --share, if --share=none or --share="" is specified, the pod's infra container is not created
```
