### PR TITLE
machine: Fix check which is always true

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -670,11 +670,11 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		// because / is immutable, we have to monkey around with permissions
 		// if we dont mount in /home or /mnt
 		args := []string{"-q", "--"}
-		if !strings.HasPrefix(mount.Target, "/home") || !strings.HasPrefix(mount.Target, "/mnt") {
+		if !strings.HasPrefix(mount.Target, "/home") && !strings.HasPrefix(mount.Target, "/mnt") {
 			args = append(args, "sudo", "chattr", "-i", "/", ";")
 		}
 		args = append(args, "sudo", "mkdir", "-p", mount.Target)
-		if !strings.HasPrefix(mount.Target, "/home") || !strings.HasPrefix(mount.Target, "/mnt") {
+		if !strings.HasPrefix(mount.Target, "/home") && !strings.HasPrefix(mount.Target, "/mnt") {
 			args = append(args, ";", "sudo", "chattr", "+i", "/", ";")
 		}
 		err = v.SSH(name, machine.SSHOptions{Args: args})


### PR DESCRIPTION
Before making / mutable/immutable, podman-machine checks if the mount is
being done in /home or /mnt. However the current check is always going
to be true:
```
!strings.HasPrefix(mount.Target, "/home") || !strings.HasPrefix(mount.Target, "/mnt")
```
is false when mount.Target starts with "/home" and mount.Target starts
with "/mnt", which cannot happen at the same time.

The correct check is:
```
!strings.HasPrefix(mount.Target, "/home") && !strings.HasPrefix(mount.Target, "/mnt")
```
which can also be written as:
```
!(strings.HasPrefix(mount.Target, "/home") || strings.HasPrefix(mount.Target, "/mnt"))
```
[NO NEW TESTS NEEDED]
The impact is not too bad, it results in extra 'chattr -i' calls which
should be unneeded.


#### Does this PR introduce a user-facing change?

**If** the chattr -i call is unneeded for /mnt and /home, then no, there won't be any user-facing change.