### PR TITLE
benchmarks: fix create test

### DIFF
--- a/test/e2e/benchmarks_test.go
+++ b/test/e2e/benchmarks_test.go
@@ -240,7 +240,7 @@ var _ = Describe("Podman Benchmark Suite", func() {
 		// --------------------------------------------------------------------------
 
 		newBenchmark("podman create", func() {
-			session := podmanTest.Podman([]string{"run", ALPINE, "true"})
+			session := podmanTest.Podman([]string{"create", ALPINE, "true"})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
 		}, nil)
@@ -259,6 +259,12 @@ var _ = Describe("Podman Benchmark Suite", func() {
 
 		newBenchmark("podman run", func() {
 			session := podmanTest.Podman([]string{"run", ALPINE, "true"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(0))
+		}, nil)
+
+		newBenchmark("podman run --detach", func() {
+			session := podmanTest.Podman([]string{"run", "--detach", ALPINE, "true"})
 			session.WaitWithDefaultTimeout()
 			Expect(session).Should(Exit(0))
 		}, nil)


### PR DESCRIPTION
And a new one for `run --detach`.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
@mheon @Luap99 @rhatdan PTAL

We can add more benchmarks in the future.