### PR TITLE
Fix: Restore a container which name is equal to a image name

### DIFF
--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -93,32 +93,49 @@ func init() {
 }
 
 func restore(cmd *cobra.Command, args []string) error {
-	var errs utils.OutputErrors
+	var (
+		e    error
+		errs utils.OutputErrors
+	)
 	podmanStart := time.Now()
 	if rootless.IsRootless() {
 		return fmt.Errorf("restoring a container requires root")
 	}
 
-	// Find out if this is an image
-	inspectOpts := entities.InspectOptions{}
-	imgData, _, err := registry.ImageEngine().Inspect(context.Background(), args, inspectOpts)
-	if err != nil {
-		return err
-	}
-
-	hostInfo, err := registry.ContainerEngine().Info(context.Background())
-	if err != nil {
-		return err
-	}
-
-	for i := range imgData {
-		restoreOptions.CheckpointImage = true
-		checkpointRuntimeName, found := imgData[i].Annotations[define.CheckpointAnnotationRuntimeName]
-		if !found {
-			return fmt.Errorf("image is not a checkpoint: %s", imgData[i].ID)
+	// Check if the container exists (#15055)
+	exists := &entities.BoolReport{Value: false}
+	for _, ctr := range args {
+		exists, e = registry.ContainerEngine().ContainerExists(registry.GetContext(), ctr, entities.ContainerExistsOptions{})
+		if e != nil {
+			return e
 		}
-		if hostInfo.Host.OCIRuntime.Name != checkpointRuntimeName {
-			return fmt.Errorf("container image \"%s\" requires runtime: \"%s\"", imgData[i].ID, checkpointRuntimeName)
+		if exists.Value {
+			break
+		}
+	}
+
+	if !exists.Value {
+		// Find out if this is an image
+		inspectOpts := entities.InspectOptions{}
+		imgData, _, err := registry.ImageEngine().Inspect(context.Background(), args, inspectOpts)
+		if err != nil {
+			return err
+		}
+
+		hostInfo, err := registry.ContainerEngine().Info(context.Background())
+		if err != nil {
+			return err
+		}
+
+		for i := range imgData {
+			restoreOptions.CheckpointImage = true
+			checkpointRuntimeName, found := imgData[i].Annotations[define.CheckpointAnnotationRuntimeName]
+			if !found {
+				return fmt.Errorf("image is not a checkpoint: %s", imgData[i].ID)
+			}
+			if hostInfo.Host.OCIRuntime.Name != checkpointRuntimeName {
+				return fmt.Errorf("container image \"%s\" requires runtime: \"%s\"", imgData[i].ID, checkpointRuntimeName)
+			}
 		}
 	}
 

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -223,6 +223,26 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(result).Should(Exit(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
+
+		// Restore a container which name is equal to a image name (#15055)
+		localRunString = getRunString([]string{"--name", "alpine", "quay.io/libpod/alpine:latest", "top"})
+		session = podmanTest.Podman(localRunString)
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		result = podmanTest.Podman([]string{"container", "checkpoint", "alpine"})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
+
+		result = podmanTest.Podman([]string{"container", "restore", "alpine"})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result).Should(Exit(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 	})
 
 	It("podman pause a checkpointed container by id", func() {


### PR DESCRIPTION
If there is a match for both container and image, we restore the container.

Fixes: https://github.com/containers/podman/issues/15055

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman can restore a container which name is equal to a image name
```
