### PR TITLE
api handlers: do not set TlsVerify

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -140,7 +140,6 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		Registry:      "docker.io",
 		Rm:            true,
 		ShmSize:       64 * 1024 * 1024,
-		TLSVerify:     true,
 	}
 
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)

--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -46,7 +46,6 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		Tag         string `schema:"tag"`
 	}{
 		// This is where you can override the golang default value for one of fields
-		TLSVerify: true,
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {

--- a/pkg/api/handlers/compat/images_search.go
+++ b/pkg/api/handlers/compat/images_search.go
@@ -26,7 +26,6 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 		ListTags  bool                `json:"listTags"`
 	}{
 		// This is where you can override the golang default value for one of fields
-		TLSVerify: true,
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {

--- a/pkg/api/handlers/libpod/images_pull.go
+++ b/pkg/api/handlers/libpod/images_pull.go
@@ -37,7 +37,6 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 		PullPolicy string `schema:"policy"`
 		Quiet      bool   `schema:"quiet"`
 	}{
-		TLSVerify:  true,
 		PullPolicy: "always",
 	}
 

--- a/pkg/api/handlers/libpod/images_push.go
+++ b/pkg/api/handlers/libpod/images_push.go
@@ -32,7 +32,6 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		TLSVerify        bool   `schema:"tlsVerify"`
 		Quiet            bool   `schema:"quiet"`
 	}{
-		TLSVerify: true,
 		// #14971: older versions did not sent *any* data, so we need
 		//         to be quiet by default to remain backwards compatible
 		Quiet: true,

--- a/pkg/api/handlers/libpod/kube.go
+++ b/pkg/api/handlers/libpod/kube.go
@@ -29,8 +29,7 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 		StaticMACs  []string          `schema:"staticMACs"`
 		NoHosts     bool              `schema:"noHosts"`
 	}{
-		TLSVerify: true,
-		Start:     true,
+		Start: true,
 	}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -310,7 +310,6 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 		TLSVerify bool `schema:"tlsVerify"`
 	}{
 		// Add defaults here once needed.
-		TLSVerify: true,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusBadRequest,


### PR DESCRIPTION
Commit 52a4642edd8a2c2f62d10c2180d785b4f04f18c5 forced the default to
`true` in the code along with the docs.  The problem with hard-setting
it is that it breaks how the optional bool is meant to be used by
containers/image.  If it is not set, c/image will default to true unless
otherwise configured in `/etc/containers/registries.conf`.  If set,
c/image will use the specified value as it assumes the _user_ knows what
they are doing.

In other words: without this fix, the API ignores the `insecure`
settings in `registries.conf`.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
