### PR TITLE
Add support for podman context as alias to podman system connection

### DIFF
--- a/cmd/podman/registry/remote.go
+++ b/cmd/podman/registry/remote.go
@@ -32,6 +32,8 @@ func IsRemote() bool {
 		fs.BoolVarP(&remoteFromCLI.Value, "remote", "r", remote, "")
 		connectionFlagName := "connection"
 		fs.StringP(connectionFlagName, "c", "", "")
+		contextFlagName := "context"
+		fs.String(contextFlagName, "", "")
 		hostFlagName := "host"
 		fs.StringP(hostFlagName, "H", "", "")
 		urlFlagName := "url"
@@ -46,7 +48,7 @@ func IsRemote() bool {
 		}
 		_ = fs.Parse(os.Args[start:])
 		// --connection or --url implies --remote
-		remoteFromCLI.Value = remoteFromCLI.Value || fs.Changed(connectionFlagName) || fs.Changed(urlFlagName) || fs.Changed(hostFlagName)
+		remoteFromCLI.Value = remoteFromCLI.Value || fs.Changed(connectionFlagName) || fs.Changed(urlFlagName) || fs.Changed(hostFlagName) || fs.Changed(contextFlagName)
 	})
 	return podmanOptions.EngineMode == entities.TunnelMode || remoteFromCLI.Value
 }

--- a/cmd/podman/system/connection/default.go
+++ b/cmd/podman/system/connection/default.go
@@ -21,9 +21,23 @@ var (
 		RunE:              defaultRunE,
 		Example:           `podman system connection default testing`,
 	}
+
+	useCmd = &cobra.Command{
+		Use:               "use NAME",
+		Args:              cobra.ExactArgs(1),
+		Short:             dfltCmd.Short,
+		Long:              dfltCmd.Long,
+		ValidArgsFunction: dfltCmd.ValidArgsFunction,
+		RunE:              dfltCmd.RunE,
+		Example:           `podman context use testing`,
+	}
 )
 
 func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: useCmd,
+		Parent:  system.ContextCmd,
+	})
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: dfltCmd,
 		Parent:  system.ConnectionCmd,

--- a/cmd/podman/system/connection/remove.go
+++ b/cmd/podman/system/connection/remove.go
@@ -31,11 +31,19 @@ var (
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: rmCmd,
+		Parent:  system.ContextCmd,
+	})
+
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: rmCmd,
 		Parent:  system.ConnectionCmd,
 	})
 
 	flags := rmCmd.Flags()
 	flags.BoolVarP(&rmOpts.All, "all", "a", false, "Remove all connections")
+
+	flags.BoolP("force", "f", false, "Ignored: for Docker compatibility")
+	_ = flags.MarkHidden("force")
 }
 
 func rm(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/system/context.go
+++ b/cmd/podman/system/context.go
@@ -1,0 +1,28 @@
+package system
+
+import (
+	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/validate"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// ContextCmd skips creating engines (PersistentPreRunE/PersistentPostRunE are No-Op's) since
+	// sub-commands will obtain connection information to said engines
+	ContextCmd = &cobra.Command{
+		Use:                "context",
+		Short:              "Manage remote API service destinations",
+		Long:               `Manage remote API service destination information in podman configuration`,
+		PersistentPreRunE:  validate.NoOp,
+		RunE:               validate.SubCommandExists,
+		PersistentPostRunE: validate.NoOp,
+		Hidden:             true,
+		TraverseChildren:   false,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: ContextCmd,
+	})
+}

--- a/docs/source/markdown/podman-system-connection-list.1.md
+++ b/docs/source/markdown/podman-system-connection-list.1.md
@@ -13,7 +13,7 @@ List ssh destination(s) for podman service(s).
 
 ## OPTIONS
 
-#### **--format**=*format*
+#### **--format**, **-f**=*format*
 
 Change the default output format.  This can be of a supported type like 'json' or a Go template.
 Valid placeholders for the Go template listed below:
@@ -24,6 +24,10 @@ Valid placeholders for the Go template listed below:
 | .Identity       | Path to file containing SSH identity |
 | .URI            | URI to podman service. Valid schemes are ssh://[user@]*host*[:port]*Unix domain socket*[?secure=True], unix://*Unix domain socket*, and tcp://localhost[:*port*] |
 | .Default        | Indicates whether connection is the default |
+
+#### **--quiet**, **-q**
+
+Only show connection names
 
 ## EXAMPLE
 ```

--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -235,6 +235,7 @@ can_use_shortcut ()
 
       if (strcmp (argv[argc], "mount") == 0
           || strcmp (argv[argc], "machine") == 0
+          || strcmp (argv[argc], "context") == 0
           || strcmp (argv[argc], "search") == 0
           || (strcmp (argv[argc], "system") == 0 && argv[argc+1] && strcmp (argv[argc+1], "service") != 0))
         {

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -56,14 +56,17 @@ function setup() {
 
 
 @test "podman --context emits reasonable output" {
+    if ! is_remote; then
+        skip "only applicable on podman-remote"
+    fi
     # All we care about here is that the command passes
     run_podman --context=default version
 
     # This one must fail
     run_podman 125 --context=swarm version
     is "$output" \
-       "Error: podman does not support swarm, the only --context value allowed is \"default\"" \
-       "--context=default or fail"
+       "Error: failed to resolve active destination: \"swarm\" service destination not found" \
+       "--context=swarm should fail"
 }
 
 @test "podman can pull an image" {


### PR DESCRIPTION
Alias
podman context use -> podman system connection default
podman context rm -> podman system connection rm
podman context create -> podman system connection add
podman context ls ->podman system connection ls

Podman context is a hidden command, but can be used for existing scripts
that assume Docker under the covers.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman context command is a hidden command available for Docker compatibility.

```
