### PR TITLE
[CI:DOCS] Cirrus: Use the latest imgts container

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -843,7 +843,7 @@ meta_task:
     container:
         cpu: 2
         memory: 2
-        image: quay.io/libpod/imgts:$IMAGE_SUFFIX
+        image: quay.io/libpod/imgts:latest
     env:
         # Space-separated list of images used by this repository state
         # Disabled ${PRIOR_FEDORA_CACHE_IMAGE_NAME} for Fedora 35


### PR DESCRIPTION
Contains important updates re: preserving release-branch CI VM images.
Ref: https://github.com/containers/automation_images/pull/157

#### Does this PR introduce a user-facing change?

```release-note
CI: Ensure all future release branches automatically preserve their CI VM images.
```
