### PR TITLE
[v4.0-rhel] [CI:DOCS] Cirrus: Use the latest imgts container

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -745,7 +745,7 @@ meta_task:
     container:
         cpu: 2
         memory: 2
-        image: quay.io/libpod/imgts:$IMAGE_SUFFIX
+        image: quay.io/libpod/imgts:latest
     env:
         # Space-separated list of images used by this repository state
         IMGNAMES: >-


### PR DESCRIPTION
Contains important updates re: preserving release-branch CI VM images.
Ref: https://github.com/containers/automation_images/pull/157

Signed-off-by: Chris Evich <cevich@redhat.com>

#### Does this PR introduce a user-facing change?

```release-note
None
```