### PR TITLE
play kube: Add --detach=true option

### DIFF
--- a/docs/source/markdown/podman-kube-play.1.md
+++ b/docs/source/markdown/podman-kube-play.1.md
@@ -145,6 +145,12 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
+#### **--detach**, **-d**
+
+Return after the pods have been started. The default is **true**.
+
+Use **--detach=false** to remain in the foreground. Pressing Ctrl-C or receiving any other interrupt signal will stop the pods.
+
 #### **--down**
 
 Tears down the pods that were created by a previous run of `kube play`.  The pods are stopped and then

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -23,6 +23,8 @@ type PlayKubeOptions struct {
 	Down bool
 	// Replace indicates whether to delete and recreate a yaml file
 	Replace bool
+	// Detach indicates whether to return after having created the pods
+	Detach bool
 	// Do not create /etc/hosts within the pod's containers,
 	// instead use the version from the image
 	NoHosts bool


### PR DESCRIPTION
Add a way to keep `play kube` running in the foreground and terminating all pods
after receiving a a SIGINT or SIGTERM signal. Defaults to true to reflect the current behaviour.

I'm unsure whether this `--detach=true` option should rather be renamed to `--foreground=false`. I named it so for consistency with the similar feature in `docker-compose up`. Suggestions are welcome.

Fixes #14522

#### Does this PR introduce a user-facing change?

```release-note
podman play kube has a new `--detach=false` option to stay in foreground and terminate the pods after receiving a Ctrl-C signal
```
