### PR TITLE
cleanup: transition from `stopping` to `exited`

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -347,7 +347,7 @@ func (c *Container) syncContainer() error {
 	}
 	// If runtime knows about the container, update its status in runtime
 	// And then save back to disk
-	if c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning, define.ContainerStateStopped, define.ContainerStatePaused) {
+	if c.ensureState(define.ContainerStateCreated, define.ContainerStateRunning, define.ContainerStateStopped, define.ContainerStateStopping, define.ContainerStatePaused) {
 		oldState := c.state.State
 
 		if err := c.checkExitFile(); err != nil {
@@ -1316,10 +1316,10 @@ func (c *Container) stop(timeout uint) error {
 
 	// Since we're now subject to a race condition with other processes who
 	// may have altered the state (and other data), let's check if the
-	// state has changed.  If so, we should return immediately and log a
-	// warning.
+	// state has changed.  If so, we should return immediately and leave
+	// breadcrumbs for debugging if needed.
 	if c.state.State != define.ContainerStateStopping {
-		logrus.Warnf(
+		logrus.Debugf(
 			"Container %q state changed from %q to %q while waiting for it to be stopped: discontinuing stop procedure as another process interfered",
 			c.ID(), define.ContainerStateStopping, c.state.State,
 		)


### PR DESCRIPTION
Allow the cleanup process (and others) to transition the container from 
`stopping` to `exited`.  This fixes a race condition detected in #14859 
where the cleanup process kicks in _before_ the stopping process can    
read the exit file.  Prior to this fix, the cleanup process left the    
container in the `stopping` state and removed the conmon files, such    
that the stopping process also left the container in this state as it
could not read the exit files.  Hence, `podman wait` timed out (see the
23 seconds execution time of the test [1]) due to the unexpected/invalid
state and the test failed.

Further turn the warning during stop to a debug message since it's a
natural race due to the daemonless/concurrent architecture and nothing
to worry about.

[NO NEW TESTS NEEDED] since we can only monitor if #14859 continues
flaking or not.

[1] https://storage.googleapis.com/cirrus-ci-6707778565701632-fcae48/artifacts/containers/podman/6210434704343040/html/sys-remote-fedora-36-rootless-host.log.html#t--00205

Fixes: #14859
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
No release note as it's fixing an unreleased bug.

@mheon @edsantiago PTAL
