### PR TITLE
remove image podman no prune

### DIFF
--- a/cmd/podman/images/rm.go
+++ b/cmd/podman/images/rm.go
@@ -61,6 +61,7 @@ func imageRemoveFlagSet(flags *pflag.FlagSet) {
 	flags.BoolVarP(&imageOpts.All, "all", "a", false, "Remove all images")
 	flags.BoolVarP(&imageOpts.Ignore, "ignore", "i", false, "Ignore errors if a specified image does not exist")
 	flags.BoolVarP(&imageOpts.Force, "force", "f", false, "Force Removal of the image")
+	flags.BoolVar(&imageOpts.NoPrune, "no-prune", false, "Do not remove dangling images")
 }
 
 func rm(cmd *cobra.Command, args []string) error {

--- a/docs/source/markdown/podman-rmi.1.md
+++ b/docs/source/markdown/podman-rmi.1.md
@@ -28,6 +28,9 @@ This option will cause podman to remove all containers that are using the image 
 
 If a specified image does not exist in the local storage, ignore it and do not throw an error.
 
+#### **--no-prune**
+
+This options will not remove dangling parents of specified image
 
 Remove an image by its short ID
 ```

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -547,6 +547,7 @@ func ImagesBatchRemove(w http.ResponseWriter, r *http.Request) {
 		Ignore         bool     `schema:"ignore"`
 		LookupManifest bool     `schema:"lookupManifest"`
 		Images         []string `schema:"images"`
+		NoPrune        bool     `schema:"noprune"`
 	}{}
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
@@ -554,7 +555,7 @@ func ImagesBatchRemove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	opts := entities.ImageRemoveOptions{All: query.All, Force: query.Force, Ignore: query.Ignore, LookupManifest: query.LookupManifest}
+	opts := entities.ImageRemoveOptions{All: query.All, Force: query.Force, Ignore: query.Ignore, LookupManifest: query.LookupManifest, NoPrune: query.NoPrune}
 	imageEngine := abi.ImageEngine{Libpod: runtime}
 	rmReport, rmErrors := imageEngine.Remove(r.Context(), query.Images, opts)
 	strErrs := errorhandling.ErrorsToStrings(rmErrors)

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -15,6 +15,8 @@ type RemoveOptions struct {
 	Ignore *bool
 	// Confirms if given name is a manifest list and removes it, otherwise returns error.
 	LookupManifest *bool
+	// Does not remove dangling parent images
+	NoPrune *bool
 }
 
 //go:generate go run ../generator/generator.go DiffOptions

--- a/pkg/bindings/images/types_remove_options.go
+++ b/pkg/bindings/images/types_remove_options.go
@@ -76,3 +76,18 @@ func (o *RemoveOptions) GetLookupManifest() bool {
 	}
 	return *o.LookupManifest
 }
+
+// WithNoPrune set field NoPrune to given value
+func (o *RemoveOptions) WithNoPrune(value bool) *RemoveOptions {
+	o.NoPrune = &value
+	return o
+}
+
+// GetNoPrune returns value of field NoPrune
+func (o *RemoveOptions) GetNoPrune() bool {
+	if o.NoPrune == nil {
+		var z bool
+		return z
+	}
+	return *o.NoPrune
+}

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -94,6 +94,8 @@ type ImageRemoveOptions struct {
 	Ignore bool
 	// Confirms if given name is a manifest list and removes it, otherwise returns error.
 	LookupManifest bool
+	// NoPrune will not remove dangling images
+	NoPrune bool
 }
 
 // ImageRemoveReport is the response for removing one or more image(s) from storage

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -565,6 +565,7 @@ func (ir *ImageEngine) Remove(ctx context.Context, images []string, opts entitie
 	libimageOptions.Force = opts.Force
 	libimageOptions.Ignore = opts.Ignore
 	libimageOptions.LookupManifest = opts.LookupManifest
+	libimageOptions.NoPrune = opts.NoPrune
 	if !opts.All {
 		libimageOptions.Filters = append(libimageOptions.Filters, "intermediate=false")
 	}
@@ -581,7 +582,7 @@ func (ir *ImageEngine) Remove(ctx context.Context, images []string, opts entitie
 
 	rmErrors = libimageErrors
 
-	return
+	return report, rmErrors
 }
 
 // Shutdown Libpod engine

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -28,7 +28,7 @@ func (ir *ImageEngine) Exists(_ context.Context, nameOrID string) (*entities.Boo
 }
 
 func (ir *ImageEngine) Remove(ctx context.Context, imagesArg []string, opts entities.ImageRemoveOptions) (*entities.ImageRemoveReport, []error) {
-	options := new(images.RemoveOptions).WithForce(opts.Force).WithIgnore(opts.Ignore).WithAll(opts.All).WithLookupManifest(opts.LookupManifest)
+	options := new(images.RemoveOptions).WithForce(opts.Force).WithIgnore(opts.Ignore).WithAll(opts.All).WithLookupManifest(opts.LookupManifest).WithNoPrune(opts.NoPrune)
 	return images.Remove(ir.ClientCtx, imagesArg, options)
 }
 


### PR DESCRIPTION
Docker supports --no-prune for rmi which does not remove dangling parents of the specified image. Podman
should support the same for compatibility.

Task from #14917 

Signed-off-by: Karthik Elango <kelango@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--Yes
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added --no-prune flag for podman rmi
```
