### PR TITLE
manifest,test: `inspect` should contain `OCI` annotations.

### DIFF
--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -173,13 +173,15 @@ var _ = Describe("Podman manifest", func() {
 		session = podmanTest.Podman([]string{"manifest", "add", "foo", imageListInstance})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		session = podmanTest.Podman([]string{"manifest", "annotate", "--arch", "bar", "foo", imageListARM64InstanceDigest})
+		session = podmanTest.Podman([]string{"manifest", "annotate", "--annotation", "hello=world", "--arch", "bar", "foo", imageListARM64InstanceDigest})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		session = podmanTest.Podman([]string{"manifest", "inspect", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring(`"architecture": "bar"`))
+		// Check added annotation
+		Expect(session.OutputToString()).To(ContainSubstring(`"hello": "world"`))
 	})
 
 	It("remove digest", func() {


### PR DESCRIPTION
Verifies https://github.com/containers/common/pull/1105 by adding a new test `inspect manifest and verify OCI annotation`
and old tests should not break.


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
manifest: inspect now supports OCI annotations
```