### PR TITLE
docs: resolve typo in create,run manpages

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1571,7 +1571,7 @@ $ podman create -v /var/lib/design:/var/lib/design --group-add keep-groups ubi8
 ### Configure execution domain for containers using personality flag
 
 ```
-$ podman create --name container1 --personaity=LINUX32 fedora bash
+$ podman create --name container1 --personality=LINUX32 fedora bash
 ```
 
 ### Create a container with external rootfs mounted as an overlay

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1924,7 +1924,7 @@ $ podman run -v /var/lib/design:/var/lib/design --group-add keep-groups ubi8
 ### Configure execution domain for containers using personality flag
 
 ```
-$ podman run --name container1 --personaity=LINUX32 fedora bash
+$ podman run --name container1 --personality=LINUX32 fedora bash
 ```
 
 ### Run a container with external rootfs mounted as an overlay


### PR DESCRIPTION
* Replace typo 'personaity' with 'personality' in several man pages

Signed-off-by: Ewout van Mansom <ewout@vanmansom.name>

#### Does this PR introduce a user-facing change?

```release-note
None
```
