### PR TITLE
Add steps to sign included qemu and notarize the built pkg

### DIFF
--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -32,6 +32,7 @@ packagedir: package_root Distribution welcome.html
 	echo -n $(PODMAN_VERSION) > $(PACKAGE_DIR)/VERSION
 	echo -n $(ARCH) > $(PACKAGE_DIR)/ARCH
 	cp ../../LICENSE $(PACKAGE_DIR)/Resources/LICENSE.txt
+	cp hvf.entitlements $(PACKAGE_DIR)/
 
 package_root: get_gvproxy get_qemu
 	mkdir -p $(PACKAGE_ROOT)/podman/bin $(PACKAGE_ROOT)/podman/qemu

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -13,11 +13,11 @@ PKG_NAME := podman-installer-macos-$(ARCH).pkg
 
 default: pkginstaller
 
-get_gvproxy:
+$(TMP_DOWNLOAD)/gvproxy:
 	mkdir -p $(TMP_DOWNLOAD)
 	cd $(TMP_DOWNLOAD) && curl -sLo gvproxy $(GVPROXY_RELEASE_URL)
 
-get_qemu:
+$(TMP_DOWNLOAD)/podman-machine-qemu-$(ARCH)-$(QEMU_VERSION).tar.xz:
 	mkdir -p $(TMP_DOWNLOAD)
 	cd $(TMP_DOWNLOAD) && curl -sLO $(QEMU_RELEASE_URL)
 
@@ -35,7 +35,7 @@ packagedir: package_root Distribution welcome.html
 	cp ../../LICENSE $(PACKAGE_DIR)/Resources/LICENSE.txt
 	cp hvf.entitlements $(PACKAGE_DIR)/
 
-package_root: get_gvproxy get_qemu
+package_root: clean-pkgroot $(TMP_DOWNLOAD)/podman-machine-qemu-$(ARCH)-$(QEMU_VERSION).tar.xz $(TMP_DOWNLOAD)/gvproxy
 	mkdir -p $(PACKAGE_ROOT)/podman/bin $(PACKAGE_ROOT)/podman/qemu
 	tar -C $(PACKAGE_ROOT)/podman/qemu -xf $(TMP_DOWNLOAD)/podman-machine-qemu-$(ARCH)-$(QEMU_VERSION).tar.xz
 	cp $(TMP_DOWNLOAD)/gvproxy $(PACKAGE_ROOT)/podman/bin/
@@ -53,6 +53,9 @@ _notarize: pkginstaller
 notarize: _notarize
 	xcrun stapler staple out/$(PKG_NAME)
 
-.PHONY: clean
+.PHONY: clean clean-pkgroot
 clean:
 	rm -rf $(TMP_DOWNLOAD) $(PACKAGE_ROOT) $(PACKAGE_DIR) Distribution welcome.html
+
+clean-pkgroot:
+	rm -rf $(PACKAGE_ROOT) $(PACKAGE_DIR) Distribution welcome.html

--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -9,6 +9,7 @@ QEMU_RELEASE_URL ?= https://github.com/containers/podman-machine-qemu/releases/d
 PACKAGE_DIR ?= out/packaging
 TMP_DOWNLOAD ?= tmp-download
 PACKAGE_ROOT ?= root
+PKG_NAME := podman-installer-macos-$(ARCH).pkg
 
 default: pkginstaller
 
@@ -45,6 +46,12 @@ package_root: get_gvproxy get_qemu
 
 pkginstaller: packagedir
 	cd $(PACKAGE_DIR) && ./package.sh ..
+
+_notarize: pkginstaller
+	xcrun notarytool submit --apple-id $(NOTARIZE_USERNAME) --password $(NOTARIZE_PASSWORD) --team-id=$(NOTARIZE_TEAM) -f json --wait out/$(PKG_NAME)
+
+notarize: _notarize
+	xcrun stapler staple out/$(PKG_NAME)
 
 .PHONY: clean
 clean:

--- a/contrib/pkginstaller/README.md
+++ b/contrib/pkginstaller/README.md
@@ -5,6 +5,9 @@ $ make ARCH=<amd64 | aarch64> NO_CODESIGN=1 pkginstaller
 
 # or to create signed pkg
 $ make ARCH=<amd64 | aarch64> CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> pkginstaller
+
+# or to prepare a signed and notarized pkg for release
+$ make ARCH=<amd64 | aarch64> CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> NOTARIZE_USERNAME=<appleID> NOTARIZE_PASSWORD=<appleID-password> NOTARIZE_TEAM=<team-id> notarize
 ```
 
 The generated pkg will be written to `out/podman-macos-installer-*.pkg`.

--- a/contrib/pkginstaller/hvf.entitlements
+++ b/contrib/pkginstaller/hvf.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.hypervisor</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

- This adds the missing signing of the qemu binary included in the pkg
- adds makefile target `notarize` to perform notarization of the built pkg installer

#### To test generation of signed and notarized pkg artifact run

```
$ make ARCH=<amd64 | aarch64> CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> NOTARIZE_USERNAME=<appleID> NOTARIZE_PASSWORD=<appleID-password> notarize
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```
