### PR TITLE
[Closes 15109] Add flag "--compression-format" to "podman manifest push" (and other fixes)

### DIFF
--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -76,6 +76,10 @@ func init() {
 	flags.BoolVarP(&manifestPushOpts.Quiet, "quiet", "q", false, "don't output progress information when pushing lists")
 	flags.SetNormalizeFunc(utils.AliasFlags)
 
+	compressionFormat := "compression-format"
+	flags.StringVar(&manifestPushOpts.CompressionFormat, compressionFormat, "", "compression format to use")
+	_ = pushCmd.RegisterFlagCompletionFunc(compressionFormat, common.AutocompleteCompressionFormat)
+
 	if registry.IsRemote() {
 		_ = flags.MarkHidden("cert-dir")
 	}

--- a/docs/source/markdown/podman-manifest-push.1.md
+++ b/docs/source/markdown/podman-manifest-push.1.md
@@ -32,6 +32,10 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
 Please refer to containers-certs.d(5) for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
+#### **--compression-format**=**gzip** | *zstd* | *zstd:chunked*
+
+Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip` unless overridden in the containers.conf file.
+
 #### **--creds**=*creds*
 
 The [username[:password]] to use to authenticate with the registry if required.

--- a/docs/source/markdown/podman-push.1.md
+++ b/docs/source/markdown/podman-push.1.md
@@ -67,7 +67,7 @@ Note: This flag can only be set when using the **dir** transport
 
 #### **--compression-format**=**gzip** | *zstd* | *zstd:chunked*
 
-Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip`.
+Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip` unless overridden in the containers.conf file.
 
 #### **--creds**=*[username[:password]]*
 

--- a/pkg/api/handlers/libpod/images_push.go
+++ b/pkg/api/handlers/libpod/images_push.go
@@ -25,12 +25,13 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 
 	query := struct {
-		All              bool   `schema:"all"`
-		Destination      string `schema:"destination"`
-		Format           string `schema:"format"`
-		RemoveSignatures bool   `schema:"removeSignatures"`
-		TLSVerify        bool   `schema:"tlsVerify"`
-		Quiet            bool   `schema:"quiet"`
+		All               bool   `schema:"all"`
+		CompressionFormat string `schema:"compressionFormat"`
+		Destination       string `schema:"destination"`
+		Format            string `schema:"format"`
+		RemoveSignatures  bool   `schema:"removeSignatures"`
+		TLSVerify         bool   `schema:"tlsVerify"`
+		Quiet             bool   `schema:"quiet"`
 	}{
 		TLSVerify: true,
 		// #14971: older versions did not sent *any* data, so we need
@@ -71,13 +72,14 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 		password = authconf.Password
 	}
 	options := entities.ImagePushOptions{
-		All:              query.All,
-		Authfile:         authfile,
-		Format:           query.Format,
-		Password:         password,
-		Quiet:            true,
-		RemoveSignatures: query.RemoveSignatures,
-		Username:         username,
+		All:               query.All,
+		Authfile:          authfile,
+		CompressionFormat: query.CompressionFormat,
+		Format:            query.Format,
+		Password:          password,
+		Quiet:             true,
+		RemoveSignatures:  query.RemoveSignatures,
+		Username:          username,
 	}
 
 	if _, found := r.URL.Query()["tlsVerify"]; found {

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -306,8 +306,11 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 
 	query := struct {
-		All       bool `schema:"all"`
-		TLSVerify bool `schema:"tlsVerify"`
+		All               bool   `schema:"all"`
+		CompressionFormat string `schema:"compressionFormat"`
+		Format            string `schema:"format"`
+		RemoveSignatures  bool   `schema:"removeSignatures"`
+		TLSVerify         bool   `schema:"tlsVerify"`
 	}{
 		// Add defaults here once needed.
 		TLSVerify: true,
@@ -336,10 +339,13 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 		password = authconf.Password
 	}
 	options := entities.ImagePushOptions{
-		Authfile: authfile,
-		Username: username,
-		Password: password,
-		All:      query.All,
+		All:               query.All,
+		Authfile:          authfile,
+		CompressionFormat: query.CompressionFormat,
+		Format:            query.Format,
+		Password:          password,
+		RemoveSignatures:  query.RemoveSignatures,
+		Username:          username,
 	}
 	if sys := runtime.SystemContext(); sys != nil {
 		options.CertDir = sys.DockerCertPath

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -123,6 +123,8 @@ type PushOptions struct {
 	Authfile *string
 	// Compress tarball image layers when pushing to a directory using the 'dir' transport.
 	Compress *bool
+	// CompressionFormat is the format to use for the compression of the blobs
+	CompressionFormat *string
 	// Manifest type of the pushed image
 	Format *string
 	// Password for authenticating against the registry.

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -62,6 +62,21 @@ func (o *PushOptions) GetCompress() bool {
 	return *o.Compress
 }
 
+// WithCompressionFormat set field CompressionFormat to given value
+func (o *PushOptions) WithCompressionFormat(value string) *PushOptions {
+	o.CompressionFormat = &value
+	return o
+}
+
+// GetCompressionFormat returns value of field CompressionFormat
+func (o *PushOptions) GetCompressionFormat() string {
+	if o.CompressionFormat == nil {
+		var z string
+		return z
+	}
+	return *o.CompressionFormat
+}
+
 // WithFormat set field Format to given value
 func (o *PushOptions) WithFormat(value string) *PushOptions {
 	o.Format = &value

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -240,7 +240,7 @@ func (ir *ImageEngine) Import(ctx context.Context, opts entities.ImageImportOpti
 
 func (ir *ImageEngine) Push(ctx context.Context, source string, destination string, opts entities.ImagePushOptions) error {
 	options := new(images.PushOptions)
-	options.WithAll(opts.All).WithCompress(opts.Compress).WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithFormat(opts.Format).WithRemoveSignatures(opts.RemoveSignatures).WithQuiet(opts.Quiet)
+	options.WithAll(opts.All).WithCompress(opts.Compress).WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithFormat(opts.Format).WithRemoveSignatures(opts.RemoveSignatures).WithQuiet(opts.Quiet).WithCompressionFormat(opts.CompressionFormat)
 
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -99,8 +99,7 @@ func (ir *ImageEngine) ManifestRm(ctx context.Context, names []string) (*entitie
 // ManifestPush pushes a manifest list or image index to the destination
 func (ir *ImageEngine) ManifestPush(ctx context.Context, name, destination string, opts entities.ImagePushOptions) (string, error) {
 	options := new(images.PushOptions)
-	options.WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithRemoveSignatures(opts.RemoveSignatures)
-	options.WithAll(opts.All)
+	options.WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithRemoveSignatures(opts.RemoveSignatures).WithAll(opts.All).WithFormat(opts.Format).WithCompressionFormat(opts.CompressionFormat)
 
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {


### PR DESCRIPTION
Add flag "--compression-format" to "podman manifest push" both in local/remote mode. Fix usage of flag "--compression-format" for remote "podman image push". Fix usage of flags "--format", "--remove-signatures" in remote "podman manifest push".

Closes #15109.


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
 - Added flag "--compression-format" to "podman manifest push"
 - Fixed usage of flag "--compression-format" for remote "podman image push".
 - Fixed usage of flags "--format" and "--remove-signatures" in remote "podman manifest push"
```

Note about the quality of this pull request: I definitely have no idea what I am doing, this is purely based on copy/pasting ;)