### PR TITLE
[CI:DOCS] man podman-volume-import: Clarify that merge happens

### DIFF
--- a/docs/source/markdown/podman-volume-import.1.md
+++ b/docs/source/markdown/podman-volume-import.1.md
@@ -9,6 +9,7 @@ podman\-volume\-import - Import tarball contents into an existing podman volume
 ## DESCRIPTION
 
 **podman volume import** imports the contents of a tarball into the podman volume's mount point.
+The contents of the volume will be merged with the content of the tarball, the latter takes precedence.
 **podman volume import** can consume piped input when using `-` as source path.
 
 The given volume must already exist and will not be created by podman volume import.

--- a/docs/source/markdown/podman-volume-import.1.md
+++ b/docs/source/markdown/podman-volume-import.1.md
@@ -9,7 +9,7 @@ podman\-volume\-import - Import tarball contents into an existing podman volume
 ## DESCRIPTION
 
 **podman volume import** imports the contents of a tarball into the podman volume's mount point.
-The contents of the volume will be merged with the content of the tarball, the latter takes precedence.
+The contents of the volume will be merged with the content of the tarball with the latter taking precedence.
 **podman volume import** can consume piped input when using `-` as source path.
 
 The given volume must already exist and will not be created by podman volume import.


### PR DESCRIPTION
Current directories and files stay the same with the current implementation as long as the tarball does not contain a directories or files with the same name.

The added sentence shall clarify that behavior so other users do not need to test this like I did.

Signed-off-by: Felix Stupp <me+github@banananet.work>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
