### PR TITLE
add omitempty to Secret in k8s VolumeSource

### DIFF
--- a/pkg/k8s.io/api/core/v1/types.go
+++ b/pkg/k8s.io/api/core/v1/types.go
@@ -56,7 +56,8 @@ type VolumeSource struct {
 	// ConfigMap represents a configMap that should populate this volume
 	// +optional
 	ConfigMap *ConfigMapVolumeSource `json:"configMap,omitempty"`
-	Secret    *SecretVolumeSource
+	// Secret represents a secret that should be mounted as a volume
+	Secret *SecretVolumeSource `json:"secret,omitempty"`
 }
 
 // PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace.


### PR DESCRIPTION
Secret was populating a generated kube as `null`. Add omitempty
so that when the volume source is not a secret, we do not print unnecessary info

resolves #15156

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix a bug that was printing Secret: null even when a secret volume type is not used in a pod for podman generate kube
```
