### PR TITLE
Cirrus: Fix e2e tests for "mount_rootless_test"

### DIFF
--- a/test/e2e/mount_rootless_test.go
+++ b/test/e2e/mount_rootless_test.go
@@ -52,9 +52,16 @@ var _ = Describe("Podman mount", func() {
 		Expect(setup).Should(Exit(0))
 		cid := setup.OutputToString()
 
-		session := podmanTest.Podman([]string{"unshare", PODMAN_BINARY, "mount", cid})
+		// command: podman <options> unshare podman <options> mount cid
+		args := []string{"unshare", podmanTest.PodmanBinary}
+		opts := podmanTest.PodmanMakeOptions([]string{"mount", cid}, false, false)
+		args = append(args, opts...)
+
+		// container root file system location is /tmp/... because "--root /tmp/..."
+		session := podmanTest.Podman(args)
 		session.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("/tmp"))
 	})
 
 	It("podman image mount", func() {
@@ -71,8 +78,15 @@ var _ = Describe("Podman mount", func() {
 		setup.WaitWithDefaultTimeout()
 		Expect(setup).Should(Exit(0))
 
-		session := podmanTest.Podman([]string{"unshare", PODMAN_BINARY, "image", "mount", ALPINE})
+		// command: podman <options> unshare podman <options> image mount ALPINE
+		args := []string{"unshare", podmanTest.PodmanBinary}
+		opts := podmanTest.PodmanMakeOptions([]string{"image", "mount", ALPINE}, false, false)
+		args = append(args, opts...)
+
+		// image location is /tmp/... because "--root /tmp/..."
+		session := podmanTest.Podman(args)
 		session.WaitWithDefaultTimeout()
-		Expect(setup).Should(Exit(0))
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("/tmp"))
 	})
 })


### PR DESCRIPTION
e2e `mount_rootless_test` did not load `podman binary path` successfully.
This PR fix this problem.

[It] podman unshare podman mount:
```
[+1596s] Running: ... unshare  mount <cid>
[+1596s] Error: exec: no command
[+1596s] output:
```

[It] podman unshare image podman mount:
```
[+1599s] Running: ... unshare  image mount quay.io/libpod/alpine:latest
[+1599s] Error: exec: no command
[+1599s] output:
```

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
