### PR TITLE
[CI:DOCS] Refactor common options in man pages

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,7 +13,8 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 clean:
-	rm -fr build/
+	$(RM) -fr build
+	cd source/markdown && $(RM) -f $$(<.gitignore)
 
 .PHONY: help Makefile
 

--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -1,0 +1,2 @@
+podman-create.1.md
+podman-run.1.md

--- a/docs/source/markdown/options/cgroup-conf.md
+++ b/docs/source/markdown/options/cgroup-conf.md
@@ -1,0 +1,3 @@
+#### **--cgroup-conf**=*KEY=VALUE*
+
+When running on cgroup v2, specify the cgroup file to write to and its value. For example **--cgroup-conf=memory.high=1073741824** sets the memory.high limit to 1GB.

--- a/docs/source/markdown/options/chrootdirs.md
+++ b/docs/source/markdown/options/chrootdirs.md
@@ -1,0 +1,5 @@
+#### **--chrootdirs**=*path*
+
+Path to a directory inside the container that should be treated as a `chroot` directory.
+Any Podman managed file (e.g., /etc/resolv.conf, /etc/hosts, etc/hostname) that is mounted into the root directory will be mounted into that location as well.
+Multiple directories should be separated with a comma.

--- a/docs/source/markdown/options/env-host.md
+++ b/docs/source/markdown/options/env-host.md
@@ -1,0 +1,3 @@
+#### **--env-host**
+
+Use host environment inside of the container. See **Environment** note below for precedence. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/options/group-add.md
+++ b/docs/source/markdown/options/group-add.md
@@ -1,0 +1,11 @@
+#### **--group-add**=*group* | *keep-groups*
+
+Assign additional groups to the primary user running within the container process.
+
+- `keep-groups` is a special flag that tells Podman to keep the supplementary group access.
+
+Allows container to use the user's supplementary group access. If file systems or
+devices are only accessible by the rootless user's group, this flag tells the OCI
+runtime to pass the group access into the container. Currently only available
+with the `crun` OCI runtime. Note: `keep-groups` is exclusive, you cannot add any other groups
+with this flag. (Not available for remote commands, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/options/hostuser.md
+++ b/docs/source/markdown/options/hostuser.md
@@ -1,0 +1,4 @@
+#### **--hostuser**=*name*
+
+Add a user account to /etc/passwd from the host to the container. The Username
+or UID must exist on the host system.

--- a/docs/source/markdown/options/image-volume.md
+++ b/docs/source/markdown/options/image-volume.md
@@ -1,0 +1,8 @@
+#### **--image-volume**=**bind** | *tmpfs* | *ignore*
+
+Tells Podman how to handle the builtin image volumes. Default is **bind**.
+
+- **bind**: An anonymous named volume will be created and mounted into the container.
+- **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
+content that disappears when the container is stopped.
+- **ignore**: All volumes are just ignored and no action is taken.

--- a/docs/source/markdown/options/init-path.md
+++ b/docs/source/markdown/options/init-path.md
@@ -1,0 +1,3 @@
+#### **--init-path**=*path*
+
+Path to the container-init binary.

--- a/docs/source/markdown/options/init.md
+++ b/docs/source/markdown/options/init.md
@@ -1,0 +1,5 @@
+#### **--init**
+
+Run an init inside the container that forwards signals and reaps processes.
+The container-init binary is mounted at `/run/podman-init`.
+Mounting over `/run` will hence break container execution.

--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -1,0 +1,77 @@
+#### **--mount**=*type=TYPE,TYPE-SPECIFIC-OPTION[,...]*
+
+Attach a filesystem mount to the container
+
+Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and **devpts**. <sup>[[1]](#Footnote1)</sup>
+
+       e.g.
+
+       type=bind,source=/path/on/host,destination=/path/in/container
+
+       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
+
+       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
+
+       type=volume,source=vol1,destination=/path/in/container,ro=true
+
+       type=tmpfs,tmpfs-size=512M,destination=/path/in/container
+
+       type=image,source=fedora,destination=/fedora-image,rw=true
+
+       type=devpts,destination=/dev/pts
+
+       Common Options:
+
+	      · src, source: mount source spec for bind and volume. Mandatory for bind.
+
+	      · dst, destination, target: mount destination spec.
+
+       Options specific to volume:
+
+	      · ro, readonly: true or false (default).
+
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
+	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
+
+       Options specific to image:
+
+	      · rw, readwrite: true or false (default).
+
+       Options specific to bind:
+
+	      · ro, readonly: true or false (default).
+
+	      · bind-propagation: shared, slave, private, unbindable, rshared, rslave, runbindable, or rprivate(default). See also mount(2).
+
+	      . bind-nonrecursive: do not set up a recursive bind mount. By default it is recursive.
+
+	      . relabel: shared, private.
+
+	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
+
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
+       Options specific to tmpfs:
+
+	      · ro, readonly: true or false (default).
+
+	      · tmpfs-size: Size of the tmpfs mount in bytes. Unlimited by default in Linux.
+
+	      · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
+
+	      · tmpcopyup: Enable copyup from the image directory at the same location to the tmpfs. Used by default.
+
+	      · notmpcopyup: Disable copying files from the image to the tmpfs.
+
+	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
+
+       Options specific to devpts:
+
+	      · uid: UID of the file owner (default 0).
+
+	      · gid: GID of the file owner (default 0).
+
+	      · mode: permission mask for the file (default 600).
+
+	      · max: maximum number of PTYs (default 1048576).

--- a/docs/source/markdown/options/no-healthcheck.md
+++ b/docs/source/markdown/options/no-healthcheck.md
@@ -1,0 +1,3 @@
+#### **--no-healthcheck**
+
+Disable any defined healthchecks for container.

--- a/docs/source/markdown/options/oom-kill-disable.md
+++ b/docs/source/markdown/options/oom-kill-disable.md
@@ -1,0 +1,5 @@
+#### **--oom-kill-disable**
+
+Whether to disable OOM Killer for the container or not.
+
+This flag is not supported on cgroups V2 systems.

--- a/docs/source/markdown/options/passwd-entry.md
+++ b/docs/source/markdown/options/passwd-entry.md
@@ -1,0 +1,5 @@
+#### **--passwd-entry**=*ENTRY*
+
+Customize the entry that is written to the `/etc/passwd` file within the container when `--passwd` is used.
+
+The variables $USERNAME, $UID, $GID, $NAME, $HOME are automatically replaced with their value at runtime.

--- a/docs/source/markdown/options/personality.md
+++ b/docs/source/markdown/options/personality.md
@@ -1,0 +1,3 @@
+#### **--personality**=*persona*
+
+Personality sets the execution domain via Linux personality(2).

--- a/docs/source/markdown/options/pidfile.md
+++ b/docs/source/markdown/options/pidfile.md
@@ -1,0 +1,9 @@
+#### **--pidfile**=*path*
+
+When the pidfile location is specified, the container process' PID will be written to the pidfile. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+If the pidfile option is not specified, the container process' PID will be written to /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
+
+After the container is started, the location for the pidfile can be discovered with the following `podman inspect` command:
+
+    $ podman inspect --format '{{ .PidFile }}' $CID
+    /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile

--- a/docs/source/markdown/options/sdnotify.md
+++ b/docs/source/markdown/options/sdnotify.md
@@ -1,0 +1,10 @@
+#### **--sdnotify**=**container** | *conmon* | *ignore*
+
+Determines how to use the NOTIFY_SOCKET, as passed with systemd and Type=notify.
+
+Default is **container**, which means allow the OCI runtime to proxy the socket into the
+container to receive ready notification. Podman will set the MAINPID to conmon's pid.
+The **conmon** option sets MAINPID to conmon's pid, and sends READY when the container
+has started. The socket is never passed to the runtime or the container.
+The **ignore** option removes NOTIFY_SOCKET from the environment for itself and child processes,
+for the case where some other process above Podman uses NOTIFY_SOCKET and Podman should not use it.

--- a/docs/source/markdown/options/seccomp-policy.md
+++ b/docs/source/markdown/options/seccomp-policy.md
@@ -1,0 +1,5 @@
+#### **--seccomp-policy**=*policy*
+
+Specify the policy to select the seccomp profile. If set to *image*, Podman will look for a "io.containers.seccomp.profile" label in the container-image config and use its value as a seccomp profile. Otherwise, Podman will follow the *default* policy by applying the default profile unless specified otherwise via *--security-opt seccomp* as described below.
+
+Note that this feature is experimental and may change in the future.

--- a/docs/source/markdown/options/timeout.md
+++ b/docs/source/markdown/options/timeout.md
@@ -1,0 +1,5 @@
+#### **--timeout**=*seconds*
+
+Maximum time a container is allowed to run before conmon sends it the kill
+signal.  By default containers will run until they exit or are stopped by
+`podman stop`.

--- a/docs/source/markdown/options/tz.md
+++ b/docs/source/markdown/options/tz.md
@@ -1,0 +1,4 @@
+#### **--tz**=*timezone*
+
+Set timezone in container. This flag takes area-based timezones, GMT time, as well as `local`, which sets the timezone in the container to match the host machine. See `/usr/share/zoneinfo/` for valid timezones.
+Remote connections use local containers.conf for defaults

--- a/docs/source/markdown/options/umask.md
+++ b/docs/source/markdown/options/umask.md
@@ -1,0 +1,4 @@
+#### **--umask**=*umask*
+
+Set the umask inside the container. Defaults to `0022`.
+Remote connections use local containers.conf for defaults

--- a/docs/source/markdown/options/unsetenv-all.md
+++ b/docs/source/markdown/options/unsetenv-all.md
@@ -1,0 +1,5 @@
+#### **--unsetenv-all**
+
+Unset all default environment variables for the container. Default environment
+variables include variables provided natively by Podman, environment variables
+configured by the image, and environment variables from containers.conf.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -115,9 +115,7 @@ Add Linux capabilities
 
 Drop Linux capabilities
 
-#### **--cgroup-conf**=*KEY=VALUE*
-
-When running on cgroup v2, specify the cgroup file to write to and its value. For example **--cgroup-conf=memory.high=1073741824** sets the memory.high limit to 1GB.
+@@option cgroup-conf
 
 #### **--cgroup-parent**=*path*
 
@@ -143,11 +141,7 @@ The *disabled* option will force the container to not create CGroups, and thus c
 The *no-conmon* option disables a new CGroup only for the conmon process.
 The *split* option splits the current cgroup in two sub-cgroups: one for conmon and one for the container payload. It is not possible to set *--cgroup-parent* with *split*.
 
-#### **--chrootdirs**=*path*
-
-Path to a directory inside the container that should be treated as a `chroot` directory.
-Any Podman managed file (e.g., /etc/resolv.conf, /etc/hosts, etc/hostname) that is mounted into the root directory will be mounted into that location as well.
-Multiple directories should be separated with a comma.
+@@option chrootdirs
 
 #### **--cidfile**=*id*
 
@@ -358,9 +352,7 @@ See [**Environment**](#environment) note below for precedence and examples.
 
 Read in a line delimited file of environment variables. See **Environment** note below for precedence.
 
-#### **--env-host**
-
-Use host environment inside of the container. See **Environment** note below for precedence. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option env-host
 
 #### **--expose**=*port*
 
@@ -376,17 +368,7 @@ __--uidmap__ maps host UIDs to container UIDs. For details see __--uidmap__.
 
 Note: the **--gidmap** flag cannot be called in conjunction with the **--pod** flag as a gidmap cannot be set on the container level when in a pod.
 
-#### **--group-add**=*group* | *keep-groups*
-
-Assign additional groups to the primary user running within the container process.
-
-- `keep-groups` is a special flag that tells Podman to keep the supplementary group access.
-
-Allows container to use the user's supplementary group access. If file systems or
-devices are only accessible by the rootless user's group, this flag tells the OCI
-runtime to pass the group access into the container. Currently only available
-with the `crun` OCI runtime. Note: `keep-groups` is exclusive, you cannot add any other groups
-with this flag. (Not available for remote commands, including Mac and Windows (excluding WSL2) machines)
+@@option group-add
 
 #### **--health-cmd**=*"command"* | *'["command", "arg1", ...]'*
 
@@ -425,10 +407,7 @@ Container host name
 
 Sets the container host name that is available inside the container. Can only be used with a private UTS namespace `--uts=private` (default). If `--pod` is specified and the pod shares the UTS namespace (default) the pod's hostname will be used.
 
-#### **--hostuser**=*name*
-
-Add a user account to /etc/passwd from the host to the container. The Username
-or UID must exist on the host system.
+@@option hostuser
 
 #### **--http-proxy**
 
@@ -450,20 +429,9 @@ container:
 
 Defaults to `true`
 
-#### **--image-volume**=**bind** | *tmpfs* | *ignore*
+@@option image-volume
 
-Tells Podman how to handle the builtin image volumes. Default is **bind**.
-
-- **bind**: An anonymous named volume will be created and mounted into the container.
-- **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
-content that disappears when the container is stopped.
-- **ignore**: All volumes are just ignored and no action is taken.
-
-#### **--init**
-
-Run an init inside the container that forwards signals and reaps processes.
-The container-init binary is mounted at `/run/podman-init`.
-Mounting over `/run` will hence break container execution.
+@@option init
 
 #### **--init-ctr**=*type*
 
@@ -480,9 +448,7 @@ Init containers are only run on pod `start`.  Restarting a pod will not execute 
 containers should they be present.  Furthermore, init containers can only be created in a
 pod when that pod is not running.
 
-#### **--init-path**=*path*
-
-Path to the container-init binary.
+@@option init-path
 
 #### **--interactive**, **-i**
 
@@ -611,83 +577,7 @@ Tune a container's memory swappiness behavior. Accepts an integer between 0 and 
 
 This flag is not supported on cgroups V2 systems.
 
-#### **--mount**=*type=TYPE,TYPE-SPECIFIC-OPTION[,...]*
-
-Attach a filesystem mount to the container
-
-Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and **devpts**. <sup>[[1]](#Footnote1)</sup>
-
-       e.g.
-
-       type=bind,source=/path/on/host,destination=/path/in/container
-
-       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
-
-       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
-
-       type=volume,source=vol1,destination=/path/in/container,ro=true
-
-       type=tmpfs,tmpfs-size=512M,destination=/path/in/container
-
-       type=image,source=fedora,destination=/fedora-image,rw=true
-
-       type=devpts,destination=/dev/pts
-
-       Common Options:
-
-	      · src, source: mount source spec for bind and volume. Mandatory for bind.
-
-	      · dst, destination, target: mount destination spec.
-
-       Options specific to volume:
-
-	      · ro, readonly: true or false (default).
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
-
-       Options specific to image:
-
-	      · rw, readwrite: true or false (default).
-
-       Options specific to bind:
-
-	      · ro, readonly: true or false (default).
-
-	      · bind-propagation: shared, slave, private, unbindable, rshared, rslave, runbindable, or rprivate(default). See also mount(2).
-
-	      . bind-nonrecursive: do not set up a recursive bind mount. By default it is recursive.
-
-	      . relabel: shared, private.
-
-	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-       Options specific to tmpfs:
-
-	      · ro, readonly: true or false (default).
-
-	      · tmpfs-size: Size of the tmpfs mount in bytes. Unlimited by default in Linux.
-
-	      · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
-
-	      · tmpcopyup: Enable copyup from the image directory at the same location to the tmpfs. Used by default.
-
-	      · notmpcopyup: Disable copying files from the image to the tmpfs.
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-       Options specific to devpts:
-
-	      · uid: UID of the file owner (default 0).
-
-	      · gid: GID of the file owner (default 0).
-
-	      · mode: permission mask for the file (default 600).
-
-	      · max: maximum number of PTYs (default 1048576).
+@@option mount
 
 #### **--name**=*name*
 
@@ -745,9 +635,7 @@ these aliases can be used for name resolution on the given network. This option 
 NOTE: When using CNI a container will only have access to aliases on the first network that it joins. This limitation does
 not exist with netavark/aardvark-dns.
 
-#### **--no-healthcheck**
-
-Disable any defined healthchecks for container.
+@@option no-healthcheck
 
 #### **--no-hosts**
 
@@ -756,11 +644,7 @@ By default, Podman will manage _/etc/hosts_, adding the container's own IP addre
 **--no-hosts** disables this, and the image's _/etc/hosts_ will be preserved unmodified.
 This option conflicts with **--add-host**.
 
-#### **--oom-kill-disable**
-
-Whether to disable OOM Killer for the container or not.
-
-This flag is not supported on cgroups V2 systems.
+@@option oom-kill-disable
 
 #### **--oom-score-adj**=*num*
 
@@ -769,15 +653,9 @@ Tune the host's OOM preferences for containers (accepts -1000 to 1000)
 #### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
 
-#### **--passwd-entry**=*ENTRY*
+@@option passwd-entry
 
-Customize the entry that is written to the `/etc/passwd` file within the container when `--passwd` is used.
-
-The variables $USERNAME, $UID, $GID, $NAME, $HOME are automatically replaced with their value at runtime.
-
-#### **--personality**=*persona*
-
-Personality sets the execution domain via Linux personality(2).
+@@option personality
 
 #### **--pid**=*pid*
 
@@ -788,15 +666,7 @@ Default is to create a private PID namespace for the container
 - `ns`: join the specified PID namespace
 - `private`: create a new namespace for the container (default)
 
-#### **--pidfile**=*path*
-
-When the pidfile location is specified, the container process' PID will be written to the pidfile. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
-If the pidfile option is not specified, the container process' PID will be written to /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
-
-After the container is started, the location for the pidfile can be discovered with the following `podman inspect` command:
-
-    $ podman inspect --format '{{ .PidFile }}' $CID
-    /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile
+@@option pidfile
 
 #### **--pids-limit**=*limit*
 
@@ -944,22 +814,9 @@ directory will be the lower, and the container storage directory will be the
 upper. Modifications to the mount point are destroyed when the container
 finishes executing, similar to a tmpfs mount point being unmounted.
 
-#### **--sdnotify**=**container** | *conmon* | *ignore*
+@@option sdnotify
 
-Determines how to use the NOTIFY_SOCKET, as passed with systemd and Type=notify.
-
-Default is **container**, which means allow the OCI runtime to proxy the socket into the
-container to receive ready notification. Podman will set the MAINPID to conmon's pid.
-The **conmon** option sets MAINPID to conmon's pid, and sends READY when the container
-has started. The socket is never passed to the runtime or the container.
-The **ignore** option removes NOTIFY_SOCKET from the environment for itself and child processes,
-for the case where some other process above Podman uses NOTIFY_SOCKET and Podman should not use it.
-
-#### **--seccomp-policy**=*policy*
-
-Specify the policy to select the seccomp profile. If set to *image*, Podman will look for a "io.containers.seccomp.profile" label in the container-image config and use its value as a seccomp profile. Otherwise, Podman will follow the *default* policy by applying the default profile unless specified otherwise via *--security-opt seccomp* as described below.
-
-Note that this feature is experimental and may change in the future.
+@@option seccomp-policy
 
 #### **--secret**=*secret[,opt=opt ...]*
 
@@ -1085,11 +942,7 @@ The `container_manage_cgroup` boolean must be enabled for this to be allowed on 
 
 `setsebool -P container_manage_cgroup true`
 
-#### **--timeout**=*seconds*
-
-Maximum time a container is allowed to run before conmon sends it the kill
-signal.  By default containers will run until they exit or are stopped by
-`podman stop`.
+@@option timeout
 
 #### **--tls-verify**
 
@@ -1119,10 +972,7 @@ interactive shell. The default is false.
 Note: The **-t** option is incompatible with a redirection of the Podman client
 standard input.
 
-#### **--tz**=*timezone*
-
-Set timezone in container. This flag takes area-based timezones, GMT time, as well as `local`, which sets the timezone in the container to match the host machine. See `/usr/share/zoneinfo/` for valid timezones.
-Remote connections use local containers.conf for defaults
+@@option tz
 
 #### **--uidmap**=*container_uid:from_uid:amount*
 
@@ -1208,10 +1058,7 @@ Ulimit options
 
 You can pass `host` to copy the current configuration from the host.
 
-#### **--umask**=*umask*
-
-Set the umask inside the container. Defaults to `0022`.
-Remote connections use local containers.conf for defaults
+@@option umask
 
 #### **--unsetenv**=*env*
 
@@ -1219,11 +1066,7 @@ Unset default environment variables for the container. Default environment
 variables include variables provided natively by Podman, environment variables
 configured by the image, and environment variables from containers.conf.
 
-#### **--unsetenv-all**
-
-Unset all default environment variables for the container. Default environment
-variables include variables provided natively by Podman, environment variables
-configured by the image, and environment variables from containers.conf.
+@@option unsetenv-all
 
 #### **--user**, **-u**=*user*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -132,9 +132,7 @@ Add Linux capabilities.
 
 Drop Linux capabilities.
 
-#### **--cgroup-conf**=*KEY=VALUE*
-
-When running on cgroup v2, specify the cgroup file to write to and its value. For example **--cgroup-conf=memory.high=1073741824** sets the memory.high limit to 1GB.
+@@option cgroup-conf
 
 #### **--cgroup-parent**=*path*
 
@@ -162,11 +160,7 @@ The **disabled** option will force the container to not create CGroups, and thus
 The **no-conmon** option disables a new CGroup only for the **conmon** process.
 The **split** option splits the current CGroup in two sub-cgroups: one for conmon and one for the container payload. It is not possible to set **--cgroup-parent** with **split**.
 
-#### **--chrootdirs**=*path*
-
-Path to a directory inside the container that should be treated as a `chroot` directory.
-Any Podman managed file (e.g., /etc/resolv.conf, /etc/hosts, etc/hostname) that is mounted into the root directory will be mounted into that location as well.
-Multiple directories should be separated with a comma.
+@@option chrootdirs
 
 #### **--cidfile**=*file*
 
@@ -393,9 +387,7 @@ See [**Environment**](#environment) note below for precedence and examples.
 
 Read in a line delimited file of environment variables. See **Environment** note below for precedence.
 
-#### **--env-host**
-
-Use host environment inside of the container. See **Environment** note below for precedence. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option env-host
 
 #### **--expose**=*port*
 
@@ -411,17 +403,7 @@ __--uidmap__ maps host UIDs to container UIDs. For details see __--uidmap__.
 
 Note: the **--gidmap** flag cannot be called in conjunction with the **--pod** flag as a gidmap cannot be set on the container level when in a pod.
 
-#### **--group-add**=*group* | *keep-groups*
-
-Assign additional groups to the primary user running within the container process.
-
-- `keep-groups` is a special flag that tells Podman to keep the supplementary group access.
-
-Allows container to use the user's supplementary group access. If file systems or
-devices are only accessible by the rootless user's group, this flag tells the OCI
-runtime to pass the group access into the container. Currently only available
-with the `crun` OCI runtime. Note: `keep-groups` is exclusive, you cannot add any other groups
-with this flag. (Not available for remote commands, including Mac and Windows (excluding WSL2) machines)
+@@option group-add
 
 #### **--health-cmd**=*"command"* | *'["command", "arg1", ...]'*
 
@@ -460,10 +442,7 @@ Container host name
 
 Sets the container host name that is available inside the container. Can only be used with a private UTS namespace `--uts=private` (default). If `--pod` is specified and the pod shares the UTS namespace (default) the pod's hostname will be used.
 
-#### **--hostuser**=*name*
-
-Add a user account to /etc/passwd from the host to the container. The Username
-or UID must exist on the host system.
+@@option hostuser
 
 #### **--http-proxy**
 
@@ -480,24 +459,11 @@ proxy environment at container build time.) (This option is not available with t
 
 Defaults to **true**.
 
-#### **--image-volume**=**bind** | *tmpfs* | *ignore*
+@@option image-volume
 
-Tells Podman how to handle the builtin image volumes. Default is **bind**.
+@@option init
 
-- **bind**: An anonymous named volume will be created and mounted into the container.
-- **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
-content that disappears when the container is stopped.
-- **ignore**: All volumes are just ignored and no action is taken.
-
-#### **--init**
-
-Run an init inside the container that forwards signals and reaps processes.
-The container-init binary is mounted at `/run/podman-init`.
-Mounting over `/run` will hence break container execution.
-
-#### **--init-path**=*path*
-
-Path to the container-init binary.
+@@option init-path
 
 #### **--interactive**, **-i**
 
@@ -627,83 +593,7 @@ Tune a container's memory swappiness behavior. Accepts an integer between *0* an
 
 This flag is not supported on cgroups V2 systems.
 
-#### **--mount**=*type=TYPE,TYPE-SPECIFIC-OPTION[,...]*
-
-Attach a filesystem mount to the container
-
-Current supported mount TYPEs are **bind**, **volume**, **image**, **tmpfs** and **devpts**. <sup>[[1]](#Footnote1)</sup>
-
-       e.g.
-
-       type=bind,source=/path/on/host,destination=/path/in/container
-
-       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared
-
-       type=bind,src=/path/on/host,dst=/path/in/container,relabel=shared,U=true
-
-       type=volume,source=vol1,destination=/path/in/container,ro=true
-
-       type=tmpfs,tmpfs-size=512M,destination=/path/in/container
-
-       type=image,source=fedora,destination=/fedora-image,rw=true
-
-       type=devpts,destination=/dev/pts
-
-       Common Options:
-
-	      · src, source: mount source spec for bind and volume. Mandatory for bind.
-
-	      · dst, destination, target: mount destination spec.
-
-       Options specific to volume:
-
-	      · ro, readonly: true or false (default).
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
-
-       Options specific to image:
-
-	      · rw, readwrite: true or false (default).
-
-       Options specific to bind:
-
-	      · ro, readonly: true or false (default).
-
-	      · bind-propagation: shared, slave, private, unbindable, rshared, rslave, runbindable, or rprivate(default). See also mount(2).
-
-	      . bind-nonrecursive: do not set up a recursive bind mount. By default it is recursive.
-
-	      . relabel: shared, private.
-
-	      · idmap: true or false (default).  If specified, create an idmapped mount to the target user namespace in the container.
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-       Options specific to tmpfs:
-
-	      · ro, readonly: true or false (default).
-
-	      · tmpfs-size: Size of the tmpfs mount in bytes. Unlimited by default in Linux.
-
-	      · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
-
-	      · tmpcopyup: Enable copyup from the image directory at the same location to the tmpfs. Used by default.
-
-	      · notmpcopyup: Disable copying files from the image to the tmpfs.
-
-	      . U, chown: true or false (default). Change recursively the owner and group of the source volume based on the UID and GID of the container.
-
-       Options specific to devpts:
-
-	      · uid: UID of the file owner (default 0).
-
-	      · gid: GID of the file owner (default 0).
-
-	      · mode: permission mask for the file (default 600).
-
-	      · max: maximum number of PTYs (default 1048576).
+@@option mount
 
 #### **--name**=*name*
 
@@ -762,9 +652,7 @@ these aliases can be used for name resolution on the given network. This option 
 NOTE: When using CNI a container will only have access to aliases on the first network that it joins. This limitation does
 not exist with netavark/aardvark-dns.
 
-#### **--no-healthcheck**
-
-Disable any defined healthchecks for container.
+@@option no-healthcheck
 
 #### **--no-hosts**
 
@@ -773,11 +661,7 @@ By default, Podman will manage _/etc/hosts_, adding the container's own IP addre
 **--no-hosts** disables this, and the image's _/etc/hosts_ will be preserved unmodified.
 This option conflicts with **--add-host**.
 
-#### **--oom-kill-disable**
-
-Whether to disable OOM Killer for the container or not.
-
-This flag is not supported on cgroups V2 systems.
+@@option oom-kill-disable
 
 #### **--oom-score-adj**=*num*
 
@@ -791,15 +675,9 @@ Override the OS, defaults to hosts, of the image to be pulled. For example, `win
 Allow Podman to add entries to /etc/passwd and /etc/group when used in conjunction with the --user option.
 This is used to override the Podman provided user setup in favor of entrypoint configurations such as libnss-extrausers.
 
-#### **--passwd-entry**=*ENTRY*
+@@option passwd-entry
 
-Customize the entry that is written to the `/etc/passwd` file within the container when `--passwd` is used.
-
-The variables $USERNAME, $UID, $GID, $NAME, $HOME are automatically replaced with their value at runtime.
-
-#### **--personality**=*persona*
-
-Personality sets the execution domain via Linux personality(2).
+@@option personality
 
 #### **--pid**=*mode*
 
@@ -811,15 +689,7 @@ The default is to create a private PID namespace for the container.
 - **private**: create a new namespace for the container (default)
 - **ns:**_path_: join the specified PID namespace.
 
-#### **--pidfile**=*path*
-
-When the pidfile location is specified, the container process' PID will be written to the pidfile. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
-If the pidfile option is not specified, the container process' PID will be written to /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile.
-
-After the container is started, the location for the pidfile can be discovered with the following `podman inspect` command:
-
-    $ podman inspect --format '{{ .PidFile }}' $CID
-    /run/containers/storage/${storage-driver}-containers/$CID/userdata/pidfile
+@@option pidfile
 
 #### **--pids-limit**=*limit*
 
@@ -982,22 +852,9 @@ finishes executing, similar to a tmpfs mount point being unmounted.
 Note: On **SELinux** systems, the rootfs needs the correct label, which is by default
 **unconfined_u:object_r:container_file_t**.
 
-#### **--sdnotify**=**container** | *conmon* | *ignore*
+@@option sdnotify
 
-Determines how to use the NOTIFY_SOCKET, as passed with systemd and Type=notify.
-
-Default is **container**, which means allow the OCI runtime to proxy the socket into the
-container to receive ready notification. Podman will set the MAINPID to conmon's pid.
-The **conmon** option sets MAINPID to conmon's pid, and sends READY when the container
-has started. The socket is never passed to the runtime or the container.
-The **ignore** option removes NOTIFY_SOCKET from the environment for itself and child processes,
-for the case where some other process above Podman uses NOTIFY_SOCKET and Podman should not use it.
-
-#### **--seccomp-policy**=*policy*
-
-Specify the policy to select the seccomp profile. If set to *image*, Podman will look for a "io.containers.seccomp.profile" label in the container-image config and use its value as a seccomp profile. Otherwise, Podman will follow the *default* policy by applying the default profile unless specified otherwise via *--security-opt seccomp* as described below.
-
-Note that this feature is experimental and may change in the future.
+@@option seccomp-policy
 
 #### **--secret**=*secret[,opt=opt ...]*
 
@@ -1139,11 +996,7 @@ The **container_manage_cgroup** boolean must be enabled for this to be allowed o
 setsebool -P container_manage_cgroup true
 ```
 
-#### **--timeout**=*seconds*
-
-Maximum time a container is allowed to run before conmon sends it the kill
-signal.  By default containers will run until they exit or are stopped by
-`podman stop`.
+@@option timeout
 
 #### **--tls-verify**
 
@@ -1178,10 +1031,7 @@ interactive shell. The default is **false**.
 echo "asdf" | podman run --rm -i someimage /bin/cat
 ```
 
-#### **--tz**=*timezone*
-
-Set timezone in container. This flag takes area-based timezones, GMT time, as well as `local`, which sets the timezone in the container to match the host machine. See `/usr/share/zoneinfo/` for valid timezones.
-Remote connections use local containers.conf for defaults
+@@option tz
 
 #### **--uidmap**=*container_uid:from_uid:amount*
 
@@ -1267,10 +1117,7 @@ Note: the **--uidmap** flag cannot be called in conjunction with the **--pod** f
 
 Ulimit options. You can use **host** to copy the current configuration from the host.
 
-#### **--umask**=*umask*
-
-Set the umask inside the container. Defaults to `0022`.
-Remote connections use local containers.conf for defaults
+@@option umask
 
 #### **--unsetenv**=*env*
 
@@ -1278,11 +1125,7 @@ Unset default environment variables for the container. Default environment
 variables include variables provided natively by Podman, environment variables
 configured by the image, and environment variables from containers.conf.
 
-#### **--unsetenv-all**
-
-Unset all default environment variables for the container. Default environment
-variables include variables provided natively by Podman, environment variables
-configured by the image, and environment variables from containers.conf.
+@@option unsetenv-all
 
 #### **--user**, **-u**=*user[:group]*
 

--- a/hack/markdown-preprocess
+++ b/hack/markdown-preprocess
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+#
+# markdown-preprocess - filter *.md.in files, convert to .md
+#
+
+import glob
+import os
+import sys
+
+def main():
+    try:
+        os.chdir("docs/source/markdown")
+    except FileNotFoundError:
+        raise Exception("Please invoke me from the base repo dir")
+
+    # If called with args, process only those files
+    infiles = [ os.path.basename(x) for x in sys.argv[1:] ]
+    if len(infiles) == 0:
+        # Called without args: process all *.md.in files
+        infiles = glob.glob('*.md.in')
+    for infile in infiles:
+        process(infile)
+
+def process(infile):
+    # Some options are the same between containers and pods; determine
+    # which description to use from the name of the source man page.
+    pod_or_container = 'container'
+    if '-pod-' in infile:
+        pod_or_container = 'pod'
+
+    # Sometimes a man page includes the subcommand.
+    subcommand = infile.removeprefix("podman-").removesuffix(".1.md.in").replace("-", " ")
+
+    # foo.md.in -> foo.md -- but always write to a tmpfile
+    outfile = os.path.splitext(infile)[0]
+    outfile_tmp = outfile + '.tmp.' + str(os.getpid())
+
+#    print("got here: ",infile, " -> ", outfile)
+
+    with open(infile, 'r') as fh_in, open(outfile_tmp, 'w') as fh_out:
+        for line in fh_in:
+            # '@@option foo' -> include file options/foo.md
+            if line.startswith('@@option '):
+                _, optionname = line.strip().split(" ")
+                optionfile = os.path.join("options", optionname + '.md')
+                fh_out.write("[//]: # (BEGIN included file " + optionfile + ")\n")
+                with open(optionfile, 'r') as fh_optfile:
+                    for opt_line in fh_optfile:
+                        opt_line = opt_line.replace('<POD-OR-CONTAINER>', pod_or_container)
+                        opt_line = opt_line.replace('<SUBCOMMAND>', subcommand)
+                        fh_out.write(opt_line)
+
+                    # Weird special case: options/image-volume.md ends in a
+                    # list, and in markdown lists are continued across lines,
+                    # so without an intervening blank line the '[//]' comment
+                    # becomes part of the final list entry.
+                    if opt_line.startswith('-'):
+                        fh_out.write("\n")
+
+                fh_out.write("[//]: # (END   included file " + optionfile + ")\n")
+            else:
+                fh_out.write(line)
+
+    os.chmod(outfile_tmp, 0o444)
+    os.rename(outfile_tmp, outfile)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
podman-create and -run have many options in common. To date,
these are copy-pasted and haphazardly maintained.

Solution: add an include mechanism, '@@option foo', such
that multiple md source files can fetch from one common file.

This is a Phase One commit, a very small subset of what's
possible. Purpose of this commit is ease of review. If this
passes review, much more (trickier stuff) will be forthcoming.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
Man page refactoring: add include mechanism for common options
```