### PR TITLE
refactor pkg/autoupdate

### DIFF
--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -45,7 +45,7 @@ const (
 var supportedPolicies = map[string]Policy{
 	"":                          PolicyDefault,
 	string(PolicyDefault):       PolicyDefault,
-	"image":                     PolicyRegistryImage,
+	"image":                     PolicyRegistryImage, // Deprecated in favor of PolicyRegistryImage
 	string(PolicyRegistryImage): PolicyRegistryImage,
 	string(PolicyLocalImage):    PolicyLocalImage,
 }

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -258,7 +258,7 @@ func (u *updater) updateRegistry(ctx context.Context, task *task) (*entities.Aut
 		return report, nil
 	}
 
-	if _, err := updateImage(ctx, u.runtime, rawImageName, authfile); err != nil {
+	if _, err := pullImage(ctx, u.runtime, rawImageName, authfile); err != nil {
 		return report, fmt.Errorf("registry auto-updating container %q: image update for %q failed: %w", cid, rawImageName, err)
 	}
 	u.updatedRawImages[rawImageName] = true
@@ -474,8 +474,8 @@ func newerLocalImageAvailable(runtime *libpod.Runtime, img *libimage.Image, rawI
 	return localImg.Digest().String() != img.Digest().String(), nil
 }
 
-// updateImage pulls the specified image.
-func updateImage(ctx context.Context, runtime *libpod.Runtime, name, authfile string) (*libimage.Image, error) {
+// pullImage pulls the specified image.
+func pullImage(ctx context.Context, runtime *libpod.Runtime, name, authfile string) (*libimage.Image, error) {
 	pullOptions := &libimage.PullOptions{}
 	pullOptions.AuthFilePath = authfile
 	pullOptions.Writer = os.Stderr

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -43,11 +43,11 @@ const (
 
 // Map for easy lookups of supported policies.
 var supportedPolicies = map[string]Policy{
-	"":         PolicyDefault,
-	"disabled": PolicyDefault,
-	"image":    PolicyRegistryImage,
-	"registry": PolicyRegistryImage,
-	"local":    PolicyLocalImage,
+	"":                          PolicyDefault,
+	string(PolicyDefault):       PolicyDefault,
+	"image":                     PolicyRegistryImage,
+	string(PolicyRegistryImage): PolicyRegistryImage,
+	string(PolicyLocalImage):    PolicyLocalImage,
 }
 
 // updater includes shared state for auto-updating one or more containers.

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -395,16 +395,16 @@ func (u *updater) imageContainersMap() []error {
 		// Skip labels not related to autoupdate
 		if policy == PolicyDefault {
 			continue
-		} else {
-			id, _ := ctr.Image()
-			policyMap, exists := u.imageToPolicyMapper[id]
-			if !exists {
-				policyMap = make(map[Policy][]*libpod.Container)
-			}
-			policyMap[policy] = append(policyMap[policy], ctr)
-			u.imageToPolicyMapper[id] = policyMap
-			// Now we know that `ctr` is configured for auto updates.
 		}
+
+		id, _ := ctr.Image()
+		policyMap, exists := u.imageToPolicyMapper[id]
+		if !exists {
+			policyMap = make(map[Policy][]*libpod.Container)
+		}
+		policyMap[policy] = append(policyMap[policy], ctr)
+		u.imageToPolicyMapper[id] = policyMap
+		// Now we know that `ctr` is configured for auto updates.
 	}
 
 	return errors

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -52,11 +52,11 @@ var supportedPolicies = map[string]Policy{
 
 // updater includes shared state for auto-updating one or more containers.
 type updater struct {
-	conn             *dbus.Conn
-	options          *entities.AutoUpdateOptions
-	unitToTasks      map[string][]*task
-	updatedRawImages map[string]bool
-	runtime          *libpod.Runtime
+	conn             *dbus.Conn                  // DBUS connection
+	options          *entities.AutoUpdateOptions // User-specified options
+	unitToTasks      map[string][]*task          // Keeps track of tasks per unit
+	updatedRawImages map[string]bool             // Keeps track of updated images
+	runtime          *libpod.Runtime             // The libpod runtime
 }
 
 const (

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -54,8 +54,8 @@ var supportedPolicies = map[string]Policy{
 type updater struct {
 	conn             *dbus.Conn
 	idToImage        map[string]*libimage.Image
-	unitToTasks      map[string][]*task
 	options          *entities.AutoUpdateOptions
+	unitToTasks      map[string][]*task
 	updatedRawImages map[string]bool
 	runtime          *libpod.Runtime
 }
@@ -278,6 +278,8 @@ func (u *updater) updateRegistry(ctx context.Context, task *task) (*entities.Aut
 	if err := task.image.Tag(rawImageName); err != nil {
 		return report, fmt.Errorf("falling back to previous image: %w", err)
 	}
+	u.updatedRawImages[rawImageName] = false
+
 	if err := u.restartSystemdUnit(ctx, task.container, task.unit); err != nil {
 		return report, fmt.Errorf("restarting unit with old image during fallback: %w", err)
 	}

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -234,6 +234,8 @@ function _confirm_update() {
     _confirm_update $cname $ori_image
 }
 
+# This test can fail in dev. environment because of SELinux.
+# quick fix: chcon -t container_runtime_exec_t ./bin/podman
 @test "podman auto-update - label io.containers.autoupdate=local with rollback" {
     # sdnotify fails with runc 1.0.0-3-dev2 on Ubuntu. Let's just
     # assume that we work only with crun, nothing else.


### PR DESCRIPTION
Refactor `pkg/autoupdate` to pave the way for running more than one container a systemd unit to support auto updates in the context of `podman kube play`.  There are many changes but broken into smaller and easier to digest commits.  None of the changes should change behavior.

Please refer to the individual commits for change descriptions.  The remainder will be done in a separate PR to facilitate reviewing.

```release-note
None
```