### PR TITLE
pkginstaller: use correct GOARCH while building podman binaries

### DIFF
--- a/contrib/pkginstaller/README.md
+++ b/contrib/pkginstaller/README.md
@@ -11,7 +11,7 @@ $ make ARCH=<amd64 | aarch64> CODESIGN_IDENTITY=<ID> PRODUCTSIGN_IDENTITY=<ID> N
 ```
 
 The generated pkg will be written to `out/podman-macos-installer-*.pkg`.
-Currently the pkg installs `podman`, `qemu`, `gvproxy` and `podman-mac-helper` to `/Applications/podman`
+Currently the pkg installs `podman`, `qemu`, `gvproxy` and `podman-mac-helper` to `/opt/podman`
 
 The `qemu` build it uses is from [containers/podman-machine-qemu](https://github.com/containers/podman-machine-qemu)
 

--- a/contrib/pkginstaller/package.sh
+++ b/contrib/pkginstaller/package.sh
@@ -17,8 +17,8 @@ arch=$(cat "${BASEDIR}/ARCH")
 
 function build_podman() {
   pushd "$1"
-    make podman-remote HELPER_BINARIES_DIR="${HELPER_BINARIES_DIR}"
-    make podman-mac-helper
+    make GOARCH="${arch}" podman-remote HELPER_BINARIES_DIR="${HELPER_BINARIES_DIR}"
+    make GOARCH="${arch}" podman-mac-helper
     cp bin/darwin/podman "contrib/pkginstaller/out/packaging/${binDir}/podman"
     cp bin/darwin/podman-mac-helper "contrib/pkginstaller/out/packaging/${binDir}/podman-mac-helper"
   popd


### PR DESCRIPTION
we were not using the correct GOARCH to build the podman remote
and podman-mac-helper binaries, this uses the ARCH value passed
to the make invocation to set the GORACH

[NO NEW TESTS NEEDED]

Signed-off-by: Anjan Nath <kaludios@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
