### PR TITLE
Fixes #15154 Change order when config and connections are written

### DIFF
--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -364,14 +364,6 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 		return false, err
 	}
 
-	if err := v.writeConfig(); err != nil {
-		return false, err
-	}
-
-	if err := setupConnections(v, opts, sshDir); err != nil {
-		return false, err
-	}
-
 	dist, err := provisionWSLDist(v)
 	if err != nil {
 		return false, err
@@ -392,6 +384,14 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 
 	// Cycle so that user change goes into effect
 	_ = terminateDist(dist)
+
+	if err := v.writeConfig(); err != nil {
+		return false, err
+	}
+
+	if err := setupConnections(v, opts, sshDir); err != nil {
+		return false, err
+	}
 
 	return true, nil
 }


### PR DESCRIPTION
**Which issue(s) this PR fixes:**
Fixes #15154 

**What this PR does / why we need it:**
This changes the order of writing config and connections to the end of the provisioning.
If the user breaks out or the WSL startup fails no connections or config is left behind.

**Does this PR introduce a user-facing change?**
```
 If podman machine init fails, Podman will not add connection data for the system.
```