### PR TITLE
fix hack/markdown-preprocess to support older python versions

### DIFF
--- a/hack/markdown-preprocess
+++ b/hack/markdown-preprocess
@@ -29,7 +29,7 @@ def process(infile):
         pod_or_container = 'pod'
 
     # Sometimes a man page includes the subcommand.
-    subcommand = infile.removeprefix("podman-").removesuffix(".1.md.in").replace("-", " ")
+    subcommand = removesuffix(removeprefix(infile,"podman-"),".1.md.in").replace("-", " ")
 
     # foo.md.in -> foo.md -- but always write to a tmpfile
     outfile = os.path.splitext(infile)[0]
@@ -63,6 +63,22 @@ def process(infile):
 
     os.chmod(outfile_tmp, 0o444)
     os.rename(outfile_tmp, outfile)
+
+# str.removeprefix() is python 3.9+, we need to support older versions on mac
+def removeprefix(string: str, prefix: str) -> str:
+    if string.startswith(prefix):
+        return string[len(prefix):]
+    else:
+        return string[:]
+
+# str.removesuffix() is python 3.9+, we need to support older versions on mac
+def removesuffix(string: str, suffix: str) -> str:
+    # suffix='' should not call self[:-0].
+    if suffix and string.endswith(suffix):
+        return string[:-len(suffix)]
+    else:
+        return string[:]
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
str.removeprefix() and str.removesuffix() is python 3.9+ only but we need to
support older versions for the OSX cross task.

This fixes broken CI on main.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
