### PR TITLE
fix sphinx build to include podman-create/run page

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,19 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 import re
+import os
+import subprocess
+
+# We have to run the preprocessor to create the actual markdown files from .in files.
+# Do it here so the it can work on readthedocs as well.
+path = os.path.join(os.path.abspath(os.path.dirname(
+    __file__)), "../../hack/markdown-preprocess")
+p = subprocess.Popen(path,
+                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+out, err = p.communicate()
+if p.returncode != 0:
+    raise Exception("failed to run markdown-preprocess", out, err)
+
 
 # -- Project information -----------------------------------------------------
 

--- a/hack/markdown-preprocess
+++ b/hack/markdown-preprocess
@@ -29,7 +29,7 @@ def process(infile):
         pod_or_container = 'pod'
 
     # Sometimes a man page includes the subcommand.
-    subcommand = infile.removeprefix("podman-").removesuffix(".1.md.in").replace("-", " ")
+    subcommand = removesuffix(removeprefix(infile,"podman-"),".1.md.in").replace("-", " ")
 
     # foo.md.in -> foo.md -- but always write to a tmpfile
     outfile = os.path.splitext(infile)[0]
@@ -63,6 +63,22 @@ def process(infile):
 
     os.chmod(outfile_tmp, 0o444)
     os.rename(outfile_tmp, outfile)
+
+# str.removeprefix() is python 3.9+, we need to support older versions on mac
+def removeprefix(string: str, prefix: str) -> str:
+    if string.startswith(prefix):
+        return string[len(prefix):]
+    else:
+        return string[:]
+
+# str.removesuffix() is python 3.9+, we need to support older versions on mac
+def removesuffix(string: str, suffix: str) -> str:
+    # suffix='' should not call self[:-0].
+    if suffix and string.endswith(suffix):
+        return string[:-len(suffix)]
+    else:
+        return string[:]
+
 
 if __name__ == "__main__":
     main()

--- a/hack/markdown-preprocess
+++ b/hack/markdown-preprocess
@@ -8,8 +8,11 @@ import os
 import sys
 
 def main():
+    script_dir = os.path.abspath(os.path.dirname(__file__))
+    man_dir = os.path.join(script_dir,"../docs/source/markdown")
+
     try:
-        os.chdir("docs/source/markdown")
+        os.chdir(man_dir)
     except FileNotFoundError:
         raise Exception("Please invoke me from the base repo dir")
 


### PR DESCRIPTION
When docs.podman.io is build on readthedocs we have to make sure to
generate the markdown pages first.

It works locally with sphinx but I have no idea if this works on the
readthedocs infra.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
