### PR TITLE
podman info: hide `--debug`

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -55,7 +55,7 @@ Briefly describe the problem you are having in a few paragraphs.
 (paste your output here)
 ```
 
-**Output of `podman info --debug`:**
+**Output of `podman info`:**
 
 ```
 (paste your output here)

--- a/cmd/podman/system/info.go
+++ b/cmd/podman/system/info.go
@@ -63,6 +63,7 @@ func infoFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
 	flags.BoolVarP(&debug, "debug", "D", false, "Display additional debug information")
+	_ = flags.MarkHidden("debug") // It's a NOP since Podman version 2.0
 
 	formatFlagName := "format"
 	flags.StringVarP(&inFormat, formatFlagName, "f", "", "Change the output format to JSON or a Go template")

--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -15,10 +15,6 @@ Displays information pertinent to the host, current storage stats, configured co
 
 ## OPTIONS
 
-#### **--debug**, **-D**
-
-Show additional information
-
 #### **--format**, **-f**=*format*
 
 Change output format to "json" or a Go template.


### PR DESCRIPTION
podman info: hide `--debug`

It's a NOP since Podman v2.0 (#5738).

Fixes: #15185
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Hide the `--debug` flag of `podman info` as it's a NOP since Podman v2.0.
```
