### PR TITLE
Cirrus: Run Cross builds in [CI:DOCS] mode

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -415,9 +415,7 @@ alt_build_task:
     alias: alt_build
     # Don't create task for [CI:DOCS] or multiarch builds
     # Docs: ./contrib/cirrus/CIModes.md
-    only_if: &not_docs_multiarch >-
-        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
-        $CIRRUS_CRON != 'multiarch'
+    only_if: $CIRRUS_CRON != 'multiarch'
     depends_on:
         - build
     env:
@@ -450,7 +448,7 @@ osx_alt_build_task:
     name: "OSX Cross"
     alias: osx_alt_build
     # Docs: ./contrib/cirrus/CIModes.md
-    only_if: *not_docs_multiarch
+    only_if: $CIRRUS_CRON != 'multiarch'
     depends_on:
         - build
     env:
@@ -1036,7 +1034,9 @@ artifacts_task:
     name: "Artifacts"
     alias: artifacts
     # Docs: ./contrib/cirrus/CIModes.md
-    only_if: *not_docs_multiarch
+    only_if: >-
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
+        $CIRRUS_CRON != 'multiarch'
     depends_on:
         - success
     # This task is a secondary/convenience for downstream consumers, don't


### PR DESCRIPTION
Fixes: #15189

A while ago I updated the only_if/skip options and forgot that several
"cross build" tasks also build documentation in addition to binaries.  Re-enable
them to execute all the time, except when Cirrus-cron is making our
multi-arch images.



<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
