### PR TITLE
Add interface for apple hypervisor

### DIFF
--- a/cmd/podman/machine/platform.go
+++ b/cmd/podman/machine/platform.go
@@ -9,5 +9,5 @@ import (
 )
 
 func GetSystemDefaultProvider() machine.Provider {
-	return qemu.GetQemuProvider()
+	return qemu.GetVirtualizationProvider()
 }

--- a/pkg/machine/applehv/machine.go
+++ b/pkg/machine/applehv/machine.go
@@ -1,0 +1,70 @@
+//go:build arm64 && !windows && !linux
+// +build darwin
+
+package applehv
+
+import (
+	"time"
+
+	"github.com/containers/podman/v4/pkg/machine"
+)
+
+type Provider struct{}
+
+var (
+	hvProvider = &Provider{}
+	// vmtype refers to qemu (vs libvirt, krun, etc).
+	vmtype = "apple"
+)
+
+func GetVirtualizationProvider() machine.Provider {
+	return hvProvider
+}
+
+const (
+	// Some of this will need to change when we are closer to having
+	// working code.
+	VolumeTypeVirtfs     = "virtfs"
+	MountType9p          = "9p"
+	dockerSock           = "/var/run/docker.sock"
+	dockerConnectTimeout = 5 * time.Second
+	apiUpTimeout         = 20 * time.Second
+)
+
+type apiForwardingState int
+
+const (
+	noForwarding apiForwardingState = iota
+	claimUnsupported
+	notInstalled
+	machineLocal
+	dockerGlobal
+)
+
+func (p *Provider) NewMachine(opts machine.InitOptions) (machine.VM, error) {
+	return nil, machine.ErrNotImplemented
+}
+
+func (p *Provider) LoadVMByName(name string) (machine.VM, error) {
+	return nil, machine.ErrNotImplemented
+}
+
+func (p *Provider) List(opts machine.ListOptions) ([]*machine.ListResponse, error) {
+	return nil, machine.ErrNotImplemented
+}
+
+func (p *Provider) IsValidVMName(name string) (bool, error) {
+	return false, machine.ErrNotImplemented
+}
+
+func (p *Provider) CheckExclusiveActiveVM() (bool, string, error) {
+	return false, "", machine.ErrNotImplemented
+}
+
+func (p *Provider) RemoveAndCleanMachines() error {
+	return machine.ErrNotImplemented
+}
+
+func (p *Provider) VMType() string {
+	return vmtype
+}

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -66,6 +66,7 @@ var (
 	ErrVMAlreadyExists                           = errors.New("VM already exists")
 	ErrVMAlreadyRunning                          = errors.New("VM already running or starting")
 	ErrMultipleActiveVM                          = errors.New("only one VM can be active at a time")
+	ErrNotImplemented                            = errors.New("functionality not implemented")
 	ForwarderBinaryName                          = "gvproxy"
 )
 

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -42,7 +42,7 @@ var (
 	vmtype = "qemu"
 )
 
-func GetQemuProvider() machine.Provider {
+func GetVirtualizationProvider() machine.Provider {
 	return qemuProvider
 }
 


### PR DESCRIPTION
The new apple silicon processesors (m1/m2) are capable of using a performent apple
hypervisor (included in macos).  Our "virtual providers" for podman
machine are part of an interface design.  This PR provides an
implementation of the interface to begin the work for supporting the
apple hypervisor.  It is basically only a skeletal PR.

The actual code for using the hypervisor and launching a machine will
come as several new PRs following the inclusion of this one.

There will likely be code reuse between the applehv and qemu code; but
none of that code is being moved at this time.  It will be moved "on
demand" during development.

[NO NEW TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>


```
None
```
