### PR TITLE
e2e: Add rootless mount cleanup test

### DIFF
--- a/test/e2e/run_cleanup_test.go
+++ b/test/e2e/run_cleanup_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Podman run exit", func() {
 
 	It("podman run -d mount cleanup test", func() {
 		SkipIfRemote("podman-remote does not support mount")
-		SkipIfRootless("TODO rootless podman mount requires podman unshare first")
+		SkipIfRootless("rootless podman mount requires podman unshare first")
 
 		result := podmanTest.Podman([]string{"run", "-dt", ALPINE, "top"})
 		result.WaitWithDefaultTimeout()
@@ -69,6 +69,49 @@ var _ = Describe("Podman run exit", func() {
 		pmount.WaitWithDefaultTimeout()
 		Expect(pmount).Should(Exit(0))
 		Expect(pmount.OutputToString()).NotTo(ContainSubstring(cid))
+	})
 
+	It("podman run -d mount cleanup rootless test", func() {
+		SkipIfRemote("podman-remote does not support mount")
+		SkipIfNotRootless("Use unshare in rootless only")
+
+		result := podmanTest.Podman([]string{"run", "-dt", ALPINE, "top"})
+		result.WaitWithDefaultTimeout()
+		cid := result.OutputToString()
+		Expect(result).Should(Exit(0))
+
+		mount := podmanTest.Podman([]string{"unshare", "mount"})
+		mount.WaitWithDefaultTimeout()
+		Expect(mount).Should(Exit(0))
+		Expect(mount.OutputToString()).To(ContainSubstring(cid))
+
+		// command: podman <options> unshare podman <options> image mount ALPINE
+		args := []string{"unshare", podmanTest.PodmanBinary}
+		opts := podmanTest.PodmanMakeOptions([]string{"mount", "--no-trunc"}, false, false)
+		args = append(args, opts...)
+
+		pmount := podmanTest.Podman(args)
+		pmount.WaitWithDefaultTimeout()
+		Expect(pmount).Should(Exit(0))
+		Expect(pmount.OutputToString()).To(ContainSubstring(cid))
+
+		stop := podmanTest.Podman([]string{"stop", cid})
+		stop.WaitWithDefaultTimeout()
+		Expect(stop).Should(Exit(0))
+
+		// We have to force cleanup so the unmount happens
+		podmanCleanupSession := podmanTest.Podman([]string{"container", "cleanup", cid})
+		podmanCleanupSession.WaitWithDefaultTimeout()
+		Expect(podmanCleanupSession).Should(Exit(0))
+
+		mount = podmanTest.Podman([]string{"unshare", "mount"})
+		mount.WaitWithDefaultTimeout()
+		Expect(mount).Should(Exit(0))
+		Expect(mount.OutputToString()).NotTo(ContainSubstring(cid))
+
+		pmount = podmanTest.Podman(args)
+		pmount.WaitWithDefaultTimeout()
+		Expect(pmount).Should(Exit(0))
+		Expect(pmount.OutputToString()).NotTo(ContainSubstring(cid))
 	})
 })


### PR DESCRIPTION
`podman run -d mount cleanup test` adapt to rootless environment.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
