### PR TITLE
Fixes #15206 Correctly handle ssh to machine when VM found for WSL

### DIFF
--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -85,7 +85,7 @@ func ssh(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("vm %s not found: %w", vmName, err)
 	}
 
-	if !validVM && sshOpts.Username == "" {
+	if vm == nil && sshOpts.Username == "" {
 		sshOpts.Username, err = remoteConnectionUsername()
 		if err != nil {
 			return err


### PR DESCRIPTION
**Which issue(s) this PR fixes:**
Fixes #15206

**What this PR does / why we need it:**
On Windows the VM is not correctly identified when the connection is not
default. The load VM by name passes, but wants to try a remote
connection which results in a no service configured.

This change will not check the `validVM` flag but instead if the load
returned a valid entry.

[NO NEW TESTS NEEDED]

Signed-off-by: Gerard Braad <me@gbraad.nl>


**Does this PR introduce a user-facing change?**
```release-note
 podman machine ssh correctly identifies the default VM
```
