### PR TITLE
Cirrus: Improve CI VM image updates for EC2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,13 +34,13 @@ env:
 
     # Image identifiers
     IMAGE_SUFFIX: "c5495735033528320"
-    FEDORA_AMI_ID: "ami-0df5df528071f1052"  # matches c5495735033528320
-    FEDORA_AARCH64_AMI_ID: "ami-02ee8b3a782a78791"  # matches c5495735033528320
-    # Complete image names
+    # EC2 images
+    FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"
+    FEDORA_AARCH64_AMI: "fedora-podman-aws-arm64-${IMAGE_SUFFIX}"
+    # GCP Images
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     #PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
-
     # Container FQIN's
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
     #PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
@@ -210,7 +210,7 @@ build_aarch64_task:
     env: &stdenvars_aarch64
         EC2_INST_TYPE: "t4g.xlarge"
         DISTRO_NV: ${FEDORA_AARCH64_NAME}
-        VM_IMAGE_NAME: ${FEDORA_AARCH64_AMI_ID}
+        VM_IMAGE_NAME: ${FEDORA_AARCH64_AMI}
         CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
         CI_DESIRED_RUNTIME: crun
         TEST_FLAVOR: build
@@ -701,7 +701,7 @@ podman_machine_task:
       TEST_FLAVOR: "machine"
       PRIV_NAME: "rootless"  # intended use-case
       DISTRO_NV: "${FEDORA_NAME}"
-      VM_IMAGE_NAME: "${FEDORA_AMI_ID}"
+      VM_IMAGE_NAME: "${FEDORA_AMI}"
     clone_script: *get_gosrc
     setup_script: *setup
     main_script: *main


### PR DESCRIPTION
AWS EC2 keys VM images by an utterly unreadable and horrible to use "AMI
ID" value.  This is very error prone for humans to use, since it's
impossible to tell one image from the next by eye.  Worse, they permit
duplicate name-tag values (or any other tag), complicating image
selection further.

However, Cirrus-CI recently implemented a feature by which AMI's may be
referenced by name-tag search, where the most recent AMI is chosen.
Since the `containers/automation_images` build workflow always assigns
a unique `$IMAGE_SUFFIX` value (based on the $CIRRUS_BUILD_ID), we can
now simply re-use it for both AWS and GCP image specification.  In other
words to update VM images, simply update the `$IMAGE_SUFFIX` value
and you're done.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
