### PR TITLE
[v4.2] Cirrus: Improve CI VM image updates for EC2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,12 +32,12 @@ env:
 
     # Image identifiers
     IMAGE_SUFFIX: "c6211193021923328"
-    FEDORA_AMI_ID: "ami-06a41d8a81ab56afa"
-    # Complete image names
+    # EC2 images
+    FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"
+    # GCP Images
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
-
     # Container FQIN's
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
@@ -610,7 +610,7 @@ podman_machine_task:
       TEST_FLAVOR: "machine"
       PRIV_NAME: "rootless"  # intended use-case
       DISTRO_NV: "${FEDORA_NAME}"
-      VM_IMAGE_NAME: "${FEDORA_AMI_ID}"
+      VM_IMAGE_NAME: "${FEDORA_AMI}"
     clone_script: *get_gosrc
     setup_script: *setup
     main_script: *main

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
     #### Global variables used for all tasks
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
-    DEST_BRANCH: "main"
+    DEST_BRANCH: "v4.2"
     # Sane (default) value for GOPROXY and GOSUMDB.
     GOPROXY: "https://proxy.golang.org,direct"
     GOSUMDB: "sum.golang.org"


### PR DESCRIPTION
AWS EC2 keys VM images by an utterly unreadable, horrible to use,
generated "AMI ID" value.  This is very error prone for humans in
practice, since it's impossible to tell one image from the next by
eye.  Worse, EC2 permits duplicate name-tag values, complicating
image specification further.

However fortunately, Cirrus-CI recently implemented a feature by
which AMI's may be referenced by a name-tag search - choosing
the most recent AMI found.  Since the `containers/automation_images`
build workflow always assigns a unique name + `$IMAGE_SUFFIX` value,
we can simply re-use it for both AWS and GCP image specification.

In other words as of this commit, specifying new CI VM images can
be done by simply updating the `$IMAGE_SUFFIX` value as we've always
done.  No need to call out a specific AMI ID just for EC2 tasks.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
