### PR TITLE
[CI:COPR] podman.spec.rpkg: add python3 dependency for el8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -308,6 +308,7 @@ bindings_task:
     only_if: >-
         $CIRRUS_PR != '' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*'
     depends_on:
         - build
@@ -483,6 +484,7 @@ docker-py_test_task:
     only_if: &not_tag_branch_build_docs >-
         $CIRRUS_PR != '' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*'
 
     depends_on:
@@ -720,6 +722,7 @@ local_system_test_task: &local_system_test_task
     only_if: &not_tag_build_docs_multiarch >-
         $CIRRUS_TAG == '' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*' &&
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:BUILD.*' &&
         $CIRRUS_CRON != 'multiarch'
     depends_on:
@@ -1036,6 +1039,7 @@ artifacts_task:
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: >-
         $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*' &&
+        $CIRRUS_CHANGE_TITLE !=~ '.*CI:COPR.*' &&
         $CIRRUS_CRON != 'multiarch'
     depends_on:
         - success

--- a/contrib/cirrus/CIModes.md
+++ b/contrib/cirrus/CIModes.md
@@ -85,6 +85,16 @@ of this document, it's not possible to override the behavior of `$CIRRUS_PR`.
 + meta
 + success
 
+### Intended `[CI:COPR]` PR Tasks:
++ ext_svc_check
++ automation
++ *build*
++ validate
++ swagger
++ consistency
++ meta
++ success
+
 ### Intend `[CI:BUILD]` PR Tasks:
 + ext_svc_check
 + automation

--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -59,6 +59,7 @@ BuildRequires: go-rpm-macros
 %endif
 %if 0%{?rhel} <= 8
 BuildRequires: pkgconfig(devmapper)
+BuildRequires: python3
 %endif
 BuildRequires: gpgme-devel
 BuildRequires: libassuan-devel


### PR DESCRIPTION
EL8 builds are failing because hack/markdown-preprocess needs python3
which AFAICT isn't included by default in EL8 build environments.

This commit also includes an additional `[CI:COPR]` mode which is
currently runs the same tests as `[CI:DOCS]` but could differ in future.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

EDIT: `s/CI:RPM/CI:COPR/g`
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@cevich @edsantiago PTAL
/cc @containers/podman-maintainers 