### PR TITLE
pkg/bindings: Support writing image push progress to specified io.Writer

### DIFF
--- a/pkg/bindings/images/push.go
+++ b/pkg/bindings/images/push.go
@@ -62,6 +62,8 @@ func Push(ctx context.Context, source string, destination string, options *PushO
 	writer := io.Writer(os.Stderr)
 	if options.GetQuiet() {
 		writer = ioutil.Discard
+	} else if progressWriter := options.GetProgressWriter(); progressWriter != nil {
+		writer = progressWriter
 	}
 
 	dec := json.NewDecoder(response.Body)

--- a/pkg/bindings/images/types.go
+++ b/pkg/bindings/images/types.go
@@ -1,6 +1,8 @@
 package images
 
 import (
+	"io"
+
 	buildahDefine "github.com/containers/buildah/define"
 )
 
@@ -131,6 +133,10 @@ type PushOptions struct {
 	Format *string
 	// Password for authenticating against the registry.
 	Password *string
+	// ProgressWriter is a writer where push progress are sent.
+	// Since API handler for image push is quiet by default, WithQuiet(false) is necessary for
+	// the writer to receive progress messages.
+	ProgressWriter *io.Writer
 	// SkipTLSVerify to skip HTTPS and certificate verification.
 	SkipTLSVerify *bool
 	// RemoveSignatures Discard any pre-existing signatures in the image.

--- a/pkg/bindings/images/types_push_options.go
+++ b/pkg/bindings/images/types_push_options.go
@@ -2,6 +2,7 @@
 package images
 
 import (
+	"io"
 	"net/url"
 
 	"github.com/containers/podman/v4/pkg/bindings/internal/util"
@@ -105,6 +106,21 @@ func (o *PushOptions) GetPassword() string {
 		return z
 	}
 	return *o.Password
+}
+
+// WithProgressWriter set field ProgressWriter to given value
+func (o *PushOptions) WithProgressWriter(value io.Writer) *PushOptions {
+	o.ProgressWriter = &value
+	return o
+}
+
+// GetProgressWriter returns value of field ProgressWriter
+func (o *PushOptions) GetProgressWriter() io.Writer {
+	if o.ProgressWriter == nil {
+		var z io.Writer
+		return z
+	}
+	return *o.ProgressWriter
 }
 
 // WithSkipTLSVerify set field SkipTLSVerify to given value

--- a/pkg/bindings/test/images_test.go
+++ b/pkg/bindings/test/images_test.go
@@ -379,6 +379,10 @@ var _ = Describe("Podman images", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("Image Push", func() {
+		Skip("TODO: implement test for image push to registry")
+	})
+
 	It("Build no options", func() {
 		results, err := images.Build(bt.conn, []string{"fixture/Containerfile"}, entities.BuildOptions{})
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -240,7 +240,7 @@ func (ir *ImageEngine) Import(ctx context.Context, opts entities.ImageImportOpti
 
 func (ir *ImageEngine) Push(ctx context.Context, source string, destination string, opts entities.ImagePushOptions) error {
 	options := new(images.PushOptions)
-	options.WithAll(opts.All).WithCompress(opts.Compress).WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithFormat(opts.Format).WithRemoveSignatures(opts.RemoveSignatures).WithQuiet(opts.Quiet).WithCompressionFormat(opts.CompressionFormat)
+	options.WithAll(opts.All).WithCompress(opts.Compress).WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithFormat(opts.Format).WithRemoveSignatures(opts.RemoveSignatures).WithQuiet(opts.Quiet).WithCompressionFormat(opts.CompressionFormat).WithProgressWriter(opts.Writer)
 
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {


### PR DESCRIPTION
Currently bindings writes image push progress to os.Stderr.

Since os.Stderr is inconvenience for bindings caller to process the progress messages, Added this support.

Signed-off-by: Naoto Kobayashi <naoto.kobayashi4c@gmail.com>

Close #15211

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Bindings: Images package now supports writing image push progress to specified io.Writer
```

Edit:
Skipped the unit test for added option since I cannot find any existing UT using container registry; e.g. UT for binding manifest push is skipped as TODO.

- https://github.com/containers/podman/blob/main/pkg/bindings/test/manifests_test.go#L175-L177
  ```go
  It("push manifest", func() {
  	Skip("TODO: implement test for manifest push to registry")
  })
  ```

If there is a registry available for UT, I would grateful if you could tell me. Will write UT.
