### PR TITLE
Refactor common man page options, phase 2

### DIFF
--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -1,2 +1,6 @@
+podman-container-clone.1.md
 podman-create.1.md
+podman-pod-clone.1.md
+podman-pod-create.1.md
+podman-pull.1.md
 podman-run.1.md

--- a/docs/source/markdown/options/README.md
+++ b/docs/source/markdown/options/README.md
@@ -1,0 +1,44 @@
+Common Man Page Options
+=======================
+
+This subdirectory contains option (flag) names and descriptions
+common to multiple podman man pages. Each file is one option. The
+filename does not necessarily need to be identical to the option
+name: for instance, `hostname.container.md` and `hostname.pod.md`
+exist because the **--hostname** option is sufficiently different
+between `podman-{create,run}` and `podman-pod-{create,run}` to
+warrant living separately.
+
+How
+===
+
+The files here are included in `podman-*.md.in` files using the `@@option`
+mechanism:
+
+```
+@@option foo           ! will include options/foo.md
+```
+
+The tool that does this is `hack/markdown-preprocess`. It is a python
+script because it needs to run on `readthedocs.io`. From a given `.md.in`
+file, this script will create a `.md` file that can then be read by
+`go-md2man`, `sphinx`, anything that groks markdown. This runs as
+part of `make docs`.
+
+Special Substitutions
+=====================
+
+Some options are almost identical except for 'pod' vs 'container'
+differences. For those, use `<<text for pods|text for containers>>`.
+Order is immaterial: the important thing is the presence of the
+string "`pod`" in one half but not the other. The correct string
+will be chosen based on the filename: if the file contains `-pod`,
+such as `podman-pod-create`, the string with `pod` (case-insensitive)
+in it will be chosen.
+
+The string `<<subcommand>>` will be replaced with the podman subcommand
+as determined from the filename, e.g., `create` for `podman-create.1.md.in`.
+This allows the shared use of examples in the option file:
+```
+    Example: podman <<subcommand>> --foo --bar
+```

--- a/docs/source/markdown/options/blkio-weight-device.md
+++ b/docs/source/markdown/options/blkio-weight-device.md
@@ -1,0 +1,3 @@
+#### **--blkio-weight-device**=*device:weight*
+
+Block IO relative device weight.

--- a/docs/source/markdown/options/blkio-weight.md
+++ b/docs/source/markdown/options/blkio-weight.md
@@ -1,0 +1,3 @@
+#### **--blkio-weight**=*weight*
+
+Block IO relative weight. The _weight_ is a value between **10** and **1000**.

--- a/docs/source/markdown/options/cap-add.md
+++ b/docs/source/markdown/options/cap-add.md
@@ -1,0 +1,3 @@
+#### **--cap-add**=*capability*
+
+Add Linux capabilities.

--- a/docs/source/markdown/options/cap-drop.md
+++ b/docs/source/markdown/options/cap-drop.md
@@ -1,0 +1,3 @@
+#### **--cap-drop**=*capability*
+
+Drop Linux capabilities.

--- a/docs/source/markdown/options/destroy.md
+++ b/docs/source/markdown/options/destroy.md
@@ -1,0 +1,3 @@
+#### **--destroy**
+
+Remove the original <<container|pod>> that we are cloning once used to mimic the configuration.

--- a/docs/source/markdown/options/entrypoint.md
+++ b/docs/source/markdown/options/entrypoint.md
@@ -1,0 +1,17 @@
+#### **--entrypoint**=*"command"* | *'["command", "arg1", ...]'*
+
+Overwrite the default ENTRYPOINT of the image.
+
+This option allows you to overwrite the default entrypoint of the image.
+
+The ENTRYPOINT of an image is similar to a COMMAND
+because it specifies what executable to run when the container starts, but it is
+(purposely) more difficult to override. The ENTRYPOINT gives a container its
+default nature or behavior, so that when you set an ENTRYPOINT you can run the
+container as if it were that binary, complete with default options, and you can
+pass in more options via the COMMAND. But, sometimes an operator may want to run
+something else inside the container, so you can override the default ENTRYPOINT
+at runtime by using a **--entrypoint** and a string to specify the new
+ENTRYPOINT.
+
+You need to specify multi option commands in the form of a json string.

--- a/docs/source/markdown/options/expose.md
+++ b/docs/source/markdown/options/expose.md
@@ -1,0 +1,4 @@
+#### **--expose**=*port*
+
+Expose a port, or a range of ports (e.g. **--expose=3300-3310**) to set up port redirection
+on the host system.

--- a/docs/source/markdown/options/health-cmd.md
+++ b/docs/source/markdown/options/health-cmd.md
@@ -1,0 +1,8 @@
+#### **--health-cmd**=*"command"* | *'["command", "arg1", ...]'*
+
+Set or alter a healthcheck command for a container. The command is a command to be executed inside your
+container that determines your container health. The command is required for other healthcheck options
+to be applied. A value of **none** disables existing healthchecks.
+
+Multiple options can be passed in the form of a JSON array; otherwise, the command will be interpreted
+as an argument to **/bin/sh -c**.

--- a/docs/source/markdown/options/health-interval.md
+++ b/docs/source/markdown/options/health-interval.md
@@ -1,0 +1,3 @@
+#### **--health-interval**=*interval*
+
+Set an interval for the healthchecks. An _interval_ of **disable** results in no automatic timer setup. The default is **30s**.

--- a/docs/source/markdown/options/health-retries.md
+++ b/docs/source/markdown/options/health-retries.md
@@ -1,0 +1,3 @@
+#### **--health-retries**=*retries*
+
+The number of retries allowed before a healthcheck is considered to be unhealthy. The default value is **3**.

--- a/docs/source/markdown/options/health-start-period.md
+++ b/docs/source/markdown/options/health-start-period.md
@@ -1,0 +1,4 @@
+#### **--health-start-period**=*period*
+
+The initialization time needed for a container to bootstrap. The value can be expressed in time format like
+**2m3s**. The default value is **0s**.

--- a/docs/source/markdown/options/health-timeout.md
+++ b/docs/source/markdown/options/health-timeout.md
@@ -1,0 +1,4 @@
+#### **--health-timeout**=*timeout*
+
+The maximum time allowed to complete the healthcheck before an interval is considered failed. Like start-period, the
+value can be expressed in a time format such as **1m22s**. The default value is **30s**.

--- a/docs/source/markdown/options/hostname.container.md
+++ b/docs/source/markdown/options/hostname.container.md
@@ -1,0 +1,5 @@
+#### **--hostname**, **-h**=*name*
+
+Container host name
+
+Sets the container host name that is available inside the container. Can only be used with a private UTS namespace `--uts=private` (default). If `--pod` is specified and the pod shares the UTS namespace (default) the pod's hostname will be used.

--- a/docs/source/markdown/options/hostname.pod.md
+++ b/docs/source/markdown/options/hostname.pod.md
@@ -1,0 +1,3 @@
+#### **--hostname**=*name*
+
+Set a hostname to the pod.

--- a/docs/source/markdown/options/infra-command.md
+++ b/docs/source/markdown/options/infra-command.md
@@ -1,0 +1,3 @@
+#### **--infra-command**=*command*
+
+The command that will be run to start the infra container. Default: "/pause".

--- a/docs/source/markdown/options/infra-conmon-pidfile.md
+++ b/docs/source/markdown/options/infra-conmon-pidfile.md
@@ -1,0 +1,3 @@
+#### **--infra-conmon-pidfile**=*file*
+
+Write the pid of the infra container's **conmon** process to a file. As **conmon** runs in a separate process than Podman, this is necessary when using systemd to manage Podman containers and pods.

--- a/docs/source/markdown/options/infra-name.md
+++ b/docs/source/markdown/options/infra-name.md
@@ -1,0 +1,3 @@
+#### **--infra-name**=*name*
+
+The name that will be used for the pod's infra container.

--- a/docs/source/markdown/options/label-file.md
+++ b/docs/source/markdown/options/label-file.md
@@ -1,0 +1,3 @@
+#### **--label-file**=*file*
+
+Read in a line-delimited file of labels.

--- a/docs/source/markdown/options/link-local-ip.md
+++ b/docs/source/markdown/options/link-local-ip.md
@@ -1,0 +1,3 @@
+#### **--link-local-ip**=*ip*
+
+Not implemented.

--- a/docs/source/markdown/options/log-driver.md
+++ b/docs/source/markdown/options/log-driver.md
@@ -1,0 +1,12 @@
+#### **--log-driver**=*driver*
+
+Logging driver for the container. Currently available options are **k8s-file**, **journald**, **none** and **passthrough**, with **json-file** aliased to **k8s-file** for scripting compatibility. (Default **journald**).
+
+The podman info command below will display the default log-driver for the system.
+```
+$ podman info --format '{{ .Host.LogDriver }}'
+journald
+```
+The **passthrough** driver passes down the standard streams (stdin, stdout, stderr) to the
+container.  It is not allowed with the remote Podman client, including Mac and Windows (excluding WSL2) machines, and on a tty, since it is
+vulnerable to attacks via TIOCSTI.

--- a/docs/source/markdown/options/mac-address.md
+++ b/docs/source/markdown/options/mac-address.md
@@ -1,0 +1,11 @@
+#### **--mac-address**=*address*
+
+<<Container|Pod>> network interface MAC address (e.g. 92:d0:c6:0a:29:33)
+This option can only be used if the <<container|pod>> is joined to only a single network - i.e., **--network=_network-name_** is used at most once -
+and if the <<container|pod>> is not joining another container's network namespace via **--network=container:_id_**.
+
+Remember that the MAC address in an Ethernet network must be unique.
+The IPv6 link-local address will be based on the device's MAC address
+according to RFC4862.
+
+To specify multiple static MAC addresses per <<container|pod>>, set multiple networks using the **--network** option with a static MAC address specified for each using the `mac` mode for that option.

--- a/docs/source/markdown/options/memory-swappiness.md
+++ b/docs/source/markdown/options/memory-swappiness.md
@@ -1,0 +1,5 @@
+#### **--memory-swappiness**=*number*
+
+Tune a container's memory swappiness behavior. Accepts an integer between *0* and *100*.
+
+This flag is not supported on cgroups V2 systems.

--- a/docs/source/markdown/options/network-alias.md
+++ b/docs/source/markdown/options/network-alias.md
@@ -1,0 +1,8 @@
+#### **--network-alias**=*alias*
+
+Add a network-scoped alias for the <<container|pod>>, setting the alias for all networks that the container joins. To set a
+name only for a specific network, use the alias option as described under the **--network** option.
+If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <name>`),
+these aliases can be used for name resolution on the given network. This option can be specified multiple times.
+NOTE: When using CNI a <<container|pod>> will only have access to aliases on the first network that it joins. This limitation does
+not exist with netavark/aardvark-dns.

--- a/docs/source/markdown/options/oom-score-adj.md
+++ b/docs/source/markdown/options/oom-score-adj.md
@@ -1,0 +1,3 @@
+#### **--oom-score-adj**=*num*
+
+Tune the host's OOM preferences for containers (accepts values from **-1000** to **1000**).

--- a/docs/source/markdown/options/pid.pod.md
+++ b/docs/source/markdown/options/pid.pod.md
@@ -1,0 +1,7 @@
+#### **--pid**=*pid*
+
+Set the PID mode for the pod. The default is to create a private PID namespace for the pod. Requires the PID namespace to be shared via --share.
+
+    host: use the host’s PID namespace for the pod
+    ns: join the specified PID namespace
+    private: create a new namespace for the pod (default)

--- a/docs/source/markdown/options/pids-limit.md
+++ b/docs/source/markdown/options/pids-limit.md
@@ -1,0 +1,3 @@
+#### **--pids-limit**=*limit*
+
+Tune the container's pids limit. Set to **-1** to have unlimited pids for the container. The default is **4096** on systems that support "pids" cgroup controller.

--- a/docs/source/markdown/options/platform.md
+++ b/docs/source/markdown/options/platform.md
@@ -1,0 +1,4 @@
+#### **--platform**=*OS/ARCH*
+
+Specify the platform for selecting the image.  (Conflicts with --arch and --os)
+The `--platform` option can be used to override the current architecture and operating system.

--- a/docs/source/markdown/options/pull.md
+++ b/docs/source/markdown/options/pull.md
@@ -1,0 +1,8 @@
+#### **--pull**=*policy*
+
+Pull image policy. The default is **missing**.
+
+- **always**: Always pull the image and throw an error if the pull fails.
+- **missing**: Pull the image only if it could not be found in the local containers storage.  Throw an error if no image could be found and the pull fails.
+- **never**: Never pull the image but use the one from the local containers storage.  Throw an error if no image could be found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.

--- a/docs/source/markdown/options/read-only-tmpfs.md
+++ b/docs/source/markdown/options/read-only-tmpfs.md
@@ -1,0 +1,3 @@
+#### **--read-only-tmpfs**
+
+If container is running in **--read-only** mode, then mount a read-write tmpfs on _/run_, _/tmp_, and _/var/tmp_. The default is **true**.

--- a/docs/source/markdown/options/read-only.md
+++ b/docs/source/markdown/options/read-only.md
@@ -1,0 +1,7 @@
+#### **--read-only**
+
+Mount the container's root filesystem as read-only.
+
+By default a container will have its root filesystem writable allowing processes
+to write files anywhere. By specifying the **--read-only** flag, the container will have
+its root filesystem mounted as read-only prohibiting any writes.

--- a/docs/source/markdown/options/replace.md
+++ b/docs/source/markdown/options/replace.md
@@ -1,0 +1,3 @@
+#### **--replace**
+
+If another <<container|pod>> with the same name already exists, replace and remove it. The default is **false**.

--- a/docs/source/markdown/options/requires.md
+++ b/docs/source/markdown/options/requires.md
@@ -1,0 +1,5 @@
+#### **--requires**=*container*
+
+Specify one or more requirements.
+A requirement is a dependency container that will be started before this container.
+Containers can be specified by name or ID, with multiple containers being separated by commas.

--- a/docs/source/markdown/options/secret.md
+++ b/docs/source/markdown/options/secret.md
@@ -1,0 +1,22 @@
+#### **--secret**=*secret[,opt=opt ...]*
+
+Give the container access to a secret. Can be specified multiple times.
+
+A secret is a blob of sensitive data which a container needs at runtime but
+should not be stored in the image or in source control, such as usernames and passwords,
+TLS certificates and keys, SSH keys or other important generic strings or binary content (up to 500 kb in size).
+
+When secrets are specified as type `mount`, the secrets are copied and mounted into the container when a container is created.
+When secrets are specified as type `env`, the secret will be set as an environment variable within the container.
+Secrets are written in the container at the time of container creation, and modifying the secret using `podman secret` commands
+after the container is created will not affect the secret inside the container.
+
+Secrets and its storage are managed using the `podman secret` command.
+
+Secret Options
+
+- `type=mount|env`    : How the secret will be exposed to the container. Default mount.
+- `target=target`     : Target of secret. Defaults to secret name.
+- `uid=0`             : UID of secret. Defaults to 0. Mount secret type only.
+- `gid=0`             : GID of secret. Defaults to 0. Mount secret type only.
+- `mode=0`            : Mode of secret. Defaults to 0444. Mount secret type only.

--- a/docs/source/markdown/options/stop-signal.md
+++ b/docs/source/markdown/options/stop-signal.md
@@ -1,0 +1,3 @@
+#### **--stop-signal**=*signal*
+
+Signal to stop a container. Default is **SIGTERM**.

--- a/docs/source/markdown/options/stop-timeout.md
+++ b/docs/source/markdown/options/stop-timeout.md
@@ -1,0 +1,4 @@
+#### **--stop-timeout**=*seconds*
+
+Timeout to stop a container. Default is **10**.
+Remote connections use local containers.conf for defaults

--- a/docs/source/markdown/options/tmpfs.md
+++ b/docs/source/markdown/options/tmpfs.md
@@ -1,0 +1,14 @@
+#### **--tmpfs**=*fs*
+
+Create a tmpfs mount.
+
+Mount a temporary filesystem (**tmpfs**) mount into a container, for example:
+
+```
+$ podman <<subcommand>> -d --tmpfs /tmp:rw,size=787448k,mode=1777 my_image
+```
+
+This command mounts a **tmpfs** at _/tmp_ within the container. The supported mount
+options are the same as the Linux default mount flags. If you do not specify
+any options, the system uses the following options:
+**rw,noexec,nosuid,nodev**.

--- a/docs/source/markdown/options/uidmap.container.md
+++ b/docs/source/markdown/options/uidmap.container.md
@@ -1,0 +1,79 @@
+#### **--uidmap**=*container_uid:from_uid:amount*
+
+Run the container in a new user namespace using the supplied UID mapping. This
+option conflicts with the **--userns** and **--subuidname** options. This
+option provides a way to map host UIDs to container UIDs. It can be passed
+several times to map different ranges.
+
+The _from_uid_ value is based upon the user running the command, either rootful or rootless users.
+* rootful user:  *container_uid*:*host_uid*:*amount*
+* rootless user: *container_uid*:*intermediate_uid*:*amount*
+
+When **podman <<subcommand>>** is called by a privileged user, the option **--uidmap**
+works as a direct mapping between host UIDs and container UIDs.
+
+host UID -> container UID
+
+The _amount_ specifies the number of consecutive UIDs that will be mapped.
+If for example _amount_ is **4** the mapping would look like:
+
+|   host UID     |    container UID    |
+| -              | -                   |
+| _from_uid_     | _container_uid_     |
+| _from_uid_ + 1 | _container_uid_ + 1 |
+| _from_uid_ + 2 | _container_uid_ + 2 |
+| _from_uid_ + 3 | _container_uid_ + 3 |
+
+When **podman <<subcommand>>** is called by an unprivileged user (i.e. running rootless),
+the value _from_uid_ is interpreted as an "intermediate UID". In the rootless
+case, host UIDs are not mapped directly to container UIDs. Instead the mapping
+happens over two mapping steps:
+
+host UID -> intermediate UID -> container UID
+
+The **--uidmap** option only influences the second mapping step.
+
+The first mapping step is derived by Podman from the contents of the file
+_/etc/subuid_ and the UID of the user calling Podman.
+
+First mapping step:
+
+| host UID                                         | intermediate UID |
+| -                                                |                - |
+| UID for the user starting Podman                 |                0 |
+| 1st subordinate UID for the user starting Podman |                1 |
+| 2nd subordinate UID for the user starting Podman |                2 |
+| 3rd subordinate UID for the user starting Podman |                3 |
+| nth subordinate UID for the user starting Podman |                n |
+
+To be able to use intermediate UIDs greater than zero, the user needs to have
+subordinate UIDs configured in _/etc/subuid_. See **subuid**(5).
+
+The second mapping step is configured with **--uidmap**.
+
+If for example _amount_ is **5** the second mapping step would look like:
+
+|   intermediate UID   |    container UID    |
+| -                    | -                   |
+| _from_uid_           | _container_uid_     |
+| _from_uid_ + 1       | _container_uid_ + 1 |
+| _from_uid_ + 2       | _container_uid_ + 2 |
+| _from_uid_ + 3       | _container_uid_ + 3 |
+| _from_uid_ + 4       | _container_uid_ + 4 |
+
+When running as rootless, Podman will use all the ranges configured in the _/etc/subuid_ file.
+
+The current user ID is mapped to UID=0 in the rootless user namespace.
+Every additional range is added sequentially afterward:
+
+|   host                |rootless user namespace | length              |
+| -                     | -                      | -                   |
+| $UID                  | 0                      | 1                   |
+| 1                     | $FIRST_RANGE_ID        | $FIRST_RANGE_LENGTH |
+| 1+$FIRST_RANGE_LENGTH | $SECOND_RANGE_ID       | $SECOND_RANGE_LENGTH|
+
+Even if a user does not have any subordinate UIDs in  _/etc/subuid_,
+**--uidmap** could still be used to map the normal UID of the user to a
+container UID by running `podman <<subcommand>> --uidmap $container_uid:0:1 --user $container_uid ...`.
+
+Note: the **--uidmap** flag cannot be called in conjunction with the **--pod** flag as a uidmap cannot be set on the container level when in a pod.

--- a/docs/source/markdown/options/uidmap.pod.md
+++ b/docs/source/markdown/options/uidmap.pod.md
@@ -1,0 +1,6 @@
+#### **--uidmap**=*container_uid:from_uid:amount*
+
+Run all containers in the pod in a new user namespace using the supplied mapping. This
+option conflicts with the **--userns** and **--subuidname** options. This
+option provides a way to map host UIDs to container UIDs. It can be passed
+several times to map different ranges.

--- a/docs/source/markdown/options/ulimit.md
+++ b/docs/source/markdown/options/ulimit.md
@@ -1,0 +1,3 @@
+#### **--ulimit**=*option*
+
+Ulimit options. You can use **host** to copy the current configuration from the host.

--- a/docs/source/markdown/options/unsetenv.md
+++ b/docs/source/markdown/options/unsetenv.md
@@ -1,0 +1,5 @@
+#### **--unsetenv**=*env*
+
+Unset default environment variables for the container. Default environment
+variables include variables provided natively by Podman, environment variables
+configured by the image, and environment variables from containers.conf.

--- a/docs/source/markdown/options/uts.container.md
+++ b/docs/source/markdown/options/uts.container.md
@@ -1,0 +1,8 @@
+#### **--uts**=*mode*
+
+Set the UTS namespace mode for the container. The following values are supported:
+
+- **host**: use the host's UTS namespace inside the container.
+- **private**: create a new namespace for the container (default).
+- **ns:[path]**: run the container in the given existing UTS namespace.
+- **container:[container]**: join the UTS namespace of the specified container.

--- a/docs/source/markdown/options/uts.pod.md
+++ b/docs/source/markdown/options/uts.pod.md
@@ -1,0 +1,7 @@
+#### **--uts**=*mode*
+
+Set the UTS namespace mode for the pod. The following values are supported:
+
+- **host**: use the host's UTS namespace inside the pod.
+- **private**: create a new namespace for the pod (default).
+- **ns:[path]**: run the pod in the given existing UTS namespace.

--- a/docs/source/markdown/podman-container-clone.1.md.in
+++ b/docs/source/markdown/podman-container-clone.1.md.in
@@ -11,13 +11,9 @@ podman\-container\-clone - Creates a copy of an existing container
 
 ## OPTIONS
 
-#### **--blkio-weight**=*weight*
+@@option blkio-weight
 
-Block IO weight (relative weight) accepts a weight value between 10 and 1000.
-
-#### **--blkio-weight-device**=*weight*
-
-Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`).
+@@option blkio-weight-device
 
 #### **--cpu-period**=*limit*
 
@@ -130,9 +126,7 @@ two memory nodes.
 
 If none are specified, the original container's CPU memory nodes are used.
 
-#### **--destroy**
-
-Remove the original container that we are cloning once used to mimic the configuration.
+@@option destroy
 
 #### **--device-read-bps**=*path*
 
@@ -179,11 +173,7 @@ The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kibibytes), `m` (mebibytes), or `g` (gibibytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
-#### **--memory-swappiness**=*number*
-
-Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
-
-This flag is not supported on cgroups V2 systems.
+@@option memory-swappiness
 
 #### **--name**
 

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -99,21 +99,15 @@ Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
 
-#### **--blkio-weight**=*weight*
+@@option blkio-weight
 
-Block IO weight (relative weight) accepts a weight value between 10 and 1000.
+#### **--blkio-weight-device**=*device:weight*
 
-#### **--blkio-weight-device**=*weight*
+Block IO relative device weight.
 
-Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`).
+@@option cap-add
 
-#### **--cap-add**=*capability*
-
-Add Linux capabilities
-
-#### **--cap-drop**=*capability*
-
-Drop Linux capabilities
+@@option cap-drop
 
 @@option cgroup-conf
 
@@ -323,22 +317,7 @@ Set custom DNS options. Invalid if using **--dns-opt** and **--network** that is
 
 Set custom DNS search domains. Invalid if using **--dns-search** and **--network** that is set to 'none' or `container:<name|id>`. (Use --dns-search=. if you don't wish to set the search domain)
 
-#### **--entrypoint**=*"command"* | *'["command", "arg1", ...]'*
-
-Overwrite the default ENTRYPOINT of the image
-
-This option allows you to overwrite the default entrypoint of the image.
-The ENTRYPOINT of an image is similar to a COMMAND
-because it specifies what executable to run when the container starts, but it is
-(purposely) more difficult to override. The ENTRYPOINT gives a container its
-default nature or behavior, so that when you set an ENTRYPOINT you can run the
-container as if it were that binary, complete with default options, and you can
-pass in more options via the COMMAND. But, sometimes an operator may want to run
-something else inside the container, so you can override the default ENTRYPOINT
-at runtime by using a **--entrypoint** and a string to specify the new
-ENTRYPOINT.
-
-You need to specify multi option commands in the form of a json string.
+@@option entrypoint
 
 #### **--env**, **-e**=*env*
 
@@ -354,10 +333,7 @@ Read in a line delimited file of environment variables. See **Environment** note
 
 @@option env-host
 
-#### **--expose**=*port*
-
-Expose a port, or a range of ports (e.g. --expose=3300-3310) to set up port redirection
-on the host system.
+@@option expose
 
 #### **--gidmap**=*container_gid:host_gid:amount*
 
@@ -370,42 +346,21 @@ Note: the **--gidmap** flag cannot be called in conjunction with the **--pod** f
 
 @@option group-add
 
-#### **--health-cmd**=*"command"* | *'["command", "arg1", ...]'*
+@@option health-cmd
 
-Set or alter a healthcheck command for a container. The command is a command to be executed inside your
-container that determines your container health. The command is required for other healthcheck options
-to be applied. A value of `none` disables existing healthchecks.
+@@option health-interval
 
-Multiple options can be passed in the form of a JSON array; otherwise, the command will be interpreted
-as an argument to `/bin/sh -c`.
+@@option health-retries
 
-#### **--health-interval**=*interval*
+@@option health-start-period
 
-Set an interval for the healthchecks (a value of `disable` results in no automatic timer setup) (default "30s")
-
-#### **--health-retries**=*retries*
-
-The number of retries allowed before a healthcheck is considered to be unhealthy. The default value is `3`.
-
-#### **--health-start-period**=*period*
-
-The initialization time needed for a container to bootstrap. The value can be expressed in time format like
-`2m3s`. The default value is `0s`
-
-#### **--health-timeout**=*timeout*
-
-The maximum time allowed to complete the healthcheck before an interval is considered failed. Like start-period, the
-value can be expressed in a time format such as `1m22s`. The default value is `30s`.
+@@option health-timeout
 
 #### **--help**
 
 Print usage statement
 
-#### **--hostname**, **-h**=*name*
-
-Container host name
-
-Sets the container host name that is available inside the container. Can only be used with a private UTS namespace `--uts=private` (default). If `--pod` is specified and the pod shares the UTS namespace (default) the pod's hostname will be used.
+@@option hostname.container
 
 @@option hostuser
 
@@ -490,26 +445,11 @@ a private IPC namespace.
 
 Add metadata to a container (e.g., --label com.example.key=value)
 
-#### **--label-file**=*file*
+@@option label-file
 
-Read in a line delimited file of labels
+@@option link-local-ip
 
-#### **--link-local-ip**=*ip*
-
-Not implemented
-
-#### **--log-driver**=*driver*
-
-Logging driver for the container. Currently available options are *k8s-file*, *journald*, *none* and *passthrough*, with *json-file* aliased to *k8s-file* for scripting compatibility.
-
-The podman info command below will display the default log-driver for the system.
-```
-$ podman info --format '{{ .Host.LogDriver }}'
-journald
-```
-The *passthrough* driver passes down the standard streams (stdin, stdout, stderr) to the
-container.  It is not allowed with the remote Podman client, including Mac and Windows (excluding WSL2) machines, and on a tty, since it is
-vulnerable to attacks via TIOCSTI.
+@@option log-driver
 
 #### **--log-opt**=*name=value*
 
@@ -528,17 +468,7 @@ It supports the same keys as **podman inspect --format**.
 
 This option is currently supported only by the **journald** log driver.
 
-#### **--mac-address**=*address*
-
-Container network interface MAC address (e.g. 92:d0:c6:0a:29:33)
-This option can only be used if the container is joined to only a single network - i.e., **--network=_network-name_** is used at most once -
-and if the container is not joining another container's network namespace via **--network=container:_id_**.
-
-Remember that the MAC address in an Ethernet network must be unique.
-The IPv6 link-local address will be based on the device's MAC address
-according to RFC4862.
-
-To specify multiple static MAC addresses per container, set multiple networks using the **--network** option with a static MAC address specified for each using the `mac` mode for that option.
+@@option mac-address
 
 #### **--memory**, **-m**=*limit*
 
@@ -571,11 +501,7 @@ The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kibibytes), `m` (mebibytes), or `g` (gibibytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
-#### **--memory-swappiness**=*number*
-
-Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
-
-This flag is not supported on cgroups V2 systems.
+@@option memory-swappiness
 
 @@option mount
 
@@ -626,14 +552,7 @@ Valid _mode_ values are:
   Note: Rootlesskit changes the source IP address of incoming packets to an IP address in the container network namespace, usually `10.0.2.100`. If your application requires the real source IP address, e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for rootless containers when connected to user-defined networks.
   - **port_handler=slirp4netns**: Use the slirp4netns port forwarding, it is slower than rootlesskit but preserves the correct source IP address. This port handler cannot be used for user-defined networks.
 
-#### **--network-alias**=*alias*
-
-Add a network-scoped alias for the container, setting the alias for all networks that the container joins. To set a
-name only for a specific network, use the alias option as described under the **--network** option.
-If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <name>`),
-these aliases can be used for name resolution on the given network. This option can be specified multiple times.
-NOTE: When using CNI a container will only have access to aliases on the first network that it joins. This limitation does
-not exist with netavark/aardvark-dns.
+@@option network-alias
 
 @@option no-healthcheck
 
@@ -646,9 +565,7 @@ This option conflicts with **--add-host**.
 
 @@option oom-kill-disable
 
-#### **--oom-score-adj**=*num*
-
-Tune the host's OOM preferences for containers (accepts -1000 to 1000)
+@@option oom-score-adj
 
 #### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
@@ -668,14 +585,9 @@ Default is to create a private PID namespace for the container
 
 @@option pidfile
 
-#### **--pids-limit**=*limit*
+@@option pids-limit
 
-Tune the container's pids limit. Set `-1` to have unlimited pids for the container. (default "4096" on systems that support PIDS cgroups).
-
-#### **--platform**=*OS/ARCH*
-
-Specify the platform for selecting the image.   (Conflicts with --arch and --os)
-The `--platform` option can be used to override the current architecture and operating system.
+@@option platform
 
 #### **--pod**=*name*
 
@@ -742,40 +654,19 @@ port to a random port on the host within an *ephemeral port range* defined by
 `/proc/sys/net/ipv4/ip_local_port_range`. To find the mapping between the host
 ports and the exposed ports, use `podman port`.
 
-#### **--pull**=*policy*
-
-Pull image policy. The default is **missing**.
-
-- **always**: Always pull the image and throw an error if the pull fails.
-- **missing**: Pull the image only if it could not be found in the local containers storage.  Throw an error if no image could be found and the pull fails.
-- **never**: Never pull the image but use the one from the local containers storage.  Throw an error if no image could be found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+@@option pull
 
 #### **--quiet**, **-q**
 
 Suppress output information when pulling images
 
-#### **--read-only**
+@@option read-only
 
-Mount the container's root filesystem as read-only.
+@@option read-only-tmpfs
 
-By default a container will have its root filesystem writable allowing processes
-to write files anywhere. By specifying the `--read-only` flag the container will have
-its root filesystem mounted as read-only prohibiting any writes.
+@@option replace
 
-#### **--read-only-tmpfs**
-
-If container is running in --read-only mode, then mount a read-write tmpfs on /run, /tmp, and /var/tmp. The default is *true*
-
-#### **--replace**
-
-If another container with the same name already exists, replace and remove it. The default is **false**.
-
-#### **--requires**=*container*
-
-Specify one or more requirements.
-A requirement is a dependency container that will be started before this container.
-Containers can be specified by name or ID, with multiple containers being separated by commas.
+@@option requires
 
 #### **--restart**=*policy*
 
@@ -818,28 +709,7 @@ finishes executing, similar to a tmpfs mount point being unmounted.
 
 @@option seccomp-policy
 
-#### **--secret**=*secret[,opt=opt ...]*
-
-Give the container access to a secret. Can be specified multiple times.
-
-A secret is a blob of sensitive data which a container needs at runtime but
-should not be stored in the image or in source control, such as usernames and passwords,
-TLS certificates and keys, SSH keys or other important generic strings or binary content (up to 500 kb in size).
-
-When secrets are specified as type `mount`, the secrets are copied and mounted into the container when a container is created.
-When secrets are specified as type `env`, the secret will be set as an environment variable within the container.
-Secrets are written in the container at the time of container creation, and modifying the secret using `podman secret` commands
-after the container is created will not affect the secret inside the container.
-
-Secrets and its storage are managed using the `podman secret` command.
-
-Secret Options
-
-- `type=mount|env`    : How the secret will be exposed to the container. Default mount.
-- `target=target`     : Target of secret. Defaults to secret name.
-- `uid=0`             : UID of secret. Defaults to 0. Mount secret type only.
-- `gid=0`             : GID of secret. Defaults to 0. Mount secret type only.
-- `mode=0`            : Mode of secret. Defaults to 0444. Mount secret type only.
+@@option secret
 
 #### **--security-opt**=*option*
 
@@ -880,14 +750,9 @@ Size of `/dev/shm` (format: `<number>[<unit>]`, where unit = b (bytes), k (kibib
 If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
 When size is `0`, there is no limit on the amount of memory used for IPC by the container.
 
-#### **--stop-signal**=*SIGTERM*
+@@option stop-signal
 
-Signal to stop a container. Default is SIGTERM.
-
-#### **--stop-timeout**=*seconds*
-
-Timeout (in seconds) to stop a container. Default is 10.
-Remote connections use local containers.conf for defaults
+@@option stop-timeout
 
 #### **--subgidname**=*name*
 
@@ -948,18 +813,7 @@ The `container_manage_cgroup` boolean must be enabled for this to be allowed on 
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true, then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified, TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
-#### **--tmpfs**=*fs*
-
-Create a tmpfs mount
-
-Mount a temporary filesystem (`tmpfs`) mount into a container, for example:
-
-$ podman create -d --tmpfs /tmp:rw,size=787448k,mode=1777 my_image
-
-This command mounts a `tmpfs` at `/tmp` within the container. The supported mount
-options are the same as the Linux default `mount` flags. If you do not specify
-any options, the systems uses the following options:
-`rw,noexec,nosuid,nodev`.
+@@option tmpfs
 
 #### **--tty**, **-t**
 
@@ -974,97 +828,13 @@ standard input.
 
 @@option tz
 
-#### **--uidmap**=*container_uid:from_uid:amount*
+@@option uidmap.container
 
-Run the container in a new user namespace using the supplied UID mapping. This
-option conflicts with the **--userns** and **--subuidname** options. This
-option provides a way to map host UIDs to container UIDs. It can be passed
-several times to map different ranges.
-
-The _from_uid_ value is based upon the user running the command, either rootful or rootless users.
-* rootful user:  *container_uid*:*host_uid*:*amount*
-* rootless user: *container_uid*:*intermediate_uid*:*amount*
-
-When **podman create** is called by a privileged user, the option **--uidmap**
-works as a direct mapping between host UIDs and container UIDs.
-
-host UID -> container UID
-
-The _amount_ specifies the number of consecutive UIDs that will be mapped.
-If for example _amount_ is **4** the mapping would look like:
-
-|   host UID     |    container UID    |
-| -              | -                   |
-| _from_uid_     | _container_uid_     |
-| _from_uid_ + 1 | _container_uid_ + 1 |
-| _from_uid_ + 2 | _container_uid_ + 2 |
-| _from_uid_ + 3 | _container_uid_ + 3 |
-
-When **podman create** is called by an unprivileged user (i.e. running rootless),
-the value _from_uid_ is interpreted as an "intermediate UID". In the rootless
-case, host UIDs are not mapped directly to container UIDs. Instead the mapping
-happens over two mapping steps:
-
-host UID -> intermediate UID -> container UID
-
-The **--uidmap** option only influences the second mapping step.
-
-The first mapping step is derived by Podman from the contents of the file
-_/etc/subuid_ and the UID of the user calling Podman.
-
-First mapping step:
-
-| host UID                                         | intermediate UID |
-| -                                                |                - |
-| UID for the user starting Podman                 |                0 |
-| 1st subordinate UID for the user starting Podman |                1 |
-| 2nd subordinate UID for the user starting Podman |                2 |
-| 3rd subordinate UID for the user starting Podman |                3 |
-| nth subordinate UID for the user starting Podman |                n |
-
-To be able to use intermediate UIDs greater than zero, the user needs to have
-subordinate UIDs configured in _/etc/subuid_. See **subuid**(5).
-
-The second mapping step is configured with **--uidmap**.
-
-If for example _amount_ is **5** the second mapping step would look like:
-
-|   intermediate UID   |    container UID    |
-| -                    | -                   |
-| _from_uid_           | _container_uid_     |
-| _from_uid_ + 1       | _container_uid_ + 1 |
-| _from_uid_ + 2       | _container_uid_ + 2 |
-| _from_uid_ + 3       | _container_uid_ + 3 |
-| _from_uid_ + 4       | _container_uid_ + 4 |
-
-The current user ID is mapped to UID=0 in the rootless user namespace.
-Every additional range is added sequentially afterward:
-
-|   host                |rootless user namespace | length              |
-| -                     | -                      | -                   |
-| $UID                  | 0                      | 1                   |
-| 1                     | $FIRST_RANGE_ID        | $FIRST_RANGE_LENGTH |
-| 1+$FIRST_RANGE_LENGTH | $SECOND_RANGE_ID       | $SECOND_RANGE_LENGTH|
-
-Even if a user does not have any subordinate UIDs in  _/etc/subuid_,
-**--uidmap** could still be used to map the normal UID of the user to a
-container UID by running `podman create --uidmap $container_uid:0:1 --user $container_uid ...`.
-
-Note: the **--uidmap** flag cannot be called in conjunction with the **--pod** flag as a uidmap cannot be set on the container level when in a pod.
-
-#### **--ulimit**=*option*
-
-Ulimit options
-
-You can pass `host` to copy the current configuration from the host.
+@@option ulimit
 
 @@option umask
 
-#### **--unsetenv**=*env*
-
-Unset default environment variables for the container. Default environment
-variables include variables provided natively by Podman, environment variables
-configured by the image, and environment variables from containers.conf.
+@@option unsetenv
 
 @@option unsetenv-all
 
@@ -1120,14 +890,7 @@ Podman allocates unique ranges of UIDs and GIDs from the `containers` subordinat
 
 This option is incompatible with **--gidmap**, **--uidmap**, **--subuidname** and **--subgidname**.
 
-#### **--uts**=*mode*
-
-Set the UTS namespace mode for the container. The following values are supported:
-
-- **host**: use the host's UTS namespace inside the container.
-- **private**: create a new namespace for the container (default).
-- **ns:[path]**: run the container in the given existing UTS namespace.
-- **container:[container]**: join the UTS namespace of the specified container.
+@@option uts.container
 
 #### **--variant**=*VARIANT*
 Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -1,48 +1,19 @@
-% podman-pod-create(1)
+% podman-pod-clone(1)
 
 ## NAME
-podman\-pod\-create - Create a new pod
+podman\-pod\-clone - Creates a copy of an existing pod
 
 ## SYNOPSIS
-**podman pod create** [*options*] [*name*]
+**podman pod clone** [*options*] *pod* *name*
 
 ## DESCRIPTION
-
-Creates an empty pod, or unit of multiple containers, and prepares it to have
-containers added to it. The pod can be created with a specific name. If a name
-is not given a random name is generated. The pod id is printed to STDOUT. You
-can then use **podman create --pod `<pod_id|pod_name>` ...** to add containers
-to the pod, and **podman pod start `<pod_id|pod_name>`** to start the pod.
-
-The operator can identify a pod in three ways:
-UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”)
-UUID short identifier (“f78375b1c487”)
-Name (“jonah”)
-
-podman generates a UUID for each pod, and if a name is not assigned
-to the container with **--name** then a random string name will be generated
-for it. The name is useful any place you need to identify a pod.
-
-Note: resource limit related flags work by setting the limits explicitly in the pod's cgroup
-which by default, is the cgroup parent for all containers joining the pod. Containers are still delegated the ability to set their own resource limits when joining a pod meaning that if you run **podman pod create --cpus=5** you can also run **podman container create --pod=`<pod_id|pod_name>` --cpus=4** and the container will only see the smaller limit. containers do NOT get the pod level cgroup resources if they specify their own cgroup when joining a pod such as **--cgroupns=host**
+**podman pod clone** creates a copy of a pod, recreating the identical config for the pod and for all of its containers. Users can modify the pods new name and select pod details within the infra container
 
 ## OPTIONS
 
-#### **--add-host**=*host:ip*
+@@option blkio-weight
 
-Add a custom host-to-IP mapping (host:ip)
-
-Add a line to /etc/hosts. The format is hostname:ip. The **--add-host**
-option can be set multiple times.
-The /etc/hosts file is shared between all containers in the pod.
-
-#### **--blkio-weight**=*weight*
-
-Block IO weight (relative weight) accepts a weight value between 10 and 1000.
-
-#### **--blkio-weight-device**=*weight*
-
-Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`).
+@@option blkio-weight-device
 
 #### **--cgroup-parent**=*path*
 
@@ -85,20 +56,14 @@ PID    container	CPU	CPU share
 101    {C1}		1	100% of CPU1
 102    {C1}		2	100% of CPU2
 
-#### **--cpus**=*amount*
+#### **--cpus**
 
-Set the total number of CPUs delegated to the pod. Default is 0.000 which indicates that there is no limit on computation power.
+Set a number of CPUs for the pod that overrides the original pods CPU limits. If none are specified, the original pod's Nano CPUs are used.
 
-#### **--cpuset-cpus**=*amount*
+#### **--cpuset-cpus**
 
-Limit the CPUs to support execution. First CPU is numbered 0. Unlike --cpus this is of type string and parsed as a list of numbers
+CPUs in which to allow execution (0-3, 0,1). If none are specified, the original pod's CPUset is used.
 
-Format is 0-3,0,1
-
-Examples of the List Format:
-
-0-4,9           # bits 0, 1, 2, 3, 4, and 9 set
-0-2,7,12-14     # bits 0, 1, 2, 7, 12, 13, and 14 set
 
 #### **--cpuset-mems**=*nodes*
 
@@ -108,7 +73,9 @@ If there are four memory nodes on the system (0-3), use `--cpuset-mems=0,1`
 then processes in the container will only use memory from the first
 two memory nodes.
 
-#### **--device**=_host-device_[**:**_container-device_][**:**_permissions_]
+@@option destroy
+
+#### **--device**=*host-device[:container-device][:permissions]*
 
 Add a host device to the pod. Optional *permissions* parameter
 can be used to specify device permissions. It is a combination of
@@ -116,7 +83,7 @@ can be used to specify device permissions. It is a combination of
 
 Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
 
-Note: if *host-device* is a symbolic link then it will be resolved first.
+Note: if _host_device_ is a symbolic link then it will be resolved first.
 The pod will only store the major and minor numbers of the host device.
 
 Note: the pod implements devices by storing the initial configuration passed by the user and recreating the device on each container added to the pod.
@@ -127,102 +94,33 @@ device. The devices that Podman will load modules for when necessary are:
 
 #### **--device-read-bps**=*path*
 
-Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)
+Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb).
 
 #### **--device-write-bps**=*path*
 
 Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
 
-#### **--dns**=*ipaddr*
+#### **--gidmap**=*pod_gid:host_gid:amount*
 
-Set custom DNS servers in the /etc/resolv.conf file that will be shared between all containers in the pod. A special option, "none" is allowed which disables creation of /etc/resolv.conf for the pod.
-
-#### **--dns-opt**=*option*
-
-Set custom DNS options in the /etc/resolv.conf file that will be shared between all containers in the pod.
-
-#### **--dns-search**=*domain*
-
-Set custom DNS search domains in the /etc/resolv.conf file that will be shared between all containers in the pod.
-
-#### **--exit-policy**=**continue** | *stop*
-
-Set the exit policy of the pod when the last container exits.  Supported policies are:
-
-| Exit Policy        | Description                                                                 |
-| ------------------ | --------------------------------------------------------------------------- |
-| *continue*         | The pod continues running when the last container exits. Used by default.   |
-| *stop*             | The pod is stopped when the last container exits. Used in `kube play`.      |
-
-#### **--gidmap**=*container_gid:host_gid:amount*
-
-GID map for the user namespace. Using this flag will run the container with user namespace enabled. It conflicts with the `--userns` and `--subgidname` flags.
+GID map for the user namespace. Using this flag will run all containers in the pod with user namespace enabled. It conflicts with the `--userns` and `--subgidname` flags.
 
 #### **--help**, **-h**
 
 Print usage statement.
 
-#### **--hostname**=*name*
+@@option hostname.pod
 
-Set a hostname to the pod
+@@option infra-command
 
-#### **--infra**
+@@option infra-conmon-pidfile
 
-Create an infra container and associate it with the pod. An infra container is a lightweight container used to coordinate the shared kernel namespace of a pod. Default: true.
-
-#### **--infra-command**=*command*
-
-The command that will be run to start the infra container. Default: "/pause".
-
-#### **--infra-conmon-pidfile**=*file*
-
-Write the pid of the infra container's **conmon** process to a file. As **conmon** runs in a separate process than Podman, this is necessary when using systemd to manage Podman containers and pods.
-
-#### **--infra-image**=*image*
-
-The custom image that will be used for the infra container.  Unless specified, Podman builds a custom local image which does not require pulling down an image.
-
-#### **--infra-name**=*name*
-
-The name that will be used for the pod's infra container.
-
-#### **--ip**=*ip*
-
-Specify a static IP address for the pod, for example **10.88.64.128**.
-This option can only be used if the pod is joined to only a single network - i.e., **--network=network-name** is used at most once -
-and if the pod is not joining another container's network namespace via **--network=container:_id_**.
-The address must be within the network's IP address pool (default **10.88.0.0/16**).
-
-To specify multiple static IP addresses per pod, set multiple networks using the **--network** option with a static IP address specified for each using the `ip` mode for that option.
-
-#### **--ip6**=*ipv6*
-
-Specify a static IPv6 address for the pod, for example **fd46:db93:aa76:ac37::10**.
-This option can only be used if the pod is joined to only a single network - i.e., **--network=network-name** is used at most once -
-and if the pod is not joining another container's network namespace via **--network=container:_id_**.
-The address must be within the network's IPv6 address pool.
-
-To specify multiple static IPv6 addresses per pod, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
+@@option infra-name
 
 #### **--label**, **-l**=*label*
 
 Add metadata to a pod (e.g., --label com.example.key=value).
 
-#### **--label-file**=*label*
-
-Read in a line delimited file of labels.
-
-#### **--mac-address**=*address*
-
-Pod network interface MAC address (e.g. 92:d0:c6:0a:29:33)
-This option can only be used if the pod is joined to only a single network - i.e., **--network=_network-name_** is used at most once -
-and if the pod is not joining another container's network namespace via **--network=container:_id_**.
-
-Remember that the MAC address in an Ethernet network must be unique.
-The IPv6 link-local address will be based on the device's MAC address
-according to RFC4862.
-
-To specify multiple static MAC addresses per pod, set multiple networks using the **--network** option with a static MAC address specified for each using the `mac` mode for that option.
+@@option label-file
 
 #### **--memory**, **-m**=*limit*
 
@@ -245,99 +143,11 @@ The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kibibytes), `m` (mebibytes), or `g` (gibibytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
-#### **--name**, **-n**=*name*
+#### **--name**, **-n**
 
-Assign a name to the pod.
+Set a custom name for the cloned pod. The default if not specified is of the syntax: **<ORIGINAL_NAME>-clone**
 
-#### **--network**=*mode*, **--net**
-
-Set the network mode for the pod. Invalid if using **--dns**, **--dns-opt**, or **--dns-search** with **--network** that is set to **none** or **container:**_id_.
-
-Valid _mode_ values are:
-
-- **bridge[:OPTIONS,...]**: Create a network stack on the default bridge. This is the default for rootful containers. It is possible to specify these additional options:
-  - **alias=name**: Add network-scoped alias for the container.
-  - **ip=IPv4**: Specify a static ipv4 address for this container.
-  - **ip=IPv6**: Specify a static ipv6 address for this container.
-  - **mac=MAC**: Specify a static mac address for this container.
-  - **interface_name**: Specify a name for the created network interface inside the container.
-
-  For example to set a static ipv4 address and a static mac address, use `--network bridge:ip=10.88.0.10,mac=44:33:22:11:00:99`.
-- \<network name or ID\>[:OPTIONS,...]: Connect to a user-defined network; this is the network name or ID from a network created by **[podman network create](podman-network-create.1.md)**. Using the network name implies the bridge network mode. It is possible to specify the same options described under the bridge mode above. You can use the **--network** option multiple times to specify additional networks.
-- **none**: Create a network namespace for the container but do not configure network interfaces for it, thus the container has no network connectivity.
-- **container:**_id_: Reuse another container's network stack.
-- **host**: Do not create a network namespace, the container will use the host's network. Note: The host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
-- **ns:**_path_: Path to a network namespace to join.
-- **private**: Create a new namespace for the container. This will use the **bridge** mode for rootful containers and **slirp4netns** for rootless ones.
-- **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
-  - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
-  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
-  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
-  - **enable_ipv6=true|false**: Enable IPv6. Default is true. (Required for `outbound_addr6`).
-  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp should bind to (ipv4 traffic only).
-  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp should bind to.
-  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp should bind to (ipv6 traffic only).
-  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp should bind to.
-  - **port_handler=rootlesskit**: Use rootlesskit for port forwarding. Default.
-  Note: Rootlesskit changes the source IP address of incoming packets to an IP address in the container network namespace, usually `10.0.2.100`. If your application requires the real source IP address, e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for rootless containers when connected to user-defined networks.
-  - **port_handler=slirp4netns**: Use the slirp4netns port forwarding, it is slower than rootlesskit but preserves the correct source IP address. This port handler cannot be used for user-defined networks.
-
-#### **--network-alias**=*alias*
-
-Add a network-scoped alias for the pod, setting the alias for all networks that the container joins. To set a
-name only for a specific network, use the alias option as described under the **--network** option.
-If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <name>`),
-these aliases can be used for name resolution on the given network. This option can be specified multiple times.
-NOTE: When using CNI a pod will only have access to aliases on the first network that it joins. This limitation does
-not exist with netavark/aardvark-dns.
-
-#### **--no-hosts**
-
-Do not create _/etc/hosts_ for the pod.
-By default, Podman will manage _/etc/hosts_, adding the container's own IP address and any hosts from **--add-host**.
-**--no-hosts** disables this, and the image's _/etc/hosts_ will be preserved unmodified.
-This option conflicts with **--add-host**.
-
-#### **--pid**=*pid*
-
-Set the PID mode for the pod. The default is to create a private PID namespace for the pod. Requires the PID namespace to be shared via --share.
-
-    host: use the host’s PID namespace for the pod
-    ns: join the specified PID namespace
-    private: create a new namespace for the pod (default)
-
-#### **--pod-id-file**=*path*
-
-Write the pod ID to the file.
-
-#### **--publish**, **-p**=*[[ip:][hostPort]:]containerPort[/protocol]*
-
-Publish a container's port, or range of ports, within this pod to the host.
-
-Both *hostPort* and *containerPort* can be specified as a range of ports.
-When specifying ranges for both, the number of container ports in the
-range must match the number of host ports in the range.
-
-If host IP is set to 0.0.0.0 or not set at all, the port will be bound on all IPs on the host.
-
-By default, Podman will publish TCP ports. To publish a UDP port instead, give
-`udp` as protocol. To publish both TCP and UDP ports, set `--publish` twice,
-with `tcp`, and `udp` as protocols respectively. Rootful containers can also
-publish ports using the `sctp` protocol.
-
-Host port does not have to be specified (e.g. `podman run -p 127.0.0.1::80`).
-If it is not, the container port will be randomly assigned a port on the host.
-
-Use **podman port** to see the actual mapping: `podman port $CONTAINER $CONTAINERPORT`.
-
-**Note:** You must not publish ports of containers in the pod individually,
-but only by the pod itself.
-
-**Note:** This cannot be modified once the pod is created.
-
-#### **--replace**
-
-If another pod with the same name already exists, replace and remove it.  The default is **false**.
+@@option pid.pod
 
 #### **--security-opt**=*option*
 
@@ -358,7 +168,7 @@ Note: Labeling can be disabled for all pods/containers by setting label=false in
 - `mask=/path/1:/path/2` : The paths to mask separated by a colon. A masked path
   cannot be accessed inside the containers within the pod.
 
-- `no-new-privileges` : Disable container processes from gaining additional privileges
+- `no-new-privileges` : Disable container processes from gaining additional privileges.
 
 - `seccomp=unconfined` : Turn off seccomp confinement for the pod
 - `seccomp=profile.json` :  Whitelisted syscalls seccomp Json file to be used as a seccomp filter
@@ -371,21 +181,16 @@ Note: Labeling can be disabled for all pods/containers by setting label=false in
 
 Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
 
-#### **--share**=*namespace*
-
-A comma-separated list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared and the infra container will not be created unless expiclity specified via **--infra=true**. The namespaces to choose from are cgroup, ipc, net, pid, uts. If the option is prefixed with a "+" then the namespace is appended to the default list, otherwise it replaces the default list. Defaults matches Kubernetes default (ipc, net, uts)
-
-#### **--share-parent**
-
-This boolean determines whether or not all containers entering the pod will use the pod as their cgroup parent. The default value of this flag is true. If you are looking to share the cgroup namespace rather than a cgroup parent in a pod, use **--share**
-
-Note: This options conflict with **--share=cgroup** since that would set the pod as the cgroup parent but enter the container into the same cgroupNS as the infra container.
-
 #### **--shm-size**=*size*
 
 Size of `/dev/shm` (format: `<number>[<unit>]`, where unit = b (bytes), k (kibibytes), m (mebibytes), or g (gibibytes))
 If the unit is omitted, the system uses bytes. If the size is omitted, the system uses `64m`.
 When size is `0`, there is no limit on the amount of memory used for IPC by the pod. This option conflicts with **--ipc=host** when running containers.
+
+#### **--start**
+
+When set to true, this flag starts the newly created pod after the
+clone process has completed. All containers within the pod are started.
 
 #### **--subgidname**=*name*
 
@@ -395,10 +200,9 @@ Name for GID map from the `/etc/subgid` file. Using this flag will run the conta
 
 Name for UID map from the `/etc/subuid` file. Using this flag will run the container with user namespace enabled. This flag conflicts with `--userns` and `--uidmap`.
 
-
 #### **--sysctl**=*name=value*
 
-Configure namespace kernel parameters for all containers in the pod.
+Configure namespace kernel parameters for all containers in the new pod.
 
 For the IPC namespace, the following sysctls are allowed:
 
@@ -418,12 +222,7 @@ For the network namespace, only sysctls beginning with net.\* are allowed.
 
 Note: if the network namespace is not shared within the pod, these sysctls are not allowed.
 
-#### **--uidmap**=*container_uid:from_uid:amount*
-
-Run the container in a new user namespace using the supplied mapping. This
-option conflicts with the **--userns** and **--subuidname** options. This
-option provides a way to map host UIDs to container UIDs. It can be passed
-several times to map different ranges.
+@@option uidmap.pod
 
 #### **--userns**=*mode*
 
@@ -450,21 +249,15 @@ Valid _mode_ values are:
 
   - *host*: run in the user namespace of the caller. The processes running in the container will have the same privileges on the host as any other process launched by the calling user (default).
 
-  - *keep-id*: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is not allowed for containers created by the root user.
+  - *keep-id*: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is ignored for containers created by the root user.
 
-  - *nomap*: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is not allowed for containers created by the root user.
+  - *nomap*: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is ignored for containers created by the root user.
 
-#### **--uts**=*mode*
-
-Set the UTS namespace mode for the pod. The following values are supported:
-
-- **host**: use the host's UTS namespace inside the pod.
-- **private**: create a new namespace for the pod (default).
-- **ns:[path]**: run the pod in the given existing UTS namespace.
+@@option uts.pod
 
 #### **--volume**, **-v**=*[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*
 
-Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Podman
+Create a bind mount. If ` -v /HOST-DIR:/CONTAINER-DIR` is specified, Podman
 bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the Podman
 container. Similarly, `-v SOURCE-VOLUME:/CONTAINER-DIR` will mount the volume
 in the host to the container. If no such named volume exists, Podman will
@@ -501,12 +294,12 @@ a named volume. If a volume with that name does not exist, it will be created.
 Volumes created with names are not anonymous, and they are not removed by the `--rm`
 option and the `podman rm --volumes` command.
 
-You can specify multiple  **-v** options to mount one or more volumes into a
+Specify multiple  **-v** options to mount one or more volumes into a
 pod.
 
   `Write Protected Volume Mounts`
 
-You can add `:ro` or `:rw` suffix to a volume to mount it read-only or
+Add `:ro` or `:rw` suffix to a volume to mount it read-only or
 read-write mode, respectively. By default, the volumes are mounted read-write.
 See examples.
 
@@ -530,7 +323,7 @@ content mounted into a pod. Without a label, the security system might
 prevent the processes running inside the pod from using the content. By
 default, Podman does not change the labels set by the OS.
 
-To change a label in the pod context, you can add either of two suffixes
+To change a label in the pod context, add either of two suffixes
 `:z` or `:Z` to the volume mount. These suffixes tell Podman to relabel file
 objects on the shared volumes. The `z` option tells Podman that two pods
 share the volume content. As a result, Podman labels the content with a shared
@@ -560,12 +353,12 @@ host into the container to allow speeding up builds.
 Content mounted into the container is labeled with the private label.
        On SELinux systems, labels in the source directory must be readable
 by the infra container label. Usually containers can read/execute `container_share_t`
-and can read/write `container_file_t`. If you cannot change the labels on a
+and can read/write `container_file_t`. If unable to change the labels on a
 source volume, SELinux container separation must be disabled for the infra container/pod
 to work.
      - The source directory mounted into the pod with an overlay mount
 should not be modified, it can cause unexpected failures. It is recommended
-that you do not modify the directory until the container finishes running.
+to not modify the directory until the container finishes running.
 
   `Mounts propagation`
 
@@ -579,13 +372,15 @@ will be visible inside container but not the other way around. <sup>[[1]](#Footn
 
 To control mount propagation property of a volume one can use the [**r**]**shared**,
 [**r**]**slave**, [**r**]**private** or the [**r**]**unbindable** propagation flag.
-For mount propagation to work the source mount point (the mount point where source dir
-is mounted on) has to have the right propagation properties. For shared volumes, the
-source mount point has to be shared. And for slave volumes, the source mount point
-has to be either shared or slave. <sup>[[1]](#Footnote1)</sup>
+Propagation property can be specified only for bind mounted volumes and not for
+internal volumes or named volumes. For mount propagation to work the source mount
+point (the mount point where source dir is mounted on) has to have the right propagation
+properties. For shared volumes, the source mount point has to be shared. And for
+slave volumes, the source mount point has to be either shared or slave.
+<sup>[[1]](#Footnote1)</sup>
 
-If you want to recursively mount a volume and all of its submounts into a
-pod, then you can use the `rbind` option. By default the bind option is
+To recursively mount a volume and all of its submounts into a
+pod, use the `rbind` option. By default the bind option is
 used, and submounts of the source directory will not be mounted into the
 pod.
 
@@ -630,21 +425,21 @@ containers and pods. The *options* is a comma-separated list with the following 
 * **z**
 
 Mounts already mounted volumes from a source container into another
-pod. You must supply the source's container-id or container-name.
+pod. Must supply the source's container-id or container-name.
 To share a volume, use the --volumes-from option when running
-the target container. You can share volumes even if the source container
+the target container. Volumes can be shared even if the source container
 is not running.
 
 By default, Podman mounts the volumes in the same mode (read-write or
 read-only) as it is mounted in the source container.
-You can change this by adding a `ro` or `rw` _option_.
+This can be changed by adding a `ro` or `rw` _option_.
 
 Labeling systems like SELinux require that proper labels are placed on volume
 content mounted into a pod. Without a label, the security system might
 prevent the processes running inside the container from using the content. By
 default, Podman does not change the labels set by the OS.
 
-To change a label in the pod context, you can add `z` to the volume mount.
+To change a label in the pod context, add `z` to the volume mount.
 This suffix tells Podman to relabel file objects on the shared volumes. The `z`
 option tells Podman that two entities share the volume content. As a result,
 Podman labels the content with a shared content label. Shared volume labels allow
@@ -656,28 +451,28 @@ that data on the target.
 
 
 ## EXAMPLES
-
 ```
-$ podman pod create --name test
-
-$ podman pod create mypod
-
-$ podman pod create --infra=false
-
-$ podman pod create --infra-command /top toppod
-
-$ podman pod create --publish 8443:443
-
-$ podman pod create --network slirp4netns:outbound_addr=127.0.0.1,allow_host_loopback=true
-
-$ podman pod create --network slirp4netns:cidr=192.168.0.0/24
-
-$ podman pod create --network net1:ip=10.89.1.5 --network net2:ip=10.89.10.10
+# podman pod clone pod-name
+6b2c73ff8a1982828c9ae2092954bcd59836a131960f7e05221af9df5939c584
 ```
 
+```
+# podman pod clone --name=cloned-pod
+d0cf1f782e2ed67e8c0050ff92df865a039186237a4df24d7acba5b1fa8cc6e7
+6b2c73ff8a1982828c9ae2092954bcd59836a131960f7e05221af9df5939c584
+```
+
+```
+# podman pod clone --destroy --cpus=5 d0cf1f782e2ed67e8c0050ff92df865a039186237a4df24d7acba5b1fa8cc6e7
+6b2c73ff8a1982828c9ae2092954bcd59836a131960f7e05221af9df5939c584
+```
+
+```
+# podman pod clone 2d4d4fca7219b4437e0d74fcdc272c4f031426a6eacd207372691207079551de new_name
+5a9b7851013d326aa4ac4565726765901b3ecc01fcbc0f237bc7fd95588a24f9
+```
 ## SEE ALSO
-**[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-kube-play(1)](podman-kube-play.1.md)**, **containers.conf(1)**, **[cgroups(7)](https://man7.org/linux/man-pages/man7/cgroups.7.html)**
-
+**[podman-pod-create(1)](podman-pod-create.1.md)**
 
 ## HISTORY
-July 2018, Originally compiled by Peter Hunt <pehunt@redhat.com>
+May 2022, Originally written by Charlie Doern <cdoern@redhat.com>

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -1,23 +1,44 @@
-% podman-pod-clone(1)
+% podman-pod-create(1)
 
 ## NAME
-podman\-pod\-clone - Creates a copy of an existing pod
+podman\-pod\-create - Create a new pod
 
 ## SYNOPSIS
-**podman pod clone** [*options*] *pod* *name*
+**podman pod create** [*options*] [*name*]
 
 ## DESCRIPTION
-**podman pod clone** creates a copy of a pod, recreating the identical config for the pod and for all of its containers. Users can modify the pods new name and select pod details within the infra container
+
+Creates an empty pod, or unit of multiple containers, and prepares it to have
+containers added to it. The pod can be created with a specific name. If a name
+is not given a random name is generated. The pod id is printed to STDOUT. You
+can then use **podman create --pod `<pod_id|pod_name>` ...** to add containers
+to the pod, and **podman pod start `<pod_id|pod_name>`** to start the pod.
+
+The operator can identify a pod in three ways:
+UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”)
+UUID short identifier (“f78375b1c487”)
+Name (“jonah”)
+
+podman generates a UUID for each pod, and if a name is not assigned
+to the container with **--name** then a random string name will be generated
+for it. The name is useful any place you need to identify a pod.
+
+Note: resource limit related flags work by setting the limits explicitly in the pod's cgroup
+which by default, is the cgroup parent for all containers joining the pod. Containers are still delegated the ability to set their own resource limits when joining a pod meaning that if you run **podman pod create --cpus=5** you can also run **podman container create --pod=`<pod_id|pod_name>` --cpus=4** and the container will only see the smaller limit. containers do NOT get the pod level cgroup resources if they specify their own cgroup when joining a pod such as **--cgroupns=host**
 
 ## OPTIONS
 
-#### **--blkio-weight**=*weight*
+#### **--add-host**=*host:ip*
 
-Block IO weight (relative weight) accepts a weight value between 10 and 1000.
+Add a custom host-to-IP mapping (host:ip)
 
-#### **--blkio-weight-device**=*weight*
+Add a line to /etc/hosts. The format is hostname:ip. The **--add-host**
+option can be set multiple times.
+The /etc/hosts file is shared between all containers in the pod.
 
-Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`).
+@@option blkio-weight
+
+@@option blkio-weight-device
 
 #### **--cgroup-parent**=*path*
 
@@ -60,14 +81,20 @@ PID    container	CPU	CPU share
 101    {C1}		1	100% of CPU1
 102    {C1}		2	100% of CPU2
 
-#### **--cpus**
+#### **--cpus**=*amount*
 
-Set a number of CPUs for the pod that overrides the original pods CPU limits. If none are specified, the original pod's Nano CPUs are used.
+Set the total number of CPUs delegated to the pod. Default is 0.000 which indicates that there is no limit on computation power.
 
-#### **--cpuset-cpus**
+#### **--cpuset-cpus**=*amount*
 
-CPUs in which to allow execution (0-3, 0,1). If none are specified, the original pod's CPUset is used.
+Limit the CPUs to support execution. First CPU is numbered 0. Unlike --cpus this is of type string and parsed as a list of numbers
 
+Format is 0-3,0,1
+
+Examples of the List Format:
+
+0-4,9           # bits 0, 1, 2, 3, 4, and 9 set
+0-2,7,12-14     # bits 0, 1, 2, 7, 12, 13, and 14 set
 
 #### **--cpuset-mems**=*nodes*
 
@@ -77,11 +104,7 @@ If there are four memory nodes on the system (0-3), use `--cpuset-mems=0,1`
 then processes in the container will only use memory from the first
 two memory nodes.
 
-#### **--destroy**
-
-Remove the original pod that we are cloning once used to mimic the configuration.
-
-#### **--device**=*host-device[:container-device][:permissions]*
+#### **--device**=_host-device_[**:**_container-device_][**:**_permissions_]
 
 Add a host device to the pod. Optional *permissions* parameter
 can be used to specify device permissions. It is a combination of
@@ -89,7 +112,7 @@ can be used to specify device permissions. It is a combination of
 
 Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
 
-Note: if _host_device_ is a symbolic link then it will be resolved first.
+Note: if *host-device* is a symbolic link then it will be resolved first.
 The pod will only store the major and minor numbers of the host device.
 
 Note: the pod implements devices by storing the initial configuration passed by the user and recreating the device on each container added to the pod.
@@ -100,43 +123,82 @@ device. The devices that Podman will load modules for when necessary are:
 
 #### **--device-read-bps**=*path*
 
-Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb).
+Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)
 
 #### **--device-write-bps**=*path*
 
 Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
 
-#### **--gidmap**=*pod_gid:host_gid:amount*
+#### **--dns**=*ipaddr*
 
-GID map for the user namespace. Using this flag will run all containers in the pod with user namespace enabled. It conflicts with the `--userns` and `--subgidname` flags.
+Set custom DNS servers in the /etc/resolv.conf file that will be shared between all containers in the pod. A special option, "none" is allowed which disables creation of /etc/resolv.conf for the pod.
+
+#### **--dns-opt**=*option*
+
+Set custom DNS options in the /etc/resolv.conf file that will be shared between all containers in the pod.
+
+#### **--dns-search**=*domain*
+
+Set custom DNS search domains in the /etc/resolv.conf file that will be shared between all containers in the pod.
+
+#### **--exit-policy**=**continue** | *stop*
+
+Set the exit policy of the pod when the last container exits.  Supported policies are:
+
+| Exit Policy        | Description                                                                 |
+| ------------------ | --------------------------------------------------------------------------- |
+| *continue*         | The pod continues running when the last container exits. Used by default.   |
+| *stop*             | The pod is stopped when the last container exits. Used in `kube play`.      |
+
+#### **--gidmap**=*container_gid:host_gid:amount*
+
+GID map for the user namespace. Using this flag will run the container with user namespace enabled. It conflicts with the `--userns` and `--subgidname` flags.
 
 #### **--help**, **-h**
 
 Print usage statement.
 
-#### **--hostname**=*name*
+@@option hostname.pod
 
-Set a hostname to the pod.
+#### **--infra**
 
-#### **--infra-command**=*command*
+Create an infra container and associate it with the pod. An infra container is a lightweight container used to coordinate the shared kernel namespace of a pod. Default: true.
 
-The command that will be run to start the infra container. Default: "/pause".
+@@option infra-command
 
-#### **--infra-conmon-pidfile**=*file*
+@@option infra-conmon-pidfile
 
-Write the pid of the infra container's **conmon** process to a file. As **conmon** runs in a separate process than Podman, this is necessary when using systemd to manage Podman containers and pods.
+#### **--infra-image**=*image*
 
-#### **--infra-name**=*name*
+The custom image that will be used for the infra container.  Unless specified, Podman builds a custom local image which does not require pulling down an image.
 
-The name that will be used for the pod's infra container.
+@@option infra-name
+
+#### **--ip**=*ip*
+
+Specify a static IP address for the pod, for example **10.88.64.128**.
+This option can only be used if the pod is joined to only a single network - i.e., **--network=network-name** is used at most once -
+and if the pod is not joining another container's network namespace via **--network=container:_id_**.
+The address must be within the network's IP address pool (default **10.88.0.0/16**).
+
+To specify multiple static IP addresses per pod, set multiple networks using the **--network** option with a static IP address specified for each using the `ip` mode for that option.
+
+#### **--ip6**=*ipv6*
+
+Specify a static IPv6 address for the pod, for example **fd46:db93:aa76:ac37::10**.
+This option can only be used if the pod is joined to only a single network - i.e., **--network=network-name** is used at most once -
+and if the pod is not joining another container's network namespace via **--network=container:_id_**.
+The address must be within the network's IPv6 address pool.
+
+To specify multiple static IPv6 addresses per pod, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
 
 #### **--label**, **-l**=*label*
 
 Add metadata to a pod (e.g., --label com.example.key=value).
 
-#### **--label-file**=*label*
+@@option label-file
 
-Read in a line delimited file of labels.
+@@option mac-address
 
 #### **--memory**, **-m**=*limit*
 
@@ -159,17 +221,84 @@ The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kibibytes), `m` (mebibytes), or `g` (gibibytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
-#### **--name**, **-n**
+#### **--name**, **-n**=*name*
 
-Set a custom name for the cloned pod. The default if not specified is of the syntax: **<ORIGINAL_NAME>-clone**
+Assign a name to the pod.
 
-#### **--pid**=*pid*
+#### **--network**=*mode*, **--net**
 
-Set the PID mode for the pod. The default is to create a private PID namespace for the pod. Requires the PID namespace to be shared via --share.
+Set the network mode for the pod. Invalid if using **--dns**, **--dns-opt**, or **--dns-search** with **--network** that is set to **none** or **container:**_id_.
 
-    host: use the host’s PID namespace for the pod
-    ns: join the specified PID namespace
-    private: create a new namespace for the pod (default)
+Valid _mode_ values are:
+
+- **bridge[:OPTIONS,...]**: Create a network stack on the default bridge. This is the default for rootful containers. It is possible to specify these additional options:
+  - **alias=name**: Add network-scoped alias for the container.
+  - **ip=IPv4**: Specify a static ipv4 address for this container.
+  - **ip=IPv6**: Specify a static ipv6 address for this container.
+  - **mac=MAC**: Specify a static mac address for this container.
+  - **interface_name**: Specify a name for the created network interface inside the container.
+
+  For example to set a static ipv4 address and a static mac address, use `--network bridge:ip=10.88.0.10,mac=44:33:22:11:00:99`.
+- \<network name or ID\>[:OPTIONS,...]: Connect to a user-defined network; this is the network name or ID from a network created by **[podman network create](podman-network-create.1.md)**. Using the network name implies the bridge network mode. It is possible to specify the same options described under the bridge mode above. You can use the **--network** option multiple times to specify additional networks.
+- **none**: Create a network namespace for the container but do not configure network interfaces for it, thus the container has no network connectivity.
+- **container:**_id_: Reuse another container's network stack.
+- **host**: Do not create a network namespace, the container will use the host's network. Note: The host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+- **ns:**_path_: Path to a network namespace to join.
+- **private**: Create a new namespace for the container. This will use the **bridge** mode for rootful containers and **slirp4netns** for rootless ones.
+- **slirp4netns[:OPTIONS,...]**: use **slirp4netns**(1) to create a user network stack. This is the default for rootless containers. It is possible to specify these additional options, they can also be set with `network_cmd_options` in containers.conf:
+  - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
+  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
+  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
+  - **enable_ipv6=true|false**: Enable IPv6. Default is true. (Required for `outbound_addr6`).
+  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp should bind to (ipv4 traffic only).
+  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp should bind to.
+  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp should bind to (ipv6 traffic only).
+  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp should bind to.
+  - **port_handler=rootlesskit**: Use rootlesskit for port forwarding. Default.
+  Note: Rootlesskit changes the source IP address of incoming packets to an IP address in the container network namespace, usually `10.0.2.100`. If your application requires the real source IP address, e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for rootless containers when connected to user-defined networks.
+  - **port_handler=slirp4netns**: Use the slirp4netns port forwarding, it is slower than rootlesskit but preserves the correct source IP address. This port handler cannot be used for user-defined networks.
+
+@@option network-alias
+
+#### **--no-hosts**
+
+Do not create _/etc/hosts_ for the pod.
+By default, Podman will manage _/etc/hosts_, adding the container's own IP address and any hosts from **--add-host**.
+**--no-hosts** disables this, and the image's _/etc/hosts_ will be preserved unmodified.
+This option conflicts with **--add-host**.
+
+@@option pid.pod
+
+#### **--pod-id-file**=*path*
+
+Write the pod ID to the file.
+
+#### **--publish**, **-p**=*[[ip:][hostPort]:]containerPort[/protocol]*
+
+Publish a container's port, or range of ports, within this pod to the host.
+
+Both *hostPort* and *containerPort* can be specified as a range of ports.
+When specifying ranges for both, the number of container ports in the
+range must match the number of host ports in the range.
+
+If host IP is set to 0.0.0.0 or not set at all, the port will be bound on all IPs on the host.
+
+By default, Podman will publish TCP ports. To publish a UDP port instead, give
+`udp` as protocol. To publish both TCP and UDP ports, set `--publish` twice,
+with `tcp`, and `udp` as protocols respectively. Rootful containers can also
+publish ports using the `sctp` protocol.
+
+Host port does not have to be specified (e.g. `podman run -p 127.0.0.1::80`).
+If it is not, the container port will be randomly assigned a port on the host.
+
+Use **podman port** to see the actual mapping: `podman port $CONTAINER $CONTAINERPORT`.
+
+**Note:** You must not publish ports of containers in the pod individually,
+but only by the pod itself.
+
+**Note:** This cannot be modified once the pod is created.
+
+@@option replace
 
 #### **--security-opt**=*option*
 
@@ -190,7 +319,7 @@ Note: Labeling can be disabled for all pods/containers by setting label=false in
 - `mask=/path/1:/path/2` : The paths to mask separated by a colon. A masked path
   cannot be accessed inside the containers within the pod.
 
-- `no-new-privileges` : Disable container processes from gaining additional privileges.
+- `no-new-privileges` : Disable container processes from gaining additional privileges
 
 - `seccomp=unconfined` : Turn off seccomp confinement for the pod
 - `seccomp=profile.json` :  Whitelisted syscalls seccomp Json file to be used as a seccomp filter
@@ -203,16 +332,21 @@ Note: Labeling can be disabled for all pods/containers by setting label=false in
 
 Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
 
+#### **--share**=*namespace*
+
+A comma-separated list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared and the infra container will not be created unless expiclity specified via **--infra=true**. The namespaces to choose from are cgroup, ipc, net, pid, uts. If the option is prefixed with a "+" then the namespace is appended to the default list, otherwise it replaces the default list. Defaults matches Kubernetes default (ipc, net, uts)
+
+#### **--share-parent**
+
+This boolean determines whether or not all containers entering the pod will use the pod as their cgroup parent. The default value of this flag is true. If you are looking to share the cgroup namespace rather than a cgroup parent in a pod, use **--share**
+
+Note: This options conflict with **--share=cgroup** since that would set the pod as the cgroup parent but enter the container into the same cgroupNS as the infra container.
+
 #### **--shm-size**=*size*
 
 Size of `/dev/shm` (format: `<number>[<unit>]`, where unit = b (bytes), k (kibibytes), m (mebibytes), or g (gibibytes))
 If the unit is omitted, the system uses bytes. If the size is omitted, the system uses `64m`.
 When size is `0`, there is no limit on the amount of memory used for IPC by the pod. This option conflicts with **--ipc=host** when running containers.
-
-#### **--start**
-
-When set to true, this flag starts the newly created pod after the
-clone process has completed. All containers within the pod are started.
 
 #### **--subgidname**=*name*
 
@@ -222,9 +356,10 @@ Name for GID map from the `/etc/subgid` file. Using this flag will run the conta
 
 Name for UID map from the `/etc/subuid` file. Using this flag will run the container with user namespace enabled. This flag conflicts with `--userns` and `--uidmap`.
 
+
 #### **--sysctl**=*name=value*
 
-Configure namespace kernel parameters for all containers in the new pod.
+Configure namespace kernel parameters for all containers in the pod.
 
 For the IPC namespace, the following sysctls are allowed:
 
@@ -244,12 +379,7 @@ For the network namespace, only sysctls beginning with net.\* are allowed.
 
 Note: if the network namespace is not shared within the pod, these sysctls are not allowed.
 
-#### **--uidmap**=*container_uid:from_uid:amount*
-
-Run all containers in the pod in a new user namespace using the supplied mapping. This
-option conflicts with the **--userns** and **--subuidname** options. This
-option provides a way to map host UIDs to container UIDs. It can be passed
-several times to map different ranges.
+@@option uidmap.pod
 
 #### **--userns**=*mode*
 
@@ -276,22 +406,15 @@ Valid _mode_ values are:
 
   - *host*: run in the user namespace of the caller. The processes running in the container will have the same privileges on the host as any other process launched by the calling user (default).
 
-  - *keep-id*: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is ignored for containers created by the root user.
+  - *keep-id*: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is not allowed for containers created by the root user.
 
-  - *nomap*: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is ignored for containers created by the root user.
+  - *nomap*: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is not allowed for containers created by the root user.
 
-#### **--uts**=*mode*
-
-Set the UTS namespace mode for the pod. The following values are supported:
-
-- **host**: use the host's UTS namespace inside the pod.
-- **private**: create a new namespace for the pod (default).
-- **ns:[path]**: run the pod in the given existing UTS namespace.
-
+@@option uts.pod
 
 #### **--volume**, **-v**=*[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*
 
-Create a bind mount. If ` -v /HOST-DIR:/CONTAINER-DIR` is specified, Podman
+Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Podman
 bind mounts `/HOST-DIR` in the host to `/CONTAINER-DIR` in the Podman
 container. Similarly, `-v SOURCE-VOLUME:/CONTAINER-DIR` will mount the volume
 in the host to the container. If no such named volume exists, Podman will
@@ -328,12 +451,12 @@ a named volume. If a volume with that name does not exist, it will be created.
 Volumes created with names are not anonymous, and they are not removed by the `--rm`
 option and the `podman rm --volumes` command.
 
-Specify multiple  **-v** options to mount one or more volumes into a
+You can specify multiple  **-v** options to mount one or more volumes into a
 pod.
 
   `Write Protected Volume Mounts`
 
-Add `:ro` or `:rw` suffix to a volume to mount it read-only or
+You can add `:ro` or `:rw` suffix to a volume to mount it read-only or
 read-write mode, respectively. By default, the volumes are mounted read-write.
 See examples.
 
@@ -357,7 +480,7 @@ content mounted into a pod. Without a label, the security system might
 prevent the processes running inside the pod from using the content. By
 default, Podman does not change the labels set by the OS.
 
-To change a label in the pod context, add either of two suffixes
+To change a label in the pod context, you can add either of two suffixes
 `:z` or `:Z` to the volume mount. These suffixes tell Podman to relabel file
 objects on the shared volumes. The `z` option tells Podman that two pods
 share the volume content. As a result, Podman labels the content with a shared
@@ -387,12 +510,12 @@ host into the container to allow speeding up builds.
 Content mounted into the container is labeled with the private label.
        On SELinux systems, labels in the source directory must be readable
 by the infra container label. Usually containers can read/execute `container_share_t`
-and can read/write `container_file_t`. If unable to change the labels on a
+and can read/write `container_file_t`. If you cannot change the labels on a
 source volume, SELinux container separation must be disabled for the infra container/pod
 to work.
      - The source directory mounted into the pod with an overlay mount
 should not be modified, it can cause unexpected failures. It is recommended
-to not modify the directory until the container finishes running.
+that you do not modify the directory until the container finishes running.
 
   `Mounts propagation`
 
@@ -406,15 +529,13 @@ will be visible inside container but not the other way around. <sup>[[1]](#Footn
 
 To control mount propagation property of a volume one can use the [**r**]**shared**,
 [**r**]**slave**, [**r**]**private** or the [**r**]**unbindable** propagation flag.
-Propagation property can be specified only for bind mounted volumes and not for
-internal volumes or named volumes. For mount propagation to work the source mount
-point (the mount point where source dir is mounted on) has to have the right propagation
-properties. For shared volumes, the source mount point has to be shared. And for
-slave volumes, the source mount point has to be either shared or slave.
-<sup>[[1]](#Footnote1)</sup>
+For mount propagation to work the source mount point (the mount point where source dir
+is mounted on) has to have the right propagation properties. For shared volumes, the
+source mount point has to be shared. And for slave volumes, the source mount point
+has to be either shared or slave. <sup>[[1]](#Footnote1)</sup>
 
-To recursively mount a volume and all of its submounts into a
-pod, use the `rbind` option. By default the bind option is
+If you want to recursively mount a volume and all of its submounts into a
+pod, then you can use the `rbind` option. By default the bind option is
 used, and submounts of the source directory will not be mounted into the
 pod.
 
@@ -459,21 +580,21 @@ containers and pods. The *options* is a comma-separated list with the following 
 * **z**
 
 Mounts already mounted volumes from a source container into another
-pod. Must supply the source's container-id or container-name.
+pod. You must supply the source's container-id or container-name.
 To share a volume, use the --volumes-from option when running
-the target container. Volumes can be shared even if the source container
+the target container. You can share volumes even if the source container
 is not running.
 
 By default, Podman mounts the volumes in the same mode (read-write or
 read-only) as it is mounted in the source container.
-This can be changed by adding a `ro` or `rw` _option_.
+You can change this by adding a `ro` or `rw` _option_.
 
 Labeling systems like SELinux require that proper labels are placed on volume
 content mounted into a pod. Without a label, the security system might
 prevent the processes running inside the container from using the content. By
 default, Podman does not change the labels set by the OS.
 
-To change a label in the pod context, add `z` to the volume mount.
+To change a label in the pod context, you can add `z` to the volume mount.
 This suffix tells Podman to relabel file objects on the shared volumes. The `z`
 option tells Podman that two entities share the volume content. As a result,
 Podman labels the content with a shared content label. Shared volume labels allow
@@ -485,28 +606,28 @@ that data on the target.
 
 
 ## EXAMPLES
-```
-# podman pod clone pod-name
-6b2c73ff8a1982828c9ae2092954bcd59836a131960f7e05221af9df5939c584
-```
 
 ```
-# podman pod clone --name=cloned-pod
-d0cf1f782e2ed67e8c0050ff92df865a039186237a4df24d7acba5b1fa8cc6e7
-6b2c73ff8a1982828c9ae2092954bcd59836a131960f7e05221af9df5939c584
+$ podman pod create --name test
+
+$ podman pod create mypod
+
+$ podman pod create --infra=false
+
+$ podman pod create --infra-command /top toppod
+
+$ podman pod create --publish 8443:443
+
+$ podman pod create --network slirp4netns:outbound_addr=127.0.0.1,allow_host_loopback=true
+
+$ podman pod create --network slirp4netns:cidr=192.168.0.0/24
+
+$ podman pod create --network net1:ip=10.89.1.5 --network net2:ip=10.89.10.10
 ```
 
-```
-# podman pod clone --destroy --cpus=5 d0cf1f782e2ed67e8c0050ff92df865a039186237a4df24d7acba5b1fa8cc6e7
-6b2c73ff8a1982828c9ae2092954bcd59836a131960f7e05221af9df5939c584
-```
-
-```
-# podman pod clone 2d4d4fca7219b4437e0d74fcdc272c4f031426a6eacd207372691207079551de new_name
-5a9b7851013d326aa4ac4565726765901b3ecc01fcbc0f237bc7fd95588a24f9
-```
 ## SEE ALSO
-**[podman-pod-create(1)](podman-pod-create.1.md)**
+**[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-kube-play(1)](podman-kube-play.1.md)**, **containers.conf(1)**, **[cgroups(7)](https://man7.org/linux/man-pages/man7/cgroups.7.html)**
+
 
 ## HISTORY
-May 2022, Originally written by Charlie Doern <cdoern@redhat.com>
+July 2018, Originally compiled by Peter Hunt <pehunt@redhat.com>

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -85,11 +85,7 @@ Print the usage statement.
 
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
 
-#### **--platform**=*OS/ARCH*
-
-Specify the platform for selecting the image. The `--platform` option can be used to override the current architecture and operating system.
-
-*IMPORTANT: Conflicts with --arch and --os*
+@@option platform
 
 #### **--quiet**, **-q**
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -116,21 +116,13 @@ Path to the authentication file. Default is *${XDG_RUNTIME_DIR}/containers/auth.
 Note: You can also override the default path of the authentication file by setting the **REGISTRY_AUTH_FILE**
 environment variable.
 
-#### **--blkio-weight**=*weight*
+@@option blkio-weight
 
-Block IO relative weight. The _weight_ is a value between **10** and **1000**.
+@@option blkio-weight-device
 
-#### **--blkio-weight-device**=*device:weight*
+@@option cap-add
 
-Block IO relative device weight.
-
-#### **--cap-add**=*capability*
-
-Add Linux capabilities.
-
-#### **--cap-drop**=*capability*
-
-Drop Linux capabilities.
+@@option cap-drop
 
 @@option cgroup-conf
 
@@ -357,23 +349,7 @@ Set custom DNS options. Invalid if using **--dns-opt** with **--network** that i
 Set custom DNS search domains. Invalid if using **--dns-search** and **--network** that is set to **none** or **container:**_id_.
 Use **--dns-search=.** if you don't wish to set the search domain.
 
-#### **--entrypoint**=*"command"* | *'["command", "arg1", ...]'*
-
-Overwrite the default ENTRYPOINT of the image.
-
-This option allows you to overwrite the default entrypoint of the image.
-
-The ENTRYPOINT of an image is similar to a COMMAND
-because it specifies what executable to run when the container starts, but it is
-(purposely) more difficult to override. The ENTRYPOINT gives a container its
-default nature or behavior, so that when you set an ENTRYPOINT you can run the
-container as if it were that binary, complete with default options, and you can
-pass in more options via the COMMAND. But, sometimes an operator may want to run
-something else inside the container, so you can override the default ENTRYPOINT
-at runtime by using a **--entrypoint** and a string to specify the new
-ENTRYPOINT.
-
-You need to specify multi option commands in the form of a json string.
+@@option entrypoint
 
 #### **--env**, **-e**=*env*
 
@@ -389,10 +365,7 @@ Read in a line delimited file of environment variables. See **Environment** note
 
 @@option env-host
 
-#### **--expose**=*port*
-
-Expose a port, or a range of ports (e.g. **--expose=3300-3310**) to set up port redirection
-on the host system.
+@@option expose
 
 #### **--gidmap**=*container_gid:host_gid:amount*
 
@@ -405,42 +378,21 @@ Note: the **--gidmap** flag cannot be called in conjunction with the **--pod** f
 
 @@option group-add
 
-#### **--health-cmd**=*"command"* | *'["command", "arg1", ...]'*
+@@option health-cmd
 
-Set or alter a healthcheck command for a container. The command is a command to be executed inside your
-container that determines your container health. The command is required for other healthcheck options
-to be applied. A value of **none** disables existing healthchecks.
+@@option health-interval
 
-Multiple options can be passed in the form of a JSON array; otherwise, the command will be interpreted
-as an argument to **/bin/sh -c**.
+@@option health-retries
 
-#### **--health-interval**=*interval*
+@@option health-start-period
 
-Set an interval for the healthchecks. An _interval_ of **disable** results in no automatic timer setup. The default is **30s**.
-
-#### **--health-retries**=*retries*
-
-The number of retries allowed before a healthcheck is considered to be unhealthy. The default value is **3**.
-
-#### **--health-start-period**=*period*
-
-The initialization time needed for a container to bootstrap. The value can be expressed in time format like
-**2m3s**. The default value is **0s**.
-
-#### **--health-timeout**=*timeout*
-
-The maximum time allowed to complete the healthcheck before an interval is considered failed. Like start-period, the
-value can be expressed in a time format such as **1m22s**. The default value is **30s**.
+@@option health-timeout
 
 #### **--help**
 
 Print usage statement
 
-#### **--hostname**, **-h**=*name*
-
-Container host name
-
-Sets the container host name that is available inside the container. Can only be used with a private UTS namespace `--uts=private` (default). If `--pod` is specified and the pod shares the UTS namespace (default) the pod's hostname will be used.
+@@option hostname.container
 
 @@option hostuser
 
@@ -504,27 +456,11 @@ a private IPC namespace.
 
 Add metadata to a container.
 
-#### **--label-file**=*file*
+@@option label-file
 
-Read in a line-delimited file of labels.
+@@option link-local-ip
 
-#### **--link-local-ip**=*ip*
-
-Not implemented.
-
-#### **--log-driver**=*driver*
-
-Logging driver for the container. Currently available options are **k8s-file**, **journald**, **none** and **passthrough**, with **json-file** aliased to **k8s-file** for scripting compatibility. (Default **journald**)
-
-The podman info command below will display the default log-driver for the system.
-```
-$ podman info --format '{{ .Host.LogDriver }}'
-journald
-```
-The **passthrough** driver passes down the standard streams (stdin, stdout, stderr) to the
-container.  It is not allowed with the remote Podman client, including Mac and Windows (excluding WSL2) machines, and on a tty, since it is
-vulnerable to attacks via TIOCSTI.
-
+@@option log-driver
 
 #### **--log-opt**=*name=value*
 
@@ -543,17 +479,7 @@ Set custom logging configuration. The following *name*s are supported:
 
 This option is currently supported only by the **journald** log driver.
 
-#### **--mac-address**=*address*
-
-Container network interface MAC address (e.g. 92:d0:c6:0a:29:33)
-This option can only be used if the container is joined to only a single network - i.e., **--network=_network-name_** is used at most once -
-and if the container is not joining another container's network namespace via **--network=container:_id_**.
-
-Remember that the MAC address in an Ethernet network must be unique.
-The IPv6 link-local address will be based on the device's MAC address
-according to RFC4862.
-
-To specify multiple static MAC addresses per container, set multiple networks using the **--network** option with a static MAC address specified for each using the `mac` mode for that option.
+@@option mac-address
 
 #### **--memory**, **-m**=*number[unit]*
 
@@ -587,11 +513,7 @@ the value of **--memory**.
 
 Set _number_ to **-1** to enable unlimited swap.
 
-#### **--memory-swappiness**=*number*
-
-Tune a container's memory swappiness behavior. Accepts an integer between *0* and *100*.
-
-This flag is not supported on cgroups V2 systems.
+@@option memory-swappiness
 
 @@option mount
 
@@ -643,14 +565,7 @@ Valid _mode_ values are:
   Note: Rootlesskit changes the source IP address of incoming packets to an IP address in the container network namespace, usually `10.0.2.100`. If your application requires the real source IP address, e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for rootless containers when connected to user-defined networks.
   - **port_handler=slirp4netns**: Use the slirp4netns port forwarding, it is slower than rootlesskit but preserves the correct source IP address. This port handler cannot be used for user-defined networks.
 
-#### **--network-alias**=*alias*
-
-Add a network-scoped alias for the container, setting the alias for all networks that the container joins. To set a
-name only for a specific network, use the alias option as described under the **--network** option.
-If the network has DNS enabled (`podman network inspect -f {{.DNSEnabled}} <name>`),
-these aliases can be used for name resolution on the given network. This option can be specified multiple times.
-NOTE: When using CNI a container will only have access to aliases on the first network that it joins. This limitation does
-not exist with netavark/aardvark-dns.
+@@option network-alias
 
 @@option no-healthcheck
 
@@ -663,9 +578,7 @@ This option conflicts with **--add-host**.
 
 @@option oom-kill-disable
 
-#### **--oom-score-adj**=*num*
-
-Tune the host's OOM preferences for containers (accepts values from **-1000** to **1000**).
+@@option oom-score-adj
 
 #### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
@@ -691,14 +604,9 @@ The default is to create a private PID namespace for the container.
 
 @@option pidfile
 
-#### **--pids-limit**=*limit*
+@@option pids-limit
 
-Tune the container's pids limit. Set to **-1** to have unlimited pids for the container. The default is **4096** on systems that support "pids" cgroup controller.
-
-#### **--platform**=*OS/ARCH*
-
-Specify the platform for selecting the image.  (Conflicts with --arch and --os)
-The `--platform` option can be used to override the current architecture and operating system.
+@@option platform
 
 #### **--pod**=*name*
 
@@ -772,40 +680,19 @@ When using this option, Podman will bind any exposed port to a random port on th
 within an ephemeral port range defined by */proc/sys/net/ipv4/ip_local_port_range*.
 To find the mapping between the host ports and the exposed ports, use **podman port**.
 
-#### **--pull**=*policy*
-
-Pull image policy. The default is **missing**.
-
-- **always**: Always pull the image and throw an error if the pull fails.
-- **missing**: Pull the image only if it could not be found in the local containers storage.  Throw an error if no image could be found and the pull fails.
-- **never**: Never pull the image but use the one from the local containers storage.  Throw an error if no image could be found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+@@option pull
 
 #### **--quiet**, **-q**
 
 Suppress output information when pulling images
 
-#### **--read-only**
+@@option read-only
 
-Mount the container's root filesystem as read-only.
+@@option read-only-tmpfs
 
-By default a container will have its root filesystem writable allowing processes
-to write files anywhere. By specifying the **--read-only** flag, the container will have
-its root filesystem mounted as read-only prohibiting any writes.
+@@option replace
 
-#### **--read-only-tmpfs**
-
-If container is running in **--read-only** mode, then mount a read-write tmpfs on _/run_, _/tmp_, and _/var/tmp_. The default is **true**.
-
-#### **--replace**
-
-If another container with the same name already exists, replace and remove it. The default is **false**.
-
-#### **--requires**=*container*
-
-Specify one or more requirements.
-A requirement is a dependency container that will be started before this container.
-Containers can be specified by name or ID, with multiple containers being separated by commas.
+@@option requires
 
 #### **--restart**=*policy*
 
@@ -856,28 +743,7 @@ Note: On **SELinux** systems, the rootfs needs the correct label, which is by de
 
 @@option seccomp-policy
 
-#### **--secret**=*secret[,opt=opt ...]*
-
-Give the container access to a secret. Can be specified multiple times.
-
-A secret is a blob of sensitive data which a container needs at runtime but
-should not be stored in the image or in source control, such as usernames and passwords,
-TLS certificates and keys, SSH keys or other important generic strings or binary content (up to 500 kb in size).
-
-When secrets are specified as type `mount`, the secrets are copied and mounted into the container when a container is created.
-When secrets are specified as type `env`, the secret will be set as an environment variable within the container.
-Secrets are written in the container at the time of container creation, and modifying the secret using `podman secret` commands
-after the container is created will not affect the secret inside the container.
-
-Secrets and its storage are managed using the `podman secret` command.
-
-Secret Options
-
-- `type=mount|env`    : How the secret will be exposed to the container. Default mount.
-- `target=target`     : Target of secret. Defaults to secret name.
-- `uid=0`             : UID of secret. Defaults to 0. Mount secret type only.
-- `gid=0`             : GID of secret. Defaults to 0. Mount secret type only.
-- `mode=0`            : Mode of secret. Defaults to 0444. Mount secret type only.
+@@option secret
 
 #### **--security-opt**=*option*
 
@@ -921,14 +787,9 @@ When _size_ is **0**, there is no limit on the amount of memory used for IPC by 
 
 Sets whether the signals sent to the **podman run** command are proxied to the container process. SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is **true**.
 
-#### **--stop-signal**=*signal*
+@@option stop-signal
 
-Signal to stop a container. Default is **SIGTERM**.
-
-#### **--stop-timeout**=*seconds*
-
-Timeout to stop a container. Default is **10**.
-Remote connections use local containers.conf for defaults
+@@option stop-timeout
 
 #### **--subgidname**=*name*
 
@@ -1002,20 +863,7 @@ setsebool -P container_manage_cgroup true
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true, then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified, TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
-#### **--tmpfs**=*fs*
-
-Create a tmpfs mount.
-
-Mount a temporary filesystem (**tmpfs**) mount into a container, for example:
-
-```
-$ podman run -d --tmpfs /tmp:rw,size=787448k,mode=1777 my_image
-```
-
-This command mounts a **tmpfs** at _/tmp_ within the container. The supported mount
-options are the same as the Linux default mount flags. If you do not specify
-any options, the system uses the following options:
-**rw,noexec,nosuid,nodev**.
+@@option tmpfs
 
 #### **--tty**, **-t**
 
@@ -1033,97 +881,13 @@ echo "asdf" | podman run --rm -i someimage /bin/cat
 
 @@option tz
 
-#### **--uidmap**=*container_uid:from_uid:amount*
+@@option uidmap.container
 
-Run the container in a new user namespace using the supplied UID mapping. This
-option conflicts with the **--userns** and **--subuidname** options. This
-option provides a way to map host UIDs to container UIDs. It can be passed
-several times to map different ranges.
-
-The _from_uid_ value is based upon the user running the command, either rootful or rootless users.
-* rootful user:  *container_uid*:*host_uid*:*amount*
-* rootless user: *container_uid*:*intermediate_uid*:*amount*
-
-When **podman run** is called by a privileged user, the option **--uidmap**
-works as a direct mapping between host UIDs and container UIDs.
-
-host UID -> container UID
-
-The _amount_ specifies the number of consecutive UIDs that will be mapped.
-If for example _amount_ is **4** the mapping would look like:
-
-|   host UID     |    container UID    |
-| -              | -                   |
-| _from_uid_     | _container_uid_     |
-| _from_uid_ + 1 | _container_uid_ + 1 |
-| _from_uid_ + 2 | _container_uid_ + 2 |
-| _from_uid_ + 3 | _container_uid_ + 3 |
-
-When **podman run** is called by an unprivileged user (i.e. running rootless),
-the value _from_uid_ is interpreted as an "intermediate UID". In the rootless
-case, host UIDs are not mapped directly to container UIDs. Instead the mapping
-happens over two mapping steps:
-
-host UID -> intermediate UID -> container UID
-
-The **--uidmap** option only influences the second mapping step.
-
-The first mapping step is derived by Podman from the contents of the file
-_/etc/subuid_ and the UID of the user calling Podman.
-
-First mapping step:
-
-| host UID                                         | intermediate UID |
-| -                                                |                - |
-| UID for the user starting Podman                 |                0 |
-| 1st subordinate UID for the user starting Podman |                1 |
-| 2nd subordinate UID for the user starting Podman |                2 |
-| 3rd subordinate UID for the user starting Podman |                3 |
-| nth subordinate UID for the user starting Podman |                n |
-
-To be able to use intermediate UIDs greater than zero, the user needs to have
-subordinate UIDs configured in _/etc/subuid_. See **subuid**(5).
-
-The second mapping step is configured with **--uidmap**.
-
-If for example _amount_ is **5** the second mapping step would look like:
-
-|   intermediate UID   |    container UID    |
-| -                    | -                   |
-| _from_uid_           | _container_uid_     |
-| _from_uid_ + 1       | _container_uid_ + 1 |
-| _from_uid_ + 2       | _container_uid_ + 2 |
-| _from_uid_ + 3       | _container_uid_ + 3 |
-| _from_uid_ + 4       | _container_uid_ + 4 |
-
-When running as rootless, Podman will use all the ranges configured in the _/etc/subuid_ file.
-
-The current user ID is mapped to UID=0 in the rootless user namespace.
-Every additional range is added sequentially afterward:
-
-|   host                |rootless user namespace | length              |
-| -                     | -                      | -                   |
-| $UID                  | 0                      | 1                   |
-| 1                     | $FIRST_RANGE_ID        | $FIRST_RANGE_LENGTH |
-| 1+$FIRST_RANGE_LENGTH | $SECOND_RANGE_ID       | $SECOND_RANGE_LENGTH|
-
-Even if a user does not have any subordinate UIDs in  _/etc/subuid_,
-**--uidmap** could still be used to map the normal UID of the user to a
-container UID by running `podman run --uidmap $container_uid:0:1 --user $container_uid ...`.
-
-Note: the **--uidmap** flag cannot be called in conjunction with the **--pod** flag as a uidmap cannot be set on the container level when in a pod.
-
-#### **--ulimit**=*option*
-
-Ulimit options. You can use **host** to copy the current configuration from the host.
+@@option ulimit
 
 @@option umask
 
-#### **--unsetenv**=*env*
-
-Unset default environment variables for the container. Default environment
-variables include variables provided natively by Podman, environment variables
-configured by the image, and environment variables from containers.conf.
+@@option unsetenv
 
 @@option unsetenv-all
 
@@ -1179,14 +943,7 @@ The rootless option `--userns=keep-id` uses all the subuids and subgids of the u
 **private**: create a new namespace for the container.
 This option is incompatible with **--gidmap**, **--uidmap**, **--subuidname** and **--subgidname**.
 
-#### **--uts**=*mode*
-
-Set the UTS namespace mode for the container. The following values are supported:
-
-- **host**: use the host's UTS namespace inside the container.
-- **private**: create a new namespace for the container (default).
-- **ns:[path]**: run the container in the given existing UTS namespace.
-- **container:[container]**: join the UTS namespace of the specified container.
+@@option uts.container
 
 #### **--variant**=*VARIANT*
 Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.

--- a/hack/markdown-preprocess
+++ b/hack/markdown-preprocess
@@ -5,6 +5,7 @@
 
 import glob
 import os
+import re
 import sys
 
 def main():
@@ -32,7 +33,7 @@ def process(infile):
         pod_or_container = 'pod'
 
     # Sometimes a man page includes the subcommand.
-    subcommand = removesuffix(removeprefix(infile,"podman-"),".1.md.in").replace("-", " ")
+    subcommand = podman_subcommand(infile)
 
     # foo.md.in -> foo.md -- but always write to a tmpfile
     outfile = os.path.splitext(infile)[0]
@@ -55,8 +56,8 @@ def process(infile):
                 fh_out.write("\n[//]: # (BEGIN included file " + optionfile + ")\n")
                 with open(optionfile, 'r') as fh_optfile:
                     for opt_line in fh_optfile:
-                        opt_line = opt_line.replace('<POD-OR-CONTAINER>', pod_or_container)
-                        opt_line = opt_line.replace('<SUBCOMMAND>', subcommand)
+                        opt_line = replace_type(opt_line, pod_or_container)
+                        opt_line = opt_line.replace('<<subcommand>>', subcommand)
                         fh_out.write(opt_line)
                 fh_out.write("\n[//]: # (END   included file " + optionfile + ")\n")
             else:
@@ -65,21 +66,46 @@ def process(infile):
     os.chmod(outfile_tmp, 0o444)
     os.rename(outfile_tmp, outfile)
 
-# str.removeprefix() is python 3.9+, we need to support older versions on mac
-def removeprefix(string: str, prefix: str) -> str:
-    if string.startswith(prefix):
-        return string[len(prefix):]
-    else:
-        return string[:]
+# Given a file path of the form podman-foo-bar.1.md.in, return "foo bar"
+def podman_subcommand(string: str) -> str:
+    if string.startswith("podman-"):
+        string = string[len("podman-"):]
+    if string.endswith(".1.md.in"):
+        string = string[:-len(".1.md.in")]
+    return string.replace("-", " ")
 
-# str.removesuffix() is python 3.9+, we need to support older versions on mac
-def removesuffix(string: str, suffix: str) -> str:
-    # suffix='' should not call self[:-0].
-    if suffix and string.endswith(suffix):
-        return string[:-len(suffix)]
-    else:
-        return string[:]
+# Replace instances of '<<pod|container>>' with the desired one (based on
+# 'type' which is 'pod' or 'container').
+def replace_type(line: str, type: str) -> str:
+    # Internal helper function: determines the desired half of the <a|b> string
+    def replwith(matchobj):
+        lhs, rhs = matchobj[0].split('|')
+        # Strip off '<<' and '>>'
+        lhs = lhs[2:]
+        rhs = rhs[:len(rhs)-2]
 
+        # Check both sides for 'pod' followed by (non-"m" or end-of-string).
+        # The non-m prevents us from triggering on 'podman', which could
+        # conceivably be present in both sides. And we check for 'pod',
+        # not 'container', because it's possible to have something like
+        # <<container in pod|container>>.
+        if re.match('pod([^m]|$)', lhs, re.IGNORECASE):
+            if re.match('pod([^m]|$)', rhs, re.IGNORECASE):
+                raise Exception("'%s' matches 'pod' in both left and right sides" % matchobj[0])
+            # Only left-hand side has "pod"
+            if type == 'pod':
+                return lhs
+            else:
+                return rhs
+        else:
+            if not re.match('pod([^m]|$)', rhs, re.IGNORECASE):
+                raise Exception("'%s' does not match 'pod' in either side" % matchobj[0])
+            if type == 'pod':
+                return rhs
+            else:
+                return lhs
+
+    return re.sub('<<[^\|>]+\|[^\|>]+>>', replwith, line)
 
 if __name__ == "__main__":
     main()

--- a/hack/markdown-preprocess-review
+++ b/hack/markdown-preprocess-review
@@ -1,0 +1,132 @@
+#!/usr/bin/perl
+
+(our $ME = $0) =~ s|^.*/||;
+
+use v5.20;
+
+our $DSM = 'docs/source/markdown';
+
+my ($oldname, $newname);
+my %oldname;
+my %changed;
+open my $git_diff, '-|', 'git', 'log', '-1', '-p'
+    or die "$ME: Cannot fork: $!\n";
+while (my $line = <$git_diff>) {
+    chomp $line;
+
+    if ($line =~ m!^\-\-\-\s+a/$DSM/(podman-\S+\.md(\.in)?)!) {
+        $oldname = $1;
+        $newname = undef;
+    }
+    elsif ($line =~ m!^\+\+\+\s+b/$DSM/(podman-\S+\.md(\.in)?)!) {
+        $newname = $1;
+        $oldname{$newname} = $oldname;
+    }
+    elsif ($newname) {
+        if ($line =~ s/^-####\s+//) {
+            $line =~ /^\*\*--(\S+?)\*\*/
+                or die "$ME: in $newname: weird '$line'";
+            $changed{$newname}{$1}{name} = $1;
+        }
+        # Usually the same, but not for host.container and host.pod.md
+        elsif ($line =~ /^\+\@\@option\s+(\S+)/) {
+            my $optfile = $1;
+            if ($optfile =~ /^(.*)\.\S+$/) {
+                $changed{$newname}{$1}{name} = $optfile;
+            }
+        }
+    }
+}
+close $git_diff;
+
+# Pass 2: read each oldfile, parse changed options
+for my $f (sort keys %changed) {
+    my $oldfile = $oldname{$f};
+    open my $git_fh, '-|', 'git', 'show', "HEAD^:$DSM/$oldfile"
+        or die "$ME: Cannot fork: $!\n";
+    my $opt;
+    while (my $line = <$git_fh>) {
+        if ($line =~ /^####\s+\*\*--(\S+?)\*\*/) {
+            $opt = $1;
+            if ($changed{$f}{$opt}) {
+                $changed{$f}{$opt}{text} = $line;
+            }
+            else {
+                undef $opt;
+            }
+        }
+        elsif ($line =~ /^#/ || $line =~ /^\@\@option\s/) {
+            undef $opt;
+        }
+        elsif ($opt) {
+            $changed{$f}{$opt}{text} .= $line;
+        }
+    }
+    close $git_fh
+        or die "$ME: Error running git on $oldfile\n";
+}
+
+# Pass 3: write out files
+my $tempdir = "/tmp/$ME.diffs";
+system('rm', '-rf', $tempdir);
+mkdir $tempdir, 0755;
+
+for my $md_file (sort keys %changed) {
+    for my $opt (sort keys %{$changed{$md_file}}) {
+        my $d = "$tempdir/$changed{$md_file}{$opt}{name}";
+        mkdir $d, 0755;
+
+        my $outfile = "$d/$md_file";
+        open my $fh, '>', $outfile
+            or die "$ME: Cannot create $outfile: $!\n";
+        # strip all trailing newlines
+        (my $text = $changed{$md_file}{$opt}{text}) =~ s/\n+$/\n/s;
+        print { $fh } $text;
+        close $fh
+            or die "$ME: Error writing $outfile: $!\n";
+
+        my $new_text = "$DSM/options/$changed{$md_file}{$opt}{name}.md";
+        die "$ME: File does not exist: $new_text\n" if ! -e $new_text;
+        system('cp', $new_text, "$d/zzz-chosen.md");
+    }
+}
+
+# Now run diffuse
+chdir $tempdir or die;
+my @all_opts = glob("*");
+for my $i (0..$#all_opts) {
+    my $opt = $all_opts[$i];
+    chdir "$tempdir/$opt"
+        or die "??? Internal error, cannot cd $tempdir/$opt: $!";
+
+    $| = 1; printf "--%s (%d/%d) ", $opt, $i+1, scalar(@all_opts);
+
+    my @all_files = glob("*");
+    if (all_files_identical(@all_files)) {
+        pop @all_files;
+        print "[identical between @all_files]\n";
+        next;
+    }
+
+    # Prompt
+    print "[Y/n/q] ";
+    my $ans = <STDIN>;
+    next if $ans =~ /^n/i;
+    exit 0 if $ans =~ /^q/i;
+
+    system("diffuse", "-w", glob("*")) == 0
+        or die "Diffuse failed\n";
+}
+
+
+sub all_files_identical {
+    my %sha;
+    for my $f (@_) {
+        my $result = qx{sha256sum $f};
+        $result =~ /^([0-9a-f]+)\s/
+            or die "Internal error: unexpected result from sha256sum $f: $result";
+        $sha{$1}++;
+    }
+
+    return (keys(%sha) == 1);
+}

--- a/hack/markdown-preprocess.t
+++ b/hack/markdown-preprocess.t
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+"""
+Tests for markdown-preprocess
+"""
+
+import unittest
+
+# https://stackoverflow.com/questions/66665217/how-to-import-a-python-script-without-a-py-extension
+from importlib.util import spec_from_loader, module_from_spec
+from importlib.machinery import SourceFileLoader
+
+spec = spec_from_loader("mp", SourceFileLoader("mp", "hack/markdown-preprocess"))
+mp = module_from_spec(spec)
+spec.loader.exec_module(mp)
+
+class TestPodReplacer(unittest.TestCase):
+    def test_basic(self):
+        """basic pod|container and vice-versa"""
+        s = '<<container|pod>>'
+        self.assertEqual(mp.replace_type(s, 'pod'), 'pod')
+        self.assertEqual(mp.replace_type(s, 'container'), 'container')
+        s = '<<container|pod>>'
+        self.assertEqual(mp.replace_type(s, 'pod'), 'pod')
+        self.assertEqual(mp.replace_type(s, 'container'), 'container')
+
+    def test_case_insensitive(self):
+        """test case-insensitive replacement of Pod, Container"""
+        s = '<<Pod|Container>>'
+        self.assertEqual(mp.replace_type(s, 'pod'), 'Pod')
+        self.assertEqual(mp.replace_type(s, 'container'), 'Container')
+        s = '<<Container|Pod>>'
+        self.assertEqual(mp.replace_type(s, 'pod'), 'Pod')
+        self.assertEqual(mp.replace_type(s, 'container'), 'Container')
+
+    def test_dont_care_about_podman(self):
+        """we ignore 'podman'"""
+        self.assertEqual(mp.replace_type('<<podman container|pod in podman>>', 'container'), 'podman container')
+
+    def test_exception_both(self):
+        """test that 'pod' on both sides raises exception"""
+        with self.assertRaisesRegex(Exception, "in both left and right sides"):
+            mp.replace_type('<<pod 123|pod 321>>', 'pod')
+
+    def test_exception_neither(self):
+        """test that 'pod' on neither side raises exception"""
+        with self.assertRaisesRegex(Exception, "in either side"):
+            mp.replace_type('<<container 123|container 321>>', 'pod')
+
+class TestPodmanSubcommand(unittest.TestCase):
+    def test_basic(self):
+        """podman subcommand basic test"""
+        self.assertEqual(mp.podman_subcommand("podman-foo.1.md.in"), "foo")
+        self.assertEqual(mp.podman_subcommand("podman-foo-bar.1.md.in"), "foo bar")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Followup to #15174. These are the options that are easy(ish)
to review: those that have only drifted slightly, and need
only minor tweaks to bring back to sanity. For the most part,
I went with the text in podman-run because that was cleaned up
in #5192 way back in 2020. These diffs primarily consist of
using '**' (star star) instead of backticks, plus other
formatting and punctuation changes.

This PR also adds a README in the options dir, and a new
convention: <<container text...|pod text...>> which tries
to do the right thing based on whether the man page name
includes "-pod-" or not. Since that's kind of hairy code,
I've also added a test suite for it.

Finally, since this is impossible to review by normal means,
I'm temporarily committing hack/markdown-preprocess-review,
a script that will diff option-by-option. I will remove it
once we finish this cleanup, but be advised that there are
still 130+ options left to examine, and some of those are
going to be really hard to reunite.

Review script usage: simply run it (you need to have 'diffuse'
installed). It isn't exactly obvious, but it shouldn't take more
than a minute to figure out. The rightmost column (zzz-chosen.md)
is the "winner", the actual content that will be used henceforth.
You really want an ultrawide screen here.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
man page cleanup: consolidate common options
```