### PR TITLE
[WIP] DO NOT MERGE - Testing EC2 Name-tagging

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -202,6 +202,7 @@ build_aarch64_task:
     # Multiarch doesn't depend on buildability in this automation context
     # Docs: ./contrib/cirrus/CIModes.md
     only_if: "$CIRRUS_CRON != 'multiarch'"
+    experimental: true  # Required to enable EC2 Instance Name-tagging
     ec2_instance: &standard_build_ec2_aarch64
         image: ${VM_IMAGE_NAME}
         type: ${EC2_INST_TYPE}
@@ -281,6 +282,7 @@ validate_aarch64_task:
         - ext_svc_check
         - automation
         - build_aarch64
+    experimental: true  # Required to enable EC2 Instance Name-tagging
     # golangci-lint is a very, very hungry beast.
     ec2_instance: *standard_build_ec2_aarch64
     env:
@@ -397,6 +399,7 @@ consistency_aarch64_task:
     only_if: *is_pr
     depends_on:
         - build_aarch64
+    experimental: true  # Required to enable EC2 Instance Name-tagging
     ec2_instance: *standard_build_ec2_aarch64
     env:
         <<: *stdenvars_aarch64
@@ -692,6 +695,7 @@ podman_machine_task:
         - remote_integration_test
         - container_integration_test
         - rootless_integration_test
+    experimental: true  # Required to enable EC2 Instance Name-tagging
     ec2_instance:
         image: "${VM_IMAGE_NAME}"
         type: "${EC2_INST_TYPE}"
@@ -745,6 +749,7 @@ local_system_test_aarch64_task: &local_system_test_task_aarch64
     depends_on:
         - build_aarch64
         - local_integration_test
+    experimental: true  # Required to enable EC2 Instance Name-tagging
     ec2_instance: *standard_build_ec2_aarch64
     env:
         <<: *stdenvars_aarch64


### PR DESCRIPTION
This is an experimental feature Cirrus-CI is working on.  It will cause
EC2 instances to be named similar to GCE VMs: `cirrus-tas-<blah>`.  This
is very helpful for debugging, auditing, monitoring, and writing tighter
security-policies.

Ref: https://github.com/cirruslabs/cirrus-ci-docs/issues/1051

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
