### PR TITLE
remote e2e: speed up populating and loading cache

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -355,6 +355,10 @@ func (p *PodmanTestIntegration) createArtifact(image string) {
 	if os.Getenv("NO_TEST_CACHE") != "" {
 		return
 	}
+	if p.RemoteTest { // Speed up remote tests by using the local binary
+		p.RemoteTest = false
+		defer func() { p.RemoteTest = true }()
+	}
 	destName := imageTarPath(image)
 	if _, err := os.Stat(destName); os.IsNotExist(err) {
 		fmt.Printf("Caching %s at %s...\n", image, destName)
@@ -805,6 +809,10 @@ func (p *PodmanTestIntegration) RestoreArtifactToCache(image string) error {
 }
 
 func populateCache(podman *PodmanTestIntegration) {
+	if podman.RemoteTest { // Speed up remote tests by using the local binary
+		podman.RemoteTest = false
+		defer func() { podman.RemoteTest = true }()
+	}
 	for _, image := range CACHE_IMAGES {
 		err := podman.RestoreArtifactToCache(image)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
The remote e2e tests run significantly slower than the local ones.
In some runs I have seen a factor of two.  Among other things, I
suspect the continuous loading of the cache to be a bottleneck as
(un)taring is CPU-intensive.

Speed up the aforementioned bottleneck by using the local podman binary
to populate and load the cache to workaround these more expensive remote
operations.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
