### PR TITLE
[CI:DOCS] docs: specify `git` protocol is not supported for github hosted repo

### DIFF
--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -988,8 +988,10 @@ use it as the context. The Containerfile at the root of the repository will be
 used and it only works if the GitHub repository is a dedicated repository.
 
 ```
-$ podman build git://github.com/scollier/purpletest
+$ podman build https://github.com/scollier/purpletest
 ```
+
+  Note: Github does not support using `git://` for performing `clone` operation due to recent changes in their security guidance (https://github.blog/2021-09-01-improving-git-protocol-security-github/). Use an `https://` URL if the source repository is hosted on Github.
 
 #### Building an image using a URL to an archive
 


### PR DESCRIPTION
Build from URL does not supports `git://` is source is hosted on Github.
Reason: https://github.blog/2021-09-01-improving-git-protocol-security-github/

[CI:DOCS]
[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]

Similar to: https://github.com/containers/buildah/pull/4179