### PR TITLE
FreeBSD build fixes for pkg/util and pkg/machine

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,7 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
+RM            ?= rm
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/pkg/machine/ignition_freebsd.go
+++ b/pkg/machine/ignition_freebsd.go
@@ -1,0 +1,8 @@
+//go:build freebsd
+// +build freebsd
+
+package machine
+
+func getLocalTimeZone() (string, error) {
+	return "", nil
+}

--- a/pkg/machine/qemu/options_freebsd.go
+++ b/pkg/machine/qemu/options_freebsd.go
@@ -1,0 +1,13 @@
+package qemu
+
+import (
+	"os"
+)
+
+func getRuntimeDir() (string, error) {
+	tmpDir, ok := os.LookupEnv("TMPDIR")
+	if !ok {
+		tmpDir = "/tmp"
+	}
+	return tmpDir, nil
+}

--- a/pkg/machine/qemu/options_freebsd_amd64.go
+++ b/pkg/machine/qemu/options_freebsd_amd64.go
@@ -1,0 +1,18 @@
+package qemu
+
+var (
+	QemuCommand = "qemu-system-x86_64"
+)
+
+func (v *MachineVM) addArchOptions() []string {
+	opts := []string{"-machine", "q35,accel=hvf:tcg", "-cpu", "host"}
+	return opts
+}
+
+func (v *MachineVM) prepare() error {
+	return nil
+}
+
+func (v *MachineVM) archRemovalFiles() []string {
+	return []string{}
+}

--- a/pkg/util/utils_freebsd.go
+++ b/pkg/util/utils_freebsd.go
@@ -1,0 +1,12 @@
+//go:build freebsd
+// +build freebsd
+
+package util
+
+import (
+	"errors"
+)
+
+func GetContainerPidInformationDescriptors() ([]string, error) {
+	return []string{}, errors.New("this function is not supported on freebsd")
+}

--- a/pkg/util/utils_unsupported.go
+++ b/pkg/util/utils_unsupported.go
@@ -1,5 +1,5 @@
-//go:build darwin || windows
-// +build darwin windows
+//go:build darwin || windows || freebsd
+// +build darwin windows freebsd
 
 package util
 


### PR DESCRIPTION
This makes the pkg/util and pkg/machine modules build on FreeBSD. It also fixes 'make clean' on FreeBSD - docs/Makefile assumes that $RM is set to something which behaves like /bin/rm and this wasn't set for me for some reason.

[NO NEW TESTS NEEDED]

#### Does this PR introduce a user-facing change?

```release-note
None
```
