### PR TITLE
podman-kube@.service.in: Remove Restart=never option with typo

### DIFF
--- a/contrib/systemd/system/podman-kube@.service.in
+++ b/contrib/systemd/system/podman-kube@.service.in
@@ -7,7 +7,6 @@ RequiresMountsFor=%t/containers
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-Restart=never
 TimeoutStopSec=70
 ExecStart=@@PODMAN@@ play kube --replace --service-container=true %I
 ExecStop=@@PODMAN@@ play kube --down %I


### PR DESCRIPTION
systemd expects the value of the option to be `no` instead, but this is
already the default behavior. This fixes the following warning when
running `systemctl status` on the unit:

    Failed to parse service restart specifier, ignoring: never

#### Does this PR introduce a user-facing change?

```release-note
podman-kube@.service.in: Remove Restart=never option with typo
```
