### PR TITLE
Add compatibility support for --debug flag from docker

### DIFF
--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -190,6 +190,9 @@ See 'podman version --help'" "podman version --remote"
     run_podman --log-level=error   info
     run_podman --log-level=fatal   info
     run_podman --log-level=panic   info
+    run_podman --debug   info
+    run_podman 1 --debug --log-level=panic info
+    is "$output" "Setting --log-level and --debug is not allowed"
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
This is another fix for https://github.com/containers/podman/issues/14917

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman now supports --debug, -D on the command line for Docker compatibility.
```
