### PR TITLE
Add Docker compatibility for --dns-option to --dns-opt

### DIFF
--- a/cmd/podman/common/netflags.go
+++ b/cmd/podman/common/netflags.go
@@ -39,6 +39,11 @@ func DefineNetFlags(cmd *cobra.Command) {
 		"Set custom DNS options",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(dnsOptFlagName, completion.AutocompleteNone)
+	netFlags.StringSlice(
+		"dns-option", containerConfig.DNSOptions(),
+		"Docker compatibility option== --dns-opt",
+	)
+	_ = netFlags.MarkHidden("dns-option")
 
 	dnsSearchFlagName := "dns-search"
 	netFlags.StringSlice(
@@ -144,6 +149,14 @@ func NetFlagsToNetOptions(opts *entities.NetOptions, flags pflag.FlagSet) (*enti
 			return nil, err
 		}
 		opts.DNSOptions = options
+	}
+
+	if flags.Changed("dns-option") {
+		options, err := flags.GetStringSlice("dns-option")
+		if err != nil {
+			return nil, err
+		}
+		opts.DNSOptions = append(opts.DNSOptions, options...)
 	}
 
 	if flags.Changed("dns-search") {

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -767,4 +767,14 @@ EOF
     is "$output" "" "Should print no output"
 }
 
+@test "podman network rm --dns-option " {
+    dns_opt=dns$(random_string)
+    run_podman run --rm --dns-opt=${dns_opt} $IMAGE cat /etc/resolv.conf
+    is "$output" ".*options ${dns_opt}" "--dns-opt was added"
+
+    dns_opt=dns$(random_string)
+    run_podman run --rm --dns-option=${dns_opt} $IMAGE cat /etc/resolv.conf
+    is "$output" ".*options ${dns_opt}" "--dns-option was added"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Fixes one of the issues found in https://github.com/containers/podman/issues/14917
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman now supports podman run --dns-option  as well as --dns-opt for Docker compatibility
```
