### PR TITLE
[CI:DOCS] podman images and friends can take one image as argument

### DIFF
--- a/docs/source/markdown/podman-images.1.md
+++ b/docs/source/markdown/podman-images.1.md
@@ -4,11 +4,11 @@
 podman\-images - List images in local storage
 
 ## SYNOPSIS
-**podman images** [*options*]
+**podman images** [*options*] [image]
 
-**podman image list** [*options*]
+**podman image list** [*options*] [image]
 
-**podman image ls** [*options*]
+**podman image ls** [*options*] [image]
 
 ## DESCRIPTION
 Displays locally stored images, their names, and their IDs.
@@ -107,15 +107,22 @@ Sort by *created*, *id*, *repository*, *size* or *tag* (default: **created**)
 ## EXAMPLE
 
 ```
-# podman images
-REPOSITORY                                   TAG      IMAGE ID       CREATED       SIZE
-docker.io/kubernetes/pause                   latest   e3d42bcaf643   3 years ago   251 kB
-<none>                                       <none>   ebb91b73692b   4 weeks ago   27.2 MB
-docker.io/library/ubuntu                     latest   4526339ae51c   6 weeks ago   126 MB
+$ podman images
+REPOSITORY                         TAG         IMAGE ID      CREATED       SIZE
+quay.io/podman/stable              latest      e0b7dabc3352  22 hours ago  331 MB
+docker.io/library/alpine           latest      9c6f07244728  5 days ago    5.83 MB
+registry.fedoraproject.org/fedora  latest      2ecb6df95994  3 weeks ago   169 MB
+quay.io/libpod/testimage           20220615    f26aa69bb3f3  2 months ago  8.4 MB
 ```
 
 ```
-# podman images --quiet
+$ podman images stable
+REPOSITORY             TAG         IMAGE ID      CREATED       SIZE
+quay.io/podman/stable  latest      e0b7dabc3352  22 hours ago  331 MB
+```
+
+```
+# podman image ls --quiet
 e3d42bcaf643
 ebb91b73692b
 4526339ae51c
@@ -129,7 +136,7 @@ docker.io/library/ubuntu                     latest   4526339ae51c   6 weeks ago
 ```
 
 ```
-# podman images --no-trunc
+# podman image list --no-trunc
 REPOSITORY                                   TAG      IMAGE ID                                                                  CREATED       SIZE
 docker.io/kubernetes/pause                   latest   sha256:e3d42bcaf643097dd1bb0385658ae8cbe100a80f773555c44690d22c25d16b27   3 years ago   251 kB
 <none>                                       <none>   sha256:ebb91b73692bd27890685846412ae338d13552165eacf7fcd5f139bfa9c2d6d9   4 weeks ago   27.2 MB


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/15309

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix up podman images man page to add option [image] specification.
```
