### PR TITLE
[CI:DOCS] Cirrus: Update podman-machine comment

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -398,9 +398,7 @@ dotest() {
 }
 
 _run_machine() {
-    # TODO: This is a manually-triggered task, if that ever changes need to
-    # add something like:
-    # _bail_if_test_can_be_skipped docs test/e2e test/system test/python
+    # N/B: Can't use _bail_if_test_can_be_skipped here b/c content isn't under test/
     make localmachine |& logformatter
 }
 


### PR DESCRIPTION
Replace TODO comment with helpful hint for future maintainers.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
