### PR TITLE
Man pages: refactor common options: --annotation

### DIFF
--- a/docs/source/markdown/options/annotation.container.md
+++ b/docs/source/markdown/options/annotation.container.md
@@ -1,0 +1,3 @@
+#### **--annotation**=*key=value*
+
+Add an annotation to the container<| or pod>. This option can be set multiple times.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -68,10 +68,7 @@ and specified with a _tag_.
 
 @@option add-host
 
-#### **--annotation**=*key=value*
-
-Add an annotation to the container. The format is key=value.
-The **--annotation** option can be set multiple times.
+@@option annotation.container
 
 @@option arch
 

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -110,10 +110,7 @@ and as a result environment variable `FOO` will be set to `bar` for container `c
 
 ## OPTIONS
 
-#### **--annotation**=*key=value*
-
-Add an annotation to the container or pod. The format is key=value.
-The **--annotation** option can be set multiple times.
+@@option annotation.container
 
 #### **--authfile**=*path*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -85,10 +85,7 @@ and specified with a _tag_.
 ## OPTIONS
 @@option add-host
 
-#### **--annotation**=*key=value*
-
-Add an annotation to the container.
-This option can be set multiple times.
+@@option annotation.container
 
 @@option arch
 


### PR DESCRIPTION
Refactor the --annotation option, but only between podman create,
kube play, and run.

This does not include:

 * podman build:
   - usage is in terms of images, not containers/pods

 * manifest add, manifest annotate:
   - usage is in terms of images, not containers/pods
   - also, wording is slightly different

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
More man page refactoring
```