### PR TITLE
Fix podman kube generate --help to show correct help message

### DIFF
--- a/cmd/podman/kube/generate.go
+++ b/cmd/podman/kube/generate.go
@@ -22,7 +22,7 @@ var (
 
   Whether the input is for a container or pod, Podman will always generate the specification as a pod.`
 
-	generateKubeCmd = &cobra.Command{
+	kubeGenerateCmd = &cobra.Command{
 		Use:               "generate [options] {CONTAINER...|POD...|VOLUME...}",
 		Short:             "Generate Kubernetes YAML from containers, pods or volumes.",
 		Long:              generateDescription,
@@ -35,33 +35,28 @@ var (
   podman kube generate volumeName
   podman kube generate ctrID podID volumeName --service`,
 	}
-	kubeGenerateDescription = generateDescription
 
-	kubeGenerateCmd = &cobra.Command{
+	generateKubeCmd = &cobra.Command{
 		Use:               "kube [options] {CONTAINER...|POD...|VOLUME...}",
-		Short:             "Generate Kubernetes YAML from containers, pods or volumes.",
-		Long:              kubeGenerateDescription,
-		RunE:              kubeGenerate,
-		Args:              cobra.MinimumNArgs(1),
-		ValidArgsFunction: common.AutocompleteForGenerate,
-		Example: `podman kube generate ctrID
-  podman kube generate podID
-  podman kube generate --service podID
-  podman kube generate volumeName
-  podman kube generate ctrID podID volumeName --service`,
+		Short:             kubeGenerateCmd.Short,
+		Long:              kubeGenerateCmd.Long,
+		RunE:              kubeGenerateCmd.RunE,
+		Args:              kubeGenerateCmd.Args,
+		ValidArgsFunction: kubeGenerateCmd.ValidArgsFunction,
+		Example:           kubeGenerateCmd.Example,
 	}
 )
 
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: generateKubeCmd,
-		Parent:  kubeCmd,
+		Parent:  generate.GenerateCmd,
 	})
 	generateFlags(generateKubeCmd)
 
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: kubeGenerateCmd,
-		Parent:  generate.GenerateCmd,
+		Parent:  kubeCmd,
 	})
 	generateFlags(kubeGenerateCmd)
 }
@@ -102,8 +97,4 @@ func generateKube(cmd *cobra.Command, args []string) error {
 
 	fmt.Println(string(content))
 	return nil
-}
-
-func kubeGenerate(cmd *cobra.Command, args []string) error {
-	return generateKube(cmd, args)
 }

--- a/test/system/710-kube.bats
+++ b/test/system/710-kube.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# Test podman kube generate
+#
+
+load helpers
+
+@test "podman kube generate - basic" {
+    run_podman kube generate --help
+    is "$output" ".*podman.* kube generate \[options\] {CONTAINER...|POD...|VOLUME...}"
+    run_podman generate kube --help
+    is "$output" ".*podman.* generate kube \[options\] {CONTAINER...|POD...|VOLUME...}"
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
