### PR TITLE
system tests: fix broken runc test

### DIFF
--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -212,7 +212,7 @@ function check_label() {
 	# https://github.com/opencontainers/selinux/pull/148/commits/a5dc47f74c56922d58ead05d1fdcc5f7f52d5f4e
 	#   from failed to set /proc/self/attr/keycreate on procfs
 	#   to   write /proc/self/attr/keycreate: invalid argument
-	runc) expect="OCI runtime error: .*: \(failed to set|write\) /proc/self/attr/keycreate" ;;
+	runc) expect="OCI runtime error: .*: \(failed to set\|write\) /proc/self/attr/keycreate.*" ;;
 	*)    skip "Unknown runtime '$runtime'";;
     esac
 


### PR DESCRIPTION
Followup to #14613, which was never actually tested until this
week in RHEL8 gating tests (see issue #15337).

 * add missing backslash in '|' expression
 * allow extra text after error (e.g., "invalid argument")

No way to test this until it makes its way into RHEL8,
so, fingers crossed.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
Fix broken (under runc) system test
```