### PR TITLE
Add non-linux build stubs for libpod

### DIFF
--- a/libpod/boltdb_state_unsupported.go
+++ b/libpod/boltdb_state_unsupported.go
@@ -1,0 +1,19 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+)
+
+// replaceNetNS handle network namespace transitions after updating a
+// container's state.
+func replaceNetNS(netNSPath string, ctr *Container, newState *ContainerState) error {
+	return errors.New("replaceNetNS not supported on this platform")
+}
+
+// getNetNSPath retrieves the netns path to be stored in the database
+func getNetNSPath(ctr *Container) string {
+	return ""
+}

--- a/libpod/container_copy_unsupported.go
+++ b/libpod/container_copy_unsupported.go
@@ -1,0 +1,17 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+	"io"
+)
+
+func (c *Container) copyFromArchive(path string, chown, noOverwriteDirNonDir bool, rename map[string]string, reader io.Reader) (func() error, error) {
+	return nil, errors.New("not implemented (*Container) copyFromArchive")
+}
+
+func (c *Container) copyToArchive(path string, writer io.Writer) (func() error, error) {
+	return nil, errors.New("not implemented (*Container) copyToArchive")
+}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -293,20 +293,8 @@ func (c *Container) handleRestartPolicy(ctx context.Context) (_ bool, retErr err
 	}
 
 	// set up slirp4netns again because slirp4netns will die when conmon exits
-	if c.config.NetMode.IsSlirp4netns() {
-		err := c.runtime.setupSlirp4netns(c, c.state.NetNS)
-		if err != nil {
-			return false, err
-		}
-	}
-
-	// set up rootlesskit port forwarder again since it dies when conmon exits
-	// we use rootlesskit port forwarder only as rootless and when bridge network is used
-	if rootless.IsRootless() && c.config.NetMode.IsBridge() && len(c.config.PortMappings) > 0 {
-		err := c.runtime.setupRootlessPortMappingViaRLK(c, c.state.NetNS.Path(), c.state.NetworkStatus)
-		if err != nil {
-			return false, err
-		}
+	if err := c.setupRootlessNetwork(); err != nil {
+		return false, err
 	}
 
 	if c.state.State == define.ContainerStateStopped {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1545,7 +1545,7 @@ func (c *Container) mountStorage() (_ string, deferredErr error) {
 
 	rootUID, rootGID := c.RootUID(), c.RootGID()
 
-	dirfd, err := unix.Open(mountPoint, unix.O_RDONLY|unix.O_PATH, 0)
+	dirfd, err := openDirectory(mountPoint)
 	if err != nil {
 		return "", fmt.Errorf("open mount point: %w", err)
 	}
@@ -1568,7 +1568,7 @@ func (c *Container) mountStorage() (_ string, deferredErr error) {
 		return "", fmt.Errorf("resolve /etc in the container: %w", err)
 	}
 
-	etcInTheContainerFd, err := unix.Open(etcInTheContainerPath, unix.O_RDONLY|unix.O_PATH, 0)
+	etcInTheContainerFd, err := openDirectory(etcInTheContainerPath)
 	if err != nil {
 		return "", fmt.Errorf("open /etc in the container: %w", err)
 	}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -3249,3 +3249,7 @@ func (c *Container) setupRootlessNetwork() error {
 	}
 	return nil
 }
+
+func openDirectory(path string) (fd int, err error) {
+	return unix.Open(path, unix.O_RDONLY|unix.O_PATH, 0)
+}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -3228,3 +3228,24 @@ func (c *Container) ChangeHostPathOwnership(src string, recurse bool, uid, gid i
 	}
 	return chown.ChangeHostPathOwnership(src, recurse, uid, gid)
 }
+
+// If the container is rootless, set up the slirp4netns network
+func (c *Container) setupRootlessNetwork() error {
+	// set up slirp4netns again because slirp4netns will die when conmon exits
+	if c.config.NetMode.IsSlirp4netns() {
+		err := c.runtime.setupSlirp4netns(c, c.state.NetNS)
+		if err != nil {
+			return err
+		}
+	}
+
+	// set up rootlesskit port forwarder again since it dies when conmon exits
+	// we use rootlesskit port forwarder only as rootless and when bridge network is used
+	if rootless.IsRootless() && c.config.NetMode.IsBridge() && len(c.config.PortMappings) > 0 {
+		err := c.runtime.setupRootlessPortMappingViaRLK(c, c.state.NetNS.Path(), c.state.NetworkStatus)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/libpod/container_internal_unsupported.go
+++ b/libpod/container_internal_unsupported.go
@@ -93,3 +93,7 @@ func getLocalhostHostEntry(c *Container) etchosts.HostEntries {
 func isRootlessCgroupSet(cgroup string) bool {
 	return false
 }
+
+func openDirectory(path string) (fd int, err error) {
+	return -1, errors.New("unsupported openDirectory")
+}

--- a/libpod/container_internal_unsupported.go
+++ b/libpod/container_internal_unsupported.go
@@ -1,0 +1,95 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"context"
+	"errors"
+
+	"github.com/containers/common/libnetwork/etchosts"
+	"github.com/containers/podman/v4/libpod/define"
+	"github.com/containers/podman/v4/pkg/lookup"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func (c *Container) mountSHM(shmOptions string) error {
+	return errors.New("not implemented (*Container) mountSHM")
+}
+
+func (c *Container) unmountSHM(mount string) error {
+	return errors.New("not implemented (*Container) unmountSHM")
+}
+
+func (c *Container) cleanupOverlayMounts() error {
+	return errors.New("not implemented (*Container) cleanupOverlayMounts")
+}
+
+// prepare mounts the container and sets up other required resources like net
+// namespaces
+func (c *Container) prepare() error {
+	return errors.New("not implemented (*Container) prepare")
+}
+
+// resolveWorkDir resolves the container's workdir and, depending on the
+// configuration, will create it, or error out if it does not exist.
+// Note that the container must be mounted before.
+func (c *Container) resolveWorkDir() error {
+	return errors.New("not implemented (*Container) resolveWorkDir")
+}
+
+// cleanupNetwork unmounts and cleans up the container's network
+func (c *Container) cleanupNetwork() error {
+	return errors.New("not implemented (*Container) cleanupNetwork")
+}
+
+// reloadNetwork reloads the network for the given container, recreating
+// firewall rules.
+func (c *Container) reloadNetwork() error {
+	return errors.New("not implemented (*Container) reloadNetwork")
+}
+
+// Generate spec for a container
+// Accepts a map of the container's dependencies
+func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
+	return nil, errors.New("not implemented (*Container) generateSpec")
+}
+
+func (c *Container) getUserOverrides() *lookup.Overrides {
+	return &lookup.Overrides{}
+}
+
+func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointOptions) (*define.CRIUCheckpointRestoreStatistics, int64, error) {
+	return nil, 0, errors.New("not implemented (*Container) checkpoint")
+}
+
+func (c *Container) restore(ctx context.Context, options ContainerCheckpointOptions) (criuStatistics *define.CRIUCheckpointRestoreStatistics, runtimeRestoreDuration int64, retErr error) {
+	return nil, 0, errors.New("not implemented (*Container) restore")
+}
+
+// getHostsEntries returns the container ip host entries for the correct netmode
+func (c *Container) getHostsEntries() (etchosts.HostEntries, error) {
+	return nil, errors.New("unspported (*Container) getHostsEntries")
+}
+
+// Fix ownership and permissions of the specified volume if necessary.
+func (c *Container) fixVolumePermissions(v *ContainerNamedVolume) error {
+	return errors.New("unspported (*Container) fixVolumePermissions")
+}
+
+func (c *Container) expectPodCgroup() (bool, error) {
+	return false, errors.New("unspported (*Container) expectPodCgroup")
+}
+
+// Get cgroup path in a format suitable for the OCI spec
+func (c *Container) getOCICgroupPath() (string, error) {
+	return "", errors.New("unspported (*Container) getOCICgroupPath")
+}
+
+func getLocalhostHostEntry(c *Container) etchosts.HostEntries {
+	return nil
+}
+
+func isRootlessCgroupSet(cgroup string) bool {
+	return false
+}

--- a/libpod/container_stat_unsupported.go
+++ b/libpod/container_stat_unsupported.go
@@ -1,0 +1,14 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+
+	"github.com/containers/podman/v4/libpod/define"
+)
+
+func (c *Container) stat(containerMountPoint string, containerPath string) (*define.FileInfo, string, string, error) {
+	return nil, "", "", errors.New("Containers stat not supported on this platform")
+}

--- a/libpod/container_top_unsupported.go
+++ b/libpod/container_top_unsupported.go
@@ -1,0 +1,14 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+)
+
+// Top gathers statistics about the running processes in a container. It returns a
+// []string for output
+func (c *Container) Top(descriptors []string) ([]string, error) {
+	return nil, errors.New("not implemented (*Container) Top")
+}

--- a/libpod/container_unsupported.go
+++ b/libpod/container_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+type containerPlatformState struct {
+}

--- a/libpod/healthcheck_unsupported.go
+++ b/libpod/healthcheck_unsupported.go
@@ -1,0 +1,25 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"context"
+	"errors"
+)
+
+// createTimer systemd timers for healthchecks of a container
+func (c *Container) createTimer() error {
+	return errors.New("not implemented (*Container) createTimer")
+}
+
+// startTimer starts a systemd timer for the healthchecks
+func (c *Container) startTimer() error {
+	return errors.New("not implemented (*Container) startTimer")
+}
+
+// removeTransientFiles removes the systemd timer and unit files
+// for the container
+func (c *Container) removeTransientFiles(ctx context.Context) error {
+	return errors.New("not implemented (*Container) removeTransientFiles")
+}

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package libpod
 
 import (

--- a/libpod/info_unsupported.go
+++ b/libpod/info_unsupported.go
@@ -1,0 +1,14 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+
+	"github.com/containers/podman/v4/libpod/define"
+)
+
+func (r *Runtime) info() (*define.Info, error) {
+	return nil, errors.New("not implemented (*Runtime) info")
+}

--- a/libpod/networking_unsupported.go
+++ b/libpod/networking_unsupported.go
@@ -1,0 +1,79 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+	"path/filepath"
+
+	"github.com/containers/common/libnetwork/types"
+	"github.com/containers/podman/v4/libpod/define"
+	"github.com/containers/storage/pkg/lockfile"
+)
+
+type RootlessNetNS struct {
+	dir  string
+	Lock lockfile.Locker
+}
+
+// ocicniPortsToNetTypesPorts convert the old port format to the new one
+// while deduplicating ports into ranges
+func ocicniPortsToNetTypesPorts(ports []types.OCICNIPortMapping) []types.PortMapping {
+	return []types.PortMapping{}
+}
+
+func (c *Container) getContainerNetworkInfo() (*define.InspectNetworkSettings, error) {
+	return nil, errors.New("not implemented (*Container) getContainerNetworkInfo")
+}
+
+func (c *Container) setupRootlessNetwork() error {
+	return errors.New("not implemented (*Container) setupRootlessNetwork")
+}
+
+func (r *Runtime) setupNetNS(ctr *Container) error {
+	return errors.New("not implemented (*Runtime) setupNetNS")
+}
+
+// normalizeNetworkName takes a network name, a partial or a full network ID and returns the network name.
+// If the network is not found a errors is returned.
+func (r *Runtime) normalizeNetworkName(nameOrID string) (string, error) {
+	return "", errors.New("not implemented (*Runtime) normalizeNetworkName")
+}
+
+// DisconnectContainerFromNetwork removes a container from its CNI network
+func (r *Runtime) DisconnectContainerFromNetwork(nameOrID, netName string, force bool) error {
+	return errors.New("not implemented (*Runtime) DisconnectContainerFromNetwork")
+}
+
+// ConnectContainerToNetwork connects a container to a CNI network
+func (r *Runtime) ConnectContainerToNetwork(nameOrID, netName string, netOpts types.PerNetworkOptions) error {
+	return errors.New("not implemented (*Runtime) ConnectContainerToNetwork")
+}
+
+// getPath will join the given path to the rootless netns dir
+func (r *RootlessNetNS) getPath(path string) string {
+	return filepath.Join(r.dir, path)
+}
+
+// Do - run the given function in the rootless netns.
+// It does not lock the rootlessCNI lock, the caller
+// should only lock when needed, e.g. for cni operations.
+func (r *RootlessNetNS) Do(toRun func() error) error {
+	return errors.New("not implemented (*RootlessNetNS) Do")
+}
+
+// Cleanup the rootless network namespace if needed.
+// It checks if we have running containers with the bridge network mode.
+// Cleanup() expects that r.Lock is locked
+func (r *RootlessNetNS) Cleanup(runtime *Runtime) error {
+	return errors.New("not implemented (*RootlessNetNS) Cleanup")
+}
+
+// GetRootlessNetNs returns the rootless netns object. If create is set to true
+// the rootless network namespace will be created if it does not exists already.
+// If called as root it returns always nil.
+// On success the returned RootlessCNI lock is locked and must be unlocked by the caller.
+func (r *Runtime) GetRootlessNetNs(new bool) (*RootlessNetNS, error) {
+	return nil, errors.New("not implemented (*Runtime) GetRootlessNetNs")
+}

--- a/libpod/oci_conmon_unsupported.go
+++ b/libpod/oci_conmon_unsupported.go
@@ -1,0 +1,24 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+
+	"github.com/containers/common/pkg/config"
+	"github.com/containers/common/pkg/resize"
+)
+
+// Make a new Conmon-based OCI runtime with the given options.
+// Conmon will wrap the given OCI runtime, which can be `runc`, `crun`, or
+// any runtime with a runc-compatible CLI.
+// The first path that points to a valid executable will be used.
+// Deliberately private. Someone should not be able to construct this outside of
+// libpod.
+func newConmonOCIRuntime(name string, paths []string, conmonPath string, runtimeFlags []string, runtimeCfg *config.Config) (OCIRuntime, error) {
+	return nil, errors.New("newConmonOCIRuntime not supported on this platform")
+}
+
+func registerResizeFunc(r <-chan resize.TerminalSize, bundlePath string) {
+}

--- a/libpod/pod_top_unsupported.go
+++ b/libpod/pod_top_unsupported.go
@@ -1,0 +1,20 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+)
+
+// GetPodPidInformation returns process-related data of all processes in
+// the pod.  The output data can be controlled via the `descriptors`
+// argument which expects format descriptors and supports all AIXformat
+// descriptors of ps (1) plus some additional ones to for instance inspect the
+// set of effective capabilities.  Each element in the returned string slice
+// is a tab-separated string.
+//
+// For more details, please refer to github.com/containers/psgo.
+func (p *Pod) GetPodPidInformation(descriptors []string) ([]string, error) {
+	return nil, errors.New("not implemented (*Pod) GetPodPidInformation")
+}

--- a/libpod/runtime_migrate_unsupported.go
+++ b/libpod/runtime_migrate_unsupported.go
@@ -1,0 +1,16 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+)
+
+func (r *Runtime) stopPauseProcess() error {
+	return errors.New("not implemented (*Runtime) stopPauseProcess")
+}
+
+func (r *Runtime) migrate() error {
+	return errors.New("not implemented (*Runtime) migrate")
+}

--- a/libpod/runtime_pod_unsupported.go
+++ b/libpod/runtime_pod_unsupported.go
@@ -1,0 +1,30 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"context"
+	"errors"
+
+	"github.com/containers/podman/v4/pkg/specgen"
+)
+
+// NewPod makes a new, empty pod
+func (r *Runtime) NewPod(ctx context.Context, p specgen.PodSpecGenerator, options ...PodCreateOption) (_ *Pod, deferredErr error) {
+	return nil, errors.New("not implemented (*Runtime) NewPod")
+}
+
+// AddInfra adds the created infra container to the pod state
+func (r *Runtime) AddInfra(ctx context.Context, pod *Pod, infraCtr *Container) (*Pod, error) {
+	return nil, errors.New("not implemented (*Runtime) AddInfra")
+}
+
+// SavePod is a helper function to save the pod state from outside of libpod
+func (r *Runtime) SavePod(pod *Pod) error {
+	return errors.New("not implemented (*Runtime) SavePod")
+}
+
+func (r *Runtime) removePod(ctx context.Context, p *Pod, removeCtrs, force bool, timeout *uint) error {
+	return errors.New("not implemented (*Runtime) removePod")
+}

--- a/libpod/runtime_volume_unsupported.go
+++ b/libpod/runtime_volume_unsupported.go
@@ -1,0 +1,42 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"context"
+	"errors"
+
+	"github.com/containers/podman/v4/libpod/define"
+)
+
+// NewVolume creates a new empty volume
+func (r *Runtime) NewVolume(ctx context.Context, options ...VolumeCreateOption) (*Volume, error) {
+	if !r.valid {
+		return nil, define.ErrRuntimeStopped
+	}
+	return r.newVolume(false, options...)
+}
+
+// NewVolume creates a new empty volume
+func (r *Runtime) newVolume(noCreatePluginVolume bool, options ...VolumeCreateOption) (*Volume, error) {
+	return nil, errors.New("not implemented (*Runtime) newVolume")
+}
+
+// UpdateVolumePlugins reads all volumes from all configured volume plugins and
+// imports them into the libpod db. It also checks if existing libpod volumes
+// are removed in the plugin, in this case we try to remove it from libpod.
+// On errors we continue and try to do as much as possible. all errors are
+// returned as array in the returned struct.
+// This function has many race conditions, it is best effort but cannot guarantee
+// a perfect state since plugins can be modified from the outside at any time.
+func (r *Runtime) UpdateVolumePlugins(ctx context.Context) *define.VolumeReload {
+	return nil
+}
+
+// removeVolume removes the specified volume from state as well tears down its mountpoint and storage.
+// ignoreVolumePlugin is used to only remove the volume from the db and not the plugin,
+// this is required when the volume was already removed from the plugin, i.e. in UpdateVolumePlugins().
+func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool, timeout *uint, ignoreVolumePlugin bool) error {
+	return errors.New("not implemented (*Runtime) removeVolume")
+}

--- a/libpod/stats_unsupported.go
+++ b/libpod/stats_unsupported.go
@@ -1,0 +1,17 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+
+	"github.com/containers/podman/v4/libpod/define"
+)
+
+// GetContainerStats gets the running stats for a given container.
+// The previousStats is used to correctly calculate cpu percentages. You
+// should pass nil if there is no previous stat for this container.
+func (c *Container) GetContainerStats(previousStats *define.ContainerStats) (*define.ContainerStats, error) {
+	return nil, errors.New("not implemented (*Container) GetContainerStats")
+}

--- a/libpod/util_unsupported.go
+++ b/libpod/util_unsupported.go
@@ -1,0 +1,27 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// systemdSliceFromPath makes a new systemd slice under the given parent with
+// the given name.
+// The parent must be a slice. The name must NOT include ".slice"
+func systemdSliceFromPath(parent, name string, resources *spec.LinuxResources) (string, error) {
+	return "", errors.New("not implemented systemdSliceFromPath")
+}
+
+// Unmount umounts a target directory
+func Unmount(mount string) {
+}
+
+// LabelVolumePath takes a mount path for a volume and gives it an
+// selinux label of either shared or not
+func LabelVolumePath(path string) error {
+	return errors.New("not implemented LabelVolumePath")
+}

--- a/libpod/volume_internal_unsupported.go
+++ b/libpod/volume_internal_unsupported.go
@@ -1,0 +1,32 @@
+//go:build !linux
+// +build !linux
+
+package libpod
+
+import (
+	"errors"
+)
+
+// mount mounts the volume if necessary.
+// A mount is necessary if a volume has any options set.
+// If a mount is necessary, v.state.MountCount will be incremented.
+// If it was 0 when the increment occurred, the volume will be mounted on the
+// host. Otherwise, we assume it is already mounted.
+// Must be done while the volume is locked.
+// Is a no-op on volumes that do not require a mount (as defined by
+// volumeNeedsMount()).
+func (v *Volume) mount() error {
+	return errors.New("not implemented (*Volume) mount")
+}
+
+// unmount unmounts the volume if necessary.
+// Unmounting a volume that is not mounted is a no-op.
+// Unmounting a volume that does not require a mount is a no-op.
+// The volume must be locked for this to occur.
+// The mount counter will be decremented if non-zero. If the counter reaches 0,
+// the volume will really be unmounted, as no further containers are using the
+// volume.
+// If force is set, the volume will be unmounted regardless of mount counter.
+func (v *Volume) unmount(force bool) error {
+	return errors.New("not implemented (*Volume) unmount")
+}


### PR DESCRIPTION
This also moves some rootless network setup code and uses of unix.O_PATH to container_internal_linux.go. With this, it is possible to build a non-functional podman on FreeBSD.

Possibly networking_slirp4netns.go would be a more suitable place for the rootless network code.

#### Does this PR introduce a user-facing change?

```release-note
None
```
