### PR TITLE
Add --insecure flag to podman manifest inspect for Docker compatibility

### DIFF
--- a/cmd/podman/manifest/inspect.go
+++ b/cmd/podman/manifest/inspect.go
@@ -3,14 +3,17 @@ package manifest
 import (
 	"fmt"
 
+	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v4/cmd/podman/common"
 	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/spf13/cobra"
 )
 
 var (
-	inspectCmd = &cobra.Command{
-		Use:               "inspect IMAGE",
+	tlsVerifyCLI bool
+	inspectCmd   = &cobra.Command{
+		Use:               "inspect [options] IMAGE",
 		Short:             "Display the contents of a manifest list or image index",
 		Long:              "Display the contents of a manifest list or image index.",
 		RunE:              inspect,
@@ -25,10 +28,24 @@ func init() {
 		Command: inspectCmd,
 		Parent:  manifestCmd,
 	})
+	flags := inspectCmd.Flags()
+
+	flags.Bool("verbose", false, "Added for Docker compatibility")
+	_ = flags.MarkHidden("verbose")
+	flags.BoolVar(&tlsVerifyCLI, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
+	flags.Bool("insecure", false, "Purely for Docker compatibility")
+	_ = flags.MarkHidden("insecure")
 }
 
 func inspect(cmd *cobra.Command, args []string) error {
-	buf, err := registry.ImageEngine().ManifestInspect(registry.Context(), args[0])
+	opts := entities.ManifestInspectOptions{}
+	if cmd.Flags().Changed("tls-verify") {
+		opts.SkipTLSVerify = types.NewOptionalBool(!tlsVerifyCLI)
+	} else if cmd.Flags().Changed("insecure") {
+		insecure, _ := cmd.Flags().GetBool("insecure")
+		opts.SkipTLSVerify = types.NewOptionalBool(insecure)
+	}
+	buf, err := registry.ImageEngine().ManifestInspect(registry.Context(), args[0], opts)
 	if err != nil {
 		return err
 	}

--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -15,6 +15,7 @@ podman-manifest-add.1.md
 podman-manifest-annotate.1.md
 podman-manifest-create.1.md
 podman-manifest-push.1.md
+podman-manifest-inspect.1.md
 podman-pause.1.md
 podman-pod-clone.1.md
 podman-pod-create.1.md

--- a/docs/source/markdown/options/tls-verify.md
+++ b/docs/source/markdown/options/tls-verify.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   podman build, container runlabel, create, kube play, login, manifest add, manifest create, manifest push, pull, push, run, search
+####>   podman build, container runlabel, create, kube play, login, manifest add, manifest create, manifest inspect, manifest push, pull, push, run, search
 ####> If you edit this file, make sure your changes
 ####> are applicable to all of those.
 #### **--tls-verify**

--- a/docs/source/markdown/podman-manifest-inspect.1.md.in
+++ b/docs/source/markdown/podman-manifest-inspect.1.md.in
@@ -4,15 +4,18 @@
 podman\-manifest\-inspect - Display a manifest list or image index
 
 ## SYNOPSIS
-**podman manifest inspect** *listnameorindexname*
+**podman manifest inspect** [*options*] *listnameorindexname*
 
 ## DESCRIPTION
 
 Displays the manifest list or image index stored using the specified image name.
-
 ## RETURN VALUE
 
 A formatted JSON representation of the manifest list or image index.
+
+## OPTIONS
+
+@@option tls-verify
 
 ## EXAMPLES
 

--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -175,6 +175,11 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//    type: string
 	//    required: true
 	//    description: the name or ID of the manifest list
+	//  - in: query
+	//    name: tlsVerify
+	//    type: boolean
+	//    default: true
+	//    description: Require HTTPS and verify signatures when contacting registries.
 	// responses:
 	//   200:
 	//     $ref: "#/responses/manifestInspect"

--- a/pkg/bindings/manifests/types.go
+++ b/pkg/bindings/manifests/types.go
@@ -4,6 +4,7 @@ package manifests
 //
 //go:generate go run ../generator/generator.go InspectOptions
 type InspectOptions struct {
+	SkipTLSVerify *bool
 }
 
 // CreateOptions are optional options for creating manifests

--- a/pkg/bindings/manifests/types_inspect_options.go
+++ b/pkg/bindings/manifests/types_inspect_options.go
@@ -16,3 +16,18 @@ func (o *InspectOptions) Changed(fieldName string) bool {
 func (o *InspectOptions) ToParams() (url.Values, error) {
 	return util.ToParams(o)
 }
+
+// WithSkipTLSVerify set field SkipTLSVerify to given value
+func (o *InspectOptions) WithSkipTLSVerify(value bool) *InspectOptions {
+	o.SkipTLSVerify = &value
+	return o
+}
+
+// GetSkipTLSVerify returns value of field SkipTLSVerify
+func (o *InspectOptions) GetSkipTLSVerify() bool {
+	if o.SkipTLSVerify == nil {
+		var z bool
+		return z
+	}
+	return *o.SkipTLSVerify
+}

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -34,7 +34,7 @@ type ImageEngine interface { //nolint:interfacebloat
 	Untag(ctx context.Context, nameOrID string, tags []string, options ImageUntagOptions) error
 	ManifestCreate(ctx context.Context, name string, images []string, opts ManifestCreateOptions) (string, error)
 	ManifestExists(ctx context.Context, name string) (*BoolReport, error)
-	ManifestInspect(ctx context.Context, name string) ([]byte, error)
+	ManifestInspect(ctx context.Context, name string, opts ManifestInspectOptions) ([]byte, error)
 	ManifestAdd(ctx context.Context, listName string, imageNames []string, opts ManifestAddOptions) (string, error)
 	ManifestAnnotate(ctx context.Context, names, image string, opts ManifestAnnotateOptions) (string, error)
 	ManifestRemoveDigest(ctx context.Context, names, image string) (string, error)

--- a/pkg/domain/entities/manifest.go
+++ b/pkg/domain/entities/manifest.go
@@ -12,6 +12,12 @@ type ManifestCreateOptions struct {
 	SkipTLSVerify types.OptionalBool `json:"-" schema:"-"`
 }
 
+// ManifestInspectOptions provides model for inspecting manifest
+type ManifestInspectOptions struct {
+	// Should TLS registry certificate be verified?
+	SkipTLSVerify types.OptionalBool `json:"-" schema:"-"`
+}
+
 // ManifestAddOptions provides model for adding digests to manifest list
 //
 // swagger:model

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -33,8 +33,17 @@ func (ir *ImageEngine) ManifestExists(ctx context.Context, name string) (*entiti
 }
 
 // ManifestInspect returns contents of manifest list with given name
-func (ir *ImageEngine) ManifestInspect(_ context.Context, name string) ([]byte, error) {
-	list, err := manifests.Inspect(ir.ClientCtx, name, nil)
+func (ir *ImageEngine) ManifestInspect(ctx context.Context, name string, opts entities.ManifestInspectOptions) ([]byte, error) {
+	options := new(manifests.InspectOptions)
+	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
+		if s == types.OptionalBoolTrue {
+			options.WithSkipTLSVerify(true)
+		} else {
+			options.WithSkipTLSVerify(false)
+		}
+	}
+
+	list, err := manifests.Inspect(ir.ClientCtx, name, options)
 	if err != nil {
 		return nil, fmt.Errorf("getting content of manifest list or image %s: %w", name, err)
 	}

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -232,20 +232,6 @@ Labels.created_at | 20[0-9-]\\\+T[0-9:]\\\+Z
     run_podman rmi ${aaa_name}:${aaa_tag} ${zzz_name}:${zzz_tag}
 }
 
-# Regression test for #8931
-@test "podman images - bare manifest list" {
-    # Create an empty manifest list and list images.
-
-    run_podman inspect --format '{{.ID}}' $IMAGE
-    iid=$output
-
-    run_podman manifest create test:1.0
-    run_podman images --format '{{.ID}}' --no-trunc
-    [[ "$output" == *"sha256:$iid"* ]]
-
-    run_podman rmi test:1.0
-}
-
 @test "podman images - rmi -af removes all containers and pods" {
     pname=$(random_string)
     run_podman create --pod new:$pname $IMAGE

--- a/test/system/012-manifest.bats
+++ b/test/system/012-manifest.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# Regression test for #8931
+@test "podman images - bare manifest list" {
+    # Create an empty manifest list and list images.
+
+    run_podman inspect --format '{{.ID}}' $IMAGE
+    iid=$output
+
+    run_podman manifest create test:1.0
+    run_podman manifest inspect --verbose $output
+    is "$output" ".*\"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\"" "--insecure is a noop want to make sure manifest inspect is successful"
+    run_podman images --format '{{.ID}}' --no-trunc
+    is "$output" ".*sha256:$iid" "Original image ID still shown in podman-images output"
+    run_podman rmi test:1.0
+}
+
+# vim: filetype=sh

--- a/test/system/150-login.bats
+++ b/test/system/150-login.bats
@@ -290,6 +290,35 @@ function _test_skopeo_credential_sharing() {
     rm -f $authfile
 }
 
+@test "podman manifest --tls-verify - basic test" {
+    run_podman login --tls-verify=false \
+               --username ${PODMAN_LOGIN_USER} \
+               --password-stdin \
+               localhost:${PODMAN_LOGIN_REGISTRY_PORT} <<<"${PODMAN_LOGIN_PASS}"
+    is "$output" "Login Succeeded!" "output from podman login"
+
+    manifest1="localhost:${PODMAN_LOGIN_REGISTRY_PORT}/test:1.0"
+    run_podman manifest create $manifest1
+    mid=$output
+    run_podman manifest push --authfile=$authfile \
+        --tls-verify=false $mid \
+        $manifest1
+    run_podman manifest rm $manifest1
+    run_podman manifest inspect --insecure $manifest1
+    is "$output" ".*\"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\"" "Verify --insecure works against an insecure registry"
+    run_podman 125 manifest inspect --insecure=false $manifest1
+    is "$output" ".*Error: reading image \"docker://$manifest1\": pinging container registry localhost:${PODMAN_LOGIN_REGISTRY_PORT}:" "Verify --insecure=false fails"
+    run_podman manifest inspect --tls-verify=false $manifest1
+    is "$output" ".*\"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\"" "Verify --tls-verify=false works against an insecure registry"
+    run_podman 125 manifest inspect --tls-verify=true $manifest1
+    is "$output" ".*Error: reading image \"docker://$manifest1\": pinging container registry localhost:${PODMAN_LOGIN_REGISTRY_PORT}:" "Verify --tls-verify=true fails"
+
+    # Now log out
+    run_podman logout localhost:${PODMAN_LOGIN_REGISTRY_PORT}
+    is "$output" "Removed login credentials for localhost:${PODMAN_LOGIN_REGISTRY_PORT}" \
+       "output from podman logout"
+}
+
 # END   cooperation with skopeo
 # END   actual tests
 ###############################################################################


### PR DESCRIPTION
Helps fix: https://github.com/containers/podman/issues/14917

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman manifest inspect now supports --insecure flag for Docker compatibility
```
