### PR TITLE
Add podman manifest create -a. Alias for --amend:Docker compatibility

### DIFF
--- a/cmd/podman/manifest/create.go
+++ b/cmd/podman/manifest/create.go
@@ -42,7 +42,7 @@ func init() {
 	})
 	flags := createCmd.Flags()
 	flags.BoolVar(&manifestCreateOpts.All, "all", false, "add all of the lists' images if the images to add are lists")
-	flags.BoolVar(&manifestCreateOpts.Amend, "amend", false, "modify an existing list if one with the desired name already exists")
+	flags.BoolVarP(&manifestCreateOpts.Amend, "amend", "a", false, "modify an existing list if one with the desired name already exists")
 	flags.BoolVar(&manifestCreateOpts.Insecure, "insecure", false, "neither require HTTPS nor verify certificates when accessing the registry")
 	_ = flags.MarkHidden("insecure")
 	flags.BoolVar(&manifestCreateOpts.TLSVerifyCLI, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")

--- a/docs/source/markdown/podman-manifest-create.1.md
+++ b/docs/source/markdown/podman-manifest-create.1.md
@@ -22,7 +22,7 @@ If any of the images which should be added to the new list or index are
 themselves lists or indexes, add all of their contents.  By default, only one
 image from such a list will be added to the newly-created list or index.
 
-#### **--amend**
+#### **--amend**, **-a**
 
 If a manifest list named *listnameorindexname* already exists, modify the
 preexisting list instead of exiting with an error.  The contents of

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -46,17 +46,23 @@ var _ = Describe("Podman manifest", func() {
 		processTestResult(f)
 	})
 	It("create w/o image", func() {
-		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+		for _, amend := range []string{"--amend", "-a"} {
+			session := podmanTest.Podman([]string{"manifest", "create", "foo"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"manifest", "create", "foo"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).To(ExitWithError())
+			session = podmanTest.Podman([]string{"manifest", "create", "foo"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).To(ExitWithError())
 
-		session = podmanTest.Podman([]string{"manifest", "create", "--amend", "foo"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
+			session = podmanTest.Podman([]string{"manifest", "create", amend, "foo"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(0))
+
+			session = podmanTest.Podman([]string{"manifest", "rm", "foo"})
+			session.WaitWithDefaultTimeout()
+			Expect(session).Should(Exit(0))
+		}
 	})
 
 	It("create w/ image", func() {


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?


<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman manifest create -a alias for --amend added, compatible with Docker CLI.
```
