### PR TITLE
Add podman stats --no-trunc option

### DIFF
--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -58,6 +58,7 @@ type statsOptionsCLI struct {
 
 var (
 	statsOptions statsOptionsCLI
+	notrunc      bool
 )
 
 func statFlags(cmd *cobra.Command) {
@@ -69,6 +70,7 @@ func statFlags(cmd *cobra.Command) {
 	flags.StringVar(&statsOptions.Format, formatFlagName, "", "Pretty-print container statistics to JSON or using a Go template")
 	_ = cmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&containerStats{}))
 
+	flags.BoolVar(&notrunc, "no-trunc", false, "Do not truncate output")
 	flags.BoolVar(&statsOptions.NoReset, "no-reset", false, "Disable resetting the screen between intervals")
 	flags.BoolVar(&statsOptions.NoStream, "no-stream", false, "Disable streaming stats and only pull the first result, default setting is false")
 	intervalFlagName := "interval"
@@ -186,6 +188,9 @@ type containerStats struct {
 }
 
 func (s *containerStats) ID() string {
+	if notrunc {
+		return s.ContainerID
+	}
 	return s.ContainerID[0:12]
 }
 

--- a/docs/source/markdown/podman-stats.1.md
+++ b/docs/source/markdown/podman-stats.1.md
@@ -61,6 +61,10 @@ Do not clear the terminal/screen in between reporting intervals
 
 Disable streaming stats and only pull the first result, default setting is false
 
+#### **--no-trunc**
+
+Do not truncate output
+
 ## EXAMPLE
 
 ```
@@ -74,6 +78,12 @@ a9f807ffaacd   frosty_hodgkin    --      3.092MB / 16.7GB    0.02%   -- / --   -
 # podman stats --no-stream a9f80
 ID             NAME             CPU %   MEM USAGE / LIMIT   MEM %   NET IO    BLOCK IO   PIDS
 a9f807ffaacd   frosty_hodgkin   --      3.092MB / 16.7GB    0.02%   -- / --   -- / --    2
+```
+
+```
+$ podman stats --no-trunc 3667 --format 'table {{ .ID }} {{ .MemUsage }}'
+ID                                                                MEM USAGE / LIMIT
+3667c6aacb06aac2eaffce914c01736420023d56ef9b0f4cfe58b6d6a78b7503  49.15kB / 67.17GB
 ```
 
 ```

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -79,9 +79,10 @@ var _ = Describe("Podman stats", func() {
 		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		session = podmanTest.Podman([]string{"stats", "--all", "--no-stream", "--format", "\"{{.ID}}\""})
+		session = podmanTest.Podman([]string{"stats", "--all", "--no-trunc", "--no-stream", "--format", "\"{{.ID}}\""})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
+		Expect(len(session.OutputToStringArray()[0])).Should(BeEquivalentTo(66))
 	})
 
 	It("podman stats with GO template", func() {


### PR DESCRIPTION
This is for compatibility with Docker.

Partial fix for https://github.com/containers/podman/issues/14917

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman stats now supports the --no-trunc flag
```
