### PR TITLE
sort hc.Binds returned from compat api

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -467,6 +467,7 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 	if err := json.Unmarshal(h, &hc); err != nil {
 		return nil, err
 	}
+	sort.Strings(hc.Binds)
 
 	// k8s-file == json-file
 	if hc.LogConfig.Type == define.KubernetesLogging {


### PR DESCRIPTION
[NO NEW TESTS NEEDED]

Description of the issue:

Saltstack is a tool that can be used for configuration management and one of its capabilities includes being able to manage Docker containers. One of the ways that it decides if a currently running container needs to be replaced is by starting a temporary container using the same image, then comparing the temporary container to the currently running container by querying the Docker API. 

 This PR aims to resolve an issue that causes Saltstack (and possibly other configuration management  tools) to restart the container each time that it ensures the state of a running container. The root cause of the issue is that when Saltstack compares the running container to the temporary container, the `HostConfig.Binds` may be in a different order for each container and therefore cause Salt to replace and restart the container due to the mismatch. This PR sorts `hc.Binds` in the container compat API prior to returning them and resolves the issue.

Signed-off-by: Josh Patterson <josh.patterson@securityonionsolutions.com>

#### Does this PR introduce a user-facing change?

```release-note
Changed: The container endpoint for the compat API will now sort the list of `HostConfig.Binds` prior to return.  
```