### PR TITLE
Improved Windows compatibility

### DIFF
--- a/cmd/rootlessport/main.go
+++ b/cmd/rootlessport/main.go
@@ -225,7 +225,7 @@ outer:
 
 	// https://github.com/containers/podman/issues/11248
 	// Copy /dev/null to stdout and stderr to prevent SIGPIPE errors
-	if f, err := os.OpenFile("/dev/null", os.O_WRONLY, 0755); err == nil {
+	if f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0755); err == nil {
 		unix.Dup2(int(f.Fd()), 1) //nolint:errcheck
 		unix.Dup2(int(f.Fd()), 2) //nolint:errcheck
 		f.Close()

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -213,8 +213,8 @@ func decompressXZ(src string, output io.WriteCloser) error {
 	var read io.Reader
 	var cmd *exec.Cmd
 	// Prefer xz utils for fastest performance, fallback to go xi2 impl
-	if _, err := exec.LookPath("xzcat"); err == nil {
-		cmd = exec.Command("xzcat", "-k", src)
+	if _, err := exec.LookPath("xz"); err == nil {
+		cmd = exec.Command("xz", "-d", "-c", "-k", src)
 		read, err = cmd.StdoutPipe()
 		if err != nil {
 			return err

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -545,12 +545,12 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 		return err
 	}
 	defer fd.Close()
-	dnr, err := os.OpenFile("/dev/null", os.O_RDONLY, 0755)
+	dnr, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0755)
 	if err != nil {
 		return err
 	}
 	defer dnr.Close()
-	dnw, err := os.OpenFile("/dev/null", os.O_WRONLY, 0755)
+	dnw, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0755)
 	if err != nil {
 		return err
 	}
@@ -1216,11 +1216,11 @@ func (v *MachineVM) startHostNetworking() (string, apiForwardingState, error) {
 	}
 
 	attr := new(os.ProcAttr)
-	dnr, err := os.OpenFile("/dev/null", os.O_RDONLY, 0755)
+	dnr, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0755)
 	if err != nil {
 		return "", noForwarding, err
 	}
-	dnw, err := os.OpenFile("/dev/null", os.O_WRONLY, 0755)
+	dnw, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0755)
 	if err != nil {
 		return "", noForwarding, err
 	}


### PR DESCRIPTION
Extracting some work done during experiments implementing https://github.com/containers/podman/issues/13006

First it replaces hardcoded "/dev/null" with os specific variant provided by Go lang. `os.DevNull` was used in other places, so, I assume this is just code cleanup change.

Next it changes use of xzcat to xz as default windows build doesn't have xzcat (in a form of application copy or symlink (not supported on that platform).

From the docs https://linux.die.net/man/1/xzcat "xzcat is equivalent to xz --decompress --stdout." So, it should have no functional changes and preserve the bahavior. Used "-d" and "-c" short keys instead of full ones as there was use of "-k" in short form already.
[NO NEW TESTS NEEDED]
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

