### PR TITLE
Packit: Enable scratch build testing for Fedora 36, 37 and Rawhide

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,18 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+upstream_package_name: podman
+downstream_package_name: podman
+
+actions:
+  post-upstream-clone:
+    - "curl -O https://src.fedoraproject.org/rpms/podman/raw/main/f/podman.spec"
+
+jobs:
+  - job: production_build
+    trigger: pull_request
+    targets: &production_dist_targets
+      - fedora-36
+      - fedora-37
+      - fedora-rawhide
+    scratch: true


### PR DESCRIPTION
This commit includes the initial addition of a .packit.yaml which will
run scratch builds for active Fedora releases which get the latest
Podman using Fedora's official packaging sources.

More packit integration to come in the future.

[NO NEW TESTS NEEDED]

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
