### PR TITLE
Enable event logging,  tunnel and ABI mode for FreeBSD

### DIFF
--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -61,7 +61,7 @@ func newPodmanConfig() {
 	switch runtime.GOOS {
 	case "darwin", "windows":
 		mode = entities.TunnelMode
-	case "linux":
+	case "linux", "freebsd":
 		// Some linux clients might only be compiled without ABI
 		// support (e.g., podman-remote).
 		if abiSupport && !IsRemote() {

--- a/libpod/events/events_freebsd.go
+++ b/libpod/events/events_freebsd.go
@@ -1,0 +1,23 @@
+package events
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// NewEventer creates an eventer based on the eventer type
+func NewEventer(options EventerOptions) (Eventer, error) {
+	logrus.Debugf("Initializing event backend %s", options.EventerType)
+	switch strings.ToUpper(options.EventerType) {
+	case strings.ToUpper(LogFile.String()):
+		return EventLogFile{options}, nil
+	case strings.ToUpper(Null.String()):
+		return NewNullEventer(), nil
+	case strings.ToUpper(Memory.String()):
+		return NewMemoryEventer(), nil
+	default:
+		return nil, fmt.Errorf("unknown event logger type: %s", strings.ToUpper(options.EventerType))
+	}
+}

--- a/libpod/events/events_unsupported.go
+++ b/libpod/events/events_unsupported.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build !linux && !freebsd
+// +build !linux,!freebsd
 
 package events
 

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux || freebsd
+// +build linux freebsd
 
 package events
 


### PR DESCRIPTION
This allows podman commands on FreeBSD to call through to libpod and is required for most commands to work. Right now, most commands are non-functional but 'podman image' is working ok.

#### Does this PR introduce a user-facing change?

```release-note
None
```
