### PR TITLE
Warning messages are printed and ignored if we use an unsupported option on cgroups V1 rootless systems

### DIFF
--- a/docs/source/markdown/options/blkio-weight.md
+++ b/docs/source/markdown/options/blkio-weight.md
@@ -1,3 +1,5 @@
 #### **--blkio-weight**=*weight*
 
 Block IO relative weight. The _weight_ is a value between **10** and **1000**.
+
+This option is not supported on cgroups V1 rootless systems.

--- a/docs/source/markdown/options/cpu-period.md
+++ b/docs/source/markdown/options/cpu-period.md
@@ -8,3 +8,5 @@ microseconds.
 On some systems, changing the resource limits may not be allowed for non-root
 users. For more details, see
 https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
+
+This option is not supported on cgroups V1 rootless systems.

--- a/docs/source/markdown/options/cpu-quota.md
+++ b/docs/source/markdown/options/cpu-quota.md
@@ -10,3 +10,5 @@ ends (controllable via **--cpu-period**).
 On some systems, changing the resource limits may not be allowed for non-root
 users. For more details, see
 https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
+
+This option is not supported on cgroups V1 rootless systems.

--- a/docs/source/markdown/options/cpu-rt-period.md
+++ b/docs/source/markdown/options/cpu-rt-period.md
@@ -4,4 +4,4 @@ Limit the CPU real-time period in microseconds.
 
 Limit the container's Real Time CPU usage. This option tells the kernel to restrict the container's Real Time CPU usage to the period specified.
 
-This option is not supported on cgroups V2 systems.
+This option is only supported on cgroups V1 rootful systems.

--- a/docs/source/markdown/options/cpu-rt-runtime.md
+++ b/docs/source/markdown/options/cpu-rt-runtime.md
@@ -7,4 +7,4 @@ Period of 1,000,000us and Runtime of 950,000us means that this container could c
 
 The sum of all runtimes across containers cannot exceed the amount allotted to the parent cgroup.
 
-This option is not supported on cgroups V2 systems.
+This option is only supported on cgroups V1 rootful systems.

--- a/docs/source/markdown/options/cpu-shares.md
+++ b/docs/source/markdown/options/cpu-shares.md
@@ -37,3 +37,5 @@ this can result in the following division of CPU shares:
 On some systems, changing the resource limits may not be allowed for non-root
 users. For more details, see
 https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
+
+This option is not supported on cgroups V1 rootless systems.

--- a/docs/source/markdown/options/cpuset-cpus.md
+++ b/docs/source/markdown/options/cpuset-cpus.md
@@ -7,3 +7,5 @@ CPUs in which to allow execution. Can be specified as a comma-separated list
 On some systems, changing the resource limits may not be allowed for non-root
 users. For more details, see
 https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
+
+This option is not supported on cgroups V1 rootless systems.

--- a/docs/source/markdown/options/cpuset-mems.md
+++ b/docs/source/markdown/options/cpuset-mems.md
@@ -10,3 +10,5 @@ two memory nodes.
 On some systems, changing the resource limits may not be allowed for non-root
 users. For more details, see
 https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
+
+This option is not supported on cgroups V1 rootless systems.

--- a/docs/source/markdown/options/memory-swappiness.md
+++ b/docs/source/markdown/options/memory-swappiness.md
@@ -2,4 +2,4 @@
 
 Tune a container's memory swappiness behavior. Accepts an integer between *0* and *100*.
 
-This flag is not supported on cgroups V2 systems.
+This flag is only supported on cgroups V1 rootful systems.

--- a/docs/source/markdown/podman-container-clone.1.md.in
+++ b/docs/source/markdown/podman-container-clone.1.md.in
@@ -40,6 +40,8 @@ Set a number of CPUs for the container that overrides the original containers CP
 This is shorthand
 for **--cpu-period** and **--cpu-quota**, so only **--cpus** or either both the **--cpu-period** and **--cpu-quota** options can be set.
 
+This option is not supported on cgroups V1 rootless systems.
+
 @@option cpuset-cpus
 
 If none are specified, the original container's CPUset is used.
@@ -54,9 +56,13 @@ If none are specified, the original container's CPU memory nodes are used.
 
 Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb).
 
+This option is not supported on cgroups V1 rootless systems.
+
 #### **--device-write-bps**=*path*
 
 Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
+
+This option is not supported on cgroups V1 rootless systems.
 
 #### **--force**, **-f**
 
@@ -74,6 +80,8 @@ system's page size (the value would be very large, that's millions of trillions)
 
 If no memory limits are specified, the original container's will be used.
 
+This option is not supported on cgroups V1 rootless systems.
+
 #### **--memory-reservation**=*limit*
 
 Memory soft limit (format: `<number>[<unit>]`, where unit = b (bytes), k (kibibytes), m (mebibytes), or g (gibibytes))
@@ -83,6 +91,8 @@ or low memory, containers are forced to restrict their consumption to their
 reservation. So you should always set the value below **--memory**, otherwise the
 hard limit will take precedence. By default, memory reservation will be the same
 as memory limit from the container being cloned.
+
+This option is not supported on cgroups V1 rootless systems.
 
 #### **--memory-swap**=*limit*
 
@@ -94,6 +104,8 @@ the value of --memory if specified. Otherwise, the container being cloned will b
 The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kibibytes), `m` (mebibytes), or `g` (gibibytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
+
+This option is not supported on cgroups V1 rootless systems.
 
 @@option memory-swappiness
 

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -131,6 +131,8 @@ On some systems, changing the CPU limits may not be allowed for non-root
 users. For more details, see
 https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
 
+This option is not supported on cgroups V1 rootless systems.
+
 @@option cpuset-cpus
 
 @@option cpuset-mems
@@ -165,17 +167,25 @@ Add a rule to the cgroup allowed devices list. The rule is expected to be in the
 
 Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)
 
+This option is not supported on cgroups V1 rootless systems.
+
 #### **--device-read-iops**=*path*
 
 Limit read rate (IO per second) from a device (e.g. --device-read-iops=/dev/sda:1000)
+
+This option is not supported on cgroups V1 rootless systems.
 
 #### **--device-write-bps**=*path*
 
 Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
 
+This option is not supported on cgroups V1 rootless systems.
+
 #### **--device-write-iops**=*path*
 
 Limit write rate (IO per second) to a device (e.g. --device-write-iops=/dev/sda:1000)
+
+This option is not supported on cgroups V1 rootless systems.
 
 #### **--disable-content-trust**
 
@@ -366,6 +376,8 @@ RAM. If a limit of 0 is specified (not using **-m**), the container's memory is
 not limited. The actual limit may be rounded up to a multiple of the operating
 system's page size (the value would be very large, that's millions of trillions).
 
+This option is not supported on cgroups V1 rootless systems.
+
 #### **--memory-reservation**=*limit*
 
 Memory soft limit (format: `<number>[<unit>]`, where unit = b (bytes), k (kibibytes), m (mebibytes), or g (gibibytes))
@@ -375,6 +387,8 @@ or low memory, containers are forced to restrict their consumption to their
 reservation. So you should always set the value below **--memory**, otherwise the
 hard limit will take precedence. By default, memory reservation will be the same
 as memory limit.
+
+This option is not supported on cgroups V1 rootless systems.
 
 #### **--memory-swap**=*limit*
 
@@ -386,6 +400,8 @@ the value of --memory.
 The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kibibytes), `m` (mebibytes), or `g` (gibibytes). If you don't specify a
 unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
+
+This option is not supported on cgroups V1 rootless systems.
 
 @@option memory-swappiness
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -146,6 +146,8 @@ On some systems, changing the CPU limits may not be allowed for non-root
 users. For more details, see
 https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-cpu-limits-fails-with-a-permissions-error
 
+This option is not supported on cgroups V1 rootless systems.
+
 @@option cpuset-cpus
 
 @@option cpuset-mems
@@ -196,17 +198,25 @@ Add a rule to the cgroup allowed devices list
 
 Limit read rate (in bytes per second) from a device (e.g. **--device-read-bps=/dev/sda:1mb**).
 
+This option is not supported on cgroups V1 rootless systems.
+
 #### **--device-read-iops**=*path:rate*
 
 Limit read rate (in IO operations per second) from a device (e.g. **--device-read-iops=/dev/sda:1000**).
+
+This option is not supported on cgroups V1 rootless systems.
 
 #### **--device-write-bps**=*path:rate*
 
 Limit write rate (in bytes per second) to a device (e.g. **--device-write-bps=/dev/sda:1mb**).
 
+This option is not supported on cgroups V1 rootless systems.
+
 #### **--device-write-iops**=*path:rate*
 
 Limit write rate (in IO operations per second) to a device (e.g. **--device-write-iops=/dev/sda:1000**).
+
+This option is not supported on cgroups V1 rootless systems.
 
 #### **--disable-content-trust**
 
@@ -377,6 +387,8 @@ RAM. If a limit of 0 is specified (not using **-m**), the container's memory is
 not limited. The actual limit may be rounded up to a multiple of the operating
 system's page size (the value would be very large, that's millions of trillions).
 
+This option is not supported on cgroups V1 rootless systems.
+
 #### **--memory-reservation**=*number[unit]*
 
 Memory soft limit. A _unit_ can be **b** (bytes), **k** (kibibytes), **m** (mebibytes), or **g** (gibibytes).
@@ -386,6 +398,8 @@ or low memory, containers are forced to restrict their consumption to their
 reservation. So you should always set the value below **--memory**, otherwise the
 hard limit will take precedence. By default, memory reservation will be the same
 as memory limit.
+
+This option is not supported on cgroups V1 rootless systems.
 
 #### **--memory-swap**=*number[unit]*
 
@@ -398,6 +412,8 @@ The argument value should always be larger than that of
 the value of **--memory**.
 
 Set _number_ to **-1** to enable unlimited swap.
+
+This option is not supported on cgroups V1 rootless systems.
 
 @@option memory-swappiness
 

--- a/pkg/specgen/generate/validate.go
+++ b/pkg/specgen/generate/validate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/common/pkg/cgroups"
 	"github.com/containers/common/pkg/sysinfo"
+	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/utils"
 )
@@ -18,6 +19,11 @@ func verifyContainerResourcesCgroupV1(s *specgen.SpecGenerator) ([]string, error
 	warnings := []string{}
 
 	sysInfo := sysinfo.New(true)
+
+	if s.ResourceLimits != nil && rootless.IsRootless() {
+		s.ResourceLimits = nil
+		warnings = append(warnings, "Resource limits are not supported and ignored on cgroups V1 rootless systems")
+	}
 
 	if s.ResourceLimits == nil {
 		return warnings, nil

--- a/test/e2e/container_clone_test.go
+++ b/test/e2e/container_clone_test.go
@@ -87,6 +87,7 @@ var _ = Describe("Podman container clone", func() {
 	})
 
 	It("podman container clone resource limits override", func() {
+		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		create := podmanTest.Podman([]string{"create", "--cpus=5", ALPINE})
 		create.WaitWithDefaultTimeout()
 		Expect(create).To(Exit(0))

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -438,6 +438,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create with -m 1000000 sets swap to 2000000", func() {
+		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		numMem := 1000000
 		ctrName := "testCtr"
 		session := podmanTest.Podman([]string{"create", "-t", "-m", fmt.Sprintf("%db", numMem), "--name", ctrName, ALPINE, "/bin/sh"})
@@ -452,6 +453,7 @@ var _ = Describe("Podman create", func() {
 	})
 
 	It("podman create --cpus 5 sets nanocpus", func() {
+		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		numCpus := 5
 		nanoCPUs := numCpus * 1000000000
 		ctrName := "testCtr"

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -490,6 +490,7 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman generate kube on pod with memory limit", func() {
+		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		podName := "testMemoryLimit"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName})
 		podSession.WaitWithDefaultTimeout()
@@ -515,6 +516,7 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman generate kube on pod with cpu limit", func() {
+		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		podName := "testCpuLimit"
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName})
 		podSession.WaitWithDefaultTimeout()

--- a/test/e2e/generate_spec_test.go
+++ b/test/e2e/generate_spec_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Podman generate spec", func() {
 	})
 
 	It("podman generate spec basic usage", func() {
+		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		session := podmanTest.Podman([]string{"create", "--cpus", "5", "--name", "specgen", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -51,6 +52,7 @@ var _ = Describe("Podman generate spec", func() {
 	})
 
 	It("podman generate spec file", func() {
+		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
 		session := podmanTest.Podman([]string{"create", "--cpus", "5", "--name", "specgen", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -56,7 +56,12 @@ echo $rand        |   0 | $rand
 
 @test "podman run --memory=0 runtime option" {
     run_podman run --memory=0 --rm $IMAGE echo hello
-    is "$output" "hello" "failed to run when --memory is set to 0"
+    if is_rootless && ! is_cgroupsv2; then
+        is "${lines[0]}" "Resource limits are not supported and ignored on cgroups V1 rootless systems" "--memory is not supported"
+        is "${lines[1]}" "hello" "--memory is ignored"
+    else
+        is "$output" "hello" "failed to run when --memory is set to 0"
+    fi
 }
 
 # 'run --preserve-fds' passes a number of additional file descriptors into the container


### PR DESCRIPTION
When an unsupported limit on cgroups V1 rootless systems
is requested, podman prints an warning message and
ignores the option/flag.

```
  Target options/flags:
    --cpu-period, --cpu-quota, --cpu-rt-period, --cpu-rt-runtime,
    --cpus, --cpu-shares, --cpuset-cpus, --cpuset-mems, --memory,
    --memory-reservation, --memory-swap, --memory-swappiness,
    --blkio-weight, --device-read-bps, --device-write-bps,
    --device-read-iops, --device-write-iops, --blkio-weight-device
```

Related to https://github.com/containers/podman/discussions/10152

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Warning messages are printed and ignored if we use an unsupported option on cgroups V1 rootless systems
```
