### PR TITLE
podman: add uid and gid options to keep-id

### DIFF
--- a/docs/source/markdown/options/userns.container.md
+++ b/docs/source/markdown/options/userns.container.md
@@ -1,0 +1,47 @@
+#### **--userns**=*mode*
+
+Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with the **--uidmap** and **--gidmap** options.
+
+This option is incompatible with **--gidmap**, **--uidmap**, **--subuidname** and **--subgidname**.
+
+Rootless user --userns=Key mappings:
+
+Key       | Host User |  Container User
+----------|---------------|---------------------
+""        |$UID           |0 (Default User account mapped to root user in container.)
+keep-id   |$UID           |$UID (Map user account to same UID within container.)
+auto      |$UID           | nil (Host User UID is not mapped into container.)
+nomap     |$UID           | nil (Host User UID is not mapped into container.)
+
+Valid _mode_ values are:
+
+**auto**[:_OPTIONS,..._]: automatically create a unique user namespace.
+
+The `--userns=auto` flag, requires that the user name `containers` and a range of subordinate user ids that the Podman container is allowed to use be specified in the /etc/subuid and /etc/subgid files.
+
+Example: `containers:2147483647:2147483648`.
+
+Podman allocates unique ranges of UIDs and GIDs from the `containers` subordinate user ids. The size of the ranges is based on the number of UIDs required in the image. The number of UIDs and GIDs can be overridden with the `size` option.
+
+The rootless option `--userns=keep-id` uses all the subuids and subgids of the user. Using `--userns=auto` when starting new containers will not work as long as any containers exist that were started with `--userns=keep-id`.
+
+  Valid `auto` options:
+
+  - *gidmapping*=_CONTAINER_GID:HOST_GID:SIZE_: to force a GID mapping to be present in the user namespace.
+  - *size*=_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will estimate a size for the user namespace.
+  - *uidmapping*=_CONTAINER_UID:HOST_UID:SIZE_: to force a UID mapping to be present in the user namespace.
+
+**container:**_id_: join the user namespace of the specified container.
+
+**host**: run in the user namespace of the caller. The processes running in the container will have the same privileges on the host as any other process launched by the calling user (default).
+
+**keep-id**: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is not allowed for containers created by the root user.
+
+  Valid `keep-id` options:
+
+  - *uid*=UID: override the UID inside the container that will be used to map the current rootless user to.
+  - *gid*=GID: override the GID inside the container that will be used to map the current rootless user to.
+
+**nomap**: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is not allowed for containers created by the root user.
+
+**ns:**_namespace_: run the <<container|pod>> in the given existing user namespace.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -652,53 +652,7 @@ The following examples are all valid:
 
 Without this argument the command will be run as root in the container.
 
-#### **--userns**=*mode*
-
-Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with the **--uidmap** and **--gidmap** options.
-
-Rootless user --userns=Key mappings:
-
-Key       | Host User |  Container User
-----------|---------------|---------------------
-""        |$UID           |0 (Default User account mapped to root user in container.)
-keep-id   |$UID           |$UID (Map user account to same UID within container.)
-auto      |$UID           | nil (Host User UID is not mapped into container.)
-nomap     |$UID           | nil (Host User UID is not mapped into container.)
-
-Valid _mode_ values are:
-
-**auto**[:_OPTIONS,..._]: automatically create a unique user namespace.
-
-The `--userns=auto` flag, requires that the user name `containers` and a range of subordinate user ids that the Podman container is allowed to use be specified in the /etc/subuid and /etc/subgid files.
-
-Example: `containers:2147483647:2147483648`.
-
-Podman allocates unique ranges of UIDs and GIDs from the `containers` subordinate user ids. The size of the ranges is based on the number of UIDs required in the image. The number of UIDs and GIDs can be overridden with the `size` option. The `auto` options currently does not work in rootless mode
-
-  Valid `auto` options:
-
-  - *gidmapping*=_CONTAINER_GID:HOST_GID:SIZE_: to force a GID mapping to be present in the user namespace.
-  - *size*=_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will estimate a size for the user namespace.
-  - *uidmapping*=_CONTAINER_UID:HOST_UID:SIZE_: to force a UID mapping to be present in the user namespace.
-
-**container:**_id_: join the user namespace of the specified container.
-
-**host**: run in the user namespace of the caller. The processes running in the container will have the same privileges on the host as any other process launched by the calling user (default).
-
-**keep-id**: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is not allowed for containers created by the root user.
-
-  Valid `keep-id` options:
-
-  - *uid*=UID: override the UID inside the container that will be used to map the current rootless user to.
-  - *gid*=GID: override the GID inside the container that will be used to map the current rootless user to.
-
-**nomap**: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is not allowed for containers created by the root user.
-
-**ns:**_namespace_: run the container in the given existing user namespace.
-
-**private**: create a new namespace for the container.
-
-This option is incompatible with **--gidmap**, **--uidmap**, **--subuidname** and **--subgidname**.
+@@option userns.container
 
 @@option uts.container
 

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -687,6 +687,11 @@ Podman allocates unique ranges of UIDs and GIDs from the `containers` subordinat
 
 **keep-id**: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is not allowed for containers created by the root user.
 
+  Valid `keep-id` options:
+
+  - *uid*=UID: override the UID inside the container that will be used to map the current rootless user to.
+  - *gid*=GID: override the GID inside the container that will be used to map the current rootless user to.
+
 **nomap**: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is not allowed for containers created by the root user.
 
 **ns:**_namespace_: run the container in the given existing user namespace.

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -225,50 +225,7 @@ Require HTTPS and verify certificates when contacting registries (default: true)
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
 TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 
-#### **--userns**=*mode*
-
-Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with the **--uidmap** and **--gidmap** options.
-
-Rootless user --userns=Key mappings:
-
-Key       | Host User |  Container User
-----------|---------------|---------------------
-""        |$UID           |0 (Default User account mapped to root user in container.)
-keep-id   |$UID           |$UID (Map user account to same UID within container.)
-auto      |$UID           | nil (Host User UID is not mapped into container.)
-nomap     |$UID           | nil (Host User UID is not mapped into container.)
-
-Valid _mode_ values are:
-
-**auto**[:_OPTIONS,..._]: automatically create a unique user namespace.
-
-The `--userns=auto` flag, requires that the user name `containers` and a range of subordinate user ids that the Podman container is allowed to use be specified in the /etc/subuid and /etc/subgid files.
-
-Example: `containers:2147483647:2147483648`.
-
-Podman allocates unique ranges of UIDs and GIDs from the `containers` subordinate user ids. The size of the ranges is based on the number of UIDs required in the image. The number of UIDs and GIDs can be overridden with the `size` option. The `auto` options currently does not work in rootless mode
-
-  Valid `auto` options:
-
-  - *gidmapping*=_CONTAINER_GID:HOST_GID:SIZE_: to force a GID mapping to be present in the user namespace.
-  - *size*=_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will estimate a size for the user namespace.
-  - *uidmapping*=_CONTAINER_UID:HOST_UID:SIZE_: to force a UID mapping to be present in the user namespace.
-
-**container:**_id_: join the user namespace of the specified container.
-
-**host**: create a new namespace for the container.
-
-**keep-id**: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is not allowed for containers created by the root user.
-
-  Valid `keep-id` options:
-
-  - *uid*=UID: override the UID inside the container that will be used to map the current rootless user to.
-  - *gid*=GID: override the GID inside the container that will be used to map the current rootless user to.
-
-**nomap**: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is not allowed for containers created by the root user.
-
-**ns:**_namespace_: run the pod in the given existing user namespace.
-
+@@option userns.container
 ## EXAMPLES
 
 Recreate the pod and containers as described in a file called `demo.yml`

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -260,6 +260,11 @@ Podman allocates unique ranges of UIDs and GIDs from the `containers` subordinat
 
 **keep-id**: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is not allowed for containers created by the root user.
 
+  Valid `keep-id` options:
+
+  - *uid*=UID: override the UID inside the container that will be used to map the current rootless user to.
+  - *gid*=GID: override the GID inside the container that will be used to map the current rootless user to.
+
 **nomap**: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is not allowed for containers created by the root user.
 
 **ns:**_namespace_: run the pod in the given existing user namespace.

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -745,6 +745,11 @@ The rootless option `--userns=keep-id` uses all the subuids and subgids of the u
 
 **keep-id**: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is not allowed for containers created by the root user.
 
+  Valid `keep-id` options:
+
+  - *uid*=UID: override the UID inside the container that will be used to map the current rootless user to.
+  - *gid*=GID: override the GID inside the container that will be used to map the current rootless user to.
+
 **nomap**: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is not allowed for containers created by the root user.
 
 **ns:**_namespace_: run the container in the given existing user namespace.

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -708,54 +708,7 @@ Without this argument, the command will run as the user specified in the contain
 
 When a user namespace is not in use, the UID and GID used within the container and on the host will match. When user namespaces are in use, however, the UID and GID in the container may correspond to another UID and GID on the host. In rootless containers, for example, a user namespace is always used, and root in the container will by default correspond to the UID and GID of the user invoking Podman.
 
-#### **--userns**=*mode*
-
-Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with the **--uidmap** and **--gidmap** options.
-
-Rootless user --userns=Key mappings:
-
-Key       | Host User |  Container User
-----------|---------------|---------------------
-""        |$UID           |0 (Default User account mapped to root user in container.)
-keep-id   |$UID           |$UID (Map user account to same UID within container.)
-auto      |$UID           | nil (Host User UID is not mapped into container.)
-nomap     |$UID           | nil (Host User UID is not mapped into container.)
-
-Valid _mode_ values are:
-
-**auto**[:_OPTIONS,..._]: automatically create a unique user namespace.
-
-The `--userns=auto` flag, requires that the user name `containers` and a range of subordinate user ids that the Podman container is allowed to use be specified in the /etc/subuid and /etc/subgid files.
-
-Example: `containers:2147483647:2147483648`.
-
-Podman allocates unique ranges of UIDs and GIDs from the `containers` subordinate user ids. The size of the ranges is based on the number of UIDs required in the image. The number of UIDs and GIDs can be overridden with the `size` option.
-
-The rootless option `--userns=keep-id` uses all the subuids and subgids of the user. Using `--userns=auto` when starting new containers will not work as long as any containers exist that were started with `--userns=keep-id`.
-
-  Valid `auto` options:
-
-  - *gidmapping*=_CONTAINER_GID:HOST_GID:SIZE_: to force a GID mapping to be present in the user namespace.
-  - *size*=_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will estimate a size for the user namespace.
-  - *uidmapping*=_CONTAINER_UID:HOST_UID:SIZE_: to force a UID mapping to be present in the user namespace.
-
-**container:**_id_: join the user namespace of the specified container.
-
-**host**: run in the user namespace of the caller. The processes running in the container will have the same privileges on the host as any other process launched by the calling user (default).
-
-**keep-id**: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is not allowed for containers created by the root user.
-
-  Valid `keep-id` options:
-
-  - *uid*=UID: override the UID inside the container that will be used to map the current rootless user to.
-  - *gid*=GID: override the GID inside the container that will be used to map the current rootless user to.
-
-**nomap**: creates a user namespace where the current rootless user's UID:GID are not mapped into the container. This option is not allowed for containers created by the root user.
-
-**ns:**_namespace_: run the container in the given existing user namespace.
-
-**private**: create a new namespace for the container.
-This option is incompatible with **--gidmap**, **--uidmap**, **--subuidname** and **--subgidname**.
+@@option userns.container
 
 @@option uts.container
 

--- a/pkg/domain/infra/runtime_libpod.go
+++ b/pkg/domain/infra/runtime_libpod.go
@@ -294,57 +294,6 @@ func ParseIDMapping(mode namespaces.UsernsMode, uidMapSlice, gidMapSlice []strin
 		options.AutoUserNsOpts = *opts
 		return &options, nil
 	}
-	if mode.IsKeepID() {
-		if len(uidMapSlice) > 0 || len(gidMapSlice) > 0 {
-			return nil, errors.New("cannot specify custom mappings with --userns=keep-id")
-		}
-		if len(subUIDMap) > 0 || len(subGIDMap) > 0 {
-			return nil, errors.New("cannot specify subuidmap or subgidmap with --userns=keep-id")
-		}
-		if !rootless.IsRootless() {
-			return nil, errors.New("keep-id is only supported in rootless mode")
-		}
-		min := func(a, b int) int {
-			if a < b {
-				return a
-			}
-			return b
-		}
-
-		uid := rootless.GetRootlessUID()
-		gid := rootless.GetRootlessGID()
-
-		uids, gids, err := rootless.GetConfiguredMappings()
-		if err != nil {
-			return nil, fmt.Errorf("cannot read mappings: %w", err)
-		}
-		maxUID, maxGID := 0, 0
-		for _, u := range uids {
-			maxUID += u.Size
-		}
-		for _, g := range gids {
-			maxGID += g.Size
-		}
-
-		options.UIDMap, options.GIDMap = nil, nil
-
-		options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: 0, HostID: 1, Size: min(uid, maxUID)})
-		options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: uid, HostID: 0, Size: 1})
-		if maxUID > uid {
-			options.UIDMap = append(options.UIDMap, idtools.IDMap{ContainerID: uid + 1, HostID: uid + 1, Size: maxUID - uid})
-		}
-
-		options.GIDMap = append(options.GIDMap, idtools.IDMap{ContainerID: 0, HostID: 1, Size: min(gid, maxGID)})
-		options.GIDMap = append(options.GIDMap, idtools.IDMap{ContainerID: gid, HostID: 0, Size: 1})
-		if maxGID > gid {
-			options.GIDMap = append(options.GIDMap, idtools.IDMap{ContainerID: gid + 1, HostID: gid + 1, Size: maxGID - gid})
-		}
-
-		options.HostUIDMapping = false
-		options.HostGIDMapping = false
-		// Simply ignore the setting and do not set up an inner namespace for root as it is a no-op
-		return &options, nil
-	}
 
 	if subGIDMap == "" && subUIDMap != "" {
 		subGIDMap = subUIDMap

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/common/pkg/cgroups"
 	cutil "github.com/containers/common/pkg/util"
 	"github.com/containers/podman/v4/libpod/define"
+	"github.com/containers/podman/v4/pkg/namespaces"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/storage"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -308,6 +309,14 @@ func ParseUserNamespace(ns string) (Namespace, error) {
 	case ns == "keep-id":
 		toReturn.NSMode = KeepID
 		return toReturn, nil
+	case strings.HasPrefix(ns, "keep-id:"):
+		split := strings.SplitN(ns, ":", 2)
+		if len(split) != 2 {
+			return toReturn, errors.New("invalid setting for keep-id: mode")
+		}
+		toReturn.NSMode = KeepID
+		toReturn.Value = split[1]
+		return toReturn, nil
 	case ns == "nomap":
 		toReturn.NSMode = NoMap
 		return toReturn, nil
@@ -490,7 +499,11 @@ func SetupUserNS(idmappings *storage.IDMappingOptions, userns Namespace, g *gene
 			return user, err
 		}
 	case KeepID:
-		mappings, uid, gid, err := util.GetKeepIDMapping()
+		opts, err := namespaces.UsernsMode(userns.String()).GetKeepIDOptions()
+		if err != nil {
+			return user, err
+		}
+		mappings, uid, gid, err := util.GetKeepIDMapping(opts)
 		if err != nil {
 			return user, err
 		}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -342,7 +342,7 @@ func ParseSignal(rawSignal string) (syscall.Signal, error) {
 }
 
 // GetKeepIDMapping returns the mappings and the user to use when keep-id is used
-func GetKeepIDMapping() (*stypes.IDMappingOptions, int, int, error) {
+func GetKeepIDMapping(opts *namespaces.KeepIDUserNsOptions) (*stypes.IDMappingOptions, int, int, error) {
 	if !rootless.IsRootless() {
 		return nil, -1, -1, errors.New("keep-id is only supported in rootless mode")
 	}
@@ -359,6 +359,12 @@ func GetKeepIDMapping() (*stypes.IDMappingOptions, int, int, error) {
 
 	uid := rootless.GetRootlessUID()
 	gid := rootless.GetRootlessGID()
+	if opts.UID != nil {
+		uid = int(*opts.UID)
+	}
+	if opts.GID != nil {
+		gid = int(*opts.GID)
+	}
 
 	uids, gids, err := rootless.GetConfiguredMappings()
 	if err != nil {

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -113,6 +113,16 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(session).Should(Exit(0))
 		uid := fmt.Sprintf("%d", os.Geteuid())
 		Expect(session.OutputToString()).To(ContainSubstring(uid))
+
+		session = podmanTest.Podman([]string{"run", "--userns=keep-id:uid=10,gid=12", "alpine", "sh", "-c", "echo $(id -u):$(id -g)"})
+		session.WaitWithDefaultTimeout()
+		if os.Geteuid() == 0 {
+			Expect(session).Should(Exit(125))
+			return
+		}
+
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("10:12"))
 	})
 
 	It("podman --userns=keep-id check passwd", func() {


### PR DESCRIPTION
add two new options to the keep-id user namespace option:
    
- uid: allow to override the UID used inside the container.
- gid: allow to override the GID used inside the container.
   
For example, the following command will map the rootless user (that
has UID=0 inside the rootless user namespace) to the UID=11 inside the
container user namespace:
    
$ podman run --userns=keep-id:uid=11 --rm -ti  fedora cat /proc/self/uid_map
         0          1         11
        11          0          1
        12         12      65525
  
Closes: https://github.com/containers/podman/issues/15294

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The --userns=keep-id now supports the options `uid` and `gid` to override the IDs used inside the user namespace
```
