### PR TITLE
Add quiet/q flag to podman secret ls

### DIFF
--- a/docs/source/markdown/podman-secret-ls.1.md
+++ b/docs/source/markdown/podman-secret-ls.1.md
@@ -30,7 +30,11 @@ Format secret output using Go template.
 
 #### **--noheading**
 
-Omit the table headings from the listing of secrets.	.
+Omit the table headings from the listing of secrets.
+
+#### **--quiet**, **-q**
+
+Print secret IDs only.
 
 ## EXAMPLES
 

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -145,6 +145,36 @@ var _ = Describe("Podman secret", func() {
 
 	})
 
+	It("podman secret ls --quiet", func() {
+		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
+		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		Expect(err).To(BeNil())
+
+		secretName := "a"
+
+		session := podmanTest.Podman([]string{"secret", "create", secretName, secretFilePath})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		secretID := session.OutputToString()
+
+		list := podmanTest.Podman([]string{"secret", "ls", "-q"})
+		list.WaitWithDefaultTimeout()
+		Expect(list).Should(Exit(0))
+		Expect(list.OutputToString()).To(Equal(secretID))
+
+		list = podmanTest.Podman([]string{"secret", "ls", "--quiet"})
+		list.WaitWithDefaultTimeout()
+		Expect(list).Should(Exit(0))
+		Expect(list.OutputToString()).To(Equal(secretID))
+
+		// Prefer format over quiet
+		list = podmanTest.Podman([]string{"secret", "ls", "-q", "--format", "{{.Name}}"})
+		list.WaitWithDefaultTimeout()
+		Expect(list).Should(Exit(0))
+		Expect(list.OutputToString()).To(Equal(secretName))
+
+	})
+
 	It("podman secret ls with filters", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
 		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)


### PR DESCRIPTION
Add quiet/q flag to podman secret ls, which will print only the secret
ID.

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add quiet/q flag to podman secret ls, which will print only the secret
ID.
```
