### PR TITLE
Improved Windows compatibility for machine command

### DIFF
--- a/pkg/machine/machine_windows.go
+++ b/pkg/machine/machine_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+// +build windows
+
+package machine
+
+import (
+	"syscall"
+)
+
+func GetProcessState(pid int) (active bool, exitCode int) {
+	const da = syscall.STANDARD_RIGHTS_READ | syscall.PROCESS_QUERY_INFORMATION | syscall.SYNCHRONIZE
+	handle, err := syscall.OpenProcess(da, false, uint32(pid))
+	if err != nil {
+		return false, int(syscall.ERROR_PROC_NOT_FOUND)
+	}
+
+	var code uint32
+	syscall.GetExitCodeProcess(handle, &code)
+	return code == 259, int(code)
+}

--- a/pkg/machine/qemu/machine_unix.go
+++ b/pkg/machine/qemu/machine_unix.go
@@ -1,0 +1,33 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package qemu
+
+import (
+	"bytes"
+	"fmt"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func isProcessAlive(pid int) bool {
+	err := unix.Kill(pid, syscall.Signal(0))
+	if err == nil || err == unix.EPERM {
+		return true
+	}
+	return false
+}
+
+func checkProcessStatus(processHint string, pid int, stderrBuf *bytes.Buffer) error {
+	var status syscall.WaitStatus
+	pid, err := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
+	if err != nil {
+		return fmt.Errorf("failed to read qem%su process status: %w", processHint, err)
+	}
+	if pid > 0 {
+		// child exited
+		return fmt.Errorf("%s exited unexpectedly with exit code %d, stderr: %s", processHint, status.ExitStatus(), stderrBuf.String())
+	}
+	return nil
+}

--- a/pkg/machine/qemu/machine_unsupported.go
+++ b/pkg/machine/qemu/machine_unsupported.go
@@ -1,4 +1,4 @@
-//go:build (!amd64 && !arm64) || windows
-// +build !amd64,!arm64 windows
+//go:build (!amd64 && !arm64)
+// +build !amd64,!arm64
 
 package qemu

--- a/pkg/machine/qemu/machine_windows.go
+++ b/pkg/machine/qemu/machine_windows.go
@@ -1,0 +1,27 @@
+package qemu
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/containers/podman/v4/pkg/machine"
+)
+
+func isProcessAlive(pid int) bool {
+	if checkProcessStatus("process", pid, nil) == nil {
+		return true
+	}
+	return false
+}
+
+func checkProcessStatus(processHint string, pid int, stderrBuf *bytes.Buffer) error {
+	active, exitCode := machine.GetProcessState(pid)
+	if !active {
+		if stderrBuf != nil {
+			return fmt.Errorf("%s exited unexpectedly, exit code: %d stderr: %s", processHint, exitCode, stderrBuf.String())
+		} else {
+			return fmt.Errorf("%s exited unexpectedly, exit code: %d", processHint, exitCode)
+		}
+	}
+	return nil
+}

--- a/pkg/machine/qemu/options_windows.go
+++ b/pkg/machine/qemu/options_windows.go
@@ -1,0 +1,13 @@
+package qemu
+
+import (
+	"os"
+)
+
+func getRuntimeDir() (string, error) {
+	tmpDir, ok := os.LookupEnv("TEMP")
+	if !ok {
+		tmpDir = os.Getenv("LOCALAPPDATA") + "\\Temp"
+	}
+	return tmpDir, nil
+}

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1063,7 +1063,7 @@ func launchWinProxy(v *MachineVM) (bool, string, error) {
 	}
 
 	return globalName, pipePrefix + waitPipe, waitPipeExists(waitPipe, 30, func() error {
-		active, exitCode := getProcessState(cmd.Process.Pid)
+		active, exitCode := machine.GetProcessState(cmd.Process.Pid)
 		if !active {
 			return fmt.Errorf("win-sshproxy.exe failed to start, exit code: %d (see windows event logs)", exitCode)
 		}

--- a/pkg/machine/wsl/util_windows.go
+++ b/pkg/machine/wsl/util_windows.go
@@ -280,18 +280,6 @@ func obtainShutdownPrivilege() error {
 	return nil
 }
 
-func getProcessState(pid int) (active bool, exitCode int) {
-	const da = syscall.STANDARD_RIGHTS_READ | syscall.PROCESS_QUERY_INFORMATION | syscall.SYNCHRONIZE
-	handle, err := syscall.OpenProcess(da, false, uint32(pid))
-	if err != nil {
-		return false, int(syscall.ERROR_PROC_NOT_FOUND)
-	}
-
-	var code uint32
-	syscall.GetExitCodeProcess(handle, &code)
-	return code == 259, int(code)
-}
-
 func addRunOnceRegistryEntry(command string) error {
 	k, _, err := registry.CreateKey(registry.CURRENT_USER, `Software\Microsoft\Windows\CurrentVersion\RunOnce`, registry.WRITE)
 	if err != nil {


### PR DESCRIPTION
Extracting more changes done during experiment in https://github.com/containers/podman/issues/13006 and continuation of https://github.com/containers/podman/pull/15372 (split into independent PRs as the first one is already reviewed and they are pretty independent).

It was checked to compile on MacOS and Windows and as it is purely refactoring, no behavior changes are expected.

#### List of changes

##### Fixing command line genarated

The only non platform specific change is 
```
append(cmd, []string{"-qmp", monitor.Network + ":" + monitor.Address.GetPath() + ",server=on,wait=off"}...)
```

This is a correction, because Qemu is using `unix:` (also `tcp:` for TCP) not `unix:/` to set the protocol. It was working before, because address is absolute and additional leading `/` is harmless).

##### Windows aware runtime directory

On windows the only option is to use either user specific or system wide AppData directories

##### Extracting unix specific parts from machine.go

Parts, which only can compile on unix are moved to `_unix` version and `_windows` alternatives (taking into account some limitations, because of lack of signaling) are provided.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
[NO NEW TESTS NEEDED]