### PR TITLE
Man pages: refactor common options: cert-dir

### DIFF
--- a/docs/source/markdown/options/cert-dir.md
+++ b/docs/source/markdown/options/cert-dir.md
@@ -1,0 +1,5 @@
+#### **--cert-dir**=*path*
+
+Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
+Please refer to **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)** for details.
+(This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -164,10 +164,7 @@ If a capability is specified to both the **--cap-add** and **--cap-drop**
 options, it will be dropped, regardless of the order in which the options were
 given.
 
-#### **--cert-dir**=*path*
-
-Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
-Please refer to containers-certs.d(5) for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option cert-dir
 
 @@option cgroup-parent
 

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -118,10 +118,7 @@ and as a result environment variable `FOO` will be set to `bar` for container `c
 
 Build images even if they are found in the local storage. Use `--build=false` to completely disable builds. (This option is not available with the remote Podman client)
 
-#### **--cert-dir**=*path*
-
-Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
-Please refer to containers-certs.d(5) for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option cert-dir
 
 #### **--configmap**=*path*
 

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -53,10 +53,7 @@ All tagged images in the repository will be pulled.
 
 @@option authfile
 
-#### **--cert-dir**=*path*
-
-Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
-Please refer to **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)** for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option cert-dir
 
 #### **--creds**=*[username[:password]]*
 

--- a/hack/markdown-preprocess-review
+++ b/hack/markdown-preprocess-review
@@ -114,8 +114,60 @@ for my $i (0..$#all_opts) {
     next if $ans =~ /^n/i;
     exit 0 if $ans =~ /^q/i;
 
-    system("diffuse", "-w", glob("*")) == 0
-        or die "Diffuse failed\n";
+    # Try to cull the files (remove identical ones)
+    my @files = glob("*");
+    my $winner = pop @files;
+
+    for my $f (@files) {
+        system('cmp', '-s', $f, $winner);
+        if ($? == 0) {
+            print "[ $f is the one we went with; removing from list ]\n";
+            unlink $f;
+            next;
+        }
+
+        system('wdiff', '-1', '-2', '-3', $f, $winner);
+        if ($? == 0) {
+            print "[ $f is whitespace-identical with what we went with ]\n";
+            unlink $f;
+            next;
+        }
+    }
+
+    # Recompute @files, in case some were deleted above
+    @files = glob("*"); pop @files;
+
+    for (my $i=0; $i < $#files; $i++) {
+        my $f1 = $files[$i];
+        next unless -e $f1;
+
+        for (my $j=$i+1; $j <= $#files; $j++) {
+            my $f2 = $files[$j];
+            next unless -e $f2;
+
+            system('wdiff', '-1', '-2', '-3', $f1, $f2);
+            if ($? == 0) {
+                print "[ $f2 : removing, it =~ $f1 ]\n";
+                unlink $f2;
+            }
+        }
+    }
+
+    # Recompute @files, in case some were deleted above
+    @files = glob("*");
+
+    # diffuse works great for 3-4 files, passable for 5, not at all for >5
+    if (@files <= 5) {
+        system("diffuse", "-w", @files) == 0
+            or die "Diffuse failed\n";
+    }
+    else {
+        # Too many files. Go by threes.
+        my $winner = pop @files;
+        for (my $i=0; $i < @files; $i += 3) {
+            system("diffuse", "-w", @files[$i..$i+2], $winner);
+        }
+    }
 }
 
 


### PR DESCRIPTION
...and, tweak markdown-process-review so it can detect and
remove identical files, making review easier.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```