### PR TITLE
[CI:DOCS] elaborate on image lookups of foreign platforms

### DIFF
--- a/docs/source/markdown/options/arch.md
+++ b/docs/source/markdown/options/arch.md
@@ -1,2 +1,3 @@
 #### **--arch**=*ARCH*
 Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
+Unless overridden, subsequent lookups of the same image in the local storage will match this architecture, regardless of the host.

--- a/docs/source/markdown/options/platform.md
+++ b/docs/source/markdown/options/platform.md
@@ -2,3 +2,4 @@
 
 Specify the platform for selecting the image.  (Conflicts with --arch and --os)
 The `--platform` option can be used to override the current architecture and operating system.
+Unless overridden, subsequent lookups of the same image in the local storage will match this platform, regardless of the host.

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -65,8 +65,9 @@ discarded when writing images in Docker formats.
 
 Set the architecture of the image to be built, and that of the base image to be
 pulled, if the build uses one, to the provided value instead of using the
-architecture of the build host. (Examples: arm, arm64, 386, amd64, ppc64le,
-s390x)
+architecture of the build host. Unless overridden, subsequent lookups of the
+same image in the local storage will match this architecture, regardless of the
+host. (Examples: arm, arm64, 386, amd64, ppc64le, s390x)
 
 @@option authfile
 
@@ -454,7 +455,8 @@ do not include `History` information in their images.
 
 Set the OS of the image to be built, and that of the base image to be pulled,
 if the build uses one, instead of using the current operating system of the
-build host.
+build host. Unless overridden, subsequent lookups of the same image in the
+local storage will match this OS, regardless of the host.
 
 #### **--os-feature**=*feature*
 
@@ -506,9 +508,12 @@ process.
 
 Set the *os/arch* of the built image (and its base image, if your build uses one)
 to the provided value instead of using the current operating system and
-architecture of the host (for example `linux/arm`). If `--platform` is set,
-then the values of the `--arch`, `--os`, and `--variant` options will be
-overridden.
+architecture of the host (for example `linux/arm`).  Unless overridden,
+subsequent lookups of the same image in the local storage will match this
+platform, regardless of the host.
+
+If `--platform` is set, then the values of the `--arch`, `--os`, and
+`--variant` options will be overridden.
 
 The `--platform` option can be specified more than once, or given a
 comma-separated list of values as its argument.  When more than one platform is

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -452,6 +452,7 @@ This option conflicts with **--add-host**.
 
 #### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
+Unless overridden, subsequent lookups of the same image in the local storage will match this OS, regardless of the host.
 
 @@option passwd-entry
 

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -77,6 +77,7 @@ Print the usage statement.
 #### **--os**=*OS*
 
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
+Unless overridden, subsequent lookups of the same image in the local storage will match this OS, regardless of the host.
 
 @@option platform
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -465,6 +465,7 @@ This option conflicts with **--add-host**.
 
 #### **--os**=*OS*
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
+Unless overridden, subsequent lookups of the same image in the local storage will match this OS, regardless of the host.
 
 #### **--passwd**
 


### PR DESCRIPTION
After pulling/creating an image of a foreign platform, Podman will
happily use it when looking it up in the local storage and will not
pull down the image matching the host platform.

As discussed in #12682, the reasoning for it is Docker compatibility and
the fact that user already rely on the behavior.  While Podman is now
emitting a warning when an image is in use not matching the local
platform, the documentation was lacking that information.

Fixes: #15300
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Elaborate on local image lookups after pulling images of foreign platforms.
```
