### PR TITLE
Allow to override default username via command line

### DIFF
--- a/cmd/podman/machine/init.go
+++ b/cmd/podman/machine/init.go
@@ -42,7 +42,6 @@ func init() {
 	})
 	flags := initCmd.Flags()
 	cfg := registry.PodmanConfig()
-	initOpts.Username = cfg.Config.Machine.User
 
 	cpusFlagName := "cpus"
 	flags.Uint64Var(
@@ -88,6 +87,10 @@ func init() {
 		"process was rexeced",
 	)
 	_ = flags.MarkHidden("reexec")
+
+	UsernameFlagName := "username"
+	flags.StringVar(&initOpts.Username, UsernameFlagName, cfg.Machine.User, "Username used in qcow image")
+	_ = initCmd.RegisterFlagCompletionFunc(UsernameFlagName, completion.AutocompleteDefault)
 
 	ImagePathFlagName := "image-path"
 	flags.StringVar(&initOpts.ImagePath, ImagePathFlagName, cfg.Machine.Image, "Path to qcow image")

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -76,6 +76,12 @@ Set the timezone for the machine and containers.  Valid values are `local` or
 a `timezone` such as `America/Chicago`.  A value of `local`, which is the default,
 means to use the timezone of the machine host.
 
+#### **--username**
+
+Username to use for executing commands in remote VM. Default value is `core`
+for FCOS and `user` for Fedora (default on Windows hosts). Should match the one
+used inside the resulting VM image.
+
 #### **--volume**, **-v**=*source:target[:options]*
 
 Mounts a volume from source to target.

--- a/pkg/machine/e2e/config_init_test.go
+++ b/pkg/machine/e2e/config_init_test.go
@@ -9,6 +9,7 @@ type initMachine struct {
 	      --cpus uint              Number of CPUs (default 1)
 	      --disk-size uint         Disk size in GB (default 100)
 	      --ignition-path string   Path to ignition file
+	      --username string        Username of the remote user (default "core" for FCOS, "user" for Fedora)
 	      --image-path string      Path to qcow image (default "testing")
 	  -m, --memory uint            Memory in MB (default 2048)
 	      --now                    Start machine now
@@ -21,6 +22,7 @@ type initMachine struct {
 	cpus         *uint
 	diskSize     *uint
 	ignitionPath string
+	username     string
 	imagePath    string
 	memory       *uint
 	now          bool
@@ -41,6 +43,9 @@ func (i *initMachine) buildCmd(m *machineTestBuilder) []string {
 	}
 	if l := len(i.ignitionPath); l > 0 {
 		cmd = append(cmd, "--ignition-path", i.ignitionPath)
+	}
+	if l := len(i.username); l > 0 {
+		cmd = append(cmd, "--username", i.username)
 	}
 	if l := len(i.imagePath); l > 0 {
 		cmd = append(cmd, "--image-path", i.imagePath)
@@ -73,6 +78,11 @@ func (i *initMachine) withDiskSize(size uint) *initMachine {
 
 func (i *initMachine) withIgnitionPath(path string) *initMachine { //nolint:unused
 	i.ignitionPath = path
+	return i
+}
+
+func (i *initMachine) withUsername(username string) *initMachine {
+	i.username = username
 	return i
 }
 

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -77,6 +77,26 @@ var _ = Describe("podman machine init", func() {
 		Expect(inspectAfter[0].State).To(Equal(machine.Running))
 	})
 
+	It("simple init with username", func() {
+		i := new(initMachine)
+		remoteUsername := "remoteuser"
+		session, err := mb.setCmd(i.withImagePath(mb.imagePath).withUsername(remoteUsername)).run()
+		Expect(err).To(BeNil())
+		Expect(session).To(Exit(0))
+
+		inspectBefore, ec, err := mb.toQemuInspectInfo()
+		Expect(err).To(BeNil())
+		Expect(ec).To(BeZero())
+
+		Expect(len(inspectBefore)).To(BeNumerically(">", 0))
+		testMachine := inspectBefore[0]
+		Expect(testMachine.Name).To(Equal(mb.names[0]))
+		Expect(testMachine.Resources.CPUs).To(Equal(uint64(1)))
+		Expect(testMachine.Resources.Memory).To(Equal(uint64(2048)))
+		Expect(testMachine.SSHConfig.RemoteUsername).To((Equal(remoteUsername)))
+
+	})
+
 	It("machine init with cpus, disk size, memory, timezone", func() {
 		name := randomString()
 		i := new(initMachine)


### PR DESCRIPTION
Fixes #15402 

Registers additional flag to override username during machine init.

Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--username` flag to override username used for initializing podman machine with `podman init` command.
```
