### PR TITLE
Man pages: refactor common options: --creds

### DIFF
--- a/docs/source/markdown/options/creds.md
+++ b/docs/source/markdown/options/creds.md
@@ -1,0 +1,5 @@
+#### **--creds**=*[username[:password]]*
+
+The [username[:password]] to use to authenticate with the registry if required.
+If one or both values are not supplied, a command line prompt will appear and the
+value can be entered.  The password is entered without echo.

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -195,11 +195,7 @@ Set additional flags to pass to the C Preprocessor cpp(1). Containerfiles ending
 
 @@option cpuset-mems
 
-#### **--creds**=*creds*
-
-The [username[:password]] to use to authenticate with the registry if required.
-If one or both values are not supplied, a command line prompt will appear and
-the value can be entered.  The password is entered without echo.
+@@option creds
 
 #### **--decryption-key**=*key[:passphrase]*
 

--- a/docs/source/markdown/podman-container-runlabel.1.md.in
+++ b/docs/source/markdown/podman-container-runlabel.1.md.in
@@ -37,9 +37,7 @@ Will be replaced with the current working directory.
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
 Please refer to containers-certs.d(5) for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--creds**=*[username[:password]]*
-
-The [username[:password]] to use to authenticate with the registry if required.  If one or both values are not supplied, a command line prompt will appear and the value can be entered.  The password is entered without echo.
+@@option creds
 
 #### **--display**
 

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -130,11 +130,7 @@ Note: The *--configmap* option can be used multiple times or a comma-separated l
 
 Use *path* as the build context directory for each image. Requires --build option be true. (This option is not available with the remote Podman client)
 
-#### **--creds**
-
-The [username[:password]] to use to authenticate with the registry if required.
-If one or both values are not supplied, a command line prompt will appear and the
-value can be entered.  The password is entered without echo.
+@@option creds
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-manifest-add.1.md.in
+++ b/docs/source/markdown/podman-manifest-add.1.md.in
@@ -40,11 +40,7 @@ retrieved from the image's configuration information.
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
 Please refer to containers-certs.d(5) for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--creds**=*creds*
-
-The [username[:password]] to use to authenticate with the registry if required.
-If one or both values are not supplied, a command line prompt will appear and the
-value can be entered.  The password is entered without echo.
+@@option creds
 
 #### **--features**
 

--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -30,11 +30,7 @@ Please refer to containers-certs.d(5) for details. (This option is not available
 
 Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip` unless overridden in the containers.conf file.
 
-#### **--creds**=*creds*
-
-The [username[:password]] to use to authenticate with the registry if required.
-If one or both values are not supplied, a command line prompt will appear and the
-value can be entered.  The password is entered without echo.
+@@option creds
 
 #### **--digestfile**=*Digestfile*
 

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -55,11 +55,7 @@ All tagged images in the repository will be pulled.
 
 @@option cert-dir
 
-#### **--creds**=*[username[:password]]*
-
-The [username[:password]] to use to authenticate with the registry if required.
-If one or both values are not supplied, a command line prompt will appear and the
-value can be entered.  The password is entered without echo.
+@@option creds
 
 #### **--disable-content-trust**
 

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -63,11 +63,7 @@ Note: This flag can only be set when using the **dir** transport
 
 Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip` unless overridden in the containers.conf file.
 
-#### **--creds**=*[username[:password]]*
-
-The [username[:password]] to use to authenticate with the registry if required.
-If one or both values are not supplied, a command line prompt will appear and the
-value can be entered.  The password is entered without echo.
+@@option creds
 
 #### **--digestfile**=*Digestfile*
 


### PR DESCRIPTION
Refactor the --creds option. I went with the one in podman-pull

The main difference between all of them is the '####' line,
differences in the param descriptions. podman-pull had the
clearest one.

This is another one that hack/markdown-preprocess-review is
good for reviewing.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```