### PR TITLE
pass environment variables to container clone

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -347,9 +347,21 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, contaierID s
 	conf.Systemd = tmpSystemd
 	conf.Mounts = tmpMounts
 
-	if conf.Spec != nil && conf.Spec.Linux != nil && conf.Spec.Linux.Resources != nil {
-		if specg.ResourceLimits == nil {
-			specg.ResourceLimits = conf.Spec.Linux.Resources
+	if conf.Spec != nil {
+		if conf.Spec.Linux != nil && conf.Spec.Linux.Resources != nil {
+			if specg.ResourceLimits == nil {
+				specg.ResourceLimits = conf.Spec.Linux.Resources
+			}
+		}
+		if conf.Spec.Process != nil && conf.Spec.Process.Env != nil {
+			env := make(map[string]string)
+			for _, entry := range conf.Spec.Process.Env {
+				split := strings.Split(entry, "=")
+				if len(split) == 2 {
+					env[split[0]] = split[1]
+				}
+			}
+			specg.Env = env
 		}
 	}
 

--- a/test/e2e/container_clone_test.go
+++ b/test/e2e/container_clone_test.go
@@ -292,4 +292,20 @@ var _ = Describe("Podman container clone", func() {
 		Expect(ok).To(BeTrue())
 
 	})
+
+	It("podman container clone env test", func() {
+		session := podmanTest.Podman([]string{"run", "--name", "env_ctr", "-e", "ENV_TEST=123", ALPINE, "printenv", "ENV_TEST"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"container", "clone", "env_ctr"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"start", "-a", "env_ctr-clone"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).Should(ContainSubstring("123"))
+
+	})
 })


### PR DESCRIPTION
the env vars are held in the spec rather than the config, so they need to be mapped manually. They are also of a different format so special handling needed to be added. All env from the parent container will now be passed to the clone.

resolves #15242

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
users can now expect env variables to be passed properly when using container clone
```
