### PR TITLE
[CI:DOCS] Man pages: fix sloppiness

### DIFF
--- a/docs/source/markdown/options/annotation.container.md
+++ b/docs/source/markdown/options/annotation.container.md
@@ -1,3 +1,3 @@
 #### **--annotation**=*key=value*
 
-Add an annotation to the container<| or pod>. This option can be set multiple times.
+Add an annotation to the container<<| or pod>>. This option can be set multiple times.

--- a/docs/source/markdown/podman-container-runlabel.1.md.in
+++ b/docs/source/markdown/podman-container-runlabel.1.md.in
@@ -32,10 +32,7 @@ Will be replaced with the current working directory.
 
 @@option authfile
 
-#### **--cert-dir**=*path*
-
-Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
-Please refer to containers-certs.d(5) for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option cert-dir
 
 @@option creds
 

--- a/docs/source/markdown/podman-image-sign.1.md.in
+++ b/docs/source/markdown/podman-image-sign.1.md.in
@@ -21,10 +21,7 @@ Sign all the manifests of the multi-architecture image (default false).
 
 @@option authfile
 
-#### **--cert-dir**=*path*
-
-Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
-Please refer to containers-certs.d(5) for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option cert-dir
 
 #### **--directory**, **-d**=*dir*
 

--- a/docs/source/markdown/podman-login.1.md.in
+++ b/docs/source/markdown/podman-login.1.md.in
@@ -30,10 +30,7 @@ For more details about format and configurations of the auth.json file, please r
 
 @@option authfile
 
-#### **--cert-dir**=*path*
-
-Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
-Please refer to containers-certs.d(5) for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option cert-dir
 
 #### **--get-login**
 

--- a/docs/source/markdown/podman-manifest-add.1.md.in
+++ b/docs/source/markdown/podman-manifest-add.1.md.in
@@ -35,10 +35,7 @@ retrieved from the image's configuration information.
 
 @@option authfile
 
-#### **--cert-dir**=*path*
-
-Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
-Please refer to containers-certs.d(5) for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option cert-dir
 
 @@option creds
 

--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -21,10 +21,7 @@ the list or index itself. (Default true)
 
 @@option authfile
 
-#### **--cert-dir**=*path*
-
-Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
-Please refer to containers-certs.d(5) for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option cert-dir
 
 #### **--compression-format**=**gzip** | *zstd* | *zstd:chunked*
 

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -49,10 +49,7 @@ $ podman push myimage oci-archive:/tmp/myimage
 
 @@option authfile
 
-#### **--cert-dir**=*path*
-
-Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)
-Please refer to containers-certs.d(5) for details. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option cert-dir
 
 #### **--compress**
 


### PR DESCRIPTION
I've been doing the man-page cleanup distractedly, while
fighting other fires, and submitted some crap:

 * #15339: I used single angle brackets, not double

 * #15407: I only refactored --cert-dir from some man pages, not all

Easy to review with hack/markdown-preprocess-review, because all the
removed texts are identical. The only diff is that container-certs.d
is now a link.

Sorry about that. I'm going to spend more time being careful.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
none
```