### PR TITLE
libpod: Add definition of containerPlatformState for FreeBSD

### DIFF
--- a/libpod/boltdb_state_freebsd.go
+++ b/libpod/boltdb_state_freebsd.go
@@ -1,19 +1,17 @@
-//go:build !linux && !freebsd
-// +build !linux,!freebsd
+//go:build freebsd
+// +build freebsd
 
 package libpod
-
-import (
-	"errors"
-)
 
 // replaceNetNS handle network namespace transitions after updating a
 // container's state.
 func replaceNetNS(netNSPath string, ctr *Container, newState *ContainerState) error {
-	return errors.New("replaceNetNS not supported on this platform")
+	// On FreeBSD, we just record the network jail's name in our state.
+	newState.NetworkJail = netNSPath
+	return nil
 }
 
 // getNetNSPath retrieves the netns path to be stored in the database
 func getNetNSPath(ctr *Container) string {
-	return ""
+	return ctr.state.NetworkJail
 }

--- a/libpod/container_freebsd.go
+++ b/libpod/container_freebsd.go
@@ -1,0 +1,12 @@
+//go:build freebsd
+// +build freebsd
+
+package libpod
+
+type containerPlatformState struct {
+	// NetworkJail is the name of the container's network VNET
+	// jail.  Will only be set if config.CreateNetNS is true, or
+	// the container was told to join another container's network
+	// namespace.
+	NetworkJail string `json:"-"`
+}

--- a/libpod/container_unsupported.go
+++ b/libpod/container_unsupported.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build !linux && !freebsd
+// +build !linux,!freebsd
 
 package libpod
 


### PR DESCRIPTION
For FreeBSD, we need the name of the 'network jail' which is the parent
of all containers in a pod. Having a separate jail for the network
configuration also simplifies the implementation of CNI plugins so we
use this pattern for solitary containers as well as pods.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### Does this PR introduce a user-facing change?

```release-note
None
```
