### PR TITLE
podman kube play/down --read from URL

### DIFF
--- a/cmd/podman/kube/down.go
+++ b/cmd/podman/kube/down.go
@@ -19,7 +19,8 @@ var (
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: common.AutocompleteDefaultOneArg,
 		Example: `podman kube down nginx.yml
-   cat nginx.yml | podman kube down -`,
+   cat nginx.yml | podman kube down -
+   podman kube down https://example.com/nginx.yml`,
 	}
 )
 

--- a/docs/source/markdown/podman-kube-down.1.md
+++ b/docs/source/markdown/podman-kube-down.1.md
@@ -4,10 +4,14 @@
 podman-kube-down - Remove containers and pods based on Kubernetes YAML
 
 ## SYNOPSIS
-**podman kube down** *file.yml|-*
+**podman kube down** *file.yml|-|https://website.io/file.yml*
 
 ## DESCRIPTION
-**podman kube down** reads a specified Kubernetes YAML file, tearing down pods that were created by the `podman kube play` command via the same Kubernetes YAML file. Any volumes that were created by the previous `podman kube play` command remain intact. If the YAML file is specified as `-`, `podman kube down` reads the YAML from stdin.
+**podman kube down** reads a specified Kubernetes YAML file, tearing down pods that were created by the `podman kube play` command via the same Kubernetes YAML
+file. Any volumes that were created by the previous `podman kube play` command remain intact. If the YAML file is specified as `-`, `podman kube down` reads the
+YAML from stdin. The input can also be a URL that points to a YAML file such as https://podman.io/demo.yml. `podman kube down` will then teardown the pods and
+containers created by `podman kube play` via the same Kubernetes YAML from the URL. However, `podman kube down` will not work with a URL if the YAML file the URL
+points to has been changed or altered since the creation of the pods and containers using `podman kube play`.
 
 ## EXAMPLES
 
@@ -30,14 +34,31 @@ spec:
 Remove the pod and containers as described in the `demo.yml` file
 ```
 $ podman kube down demo.yml
+Pods stopped:
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+Pods removed:
 52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
 ```
 
-Remove the pod and containers as described in the`demo.yml` file YAML sent to stdin
+Remove the pod and containers as described in the `demo.yml` file YAML sent to stdin
 ```
 $ cat demo.yml | podman kube play -
+Pods stopped:
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+Pods removed:
 52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
 ```
+
+Remove the pods and containers as described in the `demo.yml` file YAML read from a URL
+```
+$ podman kube down https://podman.io/demo.yml
+Pods stopped:
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+Pods removed:
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+```
+`podman kube down` will not work with a URL if the YAML file the URL points to has been changed
+or altered since it was used to create the pods and containers.
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-kube(1)](podman-kube.1.md)**, **[podman-kube-play(1)](podman-kube-play.1.md)**, **[podman-kube-generate(1)](podman-kube-generate.1.md)**, **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -4,13 +4,14 @@
 podman-kube-play - Create containers, pods and volumes based on Kubernetes YAML
 
 ## SYNOPSIS
-**podman kube play** [*options*] *file.yml|-*
+**podman kube play** [*options*] *file.yml|-|https://website.io/file.yml*
 
 ## DESCRIPTION
 **podman kube play** will read in a structured file of Kubernetes YAML.  It will then recreate the containers, pods or volumes described in the YAML.  Containers within a pod are then started and the ID of the new Pod or the name of the new Volume is output. If the yaml file is specified as "-" then `podman kube play` will read the YAML file from stdin.
 Using the `--down` command line option, it is also capable of tearing down the pods created by a previous run of `podman kube play`.
 Using the `--replace` command line option, it will tear down the pods(if any) created by a previous run of `podman kube play` and recreate the pods with the Kubernetes YAML file.
 Ideally the input file would be one created by Podman (see podman-kube-generate(1)).  This would guarantee a smooth import and expected results.
+The input can also be a URL that points to a YAML file such as https://podman.io/demo.yml. `podman kube play` will read the YAML from the URL and create pods and containers from it.
 
 Currently, the supported Kubernetes kinds are:
 - Pod
@@ -300,8 +301,23 @@ Create a pod connected to two networks (called net1 and net2) with a static ip
 $ podman kube play demo.yml --network net1:ip=10.89.1.5 --network net2:ip=10.89.10.10
 52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
 ```
-
 Please take into account that networks must be created first using podman-network-create(1).
+
+Create and teardown from a URL pointing to a YAML file
+```
+$ podman kube play https://podman.io/demo.yml
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+
+$ podman kube play --down https://podman.io/demo.yml
+Pods stopped:
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+Pods removed:
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+```
+`podman kube play --down` will not work with a URL if the YAML file the URL points to
+has been changed or altered.
+
+
 
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-kube(1)](podman-kube.1.md)**, **[podman-kube-down(1)](podman-kube-down.1.md)**, **[podman-network-create(1)](podman-network-create.1.md)**, **[podman-kube-generate(1)](podman-kube-generate.1.md)**, **[containers-certs.d(5)](https://github.com/containers/image/blob/main/docs/containers-certs.d.5.md)**


### PR DESCRIPTION
`podman kube play` can create pods and containers from YAML
read from a URL poiniting to a YAML file.
For example: `podman kube play https://example.com/demo.yml`.
`podman kube down` can also teardown pods and containers created
from that YAML file by also reading YAML from a URL, provided the
YAML file the URL points to has not been changed or altered since
it was used to create pods and containers

Closes #14955 
Signed-off-by: Niall Crowe <nicrowe@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`podman kube play` can create pods and containers by reading YAML from a URL.
`podman kube down` can teardown pods and containers by reading YAML from a URL,
provided the YAML file the URL points to has not been changed or altered since the creation
of the pods and containers that need to be removed.
```
