### PR TITLE
[CI:DOCS] Man pages: refactor common options: --cpus

### DIFF
--- a/docs/source/markdown/options/cpus.container.md
+++ b/docs/source/markdown/options/cpus.container.md
@@ -1,0 +1,11 @@
+#### **--cpus**=*number*
+
+Number of CPUs. The default is *0.0* which means no limit. This is shorthand
+for **--cpu-period** and **--cpu-quota**, so you may only set either
+**--cpus** or **--cpu-period** and **--cpu-quota**.
+
+On some systems, changing the CPU limits may not be allowed for non-root
+users. For more details, see
+https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
+
+This option is not supported on cgroups V1 rootless systems.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -119,17 +119,7 @@ Block IO relative device weight.
 
 @@option cpu-shares
 
-#### **--cpus**=*number*
-
-Number of CPUs. The default is *0.0* which means no limit. This is shorthand
-for **--cpu-period** and **--cpu-quota**, so you may only set either
-**--cpus** or **--cpu-period** and **--cpu-quota**.
-
-On some systems, changing the CPU limits may not be allowed for non-root
-users. For more details, see
-https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
-
-This option is not supported on cgroups V1 rootless systems.
+@@option cpus.container
 
 @@option cpuset-cpus
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -134,17 +134,7 @@ each of **stdin**, **stdout**, and **stderr**.
 
 @@option cpu-shares
 
-#### **--cpus**=*number*
-
-Number of CPUs. The default is *0.0* which means no limit. This is shorthand
-for **--cpu-period** and **--cpu-quota**, so you may only set either
-**--cpus** or **--cpu-period** and **--cpu-quota**.
-
-On some systems, changing the CPU limits may not be allowed for non-root
-users. For more details, see
-https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
-
-This option is not supported on cgroups V1 rootless systems.
+@@option cpus.container
 
 @@option cpuset-cpus
 


### PR DESCRIPTION
Only on podman create and run: the --cpus option on container-clone
and pod-clone can probably be combined, but maybe later. pod-create
has unique wording that can't be combined.

This is a freebie to review: the text in both files was already
identical, and I made no changes to it. hack/markdown-preprocess-review
will agree, and show you no diffs, because there are none worth
seeing.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```