### PR TITLE
Document restrictions on transport in FROM

### DIFF
--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -297,6 +297,12 @@ environment variable.  `export BUILDAH_FORMAT=docker`
 Overrides the first `FROM` instruction within the Containerfile.  If there are multiple
 FROM instructions in a Containerfile, only the first is changed.
 
+With the remote podman client, not all container transports will work as
+expected. For example, oci-archive:/x.tar will reference /x.tar on the remote
+machine instead of on the client. If you need to support remote podman clients,
+it is best to restrict yourself to containers-storage: and docker://
+transports.
+
 #### **--help**, **-h**
 
 Print usage statement


### PR DESCRIPTION
When using remote podman client, not all transports work as expected. So
document this limitation.

Fixes: containers/podman#15141

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve documentation for --from in context of remote podman client
```
