### PR TITLE
Fixes isRootful check using qemu machine on Windows

### DIFF
--- a/pkg/machine/qemu/claim_unsupported.go
+++ b/pkg/machine/qemu/claim_unsupported.go
@@ -1,5 +1,5 @@
-//go:build !darwin && !windows
-// +build !darwin,!windows
+//go:build !darwin
+// +build !darwin
 
 package qemu
 

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -1,6 +1,3 @@
-//go:build (amd64 && !windows) || (arm64 && !windows)
-// +build amd64,!windows arm64,!windows
-
 package qemu
 
 import (

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -870,7 +870,7 @@ func NewQMPMonitor(network, name string, timeout time.Duration) (Monitor, error)
 	if err != nil {
 		return Monitor{}, err
 	}
-	if !rootless.IsRootless() {
+	if isRootful() {
 		rtDir = "/run"
 	}
 	rtDir = filepath.Join(rtDir, "podman")
@@ -1371,7 +1371,7 @@ func (v *MachineVM) setPIDSocket() error {
 	if err != nil {
 		return err
 	}
-	if !rootless.IsRootless() {
+	if isRootful() {
 		rtPath = "/run"
 	}
 	socketDir := filepath.Join(rtPath, "podman")
@@ -1397,7 +1397,7 @@ func (v *MachineVM) getSocketandPid() (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	if !rootless.IsRootless() {
+	if isRootful() {
 		rtPath = "/run"
 	}
 	socketDir := filepath.Join(rtPath, "podman")
@@ -1734,4 +1734,12 @@ func isProcessAlive(pid int) bool {
 
 func (p *Provider) VMType() string {
 	return vmtype
+}
+
+func isRootful() bool {
+	// Rootless is not relevant on Windows. In the future rootless.IsRootless
+	// could be switched to return true on Windows, and other codepaths migrated
+	// for now will check additionally for valid os.Getuid
+
+	return !rootless.IsRootless() && os.Getuid() != -1
 }


### PR DESCRIPTION
No user facing changes. No logic changes for platforms other than windows (and Qemu machine is not immediately available for windows after this PR, so, should be treated as code refactoring). No additional tests provided, as old behavior should be preserved and everything should be covered by the current test set.

This is another PR in the series of refactorings extracted during experiment here https://github.com/containers/podman/issues/13006

##### Additional criteria for isRootfull

Updated isRootfull check in qemu machine for correct behavior on windows. Right now isRootless on Windows is returing false and there are a lot of places, where it is called. So, workaround to check if we have a valid Getuid result (are not running on windows) and if not - the assume rootless.

It is similar to https://github.com/containers/podman/blob/7688c5ac63ae33e3caa7fe00b122f95bf60abdd5/cmd/podman/machine/machine_windows.go#L15

##### Additional changes

`machine/claim_unsupported.go` is whitelisted for windows compilation. It has only specialized version for Darwin, so, I assume it is safe to guess that windows should fall under unsupported or have dedicated implementation.

`machine/config.go` is whitelisted for windows compilation.

`machine/qemu/machine.go` go was added to windows compilation in https://github.com/containers/podman/pull/15404 This is a follow adding more missing files.

Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
[NO NEW TESTS NEEDED]
```release-note
None
```
