### PR TITLE
Allow podman to run in an environment with keys containing spaces

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -37,6 +37,22 @@ func Slice(m map[string]string) []string {
 	return env
 }
 
+// Map transforms the specified slice of environment variables into a
+// map.
+func Map(slice []string) map[string]string {
+	envmap := make(map[string]string, len(slice))
+	for _, val := range slice {
+		data := strings.SplitN(val, "=", 2)
+
+		if len(data) > 1 {
+			envmap[data[0]] = data[1]
+		} else {
+			envmap[data[0]] = ""
+		}
+	}
+	return envmap
+}
+
 // Join joins the two environment maps with override overriding base.
 func Join(base map[string]string, override map[string]string) map[string]string {
 	if len(base) == 0 {
@@ -87,10 +103,6 @@ func parseEnv(env map[string]string, line string) error {
 	}
 	// trim the front of a variable, but nothing else
 	name := strings.TrimLeft(data[0], whiteSpaces)
-	if strings.ContainsAny(name, whiteSpaces) {
-		return fmt.Errorf("name %q has white spaces, poorly formatted name", name)
-	}
-
 	if len(data) > 1 {
 		env[name] = data[1]
 	} else {

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -140,10 +140,8 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 	}
 	// First transform the os env into a map. We need it for the labels later in
 	// any case.
-	osEnv, err := envLib.ParseSlice(os.Environ())
-	if err != nil {
-		return nil, fmt.Errorf("error parsing host environment variables: %w", err)
-	}
+	osEnv := envLib.Map(os.Environ())
+
 	// Caller Specified defaults
 	if s.EnvHost {
 		defaultEnvs = envLib.Join(defaultEnvs, osEnv)

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -362,10 +362,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 
 	// First transform the os env into a map. We need it for the labels later in
 	// any case.
-	osEnv, err := envLib.ParseSlice(os.Environ())
-	if err != nil {
-		return fmt.Errorf("error parsing host environment variables: %w", err)
-	}
+	osEnv := envLib.Map(os.Environ())
 
 	if !s.EnvHost {
 		s.EnvHost = c.EnvHost

--- a/test/e2e/run_env_test.go
+++ b/test/e2e/run_env_test.go
@@ -58,6 +58,13 @@ var _ = Describe("Podman run", func() {
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring("/bin"))
 
+		// Verify environ keys with spaces do not blow up podman command
+		os.Setenv("FOO BAR", "BAZ")
+		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "true"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		os.Unsetenv("FOO BAR")
+
 		os.Setenv("FOO", "BAR")
 		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO", ALPINE, "printenv", "FOO"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

Fixes: https://github.com/containers/podman/issues/15251

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman will work on systemd where environment variable keys contain spaces.
```
