### PR TITLE
[CI:DOCS] Man pages: refactor common options: --disable-content-trust

### DIFF
--- a/docs/source/markdown/options/disable-content-trust.md
+++ b/docs/source/markdown/options/disable-content-trust.md
@@ -1,0 +1,5 @@
+#### **--disable-content-trust**
+
+This is a Docker-specific option to disable image verification to a container
+registry and is not supported by Podman. This option is a NOOP and provided
+solely for scripting compatibility.

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -230,11 +230,7 @@ registries, and images being written to local storage would only need to be
 decompressed again to be stored.  Compression can be forced in all cases by
 specifying **--disable-compression=false**.
 
-#### **--disable-content-trust**
-
-This is a Docker specific option to disable image verification to a container
-registry and is not supported by Podman.  This option is a NOOP and provided
-solely for scripting compatibility. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option disable-content-trust
 
 #### **--dns**=*dns*
 

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -175,11 +175,7 @@ Limit write rate (IO per second) to a device (e.g. --device-write-iops=/dev/sda:
 
 This option is not supported on cgroups V1 rootless systems.
 
-#### **--disable-content-trust**
-
-This is a Docker specific option to disable image verification to a Docker
-registry and is not supported by Podman. This flag is a NOOP and provided
-solely for scripting compatibility.
+@@option disable-content-trust
 
 #### **--dns**=*dns*
 

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -57,11 +57,7 @@ All tagged images in the repository will be pulled.
 
 @@option creds
 
-#### **--disable-content-trust**
-
-This is a Docker specific option to disable image verification to a Docker
-registry and is not supported by Podman.  This flag is a NOOP and provided
-solely for scripting compatibility.
+@@option disable-content-trust
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -66,11 +66,7 @@ Specifies the compression format to use.  Supported values are: `gzip`, `zstd` a
 
 After copying the image, write the digest of the resulting image to the file.  (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--disable-content-trust**
-
-This is a Docker specific option to disable image verification to a Docker
-registry and is not supported by Podman.  This flag is a NOOP and provided
-solely for scripting compatibility.
+@@option disable-content-trust
 
 #### **--format**, **-f**=*format*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -206,11 +206,7 @@ Limit write rate (in IO operations per second) to a device (e.g. **--device-writ
 
 This option is not supported on cgroups V1 rootless systems.
 
-#### **--disable-content-trust**
-
-This is a Docker specific option to disable image verification to a Docker
-registry and is not supported by Podman. This flag is a NOOP and provided
-solely for scripting compatibility.
+@@option disable-content-trust
 
 #### **--dns**=*ipaddr*
 


### PR DESCRIPTION
A NOP option. I chose the container word, of course, and the
word 'option' instead of 'flag'. I also hyphenated where needed.

I'm choosing to eliminate the "not on remote" text, because I
don't think it's true: podman-remote happily accepts that
flag on all those commands, including build. (It's marked
as hidden on build, but still accepted).

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```