### PR TITLE
[CI:DOCS] Man pages: refactor common options: --device-cgroup-rule

### DIFF
--- a/docs/source/markdown/options/device-cgroup-rule.md
+++ b/docs/source/markdown/options/device-cgroup-rule.md
@@ -1,0 +1,6 @@
+#### **--device-cgroup-rule**=*"type major:minor mode"*
+
+Add a rule to the cgroup allowed devices list. The rule is expected to be in the format specified in the Linux kernel documentation (Documentation/cgroup-v1/devices.txt):
+       - type: a (all), c (char), or b (block);
+       - major and minor: either a number, or * for all;
+       - mode: a composition of r (read), w (write), and m (mknod(2)).

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -144,12 +144,7 @@ Podman may load kernel modules required for using the specified
 device. The devices that podman will load modules when necessary are:
 /dev/fuse.
 
-#### **--device-cgroup-rule**=*"type major:minor mode"*
-
-Add a rule to the cgroup allowed devices list. The rule is expected to be in the format specified in the Linux kernel documentation (Documentation/cgroup-v1/devices.txt):
-       - type: a (all), c (char), or b (block);
-       - major and minor: either a number, or * for all;
-       - mode: a composition of r (read), w (write), and m (mknod(2)).
+@@option device-cgroup-rule
 
 #### **--device-read-bps**=*path*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -178,9 +178,7 @@ Podman may load kernel modules required for using the specified
 device. The devices that Podman will load modules when necessary are:
 /dev/fuse.
 
-#### **--device-cgroup-rule**=*rule*
-
-Add a rule to the cgroup allowed devices list
+@@option device-cgroup-rule
 
 #### **--device-read-bps**=*path:rate*
 


### PR DESCRIPTION
I chose the version from podman-create. (This is unusual. podman-run
tends to have the better-maintained, more up-to-date version.)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```