### PR TITLE
Man pages: refactor common options: --ignore

### DIFF
--- a/docs/source/markdown/options/ignore.md
+++ b/docs/source/markdown/options/ignore.md
@@ -1,0 +1,5 @@
+#### **--ignore**, **-i**
+
+Ignore errors when specified <<containers|pods>> are not in the container store.  A user
+might have decided to manually remove a <<container|pod>> which would lead to a failure
+during the ExecStop directive of a systemd service referencing that <<container|pod>>.

--- a/docs/source/markdown/podman-pod-rm.1.md.in
+++ b/docs/source/markdown/podman-pod-rm.1.md.in
@@ -19,11 +19,7 @@ Remove all pods.  Can be used in conjunction with \-f as well.
 
 Stop running containers and delete all stopped containers before removal of pod.
 
-#### **--ignore**, **-i**
-
-Ignore errors when specified pods are not in the container store.  A user might
-have decided to manually remove a pod which would lead to a failure during the
-ExecStop directive of a systemd service referencing that pod.
+@@option ignore
 
 #### **--latest**, **-l**
 

--- a/docs/source/markdown/podman-pod-stop.1.md.in
+++ b/docs/source/markdown/podman-pod-stop.1.md.in
@@ -15,11 +15,7 @@ Stop containers in one or more pods.  You may use pod IDs or names as input.
 
 Stops all pods
 
-#### **--ignore**, **-i**
-
-Ignore errors when specified pods are not in the container store.  A user might
-have decided to manually remove a pod which would lead to a failure during the
-ExecStop directive of a systemd service referencing that pod.
+@@option ignore
 
 #### **--latest**, **-l**
 

--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -56,11 +56,7 @@ Containers could have been created by a different container engine.
 In addition, forcing can be used to remove unusable containers, e.g. containers
 whose OCI runtime has become unavailable.
 
-#### **--ignore**, **-i**
-
-Ignore errors when specified containers are not in the container store.  A user
-might have decided to manually remove a container which would lead to a failure
-during the ExecStop directive of a systemd service referencing that container.
+@@option ignore
 
 #### **--latest**, **-l**
 

--- a/docs/source/markdown/podman-stop.1.md.in
+++ b/docs/source/markdown/podman-stop.1.md.in
@@ -47,11 +47,7 @@ Valid filters are listed below:
 | pod             | [Pod] name or full or partial ID of pod                                          |
 | network         | [Network] name or full ID of network                                             |
 
-#### **--ignore**, **-i**
-
-Ignore errors when specified containers are not in the container store.  A user
-might have decided to manually remove a container which would lead to a failure
-during the ExecStop directive of a systemd service referencing that container.
+@@option ignore
 
 #### **--latest**, **-l**
 


### PR DESCRIPTION
Should be an easy one to review.

Note that the podman-rmi --ignore option cannot be combined into this one.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```