### PR TITLE
run,create: add support for `--env-merge` for preprocessing default environment variables

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -124,6 +124,14 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 			"This is a Docker specific option and is a NOOP",
 		)
 
+		envMergeFlagName := "env-merge"
+		createFlags.StringArrayVar(
+			&cf.EnvMerge,
+			envMergeFlagName, []string{},
+			"Preprocess environment variables from image before injecting them into the container",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(envMergeFlagName, completion.AutocompleteNone)
+
 		envFlagName := "env"
 		createFlags.StringArrayP(
 			envFlagName, "e", Env(),

--- a/docs/source/markdown/options/env-merge.md
+++ b/docs/source/markdown/options/env-merge.md
@@ -1,0 +1,5 @@
+#### **--env-merge**=*env*
+
+Preprocess default environment variables for the containers. For example
+if image contains environment variable `hello=world` user can preprocess
+it using `--env-merge hello=${hello}-some` so new value will be `hello=world-some`.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -208,6 +208,8 @@ Read in a line delimited file of environment variables. See **Environment** note
 
 @@option env-host
 
+@@option env-merge
+
 @@option expose
 
 #### **--gidmap**=*container_gid:host_gid:amount*

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -243,6 +243,8 @@ Read in a line delimited file of environment variables. See **Environment** note
 
 @@option env-host
 
+@@option env-merge
+
 @@option expose
 
 #### **--gidmap**=*container_gid:host_gid:amount*

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20211214071223-8958f93039ab
 	github.com/opencontainers/runtime-tools v0.9.1-0.20220714195903-17b3287fafb7
 	github.com/opencontainers/selinux v1.10.1
+	github.com/openshift/imagebuilder v1.2.4-0.20220711175835-4151e43600df
 	github.com/rootless-containers/rootlesskit v1.0.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0

--- a/pkg/api/handlers/compat/containers_create.go
+++ b/pkg/api/handlers/compat/containers_create.go
@@ -408,6 +408,7 @@ func cliOpts(cc handlers.CreateContainerConfig, rtc *config.Config) (*entities.C
 		Systemd:           "true", // podman default
 		TmpFS:             parsedTmp,
 		TTY:               cc.Config.Tty,
+		EnvMerge:          cc.EnvMerge,
 		UnsetEnv:          cc.UnsetEnv,
 		UnsetEnvAll:       cc.UnsetEnvAll,
 		User:              cc.Config.User,

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -127,6 +127,7 @@ type CreateContainerConfig struct {
 	dockerContainer.Config                                // desired container configuration
 	HostConfig             dockerContainer.HostConfig     // host dependent configuration for container
 	NetworkingConfig       dockerNetwork.NetworkingConfig // network configuration for container
+	EnvMerge               []string                       // preprocess env variables from image before injecting into containers
 	UnsetEnv               []string                       // unset specified default environment variables
 	UnsetEnvAll            bool                           // unset all default environment variables
 }

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -263,6 +263,7 @@ type ContainerCreateOptions struct {
 	TTY               bool
 	Timezone          string
 	Umask             string
+	EnvMerge          []string
 	UnsetEnv          []string
 	UnsetEnvAll       bool
 	UIDMap            []string

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -204,6 +204,9 @@ type ContainerBasicConfig struct {
 	// The execution domain system allows Linux to provide limited support
 	// for binaries compiled under other UNIX-like operating systems.
 	Personality *spec.LinuxPersonality `json:"personality,omitempty"`
+	// EnvMerge takes the specified environment variables from image and preprocess them before injecting them into the
+	// container.
+	EnvMerge []string `json:"envmerge,omitempty"`
 	// UnsetEnv unsets the specified default environment variables from the image or from buildin or containers.conf
 	// Optional.
 	UnsetEnv []string `json:"unsetenv,omitempty"`

--- a/pkg/specgenutil/specgen.go
+++ b/pkg/specgenutil/specgen.go
@@ -839,6 +839,9 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *entities.ContainerCreateOptions
 	if !s.Volatile {
 		s.Volatile = c.Rm
 	}
+	if len(s.EnvMerge) == 0 || len(c.EnvMerge) != 0 {
+		s.EnvMerge = c.EnvMerge
+	}
 	if len(s.UnsetEnv) == 0 || len(c.UnsetEnv) != 0 {
 		s.UnsetEnv = c.UnsetEnv
 	}

--- a/test/e2e/run_env_test.go
+++ b/test/e2e/run_env_test.go
@@ -82,6 +82,17 @@ var _ = Describe("Podman run", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("HOSTNAME"))
 	})
 
+	It("podman run with --env-merge", func() {
+		dockerfile := `FROM quay.io/libpod/alpine:latest
+ENV hello=world
+`
+		podmanTest.BuildImage(dockerfile, "test", "false")
+		session := podmanTest.Podman([]string{"run", "--rm", "--env-merge", "hello=${hello}-earth", "test", "env"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("world-earth"))
+	})
+
 	It("podman run --env-host environment test", func() {
 		env := append(os.Environ(), "FOO=BAR")
 		session := podmanTest.PodmanAsUser([]string{"run", "--rm", "--env-host", ALPINE, "/bin/printenv", "FOO"}, 0, 0, "", env)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -620,6 +620,7 @@ github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 github.com/opencontainers/selinux/pkg/pwalkdir
 # github.com/openshift/imagebuilder v1.2.4-0.20220711175835-4151e43600df
+## explicit
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerfile/command
 github.com/openshift/imagebuilder/dockerfile/parser


### PR DESCRIPTION
Allow end users to preprocess default environment variables before
injecting them into container using `--env-merge`

Usage
```
podman run -it --rm --env-merge some=${some}-edit --env-merge
some2=${some2}-edit2 myimage sh
```

Closes: https://github.com/containers/podman/issues/15288


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
run,create: add support for --env-merge for preprocessing default environment variables
```
