### PR TITLE
Rootless Docker API socket alias can be exposed with user mode systemd-tmpfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ MANDIR ?= ${PREFIX}/share/man
 SHAREDIR_CONTAINERS ?= ${PREFIX}/share/containers
 ETCDIR ?= ${PREFIX}/etc
 TMPFILESDIR ?= ${PREFIX}/lib/tmpfiles.d
+USERTMPFILESDIR ?= ${PREFIX}/share/user-tmpfiles.d
 MODULESLOADDIR ?= ${PREFIX}/lib/modules-load.d
 SYSTEMDDIR ?= ${PREFIX}/lib/systemd/system
 USERSYSTEMDDIR ?= ${PREFIX}/lib/systemd/user
@@ -795,8 +796,9 @@ install.completions:
 install.docker:
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 docker $(DESTDIR)$(BINDIR)/docker
-	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR}  ${DESTDIR}${USERSYSTEMDDIR} ${DESTDIR}${TMPFILESDIR}
+	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR}  ${DESTDIR}${USERSYSTEMDDIR} ${DESTDIR}${TMPFILESDIR} ${DESTDIR}${USERTMPFILESDIR}
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-docker.conf -t ${DESTDIR}${TMPFILESDIR}
+	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-docker.conf -t ${DESTDIR}${USERTMPFILESDIR}
 
 .PHONY: install.docker-docs
 install.docker-docs:

--- a/contrib/systemd/system/podman-docker.conf
+++ b/contrib/systemd/system/podman-docker.conf
@@ -1,1 +1,1 @@
-L+  /run/docker.sock   -    -    -     -   /run/podman/podman.sock
+L+  %t/docker.sock   -    -    -     -   %t/podman/podman.sock

--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -233,6 +233,7 @@ done
 %{_userunitdir}/%{name}-restart.service
 %{_userunitdir}/%{name}-kube@.service
 %{_tmpfilesdir}/%{name}.conf
+%{_user_tmpfilesdir}/%{name}-docker.conf
 %if 0%{?fedora} >= 36
 %{_modulesloaddir}/%{name}-iptables.conf
 %endif


### PR DESCRIPTION
Rootless Docker daemon exposes its API socket on
`$XDG_RUNTIME_DIR/docker.sock`. On tmpfiles.d, `%t` is same as
`$XDG_RUNTIME_DIR` in `--user` mode, and `/run` otherwise.
We can reuse the same config file for both mode with this change.

`systemd-tmpfiles` reads "user" configurations in
`/usr/share/user-tmpfiles.d` when `--user` mode is set.
User unit `systemd-tmpfiles-setup.service` can be enabled to alias
rootless socket through systemd-tmpfiles.

#### Does this PR introduce a user-facing change?

```release-note
Rootless Docker API socket alias can be exposed with user mode systemd-tmpfiles
```
