### PR TITLE
[CI:DOCS] Man pages: Refactor common options: --workdir

### DIFF
--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -3,6 +3,7 @@ podman-build.1.md
 podman-container-clone.1.md
 podman-container-runlabel.1.md
 podman-create.1.md
+podman-exec.1.md
 podman-image-sign.1.md
 podman-kill.1.md
 podman-kube-play.1.md

--- a/docs/source/markdown/options/workdir.md
+++ b/docs/source/markdown/options/workdir.md
@@ -1,0 +1,7 @@
+#### **--workdir**, **-w**=*dir*
+
+Working directory inside the container.
+
+The default working directory for running binaries within a container is the root directory (**/**).
+The image developer can set a different default with the WORKDIR instruction. The operator
+can override the working directory by using the **-w** option.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -975,13 +975,7 @@ If the location of the volume from the source container overlaps with
 data residing on a target container, then the volume hides
 that data on the target.
 
-#### **--workdir**, **-w**=*dir*
-
-Working directory inside the container
-
-The default working directory for running binaries within a container is the root directory (/).
-The image developer can set a different default with the WORKDIR instruction. The operator
-can override the working directory by using the **-w** option.
+@@option workdir
 
 ## EXAMPLES
 

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -70,13 +70,7 @@ Sets the username or UID used and optionally the groupname or GID for the specif
 The following examples are all valid:
 --user [user | user:group | uid | uid:gid | user:gid | uid:group ]
 
-#### **--workdir**, **-w**=*path*
-
-Working directory inside the container
-
-The default working directory for running binaries within a container is the root directory (/).
-The image developer can set a different default with the WORKDIR instruction, which can be overridden
-when creating the container.
+@@option workdir
 
 ## Exit Status
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -1034,13 +1034,7 @@ If the location of the volume from the source container overlaps with
 data residing on a target container, then the volume hides
 that data on the target.
 
-#### **--workdir**, **-w**=*dir*
-
-Working directory inside the container.
-
-The default working directory for running binaries within a container is the root directory (**/**).
-The image developer can set a different default with the WORKDIR instruction. The operator
-can override the working directory by using the **-w** option.
+@@option workdir
 
 ## Exit Status
 


### PR DESCRIPTION
I chose the version from podman-run because it is the most
up-to-date, and most correct wrt current syntax guidelines.
Differences are in arg description, language, and asterisks.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```