### PR TITLE
[CI:DOCS] Man pages: refactor common options: --gidmap

### DIFF
--- a/docs/source/markdown/options/gidmap.container.md
+++ b/docs/source/markdown/options/gidmap.container.md
@@ -1,0 +1,8 @@
+#### **--gidmap**=*container_gid:host_gid:amount*
+
+Run the container in a new user namespace using the supplied GID mapping. This
+option conflicts with the **--userns** and **--subgidname** options. This
+option provides a way to map host GIDs to container GIDs in the same way as
+__--uidmap__ maps host UIDs to container UIDs. For details see __--uidmap__.
+
+Note: the **--gidmap** flag cannot be called in conjunction with the **--pod** flag as a gidmap cannot be set on the container level when in a pod.

--- a/docs/source/markdown/options/gidmap.pod.md
+++ b/docs/source/markdown/options/gidmap.pod.md
@@ -1,0 +1,4 @@
+#### **--gidmap**=*pod_gid:host_gid:amount*
+
+GID map for the user namespace. Using this flag will run all containers in the pod with user namespace enabled.
+It conflicts with the **--userns** and **--subgidname** flags.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -210,14 +210,7 @@ Read in a line delimited file of environment variables. See **Environment** note
 
 @@option expose
 
-#### **--gidmap**=*container_gid:host_gid:amount*
-
-Run the container in a new user namespace using the supplied GID mapping. This
-option conflicts with the **--userns** and **--subgidname** options. This
-option provides a way to map host GIDs to container GIDs in the same way as
-__--uidmap__ maps host UIDs to container UIDs. For details see __--uidmap__.
-
-Note: the **--gidmap** flag cannot be called in conjunction with the **--pod** flag as a gidmap cannot be set on the container level when in a pod.
+@@option gidmap.container
 
 @@option group-add
 

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -56,9 +56,7 @@ Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sd
 
 Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
 
-#### **--gidmap**=*pod_gid:host_gid:amount*
-
-GID map for the user namespace. Using this flag will run all containers in the pod with user namespace enabled. It conflicts with the `--userns` and `--subgidname` flags.
+@@option gidmap.pod
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -94,9 +94,7 @@ Set the exit policy of the pod when the last container exits.  Supported policie
 | *continue*         | The pod continues running, by keeping its infra container alive, when the last container exits. Used by default.           |
 | *stop*             | The pod (including its infra container) is stopped when the last container exits. Used in `kube play`.                     |
 
-#### **--gidmap**=*container_gid:host_gid:amount*
-
-GID map for the user namespace. Using this flag will run the container with user namespace enabled. It conflicts with the `--userns` and `--subgidname` flags.
+@@option gidmap.pod
 
 #### **--help**, **-h**
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -245,14 +245,7 @@ Read in a line delimited file of environment variables. See **Environment** note
 
 @@option expose
 
-#### **--gidmap**=*container_gid:host_gid:amount*
-
-Run the container in a new user namespace using the supplied GID mapping. This
-option conflicts with the **--userns** and **--subgidname** options. This
-option provides a way to map host GIDs to container GIDs in the same way as
-__--uidmap__ maps host UIDs to container UIDs. For details see __--uidmap__.
-
-Note: the **--gidmap** flag cannot be called in conjunction with the **--pod** flag as a gidmap cannot be set on the container level when in a pod.
+@@option gidmap.container
 
 @@option group-add
 


### PR DESCRIPTION
Two versions: one for container-related commands, one for pods.

The container one is easy: all versions matched, so I made no
changes.

The pod one is hard to review. I went with the pod-clone
version because the pod-create one looks suspicious: it
talks in terms of containers, not pods. It's possible
that I've got it wrong, and that these two cannot be
combined, so please review very carefully. I strongly
recommend using hack/markdown-preprocess-review for this one.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```