### PR TITLE
[CI:DOCS] Man pages: refactor common options: --ipc

### DIFF
--- a/docs/source/markdown/options/ipc.md
+++ b/docs/source/markdown/options/ipc.md
@@ -1,0 +1,12 @@
+#### **--ipc**=*ipc*
+
+Set the IPC namespace mode for a container. The default is to create
+a private IPC namespace.
+
+- "": Use Podman's default, defined in containers.conf.
+- **container:**_id_: reuses another container's shared memory, semaphores, and message queues
+- **host**: use the host's shared memory, semaphores, and message queues inside the container. Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+- **none**:  private IPC namespace, with /dev/shm not mounted.
+- **ns:**_path_: path to an IPC namespace to join.
+- **private**: private IPC namespace.
+= **shareable**: private IPC namespace with a possibility to share it with other containers.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -296,18 +296,7 @@ The address must be within the network's IPv6 address pool.
 To specify multiple static IPv6 addresses per container, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
 
 
-#### **--ipc**=*ipc*
-
-Set the IPC namespace mode for a container. The default is to create
-a private IPC namespace.
-
-- "": Use Podman's default, defined in containers.conf.
-- **container:**_id_: reuses another container's shared memory, semaphores, and message queues
-- **host**: use the host's shared memory, semaphores, and message queues inside the container. Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
-- **none**:  private IPC namespace, with /dev/shm not mounted.
-- **ns:**_path_: path to an IPC namespace to join.
-- **private**: private IPC namespace.
-= **shareable**: private IPC namespace with a possibility to share it with other containers.
+@@option ipc
 
 #### **--label**, **-l**=*label*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -310,18 +310,7 @@ The address must be within the network's IPv6 address pool.
 
 To specify multiple static IPv6 addresses per container, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
 
-#### **--ipc**=*mode*
-
-Set the IPC namespace mode for a container. The default is to create
-a private IPC namespace.
-
-- "": Use Podman's default, defined in containers.conf.
-- **container:**_id_: reuses another container shared memory, semaphores and message queues
-- **host**: use the host shared memory,semaphores and message queues inside the container. Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
-- **none**:  private IPC namespace, with /dev/shm not mounted.
-- **ns:**_path_: path to an IPC namespace to join.
-- **private**: private IPC namespace.
-= **shareable**: private IPC namespace with a possibility to share it with  other containers.
+@@option ipc
 
 #### **--label**, **-l**=*key=value*
 


### PR DESCRIPTION
This is not an easy one to review, sorry.

I went with the version from podman-create. The differences
against podman-run are subtle: apostrophes, whitespace, and
the arg description in the '####' line. Suggestion for review:
run hack/markdown-preprocess-review, then after you finish
with that, cd /tmp/markdown<TAB>/ipc and use your favorite
two-file diff tool to compare podman-run* against zzz*.

I did not even try to combine the podman-build one; that one
is too different.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```