### PR TITLE
Allow colons in windows file paths

### DIFF
--- a/cmd/podman/parse/net.go
+++ b/cmd/podman/parse/net.go
@@ -151,15 +151,6 @@ func parseEnvOrLabelFile(envOrLabel map[string]string, filename, configType stri
 	return scanner.Err()
 }
 
-// ValidateFileName returns an error if filename contains ":"
-// as it is currently not supported
-func ValidateFileName(filename string) error {
-	if strings.Contains(filename, ":") {
-		return fmt.Errorf("invalid filename (should not contain ':') %q", filename)
-	}
-	return nil
-}
-
 // ValidURL checks a string urlStr is a url or not
 func ValidURL(urlStr string) error {
 	url, err := url.ParseRequestURI(urlStr)

--- a/cmd/podman/parse/parse.go
+++ b/cmd/podman/parse/parse.go
@@ -1,0 +1,18 @@
+//go:build !windows
+// +build !windows
+
+package parse
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateFileName returns an error if filename contains ":"
+// as it is currently not supported
+func ValidateFileName(filename string) error {
+	if strings.Contains(filename, ":") {
+		return fmt.Errorf("invalid filename (should not contain ':') %q", filename)
+	}
+	return nil
+}

--- a/cmd/podman/parse/parse_windows.go
+++ b/cmd/podman/parse/parse_windows.go
@@ -1,0 +1,5 @@
+package parse
+
+func ValidateFileName(filename string) error {
+	return nil
+}


### PR DESCRIPTION
the `podman save` command was failing on windows due to the use of a
colon between the drive letter and first directory.  the check was
intended for Linux and not windows.

Fixes #15247

[NO NEW TESTS NEEDED]

Signed-off-by: Brent Baude <bbaude@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow the use of colons in file path for `podman save` on Windows.

```
