### PR TITLE
[CI:BUILD] Packit: Re-introduce packit with fix-spec-file action

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -431,7 +431,7 @@ alt_build_task:
       - env:
             ALT_NAME: 'Build Without CGO'
       - env:
-            ALT_NAME: 'Test build RPM'
+            ALT_NAME: 'Test build podman-next Copr RPM'
       - env:
             ALT_NAME: 'Alt Arch. Cross'
     # This task cannot make use of the shared repo.tbz artifact.

--- a/.packit.sh
+++ b/.packit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Packit's default fix-spec-file often doesn't fetch version string correctly.
+# This script handles any custom processing of the dist-git spec file and gets used by the
+# fix-spec-file action in .packit.yaml
+
+set -eo pipefail
+
+# Get Version from HEAD
+HEAD_VERSION=$(grep 'var Version = semver.MustParse' version/version.go | cut -d\" -f2 | sed -e 's/-/~/')
+
+# Generate source tarball
+git archive --prefix=podman-$HEAD_VERSION/ -o podman-$HEAD_VERSION.tar.gz HEAD
+
+# RPM Spec modifications
+
+# Fix Version
+sed -i "s/^Version:.*/Version: $HEAD_VERSION/" podman.spec
+
+# Fix Release
+sed -i "s/^Release: %autorelease/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" podman.spec
+
+# Fix Source0
+sed -i "s/^Source0:.*.tar.gz/Source0: %{name}-$HEAD_VERSION.tar.gz/" podman.spec
+
+# Fix autosetup
+sed -i "s/^%autosetup.*/%autosetup -Sgit -n %{name}-$HEAD_VERSION/" podman.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,20 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+upstream_package_name: podman
+downstream_package_name: podman
+
+actions:
+  post-upstream-clone:
+    - "curl -O https://src.fedoraproject.org/rpms/podman/raw/main/f/podman.spec"
+  fix-spec-file:
+    - bash .packit.sh
+
+jobs:
+  - job: production_build
+    trigger: pull_request
+    targets: &production_dist_targets
+      - fedora-36
+      - fedora-37
+      - fedora-rawhide
+    scratch: true


### PR DESCRIPTION
Any new files installed by new PRs and those present in unreleased
versions of Podman will need additional manipulation of the
dist-git spec file in the files section to workaround the
`installed but unpackaged files` issue.

The fix-spec-file packit action is useful for this.

The default fix-spec-file action often has trouble guessing the correct
version from upstream code, so it would be beneficial to specify the
correct upstream version as well.

See: https://packit.dev/docs/actions/#fix-spec-file

[NO NEW TESTS NEEDED]

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
