### PR TITLE
[CI:DOCS] Man pages: refactor common options: --pid

### DIFF
--- a/docs/source/markdown/options/pid.md
+++ b/docs/source/markdown/options/pid.md
@@ -1,0 +1,9 @@
+#### **--pid**=*mode*
+
+Set the PID namespace mode for the container.
+The default is to create a private PID namespace for the container.
+
+- **container:**_id_: join another container's PID namespace;
+- **host**: use the host's PID namespace for the container. Note the host mode gives the container full access to local PID and is therefore considered insecure;
+- **ns:**_path_: join the specified PID namespace;
+- **private**: create a new namespace for the container (default).

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -437,14 +437,7 @@ Unless overridden, subsequent lookups of the same image in the local storage wil
 
 @@option personality
 
-#### **--pid**=*pid*
-
-Set the PID mode for the container
-Default is to create a private PID namespace for the container
-- `container:<name|id>`: join another container's PID namespace
-- `host`: use the host's PID namespace for the container. Note: the host mode gives the container full access to local PID and is therefore considered insecure.
-- `ns`: join the specified PID namespace
-- `private`: create a new namespace for the container (default)
+@@option pid
 
 @@option pidfile
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -458,15 +458,7 @@ This is used to override the Podman provided user setup in favor of entrypoint c
 
 @@option personality
 
-#### **--pid**=*mode*
-
-Set the PID namespace mode for the container.
-The default is to create a private PID namespace for the container.
-
-- **container:**_id_: join another container's PID namespace;
-- **host**: use the host's PID namespace for the container. Note the host mode gives the container full access to local PID and is therefore considered insecure;
-- **private**: create a new namespace for the container (default)
-- **ns:**_path_: join the specified PID namespace.
+@@option pid
 
 @@option pidfile
 


### PR DESCRIPTION
I chose the one from podman-run, but reordered ns/private
to put them in alphabetical order.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```