### PR TITLE
test: use private instead of slave for the mount

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1236,7 +1236,7 @@ USER mail`, BB)
 
 	It("podman run --mount type=bind,bind-nonrecursive", func() {
 		SkipIfRootless("FIXME: rootless users are not allowed to mount bind-nonrecursive")
-		session := podmanTest.Podman([]string{"run", "--mount", "type=bind,bind-nonrecursive,slave,src=/,target=/host", fedoraMinimal, "findmnt", "-nR", "/host"})
+		session := podmanTest.Podman([]string{"run", "--mount", "type=bind,bind-nonrecursive,private,src=/sys,target=/host-sys", fedoraMinimal, "findmnt", "-nR", "/host-sys"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToStringArray()).To(HaveLen(1))


### PR DESCRIPTION
using "slave" means that every mount operation on the host that
happens between the mount creation for `/host` and running `findmnt`
will be propagated to the container mount.  To prevent new mounts on
the host to appear in the container thus invalidating the test we
have, just create the mount as private and use `/sys` as source as it
has multiple mounts on the top but less likely to get new mounts once
it is configured.

Closes: https://github.com/containers/podman/issues/15241

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
