### PR TITLE
APIv2 test cleanup

### DIFF
--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -63,7 +63,7 @@ podman pull -q $IMAGE
 
 # test podman image SCP
 # ssh needs to work so we can validate that the failure is past argument parsing
-podman system connection add --default test ssh://$USER@localhost/run/user/$UID/podman/podman.sock
+podman system connection add --default test ssh://$USER@localhost/run/user/$MYUID/podman/podman.sock
 # should fail but need to check the output...
 # status 125 here means that the save/load fails due to
 # cirrus weirdness with exec.Command. All of the args have been parsed successfully.

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -529,21 +529,21 @@ sleep 3
 t GET containers/status-test/json 200 .State.Status="exited"
 
 # test podman generate spec as input for the api
-podman create --name=specgen alpine_labels
+cname=specgen$(random_string 10)
+podman create --name=$cname $IMAGE
 
 TMPD=$(mktemp -d podman-apiv2-test.build.XXXXXXXX)
 
-podman generate spec -f ${TMPD}/input.txt -c specgen
+podman generate spec -f ${TMPD}/myspec.json -c $cname
 
-curl -XPOST -o ${TMPD}/response.txt --dump-header ${TMPD}/headers.txt -H content-type:application/json http://$HOST:$PORT/v4.0.0/libpod/containers/create -d "@${TMPD}/input.txt"
+# Create a container based on that spec
+t POST libpod/containers/create ${TMPD}/myspec.json 201 \
+  .Id~[0-9a-f]\\{64\\}
 
-if ! grep -q '201 Created' "${TMPD}/headers.txt"; then
-    cat "${TMPD}/headers.txt"
-    cat "${TMPD}/response.txt"
-    echo -e "${red}NOK: container create failed"
-    rm -rf $TMPD
-    exit 1
-fi
+# Verify
+t GET libpod/containers/$cname/json 200 \
+  .ImageName=$IMAGE \
+  .Name=$cname
 
 rm -rf $TMPD
 

--- a/test/apiv2/23-containersArchive.at
+++ b/test/apiv2/23-containersArchive.at
@@ -11,14 +11,26 @@ podman pull $IMAGE &>/dev/null
 # Ensure clean slate
 podman rm -a -f &>/dev/null
 
-CTR="ArchiveTestingCtr"
+CTR="ArchiveTestingCtr$(random_string 5)"
 
 TMPD=$(mktemp -d podman-apiv2-test.archive.XXXXXXXX)
 HELLO_TAR="${TMPD}/hello.tar"
-echo "Hello" > $TMPD/hello.txt
+HELLO_S="Hello_$(random_string 8)"
+echo "$HELLO_S" > $TMPD/hello.txt
 tar --owner=1042 --group=1043 --format=posix -C $TMPD -cvf ${HELLO_TAR} hello.txt &> /dev/null
 
+# Start a container, and wait for it. (I know we don't actually do anything
+# if we time out. If we do, subsequent tests will fail. I just want to avoid
+# a race between container-start and tests-start)
 podman run -d --name "${CTR}" "${IMAGE}" top
+timeout=10
+while [[ $timeout -gt 0 ]]; do
+    if podman container exists "${CTR}"; then
+        break
+    fi
+    timeout=$((timeout - 1))
+    sleep 1
+done
 
 function cleanUpArchiveTest() {
     podman container stop "${CTR}" &> /dev/null
@@ -30,63 +42,47 @@ t HEAD "containers/nonExistentCtr/archive?path=%2F" 404
 t HEAD "containers/${CTR}/archive?path=%2Fnon%2Fexistent%2Fpath" 404
 t HEAD "containers/${CTR}/archive?path=%2Fetc%2Fpasswd" 200
 
-curl "http://$HOST:$PORT/containers/${CTR}/archive?path=%2Ftmp%2F" \
-  -X PUT \
-  -H "Content-Type: application/x-tar" \
-  --upload-file "${HELLO_TAR}" &> /dev/null
+# Send tarfile to container...
+t PUT "/containers/${CTR}/archive?path=%2Ftmp%2F" ${HELLO_TAR} 200 ''
 
-if ! podman exec -it "${CTR}" "grep" "Hello" "/tmp/hello.txt" &> /dev/null ; then
-  echo -e "${red}NOK: The hello.txt file has not been uploaded.${nc}"  1>&2;
-  cleanUpArchiveTest
-  exit 1
-fi
+# ...and 'exec cat file' to confirm that it got extracted into place.
+cat >$TMPD/exec.json <<EOF
+{ "AttachStdout":true,"Cmd":["cat","/tmp/hello.txt"]}
+EOF
+t POST containers/${CTR}/exec $TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
+eid=$(jq -r '.Id' <<<"$output")
+# The 017 is the byte length
+t POST exec/$eid/start 200 $'\001\017'$HELLO_S
 
+# Now fetch hello.txt back as a tarfile
 t HEAD "containers/${CTR}/archive?path=%2Ftmp%2Fhello.txt" 200
+t GET  "containers/${CTR}/archive?path=%2Ftmp%2Fhello.txt" 200
 
-curl "http://$HOST:$PORT/containers/${CTR}/archive?path=%2Ftmp%2Fhello.txt" \
-  --dump-header "${TMPD}/headers.txt" \
-  -o "${TMPD}/body.tar" \
-  -X GET &> /dev/null
+# Check important-looking header
+PATH_STAT="$(grep X-Docker-Container-Path-Stat "$WORKDIR/curl.headers.out" | cut -d " " -f 2 | base64 -d --ignore-garbage)"
 
-PATH_STAT="$(grep X-Docker-Container-Path-Stat "${TMPD}/headers.txt" | cut -d " " -f 2 | base64 -d --ignore-garbage)"
+is "$(jq -r .name <<<$PATH_STAT)" "hello.txt" "Docker-Path-Stat .name"
+is "$(jq -r .size <<<$PATH_STAT)" "15"        "Docker-Path-Stat .size"
 
-ARCHIVE_TEST_ERROR=""
+# Check filename and its contents
+tar_tf=$(tar tf $WORKDIR/curl.result.out)
+is "$tar_tf" "hello.txt" "fetched tarball: file name"
 
-if [ "$(echo "${PATH_STAT}" | jq ".name")" != '"hello.txt"' ]; then
-  echo -e "${red}NOK: Wrong name in X-Docker-Container-Path-Stat header.${nc}"  1>&2;
-  ARCHIVE_TEST_ERROR="1"
-fi
-
-if [ "$(echo "${PATH_STAT}" | jq ".size")" != "6" ]; then
-  echo -e "${red}NOK: Wrong size in X-Docker-Container-Path-Stat header.${nc}"  1>&2;
-  ARCHIVE_TEST_ERROR="1"
-fi
-
-if ! tar -tf "${TMPD}/body.tar" | grep "hello.txt" &> /dev/null; then
-  echo -e "${red}NOK: Body doesn't contain expected file.${nc}"  1>&2;
-  ARCHIVE_TEST_ERROR="1"
-fi
-
-if [ "$(tar -xf "${TMPD}/body.tar" hello.txt  --to-stdout)" != "Hello" ]; then
-  echo -e "${red}NOK: Content of file doesn't match.${nc}" 1>&2;
-  ARCHIVE_TEST_ERROR="1"
-fi
-
-# test if uid/gid was set correctly in the server
-uidngid=$($PODMAN_BIN --root $WORKDIR/server_root exec "${CTR}" stat -c "%u:%g" "/tmp/hello.txt")
-if [[ "${uidngid}" != "1042:1043" ]]; then
-  echo -e "${red}NOK: UID/GID of the file doesn't match.${nc}" 1>&2;
-  ARCHIVE_TEST_ERROR="1"
-fi
+tar_contents=$(tar xf $WORKDIR/curl.result.out --to-stdout)
+is "$tar_contents" "$HELLO_S" "fetched tarball: file contents"
 
 # TODO: uid/gid should be also preserved on way back (GET request)
-# right now it ends up as root:root instead of 1042:1043
-#if [[ "$(tar -tvf "${TMPD}/body.tar")" != *"1042/1043"* ]]; then
-#  echo -e "${red}NOK: UID/GID of the file doesn't match.${nc}" 1>&2;
-#  ARCHIVE_TEST_ERROR="1"
-#fi
+# right now it ends up as 0/0 instead of 1042/1043
+tar_uidgid=$(tar tvf $WORKDIR/curl.result.out | awk '{print $2}')
+is "$tar_uidgid" "0/0" "fetched tarball: file uid/gid"
+
+# test if uid/gid was set correctly in the server. Again, via exec.
+cat >$TMPD/exec.json <<EOF
+{ "AttachStdout":true,"Cmd":["stat","-c","%u:%g","/tmp/hello.txt"]}
+EOF
+
+t POST containers/${CTR}/exec $TMPD/exec.json 201 .Id~[0-9a-f]\\{64\\}
+eid=$(jq -r '.Id' <<<"$output")
+t POST exec/$eid/start 200 $'\001\012'1042:1043
 
 cleanUpArchiveTest
-if [[ "${ARCHIVE_TEST_ERROR}" ]] ; then
-  exit 1;
-fi

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -24,7 +24,7 @@ REGISTRY_IMAGE="${PODMAN_TEST_IMAGE_REGISTRY}/${PODMAN_TEST_IMAGE_USER}/registry
 # BEGIN setup
 
 USER=$PODMAN_ROOTLESS_USER
-UID=$PODMAN_ROOTLESS_UID
+MYUID=$PODMAN_ROOTLESS_UID
 TMPDIR=${TMPDIR:-/tmp}
 WORKDIR=$(mktemp --tmpdir -d $ME.tmp.XXXXXX)
 
@@ -135,7 +135,8 @@ function like() {
 ##############
 function _show_ok() {
     local ok=$1
-    local testname=$2
+    # Exec tests include control characters; filter them out
+    local testname=$(tr -d \\012 <<<"$2"|cat -vT)
 
     # If output is a tty, colorize pass/fail
     local red=
@@ -254,14 +255,24 @@ function t() {
     # Slurp the command line until we see a 3-digit status code.
     if [[ $method = "POST" || $method == "PUT" || $method = "DELETE" ]]; then
         local -a post_args
+
+        if [[ $method = "POST" ]]; then
+            function _add_curl_args() { curl_args+=(--data-binary @$1); }
+        else
+            function _add_curl_args() { curl_args+=(--upload-file $1); }
+        fi
+
         for arg; do
             case "$arg" in
                 *=*)              post_args+=("$arg");
                                   shift;;
-                *.tar)            curl_args+=(--data-binary @$arg);
+                *.json)           _add_curl_args $arg;
+                                  content_type="application/json";
+                                  shift;;
+                *.tar)            _add_curl_args $arg;
                                   content_type="application/x-tar";
                                   shift;;
-                *.yaml)           curl_args+=(--data-binary @$arg);
+                *.yaml)           _add_curl_args $arg;
                                   shift;;
                 application/*)    content_type="$arg";
                                   shift;;


### PR DESCRIPTION
Whole slew of bugs that got introduced while I wasn't paying
attention. Most of them are of the form "let's use hand-crafted
curl commands and do our own error checking and exit uncleanly
on error and leave the system in an unstable state". To be
fair, those were done because there was no existing mechanism
for uploading JSON files or somesuch. So, add one.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```