### PR TITLE
[CI:DOCS] Man pages: refactor common options: log-related options

### DIFF
--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -9,11 +9,13 @@ podman-kill.1.md
 podman-kube-play.1.md
 podman-login.1.md
 podman-logout.1.md
+podman-logs.1.md
 podman-manifest-add.1.md
 podman-manifest-push.1.md
 podman-pause.1.md
 podman-pod-clone.1.md
 podman-pod-create.1.md
+podman-pod-logs.1.md
 podman-pod-rm.1.md
 podman-pod-start.1.md
 podman-pod-stop.1.md

--- a/docs/source/markdown/options/color.md
+++ b/docs/source/markdown/options/color.md
@@ -1,0 +1,3 @@
+#### **--color**
+
+Output the containers with different colors in the log.

--- a/docs/source/markdown/options/follow.md
+++ b/docs/source/markdown/options/follow.md
@@ -1,0 +1,7 @@
+#### **--follow**, **-f**
+
+Follow log output.  Default is false.
+
+Note: If you are following a <<container|pod>> which is removed by `podman <<container|pod>> rm`
+or removed on exit (`podman run --rm ...`), then there is a chance that the log
+file will be removed before `podman<< pod|>> logs` reads the final content.

--- a/docs/source/markdown/options/names.md
+++ b/docs/source/markdown/options/names.md
@@ -1,0 +1,3 @@
+#### **--names**, **-n**
+
+Output the container names instead of the container IDs in the log.

--- a/docs/source/markdown/options/since.md
+++ b/docs/source/markdown/options/since.md
@@ -1,0 +1,6 @@
+#### **--since**=*TIMESTAMP*
+
+Show logs since TIMESTAMP. The --since option can be Unix timestamps, date formatted timestamps, or Go duration
+strings (e.g. 10m, 1h30m) computed relative to the client machine's time. Supported formats for date formatted
+time stamps include RFC3339Nano, RFC3339, 2006-01-02T15:04:05, 2006-01-02T15:04:05.999999999, 2006-01-02Z07:00,
+and 2006-01-02.

--- a/docs/source/markdown/options/tail.md
+++ b/docs/source/markdown/options/tail.md
@@ -1,0 +1,4 @@
+#### **--tail**=*LINES*
+
+Output the specified number of LINES at the end of the logs.  LINES must be an integer.  Defaults to -1,
+which prints all lines

--- a/docs/source/markdown/options/timestamps.md
+++ b/docs/source/markdown/options/timestamps.md
@@ -1,0 +1,3 @@
+#### **--timestamps**, **-t**
+
+Show timestamps in the log outputs.  The default is false

--- a/docs/source/markdown/options/until.md
+++ b/docs/source/markdown/options/until.md
@@ -1,0 +1,6 @@
+#### **--until**=*TIMESTAMP*
+
+Show logs until TIMESTAMP. The --until option can be Unix timestamps, date formatted timestamps, or Go duration
+strings (e.g. 10m, 1h30m) computed relative to the client machine's time. Supported formats for date formatted
+time stamps include RFC3339Nano, RFC3339, 2006-01-02T15:04:05, 2006-01-02T15:04:05.999999999, 2006-01-02Z07:00,
+and 2006-01-02.

--- a/docs/source/markdown/podman-logs.1.md.in
+++ b/docs/source/markdown/podman-logs.1.md.in
@@ -15,49 +15,24 @@ any logs at the time you execute podman logs).
 
 ## OPTIONS
 
-#### **--color**
+@@option color
 
-Output the containers with different colors in the log.
-
-#### **--follow**, **-f**
-
-Follow log output.  Default is false.
-
-Note: If you are following a container which is removed `podman container rm`
-or removed on exit `podman run --rm ...`, then there is a chance that the log
-file will be removed before `podman logs` reads the final content.
+@@option follow
 
 #### **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--names**, **-n**
+@@option names
 
-Output the container name in the log
+@@option since
 
-#### **--since**=*TIMESTAMP*
+@@option tail
 
-Show logs since TIMESTAMP. The --since option can be Unix timestamps, date formatted timestamps, or Go duration
-strings (e.g. 10m, 1h30m) computed relative to the client machine's time. Supported formats for date formatted
-time stamps include RFC3339Nano, RFC3339, 2006-01-02T15:04:05, 2006-01-02T15:04:05.999999999, 2006-01-02Z07:00,
-and 2006-01-02.
+@@option timestamps
 
-#### **--tail**=*LINES*
-
-Output the specified number of LINES at the end of the logs.  LINES must be an integer.  Defaults to -1,
-which prints all lines
-
-#### **--timestamps**, **-t**
-
-Show timestamps in the log outputs.  The default is false
-
-#### **--until**=*TIMESTAMP*
-
-Show logs until TIMESTAMP. The --until option can be Unix timestamps, date formatted timestamps, or Go duration
-strings (e.g. 10m, 1h30m) computed relative to the client machine's time. Supported formats for date formatted
-time stamps include RFC3339Nano, RFC3339, 2006-01-02T15:04:05, 2006-01-02T15:04:05.999999999, 2006-01-02Z07:00,
-and 2006-01-02.
+@@option until
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-pod-logs.1.md.in
+++ b/docs/source/markdown/podman-pod-logs.1.md.in
@@ -13,51 +13,27 @@ Note: Long running command of `podman pod log` with a `-f` or `--follow` needs t
 
 ## OPTIONS
 
-#### **--color**
-
-Output the containers with different colors in the log.
+@@option color
 
 #### **--container**, **-c**
 
 By default `podman pod logs` retrieves logs for all the containers available within the pod differentiate by field `container`. However there are use-cases where user would want to limit the log stream only to a particular container of a pod for such cases `-c` can be used like `podman pod logs -c ctrNameorID podname`.
 
-#### **--follow**, **-f**
-
-Follow log output.  Default is false.
-
-Note: If you are following a pod which is removed `podman pod rm`, then there is a
-chance that the log file will be removed before `podman pod logs` reads the final content.
+@@option follow
 
 #### **--latest**, **-l**
 
 Instead of providing the pod name or id, get logs of the last created pod. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--names**, **-n**
+@@option names
 
-Output the container names instead of the container IDs in the log.
+@@option since
 
-#### **--since**=*TIMESTAMP*
+@@option tail
 
-Show logs since TIMESTAMP. The --since option can be Unix timestamps, date formatted timestamps, or Go duration
-strings (e.g. 10m, 1h30m) computed relative to the client machine's time. Supported formats for date formatted
-time stamps include RFC3339Nano, RFC3339, 2006-01-02T15:04:05, 2006-01-02T15:04:05.999999999, 2006-01-02Z07:00,
-and 2006-01-02.
+@@option timestamps
 
-#### **--tail**=*LINES*
-
-Output the specified number of LINES at the end of the logs.  LINES must be an integer.  Defaults to -1,
-which prints all lines
-
-#### **--timestamps**, **-t**
-
-Show timestamps in the log outputs.  The default is false
-
-#### **--until**=*TIMESTAMP*
-
-Show logs until TIMESTAMP. The --until option can be Unix timestamps, date formatted timestamps, or Go duration
-strings (e.g. 10m, 1h30m) computed relative to the client machine's time. Supported formats for date formatted
-time stamps include RFC3339Nano, RFC3339, 2006-01-02T15:04:05, 2006-01-02T15:04:05.999999999, 2006-01-02Z07:00,
-and 2006-01-02.
+@@option until
 
 ## EXAMPLE
 


### PR DESCRIPTION
podman-logs and podman-pod-logs. Most of these were already
identical, needing no review. Exceptions:

  --follow : needed some container/pod tweaking. This is the
             only one that really needs careful review.

  --names  : I went with the longer version

Note that podman-events has --since and --until options too, but
those are too different to be combined here.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```