### PR TITLE
podman machine ssh handling

### DIFF
--- a/cmd/podman/machine/ssh.go
+++ b/cmd/podman/machine/ssh.go
@@ -101,7 +101,7 @@ func remoteConnectionUsername() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dest, _, err := cfg.ActiveDestination()
+	dest, _, _, err := cfg.ActiveDestination()
 	if err != nil {
 		return "", err
 	}

--- a/cmd/podman/system/connection/list.go
+++ b/cmd/podman/system/connection/list.go
@@ -105,8 +105,9 @@ func inspect(cmd *cobra.Command, args []string) error {
 		r := namedDestination{
 			Name: k,
 			Destination: config.Destination{
-				Identity: v.Identity,
-				URI:      v.URI,
+				Identity:  v.Identity,
+				URI:       v.URI,
+				IsMachine: v.IsMachine,
 			},
 			Default: def,
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.1.1
 	github.com/containers/buildah v1.27.1-0.20220921131114-d3064796af36
-	github.com/containers/common v0.49.2-0.20220920205255-8062f81c5497
+	github.com/containers/common v0.49.2-0.20220926195839-590004b80685
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.22.1-0.20220919112403-fe51f7ffca50
 	github.com/containers/ocicrypt v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,9 @@ github.com/containernetworking/plugins v1.1.1 h1:+AGfFigZ5TiQH00vhR8qPeSatj53eNG
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
 github.com/containers/buildah v1.27.1-0.20220921131114-d3064796af36 h1:LTSEbPUbs0slJSJ+IH6atAjYDe0IDzA0sPgBLjT1yAo=
 github.com/containers/buildah v1.27.1-0.20220921131114-d3064796af36/go.mod h1:cY3pGPyMmrNp/sEDK8ESoBOf4hoNovptZSI0oyo8eQM=
-github.com/containers/common v0.49.2-0.20220920205255-8062f81c5497 h1:LB9SxcAglqSAHiiHGacN1Abi0ZL9haJpQ1numVlqtxM=
 github.com/containers/common v0.49.2-0.20220920205255-8062f81c5497/go.mod h1:ZnhOPR/07UOkfIg5bezUpBilGjxEUdaeoUpu7gRBGc0=
+github.com/containers/common v0.49.2-0.20220926195839-590004b80685 h1:rutCgIKcew85mTUO0JTnh7XDXQfaTz/qQ3HyQHb0jZE=
+github.com/containers/common v0.49.2-0.20220926195839-590004b80685/go.mod h1:ZnhOPR/07UOkfIg5bezUpBilGjxEUdaeoUpu7gRBGc0=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.22.1-0.20220907162003-651744379993/go.mod h1:/Ruurd87C6Ap45t1PWNOD8+SGwiZbk79XCgs1iUTvYA=

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -59,7 +59,7 @@ func JoinURL(elements ...string) string {
 
 // NewConnection creates a new service connection without an identity
 func NewConnection(ctx context.Context, uri string) (context.Context, error) {
-	return NewConnectionWithIdentity(ctx, uri, "")
+	return NewConnectionWithIdentity(ctx, uri, "", false)
 }
 
 // NewConnectionWithIdentity takes a URI as a string and returns a context with the
@@ -70,7 +70,7 @@ func NewConnection(ctx context.Context, uri string) (context.Context, error) {
 // For example tcp://localhost:<port>
 // or unix:///run/podman/podman.sock
 // or ssh://<user>@<host>[:port]/run/podman/podman.sock?secure=True
-func NewConnectionWithIdentity(ctx context.Context, uri string, identity string) (context.Context, error) {
+func NewConnectionWithIdentity(ctx context.Context, uri string, identity string, machine bool) (context.Context, error) {
 	var (
 		err error
 	)
@@ -96,10 +96,11 @@ func NewConnectionWithIdentity(ctx context.Context, uri string, identity string)
 			return nil, err
 		}
 		conn, err := ssh.Dial(&ssh.ConnectionDialOptions{
-			Host:     uri,
-			Identity: identity,
-			User:     _url.User,
-			Port:     port,
+			Host:                        uri,
+			Identity:                    identity,
+			User:                        _url.User,
+			Port:                        port,
+			InsecureIsMachineConnection: machine,
 		}, "golang")
 		if err != nil {
 			return nil, err

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -54,4 +54,5 @@ type PodmanConfig struct {
 	StorageDriver string
 	StorageOpts   []string
 	SSHMode       string
+	MachineMode   bool
 }

--- a/pkg/domain/infra/runtime_abi.go
+++ b/pkg/domain/infra/runtime_abi.go
@@ -21,7 +21,7 @@ func NewContainerEngine(facts *entities.PodmanConfig) (entities.ContainerEngine,
 		r, err := NewLibpodRuntime(facts.FlagSet, facts)
 		return r, err
 	case entities.TunnelMode:
-		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), facts.URI, facts.Identity)
+		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), facts.URI, facts.Identity, facts.MachineMode)
 		return &tunnel.ContainerEngine{ClientCtx: ctx}, err
 	}
 	return nil, fmt.Errorf("runtime mode '%v' is not supported", facts.EngineMode)
@@ -35,7 +35,7 @@ func NewImageEngine(facts *entities.PodmanConfig) (entities.ImageEngine, error) 
 		return r, err
 	case entities.TunnelMode:
 		// TODO: look at me!
-		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), facts.URI, facts.Identity)
+		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), facts.URI, facts.Identity, facts.MachineMode)
 		return &tunnel.ImageEngine{ClientCtx: ctx}, err
 	}
 	return nil, fmt.Errorf("runtime mode '%v' is not supported", facts.EngineMode)

--- a/pkg/domain/infra/runtime_tunnel.go
+++ b/pkg/domain/infra/runtime_tunnel.go
@@ -18,12 +18,12 @@ var (
 	connection      *context.Context
 )
 
-func newConnection(uri string, identity string) (context.Context, error) {
+func newConnection(uri string, identity string, machine bool) (context.Context, error) {
 	connectionMutex.Lock()
 	defer connectionMutex.Unlock()
 
 	if connection == nil {
-		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), uri, identity)
+		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), uri, identity, machine)
 		if err != nil {
 			return ctx, err
 		}
@@ -37,7 +37,7 @@ func NewContainerEngine(facts *entities.PodmanConfig) (entities.ContainerEngine,
 	case entities.ABIMode:
 		return nil, fmt.Errorf("direct runtime not supported")
 	case entities.TunnelMode:
-		ctx, err := newConnection(facts.URI, facts.Identity)
+		ctx, err := newConnection(facts.URI, facts.Identity, facts.MachineMode)
 		return &tunnel.ContainerEngine{ClientCtx: ctx}, err
 	}
 	return nil, fmt.Errorf("runtime mode '%v' is not supported", facts.EngineMode)
@@ -49,7 +49,7 @@ func NewImageEngine(facts *entities.PodmanConfig) (entities.ImageEngine, error) 
 	case entities.ABIMode:
 		return nil, fmt.Errorf("direct image runtime not supported")
 	case entities.TunnelMode:
-		ctx, err := newConnection(facts.URI, facts.Identity)
+		ctx, err := newConnection(facts.URI, facts.Identity, facts.MachineMode)
 		return &tunnel.ImageEngine{ClientCtx: ctx}, err
 	}
 	return nil, fmt.Errorf("runtime mode '%v' is not supported", facts.EngineMode)

--- a/pkg/machine/connection.go
+++ b/pkg/machine/connection.go
@@ -25,7 +25,8 @@ func AddConnection(uri fmt.Stringer, name, identity string, isDefault bool) erro
 		cfg.Engine.ActiveService = name
 	}
 	dst := config.Destination{
-		URI: uri.String(),
+		URI:       uri.String(),
+		IsMachine: true,
 	}
 	dst.Identity = identity
 	if cfg.Engine.ServiceDestinations == nil {

--- a/pkg/machine/e2e/basic_test.go
+++ b/pkg/machine/e2e/basic_test.go
@@ -1,8 +1,6 @@
 package e2e_test
 
 import (
-	"os"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -24,10 +22,6 @@ var _ = Describe("run basic podman commands", func() {
 	It("Basic ops", func() {
 		// golangci-lint has trouble with actually skipping tests marked Skip
 		// so skip it on cirrus envs and where CIRRUS_CI isn't set.
-		if os.Getenv("CIRRUS_CI") != "false" {
-			Skip("FIXME: #15347 - ssh know hosts broken - fails on PR runs and on x86_64")
-		}
-
 		name := randomString()
 		i := new(initMachine)
 		session, err := mb.setName(name).setCmd(i.withImagePath(mb.imagePath).withNow()).run()

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -405,6 +405,7 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 		WritePath: v.getIgnitionFile(),
 		UID:       v.UID,
 	}
+
 	err = machine.NewIgnitionFile(ign)
 	return err == nil, err
 }
@@ -1033,7 +1034,7 @@ func (v *MachineVM) SSH(_ string, opts machine.SSHOptions) error {
 	sshDestination := username + "@localhost"
 	port := strconv.Itoa(v.Port)
 
-	args := []string{"-i", v.IdentityPath, "-p", port, sshDestination, "-o", "UserKnownHostsFile=/dev/null",
+	args := []string{"-i", v.IdentityPath, "-p", port, sshDestination,
 		"-o", "StrictHostKeyChecking=no", "-o", "LogLevel=ERROR", "-o", "SetEnv=LC_ALL="}
 	if len(opts.Args) > 0 {
 		args = append(args, opts.Args...)

--- a/vendor/github.com/containers/common/libimage/platform.go
+++ b/vendor/github.com/containers/common/libimage/platform.go
@@ -63,6 +63,9 @@ func toPlatformString(os, arch, variant string) string {
 //  * 2) a bool indicating whether architecture, os or variant were set (some callers need that to decide whether they need to throw an error)
 //  * 3) a fatal error that occurred prior to check for matches (e.g., storage errors etc.)
 func (i *Image) matchesPlatform(ctx context.Context, os, arch, variant string) (error, bool, error) {
+	if err := i.isCorrupted(""); err != nil {
+		return err, false, nil
+	}
 	inspectInfo, err := i.inspectInfo(ctx)
 	if err != nil {
 		return nil, false, fmt.Errorf("inspecting image: %w", err)

--- a/vendor/github.com/containers/common/pkg/ssh/types.go
+++ b/vendor/github.com/containers/common/pkg/ssh/types.go
@@ -27,12 +27,13 @@ type ConnectionCreateOptions struct {
 }
 
 type ConnectionDialOptions struct {
-	Host     string
-	Identity string
-	User     *url.Userinfo
-	Port     int
-	Auth     []string
-	Timeout  time.Duration
+	Host                        string
+	Identity                    string
+	User                        *url.Userinfo
+	Port                        int
+	Auth                        []string
+	Timeout                     time.Duration
+	InsecureIsMachineConnection bool
 }
 
 type ConnectionDialReport struct {

--- a/vendor/github.com/containers/common/pkg/ssh/utils.go
+++ b/vendor/github.com/containers/common/pkg/ssh/utils.go
@@ -21,6 +21,7 @@ func Validate(user *url.Userinfo, path string, port int, identity string) (*conf
 	if strings.Contains(path, "/run") {
 		sock = strings.Split(path, "/run")[1]
 	}
+	// url.Parse NEEDS ssh://, if this ever fails or returns some nonsense, that is why.
 	uri, err := url.Parse(path)
 	if err != nil {
 		return nil, nil, err
@@ -33,9 +34,9 @@ func Validate(user *url.Userinfo, path string, port int, identity string) (*conf
 
 	if uri.Port() == "" {
 		if port != 0 {
-			uri.Host = net.JoinHostPort(uri.Hostname(), strconv.Itoa(port))
+			uri.Host = net.JoinHostPort(uri.Host, strconv.Itoa(port))
 		} else {
-			uri.Host = net.JoinHostPort(uri.Hostname(), "22")
+			uri.Host = net.JoinHostPort(uri.Host, "22")
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -120,7 +120,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.49.2-0.20220920205255-8062f81c5497
+# github.com/containers/common v0.49.2-0.20220926195839-590004b80685
 ## explicit; go 1.17
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
add the key used in newly initialized machines to the user's known_hosts file. This ensures that golang will be able to ssh into the machine using
podman-remote. Also, remove the /dev/null redirection for podman machine ssh's known_hosts file.

resolves #15347

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
introduce the new ssh interface to podman machine, initializing new keys properly, and warning users about the upcoming change.
```
