### PR TITLE
Remove duplicate annotations in generated service yaml

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -267,6 +267,8 @@ func GenerateKubeServiceFromV1Pod(pod *v1.Pod, servicePorts []v1.ServicePort) (Y
 	}
 	service.Spec = serviceSpec
 	service.ObjectMeta = pod.ObjectMeta
+	// Reset the annotations for the service as the pod annotations are not needed for the service
+	service.ObjectMeta.Annotations = nil
 	tm := v12.TypeMeta{
 		Kind:       "Service",
 		APIVersion: pod.TypeMeta.APIVersion,


### PR DESCRIPTION
Don't add the same annotations as the pod yaml to the
service yaml as it is not needed.

Fixes https://github.com/containers/podman/issues/15208

[NO NEW TESTS NEEDED]

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
