### PR TITLE
APIv2 test cleanup, part 2 of 2

### DIFF
--- a/test/apiv2/12-imagesMore.at
+++ b/test/apiv2/12-imagesMore.at
@@ -3,9 +3,6 @@
 # Tests for more image-related endpoints
 #
 
-red='\e[31m'
-nc='\e[0m'
-
 start_registry
 
 podman pull -q $IMAGE
@@ -63,7 +60,9 @@ podman pull -q $IMAGE
 
 # test podman image SCP
 # ssh needs to work so we can validate that the failure is past argument parsing
-podman system connection add --default test ssh://$USER@localhost/run/user/$MYUID/podman/podman.sock
+conn=apiv2test-temp-connection
+podman system connection add --default $conn \
+       ssh://$USER@localhost/run/user/$UID/podman/podman.sock
 # should fail but need to check the output...
 # status 125 here means that the save/load fails due to
 # cirrus weirdness with exec.Command. All of the args have been parsed successfully.
@@ -71,5 +70,8 @@ t POST "libpod/images/scp/$IMAGE?destination=QA::" 500 \
     .cause="exit status 125"
 t DELETE libpod/images/$IMAGE 200 \
   .ExitCode=0
+
+# Clean up
+podman system connection rm $conn
 
 stop_registry

--- a/test/apiv2/23-containersArchive.at
+++ b/test/apiv2/23-containersArchive.at
@@ -3,9 +3,6 @@
 # test more container-related endpoints
 #
 
-red='\e[31m'
-nc='\e[0m'
-
 podman pull $IMAGE &>/dev/null
 
 # Ensure clean slate

--- a/test/apiv2/26-containersWait.at
+++ b/test/apiv2/26-containersWait.at
@@ -3,9 +3,6 @@
 # test more container-related endpoints
 #
 
-red='\e[31m'
-nc='\e[0m'
-
 podman pull "${IMAGE}" &>/dev/null
 
 # Ensure clean slate
@@ -21,29 +18,29 @@ t POST "containers/${CTR}/wait?condition=non-existent-cond" 400
 
 t POST "containers/${CTR}/wait?condition=not-running" 200
 
+# Test waiting for EXIT (need to start a background trigger first)
+(sleep 2;podman start "${CTR}") &
+child_pid=$!
+
+# This will block until the background job completes
 t POST "containers/${CTR}/wait?condition=next-exit" 200 \
   .StatusCode=0 \
-  .Error=null &
-child_pid=$!
-podman start "${CTR}"
+  .Error=null
 wait "${child_pid}"
 
-
-# check if headers are sent in advance before body
-WAIT_TEST_ERROR=""
-curl -I -X POST "http://$HOST:$PORT/containers/${CTR}/wait?condition=next-exit" &> "/dev/null" &
-child_pid=$!
-sleep 0.5
-if kill -2 "${child_pid}" 2> "/dev/null"; then
-  echo -e "${red}NOK: Failed to get response headers immediately.${nc}"  1>&2;
-  WAIT_TEST_ERROR="1"
+# Test that headers are sent before body. (We should actually never get a body)
+APIV2_TEST_EXPECT_TIMEOUT=2 t POST "containers/${CTR}/wait?condition=next-exit" 999
+like "$(<$WORKDIR/curl.headers.out)" ".*HTTP.* 200 OK.*" \
+     "Received headers from /wait"
+if [[ -e $WORKDIR/curl.result.out ]]; then
+    _show_ok 0 "UNEXPECTED: curl on /wait returned results"
 fi
 
-t POST "containers/${CTR}/wait?condition=removed" 200 &
+# Test waiting for REMOVE. Like above, start a background trigger.
+(sleep 2;podman container rm "${CTR}") &
 child_pid=$!
-podman container rm "${CTR}"
+
+t POST "containers/${CTR}/wait?condition=removed" 200 \
+  .StatusCode=0 \
+  .Error=null
 wait "${child_pid}"
-
-if [[ "${WAIT_TEST_ERROR}" ]] ; then
-  exit 1;
-fi

--- a/test/apiv2/40-pods.at
+++ b/test/apiv2/40-pods.at
@@ -134,23 +134,17 @@ t GET libpod/pods/json?filters='{"label":["testl' 400 \
 t DELETE  libpod/pods/foo 200
 t DELETE "libpod/pods/foo (pod has already been deleted)" 404
 
-t_timeout 5 GET "libpod/pods/stats?stream=true&delay=1" 200
+# Expect this to time out
+APIV2_TEST_EXPECT_TIMEOUT=5 t GET "libpod/pods/stats?stream=true&delay=1" 999
 
 podman pod create --name=specgen
 
 TMPD=$(mktemp -d podman-apiv2-test.build.XXXXXXXX)
 
-podman generate spec -f ${TMPD}/input.txt -c specgen
+podman generate spec -f ${TMPD}/myspec.json -c specgen
 
-curl -XPOST -o ${TMPD}/response.txt --dump-header ${TMPD}/headers.txt -H content-type:application/json http://$HOST:$PORT/v4.0.0/libpod/pods/create -d "@${TMPD}/input.txt"
-
-if ! grep -q '201 Created' "${TMPD}/headers.txt"; then
-    cat "${TMPD}/headers.txt"
-    cat "${TMPD}/response.txt"
-    echo -e "${red}NOK: pod create failed"
-    rm -rf $TMPD
-    exit 1
-fi
+t POST libpod/pods/create ${TMPD}/myspec.json 201 \
+  .Id~[0-9a-f]\\{64\\}
 
 rm -rf $TMPD
 

--- a/test/apiv2/70-short-names.at
+++ b/test/apiv2/70-short-names.at
@@ -33,18 +33,8 @@ RUN  touch /foo
 EOF
     tar --format=posix -C $TMPD -cvf ${CONTAINERFILE_TAR} containerfile &> /dev/null
 
-    curl -XPOST --data-binary @<(cat $CONTAINERFILE_TAR) \
-        -H "content-type: application/x-tar" \
-        --dump-header "${TMPD}/headers.txt" \
-        -o "${TMPD}/response.txt" \
-        "http://$HOST:$PORT/build?dockerfile=containerfile&t=$tag" &> /dev/null
-
-    if ! grep -q '200 OK' "${TMPD}/headers.txt"; then
-        cat "${TMPD}/headers.txt"
-        cat "${TMPD}/response.txt"
-        echo -e "${red}NOK: Image build from tar failed response was not 200 OK (application/x-tar)"
-        exit 1
-    fi
+    t POST "/build?dockerfile=containerfile&t=$tag" $CONTAINERFILE_TAR 200 \
+      .stream~".*Successfully tagged .*"
 
     rm -rf $TMPD
     t DELETE "images/$fqn" 200

--- a/test/apiv2/README.md
+++ b/test/apiv2/README.md
@@ -46,6 +46,9 @@ with POST parameters if present, and compares return status and
            |                     +----------- POST params
            +--------------------------------- note the missing slash
 
+Never, ever, ever, seriously _EVER_ `exit` from a test. Just don't.
+That skips cleanup, and leaves the system in a broken state.
+
 Notes:
 
 * If the endpoint has a leading slash (`/_ping`), `t` leaves it unchanged.
@@ -61,14 +64,19 @@ of POST parameters in the form 'key=value', separated by spaces:
 `t` will convert the param list to JSON form for passing to the server.
 A numeric status code terminates processing of POST parameters.
 ** As a special case, when one POST argument is a string ending in `.tar`,
-`t` will invoke `curl` with `--data-binary @PATH` and
-set `Content-type: application/x-tar`. This is useful for `build` endpoints.
+`.yaml`, or `.json`, `t` will invoke `curl` with `--data-binary @PATH` and
+set `Content-type` as appropriate. This is useful for `build` endpoints.
 (To override `Content-type`, simply pass along an extra string argument
 matching `application/*`):
       t POST myentrypoint /mytmpdir/myfile.tar application/foo 400
+** Like above, when using PUT, `t` does `--upload-time` instead of
+`--data-binary`
 
 * The final arguments are one or more expected string results. If an
 argument starts with a dot, `t` will invoke `jq` on the output to
 fetch that field, and will compare it to the right-hand side of
 the argument. If the separator is `=` (equals), `t` will require
 an exact match; if `~` (tilde), `t` will use `expr` to compare.
+
+* If your test expects `curl` to time out:
+     APIV2_TEST_EXPECT_TIMEOUT=5 t POST /foo 999

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -23,8 +23,6 @@ REGISTRY_IMAGE="${PODMAN_TEST_IMAGE_REGISTRY}/${PODMAN_TEST_IMAGE_USER}/registry
 ###############################################################################
 # BEGIN setup
 
-USER=$PODMAN_ROOTLESS_USER
-MYUID=$PODMAN_ROOTLESS_UID
 TMPDIR=${TMPDIR:-/tmp}
 WORKDIR=$(mktemp --tmpdir -d $ME.tmp.XXXXXX)
 
@@ -55,9 +53,6 @@ fi
 
 # Path to podman binary
 PODMAN_BIN=${PODMAN:-${CONTAINERS_HELPER_BINARY_DIR}/podman}
-
-# Timeout for streamed responses
-CURL_TIMEOUT=0
 
 # Cleanup handlers
 clean_up_server() {
@@ -221,21 +216,6 @@ function jsonify() {
 }
 
 #######
-#  t_timeout  #  Timeout wrapper for test helper
-#######
-function t_timeout() {
-    CURL_TIMEOUT=$1; shift
-    local min_runtime=$((CURL_TIMEOUT - 1))
-    start=`date +%s`
-    t $@
-    local end=`date +%s`
-    local runtime=$((end-start))
-    if ! [[ "$runtime" -ge "$min_runtime" ]]; then
-        die "Error: Streaming time should be greater or equal to '$min_runtime'"
-    fi
-}
-
-#######
 #  t  #  Main test helper
 #######
 function t() {
@@ -246,11 +226,6 @@ function t() {
 
     local testname="$method $path"
 
-    if [[ $CURL_TIMEOUT != 0 ]]; then
-        local c_timeout=$CURL_TIMEOUT
-        curl_args+=("-m $CURL_TIMEOUT")
-        CURL_TIMEOUT=0 # 'consume' timeout
-    fi
     # POST and PUT requests may be followed by one or more key=value pairs.
     # Slurp the command line until we see a 3-digit status code.
     if [[ $method = "POST" || $method == "PUT" || $method = "DELETE" ]]; then
@@ -312,6 +287,11 @@ function t() {
         curl_args+=("--head")
     fi
 
+    # If this is set, we're *expecting* curl to time out
+    if [[ -n "$APIV2_TEST_EXPECT_TIMEOUT" ]]; then
+        curl_args+=("-m" $APIV2_TEST_EXPECT_TIMEOUT)
+    fi
+
     local expected_code=$1; shift
 
     # Log every action we do
@@ -327,8 +307,19 @@ function t() {
                     --write-out '%{http_code}^%{content_type}^%{time_total}' \
                     -o $WORKDIR/curl.result.out "$url"); rc=$?; } || :
 
+    # Special case: this means we *expect and want* a timeout
+    if [[ -n "$APIV2_TEST_EXPECT_TIMEOUT" ]]; then
+        # Hardcoded. See curl(1) for list of exit codes
+        if [[ $rc -eq 28 ]]; then
+            _show_ok 1 "$testname: curl timed out (expected)"
+        else
+            _show_ok 0 "$testname: expected curl to time out; it did not"
+        fi
+        return
+    fi
+
     # Any error from curl is instant bad news, from which we can't recover
-    if [[ $rc -ne 0 ]] && [[ $c_timeout -eq 0 ]]; then
+    if [[ $rc -ne 0 ]]; then
         die "curl failure ($rc) on $url - cannot continue"
     fi
 


### PR DESCRIPTION
This finishes the removal of curls and exits.

Please please please, everyone, if you see a 'curl' or 'exit'
in any new PR, reject the PR and tell me immediately so I can
help the developer do it the proper way.

Also, removed some very-very-wrong USER/UID code. Both are
reserved variables in bash. You cannot override them.

Also, added a cleanup to a system-connection test. I wasted
a lot of time because my podman-remote stopped working, all
because I had run this test as part of something unrelated.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```