### PR TITLE
Compat API image remove events now have 'delete' status

### DIFF
--- a/pkg/api/handlers/compat/events.go
+++ b/pkg/api/handlers/compat/events.go
@@ -89,6 +89,12 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 			}
 
 			e := entities.ConvertToEntitiesEvent(*evt)
+			// Some events differ between Libpod and Docker endpoints.
+			// Handle these differences for Docker-compat.
+			if !utils.IsLibpodRequest(r) && e.Type == "image" && e.Status == "remove" {
+				e.Status = "delete"
+				e.Action = "delete"
+			}
 			if !utils.IsLibpodRequest(r) && e.Status == "died" {
 				e.Status = "die"
 				e.Action = "die"

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -239,4 +239,23 @@ fi
 
 cleanBuildTest
 
+# compat API vs libpod API event differences:
+# on image removal, libpod produces 'remove' events.
+# compat produces 'delete' events.
+podman image build -t test:test -<<EOF
+from $IMAGE
+EOF
+
+START=$(date +%s)
+
+t DELETE libpod/images/test:test 200
+# HACK HACK HACK There is a race around events being added to the journal
+# This sleep seems to avoid the race.
+# If it fails and begins to flake, investigate a retry loop.
+sleep 1
+t GET "libpod/events?stream=false&since=$START"  200  \
+  'select(.status | contains("remove")).Action=remove'
+t GET "events?stream=false&since=$START"  200  \
+  'select(.status | contains("delete")).Action=delete'
+
 # vim: filetype=sh


### PR DESCRIPTION
Change only the compat API, so we don't force a breaking change on Libpod API users.

Partial fix for #15485

```release-note
Fixed a bug where the Compat Events endpoint set an incorrect status for image removal events (`remove` instead of `delete`)
```
