### PR TITLE
[CI:DOCS] Automatically set podman version in pkginstaller

### DIFF
--- a/contrib/pkginstaller/Makefile
+++ b/contrib/pkginstaller/Makefile
@@ -1,7 +1,6 @@
 SHELL := bash
 
 ARCH ?= aarch64
-PODMAN_VERSION ?= 4.1.0
 GVPROXY_VERSION ?= 0.4.0
 QEMU_VERSION ?= 7.0.0-2
 GVPROXY_RELEASE_URL ?= https://github.com/containers/gvisor-tap-vsock/releases/download/v$(GVPROXY_VERSION)/gvproxy-darwin
@@ -13,6 +12,9 @@ PKG_NAME := podman-installer-macos-$(ARCH).pkg
 
 default: pkginstaller
 
+podman_version:
+	make -C ../../ test/version/version
+
 $(TMP_DOWNLOAD)/gvproxy:
 	mkdir -p $(TMP_DOWNLOAD)
 	cd $(TMP_DOWNLOAD) && curl -sLo gvproxy $(GVPROXY_RELEASE_URL)
@@ -21,7 +23,7 @@ $(TMP_DOWNLOAD)/podman-machine-qemu-$(ARCH)-$(QEMU_VERSION).tar.xz:
 	mkdir -p $(TMP_DOWNLOAD)
 	cd $(TMP_DOWNLOAD) && curl -sLO $(QEMU_RELEASE_URL)
 
-packagedir: package_root Distribution welcome.html
+packagedir: podman_version package_root Distribution welcome.html
 	mkdir -p $(PACKAGE_DIR)
 	cp -r Resources $(PACKAGE_DIR)/
 	cp welcome.html $(PACKAGE_DIR)/Resources/
@@ -30,7 +32,7 @@ packagedir: package_root Distribution welcome.html
 	cp -r $(PACKAGE_ROOT) $(PACKAGE_DIR)/
 	cp package.sh $(PACKAGE_DIR)/
 	cd $(PACKAGE_DIR) && pkgbuild --analyze --root ./root component.plist
-	echo -n $(PODMAN_VERSION) > $(PACKAGE_DIR)/VERSION
+	../../test/version/version > $(PACKAGE_DIR)/VERSION
 	echo -n $(ARCH) > $(PACKAGE_DIR)/ARCH
 	cp ../../LICENSE $(PACKAGE_DIR)/Resources/LICENSE.txt
 	cp hvf.entitlements $(PACKAGE_DIR)/
@@ -41,8 +43,8 @@ package_root: clean-pkgroot $(TMP_DOWNLOAD)/podman-machine-qemu-$(ARCH)-$(QEMU_V
 	cp $(TMP_DOWNLOAD)/gvproxy $(PACKAGE_ROOT)/podman/bin/
 	chmod a+x $(PACKAGE_ROOT)/podman/bin/*
 
-%: %.in
-	@sed -e 's/__VERSION__/'$(PODMAN_VERSION)'/g' $< >$@
+%: %.in podman_version
+	@sed -e 's/__VERSION__/'$(shell ../../test/version/version)'/g' $< >$@
 
 pkginstaller: packagedir
 	cd $(PACKAGE_DIR) && ./package.sh ..
@@ -55,7 +57,7 @@ notarize: _notarize
 
 .PHONY: clean clean-pkgroot
 clean:
-	rm -rf $(TMP_DOWNLOAD) $(PACKAGE_ROOT) $(PACKAGE_DIR) Distribution welcome.html
+	rm -rf $(TMP_DOWNLOAD) $(PACKAGE_ROOT) $(PACKAGE_DIR) Distribution welcome.html ../../test/version/version
 
 clean-pkgroot:
 	rm -rf $(PACKAGE_ROOT) $(PACKAGE_DIR) Distribution welcome.html


### PR DESCRIPTION
Allow the pkginstaller makefile target to take advantage of Podman's version binary, alleviating the need to manually set Podman's version (and inevitably forgetting to do so). This means the pkginstaller Makefile will automatically detect what version of Podman we're packaging.

Closes: https://github.com/containers/podman/issues/15406

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
