### PR TITLE
service: make move to sub-cgroup non fatal

### DIFF
--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -105,7 +105,9 @@ func restService(flags *pflag.FlagSet, cfg *entities.PodmanConfig, opts entities
 	}
 
 	if err := utils.MaybeMoveToSubCgroup(); err != nil {
-		return err
+		// it is a best effort operation, so just print the
+		// error for debugging purposes.
+		logrus.Debugf("Could not move to subcgroup: %v", err)
 	}
 
 	servicereaper.Start()


### PR DESCRIPTION
if we are running in a container in the root cgroup, Podman tries to
move itself to a sub-cgroup.  This could be a problem in a setup where
the cgroups are not writeable, so just log a debug message and
continue, since anyway it is a best-effort operation.

Closes: https://github.com/containers/podman/issues/15498

[NO NEW TESTS NEEDED]

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
