### PR TITLE
[CI:DOCS] Fix example sections to follow the same format

### DIFF
--- a/docs/source/markdown/podman-pod-restart.1.md
+++ b/docs/source/markdown/podman-pod-restart.1.md
@@ -24,17 +24,27 @@ Instead of providing the pod name or ID, restart the last created pod. (This opt
 
 ## EXAMPLE
 
+Restart pod with a given name
 ```
 podman pod restart mywebserverpod
 cc8f0bea67b1a1a11aec1ecd38102a1be4b145577f21fc843c7c83b77fc28907
+```
 
+Restart multiple pods with given IDs
+```
 podman pod restart 490eb 3557fb
 490eb241aaf704d4dd2629904410fe4aa31965d9310a735f8755267f4ded1de5
 3557fbea6ad61569de0506fe037479bd9896603c31d3069a6677f23833916fab
+```
 
+Restart the last created pod
+```
 podman pod restart --latest
 3557fbea6ad61569de0506fe037479bd9896603c31d3069a6677f23833916fab
+```
 
+Restart all pods
+```
 podman pod restart --all
 19456b4cd557eaf9629825113a552681a6013f8c8cad258e36ab825ef536e818
 3557fbea6ad61569de0506fe037479bd9896603c31d3069a6677f23833916fab
@@ -42,7 +52,6 @@ podman pod restart --all
 70c358daecf71ef9be8f62404f926080ca0133277ef7ce4f6aa2d5af6bb2d3e9
 cc8f0bea67b1a1a11aec1ecd38102a1be4b145577f21fc843c7c83b77fc28907
 ```
-
 ## SEE ALSO
 **[podman(1)](podman.1.md)**, **[podman-pod(1)](podman-pod.1.md)**, **[podman-restart(1)](podman-restart.1.md)**
 

--- a/docs/source/markdown/podman-pod-stop.1.md.in
+++ b/docs/source/markdown/podman-pod-stop.1.md.in
@@ -29,20 +29,20 @@ Seconds to wait before forcibly stopping the containers in the pod.
 
 ## EXAMPLE
 
-Stop a pod called *mywebserverpod*
+Stop pod with a given name
 ```
 $ podman pod stop mywebserverpod
 cc8f0bea67b1a1a11aec1ecd38102a1be4b145577f21fc843c7c83b77fc28907
 ```
 
-Stop two pods by their short IDs.
+Stop multiple pods with given IDs.
 ```
 $ podman pod stop 490eb 3557fb
 490eb241aaf704d4dd2629904410fe4aa31965d9310a735f8755267f4ded1de5
 3557fbea6ad61569de0506fe037479bd9896603c31d3069a6677f23833916fab
 ```
 
-Stop the most recent pod
+Stop the last created pod
 ```
 $ podman pod stop --latest
 3557fbea6ad61569de0506fe037479bd9896603c31d3069a6677f23833916fab
@@ -65,7 +65,7 @@ $ podman pod stop --pod-id-file file1 --pod-id-file file2
 cc8f0bea67b1a1a11aec1ecd38102a1be4b145577f21fc843c7c83b77fc28907
 ```
 
-Stop all pods with a timeout of 1 second.
+Stop all pods with a timeout of 1 second
 ```
 $ podman pod stop -a -t 1
 3557fbea6ad61569de0506fe037479bd9896603c31d3069a6677f23833916fab

--- a/docs/source/markdown/podman-rename.1.md
+++ b/docs/source/markdown/podman-rename.1.md
@@ -19,18 +19,18 @@ At present, only containers are supported; pods and volumes cannot be renamed.
 
 ## EXAMPLES
 
+Rename container with a given name
 ```
-# Rename a container by name
 $ podman rename oldContainer aNewName
 ```
 
+Rename container with a given ID
 ```
-# Rename a container by ID
 $ podman rename 717716c00a6b testcontainer
 ```
 
+Create an alias for container with a given ID
 ```
-# Use the container rename alias
 $ podman container rename 6e7514b47180 databaseCtr
 ```
 

--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -73,37 +73,37 @@ Remove anonymous volumes associated with the container. This does not include na
 created with **podman volume create**, or the **--volume** option of **podman run** and **podman create**.
 
 ## EXAMPLE
-Remove a container by its name *mywebserver*
+Remove container with a given name
 ```
 $ podman rm mywebserver
 ```
 
-Remove a *mywebserver* container and all of the containers that depend on it
+Remove container with a given name and all of the containers that depend on it
 ```
 $ podman rm --depend mywebserver
 ```
 
-Remove several containers by name and container id.
+Remove multiple containers with given names or IDs
 ```
 $ podman rm mywebserver myflaskserver 860a4b23
 ```
 
-Remove several containers reading their IDs from files.
+Remove multiple containers with IDs read from files
 ```
 $ podman rm --cidfile ./cidfile-1 --cidfile /home/user/cidfile-2
 ```
 
-Forcibly remove a container by container ID.
+Forcibly remove container with a given ID
 ```
 $ podman rm -f 860a4b23
 ```
 
-Remove all containers regardless of its run state.
+Remove all containers regardless of the run state
 ```
 $ podman rm -f -a
 ```
 
-Forcibly remove the latest container created.
+Forcibly remove the last created container
 ```
 $ podman rm -f --latest
 ```


### PR DESCRIPTION
This commit adjusts example sections across several man pages to the format seen in other pages.
Follow up PR #13786, #13682 and #13771.

```release-note
None
```