### PR TITLE
Handle an already connected network in libpod API

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -1278,7 +1278,7 @@ func (s *BoltState) NetworkConnect(ctr *Container, network string, opts types.Pe
 		}
 		netConnected := ctrNetworksBkt.Get([]byte(network))
 		if netConnected != nil {
-			return fmt.Errorf("container %s is already connected to network %q: %w", ctr.ID(), network, define.ErrNetworkExists)
+			return fmt.Errorf("container %s is already connected to network %q: %w", ctr.ID(), network, define.ErrNetworkConnected)
 		}
 
 		// Add the network

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -179,6 +179,9 @@ var (
 	// ErrNetworkInUse indicates the requested operation failed because the network was in use
 	ErrNetworkInUse = errors.New("network is being used")
 
+	// ErrNetworkConnected indicates that the required operation failed because the container is already a network endpoint
+	ErrNetworkConnected = errors.New("network is already connected")
+
 	// ErrStoreNotInitialized indicates that the container storage was never
 	// initialized.
 	ErrStoreNotInitialized = errors.New("the container storage was never initialized")

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -1357,6 +1357,11 @@ func (c *Container) NetworkConnect(nameOrID, netName string, netOpts types.PerNe
 	}
 
 	if err := c.runtime.state.NetworkConnect(c, netName, netOpts); err != nil {
+		// Docker compat: treat requests to attach already attached networks as a no-op, ignoring opts
+		if errors.Is(err, define.ErrNetworkConnected) && c.ensureState(define.ContainerStateConfigured) {
+			return nil
+		}
+
 		return err
 	}
 	c.newNetworkEvent(events.NetworkConnect, netName)

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(con.ErrorToString()).To(ContainSubstring(`"slirp4netns" is not supported: invalid network mode`))
 	})
 
-	It("podman connect on a container that already is connected to the network should error", func() {
+	It("podman connect on a container that already is connected to the network should error after init", func() {
 		netName := "aliasTest" + stringid.GenerateNonCryptoID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
@@ -177,7 +177,15 @@ var _ = Describe("Podman network connect and disconnect", func() {
 
 		con := podmanTest.Podman([]string{"network", "connect", netName, "test"})
 		con.WaitWithDefaultTimeout()
-		Expect(con).Should(ExitWithError())
+		Expect(con).Should(Exit(0))
+
+		init := podmanTest.Podman([]string{"init", "test"})
+		init.WaitWithDefaultTimeout()
+		Expect(init).Should(Exit(0))
+
+		con2 := podmanTest.Podman([]string{"network", "connect", netName, "test"})
+		con2.WaitWithDefaultTimeout()
+		Expect(con2).Should(ExitWithError())
 	})
 
 	It("podman network connect", func() {


### PR DESCRIPTION
Signed-off-by: Alessandro Rossi <al.rossi87@gmail.com>
The PR introduces a new "ErrNetworkConnected" error in libpod defines, to handle the specific case where a user tries to connect a container to a network that is already connected to it.

The user from the CLI will still receive an error, but since from API point of view the operation results in nothing to be done and the state is preserved, it should return 200, aligned with the behavior that docker has.

This should address #15499

#### Does this PR introduce a user-facing change?
None

```release-note
ErrNetworkConnected was introduced for when trying to connect a container to a network it is already connected to

```
