### PR TITLE
api: support build `--hooks-dir` for API

### DIFF
--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -192,6 +192,7 @@ func buildFlags(cmd *cobra.Command) {
 		_ = flags.MarkHidden("volume")
 		_ = flags.MarkHidden("output")
 		_ = flags.MarkHidden("logsplit")
+		_ = flags.MarkHidden("hooks-dir")
 	}
 }
 

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -115,6 +115,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		Memory                  int64    `schema:"memory"`
 		NamespaceOptions        string   `schema:"nsoptions"`
 		NoCache                 bool     `schema:"nocache"`
+		OCIHooksDir             string   `schema:"ocihooksdir"`
 		OmitHistory             bool     `schema:"omithistory"`
 		OSFeatures              []string `schema:"osfeature"`
 		OSVersion               string   `schema:"osversion"`
@@ -294,6 +295,16 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		dnssearch = m
+	}
+
+	var ociHooksDir = []string{}
+	if _, found := r.URL.Query()["ocihooksdir"]; found {
+		var m = []string{}
+		if err := json.Unmarshal([]byte(query.OCIHooksDir), &m); err != nil {
+			utils.BadRequest(w, "ocihooksdir", query.OCIHooksDir, err)
+			return
+		}
+		ociHooksDir = m
 	}
 
 	var secrets = []string{}
@@ -637,6 +648,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 			LabelOpts:          labelOpts,
 			Memory:             query.Memory,
 			MemorySwap:         query.MemSwap,
+			OCIHooksDir:        ociHooksDir,
 			OmitHistory:        query.OmitHistory,
 			SeccompProfilePath: seccomp,
 			ShmSize:            strconv.Itoa(query.ShmSize),

--- a/pkg/bindings/images/build.go
+++ b/pkg/bindings/images/build.go
@@ -161,6 +161,14 @@ func Build(ctx context.Context, containerFiles []string, options entities.BuildO
 		params.Add("dnssearch", c)
 	}
 
+	if ociHooksDir := options.CommonBuildOpts.OCIHooksDir; len(ociHooksDir) > 0 {
+		c, err := jsoniter.MarshalToString(ociHooksDir)
+		if err != nil {
+			return nil, err
+		}
+		params.Add("ocihooksdir", c)
+	}
+
 	if caps := options.DropCapabilities; len(caps) > 0 {
 		c, err := jsoniter.MarshalToString(caps)
 		if err != nil {


### PR DESCRIPTION
Build API now accepts `ocihooksdir` expecting that hooks script and configuration
json file is already present on server side.

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]
Not sure if this is easily testable in CI

See: https://github.com/containers/buildah/issues/4068#issuecomment-1226047477

```release-note
api: support build `ocihooksdir` for API
```