### PR TITLE
[CI:DOCS] Man pages: refactor common options: --dns-*

### DIFF
--- a/docs/source/markdown/options/dns-opt.container.md
+++ b/docs/source/markdown/options/dns-opt.container.md
@@ -1,0 +1,3 @@
+#### **--dns-opt**=*option*
+
+Set custom DNS options. Invalid if using **--dns-opt** with **--network** that is set to **none** or **container:**_id_.

--- a/docs/source/markdown/options/dns-search.container.md
+++ b/docs/source/markdown/options/dns-search.container.md
@@ -1,0 +1,4 @@
+#### **--dns-search**=*domain*
+
+Set custom DNS search domains. Invalid if using **--dns-search** with **--network** that is set to **none** or **container:**_id_.
+Use **--dns-search=.** if you don't wish to set the search domain.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -184,13 +184,9 @@ is the case the **--dns** flag is necessary for every run.
 The special value **none** can be specified to disable creation of **/etc/resolv.conf** in the container by Podman.
 The **/etc/resolv.conf** file in the image will be used without changes.
 
-#### **--dns-opt**=*option*
+@@option dns-opt.container
 
-Set custom DNS options. Invalid if using **--dns-opt** and **--network** that is set to 'none' or `container:<name|id>`.
-
-#### **--dns-search**=*domain*
-
-Set custom DNS search domains. Invalid if using **--dns-search** and **--network** that is set to 'none' or `container:<name|id>`. (Use --dns-search=. if you don't wish to set the search domain)
+@@option dns-search.container
 
 @@option entrypoint
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -218,14 +218,9 @@ is the case the **--dns** flag is necessary for every run.
 The special value **none** can be specified to disable creation of _/etc/resolv.conf_ in the container by Podman.
 The _/etc/resolv.conf_ file in the image will be used without changes.
 
-#### **--dns-opt**=*option*
+@@option dns-opt.container
 
-Set custom DNS options. Invalid if using **--dns-opt** with **--network** that is set to **none** or **container:**_id_.
-
-#### **--dns-search**=*domain*
-
-Set custom DNS search domains. Invalid if using **--dns-search** and **--network** that is set to **none** or **container:**_id_.
-Use **--dns-search=.** if you don't wish to set the search domain.
+@@option dns-search.container
 
 @@option entrypoint
 


### PR DESCRIPTION
--dns-opt and --dns-search, but only in podman-create and -run.
Went with the -run version in both cases; --dns-opt remained
unchanged, but in --dns-search I changed 'and' to 'with'.

Did not consolidate podman-build or podman-pod-create: too
different.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```