### PR TITLE
libpod: Make sure writeConmonPipeData is called on FreeBSD

### DIFF
--- a/libpod/oci_conmon_freebsd.go
+++ b/libpod/oci_conmon_freebsd.go
@@ -19,6 +19,9 @@ func (r *ConmonOCIRuntime) withContainerSocketLabel(ctr *Container, closure func
 // moveConmonToCgroupAndSignal gets a container's cgroupParent and moves the conmon process to that cgroup
 // it then signals for conmon to start by sending nonce data down the start fd
 func (r *ConmonOCIRuntime) moveConmonToCgroupAndSignal(ctr *Container, cmd *exec.Cmd, startFd *os.File) error {
-	// No equivalent on FreeBSD
+	// No equivalent to cgroup on FreeBSD, just signal conmon to start
+	if err := writeConmonPipeData(startFd); err != nil {
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
I managed to miss this while factoring out moveConmonToCgroupAndSignal.
Perhaps the signalling part should move to the caller instead?

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### Does this PR introduce a user-facing change?

```release-note
None
```
