### PR TITLE
[CI:DOCS] Man pages: refactor common options: --http-proxy

### DIFF
--- a/docs/source/markdown/options/http-proxy.md
+++ b/docs/source/markdown/options/http-proxy.md
@@ -1,0 +1,15 @@
+#### **--http-proxy**
+
+By default proxy environment variables are passed into the container if set
+for the Podman process. This can be disabled by setting the value to **false**.
+The environment variables passed in include **http_proxy**,
+**https_proxy**, **ftp_proxy**, **no_proxy**, and also the upper case versions of
+those. This option is only needed when the host system must use a proxy but
+the container should not use any proxy. Proxy environment variables specified
+for the container in any other way will override the values that would have
+been passed through from the host. (Other ways to specify the proxy for the
+container include passing the values with the **--env** flag, or hard coding the
+proxy environment at container build time.)
+(This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+
+Defaults to **true**.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -230,25 +230,7 @@ Print usage statement
 
 @@option hostuser
 
-#### **--http-proxy**
-
-By default proxy environment variables are passed into the container if set
-for the Podman process. This can be disabled by setting the `--http-proxy`
-option to `false`. The environment variables passed in include `http_proxy`,
-`https_proxy`, `ftp_proxy`, `no_proxy`, and also the upper case versions of
-those. This option is only needed when the host system must use a proxy but
-the container should not use any proxy. Proxy environment variables specified
-for the container in any other way will override the values that would have
-been passed through from the host. (Other ways to specify the proxy for the
-container include passing the values with the `--env` flag, or hard coding the
-proxy environment at container build time.)  (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
-
-For example, to disable passing these environment variables from host to
-container:
-
-`--http-proxy=false`
-
-Defaults to `true`
+@@option http-proxy
 
 @@option image-volume
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -264,20 +264,7 @@ Print usage statement
 
 @@option hostuser
 
-#### **--http-proxy**
-
-By default proxy environment variables are passed into the container if set
-for the Podman process. This can be disabled by setting the value to **false**.
-The environment variables passed in include **http_proxy**,
-**https_proxy**, **ftp_proxy**, **no_proxy**, and also the upper case versions of
-those. This option is only needed when the host system must use a proxy but
-the container should not use any proxy. Proxy environment variables specified
-for the container in any other way will override the values that would have
-been passed through from the host. (Other ways to specify the proxy for the
-container include passing the values with the **--env** flag, or hard coding the
-proxy environment at container build time.) (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
-
-Defaults to **true**.
+@@option http-proxy
 
 @@option image-volume
 


### PR DESCRIPTION
Only between podman-create and -run. (podman-build is too
different). I went with the podman-run version.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```