### PR TITLE
e2e tests: try to deflake 5000

### DIFF
--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -550,6 +550,11 @@ var _ = Describe("Podman generate kube", func() {
 
 	It("podman generate kube on pod with ports", func() {
 		podName := "test"
+
+		lock4 := GetPortLock("4000")
+		defer lock4.Unlock()
+		lock5 := GetPortLock("5000")
+		defer lock5.Unlock()
 		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName, "-p", "4000:4000", "-p", "5000:5000"})
 		podSession.WaitWithDefaultTimeout()
 		Expect(podSession).Should(Exit(0))

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2482,7 +2482,7 @@ spec:
 
 	It("podman play kube test with network portbindings", func() {
 		ip := "127.0.0.100"
-		port := "5000"
+		port := "8087"
 		ctr := getCtr(withHostIP(ip, port), withImage(BB))
 
 		pod := getPod(withCtr(ctr))
@@ -2496,7 +2496,7 @@ spec:
 		inspect := podmanTest.Podman([]string{"port", getCtrNameInPod(pod)})
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).Should(Exit(0))
-		Expect(inspect.OutputToString()).To(Equal("5000/tcp -> 127.0.0.100:5000"))
+		Expect(inspect.OutputToString()).To(Equal("8087/tcp -> 127.0.0.100:8087"))
 	})
 
 	It("podman play kube test with nonexistent empty HostPath type volume", func() {

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -153,6 +153,9 @@ var _ = Describe("Podman save", func() {
 		defer os.Setenv("GNUPGHOME", origGNUPGHOME)
 
 		port := 5000
+		portlock := GetPortLock(strconv.Itoa(port))
+		defer portlock.Unlock()
+
 		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", strings.Join([]string{strconv.Itoa(port), strconv.Itoa(port)}, ":"), REGISTRY_IMAGE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))


### PR DESCRIPTION
We keep getting flakes in tests that use port 5000. Try to
find and fix, by switching ports where possible, and locking
5000 when not possible (or not easy) to switch.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
none
```