### PR TITLE
[CI:DOCS] Man pages: refactor common options: --subXidname

### DIFF
--- a/docs/source/markdown/options/subgidname.md
+++ b/docs/source/markdown/options/subgidname.md
@@ -1,0 +1,5 @@
+#### **--subgidname**=*name*
+
+Run the container in a new user namespace using the map with _name_ in the _/etc/subgid_ file.
+If running rootless, the user needs to have the right to use the mapping. See **subgid**(5).
+This flag conflicts with **--userns** and **--gidmap**.

--- a/docs/source/markdown/options/subuidname.md
+++ b/docs/source/markdown/options/subuidname.md
@@ -1,0 +1,5 @@
+#### **--subuidname**=*name*
+
+Run the container in a new user namespace using the map with _name_ in the _/etc/subuid_ file.
+If running rootless, the user needs to have the right to use the mapping. See **subuid**(5).
+This flag conflicts with **--userns** and **--uidmap**.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -586,13 +586,9 @@ When size is `0`, there is no limit on the amount of memory used for IPC by the 
 
 @@option stop-timeout
 
-#### **--subgidname**=*name*
+@@option subgidname
 
-Name for GID map from the `/etc/subgid` file. Using this flag will run the container with user namespace enabled. This flag conflicts with `--userns` and `--gidmap`.
-
-#### **--subuidname**=*name*
-
-Name for UID map from the `/etc/subuid` file. Using this flag will run the container with user namespace enabled. This flag conflicts with `--userns` and `--uidmap`.
+@@option subuidname
 
 #### **--sysctl**=*SYSCTL*
 

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -146,13 +146,9 @@ When size is `0`, there is no limit on the amount of memory used for IPC by the 
 When set to true, this flag starts the newly created pod after the
 clone process has completed. All containers within the pod are started.
 
-#### **--subgidname**=*name*
+@@option subgidname
 
-Name for GID map from the `/etc/subgid` file. Using this flag will run the container with user namespace enabled. This flag conflicts with `--userns` and `--gidmap`.
-
-#### **--subuidname**=*name*
-
-Name for UID map from the `/etc/subuid` file. Using this flag will run the container with user namespace enabled. This flag conflicts with `--userns` and `--uidmap`.
+@@option subuidname
 
 #### **--sysctl**=*name=value*
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -287,14 +287,9 @@ Size of `/dev/shm` (format: `<number>[<unit>]`, where unit = b (bytes), k (kibib
 If the unit is omitted, the system uses bytes. If the size is omitted, the system uses `64m`.
 When size is `0`, there is no limit on the amount of memory used for IPC by the pod. This option conflicts with **--ipc=host** when running containers.
 
-#### **--subgidname**=*name*
+@@option subgidname
 
-Name for GID map from the `/etc/subgid` file. Using this flag will run the container with user namespace enabled. This flag conflicts with `--userns` and `--gidmap`.
-
-#### **--subuidname**=*name*
-
-Name for UID map from the `/etc/subuid` file. Using this flag will run the container with user namespace enabled. This flag conflicts with `--userns` and `--uidmap`.
-
+@@option subuidname
 
 #### **--sysctl**=*name=value*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -628,17 +628,9 @@ Sets whether the signals sent to the **podman run** command are proxied to the c
 
 @@option stop-timeout
 
-#### **--subgidname**=*name*
+@@option subgidname
 
-Run the container in a new user namespace using the map with _name_ in the _/etc/subgid_ file.
-If calling **podman run** as an unprivileged user, the user needs to have the right to use the mapping. See **subgid**(5).
-This flag conflicts with **--userns** and **--gidmap**.
-
-#### **--subuidname**=*name*
-
-Run the container in a new user namespace using the map with _name_ in the _/etc/subuid_ file.
-If calling **podman run** as an unprivileged user, the user needs to have the right to use the mapping. See **subuid**(5).
-This flag conflicts with **--userns** and **--uidmap**.
+@@option subuidname
 
 #### **--sysctl**=*name=value*
 


### PR DESCRIPTION
Whew! This one started off identical everywhere, but the version
in podman-run got fixed in #1380, then again in #5192, with no
corresponding fixes to any of the other man pages.

I went with the podman-run version, with a small change in wording.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```