### PR TITLE
Support auto updates for Kubernetes workloads

### DIFF
--- a/docs/source/markdown/podman-auto-update.1.md.in
+++ b/docs/source/markdown/podman-auto-update.1.md.in
@@ -29,6 +29,18 @@ This data is then being used in the auto-update sequence to instruct systemd (vi
 Note that **podman auto-update** relies on systemd. The systemd units are expected to be generated with **[podman-generate-systemd --new](podman-generate-systemd.1.md#--new)**, or similar units that create new containers in order to run the updated images.
 Systemd units that start and stop a container cannot run a new image.
 
+### Auto Updates and Kubernetes YAML
+
+Podman supports auto updates for Kubernetes workloads.  As mentioned above, `podman auto-update` requires the containers to be running systemd.  Podman ships with a systemd template that can be instantiated with a Kubernetes YAML file, see podman-generate-systemd(1).
+
+To enable auto updates for containers running in a Kubernetes workload, set the following Podman-specific annotations in the YAML:
+ * `io.containers.autoupdate: "registry|local"` to apply the auto-update policy to all containers
+ * `io.containers.autoupdate/$container: "registry|local"` to apply the auto-update policy to `$container` only
+ * `io.containers.sdnotify: "conmon|container"` to apply the sdnotify policy to all containers
+ * `io.containers.sdnotify/$container: "conmon|container"` to apply the sdnotify policy to `$container` only
+
+By default, the autoupdate policy is set to "disabled", the sdnotify policy is set to "conmon".
+
 ### Systemd Unit and Timer
 
 Podman ships with a `podman-auto-update.service` systemd unit. This unit is triggered daily at midnight by the `podman-auto-update.timer` systemd timer.  The timer can be altered for custom time-based updates if desired.  The unit can further be invoked by other systemd units (e.g., via the dependency tree) or manually via **systemctl start podman-auto-update.service**.

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -153,18 +153,19 @@ func AutoUpdate(ctx context.Context, runtime *libpod.Runtime, options entities.A
 	}
 
 	// Find auto-update tasks and assemble them by unit.
-	errors := auto.assembleTasks(ctx)
+	allErrors := auto.assembleTasks(ctx)
 
 	// Nothing to do.
 	if len(auto.unitToTasks) == 0 {
-		return nil, errors
+		return nil, allErrors
 	}
 
 	// Connect to DBUS.
 	conn, err := systemd.ConnectToDBUS()
 	if err != nil {
 		logrus.Errorf(err.Error())
-		return nil, []error{err}
+		allErrors = append(allErrors, err)
+		return nil, allErrors
 	}
 	defer conn.Close()
 	auto.conn = conn
@@ -174,72 +175,96 @@ func AutoUpdate(ctx context.Context, runtime *libpod.Runtime, options entities.A
 	// Update all images/container according to their auto-update policy.
 	var allReports []*entities.AutoUpdateReport
 	for unit, tasks := range auto.unitToTasks {
-		// Sanity check: we'll support that in the future.
-		if len(tasks) != 1 {
-			errors = append(errors, fmt.Errorf("only 1 task per unit supported but unit %s has %d", unit, len(tasks)))
-			return nil, errors
-		}
-
+		unitErrors := auto.updateUnit(ctx, unit, tasks)
+		allErrors = append(allErrors, unitErrors...)
 		for _, task := range tasks {
-			err := func() error {
-				// Transition from state to state.  Will be
-				// split into multiple loops in the future to
-				// support more than one container/task per
-				// unit.
-				updateAvailable, err := task.updateAvailable(ctx)
-				if err != nil {
-					task.status = statusFailed
-					return fmt.Errorf("checking image updates for container %s: %w", task.container.ID(), err)
-				}
-
-				if !updateAvailable {
-					task.status = statusNotUpdated
-					return nil
-				}
-
-				if options.DryRun {
-					task.status = statusPending
-					return nil
-				}
-
-				if err := task.update(ctx); err != nil {
-					task.status = statusFailed
-					return fmt.Errorf("updating image for container %s: %w", task.container.ID(), err)
-				}
-
-				updateError := auto.restartSystemdUnit(ctx, unit)
-				if updateError == nil {
-					task.status = statusUpdated
-					return nil
-				}
-
-				if !options.Rollback {
-					task.status = statusFailed
-					return fmt.Errorf("restarting unit %s for container %s: %w", task.unit, task.container.ID(), err)
-				}
-
-				if err := task.rollbackImage(); err != nil {
-					task.status = statusFailed
-					return fmt.Errorf("rolling back image for container %s: %w", task.container.ID(), err)
-				}
-
-				if err := auto.restartSystemdUnit(ctx, unit); err != nil {
-					task.status = statusFailed
-					return fmt.Errorf("restarting unit %s for container %s during rollback: %w", task.unit, task.container.ID(), err)
-				}
-
-				task.status = statusRolledBack
-				return nil
-			}()
-
-			if err != nil {
-				errors = append(errors, err)
-			}
 			allReports = append(allReports, task.report())
 		}
 	}
 
-	return allReports, errors
+	return allReports, allErrors
+}
+
+// updateUnit auto updates the tasks in the specified systemd unit.
+func (u *updater) updateUnit(ctx context.Context, unit string, tasks []*task) []error {
+	var errors []error
+	// Sanity check: we'll support that in the future.
+	if len(tasks) != 1 {
+		errors = append(errors, fmt.Errorf("only 1 task per unit supported but unit %s has %d", unit, len(tasks)))
+		return errors
+	}
+
+	tasksUpdated := false
+	for _, task := range tasks {
+		err := func() error { // Use an anonymous function to avoid spaghetti continue's
+			updateAvailable, err := task.updateAvailable(ctx)
+			if err != nil {
+				task.status = statusFailed
+				return fmt.Errorf("checking image updates for container %s: %w", task.container.ID(), err)
+			}
+
+			if !updateAvailable {
+				task.status = statusNotUpdated
+				return nil
+			}
+
+			if u.options.DryRun {
+				task.status = statusPending
+				return nil
+			}
+
+			if err := task.update(ctx); err != nil {
+				task.status = statusFailed
+				return fmt.Errorf("updating image for container %s: %w", task.container.ID(), err)
+			}
+
+			tasksUpdated = true
+			return nil
+		}()
+
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	// If no task has been updated, we can jump directly to the next unit.
+	if !tasksUpdated {
+		return errors
+	}
+
+	updateError := u.restartSystemdUnit(ctx, unit)
+	for _, task := range tasks {
+		if updateError == nil {
+			task.status = statusUpdated
+		} else {
+			task.status = statusFailed
+		}
+	}
+
+	// Jump to the next unit on successful update or if rollbacks are disabled.
+	if updateError == nil || !u.options.Rollback {
+		return errors
+	}
+
+	// The update has failed and rollbacks are enabled.
+	for _, task := range tasks {
+		if err := task.rollbackImage(); err != nil {
+			err = fmt.Errorf("rolling back image for container %s in unit %s: %w", task.container.ID(), unit, err)
+			errors = append(errors, err)
+		}
+	}
+
+	if err := u.restartSystemdUnit(ctx, unit); err != nil {
+		err = fmt.Errorf("restarting unit %s during rollback: %w", unit, err)
+		errors = append(errors, err)
+		return errors
+	}
+
+	for _, task := range tasks {
+		task.status = statusRolledBack
+	}
+
+	return errors
 }
 
 // report creates an auto-update report for the task.

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"os"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -26,6 +27,7 @@ import (
 	"github.com/containers/podman/v4/pkg/k8s.io/apimachinery/pkg/api/resource"
 	"github.com/containers/podman/v4/pkg/specgen"
 	"github.com/containers/podman/v4/pkg/specgen/generate"
+	systemdDefine "github.com/containers/podman/v4/pkg/systemd/define"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/go-units"
@@ -443,6 +445,12 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 		for k, v := range opts.Labels {
 			s.Labels[k] = v
 		}
+	}
+
+	// Make sure the container runs in a systemd unit which is
+	// stored as a label at container creation.
+	if unit := os.Getenv(systemdDefine.EnvVariable); unit != "" {
+		s.Labels[systemdDefine.EnvVariable] = unit
 	}
 
 	return s, nil

--- a/pkg/systemd/notifyproxy/notifyproxy.go
+++ b/pkg/systemd/notifyproxy/notifyproxy.go
@@ -1,12 +1,17 @@
 package notifyproxy
 
 import (
+	"errors"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
 	"strings"
 	"syscall"
+	"time"
 
+	"github.com/containers/podman/v4/libpod/define"
 	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/sirupsen/logrus"
 )
@@ -39,6 +44,7 @@ func SendMessage(socketPath string, message string) error {
 type NotifyProxy struct {
 	connection *net.UnixConn
 	socketPath string
+	container  Container // optional
 }
 
 // New creates a NotifyProxy.  The specified temp directory can be left empty.
@@ -77,9 +83,26 @@ func (p *NotifyProxy) close() error {
 	return p.connection.Close()
 }
 
+// AddContainer associates a container with the proxy.
+func (p *NotifyProxy) AddContainer(container Container) {
+	p.container = container
+}
+
+// ErrNoReadyMessage is returned when we are waiting for the READY message of a
+// container that is not in the running state anymore.
+var ErrNoReadyMessage = errors.New("container stopped running before READY message was received")
+
+// Container avoids a circular dependency among this package and libpod.
+type Container interface {
+	State() (define.ContainerStatus, error)
+	ID() string
+}
+
 // WaitAndClose waits until receiving the `READY` notify message and close the
 // listener. Note that the this function must only be executed inside a systemd
 // service which will kill the process after a given timeout.
+// If the (optional) container stopped running before the `READY` is received,
+// the waiting gets canceled and ErrNoReadyMessage is returned.
 func (p *NotifyProxy) WaitAndClose() error {
 	defer func() {
 		if err := p.close(); err != nil {
@@ -87,16 +110,48 @@ func (p *NotifyProxy) WaitAndClose() error {
 		}
 	}()
 
+	const bufferSize = 1024
+	sBuilder := strings.Builder{}
 	for {
-		buf := make([]byte, 1024)
-		num, err := p.connection.Read(buf)
+		// Set a read deadline of one second such that we achieve a
+		// non-blocking read and can check if the container has already
+		// stopped running; in that case no READY message will be send
+		// and we're done.
+		if err := p.connection.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			return err
+		}
+
+		for {
+			buffer := make([]byte, bufferSize)
+			num, err := p.connection.Read(buffer)
+			if err != nil {
+				if !errors.Is(err, os.ErrDeadlineExceeded) && !errors.Is(err, io.EOF) {
+					return err
+				}
+			}
+			sBuilder.Write(buffer[:num])
+			if num != bufferSize || buffer[num-1] == '\n' {
+				break
+			}
+		}
+
+		for _, line := range strings.Split(sBuilder.String(), "\n") {
+			if line == daemon.SdNotifyReady {
+				return nil
+			}
+		}
+		sBuilder.Reset()
+
+		if p.container == nil {
+			continue
+		}
+
+		state, err := p.container.State()
 		if err != nil {
 			return err
 		}
-		for _, s := range strings.Split(string(buf[:num]), "\n") {
-			if s == daemon.SdNotifyReady {
-				return nil
-			}
+		if state != define.ContainerStateRunning {
+			return fmt.Errorf("%w: %s", ErrNoReadyMessage, p.container.ID())
 		}
 	}
 }

--- a/pkg/systemd/notifyproxy/notifyproxy_test.go
+++ b/pkg/systemd/notifyproxy/notifyproxy_test.go
@@ -41,7 +41,7 @@ func TestWaitAndClose(t *testing.T) {
 	default:
 	}
 
-	sendMessage(t, proxy, daemon.SdNotifyReady+"\nsomething else")
+	sendMessage(t, proxy, daemon.SdNotifyReady+"\nsomething else\n")
 	done := func() bool {
 		for i := 0; i < 10; i++ {
 			select {

--- a/test/system/helpers.systemd.bash
+++ b/test/system/helpers.systemd.bash
@@ -32,3 +32,17 @@ journalctl() {
 systemd-run() {
     command systemd-run $_DASHUSER "$@";
 }
+
+install_kube_template() {
+    # If running from a podman source directory, build and use the source
+    # version of the play-kube-@ unit file
+    unit_name="podman-kube@.service"
+    unit_file="contrib/systemd/system/${unit_name}"
+    if [[ -e ${unit_file}.in ]]; then
+        echo "# [Building & using $unit_name from source]" >&3
+        # Force regenerating unit file (existing one may have /usr/bin path)
+        rm -f $unit_file
+        BINDIR=$(dirname $PODMAN) make $unit_file
+        cp $unit_file $UNIT_DIR/$unit_name
+    fi
+}


### PR DESCRIPTION
Add auto-update support to `podman kube play`.  Auto-update policies can    
be configured for:                                                          
 * the entire pod via the `io.containers.autoupdate` annotation             
 * a specific container via the `io.containers.autoupdate/$name` annotation 
                                                                            
To make use of rollbacks, the `io.containers.sdnotify` policy should be     
set to `container` such that the workload running _inside_ the container    
can send the READY message via the NOTIFY_SOCKET once ready.  For           
further details on auto updates and rollbacks, please refer to the          
specific article [1].                                                       
                                                                            
Since auto updates and rollbacks bases on Podman's systemd integration,     
the k8s YAML must be executed in the `podman-kube@` systemd template.       
For further details on how to run k8s YAML in systemd via Podman, please    
refer to the specific article [2].                                          
                                                                            
An examplary k8s YAML may look as follows:                                  
```YAML                                                                     
apiVersion: v1                                                              
kind: Pod                                                                   
metadata:                                                                   
  annotations:                                                              
      io.containers.autoupdate: "local"                                     
      io.containers.autoupdate/b: "registry"                                
  labels:                                                                   
    app: test                                                               
  name: test_pod                                                            
spec:                                                                       
  containers:                                                               
  - command:                                                                
    - top                                                                   
    image: alpine                                                           
    name: a                                                                 
  - command:                                                                
    - top                                                                   
    image: alpine                                                           
    name: b                                                                 
```                                                                         
                                                                            
[1] https://www.redhat.com/sysadmin/podman-auto-updates-rollbacks           
[2] https://www.redhat.com/sysadmin/kubernetes-workloads-podman-systemd     
                                                                            
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>                     

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support auto updates for `podman kube play`.
```
