### PR TITLE
[CI:DOCS] Man pages: refactor common options: --restart

### DIFF
--- a/docs/source/markdown/options/restart.md
+++ b/docs/source/markdown/options/restart.md
@@ -1,0 +1,15 @@
+#### **--restart**=*policy*
+
+Restart policy to follow when containers exit.
+Restart policy will not take effect if a container is stopped via the **podman kill** or **podman stop** commands.
+
+Valid _policy_ values are:
+
+- `no`                       : Do not restart containers on exit
+- `on-failure[:max_retries]` : Restart containers when they exit with a non-zero exit code, retrying indefinitely or until the optional *max_retries* count is hit
+- `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
+- `unless-stopped`           : Identical to **always**
+
+Please note that restart will not restart containers after a system reboot.
+If this functionality is required in your environment, you can invoke Podman from a **systemd.unit**(5) file, or create an init script for whichever init system is in use.
+To generate systemd unit files, please see **podman generate systemd**.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -500,21 +500,7 @@ Suppress output information when pulling images
 
 @@option requires
 
-#### **--restart**=*policy*
-
-Restart policy to follow when containers exit.
-Restart policy will not take effect if a container is stopped via the `podman kill` or `podman stop` commands.
-
-Valid values are:
-
-- `no`                       : Do not restart containers on exit
-- `on-failure[:max_retries]` : Restart containers when they exit with a non-0 exit code, retrying indefinitely or until the optional max_retries count is hit
-- `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
-- `unless-stopped`           : Identical to **always**
-
-Please note that restart will not restart containers after a system reboot.
-If this functionality is required in your environment, you can invoke Podman from a systemd unit file, or create an init script for whichever init system is in use.
-To generate systemd unit files, please see *podman generate systemd*
+@@option restart
 
 #### **--rm**
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -531,21 +531,7 @@ Suppress output information when pulling images
 
 @@option requires
 
-#### **--restart**=*policy*
-
-Restart policy to follow when containers exit.
-Restart policy will not take effect if a container is stopped via the **podman kill** or **podman stop** commands.
-
-Valid _policy_ values are:
-
-- `no`                       : Do not restart containers on exit
-- `on-failure[:max_retries]` : Restart containers when they exit with a non-zero exit code, retrying indefinitely or until the optional *max_retries* count is hit
-- `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
-- `unless-stopped`           : Identical to **always**
-
-Please note that restart will not restart containers after a system reboot.
-If this functionality is required in your environment, you can invoke Podman from a **systemd.unit**(5) file, or create an init script for whichever init system is in use.
-To generate systemd unit files, please see **podman generate systemd**.
+@@option restart
 
 #### **--rm**
 


### PR DESCRIPTION
Only applicable to podman-create and -run. I went with the -run
version because it is cleaner and more recently updated.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```