### PR TITLE
[CI:BUILD] Packit: add copr_build task

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,17 +4,56 @@
 upstream_package_name: podman
 downstream_package_name: podman
 
-actions:
-  post-upstream-clone:
-    - "curl -O https://src.fedoraproject.org/rpms/podman/raw/main/f/podman.spec"
-  fix-spec-file:
-    - bash .packit.sh
-
 jobs:
-  - job: production_build
+  - job: copr_build
+    # Run on every PR
     trigger: pull_request
-    targets: &production_dist_targets
-      - fedora-36
-      - fedora-37
-      - fedora-rawhide
-    scratch: true
+    # Defaults to x86_64 unless architecture is explicitly specified
+    targets:
+      - fedora-rawhide-aarch64
+      - fedora-rawhide-i386
+      - fedora-rawhide-ppc64le
+      - fedora-rawhide-s390x
+      - fedora-rawhide-x86_64
+    actions:
+      post-upstream-clone:
+        - "curl -O https://src.fedoraproject.org/rpms/podman/raw/rawhide/f/podman.spec"
+      fix-spec-file:
+        - bash .packit.sh
+
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - fedora-37-aarch64
+      - fedora-37-i386
+      - fedora-37-ppc64le
+      - fedora-37-s390x
+      - fedora-37-x86_64
+    actions:
+      post-upstream-clone:
+        - "curl -O https://src.fedoraproject.org/rpms/podman/raw/f37/f/podman.spec"
+      fix-spec-file:
+        - bash .packit.sh
+
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - fedora-36-aarch64
+      - fedora-36-i386
+      - fedora-36-ppc64le
+      - fedora-36-s390x
+      - fedora-36-x86_64
+    actions:
+      post-upstream-clone:
+        - "curl -O https://src.fedoraproject.org/rpms/podman/raw/f36/f/podman.spec"
+      fix-spec-file:
+        - bash .packit.sh
+
+        # Disable production_build until we realize a good place to use it
+        #- job: production_build
+        #trigger: release
+        #targets: &production_dist_targets
+        #- fedora-36
+        #- fedora-37
+        #- fedora-rawhide
+        #scratch: true


### PR DESCRIPTION
The production_build task can only be triggered when users with write
access submit PRs or add `slash-packit production_build` to PRs from
external contributors. This is because of koji's restriction to build
only `verified code`.

This could mean quite some manual intervention but would be really useful
for release PRs, cherry-picks and any other PRs where we could use extra
confirmation.

This commit adds a new `copr_build` task which gets triggered
automatically regardless of the PR submitter's privs.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
