### PR TITLE
[v3.0.1-rhel] CI: disable swagger step

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -241,25 +241,6 @@ bindings_task:
     always: *runner_stats
 
 
-# Build the "libpod" API documentation `swagger.yaml` for eventual
-# publishing along side the official podman documentation.
-swagger_task:
-    name: "Test Swagger"
-    alias: swagger
-    depends_on:
-        - build
-    container: *smallcontainer
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: swagger
-        TEST_ENVIRON: container
-        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
-    clone_script: *full_clone  # build-cache not available to container tasks
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts
-
-
 # Check that all included go modules from other sources match
 # what is expected in `vendor/modules.txt` vs `go.mod`.  Also
 # make sure that the generated bindings in pkg/bindings/...
@@ -522,7 +503,6 @@ success_task:
         - build
         - validate
         - bindings
-        - swagger
         - consistency
         - alt_build
         - unit_test


### PR DESCRIPTION
On this branch, /usr/local/bin/swagger is fetched on each run
(vs, on current 2022-08 main, installed at VM-setup time).
Something changed, and the new binary is very strict about
bugs in our swagger comments, of which there seem to be many.

Possible solution: fix our code. Doesn't seem worth the bother
for an old branch like this one.

Possible solution: re-fetch an old version of swagger tool.
Ditto.

This solution: just skip the swagger test. It seems unlikely
that anyone will make significant API changes on this branch.

Signed-off-by: Ed Santiago <santiago@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
