### PR TITLE
[CI:DOCS] Man pages: refactor common options: --signal

### DIFF
--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -15,6 +15,7 @@ podman-manifest-push.1.md
 podman-pause.1.md
 podman-pod-clone.1.md
 podman-pod-create.1.md
+podman-pod-kill.1.md
 podman-pod-logs.1.md
 podman-pod-rm.1.md
 podman-pod-start.1.md

--- a/docs/source/markdown/options/signal.md
+++ b/docs/source/markdown/options/signal.md
@@ -1,0 +1,4 @@
+#### **--signal**, **-s**=**signal**
+
+Signal to send to the container<<|s in the pod>>. For more information on Linux signals, refer to *signal(7)*.
+The default is **SIGKILL**.

--- a/docs/source/markdown/podman-kill.1.md.in
+++ b/docs/source/markdown/podman-kill.1.md.in
@@ -23,10 +23,7 @@ Signal all running and paused containers.
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--signal**, **-s**
-
-Signal to send to the container. For more information on Linux signals, refer to *man signal(7)*.
-
+@@option signal
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-pod-kill.1.md.in
+++ b/docs/source/markdown/podman-pod-kill.1.md.in
@@ -19,10 +19,7 @@ Sends signal to all containers associated with a pod.
 Instead of providing the pod name or ID, use the last created pod. If you use methods other than Podman
 to run pods such as CRI-O, the last started pod could be from either of those methods. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--signal**, **-s**
-
-Signal to send to the containers in the pod. For more information on Linux signals, refer to *man signal(7)*.
-
+@@option signal
 
 ## EXAMPLE
 


### PR DESCRIPTION
Would've been an easy one, except I decided to fix the text
to conform to our guidelines. I haven't been doing this,
but in this case it's only two man pages and the text is
short enough to make for easy review.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```