### PR TITLE
[CI:DOCS] Man pages: refactor common options: --device-X-Y

### DIFF
--- a/docs/source/markdown/options/device-read-bps.md
+++ b/docs/source/markdown/options/device-read-bps.md
@@ -1,0 +1,9 @@
+#### **--device-read-bps**=*path:rate*
+
+Limit read rate (in bytes per second) from a device (e.g. **--device-read-bps=/dev/sda:1mb**).
+
+On some systems, changing the resource limits may not be allowed for non-root
+users. For more details, see
+https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
+
+This option is not supported on cgroups V1 rootless systems.

--- a/docs/source/markdown/options/device-read-iops.md
+++ b/docs/source/markdown/options/device-read-iops.md
@@ -1,0 +1,9 @@
+#### **--device-read-iops**=*path:rate*
+
+Limit read rate (in IO operations per second) from a device (e.g. **--device-read-iops=/dev/sda:1000**).
+
+On some systems, changing the resource limits may not be allowed for non-root
+users. For more details, see
+https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
+
+This option is not supported on cgroups V1 rootless systems.

--- a/docs/source/markdown/options/device-write-bps.md
+++ b/docs/source/markdown/options/device-write-bps.md
@@ -1,0 +1,9 @@
+#### **--device-write-bps**=*path:rate*
+
+Limit write rate (in bytes per second) to a device (e.g. **--device-write-bps=/dev/sda:1mb**).
+
+On some systems, changing the resource limits may not be allowed for non-root
+users. For more details, see
+https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
+
+This option is not supported on cgroups V1 rootless systems.

--- a/docs/source/markdown/options/device-write-iops.md
+++ b/docs/source/markdown/options/device-write-iops.md
@@ -1,0 +1,9 @@
+#### **--device-write-iops**=*path:rate*
+
+Limit write rate (in IO operations per second) to a device (e.g. **--device-write-iops=/dev/sda:1000**).
+
+On some systems, changing the resource limits may not be allowed for non-root
+users. For more details, see
+https://github.com/containers/podman/blob/main/troubleshooting.md#26-running-containers-with-resource-limits-fails-with-a-permissions-error
+
+This option is not supported on cgroups V1 rootless systems.

--- a/docs/source/markdown/podman-container-clone.1.md.in
+++ b/docs/source/markdown/podman-container-clone.1.md.in
@@ -52,17 +52,9 @@ If none are specified, the original container's CPU memory nodes are used.
 
 @@option destroy
 
-#### **--device-read-bps**=*path*
+@@option device-read-bps
 
-Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb).
-
-This option is not supported on cgroups V1 rootless systems.
-
-#### **--device-write-bps**=*path*
-
-Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
-
-This option is not supported on cgroups V1 rootless systems.
+@@option device-write-bps
 
 #### **--force**, **-f**
 

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -146,29 +146,13 @@ device. The devices that podman will load modules when necessary are:
 
 @@option device-cgroup-rule
 
-#### **--device-read-bps**=*path*
+@@option device-read-bps
 
-Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)
+@@option device-read-iops
 
-This option is not supported on cgroups V1 rootless systems.
+@@option device-write-bps
 
-#### **--device-read-iops**=*path*
-
-Limit read rate (IO per second) from a device (e.g. --device-read-iops=/dev/sda:1000)
-
-This option is not supported on cgroups V1 rootless systems.
-
-#### **--device-write-bps**=*path*
-
-Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
-
-This option is not supported on cgroups V1 rootless systems.
-
-#### **--device-write-iops**=*path*
-
-Limit write rate (IO per second) to a device (e.g. --device-write-iops=/dev/sda:1000)
-
-This option is not supported on cgroups V1 rootless systems.
+@@option device-write-iops
 
 @@option disable-content-trust
 

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -48,13 +48,9 @@ Podman may load kernel modules required for using the specified
 device. The devices that Podman will load modules for when necessary are:
 /dev/fuse.
 
-#### **--device-read-bps**=*path*
+@@option device-read-bps
 
-Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb).
-
-#### **--device-write-bps**=*path*
-
-Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
+@@option device-write-bps
 
 @@option gidmap.pod
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -65,13 +65,9 @@ Podman may load kernel modules required for using the specified
 device. The devices that Podman will load modules for when necessary are:
 /dev/fuse.
 
-#### **--device-read-bps**=*path*
+@@option device-read-bps
 
-Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)
-
-#### **--device-write-bps**=*path*
-
-Limit write rate (bytes per second) to a device (e.g. --device-write-bps=/dev/sda:1mb)
+@@option device-write-bps
 
 #### **--dns**=*ipaddr*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -180,29 +180,13 @@ device. The devices that Podman will load modules when necessary are:
 
 @@option device-cgroup-rule
 
-#### **--device-read-bps**=*path:rate*
+@@option device-read-bps
 
-Limit read rate (in bytes per second) from a device (e.g. **--device-read-bps=/dev/sda:1mb**).
+@@option device-read-iops
 
-This option is not supported on cgroups V1 rootless systems.
+@@option device-write-bps
 
-#### **--device-read-iops**=*path:rate*
-
-Limit read rate (in IO operations per second) from a device (e.g. **--device-read-iops=/dev/sda:1000**).
-
-This option is not supported on cgroups V1 rootless systems.
-
-#### **--device-write-bps**=*path:rate*
-
-Limit write rate (in bytes per second) to a device (e.g. **--device-write-bps=/dev/sda:1mb**).
-
-This option is not supported on cgroups V1 rootless systems.
-
-#### **--device-write-iops**=*path:rate*
-
-Limit write rate (in IO operations per second) to a device (e.g. **--device-write-iops=/dev/sda:1000**).
-
-This option is not supported on cgroups V1 rootless systems.
+@@option device-write-iops
 
 @@option disable-content-trust
 


### PR DESCRIPTION
In all cases, went with the version from podman-run because
it conforms to our documentation guidelines. I then added
the FAQ-26 link to each one.

This does not review easily with hack/markdown-preprocess-review
because there are too many files involved. Sorry.

This will cause conflicts in #15276 - again, I'm sorry. On the bright
side, that PR still needs work anyway, and rebasing on top of
this should make it easier to review.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```