### PR TITLE
Set enableServiceLinks to false in generated yaml

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -468,12 +468,15 @@ func newPodObject(podName string, annotations map[string]string, initCtrs, conta
 		CreationTimestamp: v12.Now(),
 		Annotations:       annotations,
 	}
+	// Set enableServiceLinks to false as podman doesn't use the service port environment variables
+	enableServiceLinks := false
 	ps := v1.PodSpec{
-		Containers:     containers,
-		Hostname:       hostname,
-		HostNetwork:    hostNetwork,
-		InitContainers: initCtrs,
-		Volumes:        volumes,
+		Containers:         containers,
+		Hostname:           hostname,
+		HostNetwork:        hostNetwork,
+		InitContainers:     initCtrs,
+		Volumes:            volumes,
+		EnableServiceLinks: &enableServiceLinks,
 	}
 	if dnsOptions != nil && (len(dnsOptions.Nameservers)+len(dnsOptions.Searches)+len(dnsOptions.Options) > 0) {
 		ps.DNSConfig = dnsOptions

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -71,6 +71,8 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(pod.Spec.Containers[0]).To(HaveField("WorkingDir", ""))
 		Expect(pod.Spec.Containers[0].Env).To(BeNil())
 		Expect(pod).To(HaveField("Name", "top-pod"))
+		enableServiceLinks := false
+		Expect(pod.Spec).To(HaveField("EnableServiceLinks", &enableServiceLinks))
 
 		numContainers := 0
 		for range pod.Spec.Containers {
@@ -165,6 +167,8 @@ var _ = Describe("Podman generate kube", func() {
 		err := yaml.Unmarshal(kube.Out.Contents(), pod)
 		Expect(err).To(BeNil())
 		Expect(pod.Spec).To(HaveField("HostNetwork", false))
+		enableServiceLinks := false
+		Expect(pod.Spec).To(HaveField("EnableServiceLinks", &enableServiceLinks))
 
 		numContainers := 0
 		for range pod.Spec.Containers {


### PR DESCRIPTION
Since podman doesn't set/use the needed service env
variable, always set enableServiceLinks to false in
the generated kube yaml.

Fixes https://github.com/containers/podman/issues/15478#event-7271977316

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add enableServiceLinks: false to the generated kube yaml.
```
