### PR TITLE
Cirrus: pick UIDs/GIDs starting at 1500, not 1000

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -158,9 +158,9 @@ setup_rootless() {
     msg "************************************************************"
     cd $GOSRC || exit 1
     # Guarantee independence from specific values
-    rootless_uid=$[RANDOM+1000]
+    rootless_uid=$((1500 + RANDOM % 5000))
     ROOTLESS_UID=$rootless_uid
-    rootless_gid=$[RANDOM+1000]
+    rootless_gid=$((1500 + RANDOM % 5000))
     msg "creating $rootless_uid:$rootless_gid $ROOTLESS_USER user"
     groupadd -g $rootless_gid $ROOTLESS_USER
     useradd -g $rootless_gid -u $rootless_uid --no-user-group --create-home $ROOTLESS_USER


### PR DESCRIPTION
Reason: looks like UIDs 1001, 1003, 1006 are already taken
in the CI VMs.

Fixes: #15573

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```