### PR TITLE
libpod: Ensure that generated container names are random

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -110,6 +111,13 @@ type Runtime struct {
 	noStore bool
 	// secretsManager manages secrets
 	secretsManager *secrets.SecretsManager
+}
+
+func init() {
+	// generateName calls namesgenerator.GetRandomName which the
+	// global RNG from math/rand. Seed it here to make sure we
+	// don't get the same name every time.
+	rand.Seed(time.Now().UnixNano())
 }
 
 // SetXdgDirs ensures the XDG_RUNTIME_DIR env and XDG_CONFIG_HOME variables are set.

--- a/libpod/runtime_test.go
+++ b/libpod/runtime_test.go
@@ -1,0 +1,28 @@
+package libpod
+
+import (
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_generateName(t *testing.T) {
+	state, path, _, err := getEmptyBoltState()
+	assert.NoError(t, err)
+	defer os.RemoveAll(path)
+	defer state.Close()
+
+	r := &Runtime{
+		state: state,
+	}
+
+	// Test that (*Runtime).generateName returns different names
+	// if called twice, even if the global RNG has the default
+	// seed.
+	n1, _ := r.generateName()
+	rand.Seed(1)
+	n2, _ := r.generateName()
+	assert.NotEqual(t, n1, n2)
+}


### PR DESCRIPTION
A suggestion for fixing #15569. The unit test isn't pretty and it assumes implementation details. A better fix would avoid using the global RNG at all but thats harder due to the dependency on docker. The global RNG is a misfeature IMO and shouldn't really be used by anything.

#### Does this PR introduce a user-facing change?

```release-note
Generated container names should be random again.
```
