### PR TITLE
Add support for FreeBSD volume mounts in specgen

### DIFF
--- a/libpod/define/mount.go
+++ b/libpod/define/mount.go
@@ -1,8 +1,6 @@
 package define
 
 const (
-	// TypeBind is the type for mounting host dir
-	TypeBind = "bind"
 	// TypeVolume is the type for named volumes
 	TypeVolume = "volume"
 	// TypeTmpfs is the type for mounting tmpfs

--- a/libpod/define/mount_freebsd.go
+++ b/libpod/define/mount_freebsd.go
@@ -1,0 +1,8 @@
+//go:build freebsd
+
+package define
+
+const (
+	// TypeBind is the type for mounting host dir
+	TypeBind = "nullfs"
+)

--- a/libpod/define/mount_linux.go
+++ b/libpod/define/mount_linux.go
@@ -1,0 +1,8 @@
+//go:build linux
+
+package define
+
+const (
+	// TypeBind is the type for mounting host dir
+	TypeBind = "bind"
+)

--- a/libpod/define/mount_unsupported.go
+++ b/libpod/define/mount_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !linux && !freebsd
+
+package define
+
+const (
+	// TypeBind is the type for mounting host dir
+	TypeBind = "bind"
+)

--- a/pkg/specgen/volumes.go
+++ b/pkg/specgen/volumes.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/containers/common/pkg/parse"
+	"github.com/containers/podman/v4/libpod/define"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
@@ -159,7 +160,7 @@ func GenVolumeMounts(volumeFlag []string) (map[string]spec.Mount, map[string]*Na
 			} else {
 				newMount := spec.Mount{
 					Destination: dest,
-					Type:        "bind",
+					Type:        define.TypeBind,
 					Source:      src,
 					Options:     options,
 				}


### PR DESCRIPTION
This makes the existing define.TypeBind platform-specific and gives it the value "nullfs" on FreeBSD where that perfoms a similar function to Linux bind mounts. The code in GenVolumeMounts is changed to use TypeBind instead of hard-coding a type of "bind".

#### Does this PR introduce a user-facing change?

```release-note
None
```
