### PR TITLE
[CI:DOCS] Man pages: refactor common options: --name

### DIFF
--- a/docs/source/markdown/options/name.container.md
+++ b/docs/source/markdown/options/name.container.md
@@ -1,0 +1,14 @@
+#### **--name**=*name*
+
+Assign a name to the container.
+
+The operator can identify a container in three ways:
+
+- UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”);
+- UUID short identifier (“f78375b1c487”);
+- Name (“jonah”).
+
+Podman generates a UUID for each container, and if a name is not assigned
+to the container with **--name** then it will generate a random
+string name. The name is useful any place you need to identify a container.
+This works for both background and foreground containers.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -348,19 +348,7 @@ This option is not supported on cgroups V1 rootless systems.
 
 @@option mount
 
-#### **--name**=*name*
-
-Assign a name to the container
-
-The operator can identify a container in three ways:
-UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”)
-UUID short identifier (“f78375b1c487”)
-Name (“jonah”)
-
-podman generates a UUID for each container, and if a name is not assigned
-to the container with **--name** then it will generate a random
-string name. The name is useful any place you need to identify a container.
-This works for both background and foreground containers.
+@@option name.container
 
 #### **--network**=*mode*, **--net**
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -367,20 +367,7 @@ This option is not supported on cgroups V1 rootless systems.
 
 @@option mount
 
-#### **--name**=*name*
-
-Assign a name to the container.
-
-The operator can identify a container in three ways:
-
-- UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”);
-- UUID short identifier (“f78375b1c487”);
-- Name (“jonah”).
-
-Podman generates a UUID for each container, and if a name is not assigned
-to the container with **--name** then it will generate a random
-string name. The name is useful any place you need to identify a container.
-This works for both background and foreground containers.
+@@option name.container
 
 #### **--network**=*mode*, **--net**
 


### PR DESCRIPTION
Only for podman-create and -run, unfortunately: all the
others are too different, and can't easily be combined.

I went with the podman-run version because it was most
recently updated in #5192.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```