### PR TITLE
[CI:DOCS] Man pages: refactor common options: --digestfile

### DIFF
--- a/docs/source/markdown/options/digestfile.md
+++ b/docs/source/markdown/options/digestfile.md
@@ -1,0 +1,4 @@
+#### **--digestfile**=*Digestfile*
+
+After copying the image, write the digest of the resulting image to the file.
+(This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -29,9 +29,7 @@ Specifies the compression format to use.  Supported values are: `gzip`, `zstd` a
 
 @@option creds
 
-#### **--digestfile**=*Digestfile*
-
-After copying the image, write the digest of the resulting image to the file.
+@@option digestfile
 
 #### **--format**, **-f**=*format*
 

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -62,9 +62,7 @@ Specifies the compression format to use.  Supported values are: `gzip`, `zstd` a
 
 @@option creds
 
-#### **--digestfile**=*Digestfile*
-
-After copying the image, write the digest of the resulting image to the file.  (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
+@@option digestfile
 
 @@option disable-content-trust
 


### PR DESCRIPTION
Only used in two pages. I took the liberty of adding the "N/A
on remote" text to manifest-push.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
more man-page deduplication
```
