### PR TITLE
Fix #15243 Set AutomountServiceAccountToken to false

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -470,13 +470,16 @@ func newPodObject(podName string, annotations map[string]string, initCtrs, conta
 	}
 	// Set enableServiceLinks to false as podman doesn't use the service port environment variables
 	enableServiceLinks := false
+	// Set automountServiceAccountToken to false as podman doesn't use service account tokens
+	automountServiceAccountToken := false
 	ps := v1.PodSpec{
-		Containers:         containers,
-		Hostname:           hostname,
-		HostNetwork:        hostNetwork,
-		InitContainers:     initCtrs,
-		Volumes:            volumes,
-		EnableServiceLinks: &enableServiceLinks,
+		Containers:                   containers,
+		Hostname:                     hostname,
+		HostNetwork:                  hostNetwork,
+		InitContainers:               initCtrs,
+		Volumes:                      volumes,
+		EnableServiceLinks:           &enableServiceLinks,
+		AutomountServiceAccountToken: &automountServiceAccountToken,
 	}
 	if dnsOptions != nil && (len(dnsOptions.Nameservers)+len(dnsOptions.Searches)+len(dnsOptions.Options) > 0) {
 		ps.DNSConfig = dnsOptions

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -73,6 +73,8 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(pod).To(HaveField("Name", "top-pod"))
 		enableServiceLinks := false
 		Expect(pod.Spec).To(HaveField("EnableServiceLinks", &enableServiceLinks))
+		automountServiceAccountToken := false
+		Expect(pod.Spec).To(HaveField("AutomountServiceAccountToken", &automountServiceAccountToken))
 
 		numContainers := 0
 		for range pod.Spec.Containers {
@@ -169,6 +171,8 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(pod.Spec).To(HaveField("HostNetwork", false))
 		enableServiceLinks := false
 		Expect(pod.Spec).To(HaveField("EnableServiceLinks", &enableServiceLinks))
+		automountServiceAccountToken := false
+		Expect(pod.Spec).To(HaveField("AutomountServiceAccountToken", &automountServiceAccountToken))
 
 		numContainers := 0
 		for range pod.Spec.Containers {


### PR DESCRIPTION
podman does not use any service account token, so we set the automount flag
to false in podman generate kube.

```release-note
None
```
