### PR TITLE
[v3.4] CI: disable swagger step

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -238,32 +238,6 @@ bindings_task:
             type: text/html
 
 
-# Build the "libpod" API documentation `swagger.yaml` and
-# publish it to google-cloud-storage (GCS).
-swagger_task:
-    name: "Test Swagger"
-    alias: swagger
-    depends_on:
-        - build
-    gce_instance: *standardvm
-    env:
-        <<: *stdenvars
-        TEST_FLAVOR: swagger
-        # TODO: Due to podman 3.0 activity (including new images), avoid
-        # disturbing the status-quo just to incorporate this one new
-        # container image.  Uncomment line below when CI activities normalize.
-        #CTR_FQIN: 'quay.io/libpod/gcsupld:${IMAGE_SUFFIX}'
-        CTR_FQIN: 'quay.io/libpod/gcsupld:c4813063494828032'
-        GCPJSON: ENCRYPTED[927dc01e755eaddb4242b0845cf86c9098d1e3dffac38c70aefb1487fd8b4fe6dd6ae627b3bffafaba70e2c63172664e]
-        GCPNAME: ENCRYPTED[c145e9c16b6fb88d476944a454bf4c1ccc84bb4ecaca73bdd28bdacef0dfa7959ebc8171a27b2e4064d66093b2cdba49]
-        GCPPROJECT: 'libpod-218412'
-    gopath_cache: *ro_gopath_cache
-    clone_script: *noop  # Comes from cache
-    setup_script: *setup
-    main_script: *main
-    always: *binary_artifacts
-
-
 # Check that all included go modules from other sources match
 # what is expected in `vendor/modules.txt` vs `go.mod`.  Also
 # make sure that the generated bindings in pkg/bindings/...
@@ -532,7 +506,6 @@ success_task:
         - build
         - validate
         - bindings
-        - swagger
         - consistency
         - alt_build
         - unit_test


### PR DESCRIPTION
On this branch, /usr/local/bin/swagger is fetched on each run
(vs, on current 2022-08 main, installed at VM-setup time).
Something changed, and the new binary is very strict about
bugs in our swagger comments, of which there seem to be many.

Possible solution: fix our code. Doesn't seem worth the bother
for an old branch like this one.

Possible solution: re-fetch an old version of swagger tool.
Ditto.

This solution: just skip the swagger test. It seems unlikely
that anyone will make significant API changes on this branch.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```
