### PR TITLE
Add container GID to additional groups

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -682,6 +682,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 		// User and Group must go together
 		g.SetProcessUID(uint32(execUser.Uid))
 		g.SetProcessGID(uint32(execUser.Gid))
+		g.AddProcessAdditionalGid(uint32(execUser.Gid))
 	}
 
 	if c.config.Umask != "" {

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -510,6 +510,7 @@ func SetupUserNS(idmappings *storage.IDMappingOptions, userns Namespace, g *gene
 		idmappings = mappings
 		g.SetProcessUID(uint32(uid))
 		g.SetProcessGID(uint32(gid))
+		g.AddProcessAdditionalGid(uint32(gid))
 		user = fmt.Sprintf("%d:%d", uid, gid)
 		if err := privateUserNamespace(idmappings, g); err != nil {
 			return user, err
@@ -522,6 +523,7 @@ func SetupUserNS(idmappings *storage.IDMappingOptions, userns Namespace, g *gene
 		idmappings = mappings
 		g.SetProcessUID(uint32(uid))
 		g.SetProcessGID(uint32(gid))
+		g.AddProcessAdditionalGid(uint32(gid))
 		user = fmt.Sprintf("%d:%d", uid, gid)
 		if err := privateUserNamespace(idmappings, g); err != nil {
 			return user, err

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -945,7 +945,7 @@ echo -n %s >%s
 		session := podmanTest.Podman([]string{"run", "--rm", "--user=1234", ALPINE, "id"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(Equal("uid=1234(1234) gid=0(root)"))
+		Expect(session.OutputToString()).To(Equal("uid=1234(1234) gid=0(root) groups=0(root)"))
 	})
 
 	It("podman run with user (integer, in /etc/passwd)", func() {
@@ -966,14 +966,14 @@ echo -n %s >%s
 		session := podmanTest.Podman([]string{"run", "--rm", "--user=mail:21", ALPINE, "id"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp)"))
+		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp) groups=21(ftp)"))
 	})
 
 	It("podman run with user:group (integer:groupname)", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--user=8:ftp", ALPINE, "id"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp)"))
+		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp) groups=21(ftp)"))
 	})
 
 	It("podman run with user, verify caps dropped", func() {
@@ -982,6 +982,14 @@ echo -n %s >%s
 		Expect(session).Should(Exit(0))
 		capEff := strings.Split(session.OutputToString(), " ")
 		Expect("0000000000000000").To(Equal(capEff[1]))
+	})
+
+	It("podman run with user, verify group added", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "--user=1000:1000", ALPINE, "grep", "Groups:", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		groups := strings.Split(session.OutputToString(), " ")[1]
+		Expect("1000").To(Equal(groups))
 	})
 
 	It("podman run with attach stdin outputs container ID", func() {


### PR DESCRIPTION
Mitigates a potential permissions issue. Mirrors https://github.com/containers/buildah/pull/4200 and https://github.com/cri-o/cri-o/pull/6159/files

```release-note
NONE
```
