### PR TITLE
[CI:BUILD] Copr: Define _user_tmpfilesdir for rhel

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -5,6 +5,11 @@
 
 %global with_debug 1
 
+# _user_tmpfiles.d currently undefined on rhel
+%if 0%{?rhel}
+%global _user_tmpfilesdir %{_datadir}/user-tmpfiles.d
+%endif
+
 %if 0%{?with_debug}
 %global _find_debuginfo_dwz_opts %{nil}
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
[NO NEW TESTS NEEDED]

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@rhatdan @mheon @TomSweeneyRedHat PTAL
/cc @containers/podman-maintainers 