### PR TITLE
[CI:DOCS] Fix manpage header formatting

### DIFF
--- a/docs/source/markdown/podman-attach.1.md
+++ b/docs/source/markdown/podman-attach.1.md
@@ -1,4 +1,4 @@
-% podman-attach(1)
+% podman-attach 1
 
 ## NAME
 podman\-attach - Attach to a running container

--- a/docs/source/markdown/podman-auto-update.1.md.in
+++ b/docs/source/markdown/podman-auto-update.1.md.in
@@ -1,4 +1,4 @@
-% podman-auto-update(1)
+% podman-auto-update 1
 
 ## NAME
 podman\-auto-update - Auto update containers according to their auto-update policy

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -1,4 +1,4 @@
-% podman-build(1)
+% podman-build 1
 
 ## NAME
 podman\-build - Build a container image using a Containerfile

--- a/docs/source/markdown/podman-commit.1.md
+++ b/docs/source/markdown/podman-commit.1.md
@@ -1,4 +1,4 @@
-% podman-commit(1)
+% podman-commit 1
 
 ## NAME
 podman\-commit - Create new image based on the changed container

--- a/docs/source/markdown/podman-completion.1.md
+++ b/docs/source/markdown/podman-completion.1.md
@@ -1,4 +1,4 @@
-% podman-completion(1)
+% podman-completion 1
 
 ## NAME
 podman\-completion - Generate shell completion scripts

--- a/docs/source/markdown/podman-container-checkpoint.1.md
+++ b/docs/source/markdown/podman-container-checkpoint.1.md
@@ -1,4 +1,4 @@
-% podman-container-checkpoint(1)
+% podman-container-checkpoint 1
 
 ## NAME
 podman\-container\-checkpoint - Checkpoints one or more running containers

--- a/docs/source/markdown/podman-container-cleanup.1.md
+++ b/docs/source/markdown/podman-container-cleanup.1.md
@@ -1,4 +1,4 @@
-% podman-container-cleanup(1)
+% podman-container-cleanup 1
 
 ## NAME
 podman\-container\-cleanup - Clean up the container's network and mountpoints

--- a/docs/source/markdown/podman-container-clone.1.md.in
+++ b/docs/source/markdown/podman-container-clone.1.md.in
@@ -1,4 +1,4 @@
-% podman-container-clone(1)
+% podman-container-clone 1
 
 ## NAME
 podman\-container\-clone - Creates a copy of an existing container

--- a/docs/source/markdown/podman-container-diff.1.md
+++ b/docs/source/markdown/podman-container-diff.1.md
@@ -1,4 +1,4 @@
-% podman-container-diff(1)
+% podman-container-diff 1
 
 ## NAME
 podman\-container\-diff - Inspect changes on a container's filesystem

--- a/docs/source/markdown/podman-container-exists.1.md
+++ b/docs/source/markdown/podman-container-exists.1.md
@@ -1,4 +1,4 @@
-% podman-container-exists(1)
+% podman-container-exists 1
 
 ## NAME
 podman\-container\-exists - Check if a container exists in local storage

--- a/docs/source/markdown/podman-container-inspect.1.md
+++ b/docs/source/markdown/podman-container-inspect.1.md
@@ -1,4 +1,4 @@
-% podman-container-inspect(1)
+% podman-container-inspect 1
 
 ## NAME
 podman\-container\-inspect - Display a container's configuration

--- a/docs/source/markdown/podman-container-prune.1.md
+++ b/docs/source/markdown/podman-container-prune.1.md
@@ -1,4 +1,4 @@
-% podman-container-prune(1)
+% podman-container-prune 1
 
 ## NAME
 podman\-container\-prune - Remove all stopped containers from local storage

--- a/docs/source/markdown/podman-container-restore.1.md
+++ b/docs/source/markdown/podman-container-restore.1.md
@@ -1,4 +1,4 @@
-% podman-container-restore(1)
+% podman-container-restore 1
 
 ## NAME
 podman\-container\-restore - Restores one or more containers from a checkpoint

--- a/docs/source/markdown/podman-container-runlabel.1.md.in
+++ b/docs/source/markdown/podman-container-runlabel.1.md.in
@@ -1,4 +1,4 @@
-% podman-container-runlabel(1)
+% podman-container-runlabel 1
 
 ## NAME
 podman-container-runlabel - Executes a command as described by a container-image label

--- a/docs/source/markdown/podman-container.1.md
+++ b/docs/source/markdown/podman-container.1.md
@@ -1,4 +1,4 @@
-% podman-container(1)
+% podman-container 1
 
 ## NAME
 podman\-container - Manage containers

--- a/docs/source/markdown/podman-cp.1.md
+++ b/docs/source/markdown/podman-cp.1.md
@@ -1,4 +1,4 @@
-% podman-cp(1)
+% podman-cp 1
 
 ## NAME
 podman\-cp - Copy files/folders between a container and the local filesystem

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -1,4 +1,4 @@
-% podman-create(1)
+% podman-create 1
 
 ## NAME
 podman\-create - Create a new container

--- a/docs/source/markdown/podman-diff.1.md
+++ b/docs/source/markdown/podman-diff.1.md
@@ -1,4 +1,4 @@
-% podman-diff(1)
+% podman-diff 1
 
 ## NAME
 podman\-diff - Inspect changes on a container or image's filesystem

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -1,4 +1,4 @@
-% podman-events(1)
+% podman-events 1
 
 ## NAME
 podman\-events - Monitor Podman events

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -1,4 +1,4 @@
-% podman-exec(1)
+% podman-exec 1
 
 ## NAME
 podman\-exec - Execute a command in a running container

--- a/docs/source/markdown/podman-export.1.md
+++ b/docs/source/markdown/podman-export.1.md
@@ -1,4 +1,4 @@
-% podman-export(1)
+% podman-export 1
 
 ## NAME
 podman\-export - Export a container's filesystem contents as a tar archive

--- a/docs/source/markdown/podman-generate-spec.1.md
+++ b/docs/source/markdown/podman-generate-spec.1.md
@@ -1,4 +1,4 @@
-% podman-generate-spec(1)
+% podman-generate-spec 1
 
 ## NAME
 podman\-generate\-spec - Generate Specgen JSON based on containers or pods

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -1,4 +1,4 @@
-% podman-generate-systemd(1)
+% podman-generate-systemd 1
 
 ## NAME
 podman\-generate\-systemd - Generate systemd unit file(s) for a container or pod

--- a/docs/source/markdown/podman-generate.1.md
+++ b/docs/source/markdown/podman-generate.1.md
@@ -1,4 +1,4 @@
-% podman-generate(1)
+% podman-generate 1
 
 ## NAME
 podman\-generate - Generate structured data based on containers, pods or volumes

--- a/docs/source/markdown/podman-healthcheck-run.1.md
+++ b/docs/source/markdown/podman-healthcheck-run.1.md
@@ -1,4 +1,4 @@
-% podman-healthcheck-run(1)
+% podman-healthcheck-run 1
 
 ## NAME
 podman\-healthcheck\-run - Run a container healthcheck

--- a/docs/source/markdown/podman-healthcheck.1.md
+++ b/docs/source/markdown/podman-healthcheck.1.md
@@ -1,4 +1,4 @@
-% podman-healthcheck(1)
+% podman-healthcheck 1
 
 ## NAME
 podman\-healthcheck - Manage healthchecks for containers

--- a/docs/source/markdown/podman-history.1.md
+++ b/docs/source/markdown/podman-history.1.md
@@ -1,4 +1,4 @@
-% podman-history(1)
+% podman-history 1
 
 ## NAME
 podman\-history - Show the history of an image

--- a/docs/source/markdown/podman-image-diff.1.md
+++ b/docs/source/markdown/podman-image-diff.1.md
@@ -1,4 +1,4 @@
-% podman-image-diff(1)
+% podman-image-diff 1
 
 ## NAME
 podman-image-diff - Inspect changes on an image's filesystem

--- a/docs/source/markdown/podman-image-exists.1.md
+++ b/docs/source/markdown/podman-image-exists.1.md
@@ -1,4 +1,4 @@
-% podman-image-exists(1)
+% podman-image-exists 1
 
 ## NAME
 podman-image-exists - Check if an image exists in local storage

--- a/docs/source/markdown/podman-image-inspect.1.md
+++ b/docs/source/markdown/podman-image-inspect.1.md
@@ -1,4 +1,4 @@
-% podman-image-inspect(1)
+% podman-image-inspect 1
 
 ## NAME
 podman\-image\-inspect - Display an image's configuration

--- a/docs/source/markdown/podman-image-mount.1.md
+++ b/docs/source/markdown/podman-image-mount.1.md
@@ -1,4 +1,4 @@
-% podman-image-mount(1)
+% podman-image-mount 1
 
 ## NAME
 podman\-image\-mount - Mount an image's root filesystem

--- a/docs/source/markdown/podman-image-prune.1.md
+++ b/docs/source/markdown/podman-image-prune.1.md
@@ -1,4 +1,4 @@
-% podman-image-prune(1)
+% podman-image-prune 1
 
 ## NAME
 podman-image-prune - Remove all unused images from the local store

--- a/docs/source/markdown/podman-image-scp.1.md
+++ b/docs/source/markdown/podman-image-scp.1.md
@@ -1,4 +1,4 @@
-% podman-image-scp(1)
+% podman-image-scp 1
 
 ## NAME
 podman-image-scp - Securely copy an image from one host to another

--- a/docs/source/markdown/podman-image-sign.1.md.in
+++ b/docs/source/markdown/podman-image-sign.1.md.in
@@ -1,4 +1,4 @@
-% podman-image-sign(1)
+% podman-image-sign 1
 
 ## NAME
 podman-image-sign - Create a signature for an image

--- a/docs/source/markdown/podman-image-tree.1.md
+++ b/docs/source/markdown/podman-image-tree.1.md
@@ -1,4 +1,4 @@
-% podman-image-tree(1)
+% podman-image-tree 1
 
 ## NAME
 podman\-image\-tree - Prints layer hierarchy of an image in a tree format

--- a/docs/source/markdown/podman-image-trust.1.md
+++ b/docs/source/markdown/podman-image-trust.1.md
@@ -1,4 +1,4 @@
-% podman-image-trust(1)
+% podman-image-trust 1
 
 ## NAME
 podman\-image\-trust - Manage container registry image trust policy

--- a/docs/source/markdown/podman-image-unmount.1.md
+++ b/docs/source/markdown/podman-image-unmount.1.md
@@ -1,4 +1,4 @@
-% podman-image-unmount(1)
+% podman-image-unmount 1
 
 ## NAME
 podman\-image\-unmount - Unmount an image's root filesystem

--- a/docs/source/markdown/podman-image.1.md
+++ b/docs/source/markdown/podman-image.1.md
@@ -1,4 +1,4 @@
-% podman-image(1)
+% podman-image 1
 
 ## NAME
 podman\-image - Manage images

--- a/docs/source/markdown/podman-images.1.md
+++ b/docs/source/markdown/podman-images.1.md
@@ -1,4 +1,4 @@
-% podman-images(1)
+% podman-images 1
 
 ## NAME
 podman\-images - List images in local storage

--- a/docs/source/markdown/podman-import.1.md
+++ b/docs/source/markdown/podman-import.1.md
@@ -1,4 +1,4 @@
-% podman-import(1)
+% podman-import 1
 
 ## NAME
 podman\-import - Import a tarball and save it as a filesystem image

--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -1,4 +1,4 @@
-% podman-info(1)
+% podman-info 1
 
 ## NAME
 podman\-info - Displays Podman related system information

--- a/docs/source/markdown/podman-init.1.md
+++ b/docs/source/markdown/podman-init.1.md
@@ -1,4 +1,4 @@
-% podman-init(1)
+% podman-init 1
 
 ## NAME
 podman\-init - Initialize one or more containers

--- a/docs/source/markdown/podman-inspect.1.md
+++ b/docs/source/markdown/podman-inspect.1.md
@@ -1,4 +1,4 @@
-% podman-inspect(1)
+% podman-inspect 1
 
 ## NAME
 podman\-inspect - Display a container, image, volume, network, or pod's configuration

--- a/docs/source/markdown/podman-kill.1.md.in
+++ b/docs/source/markdown/podman-kill.1.md.in
@@ -1,4 +1,4 @@
-% podman-kill(1)
+% podman-kill 1
 
 ## NAME
 podman\-kill - Kill the main process in one or more containers

--- a/docs/source/markdown/podman-kube-down.1.md
+++ b/docs/source/markdown/podman-kube-down.1.md
@@ -1,4 +1,4 @@
-% podman-kube-down(1)
+% podman-kube-down 1
 
 ## NAME
 podman-kube-down - Remove containers and pods based on Kubernetes YAML

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -1,4 +1,4 @@
-% podman-kube-play(1)
+% podman-kube-play 1
 
 ## NAME
 podman-kube-play - Create containers, pods and volumes based on Kubernetes YAML

--- a/docs/source/markdown/podman-kube.1.md
+++ b/docs/source/markdown/podman-kube.1.md
@@ -1,4 +1,4 @@
-% podman-kube(1)
+% podman-kube 1
 
 ## NAME
 podman\-kube - Play containers, pods or volumes based on a structured input file

--- a/docs/source/markdown/podman-load.1.md
+++ b/docs/source/markdown/podman-load.1.md
@@ -1,4 +1,4 @@
-% podman-load(1)
+% podman-load 1
 
 ## NAME
 podman\-load - Load image(s) from a tar archive into container storage

--- a/docs/source/markdown/podman-login.1.md.in
+++ b/docs/source/markdown/podman-login.1.md.in
@@ -1,4 +1,4 @@
-% podman-login(1)
+% podman-login 1
 
 ## NAME
 podman\-login - Login to a container registry

--- a/docs/source/markdown/podman-logout.1.md.in
+++ b/docs/source/markdown/podman-logout.1.md.in
@@ -1,4 +1,4 @@
-% podman-logout(1)
+% podman-logout 1
 
 ## NAME
 podman\-logout - Logout of a container registry

--- a/docs/source/markdown/podman-logs.1.md.in
+++ b/docs/source/markdown/podman-logs.1.md.in
@@ -1,4 +1,4 @@
-% podman-logs(1)
+% podman-logs 1
 
 ## NAME
 podman\-logs - Display the logs of one or more containers

--- a/docs/source/markdown/podman-machine-info.1.md
+++ b/docs/source/markdown/podman-machine-info.1.md
@@ -1,4 +1,4 @@
-% podman-machine-info(1)
+% podman-machine-info 1
 
 ## NAME
 podman\-machine\-info - Display machine host info

--- a/docs/source/markdown/podman-machine-init.1.md
+++ b/docs/source/markdown/podman-machine-init.1.md
@@ -1,4 +1,4 @@
-% podman-machine-init(1)
+% podman-machine-init 1
 
 ## NAME
 podman\-machine\-init - Initialize a new virtual machine

--- a/docs/source/markdown/podman-machine-inspect.1.md
+++ b/docs/source/markdown/podman-machine-inspect.1.md
@@ -1,4 +1,4 @@
-% podman-machine-inspect(1)
+% podman-machine-inspect 1
 
 ## NAME
 podman\-machine\-inspect - Inspect one or more virtual machines

--- a/docs/source/markdown/podman-machine-list.1.md
+++ b/docs/source/markdown/podman-machine-list.1.md
@@ -1,4 +1,4 @@
-% podman-machine-ls(1)
+% podman-machine-ls 1
 
 ## NAME
 podman\-machine\-list - List virtual machines

--- a/docs/source/markdown/podman-machine-rm.1.md
+++ b/docs/source/markdown/podman-machine-rm.1.md
@@ -1,4 +1,4 @@
-% podman-machine-rm(1)
+% podman-machine-rm 1
 
 ## NAME
 podman\-machine\-rm - Remove a virtual machine

--- a/docs/source/markdown/podman-machine-set.1.md
+++ b/docs/source/markdown/podman-machine-set.1.md
@@ -1,4 +1,4 @@
-% podman-machine-set(1)
+% podman-machine-set 1
 
 ## NAME
 podman\-machine\-set - Sets a virtual machine setting

--- a/docs/source/markdown/podman-machine-ssh.1.md
+++ b/docs/source/markdown/podman-machine-ssh.1.md
@@ -1,4 +1,4 @@
-% podman-machine-ssh(1)
+% podman-machine-ssh 1
 
 ## NAME
 podman\-machine\-ssh - SSH into a virtual machine

--- a/docs/source/markdown/podman-machine-start.1.md
+++ b/docs/source/markdown/podman-machine-start.1.md
@@ -1,4 +1,4 @@
-% podman-machine-start(1)
+% podman-machine-start 1
 
 ## NAME
 podman\-machine\-start - Start a virtual machine

--- a/docs/source/markdown/podman-machine-stop.1.md
+++ b/docs/source/markdown/podman-machine-stop.1.md
@@ -1,4 +1,4 @@
-% podman-machine-stop(1)
+% podman-machine-stop 1
 
 ## NAME
 podman\-machine\-stop - Stop a virtual machine

--- a/docs/source/markdown/podman-machine.1.md
+++ b/docs/source/markdown/podman-machine.1.md
@@ -1,4 +1,4 @@
-% podman-machine(1)
+% podman-machine 1
 
 ## NAME
 podman\-machine - Manage Podman's virtual machine

--- a/docs/source/markdown/podman-manifest-add.1.md.in
+++ b/docs/source/markdown/podman-manifest-add.1.md.in
@@ -1,4 +1,4 @@
-% podman-manifest-add(1)
+% podman-manifest-add 1
 
 ## NAME
 podman\-manifest\-add - Add an image to a manifest list or image index

--- a/docs/source/markdown/podman-manifest-annotate.1.md
+++ b/docs/source/markdown/podman-manifest-annotate.1.md
@@ -1,4 +1,4 @@
-% podman-manifest-annotate(1)
+% podman-manifest-annotate 1
 
 ## NAME
 podman\-manifest\-annotate - Add or update information about an entry in a manifest list or image index

--- a/docs/source/markdown/podman-manifest-create.1.md
+++ b/docs/source/markdown/podman-manifest-create.1.md
@@ -1,4 +1,4 @@
-% podman-manifest-create(1)
+% podman-manifest-create 1
 
 ## NAME
 podman\-manifest\-create - Create a manifest list or image index

--- a/docs/source/markdown/podman-manifest-exists.1.md
+++ b/docs/source/markdown/podman-manifest-exists.1.md
@@ -1,4 +1,4 @@
-% podman-manifest-exists(1)
+% podman-manifest-exists 1
 
 ## NAME
 podman\-manifest\-exists - Check if the given manifest list exists in local storage

--- a/docs/source/markdown/podman-manifest-inspect.1.md
+++ b/docs/source/markdown/podman-manifest-inspect.1.md
@@ -1,4 +1,4 @@
-% podman-manifest-inspect(1)
+% podman-manifest-inspect 1
 
 ## NAME
 podman\-manifest\-inspect - Display a manifest list or image index

--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -1,4 +1,4 @@
-% podman-manifest-push(1)
+% podman-manifest-push 1
 
 ## NAME
 podman\-manifest\-push - Push a manifest list or image index to a registry

--- a/docs/source/markdown/podman-manifest-remove.1.md
+++ b/docs/source/markdown/podman-manifest-remove.1.md
@@ -1,4 +1,4 @@
-% podman-manifest-remove(1)
+% podman-manifest-remove 1
 
 ## NAME
 podman\-manifest\-remove - Remove an image from a manifest list or image index

--- a/docs/source/markdown/podman-manifest.1.md
+++ b/docs/source/markdown/podman-manifest.1.md
@@ -1,4 +1,4 @@
-% podman-manifest(1)
+% podman-manifest 1
 
 ## NAME
 podman\-manifest - Create and manipulate manifest lists and image indexes

--- a/docs/source/markdown/podman-mount.1.md
+++ b/docs/source/markdown/podman-mount.1.md
@@ -1,4 +1,4 @@
-% podman-mount(1)
+% podman-mount 1
 
 ## NAME
 podman\-mount - Mount a working container's root filesystem

--- a/docs/source/markdown/podman-network-connect.1.md
+++ b/docs/source/markdown/podman-network-connect.1.md
@@ -1,4 +1,4 @@
-% podman-network-connect(1)
+% podman-network-connect 1
 
 ## NAME
 podman\-network\-connect - Connect a container to a network

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -1,4 +1,4 @@
-% podman-network-create(1)
+% podman-network-create 1
 
 ## NAME
 podman\-network-create - Create a Podman network

--- a/docs/source/markdown/podman-network-disconnect.1.md
+++ b/docs/source/markdown/podman-network-disconnect.1.md
@@ -1,4 +1,4 @@
-% podman-network-disconnect(1)
+% podman-network-disconnect 1
 
 ## NAME
 podman\-network\-disconnect - Disconnect a container from a network

--- a/docs/source/markdown/podman-network-exists.1.md
+++ b/docs/source/markdown/podman-network-exists.1.md
@@ -1,4 +1,4 @@
-% podman-network-exists(1)
+% podman-network-exists 1
 
 ## NAME
 podman\-network\-exists - Check if the given network exists

--- a/docs/source/markdown/podman-network-inspect.1.md
+++ b/docs/source/markdown/podman-network-inspect.1.md
@@ -1,4 +1,4 @@
-% podman-network-inspect(1)
+% podman-network-inspect 1
 
 ## NAME
 podman\-network\-inspect - Displays the network configuration for one or more networks

--- a/docs/source/markdown/podman-network-ls.1.md
+++ b/docs/source/markdown/podman-network-ls.1.md
@@ -1,4 +1,4 @@
-% podman-network-ls(1)
+% podman-network-ls 1
 
 ## NAME
 podman\-network\-ls - Display a summary of networks

--- a/docs/source/markdown/podman-network-prune.1.md
+++ b/docs/source/markdown/podman-network-prune.1.md
@@ -1,4 +1,4 @@
-% podman-network-prune(1)
+% podman-network-prune 1
 
 ## NAME
 podman\-network\-prune - Remove all unused networks

--- a/docs/source/markdown/podman-network-reload.1.md
+++ b/docs/source/markdown/podman-network-reload.1.md
@@ -1,4 +1,4 @@
-% podman-network-reload(1)
+% podman-network-reload 1
 
 ## NAME
 podman\-network\-reload - Reload network configuration for containers

--- a/docs/source/markdown/podman-network-rm.1.md
+++ b/docs/source/markdown/podman-network-rm.1.md
@@ -1,4 +1,4 @@
-% podman-network-rm(1)
+% podman-network-rm 1
 
 ## NAME
 podman\-network\-rm - Remove one or more networks

--- a/docs/source/markdown/podman-network.1.md
+++ b/docs/source/markdown/podman-network.1.md
@@ -1,4 +1,4 @@
-% podman-network(1)
+% podman-network 1
 
 ## NAME
 podman\-network - Manage Podman networks

--- a/docs/source/markdown/podman-pause.1.md.in
+++ b/docs/source/markdown/podman-pause.1.md.in
@@ -1,4 +1,4 @@
-% podman-pause(1)
+% podman-pause 1
 
 ## NAME
 podman\-pause - Pause one or more containers

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -1,4 +1,4 @@
-% podman-pod-clone(1)
+% podman-pod-clone 1
 
 ## NAME
 podman\-pod\-clone - Creates a copy of an existing pod

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -1,4 +1,4 @@
-% podman-pod-create(1)
+% podman-pod-create 1
 
 ## NAME
 podman\-pod\-create - Create a new pod

--- a/docs/source/markdown/podman-pod-exists.1.md
+++ b/docs/source/markdown/podman-pod-exists.1.md
@@ -1,4 +1,4 @@
-% podman-pod-exists(1)
+% podman-pod-exists 1
 
 ## NAME
 podman-pod-exists - Check if a pod exists in local storage

--- a/docs/source/markdown/podman-pod-inspect.1.md
+++ b/docs/source/markdown/podman-pod-inspect.1.md
@@ -1,4 +1,4 @@
-% podman-pod-inspect(1)
+% podman-pod-inspect 1
 
 ## NAME
 podman\-pod\-inspect - Displays information describing a pod

--- a/docs/source/markdown/podman-pod-kill.1.md.in
+++ b/docs/source/markdown/podman-pod-kill.1.md.in
@@ -1,4 +1,4 @@
-% podman-pod-kill(1)
+% podman-pod-kill 1
 
 ## NAME
 podman\-pod\-kill - Kill the main process of each container in one or more pods

--- a/docs/source/markdown/podman-pod-logs.1.md.in
+++ b/docs/source/markdown/podman-pod-logs.1.md.in
@@ -1,4 +1,4 @@
-% podman-pod-logs(1)
+% podman-pod-logs 1
 
 ## NAME
 podman\-pod\-logs - Displays logs for pod with one or more containers

--- a/docs/source/markdown/podman-pod-pause.1.md
+++ b/docs/source/markdown/podman-pod-pause.1.md
@@ -1,4 +1,4 @@
-% podman-pod-pause(1)
+% podman-pod-pause 1
 
 ## NAME
 podman\-pod\-pause - Pause one or more pods

--- a/docs/source/markdown/podman-pod-prune.1.md
+++ b/docs/source/markdown/podman-pod-prune.1.md
@@ -1,4 +1,4 @@
-% podman-pod-prune(1)
+% podman-pod-prune 1
 
 ## NAME
 podman-pod-prune - Remove all stopped pods and their containers

--- a/docs/source/markdown/podman-pod-ps.1.md
+++ b/docs/source/markdown/podman-pod-ps.1.md
@@ -1,4 +1,4 @@
-% podman-pod-ps(1)
+% podman-pod-ps 1
 
 ## NAME
 podman\-pod\-ps - Prints out information about pods

--- a/docs/source/markdown/podman-pod-restart.1.md
+++ b/docs/source/markdown/podman-pod-restart.1.md
@@ -1,4 +1,4 @@
-% podman-pod-restart(1)
+% podman-pod-restart 1
 
 ## NAME
 podman\-pod\-restart - Restart one or more pods

--- a/docs/source/markdown/podman-pod-rm.1.md.in
+++ b/docs/source/markdown/podman-pod-rm.1.md.in
@@ -1,4 +1,4 @@
-% podman-pod-rm(1)
+% podman-pod-rm 1
 
 ## NAME
 podman\-pod\-rm - Remove one or more stopped pods and containers

--- a/docs/source/markdown/podman-pod-start.1.md.in
+++ b/docs/source/markdown/podman-pod-start.1.md.in
@@ -1,4 +1,4 @@
-% podman-pod-start(1)
+% podman-pod-start 1
 
 ## NAME
 podman\-pod\-start - Start one or more pods

--- a/docs/source/markdown/podman-pod-stats.1.md
+++ b/docs/source/markdown/podman-pod-stats.1.md
@@ -1,4 +1,4 @@
-% podman-pod-stats(1)
+% podman-pod-stats 1
 
 ## NAME
 podman\-pod\-stats - Display a live stream of resource usage stats for containers in one or more pods

--- a/docs/source/markdown/podman-pod-stop.1.md.in
+++ b/docs/source/markdown/podman-pod-stop.1.md.in
@@ -1,4 +1,4 @@
-% podman-pod-stop(1)
+% podman-pod-stop 1
 
 ## NAME
 podman\-pod\-stop - Stop one or more pods

--- a/docs/source/markdown/podman-pod-top.1.md
+++ b/docs/source/markdown/podman-pod-top.1.md
@@ -1,4 +1,4 @@
-% podman-pod-top(1)
+% podman-pod-top 1
 
 ## NAME
 podman\-pod\-top - Display the running processes of containers in a pod

--- a/docs/source/markdown/podman-pod-unpause.1.md
+++ b/docs/source/markdown/podman-pod-unpause.1.md
@@ -1,4 +1,4 @@
-% podman-pod-unpause(1)
+% podman-pod-unpause 1
 
 ## NAME
 podman\-pod\-unpause - Unpause one or more pods

--- a/docs/source/markdown/podman-pod.1.md
+++ b/docs/source/markdown/podman-pod.1.md
@@ -1,4 +1,4 @@
-% podman-pod(1)
+% podman-pod 1
 
 ## NAME
 podman\-pod - Management tool for groups of containers, called pods

--- a/docs/source/markdown/podman-port.1.md
+++ b/docs/source/markdown/podman-port.1.md
@@ -1,4 +1,4 @@
-% podman-port(1)
+% podman-port 1
 
 ## NAME
 podman\-port - List port mappings for a container

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -1,4 +1,4 @@
-% podman-ps(1)
+% podman-ps 1
 
 ## NAME
 podman\-ps - Prints out information about containers

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -1,4 +1,4 @@
-% podman-pull(1)
+% podman-pull 1
 
 ## NAME
 podman\-pull - Pull an image from a registry

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -1,4 +1,4 @@
-% podman-push(1)
+% podman-push 1
 
 ## NAME
 podman\-push - Push an image, manifest list or image index from local storage to elsewhere

--- a/docs/source/markdown/podman-remote.1.md
+++ b/docs/source/markdown/podman-remote.1.md
@@ -1,4 +1,4 @@
-% podman-remote(1)
+% podman-remote 1
 
 ## NAME
 podman-remote - A remote CLI for Podman: A Simple management tool for pods, containers and images.

--- a/docs/source/markdown/podman-rename.1.md
+++ b/docs/source/markdown/podman-rename.1.md
@@ -1,4 +1,4 @@
-% podman-rename(1)
+% podman-rename 1
 
 ## NAME
 podman\-rename - Rename an existing container

--- a/docs/source/markdown/podman-restart.1.md
+++ b/docs/source/markdown/podman-restart.1.md
@@ -1,4 +1,4 @@
-% podman-restart(1)
+% podman-restart 1
 
 ## NAME
 podman\-restart - Restart one or more containers

--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -1,4 +1,4 @@
-% podman-rm(1)
+% podman-rm 1
 
 ## NAME
 podman\-rm - Remove one or more containers

--- a/docs/source/markdown/podman-rmi.1.md
+++ b/docs/source/markdown/podman-rmi.1.md
@@ -1,4 +1,4 @@
-% podman-rmi(1)
+% podman-rmi 1
 
 ## NAME
 podman\-rmi - Removes one or more locally stored images

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -1,4 +1,4 @@
-% podman-run(1)
+% podman-run 1
 
 ## NAME
 podman\-run - Run a command in a new container

--- a/docs/source/markdown/podman-save.1.md
+++ b/docs/source/markdown/podman-save.1.md
@@ -1,4 +1,4 @@
-% podman-save(1)
+% podman-save 1
 
 ## NAME
 podman\-save - Save image(s) to an archive

--- a/docs/source/markdown/podman-search.1.md.in
+++ b/docs/source/markdown/podman-search.1.md.in
@@ -1,4 +1,4 @@
-% podman-search(1)
+% podman-search 1
 
 ## NAME
 podman\-search - Search a registry for an image

--- a/docs/source/markdown/podman-secret-create.1.md
+++ b/docs/source/markdown/podman-secret-create.1.md
@@ -1,4 +1,4 @@
-% podman-secret-create(1)
+% podman-secret-create 1
 
 ## NAME
 podman\-secret\-create - Create a new secret

--- a/docs/source/markdown/podman-secret-inspect.1.md
+++ b/docs/source/markdown/podman-secret-inspect.1.md
@@ -1,4 +1,4 @@
-% podman-secret-inspect(1)
+% podman-secret-inspect 1
 
 ## NAME
 podman\-secret\-inspect - Display detailed information on one or more secrets

--- a/docs/source/markdown/podman-secret-ls.1.md
+++ b/docs/source/markdown/podman-secret-ls.1.md
@@ -1,4 +1,4 @@
-% podman-secret-ls(1)
+% podman-secret-ls 1
 
 ## NAME
 podman\-secret\-ls - List all available secrets

--- a/docs/source/markdown/podman-secret-rm.1.md
+++ b/docs/source/markdown/podman-secret-rm.1.md
@@ -1,4 +1,4 @@
-% podman-secret-rm(1)
+% podman-secret-rm 1
 
 ## NAME
 podman\-secret\-rm - Remove one or more secrets

--- a/docs/source/markdown/podman-secret.1.md
+++ b/docs/source/markdown/podman-secret.1.md
@@ -1,4 +1,4 @@
-% podman-secret(1)
+% podman-secret 1
 
 ## NAME
 podman\-secret - Manage podman secrets

--- a/docs/source/markdown/podman-start.1.md
+++ b/docs/source/markdown/podman-start.1.md
@@ -1,4 +1,4 @@
-% podman-start(1)
+% podman-start 1
 
 ## NAME
 podman\-start - Start one or more containers

--- a/docs/source/markdown/podman-stats.1.md
+++ b/docs/source/markdown/podman-stats.1.md
@@ -1,4 +1,4 @@
-% podman-stats(1)
+% podman-stats 1
 
 ## NAME
 podman\-stats - Display a live stream of one or more container's resource usage statistics

--- a/docs/source/markdown/podman-stop.1.md.in
+++ b/docs/source/markdown/podman-stop.1.md.in
@@ -1,4 +1,4 @@
-% podman-stop(1)
+% podman-stop 1
 
 ## NAME
 podman\-stop - Stop one or more running containers

--- a/docs/source/markdown/podman-system-connection-add.1.md
+++ b/docs/source/markdown/podman-system-connection-add.1.md
@@ -1,4 +1,4 @@
-% podman-system-connection-add(1)
+% podman-system-connection-add 1
 
 ## NAME
 podman\-system\-connection\-add - Record destination for the Podman service

--- a/docs/source/markdown/podman-system-connection-default.1.md
+++ b/docs/source/markdown/podman-system-connection-default.1.md
@@ -1,4 +1,4 @@
-% podman-system-connection-default(1)
+% podman-system-connection-default 1
 
 ## NAME
 podman\-system\-connection\-default - Set named destination as default for the Podman service

--- a/docs/source/markdown/podman-system-connection-list.1.md
+++ b/docs/source/markdown/podman-system-connection-list.1.md
@@ -1,4 +1,4 @@
-% podman-system-connection-list(1)
+% podman-system-connection-list 1
 
 ## NAME
 podman\-system\-connection\-list - List the destination for the Podman service(s)

--- a/docs/source/markdown/podman-system-connection-remove.1.md
+++ b/docs/source/markdown/podman-system-connection-remove.1.md
@@ -1,4 +1,4 @@
-% podman-system-connection-remove(1)
+% podman-system-connection-remove 1
 
 ## NAME
 podman\-system\-connection\-remove - Delete named destination

--- a/docs/source/markdown/podman-system-connection-rename.1.md
+++ b/docs/source/markdown/podman-system-connection-rename.1.md
@@ -1,4 +1,4 @@
-% podman-system-connection-rename(1)
+% podman-system-connection-rename 1
 
 ## NAME
 podman\-system\-connection\-rename - Rename the destination for Podman service

--- a/docs/source/markdown/podman-system-connection.1.md
+++ b/docs/source/markdown/podman-system-connection.1.md
@@ -1,4 +1,4 @@
-% podman-system-connection(1)
+% podman-system-connection 1
 
 ## NAME
 podman\-system\-connection - Manage the destination(s) for Podman service(s)

--- a/docs/source/markdown/podman-system-df.1.md
+++ b/docs/source/markdown/podman-system-df.1.md
@@ -1,4 +1,4 @@
-% podman-system-df(1)
+% podman-system-df 1
 
 ## NAME
 podman\-system\-df - Show podman disk usage

--- a/docs/source/markdown/podman-system-migrate.1.md
+++ b/docs/source/markdown/podman-system-migrate.1.md
@@ -1,4 +1,4 @@
-% podman-system-migrate(1)
+% podman-system-migrate 1
 
 ## NAME
 podman\-system\-migrate - Migrate existing containers to a new podman version

--- a/docs/source/markdown/podman-system-prune.1.md
+++ b/docs/source/markdown/podman-system-prune.1.md
@@ -1,4 +1,4 @@
-% podman-system-prune(1)
+% podman-system-prune 1
 
 ## NAME
 podman\-system\-prune - Remove all unused pods, containers, images, networks, and volume data

--- a/docs/source/markdown/podman-system-renumber.1.md
+++ b/docs/source/markdown/podman-system-renumber.1.md
@@ -1,4 +1,4 @@
-% podman-system-renumber(1)
+% podman-system-renumber 1
 
 ## NAME
 podman\-system\-renumber - Migrate lock numbers to handle a change in maximum number of locks

--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -1,4 +1,4 @@
-% podman-system-reset(1)
+% podman-system-reset 1
 
 ## NAME
 podman\-system\-reset - Reset storage back to initial state

--- a/docs/source/markdown/podman-system-service.1.md
+++ b/docs/source/markdown/podman-system-service.1.md
@@ -1,4 +1,4 @@
-% podman-service(1)
+% podman-service 1
 
 ## NAME
 podman\-system\-service - Run an API service

--- a/docs/source/markdown/podman-system.1.md
+++ b/docs/source/markdown/podman-system.1.md
@@ -1,4 +1,4 @@
-% podman-system(1)
+% podman-system 1
 
 ## NAME
 podman\-system - Manage podman

--- a/docs/source/markdown/podman-tag.1.md
+++ b/docs/source/markdown/podman-tag.1.md
@@ -1,4 +1,4 @@
-% podman-tag(1)
+% podman-tag 1
 
 ## NAME
 podman\-tag - Add an additional name to a local image

--- a/docs/source/markdown/podman-top.1.md
+++ b/docs/source/markdown/podman-top.1.md
@@ -1,4 +1,4 @@
-% podman-top(1)
+% podman-top 1
 
 ## NAME
 podman\-top - Display the running processes of a container

--- a/docs/source/markdown/podman-unmount.1.md
+++ b/docs/source/markdown/podman-unmount.1.md
@@ -1,4 +1,4 @@
-% podman-unmount(1)
+% podman-unmount 1
 
 ## NAME
 podman\-unmount - Unmount a working container's root filesystem

--- a/docs/source/markdown/podman-unpause.1.md.in
+++ b/docs/source/markdown/podman-unpause.1.md.in
@@ -1,4 +1,4 @@
-% podman-unpause(1)
+% podman-unpause 1
 
 ## NAME
 podman\-unpause - Unpause one or more containers

--- a/docs/source/markdown/podman-unshare.1.md
+++ b/docs/source/markdown/podman-unshare.1.md
@@ -1,4 +1,4 @@
-% podman-unshare(1)
+% podman-unshare 1
 
 ## NAME
 podman\-unshare - Run a command inside of a modified user namespace

--- a/docs/source/markdown/podman-untag.1.md
+++ b/docs/source/markdown/podman-untag.1.md
@@ -1,4 +1,4 @@
-% podman-untag(1)
+% podman-untag 1
 
 ## NAME
 podman\-untag - Removes one or more names from a locally-stored image

--- a/docs/source/markdown/podman-update.1.md.in
+++ b/docs/source/markdown/podman-update.1.md.in
@@ -1,4 +1,4 @@
-% podman-update(1)
+% podman-update 1
 
 ## NAME
 podman\-update - Updates the cgroup configuration of a given container

--- a/docs/source/markdown/podman-version.1.md
+++ b/docs/source/markdown/podman-version.1.md
@@ -1,4 +1,4 @@
-% podman-version(1)
+% podman-version 1
 
 ## NAME
 podman\-version - Display the Podman version information

--- a/docs/source/markdown/podman-volume-create.1.md
+++ b/docs/source/markdown/podman-volume-create.1.md
@@ -1,4 +1,4 @@
-% podman-volume-create(1)
+% podman-volume-create 1
 
 ## NAME
 podman\-volume\-create - Create a new volume

--- a/docs/source/markdown/podman-volume-exists.1.md
+++ b/docs/source/markdown/podman-volume-exists.1.md
@@ -1,4 +1,4 @@
-% podman-volume-exists(1)
+% podman-volume-exists 1
 
 ## NAME
 podman\-volume\-exists - Check if the given volume exists

--- a/docs/source/markdown/podman-volume-export.1.md
+++ b/docs/source/markdown/podman-volume-export.1.md
@@ -1,4 +1,4 @@
-% podman-volume-export(1)
+% podman-volume-export 1
 
 ## NAME
 podman\-volume\-export - Exports volume to external tar

--- a/docs/source/markdown/podman-volume-import.1.md
+++ b/docs/source/markdown/podman-volume-import.1.md
@@ -1,4 +1,4 @@
-% podman-volume-import(1)
+% podman-volume-import 1
 
 ## NAME
 podman\-volume\-import - Import tarball contents into an existing podman volume

--- a/docs/source/markdown/podman-volume-inspect.1.md
+++ b/docs/source/markdown/podman-volume-inspect.1.md
@@ -1,4 +1,4 @@
-% podman-volume-inspect(1)
+% podman-volume-inspect 1
 
 ## NAME
 podman\-volume\-inspect - Get detailed information on one or more volumes

--- a/docs/source/markdown/podman-volume-ls.1.md
+++ b/docs/source/markdown/podman-volume-ls.1.md
@@ -1,4 +1,4 @@
-% podman-volume-ls(1)
+% podman-volume-ls 1
 
 ## NAME
 podman\-volume\-ls - List all the available volumes

--- a/docs/source/markdown/podman-volume-mount.1.md
+++ b/docs/source/markdown/podman-volume-mount.1.md
@@ -1,4 +1,4 @@
-% podman-volume-mount(1)
+% podman-volume-mount 1
 
 ## NAME
 podman\-volume\-mount - Mount a volume filesystem

--- a/docs/source/markdown/podman-volume-prune.1.md
+++ b/docs/source/markdown/podman-volume-prune.1.md
@@ -1,4 +1,4 @@
-% podman-volume-prune(1)
+% podman-volume-prune 1
 
 ## NAME
 podman\-volume\-prune - Remove all unused volumes

--- a/docs/source/markdown/podman-volume-reload.1.md
+++ b/docs/source/markdown/podman-volume-reload.1.md
@@ -1,4 +1,4 @@
-% podman-volume-reload(1)
+% podman-volume-reload 1
 
 ## NAME
 podman\-volume\-reload - Reload all volumes from volumes plugins

--- a/docs/source/markdown/podman-volume-rm.1.md
+++ b/docs/source/markdown/podman-volume-rm.1.md
@@ -1,4 +1,4 @@
-% podman-volume-rm(1)
+% podman-volume-rm 1
 
 ## NAME
 podman\-volume\-rm - Remove one or more volumes

--- a/docs/source/markdown/podman-volume-unmount.1.md
+++ b/docs/source/markdown/podman-volume-unmount.1.md
@@ -1,4 +1,4 @@
-% podman-volume-unmount(1)
+% podman-volume-unmount 1
 
 ## NAME
 podman\-volume\-unmount - Unmount a volume

--- a/docs/source/markdown/podman-volume.1.md
+++ b/docs/source/markdown/podman-volume.1.md
@@ -1,4 +1,4 @@
-% podman-volume(1)
+% podman-volume 1
 
 ## NAME
 podman\-volume - Simple management tool for volumes

--- a/docs/source/markdown/podman-wait.1.md
+++ b/docs/source/markdown/podman-wait.1.md
@@ -1,4 +1,4 @@
-% podman-wait(1)
+% podman-wait 1
 
 ## NAME
 podman\-wait - Wait on one or more containers to stop and print their exit codes

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -1,4 +1,4 @@
-% podman(1)
+% podman 1
 
 ## NAME
 podman - Simple management tool for pods, containers and images


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Current podman manpages cause the Gnome yelp manpage viewer to fail to render the manpage with an error `Don't understand title line: 'tpodman(1)()'`. This is caused by the title line being malformed. Ultimately the problem is that go-md2man wants the title line to be space separated, not formatted with parenthesis around the section number.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
