### PR TITLE
[CI:DOCS] Man pages: refactor common options: --label

### DIFF
--- a/docs/source/markdown/options/label.md
+++ b/docs/source/markdown/options/label.md
@@ -1,0 +1,3 @@
+#### **--label**, **-l**=*key=value*
+
+Add metadata to a <<container|pod>>.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -260,9 +260,7 @@ To specify multiple static IPv6 addresses per container, set multiple networks u
 
 @@option ipc
 
-#### **--label**, **-l**=*label*
-
-Add metadata to a container (e.g., --label com.example.key=value)
+@@option label
 
 @@option label-file
 

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -66,9 +66,7 @@ Print usage statement.
 
 @@option infra-name
 
-#### **--label**, **-l**=*label*
-
-Add metadata to a pod (e.g., --label com.example.key=value).
+@@option label
 
 @@option label-file
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -130,9 +130,7 @@ The address must be within the network's IPv6 address pool.
 
 To specify multiple static IPv6 addresses per pod, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
 
-#### **--label**, **-l**=*label*
-
-Add metadata to a pod (e.g., --label com.example.key=value).
+@@option label
 
 @@option label-file
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -280,9 +280,7 @@ To specify multiple static IPv6 addresses per container, set multiple networks u
 
 @@option ipc
 
-#### **--label**, **-l**=*key=value*
-
-Add metadata to a container.
+@@option label
 
 @@option label-file
 


### PR DESCRIPTION
Went with the podman-run version, where the "example" is
in the option template as per our guidelines.

I could not include the network- or volume-create
man pages, nor podman build.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```