### PR TITLE
Update system reset warning message regarding deletion of volumes

### DIFF
--- a/cmd/podman/system/reset.go
+++ b/cmd/podman/system/reset.go
@@ -62,7 +62,8 @@ func reset(cmd *cobra.Command, args []string) {
         - all images
         - all networks
         - all build cache
-        - all machines`)
+        - all machines
+        - all volumes`)
 
 		if len(listCtn) > 0 {
 			fmt.Println(`WARNING! The following external containers will be purged:`)

--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -37,6 +37,7 @@ WARNING! This will remove:
         - all networks
         - all build cache
         - all machines
+        - all volumes
 Are you sure you want to continue? [y/N] y
 ```
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

**TL;DR:** I almost lost an awful amount of work.

**Story:** Yesterday, I needed to use netavark, to have the DNS feature enabled on my network. As my podman install was pre-netavark, I had to use the system reset command to enable it. It warned me that almost everything was going to be removed. As I understoot it, everything except my volumes was going to be deleted ... I asked myself, do I trust that? Well, yes, it looks like an exhaustive list, and maybe because volumes are basic enough, it may not be needed to delete them. It will just reset the core features of podman I guess, right? Do I confirm reset then? I said Yes. You know what followed.

Fortunately, I ran a backup script for my volumes very recently. But it wasn't planed in the first place. I am VERY lucky not to have lost a week of work! ... and it was a dense and tricky kind of work on top of that.

**This is the motivation for this PR: Warning users that the volumes will get deleted too.** It is mentioned in the documentation, but not in the warning message shown to the user when running the command.

And folks, BACKUP, BACKUP, BACKUP!!!