### PR TITLE
CI: Cirrus setup: retry failed curls

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -61,7 +61,7 @@ env:
     # Curl-command prefix for downloading task artifacts, simply add the
     # the url-encoded task name, artifact name, and path as a suffix.
     ARTCURL: >-
-        curl --fail --location -O
+        curl --retry 5 --retry-delay 8 --fail --location -O
         --url https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}
 
 


### PR DESCRIPTION
We're seeing a huge number of "unknown failure" flakes,
and all seem to be in the 'clone' step, failing with:

   echo "$ARTCURL..."
   curl ... https://api.cirrus-ci.com/.../repo.tbz
   (lots of pretty curl output lines)
   curl: (22) The requested URL returned error: 502

Solution: use --retry, which will backoff-retry transient
failures. Start with a backoff of 8s, not the default 1.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```