### PR TITLE
(Windows) Drop stale config value resulting in asymmetric config

### DIFF
--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -44,7 +44,6 @@ const containersConf = `[containers]
 
 [engine]
 cgroup_manager = "cgroupfs"
-events_logger = "file"
 `
 
 const appendPort = `grep -q Port\ %d /etc/ssh/sshd_config || echo Port %d >> /etc/ssh/sshd_config`


### PR DESCRIPTION
Fixes log follow operations since the corresponding k8s-file backend was previously dropped from usage (unintentionally   leaving behind the file events backend)

[NO NEW TESTS NEEDED]

```release-note
Fixed log follow operations on podman machine on Windows
```
