### PR TITLE
system tests: fix some tests in proxy environment

### DIFF
--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -375,6 +375,12 @@ After=network-online.target
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/podman auto-update
+Environment="http_proxy=${http_proxy}"
+Environment="HTTP_PROXY=${HTTP_PROXY}"
+Environment="https_proxy=${https_proxy}"
+Environment="HTTPS_PROXY=${HTTPS_PROXY}"
+Environment="no_proxy=${no_proxy}"
+Environment="NO_PROXY=${NO_PROXY}"
 
 [Install]
 WantedBy=default.target

--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -61,9 +61,9 @@ load helpers
     is "$output" "$random_2" "curl 127.0.0.1:/index2.txt"
 
     # Verify http contents: wget from a second container
-    run_podman run --rm --net=host $IMAGE wget -qO - $SERVER/index.txt
+    run_podman run --rm --net=host --http-proxy=false $IMAGE wget -qO - $SERVER/index.txt
     is "$output" "$random_1" "podman wget /index.txt"
-    run_podman run --rm --net=host $IMAGE wget -qO - $SERVER/index2.txt
+    run_podman run --rm --net=host --http-proxy=false $IMAGE wget -qO - $SERVER/index2.txt
     is "$output" "$random_2" "podman wget /index2.txt"
 
     # Tests #4889 - two-argument form of "podman ports" was broken


### PR DESCRIPTION
Some system tests in `255-auto-update.bats` and `500-networking.bats`
fail under proxy environment.
This PR fixes this problem.

In `255-auto-update.bats`, `Environment` parameters for proxy are added to systemd unit file.
In `500-networking.bats`, `run --http-proxy=false` is added to prevent proxy connections in connections between containers.

Signed-off-by: Tsubasa Watanabe <w.tsubasa@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
