### PR TITLE
Fixes for conmon support on FreeBSD

### DIFF
--- a/libpod/oci_conmon_attach_common.go
+++ b/libpod/oci_conmon_attach_common.go
@@ -280,20 +280,20 @@ func readStdio(conn *net.UnixConn, streams *define.AttachStreams, receiveStdoutE
 	var err error
 	select {
 	case err = <-receiveStdoutError:
-		if err := conn.CloseWrite(); err != nil {
+		if err := socketCloseWrite(conn); err != nil {
 			logrus.Errorf("Failed to close stdin: %v", err)
 		}
 		return err
 	case err = <-stdinDone:
 		if err == define.ErrDetach {
-			if err := conn.CloseWrite(); err != nil {
+			if err := socketCloseWrite(conn); err != nil {
 				logrus.Errorf("Failed to close stdin: %v", err)
 			}
 			return err
 		}
 		if err == nil {
 			// copy stdin is done, close it
-			if connErr := conn.CloseWrite(); connErr != nil {
+			if connErr := socketCloseWrite(conn); connErr != nil {
 				logrus.Errorf("Unable to close conn: %v", connErr)
 			}
 		}

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -653,7 +653,7 @@ func attachExecHTTP(c *Container, sessionID string, r *http.Request, w http.Resp
 				return err
 			}
 			// copy stdin is done, close it
-			if connErr := conn.CloseWrite(); connErr != nil {
+			if connErr := socketCloseWrite(conn); connErr != nil {
 				logrus.Errorf("Unable to close conn: %v", connErr)
 			}
 		case <-cancel:

--- a/libpod/oci_conmon_exec_freebsd.go
+++ b/libpod/oci_conmon_exec_freebsd.go
@@ -1,0 +1,10 @@
+package libpod
+
+import (
+	"github.com/opencontainers/runc/libcontainer/user"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func (c *Container) setProcessCapabilitiesExec(options *ExecOptions, user string, execUser *user.ExecUser, pspec *spec.Process) error {
+	return nil
+}

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -1,0 +1,39 @@
+package libpod
+
+import (
+	"github.com/containers/common/pkg/capabilities"
+	"github.com/opencontainers/runc/libcontainer/user"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func (c *Container) setProcessCapabilitiesExec(options *ExecOptions, user string, execUser *user.ExecUser, pspec *spec.Process) error {
+	ctrSpec, err := c.specFromState()
+	if err != nil {
+		return err
+	}
+
+	allCaps, err := capabilities.BoundingSet()
+	if err != nil {
+		return err
+	}
+	if options.Privileged {
+		pspec.Capabilities.Bounding = allCaps
+	} else {
+		pspec.Capabilities.Bounding = ctrSpec.Process.Capabilities.Bounding
+	}
+
+	// Always unset the inheritable capabilities similarly to what the Linux kernel does
+	// They are used only when using capabilities with uid != 0.
+	pspec.Capabilities.Inheritable = []string{}
+
+	if execUser.Uid == 0 {
+		pspec.Capabilities.Effective = pspec.Capabilities.Bounding
+		pspec.Capabilities.Permitted = pspec.Capabilities.Bounding
+	} else if user == c.config.User {
+		pspec.Capabilities.Effective = ctrSpec.Process.Capabilities.Effective
+		pspec.Capabilities.Inheritable = ctrSpec.Process.Capabilities.Effective
+		pspec.Capabilities.Permitted = ctrSpec.Process.Capabilities.Effective
+		pspec.Capabilities.Ambient = ctrSpec.Process.Capabilities.Effective
+	}
+	return nil
+}


### PR DESCRIPTION
This PR fixes two small problems in the conmon support code:

- Moving linux-specific capabilites code from oci_conmon_exec_common.go to the platform-specific file. This fixes a problem that stopped 'podman exec' from working on FreeBSD.
- Filtering out a confusing (but harmless) error which happened on FreeBSD when the container stdin closes.

#### Does this PR introduce a user-facing change?

```release-note
None
```
