### PR TITLE
[CI:DOCS] Man pages: refactor common options: --device

### DIFF
--- a/docs/source/markdown/options/device.md
+++ b/docs/source/markdown/options/device.md
@@ -1,0 +1,14 @@
+#### **--device**=*host-device[:container-device][:permissions]*
+
+Add a host device to the <<container|pod>>. Optional *permissions* parameter
+can be used to specify device permissions by combining
+**r** for read, **w** for write, and **m** for **mknod**(2).
+
+Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
+
+Note: if *host-device* is a symbolic link then it will be resolved first.
+The <<container|pod>> will only store the major and minor numbers of the host device.
+
+Podman may load kernel modules required for using the specified
+device. The devices that Podman will load modules for when necessary are:
+/dev/fuse.

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -205,16 +205,7 @@ keys and/or certificates. Decryption will be tried with all keys. If the key is
 protected by a passphrase, it is required to be passed in the argument and
 omitted otherwise.
 
-#### **--device**=*host-device[:container-device][:permissions]*
-
-Add a host device to the container. Optional *permissions* parameter
-can be used to specify device permissions, it is combination of
-**r** for read, **w** for write, and **m** for **mknod**(2).
-
-Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
-
-Note: if *host-device* is a symbolic link then it will be resolved first.
-The container will only store the major and minor numbers of the host device.
+@@option device
 
 Note: if the user only has access rights via a group, accessing the device
 from inside a rootless container will fail. The **[crun(1)](https://github.com/containers/crun/tree/main/crun.1.md)** runtime offers a

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -123,24 +123,11 @@ each of stdin, stdout, and stderr.
 
 @@option cpuset-mems
 
-#### **--device**=*host-device[:container-device][:permissions]*
-
-Add a host device to the container. Optional *permissions* parameter
-can be used to specify device permissions, it is combination of
-**r** for read, **w** for write, and **m** for **mknod**(2).
-
-Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
-
-Note: if *host-device* is a symbolic link then it will be resolved first.
-The container will only store the major and minor numbers of the host device.
+@@option device
 
 Note: if the user only has access rights via a group, accessing the device
 from inside a rootless container will fail. Use the `--group-add keep-groups`
 flag to pass the user's supplementary group access into the container.
-
-Podman may load kernel modules required for using the specified
-device. The devices that podman will load modules when necessary are:
-/dev/fuse.
 
 @@option device-cgroup-rule
 

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -31,22 +31,9 @@ If none are specified, the original pod's CPUset is used.
 
 @@option destroy
 
-#### **--device**=*host-device[:container-device][:permissions]*
-
-Add a host device to the pod. Optional *permissions* parameter
-can be used to specify device permissions. It is a combination of
-**r** for read, **w** for write, and **m** for **mknod**(2).
-
-Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
-
-Note: if _host_device_ is a symbolic link then it will be resolved first.
-The pod will only store the major and minor numbers of the host device.
+@@option device
 
 Note: the pod implements devices by storing the initial configuration passed by the user and recreating the device on each container added to the pod.
-
-Podman may load kernel modules required for using the specified
-device. The devices that Podman will load modules for when necessary are:
-/dev/fuse.
 
 @@option device-read-bps
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -48,22 +48,9 @@ Set the total number of CPUs delegated to the pod. Default is 0.000 which indica
 
 @@option cpuset-mems
 
-#### **--device**=_host-device_[**:**_container-device_][**:**_permissions_]
-
-Add a host device to the pod. Optional *permissions* parameter
-can be used to specify device permissions. It is a combination of
-**r** for read, **w** for write, and **m** for **mknod**(2).
-
-Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
-
-Note: if *host-device* is a symbolic link then it will be resolved first.
-The pod will only store the major and minor numbers of the host device.
+@@option device
 
 Note: the pod implements devices by storing the initial configuration passed by the user and recreating the device on each container added to the pod.
-
-Podman may load kernel modules required for using the specified
-device. The devices that Podman will load modules for when necessary are:
-/dev/fuse.
 
 @@option device-read-bps
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -159,24 +159,11 @@ Specify the key sequence for detaching a container. Format is a single character
 
 This option can also be set in **containers.conf**(5) file.
 
-#### **--device**=*host-device[:container-device][:permissions]*
-
-Add a host device to the container. Optional *permissions* parameter
-can be used to specify device permissions by combining
-**r** for read, **w** for write, and **m** for **mknod**(2).
-
-Example: **--device=/dev/sdc:/dev/xvdc:rwm**.
-
-Note: if _host_device_ is a symbolic link then it will be resolved first.
-The container will only store the major and minor numbers of the host device.
+@@option device
 
 Note: if the user only has access rights via a group, accessing the device
 from inside a rootless container will fail. Use the `--group-add keep-groups`
 flag to pass the user's supplementary group access into the container.
-
-Podman may load kernel modules required for using the specified
-device. The devices that Podman will load modules when necessary are:
-/dev/fuse.
 
 @@option device-cgroup-rule
 


### PR DESCRIPTION
The refactors are starting to get harder to review - sorry.

Here the differences are pretty small, mostly changes to the
"it is a combination" wording and some asteriskization.

The more significant diffs are that there are some Notes that
are pod- or container- or build-specific; I needed to move those
from the middle to the end, then keep them in the source files
themselves. I don't think this affects readability of the
resulting man pages, but your opinion may differ.

Last important thing: I included the /dev/fuse text in the
common option, which means it will now show up in podman-build
(it was not previously there). If this text is not applicable
to podman-build, please LMK ASAP so I can just move it back
to individual source files.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```