### PR TITLE
[CI:DOCS] Man pages: refactor common options: --sysctl

### DIFF
--- a/docs/source/markdown/options/sysctl.md
+++ b/docs/source/markdown/options/sysctl.md
@@ -1,0 +1,21 @@
+#### **--sysctl**=*name=value*
+
+Configure namespaced kernel parameters <<at runtime|for all containers in the pod>>.
+
+For the IPC namespace, the following sysctls are allowed:
+
+- kernel.msgmax
+- kernel.msgmnb
+- kernel.msgmni
+- kernel.sem
+- kernel.shmall
+- kernel.shmmax
+- kernel.shmmni
+- kernel.shm_rmid_forced
+- Sysctls beginning with fs.mqueue.\*
+
+Note: <<if you use the **--ipc=host** option|if the ipc namespace is not shared within the pod>>, the above sysctls are not allowed.
+
+For the network namespace, only sysctls beginning with net.\* are allowed.
+
+Note: <<if you use the **--network=host** option|if the network namespace is not shared within the pod>>, the above sysctls are not allowed.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -500,21 +500,7 @@ When size is `0`, there is no limit on the amount of memory used for IPC by the 
 
 @@option subuidname
 
-#### **--sysctl**=*SYSCTL*
-
-Configure namespaced kernel parameters at runtime
-
-IPC Namespace - current sysctls allowed:
-
-kernel.msgmax, kernel.msgmnb, kernel.msgmni, kernel.sem, kernel.shmall, kernel.shmmax, kernel.shmmni, kernel.shm_rmid_forced
-Sysctls beginning with fs.mqueue.*
-
-Note: if you use the --ipc=host option these sysctls will not be allowed.
-
-Network Namespace - current sysctls allowed:
-    Sysctls beginning with net.*
-
-Note: if you use the --network=host option these sysctls will not be allowed.
+@@option sysctl
 
 @@option systemd
 

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -114,27 +114,7 @@ clone process has completed. All containers within the pod are started.
 
 @@option subuidname
 
-#### **--sysctl**=*name=value*
-
-Configure namespace kernel parameters for all containers in the new pod.
-
-For the IPC namespace, the following sysctls are allowed:
-
-- kernel.msgmax
-- kernel.msgmnb
-- kernel.msgmni
-- kernel.sem
-- kernel.shmall
-- kernel.shmmax
-- kernel.shmmni
-- kernel.shm_rmid_forced
-- Sysctls beginning with fs.mqueue.\*
-
-Note: if the ipc namespace is not shared within the pod, these sysctls are not allowed.
-
-For the network namespace, only sysctls beginning with net.\* are allowed.
-
-Note: if the network namespace is not shared within the pod, these sysctls are not allowed.
+@@option sysctl
 
 @@option uidmap.pod
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -255,27 +255,7 @@ When size is `0`, there is no limit on the amount of memory used for IPC by the 
 
 @@option subuidname
 
-#### **--sysctl**=*name=value*
-
-Configure namespace kernel parameters for all containers in the pod.
-
-For the IPC namespace, the following sysctls are allowed:
-
-- kernel.msgmax
-- kernel.msgmnb
-- kernel.msgmni
-- kernel.sem
-- kernel.shmall
-- kernel.shmmax
-- kernel.shmmni
-- kernel.shm_rmid_forced
-- Sysctls beginning with fs.mqueue.\*
-
-Note: if the ipc namespace is not shared within the pod, these sysctls are not allowed.
-
-For the network namespace, only sysctls beginning with net.\* are allowed.
-
-Note: if the network namespace is not shared within the pod, these sysctls are not allowed.
+@@option sysctl
 
 @@option uidmap.pod
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -542,29 +542,7 @@ Sets whether the signals sent to the **podman run** command are proxied to the c
 
 @@option subuidname
 
-#### **--sysctl**=*name=value*
-
-Configure namespaced kernel parameters at runtime.
-
-For the IPC namespace, the following sysctls are allowed:
-
-- kernel.msgmax
-- kernel.msgmnb
-- kernel.msgmni
-- kernel.sem
-- kernel.shmall
-- kernel.shmmax
-- kernel.shmmni
-- kernel.shm_rmid_forced
-- Sysctls beginning with fs.mqueue.\*
-
-Note: if you use the **--ipc=host** option, the above sysctls will not be allowed.
-
-For the network namespace, the following sysctls are allowed:
-
-- Sysctls beginning with net.\*
-
-Note: if you use the **--network=host** option, these sysctls will not be allowed.
+@@option sysctl
 
 @@option systemd
 


### PR DESCRIPTION
As promised, harder and harder to review. Please take your time
with this one.

For IPC, I went with the list form. For net, I used the single-
sentence form instead of a one-element list.

The container/pod diffs are clumsy, sorry. Maybe it's time to
start thinking of a more flexible conditional mechanism, but
I'd really like to avoid that so I hope this is acceptable.

In the first sentence I went with 'namespaced' (final 'd') in
all instances. I also got rid of the 'new' in 'new pod' in
pod-clone.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```