### PR TITLE
Fix intermittent issue with Compat API proxy startup on Windows

### DIFF
--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1061,7 +1061,7 @@ func launchWinProxy(v *MachineVM) (bool, string, error) {
 		return globalName, "", err
 	}
 
-	return globalName, pipePrefix + waitPipe, waitPipeExists(waitPipe, 30, func() error {
+	return globalName, pipePrefix + waitPipe, waitPipeExists(waitPipe, 80, func() error {
 		active, exitCode := machine.GetProcessState(cmd.Process.Pid)
 		if !active {
 			return fmt.Errorf("win-sshproxy.exe failed to start, exit code: %d (see windows event logs)", exitCode)
@@ -1099,7 +1099,7 @@ func waitPipeExists(pipeName string, retries int, checkFailure func() error) err
 		if fail := checkFailure(); fail != nil {
 			return fail
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(250 * time.Millisecond)
 	}
 
 	return err


### PR DESCRIPTION
Fixes #14811

Changes pipe busy-wait to 20 seconds, slightly less aggressively. 

```release-note
Fixed intermittent issue with Compat API proxy startup on Windows
```
