### PR TITLE
Add --config for Docker compatibility

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -73,6 +73,7 @@ var (
 
 	defaultLogLevel = "warn"
 	logLevel        = defaultLogLevel
+	dockerConfig    = ""
 	debug           bool
 
 	useSyslog      bool
@@ -85,6 +86,7 @@ func init() {
 		loggingHook,
 		syslogHook,
 		earlyInitHook,
+		configHook,
 	)
 
 	rootFlags(rootCmd, registry.PodmanConfig())
@@ -311,6 +313,12 @@ func persistentPostRunE(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func configHook() {
+	if dockerConfig != "" {
+		logrus.Warn("The --config flag is ignored by Podman. Exists for Docker compatibility")
+	}
+}
+
 func loggingHook() {
 	var found bool
 	if debug {
@@ -363,6 +371,8 @@ func rootFlags(cmd *cobra.Command, opts *entities.PodmanConfig) {
 	lFlags.StringVarP(&opts.URI, "host", "H", uri, "Used for Docker compatibility")
 	_ = lFlags.MarkHidden("host")
 
+	lFlags.StringVar(&dockerConfig, "config", "", "Ignored for Docker compatibility")
+	_ = lFlags.MarkHidden("config")
 	// Context option added just for compatibility with DockerCLI.
 	lFlags.String("context", "default", "Name of the context to use to connect to the daemon (This flag is a NOOP and provided solely for scripting compatibility.)")
 	_ = lFlags.MarkHidden("context")

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -33,6 +33,7 @@ type PodmanConfig struct {
 	*config.Config
 	*pflag.FlagSet
 
+	DockerConfig   string     // Used for Docker compatibility
 	CgroupUsage    string     // rootless code determines Usage message
 	ConmonPath     string     // --conmon flag will set Engine.ConmonPath
 	CPUProfile     string     // Hidden: Should CPU profile be taken

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -29,6 +29,12 @@ function setup() {
     local built=$(expr "$output" : ".*Built: \+\(.*\)" | head -n1)
     local built_t=$(date --date="$built" +%s)
     assert "$built_t" -gt 1546300800 "Preposterous 'Built' time in podman version"
+
+    run_podman -v
+    is "$output" "podman.*version \+"               "'Version line' in output"
+
+    run_podman --config foobar version
+    is "$output" ".*The --config flag is ignored by Podman. Exists for Docker compatibility\+"		  "verify warning for --config option"
 }
 
 @test "podman info" {


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/14767

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman --config test ... is now a hidden option for Docker compatibility.
```
