### PR TITLE
specgen/generate: Factor out setting resource limits from CompleteSpec

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -18,7 +18,6 @@ import (
 	envLib "github.com/containers/podman/v4/pkg/env"
 	"github.com/containers/podman/v4/pkg/signal"
 	"github.com/containers/podman/v4/pkg/specgen"
-	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/openshift/imagebuilder"
 	"github.com/sirupsen/logrus"
 )
@@ -272,19 +271,7 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 	}
 
 	// If caller did not specify Pids Limits load default
-	if s.ResourceLimits == nil || s.ResourceLimits.Pids == nil {
-		if s.CgroupsMode != "disabled" {
-			limit := rtc.PidsLimit()
-			if limit != 0 {
-				if s.ResourceLimits == nil {
-					s.ResourceLimits = &spec.LinuxResources{}
-				}
-				s.ResourceLimits.Pids = &spec.LinuxPids{
-					Limit: limit,
-				}
-			}
-		}
-	}
+	s.InitResourceLimits(rtc)
 
 	if s.LogConfiguration == nil {
 		s.LogConfiguration = &specgen.LogConfig{}

--- a/pkg/specgen/resources_freebsd.go
+++ b/pkg/specgen/resources_freebsd.go
@@ -1,0 +1,8 @@
+package specgen
+
+import (
+	"github.com/containers/common/pkg/config"
+)
+
+func (s *SpecGenerator) InitResourceLimits(rtc *config.Config) {
+}

--- a/pkg/specgen/resources_linux.go
+++ b/pkg/specgen/resources_linux.go
@@ -1,0 +1,22 @@
+package specgen
+
+import (
+	"github.com/containers/common/pkg/config"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func (s *SpecGenerator) InitResourceLimits(rtc *config.Config) {
+	if s.ResourceLimits == nil || s.ResourceLimits.Pids == nil {
+		if s.CgroupsMode != "disabled" {
+			limit := rtc.PidsLimit()
+			if limit != 0 {
+				if s.ResourceLimits == nil {
+					s.ResourceLimits = &spec.LinuxResources{}
+				}
+				s.ResourceLimits.Pids = &spec.LinuxPids{
+					Limit: limit,
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This avoids setting values in the spec which are not supported on FreeBSD - including these values causes warning messages for the unsupported features.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### Does this PR introduce a user-facing change?

```release-note
None
```
