### PR TITLE
[CI:DOCS] Man pages: refactor common options: --privileged

### DIFF
--- a/docs/source/markdown/options/privileged.md
+++ b/docs/source/markdown/options/privileged.md
@@ -1,0 +1,14 @@
+#### **--privileged**
+
+Give extended privileges to this container. The default is **false**.
+
+By default, Podman containers are unprivileged (**=false**) and cannot, for
+example, modify parts of the operating system. This is because by default a
+container is only allowed limited access to devices. A "privileged" container
+is given the same access to devices as the user launching the container.
+
+A privileged container turns off the security features that isolate the
+container from the host. Dropped Capabilities, limited devices, read-only mount
+points, Apparmor/SELinux separation, and Seccomp filters are all disabled.
+
+Rootless containers cannot have more privileges than the account that launched them.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -354,21 +354,7 @@ To make a pod with more granular options, use the `podman pod create` command be
 
 @@option pod-id-file.container
 
-#### **--privileged**
-
-Give extended privileges to this container. The default is *false*.
-
-By default, Podman containers are
-“unprivileged” (=false) and cannot, for example, modify parts of the operating system.
-This is because by default a container is not allowed to access any devices.
-A “privileged” container is given access to all devices.
-
-When the operator executes a privileged container, Podman enables access
-to all devices on the host, turns off graphdriver mount options, as well as
-turning off most of the security measures protecting the host from the
-container.
-
-Rootless containers cannot have more privileges than the account that launched them.
+@@option privileged
 
 #### **--publish**, **-p**=*[[ip:][hostPort]:]containerPort[/protocol]*
 

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -44,21 +44,7 @@ to run containers such as CRI-O, the last started container could be from either
 
 Pass down to the process N additional file descriptors (in addition to 0, 1, 2).  The total FDs will be 3+N.
 
-#### **--privileged**
-
-Give extended privileges to this container. The default is *false*.
-
-By default, Podman containers are
-"unprivileged" and cannot, for example, modify parts of the operating system.
-This is because by default a container is only allowed limited access to devices.
-A "privileged" container is given the same access to devices as the user launching the container.
-
-A privileged container turns off the security features that isolate the
-container from the host. Dropped Capabilities, limited devices, read/only mount
-points, Apparmor/SELinux separation, and Seccomp filters are all disabled.
-
-Rootless containers cannot have more privileges than the account that launched them.
-
+@@option privileged
 
 #### **--tty**, **-t**
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -385,20 +385,7 @@ If a container is run with a pod, and the pod has an infra-container, the infra-
 Pass down to the process N additional file descriptors (in addition to 0, 1, 2).
 The total FDs will be 3+N. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--privileged**
-
-Give extended privileges to this container. The default is **false**.
-
-By default, Podman containers are unprivileged (**=false**) and cannot, for
-example, modify parts of the operating system. This is because by default a
-container is only allowed limited access to devices. A "privileged" container
-is given the same access to devices as the user launching the container.
-
-A privileged container turns off the security features that isolate the
-container from the host. Dropped Capabilities, limited devices, read-only mount
-points, Apparmor/SELinux separation, and Seccomp filters are all disabled.
-
-Rootless containers cannot have more privileges than the account that launched them.
+@@option privileged
 
 #### **--publish**, **-p**=*[[ip:][hostPort]:]containerPort[/protocol]*
 


### PR DESCRIPTION
An easy one. Went with the version from podman-run.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```