### PR TITLE
proper --debug/-D flag support

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -475,8 +475,8 @@ func rootFlags(cmd *cobra.Command, opts *entities.PodmanConfig) {
 	pFlags.StringVar(&logLevel, logLevelFlagName, logLevel, fmt.Sprintf("Log messages above specified level (%s)", strings.Join(common.LogLevels, ", ")))
 	_ = rootCmd.RegisterFlagCompletionFunc(logLevelFlagName, common.AutocompleteLogLevel)
 
-	pFlags.BoolVar(&debug, "debug", false, "Docker compatibility, force setting of log-level")
-	_ = pFlags.MarkHidden("debug")
+	lFlags.BoolVarP(&debug, "debug", "D", false, "Docker compatibility, force setting of log-level")
+	_ = lFlags.MarkHidden("debug")
 
 	// Only create these flags for ABI connections
 	if !registry.IsRemote() {

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -190,7 +190,9 @@ See 'podman version --help'" "podman version --remote"
     run_podman --log-level=error   info
     run_podman --log-level=fatal   info
     run_podman --log-level=panic   info
+    # docker compat
     run_podman --debug   info
+    run_podman -D        info
     run_podman 1 --debug --log-level=panic info
     is "$output" "Setting --log-level and --debug is not allowed"
 }


### PR DESCRIPTION
--debug should not be a global flag, you can only use this as podman --debug ... never podman ps --debug. This matches docker and allows us to add the shorthand "D" since they now no longer conflict.

Fixes changes from commit 2d30b4dee596 which claims to add -D but never did.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

The other commit already includes a proper release note and is not released yet.
```release-note
None
```
