### PR TITLE
Fix go template parsing with "\n" in it

### DIFF
--- a/cmd/podman/auto-update.go
+++ b/cmd/podman/auto-update.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/completion"
@@ -104,15 +103,15 @@ func reportsToOutput(allReports []*entities.AutoUpdateReport) []autoUpdateOutput
 }
 
 func writeTemplate(allReports []*entities.AutoUpdateReport, inputFormat string) error {
-	var format string
-	var printHeader bool
+	rpt := report.New(os.Stdout, "auto-update")
+	defer rpt.Flush()
 
 	output := reportsToOutput(allReports)
+	var err error
 	switch inputFormat {
 	case "":
-		rows := []string{"{{.Unit}}", "{{.Container}}", "{{.Image}}", "{{.Policy}}", "{{.Updated}}"}
-		format = "{{range . }}" + strings.Join(rows, "\t") + "\n{{end -}}"
-		printHeader = true
+		format := "{{range . }}\t{{.Unit}}\t{{.Container}}\t{{.Image}}\t{{.Policy}}\t{{.Updated}}\n{{end -}}"
+		rpt, err = rpt.Parse(report.OriginPodman, format)
 	case "json":
 		prettyJSON, err := json.MarshalIndent(output, "", "    ")
 		if err != nil {
@@ -121,26 +120,17 @@ func writeTemplate(allReports []*entities.AutoUpdateReport, inputFormat string) 
 		fmt.Println(string(prettyJSON))
 		return nil
 	default:
-		format = "{{range . }}" + inputFormat + "\n{{end -}}"
+		rpt, err = rpt.Parse(report.OriginUser, inputFormat)
 	}
-
-	tmpl, err := report.NewTemplate("auto-update").Parse(format)
 	if err != nil {
 		return err
 	}
 
-	w, err := report.NewWriterDefault(os.Stdout)
-	if err != nil {
-		return err
-	}
-	defer w.Flush()
-
-	if printHeader {
+	if rpt.RenderHeaders {
 		headers := report.Headers(autoUpdateOutput{}, nil)
-		if err := tmpl.Execute(w, headers); err != nil {
+		if err := rpt.Execute(headers); err != nil {
 			return err
 		}
 	}
-
-	return tmpl.Execute(w, output)
+	return rpt.Execute(output)
 }

--- a/cmd/podman/inspect/inspect.go
+++ b/cmd/podman/inspect/inspect.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -186,7 +185,7 @@ func (i *inspector) inspect(namesOrIDs []string) error {
 		err = rpt.Execute(data)
 	}
 	if err != nil {
-		logrus.Errorf("Printing inspect output: %v", err)
+		errs = append(errs, fmt.Errorf("printing inspect output: %w", err))
 	}
 
 	if len(errs) > 0 {

--- a/cmd/podman/machine/info.go
+++ b/cmd/podman/machine/info.go
@@ -5,7 +5,6 @@ package machine
 
 import (
 	"fmt"
-	"html/template"
 	"os"
 	"runtime"
 
@@ -75,13 +74,16 @@ func info(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Println(string(b))
 	case cmd.Flags().Changed("format"):
-		tmpl := template.New(cmd.Name()).Funcs(template.FuncMap(report.DefaultFuncs))
-		inFormat = report.NormalizeFormat(inFormat)
-		tmpl, err := tmpl.Parse(inFormat)
+		rpt := report.New(os.Stdout, cmd.Name())
+		defer rpt.Flush()
+
+		// Use OriginUnknown so it does not add an extra range since it
+		// will only be called for a single element and not a slice.
+		rpt, err = rpt.Parse(report.OriginUnknown, inFormat)
 		if err != nil {
 			return err
 		}
-		return tmpl.Execute(os.Stdout, info)
+		return rpt.Execute(info)
 	default:
 		b, err := yaml.Marshal(info)
 		if err != nil {

--- a/cmd/podman/secrets/inspect.go
+++ b/cmd/podman/secrets/inspect.go
@@ -47,20 +47,15 @@ func inspect(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flags().Changed("format") {
-		row := report.NormalizeFormat(format)
-		formatted := report.EnforceRange(row)
+		rpt := report.New(os.Stdout, cmd.Name())
+		defer rpt.Flush()
 
-		tmpl, err := report.NewTemplate("inspect").Parse(formatted)
+		rpt, err := rpt.Parse(report.OriginUser, format)
 		if err != nil {
 			return err
 		}
 
-		w, err := report.NewWriterDefault(os.Stdout)
-		if err != nil {
-			return err
-		}
-		defer w.Flush()
-		if err := tmpl.Execute(w, inspected); err != nil {
+		if err := rpt.Execute(inspected); err != nil {
 			return err
 		}
 	} else {

--- a/cmd/podman/system/info.go
+++ b/cmd/podman/system/info.go
@@ -3,7 +3,6 @@ package system
 import (
 	"fmt"
 	"os"
-	"text/template"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/report"
@@ -86,14 +85,16 @@ func info(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Println(string(b))
 	case cmd.Flags().Changed("format"):
-		// Cannot use report.New() as it enforces {{range .}} for OriginUser templates
-		tmpl := template.New(cmd.Name()).Funcs(template.FuncMap(report.DefaultFuncs))
-		inFormat = report.NormalizeFormat(inFormat)
-		tmpl, err := tmpl.Parse(inFormat)
+		rpt := report.New(os.Stdout, cmd.Name())
+		defer rpt.Flush()
+
+		// Use OriginUnknown so it does not add an extra range since it
+		// will only be called for a single element and not a slice.
+		rpt, err = rpt.Parse(report.OriginUnknown, inFormat)
 		if err != nil {
 			return err
 		}
-		return tmpl.Execute(os.Stdout, info)
+		return rpt.Execute(info)
 	default:
 		b, err := yaml.Marshal(info)
 		if err != nil {

--- a/cmd/podman/system/version.go
+++ b/cmd/podman/system/version.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"text/template"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/common/pkg/report"
@@ -12,6 +11,7 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -53,22 +53,25 @@ func version(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flag("format").Changed {
-		// Cannot use report.New() as it enforces {{range .}} for OriginUser templates
-		tmpl := template.New(cmd.Name()).Funcs(template.FuncMap(report.DefaultFuncs))
+		rpt := report.New(os.Stdout, cmd.Name())
+		defer rpt.Flush()
 
-		versionFormat = report.NormalizeFormat(versionFormat)
-		tmpl, err := tmpl.Parse(versionFormat)
+		// Use OriginUnknown so it does not add an extra range since it
+		// will only be called for a single element and not a slice.
+		rpt, err = rpt.Parse(report.OriginUnknown, versionFormat)
 		if err != nil {
 			return err
 		}
-		if err := tmpl.Execute(os.Stdout, versions); err != nil {
+		if err := rpt.Execute(versions); err != nil {
+			// only log at debug since we fall back to the client only template
+			logrus.Debugf("Failed to execute template: %v", err)
 			// On Failure, assume user is using older version of podman version --format and check client
 			versionFormat = strings.ReplaceAll(versionFormat, ".Server.", ".")
-			tmpl, err := tmpl.Parse(versionFormat)
+			rpt, err := rpt.Parse(report.OriginUnknown, versionFormat)
 			if err != nil {
 				return err
 			}
-			if err := tmpl.Execute(os.Stdout, versions.Client); err != nil {
+			if err := rpt.Execute(versions.Client); err != nil {
 				return err
 			}
 		}

--- a/pkg/machine/e2e/inspect_test.go
+++ b/pkg/machine/e2e/inspect_test.go
@@ -75,5 +75,13 @@ var _ = Describe("podman machine stop", func() {
 		Expect(err).To(BeNil())
 		Expect(inspectSession).To(Exit(0))
 		Expect(inspectSession.Bytes()).To(ContainSubstring(name))
+
+		// check invalid template returns error
+		inspect = new(inspectMachine)
+		inspect = inspect.withFormat("{{.Abcde}}")
+		inspectSession, err = mb.setName(name).setCmd(inspect).run()
+		Expect(err).To(BeNil())
+		Expect(inspectSession).To(Exit(125))
+		Expect(inspectSession.errorToString()).To(ContainSubstring("can't evaluate field Abcde in type machine.InspectInfo"))
 	})
 })

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -75,7 +75,10 @@ var _ = Describe("Podman volume ls", func() {
 		session.WaitWithDefaultTimeout()
 
 		Expect(session).Should(Exit(0))
-		Expect(session.OutputToStringArray()).To(HaveLen(1), session.OutputToString())
+		arr := session.OutputToStringArray()
+		Expect(arr).To(HaveLen(2))
+		Expect(arr[0]).To(ContainSubstring("NAME"))
+		Expect(arr[1]).To(ContainSubstring("myvol"))
 	})
 
 	It("podman ls volume with --filter flag", func() {

--- a/test/system/610-format.bats
+++ b/test/system/610-format.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# PR #15673: For all commands that accept --format '{{.GoTemplate}}',
+# invoke with --format '{{"\n"}}' and make sure they don't choke.
+#
+
+load helpers
+
+function teardown() {
+    # In case test fails: standard teardown does not wipe machines
+    run_podman '?' machine rm -f mymachine
+
+    basic_teardown
+}
+
+# Most commands can't just be run with --format; they need an argument or
+# option. This table defines what those are.
+#
+# FIXME: once you've finished fixing them all, remove the SKIPs (just
+# remove the entire lines, except for pod-inspect, just remove the SKIP
+# but leave "mypod")
+extra_args_table="
+info              | SKIP
+system info       | SKIP
+machine info      | SKIP
+version           | SKIP
+
+history           | $IMAGE
+image history     | $IMAGE
+image inspect     | $IMAGE
+container inspect | no-such-container
+machine inspect   | mymachine
+
+volume inspect    | -a
+secret inspect    | -a
+network inspect   | podman
+ps                | -a
+
+image search      | sdfsdf
+search            | sdfsdf
+
+pod inspect       | mypod SKIP
+
+container stats   | --no-stream
+pod stats         | --no-stream
+stats             | --no-stream
+events            | --stream=false --events-backend=file
+"
+
+# Main test loop. Recursively runs 'podman [subcommand] help', looks for:
+#    > '[command]', which indicates, recurse; or
+#    > '--format', in which case we
+#      > check autocompletion, look for Go templates, in which case we
+#        > run the command with --format '{{"\n"}}' and make sure it passes
+function check_subcommand() {
+    for cmd in $(_podman_commands "$@"); do
+        # Human-readable podman command string, with multiple spaces collapsed
+        command_string="podman $* $cmd"
+        command_string=${command_string//  / }  # 'podman  x' -> 'podman x'
+
+        # Run --help, decide if this is a subcommand with subcommands
+        run_podman "$@" $cmd --help
+        local full_help="$output"
+
+        # The line immediately after 'Usage:' gives us a 1-line synopsis
+        usage=$(echo "$full_help" | grep -A1 '^Usage:' | tail -1)
+        assert "$usage" != "" "podman $cmd: no Usage message found"
+
+        # Strip off the leading command string; we no longer need it
+        usage=$(sed -e "s/^  $command_string \?//" <<<"$usage")
+
+        # If usage ends in '[command]', recurse into subcommands
+        if expr "$usage" : '\[command\]' >/dev/null; then
+            # (except for 'podman help', which is a special case)
+            if [[ $cmd != "help" ]]; then
+                check_subcommand "$@" $cmd
+            fi
+            continue
+        fi
+
+        # Not a subcommand-subcommand. Look for --format option
+        if [[ ! "$output" =~ "--format" ]]; then
+            continue
+        fi
+
+        # Have --format. Make sure it's a Go-template option, not like --push
+        run_podman __completeNoDesc "$@" "$cmd" --format '{{.'
+        if [[ ! "$output" =~ \{\{\.[A-Z] ]]; then
+            continue
+        fi
+
+        # Got one.
+        dprint "$command_string has --format"
+
+        # Whatever is needed to make a runnable command
+        local extra=${extra_args[$command_string]}
+        if [[ -n "$extra" ]]; then
+            # Cross off our list
+            unset extra_args["$command_string"]
+        fi
+
+        # FIXME: you can remove this once you're finished with #15673
+        if [[ "$extra" =~ SKIP ]]; then
+            continue
+        fi
+
+        # This is what does the work. We should never see the unterminated err
+        run_podman '?' "$@" "$cmd" $extra --format '{{"\n"}}'
+        assert "$output" !~ "unterminated quoted string" \
+               "$command_string --format <newline>"
+
+        # This will (probably) only trigger if we get a new podman subcommand.
+        # It means someone needs to figure out the right magic args to use
+        # when invoking the subcommand.
+        if [[ $status -ne 0 ]]; then
+            if [[ -z "$extra" ]]; then
+                die "'$command_string' barfed with '$output'. You probably need to special-case this command in extra_args_table in this script."
+            fi
+        fi
+    done
+}
+
+# Test entry point
+@test "check Go template formatting" {
+    skip_if_remote
+
+    # Convert the table at top to an associative array, keyed on subcommand
+    declare -A extra_args
+    while read subcommand extra; do
+        extra_args["podman $subcommand"]=$extra
+    done < <(parse_table "$extra_args_table")
+
+    # Setup: 'pod ps' needs an actual pod; 'machine inspect' needs a machine
+    run_podman pod create mypod
+    run_podman machine init --image-path=/dev/null mymachine
+
+    # Run the test
+    check_subcommand
+
+    # Clean up
+    run_podman pod rm mypod
+    run_podman rmi $(pause_image)
+    run_podman machine rm -f mymachine
+
+    # Make sure there are no leftover commands in our table - this would
+    # indicate a typo in the table, or a flaw in our logic such that
+    # we're not actually recursing.
+    local leftovers="${!extra_args[@]}"
+    assert "$leftovers" = "" "Did not find (or test) subcommands:"
+}
+
+# vim: filetype=sh

--- a/test/system/610-format.bats
+++ b/test/system/610-format.bats
@@ -20,8 +20,6 @@ function teardown() {
 # remove the entire lines, except for pod-inspect, just remove the SKIP
 # but leave "mypod")
 extra_args_table="
-version           | SKIP
-
 history           | $IMAGE
 image history     | $IMAGE
 image inspect     | $IMAGE

--- a/test/system/610-format.bats
+++ b/test/system/610-format.bats
@@ -34,7 +34,7 @@ ps                | -a
 image search      | sdfsdf
 search            | sdfsdf
 
-pod inspect       | mypod SKIP
+pod inspect       | mypod
 
 container stats   | --no-stream
 pod stats         | --no-stream
@@ -92,11 +92,6 @@ function check_subcommand() {
         if [[ -n "$extra" ]]; then
             # Cross off our list
             unset extra_args["$command_string"]
-        fi
-
-        # FIXME: you can remove this once you're finished with #15673
-        if [[ "$extra" =~ SKIP ]]; then
-            continue
         fi
 
         # This is what does the work. We should never see the unterminated err

--- a/test/system/610-format.bats
+++ b/test/system/610-format.bats
@@ -20,8 +20,6 @@ function teardown() {
 # remove the entire lines, except for pod-inspect, just remove the SKIP
 # but leave "mypod")
 extra_args_table="
-info              | SKIP
-system info       | SKIP
 machine info      | SKIP
 version           | SKIP
 

--- a/test/system/610-format.bats
+++ b/test/system/610-format.bats
@@ -20,7 +20,6 @@ function teardown() {
 # remove the entire lines, except for pod-inspect, just remove the SKIP
 # but leave "mypod")
 extra_args_table="
-machine info      | SKIP
 version           | SKIP
 
 history           | $IMAGE


### PR DESCRIPTION
- update all commands to use the report.Formatter
- update c/common with the latest version so that report.Formatter can handle newlines
see individual commit for more information

Fixes #13446
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2059658

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The format flag now handles template strings with `\n` in it correctly.
```
