### PR TITLE
fix podman pod inspect to support multiple pods

### DIFF
--- a/cmd/podman/common/inspect.go
+++ b/cmd/podman/common/inspect.go
@@ -11,6 +11,10 @@ const (
 	NetworkType = "network"
 	// PodType is the pod type.
 	PodType = "pod"
+	// PodLegacyType is the pod type for backwards compatibility with the old pod inspect code.
+	// This allows us to use the shared inspect code but still provide the correct output format
+	// when podman pod inspect was called.
+	PodLegacyType = "pod-legacy"
 	// VolumeType is the volume type
 	VolumeType = "volume"
 )

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -1,21 +1,12 @@
 package pods
 
 import (
-	"context"
-	"errors"
-	"os"
-	"text/template"
-
-	"github.com/containers/common/pkg/report"
 	"github.com/containers/podman/v4/cmd/podman/common"
+	"github.com/containers/podman/v4/cmd/podman/inspect"
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/validate"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/spf13/cobra"
-)
-
-var (
-	inspectOptions = entities.PodInspectOptions{}
 )
 
 var (
@@ -27,10 +18,12 @@ var (
 		Use:               "inspect [options] POD [POD...]",
 		Short:             "Displays a pod configuration",
 		Long:              inspectDescription,
-		RunE:              inspect,
+		RunE:              inspectExec,
 		ValidArgsFunction: common.AutocompletePods,
 		Example:           `podman pod inspect podID`,
 	}
+
+	inspectOpts = &entities.InspectOptions{}
 )
 
 func init() {
@@ -41,40 +34,15 @@ func init() {
 	flags := inspectCmd.Flags()
 
 	formatFlagName := "format"
-	flags.StringVarP(&inspectOptions.Format, formatFlagName, "f", "json", "Format the output to a Go template or json")
+	flags.StringVarP(&inspectOpts.Format, formatFlagName, "f", "json", "Format the output to a Go template or json")
 	_ = inspectCmd.RegisterFlagCompletionFunc(formatFlagName, common.AutocompleteFormat(&entities.PodInspectReport{}))
 
-	validate.AddLatestFlag(inspectCmd, &inspectOptions.Latest)
+	validate.AddLatestFlag(inspectCmd, &inspectOpts.Latest)
 }
 
-func inspect(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 && !inspectOptions.Latest {
-		return errors.New("you must provide the name or id of a running pod")
-	}
-	if len(args) > 0 && inspectOptions.Latest {
-		return errors.New("--latest and containers cannot be used together")
-	}
-
-	if !inspectOptions.Latest {
-		inspectOptions.NameOrID = args[0]
-	}
-	responses, err := registry.ContainerEngine().PodInspect(context.Background(), inspectOptions)
-	if err != nil {
-		return err
-	}
-
-	if report.IsJSON(inspectOptions.Format) {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "     ")
-		return enc.Encode(responses)
-	}
-
-	// Cannot use report.New() as it enforces {{range .}} for OriginUser templates
-	tmpl := template.New(cmd.Name()).Funcs(template.FuncMap(report.DefaultFuncs))
-	format := report.NormalizeFormat(inspectOptions.Format)
-	tmpl, err = tmpl.Parse(format)
-	if err != nil {
-		return err
-	}
-	return tmpl.Execute(os.Stdout, *responses)
+func inspectExec(cmd *cobra.Command, args []string) error {
+	// We need backwards compat with the old podman pod inspect behavior.
+	// https://github.com/containers/podman/pull/15675
+	inspectOpts.Type = common.PodLegacyType
+	return inspect.Inspect(args, *inspectOpts)
 }

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -75,7 +75,7 @@ type ContainerEngine interface {
 	PodCreate(ctx context.Context, specg PodSpec) (*PodCreateReport, error)
 	PodClone(ctx context.Context, podClone PodCloneOptions) (*PodCloneReport, error)
 	PodExists(ctx context.Context, nameOrID string) (*BoolReport, error)
-	PodInspect(ctx context.Context, options PodInspectOptions) (*PodInspectReport, error)
+	PodInspect(ctx context.Context, namesOrID []string, options InspectOptions) ([]*PodInspectReport, []error, error)
 	PodKill(ctx context.Context, namesOrIds []string, options PodKillOptions) ([]*PodKillReport, error)
 	PodLogs(ctx context.Context, pod string, options PodLogsOptions) error
 	PodPause(ctx context.Context, namesOrIds []string, options PodPauseOptions) ([]*PodPauseReport, error)

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -438,15 +438,6 @@ type PodPSOptions struct {
 	Sort      string
 }
 
-type PodInspectOptions struct {
-	Latest bool
-
-	// Options for the API.
-	NameOrID string
-
-	Format string
-}
-
 type PodInspectReport struct {
 	*define.InspectPodData
 }

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -571,7 +571,7 @@ func (s *PodmanSessionIntegration) InspectContainerToJSON() []define.InspectCont
 func (s *PodmanSessionIntegration) InspectPodToJSON() define.InspectPodData {
 	var i define.InspectPodData
 	err := jsoniter.Unmarshal(s.Out.Contents(), &i)
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 	return i
 }
 

--- a/test/e2e/pod_inspect_test.go
+++ b/test/e2e/pod_inspect_test.go
@@ -118,4 +118,21 @@ var _ = Describe("Podman pod inspect", func() {
 
 		Expect(inspectOut.OutputToString()).To(ContainSubstring(macAddr))
 	})
+
+	It("podman inspect two pods", func() {
+		_, ec, podid1 := podmanTest.CreatePod(nil)
+		Expect(ec).To(Equal(0))
+
+		_, ec, podid2 := podmanTest.CreatePod(nil)
+		Expect(ec).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"pod", "inspect", podid1, podid2})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		Expect(inspect.OutputToString()).To(BeValidJSON())
+		podData := inspect.InspectPodArrToJSON()
+		Expect(podData).To(HaveLen(2))
+		Expect(podData[0]).To(HaveField("ID", podid1))
+		Expect(podData[1]).To(HaveField("ID", podid2))
+	})
 })


### PR DESCRIPTION
Just like the other inspect commands `podman pod inspect p1 p2` should return the json for both.

To correctly implement this we follow the container inspect logic, this
allows use to reuse the global inspect command.
Note: To not break the existing single pod output format for podman pod
inspect I added a pod-legacy inspect type. This is only used to make
sure we will print the pod as single json and not an array like for the
other commands. We cannot use the pod type since podman inspect --type
pod did return an array and we should not break that as well.

Fixes #15674

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman pod inspect will now correctly work for more than one pod.
```
