### PR TITLE
[v3.0.1-rhel] Add container GID to additional groups

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -473,6 +473,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 		// User and Group must go together
 		g.SetProcessUID(uint32(execUser.Uid))
 		g.SetProcessGID(uint32(execUser.Gid))
+		g.AddProcessAdditionalGid(uint32(execUser.Gid))
 	}
 
 	if c.config.Umask != "" {

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -398,6 +398,7 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 		}
 		g.SetProcessUID(uint32(uid))
 		g.SetProcessGID(uint32(gid))
+		g.AddProcessAdditionalGid(uint32(gid))
 		fallthrough
 	case specgen.Private:
 		if err := g.AddOrReplaceLinuxNamespace(string(spec.UserNamespace), ""); err != nil {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -771,7 +771,7 @@ USER bin`
 		session := podmanTest.Podman([]string{"run", "--rm", "--user=1234", ALPINE, "id"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(Equal("uid=1234(1234) gid=0(root)"))
+		Expect(session.OutputToString()).To(Equal("uid=1234(1234) gid=0(root) groups=0(root)"))
 	})
 
 	It("podman run with user (integer, in /etc/passwd)", func() {
@@ -792,14 +792,14 @@ USER bin`
 		session := podmanTest.Podman([]string{"run", "--rm", "--user=mail:21", ALPINE, "id"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp)"))
+		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp) groups=21(ftp)"))
 	})
 
 	It("podman run with user:group (integer:groupname)", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--user=8:ftp", ALPINE, "id"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp)"))
+		Expect(session.OutputToString()).To(Equal("uid=8(mail) gid=21(ftp) groups=21(ftp)"))
 	})
 
 	It("podman run with user, verify caps dropped", func() {
@@ -808,6 +808,14 @@ USER bin`
 		Expect(session.ExitCode()).To(Equal(0))
 		capEff := strings.Split(session.OutputToString(), " ")
 		Expect("0000000000000000").To(Equal(capEff[1]))
+	})
+
+	It("podman run with user, verify group added", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "--user=1000:1000", ALPINE, "grep", "Groups:", "/proc/self/status"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		groups := strings.Split(session.OutputToString(), " ")[1]
+		Expect("1000").To(Equal(groups))
 	})
 
 	It("podman run with attach stdin outputs container ID", func() {


### PR DESCRIPTION
Mitigates a potential permissions issue. Mirrors Buildah PR #4200 and CRI-O PR #6159.

Cherry-pick conflicts for v3.0.1-rhel branch have been addressed.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2121540
