### PR TITLE
Fix swagger documentation

### DIFF
--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -897,7 +897,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: signal
 	//    type: string
-	//    default: TERM
+	//    default: SIGKILL
 	//    description: signal to be sent to container, either by integer or SIG_ name
 	// produces:
 	// - application/json
@@ -1290,11 +1290,6 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    type: string
 	//    required: true
 	//    description: the name or ID of the container
-	//  - in: query
-	//    name: all
-	//    type: boolean
-	//    default: false
-	//    description: Stop all containers
 	//  - in: query
 	//    name: timeout
 	//    type: integer


### PR DESCRIPTION
* ContainerKillLibpod "signal" query default is SIGKILL.
* ContainerStopLibpod "all" query doesn't exist.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
