### PR TITLE
Ignore cpu realtime options on cgroups V2 systems

### DIFF
--- a/pkg/specgen/generate/validate.go
+++ b/pkg/specgen/generate/validate.go
@@ -82,7 +82,7 @@ func verifyContainerResourcesCgroupV1(s *specgen.SpecGenerator) ([]string, error
 		}
 	}
 
-	// CPU Checks
+	// CPU checks
 	if s.ResourceLimits.CPU != nil {
 		cpu := s.ResourceLimits.CPU
 		if cpu.Shares != nil && !sysInfo.CPUShares {
@@ -169,6 +169,7 @@ func verifyContainerResourcesCgroupV2(s *specgen.SpecGenerator) ([]string, error
 		return warnings, nil
 	}
 
+	// Memory checks
 	if s.ResourceLimits.Memory != nil && s.ResourceLimits.Memory.Swap != nil {
 		own, err := utils.GetOwnCgroup()
 		if err != nil {
@@ -196,6 +197,19 @@ func verifyContainerResourcesCgroupV2(s *specgen.SpecGenerator) ([]string, error
 		if errMemoryMax == nil && errMemorySwapMax != nil {
 			warnings = append(warnings, "Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.")
 			s.ResourceLimits.Memory.Swap = nil
+		}
+	}
+
+	// CPU checks
+	if s.ResourceLimits.CPU != nil {
+		cpu := s.ResourceLimits.CPU
+		if cpu.RealtimePeriod != nil {
+			warnings = append(warnings, "Realtime period not supported on cgroups V2 systems")
+			cpu.RealtimePeriod = nil
+		}
+		if cpu.RealtimeRuntime != nil {
+			warnings = append(warnings, "Realtime runtime not supported on cgroups V2 systems")
+			cpu.RealtimeRuntime = nil
 		}
 	}
 	return warnings, nil

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -138,4 +138,20 @@ var _ = Describe("Podman run cpu", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result).To(ExitWithError())
 	})
+
+	It("podman run invalid cpu-rt-period with cgroupsv2", func() {
+		SkipIfCgroupV1("testing options that only work in cgroup v2")
+		result := podmanTest.Podman([]string{"run", "--rm", "--cpu-rt-period=5000", ALPINE, "ls"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(result.ErrorToString()).To(ContainSubstring("Realtime period not supported on cgroups V2 systems"))
+	})
+
+	It("podman run invalid cpu-rt-runtime with cgroupsv2", func() {
+		SkipIfCgroupV1("testing options that only work in cgroup v2")
+		result := podmanTest.Podman([]string{"run", "--rm", "--cpu-rt-runtime=5000", ALPINE, "ls"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(result.ErrorToString()).To(ContainSubstring("Realtime runtime not supported on cgroups V2 systems"))
+	})
 })


### PR DESCRIPTION
`--cpu-rt-period` and `--cpu-rt-runtime` options are only supported on cgroups V2 systems.

Therefore, podman prints an warning message and ignores these options when we use cgroups V2 systems.

Related to: #15666

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Print an warning message and ignore cpu realtime options when we use cgroups V2 systems
```
