### PR TITLE
stop: fix error handling

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -429,13 +429,11 @@ func (r *ConmonOCIRuntime) StopContainer(ctr *Container, timeout uint, all bool)
 		}
 	}
 
-	if err := r.KillContainer(ctr, 9, all); err != nil {
+	if err := r.KillContainer(ctr, uint(unix.SIGKILL), all); err != nil {
 		// Again, check if the container is gone. If it is, exit cleanly.
-		err := unix.Kill(ctr.state.PID, 0)
-		if err == unix.ESRCH {
+		if aliveErr := unix.Kill(ctr.state.PID, 0); errors.Is(aliveErr, unix.ESRCH) {
 			return nil
 		}
-
 		return fmt.Errorf("error sending SIGKILL to container %s: %w", ctr.ID(), err)
 	}
 


### PR DESCRIPTION
Fix the error handling in the fallback logic of `stop` when Podman resorts to killing a container; the error message wrapped the wrong error.

[NO NEW TESTS NEEDED] as it is a rare flake in the tests and I do not know how to reliably reproduce it.

Fixes: #15661
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in `podman stop` where it mistakenly returned an error when resorting to sending sigkill.
```
