### PR TITLE
fix several podman events issues

### DIFF
--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -117,7 +117,6 @@ func eventsCmd(cmd *cobra.Command, _ []string) error {
 				if err := rpt.Execute(event); err != nil {
 					return err
 				}
-				os.Stdout.WriteString("\n")
 			default:
 				fmt.Println(event.ToHumanReadable(!noTrunc))
 			}

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -43,8 +43,8 @@ Remote connections use local containers.conf for default.
 #### **--events-backend**=*type*
 
 Backend to use for storing events. Allowed values are **file**, **journald**, and
-**none**. When *file* is specified, the events are stored under a subdirectory
-of the *tmpdir* location (see **--tmpdir** below).
+**none**. When *file* is specified, the events are stored under
+`<tmpdir>/events/events.log` (see **--tmpdir** below).
 
 #### **--help**, **-h**
 
@@ -158,7 +158,7 @@ On remote clients, including Mac and Windows (excluding WSL2) machines, logging 
 
 #### **--tmpdir**
 
-Path to the tmp directory, for libpod runtime content.
+Path to the tmp directory, for libpod runtime content. Defaults to `$XDG\_RUNTIME\_DIR/libpod/tmp` as rootless and `run/libpod/tmp` as rootful.
 
 NOTE --tmpdir is not used for the temporary storage of downloaded images.  Use the environment variable `TMPDIR` to change the temporary storage location of downloaded container images. Podman defaults to use `/var/tmp`.
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.1.1
 	github.com/containers/buildah v1.27.1-0.20220907121344-97a52b13bb27
-	github.com/containers/common v0.49.2-0.20220908074553-1a09baf471c4
+	github.com/containers/common v0.49.2-0.20220909190843-e5685792b5d7
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.22.1-0.20220907162003-651744379993
 	github.com/containers/ocicrypt v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -424,8 +424,8 @@ github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19
 github.com/containers/buildah v1.27.1-0.20220907121344-97a52b13bb27 h1:LRgKJ/JUd6iTocPg/q7oMZ9ilnbew50JXClXgiEoR9Q=
 github.com/containers/buildah v1.27.1-0.20220907121344-97a52b13bb27/go.mod h1:0iWhIkE70dkoVuwpmZy5/DXpBdI3C23iYmBQccTDWMU=
 github.com/containers/common v0.49.1/go.mod h1:ueM5hT0itKqCQvVJDs+EtjornAQtrHYxQJzP2gxeGIg=
-github.com/containers/common v0.49.2-0.20220908074553-1a09baf471c4 h1:+Z/KvBR34ihTFkliEGuj+kNX+8G/OEv1n8Nv4OiAXkI=
-github.com/containers/common v0.49.2-0.20220908074553-1a09baf471c4/go.mod h1:HaPvle8BvLTyjtY9B4HJoNCl60DpHwCDLA2FsZTWaak=
+github.com/containers/common v0.49.2-0.20220909190843-e5685792b5d7 h1:iSrqOya92AllZSA7y64Aamfcr4iOxgf4iatc9uFeL0U=
+github.com/containers/common v0.49.2-0.20220909190843-e5685792b5d7/go.mod h1:HaPvle8BvLTyjtY9B4HJoNCl60DpHwCDLA2FsZTWaak=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.22.0/go.mod h1:D8Ksv2RNB8qLJ7xe1P3rgJJOSQpahA6amv2Ax++/YO4=

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -133,11 +133,7 @@ func (v *Volume) newVolumeEvent(status events.Status) {
 // Events is a wrapper function for everyone to begin tailing the events log
 // with options
 func (r *Runtime) Events(ctx context.Context, options events.ReadOptions) error {
-	eventer, err := r.newEventer()
-	if err != nil {
-		return err
-	}
-	return eventer.Read(ctx, options)
+	return r.eventer.Read(ctx, options)
 }
 
 // GetEvents reads the event log and returns events based on input filters
@@ -148,10 +144,6 @@ func (r *Runtime) GetEvents(ctx context.Context, filters []string) ([]*events.Ev
 		Filters:      filters,
 		FromStart:    true,
 		Stream:       false,
-	}
-	eventer, err := r.newEventer()
-	if err != nil {
-		return nil, err
 	}
 
 	logEvents := make([]*events.Event, 0, len(eventChannel))
@@ -164,7 +156,7 @@ func (r *Runtime) GetEvents(ctx context.Context, filters []string) ([]*events.Ev
 		readLock.Unlock()
 	}()
 
-	readErr := eventer.Read(ctx, options)
+	readErr := r.eventer.Read(ctx, options)
 	readLock.Lock() // Wait for the events to be consumed.
 	return logEvents, readErr
 }

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sync"
 
 	"github.com/containers/podman/v4/libpod/events"
@@ -11,6 +12,10 @@ import (
 
 // newEventer returns an eventer that can be used to read/write events
 func (r *Runtime) newEventer() (events.Eventer, error) {
+	if r.config.Engine.EventsLogFilePath == "" {
+		// default, use path under tmpdir when none was explicitly set by the user
+		r.config.Engine.EventsLogFilePath = filepath.Join(r.config.Engine.TmpDir, "events", "events.log")
+	}
 	options := events.EventerOptions{
 		EventerType:    r.config.Engine.EventsLogger,
 		LogFilePath:    r.config.Engine.EventsLogFilePath,

--- a/libpod/events/events_linux.go
+++ b/libpod/events/events_linux.go
@@ -20,7 +20,7 @@ func NewEventer(options EventerOptions) (Eventer, error) {
 	case strings.ToUpper(LogFile.String()):
 		return newLogFileEventer(options)
 	case strings.ToUpper(Null.String()):
-		return NewNullEventer(), nil
+		return newNullEventer(), nil
 	case strings.ToUpper(Memory.String()):
 		return NewMemoryEventer(), nil
 	default:

--- a/libpod/events/events_linux.go
+++ b/libpod/events/events_linux.go
@@ -18,7 +18,7 @@ func NewEventer(options EventerOptions) (Eventer, error) {
 		}
 		return eventer, nil
 	case strings.ToUpper(LogFile.String()):
-		return EventLogFile{options}, nil
+		return newLogFileEventer(options)
 	case strings.ToUpper(Null.String()):
 		return NewNullEventer(), nil
 	case strings.ToUpper(Memory.String()):

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -38,7 +38,7 @@ func newLogFileEventer(options EventerOptions) (*EventLogFile, error) {
 	// https://github.com/containers/podman/issues/15688
 	fd, err := os.OpenFile(options.LogFilePath, os.O_RDONLY|os.O_CREATE, 0700)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create event log file: %w", err)
 	}
 	return &EventLogFile{options: options}, fd.Close()
 }

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/containers/podman/v4/pkg/util"
@@ -25,6 +26,21 @@ import (
 // options and the event itself.  Methods for reading and writing are also defined from it.
 type EventLogFile struct {
 	options EventerOptions
+}
+
+// newLogFileEventer creates a new EventLogFile eventer
+func newLogFileEventer(options EventerOptions) (*EventLogFile, error) {
+	// Create events log dir
+	if err := os.MkdirAll(filepath.Dir(options.LogFilePath), 0700); err != nil {
+		return nil, fmt.Errorf("creating events dirs: %w", err)
+	}
+	// We have to make sure the file is created otherwise reading events will hang.
+	// https://github.com/containers/podman/issues/15688
+	fd, err := os.OpenFile(options.LogFilePath, os.O_RDONLY|os.O_CREATE, 0700)
+	if err != nil {
+		return nil, err
+	}
+	return &EventLogFile{options: options}, fd.Close()
 }
 
 // Writes to the log file
@@ -108,6 +124,8 @@ func (e EventLogFile) Read(ctx context.Context, options ReadOptions) error {
 			}
 		}()
 	}
+	logrus.Debugf("Reading events from file %q", e.options.LogFilePath)
+
 	var line *tail.Line
 	var ok bool
 	for {

--- a/libpod/events/nullout.go
+++ b/libpod/events/nullout.go
@@ -2,10 +2,11 @@ package events
 
 import (
 	"context"
+	"errors"
 )
 
-// EventToNull is an eventer type that only performs write operations
-// and only writes to /dev/null. It is meant for unittests only
+// EventToNull is an eventer type that does nothing.
+// It is meant for unittests only
 type EventToNull struct{}
 
 // Write eats the event and always returns nil
@@ -13,14 +14,14 @@ func (e EventToNull) Write(ee Event) error {
 	return nil
 }
 
-// Read does nothing. Do not use it.
+// Read does nothing and returns an error.
 func (e EventToNull) Read(ctx context.Context, options ReadOptions) error {
-	return nil
+	return errors.New("cannot read events with the \"none\" backend")
 }
 
-// NewNullEventer returns a new null eventer.  You should only do this for
+// newNullEventer returns a new null eventer.  You should only do this for
 // the purposes of internal libpod testing.
-func NewNullEventer() Eventer {
+func newNullEventer() Eventer {
 	return EventToNull{}
 }
 

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1030,9 +1030,6 @@ func (r *Runtime) mergeDBConfig(dbConfig *DBConfig) {
 			logrus.Debugf("Overriding tmp dir %q with %q from database", c.TmpDir, dbConfig.LibpodTmp)
 		}
 		c.TmpDir = dbConfig.LibpodTmp
-		if c.EventsLogFilePath == "" {
-			c.EventsLogFilePath = filepath.Join(dbConfig.LibpodTmp, "events", "events.log")
-		}
 	}
 
 	if !r.storageSet.VolumePathSet && dbConfig.VolumePath != "" {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -466,14 +466,6 @@ func makeRuntime(runtime *Runtime) (retErr error) {
 		}
 	}
 
-	// Create events log dir
-	if err := os.MkdirAll(filepath.Dir(runtime.config.Engine.EventsLogFilePath), 0700); err != nil {
-		// The directory is allowed to exist
-		if !errors.Is(err, os.ErrExist) {
-			return fmt.Errorf("creating events dirs: %w", err)
-		}
-	}
-
 	// Get us at least one working OCI runtime.
 	runtime.ociRuntimes = make(map[string]OCIRuntime)
 

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/common/libimage"
 	nettypes "github.com/containers/common/libnetwork/types"
 	"github.com/containers/common/pkg/config"
+	"github.com/containers/common/pkg/secrets"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/libpod/define"
@@ -1110,7 +1111,13 @@ func (ic *ContainerEngine) playKubeSecret(secret *v1.Secret) (*entities.SecretCr
 	if secret.Immutable != nil && *secret.Immutable {
 		meta["immutable"] = "true"
 	}
-	secretID, err := secretsManager.Store(secret.Name, data, "file", opts, meta)
+
+	storeOpts := secrets.StoreOptions{
+		DriverOpts: opts,
+		Metadata:   meta,
+	}
+
+	secretID, err := secretsManager.Store(secret.Name, data, "file", storeOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/infra/abi/secrets.go
+++ b/pkg/domain/infra/abi/secrets.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containers/common/pkg/secrets"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/domain/utils"
 )
@@ -42,10 +43,15 @@ func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader
 		}
 	}
 
-	secretID, err := manager.Store(name, data, options.Driver, options.DriverOpts, nil)
+	storeOpts := secrets.StoreOptions{
+		DriverOpts: options.DriverOpts,
+	}
+
+	secretID, err := manager.Store(name, data, options.Driver, storeOpts)
 	if err != nil {
 		return nil, err
 	}
+
 	return &entities.SecretCreateReport{
 		ID: secretID,
 	}, nil

--- a/pkg/specgen/generate/kube/play_test.go
+++ b/pkg/specgen/generate/kube/play_test.go
@@ -24,11 +24,15 @@ func createSecrets(t *testing.T, d string) *secrets.SecretsManager {
 		"path": d,
 	}
 
+	storeOpts := secrets.StoreOptions{
+		DriverOpts: driverOpts,
+	}
+
 	for _, s := range k8sSecrets {
 		data, err := json.Marshal(s.Data)
 		assert.NoError(t, err)
 
-		_, err = secretsManager.Store(s.ObjectMeta.Name, data, driver, driverOpts, nil)
+		_, err = secretsManager.Store(s.ObjectMeta.Name, data, driver, storeOpts)
 		assert.NoError(t, err)
 	}
 

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -147,13 +147,17 @@ function _populate_events_file() {
 
     # Config without a limit
     eventsFile=$PODMAN_TMPDIR/events.txt
-    _populate_events_file $eventsFile
     containersConf=$PODMAN_TMPDIR/containers.conf
     cat >$containersConf <<EOF
 [engine]
 events_logger="file"
 events_logfile_path="$eventsFile"
 EOF
+
+    # Check that a non existing event file does not cause a hang (#15688)
+    CONTAINERS_CONF=$containersConf run_podman events --stream=false
+
+    _populate_events_file $eventsFile
 
     # Create events *without* a limit and make sure that it has not been
     # rotated/truncated.

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -74,6 +74,7 @@ load helpers
 .*image tag $imageID $tag
 .*image untag $imageID $tag:latest
 .*image tag $imageID $tag
+.*image untag $imageID $IMAGE
 .*image untag $imageID $tag:latest
 .*image remove $imageID $imageID" \
        "podman events"

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -217,3 +217,12 @@ EOF
                --format="{{.Attributes.$lname}}"
     assert "$output" = "$lvalue" "podman-events output includes container label"
 }
+
+@test "events - backend none should error" {
+    skip_if_remote "remote does not support --events-backend"
+
+    run_podman 125 --events-backend none events
+    is "$output" "Error: cannot read events with the \"none\" backend" "correct error message"
+    run_podman 125 --events-backend none events --stream=false
+    is "$output" "Error: cannot read events with the \"none\" backend" "correct error message"
+}

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -280,8 +280,6 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 	}
 	c.TmpDir = tmp
 
-	c.EventsLogFilePath = filepath.Join(c.TmpDir, "events", "events.log")
-
 	c.EventsLogFileMaxSize = eventsLogMaxSize(DefaultEventsLogSizeMax)
 
 	c.CompatAPIEnforceDockerHub = true

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -110,7 +110,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.49.2-0.20220908074553-1a09baf471c4
+# github.com/containers/common v0.49.2-0.20220909190843-e5685792b5d7
 ## explicit
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
### fix hang with podman events file logger
podman --events-backend file events --stream=false should never hang. The
problem is that our tail library will wait for the file to be created
which makes sense when we do not run with --stream=false. To fix this we
can just always create the file when the logger is initialized. This
would also help to report errors early on in case the file is not
accessible.


### event backend none: return an error when reading events
podman --events-backend none events should return with an error since it
will never be able to actually list events.

### event backend journald: fix problem with empty journal

Currently podman events will just fail with `Error: failed to get journal
cursor: failed to get cursor: cannot assign requested address` when the
journal contains zero podman events.

The problem is that we are using the journal accessors wrong. There is no
need to call GetCursor() and compare them manually. The Next() return an
integer which tells if it moved to the next or not. This means the we can
remove GetCursor() which would fail when there is no entry.

This also includes another bug fix. Previously the logic called Next()
twice for the first entry which caused us to miss the first entry.

To reproduce this issue you can run the following commands:
```
sudo journalctl --rotate
sudo journalctl --vacuum-time=1s
```
Note that this will delete the full journal.

Now run podman events and it fails but with this patch it works.
Now generate a single event, i.e. podman pull alpine, and run
podman events --until 1s.

I am not sure how to get a reliable test into CI, I really do not want
to delete the journal and developer or CI systems.

### libpod: runtime newEventer() cleanup

There is no reason to create a new eventer every time. The libpod runtime
already has one attached which should be used instead.


Fixes #15688

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
podman --events-backend file events --stream=false will now no longer hang when the event file does not exists.
podman --events-backend none events now returns an error because it can never list events.
podman --events-backend journald will now work with an empty journal and no longer skip the first event.
```
