### PR TITLE
TEMPORARY: instrumenting for 15488

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -177,6 +177,15 @@ function run_podman() {
     # without "quotes", multiple lines are glommed together into one
     if [ -n "$output" ]; then
         echo "$output"
+
+        # FIXME FIXME FIXME: instrumenting to track down #15488. Please
+        # remove once that's fixed. We include the args because, remember,
+        # bats only shows output on error; it's possible that the first
+        # instance of the metacopy warning happens in a test that doesn't
+        # check output, hence doesn't fail.
+        if [[ "$output" =~ Ignoring.global.metacopy.option ]]; then
+            echo "# YO! metacopy warning triggered by: podman $*" >&3
+        fi
     fi
     if [ "$status" -ne 0 ]; then
         echo -n "[ rc=$status ";


### PR DESCRIPTION
Trying to catch the wiley metacopy flake: add a debug
condition to run_podman, in system tests, to log all
instances in which output includes the metacopy warning.
The idea is to detect the very first time it happens,
and see what is triggering it.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```