### PR TITLE
[CI:BUILD] Cirrus: Don't run win_installer in multiarch cron

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1110,6 +1110,8 @@ artifacts_task:
 win_installer_task:
     name: "Verify Win Installer Build"
     alias: win_installer
+    # Don't run for multiarch container image cirrus-cron job.
+    only_if: $CIRRUS_CRON != 'multiarch'
     depends_on:
       - alt_build
     windows_container:


### PR DESCRIPTION
The win_installer task fails on the `multiarch` cirrus-cron build. This is because it depends on the `Windows Cross` (alt_build) task which is bypassed in this context.  This will cause the `repo.tbz` download to constantly throw 404s.  Fix this by skipping the win_installer task for the `multiarch` (container images) build.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
