### PR TITLE
Fix CPU usage limitation in play kube for non integer values

### DIFF
--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -207,12 +207,9 @@ func ToSpecGen(ctx context.Context, opts *CtrSpecGenOptions) (*specgen.SpecGener
 	s.SeccompProfilePath = opts.SeccompPaths.FindForContainer(opts.Container.Name)
 
 	s.ResourceLimits = &spec.LinuxResources{}
-	milliCPU, err := quantityToInt64(opts.Container.Resources.Limits.Cpu())
-	if err != nil {
-		return nil, fmt.Errorf("failed to set CPU quota: %w", err)
-	}
+	milliCPU := opts.Container.Resources.Limits.Cpu().MilliValue()
 	if milliCPU > 0 {
-		period, quota := util.CoresToPeriodAndQuota(float64(milliCPU))
+		period, quota := util.CoresToPeriodAndQuota(float64(milliCPU) / 1000)
 		s.ResourceLimits.CPU = &spec.LinuxCPU{
 			Quota:  &quota,
 			Period: &period,


### PR DESCRIPTION
Signed-off-by: Mikhail Khachayants <tyler92@inbox.ru>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix CPU usage limitation in play kube for non integer values
```
