### PR TITLE
[WIP] Add support for podman cp --follow-link

### DIFF
--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -51,14 +51,16 @@ var (
 )
 
 var (
-	cpOpts entities.ContainerCpOptions
-	chown  bool
+	cpOpts     entities.ContainerCpOptions
+	chown      bool
+	followLink bool
 )
 
 func cpFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	flags.BoolVar(&cpOpts.OverwriteDirNonDir, "overwrite", false, "Allow to overwrite directories with non-directories and vice versa")
 	flags.BoolVarP(&chown, "archive", "a", true, `Chown copied files to the primary uid/gid of the destination container.`)
+	flags.BoolVarP(&followLink, "follow-link", "L", true, `Always follow symbol link in SRC_PATH`)
 
 	// Deprecated flags (both are NOPs): exist for backwards compat
 	flags.BoolVar(&cpOpts.Extract, "extract", false, "Deprecated...")
@@ -93,6 +95,12 @@ func cp(cmd *cobra.Command, args []string) error {
 		return copyFromContainer(sourceContainerStr, sourcePath, destPath)
 	}
 
+	if followLink {
+		sourcePath, err = filepath.EvalSymlinks(sourcePath)
+		if err != nil {
+			return err
+		}
+	}
 	return copyToContainer(destContainerStr, destPath, sourcePath)
 }
 


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman cp --follow-link is now support, Tells Podman to de-reference symbolic links before copying them.
```
