### PR TITLE
Include PATH in conmon env.

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -1221,9 +1221,14 @@ func (r *ConmonOCIRuntime) configureConmonEnv(runtimeDir string) []string {
 			env = append(env, e)
 		}
 	}
-	conf, ok := os.LookupEnv("CONTAINERS_CONF")
-	if ok {
+	if path, ok := os.LookupEnv("PATH"); ok {
+		env = append(env, fmt.Sprintf("PATH=%s", path))
+	}
+	if conf, ok := os.LookupEnv("CONTAINERS_CONF"); ok {
 		env = append(env, fmt.Sprintf("CONTAINERS_CONF=%s", conf))
+	}
+	if conf, ok := os.LookupEnv("CONTAINERS_HELPER_BINARY_DIR"); ok {
+		env = append(env, fmt.Sprintf("CONTAINERS_HELPER_BINARY_DIR=%s", conf))
 	}
 	env = append(env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", runtimeDir))
 	env = append(env, fmt.Sprintf("_CONTAINERS_USERNS_CONFIGURED=%s", os.Getenv("_CONTAINERS_USERNS_CONFIGURED")))


### PR DESCRIPTION
Pass along the path so that when conmon calls podman as part of the exit command podman has the correct path.

Also adjusted the CONTAINERS_CONF lookup to match the codestyle of other environment lookups.

Resolves #15707

#### Does this PR introduce a user-facing change?

```release-note
Pass PATH and CONTAINERS_HELPER_BINARY_DIR environment variables to conmon calls
```