### PR TITLE
refactor: use `os.ReadDir` for lightweight directory reading

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1671,7 +1671,7 @@ func (c *Container) mountNamedVolume(v *ContainerNamedVolume, mountpoint string)
 		// a bizarre issue where something copier.Get will ENOENT on
 		// empty directories and sometimes it will not.
 		// RHBZ#1928643
-		srcContents, err := ioutil.ReadDir(srcDir)
+		srcContents, err := os.ReadDir(srcDir)
 		if err != nil {
 			return nil, fmt.Errorf("error reading contents of source directory for copy up into volume %s: %w", vol.Name(), err)
 		}
@@ -1681,7 +1681,7 @@ func (c *Container) mountNamedVolume(v *ContainerNamedVolume, mountpoint string)
 
 		// If the volume is not empty, we should not copy up.
 		volMount := vol.mountPoint()
-		contents, err := ioutil.ReadDir(volMount)
+		contents, err := os.ReadDir(volMount)
 		if err != nil {
 			return nil, fmt.Errorf("error listing contents of volume %s mountpoint when copying up from container %s: %w", vol.Name(), c.ID(), err)
 		}

--- a/libpod/lock/file/file_lock.go
+++ b/libpod/lock/file/file_lock.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -129,7 +128,7 @@ func (locks *FileLocks) DeallocateAllLocks() error {
 	if !locks.valid {
 		return fmt.Errorf("locks have already been closed: %w", syscall.EINVAL)
 	}
-	files, err := ioutil.ReadDir(locks.lockPath)
+	files, err := os.ReadDir(locks.lockPath)
 	if err != nil {
 		return fmt.Errorf("error reading directory %s: %w", locks.lockPath, err)
 	}

--- a/pkg/api/handlers/compat/info.go
+++ b/pkg/api/handlers/compat/info.go
@@ -2,7 +2,6 @@ package compat
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	goRuntime "runtime"
@@ -198,7 +197,7 @@ func getRuntimes(configInfo *config.Config) map[string]docker.Runtime {
 
 func getFdCount() (count int) {
 	count = -1
-	if entries, err := ioutil.ReadDir("/proc/self/fd"); err == nil {
+	if entries, err := os.ReadDir("/proc/self/fd"); err == nil {
 		count = len(entries)
 	}
 	return

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"sync"
@@ -858,7 +857,7 @@ func makeExecConfig(options entities.ExecOptions, rt *libpod.Runtime) (*libpod.E
 
 func checkExecPreserveFDs(options entities.ExecOptions) error {
 	if options.PreserveFDs > 0 {
-		entries, err := ioutil.ReadDir("/proc/self/fd")
+		entries, err := os.ReadDir("/proc/self/fd")
 		if err != nil {
 			return err
 		}

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -869,7 +869,7 @@ func execTransferPodman(execUser *user.User, command []string, needToTag bool) (
 
 func getSigFilename(sigStoreDirPath string) (string, error) {
 	sigFileSuffix := 1
-	sigFiles, err := ioutil.ReadDir(sigStoreDirPath)
+	sigFiles, err := os.ReadDir(sigStoreDirPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,7 +118,7 @@ func AddPrivilegedDevices(g *generate.Generator) error {
 
 // based on getDevices from runc (libcontainer/devices/devices.go)
 func getDevices(path string) ([]spec.LinuxDevice, error) {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		if rootless.IsRootless() && os.IsPermission(err) {
 			return nil, nil
@@ -146,7 +145,7 @@ func getDevices(path string) ([]spec.LinuxDevice, error) {
 			}
 		case f.Name() == "console":
 			continue
-		case f.Mode()&os.ModeSymlink != 0:
+		case f.Type()&os.ModeSymlink != 0:
 			continue
 		}
 

--- a/test/e2e/benchmarks_test.go
+++ b/test/e2e/benchmarks_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Podman Benchmark Suite", func() {
 	}
 
 	totalMemoryInKb := func() (total uint64) {
-		files, err := ioutil.ReadDir(timedir)
+		files, err := os.ReadDir(timedir)
 		if err != nil {
 			Fail(fmt.Sprintf("Error reading timing dir: %v", err))
 		}

--- a/test/e2e/container_create_volume_test.go
+++ b/test/e2e/container_create_volume_test.go
@@ -58,7 +58,7 @@ func checkDataVolumeContainer(pTest *PodmanTestIntegration, image, cont, dest, d
 	Expect(volList.OutputToStringArray()[0]).To(Equal(mntName))
 
 	// Check the mount source directory
-	files, err := ioutil.ReadDir(mntSource)
+	files, err := os.ReadDir(mntSource)
 	Expect(err).To(BeNil())
 
 	if data == "" {

--- a/test/e2e/image_sign_test.go
+++ b/test/e2e/image_sign_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -69,7 +68,7 @@ var _ = Describe("Podman image sign", func() {
 		session := podmanTest.Podman([]string{"image", "sign", "--all", "--directory", sigDir, "--sign-by", "foo@bar.com", "docker://library/alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		fInfos, err := ioutil.ReadDir(filepath.Join(sigDir, "library"))
+		fInfos, err := os.ReadDir(filepath.Join(sigDir, "library"))
 		Expect(err).To(BeNil())
 		Expect(len(fInfos)).To(BeNumerically(">", 1), "len(fInfos)")
 	})

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -332,7 +332,7 @@ var _ = Describe("Podman manifest", func() {
 
 		blobsDir := filepath.Join(dest, "blobs", "sha256")
 
-		blobs, err := ioutil.ReadDir(blobsDir)
+		blobs, err := os.ReadDir(blobsDir)
 		Expect(err).To(BeNil())
 
 		for _, f := range blobs {

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Podman push", func() {
 
 		blobsDir := filepath.Join(bbdir, "blobs/sha256")
 
-		blobs, err := ioutil.ReadDir(blobsDir)
+		blobs, err := os.ReadDir(blobsDir)
 		Expect(err).To(BeNil())
 
 		for _, f := range blobs {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name.  Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

This PR replaces all `ioutil.ReadDir` to `os.ReadDir`. `ioutil.ReadDir` has been deprecated in Go 1.16. The new `os.ReadDir` is a more efficient implementation than `ioutil.ReadDir`. 

The full proposal can be read here: https://<!---->github.com<!---->/<!---->golang<!---->/go/issues/41467

Reference: https://pkg.go.dev/io/ioutil#ReadDir