### PR TITLE
Add PodName to ContainerConfig to be exposed in inspect

### DIFF
--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -46,6 +46,11 @@ const (
 	// If an annotation with this key is found in the OCI spec, it will be
 	// used in the output of Inspect().
 	InspectAnnotationLabel = "io.podman.annotations.label"
+	// InspectAnnotationPodName is used by Inspect to identify containers with
+	// their pod name.
+	// If an annotation with this key is found in the OCI spec, it will be
+	// used in the output of Inspect().
+	InspectAnnotationPodName = "io.podman.annotations.podname"
 	// InspectAnnotationSeccomp is used by Inspect to identify containers
 	// with special Seccomp-related settings. It is used to populate the
 	// output of the SecurityOpt setting in Inspect.

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -44,6 +44,7 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 				return nil, nil, nil, err
 			}
 		}
+		s.Annotations[define.InspectAnnotationPodName] = pod.Name()
 	}
 
 	options := []libpod.CtrCreateOption{}

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -33,6 +33,19 @@ var _ = Describe("Podman container inspect", func() {
 		processTestResult(f)
 	})
 
+	It("podman inspect a pod container for the podName in annotation", func() {
+		const podName = "test-pod-1"
+		setup, _, podID := podmanTest.CreatePod(map[string][]string{"--name": {podName}})
+		Expect(setup).Should(Exit(0))
+		const testContainer = "container-in-a-pod"
+		setup = podmanTest.RunTopContainerInPod(testContainer, podID)
+		setup.WaitWithDefaultTimeout()
+		Expect(setup).Should(Exit(0))
+		data := podmanTest.InspectContainer(testContainer)
+		Expect(data[0].Pod).To(Equal(podID))
+		Expect(data[0].Config.Annotations[define.InspectAnnotationPodName]).To(Equal(podName))
+	})
+
 	It("podman inspect a container for the container manager annotation", func() {
 		const testContainer = "container-inspect-test-1"
 		setup := podmanTest.RunTopContainer(testContainer)


### PR DESCRIPTION
closes #15374 
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
