### PR TITLE
[v4.2.0-rhel] libpod: UpdateContainerStatus: do not wait for container

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -337,15 +337,6 @@ func (r *ConmonOCIRuntime) UpdateContainerStatus(ctr *Container) error {
 			ctr.ID(), state.Status, define.ErrInternal)
 	}
 
-	// Only grab exit status if we were not already stopped
-	// If we were, it should already be in the database
-	if ctr.state.State == define.ContainerStateStopped && oldState != define.ContainerStateStopped {
-		if _, err := ctr.Wait(context.Background()); err != nil {
-			logrus.Errorf("Waiting for container %s to exit: %v", ctr.ID(), err)
-		}
-		return nil
-	}
-
 	// Handle ContainerStateStopping - keep it unless the container
 	// transitioned to no longer running.
 	if oldState == define.ContainerStateStopping && (ctr.state.State == define.ContainerStatePaused || ctr.state.State == define.ContainerStateRunning) {


### PR DESCRIPTION
Commit 30e7cbccc194 accidentally added a deadlock as Podman was waiting for the exit code to show up when the container transitioned to stopped. Code paths that require the exit code to be written (by the cleanup process) should already be using `(*Container).Wait()` in a deadlock free way.

[NO NEW TESTS NEEDED] as I did not manage to a reproducer that would work in CI.  Ultimately, it's a race condition.

Backport-for: #15492
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2124716
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2125647
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a potential deadlock in `podman kill`.
```

@TomSweeneyRedHat @mheon PTAL