### PR TITLE
health checks: restart timers

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1286,6 +1286,12 @@ func (c *Container) stop(timeout uint) error {
 		c.lock.Unlock()
 	}
 
+	if c.config.HealthCheckConfig != nil {
+		if err := c.removeTransientFiles(context.Background()); err != nil {
+			logrus.Error(err.Error())
+		}
+	}
+
 	stopErr := c.ociRuntime.StopContainer(c, timeout, all)
 
 	if !c.batched {

--- a/libpod/healthcheck_linux.go
+++ b/libpod/healthcheck_linux.go
@@ -70,7 +70,7 @@ func (c *Container) startTimer() error {
 
 	startFile := fmt.Sprintf("%s.service", c.ID())
 	startChan := make(chan string)
-	if _, err := conn.StartUnitContext(context.Background(), startFile, "fail", startChan); err != nil {
+	if _, err := conn.RestartUnitContext(context.Background(), startFile, "fail", startChan); err != nil {
 		return err
 	}
 	if err := systemdOpSuccessful(startChan); err != nil {

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -106,8 +106,7 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
 
         # healthcheck should now fail, with exit status 1 and 'unhealthy' output
         run_podman 1 healthcheck run $ctr
-	# FIXME: #15691 - `healthcheck run` may emit an error log that the timer already exists
-        is "$output" ".*unhealthy.*" "output from 'podman healthcheck run'"
+        is "$output" "unhealthy" "output from 'podman healthcheck run'"
 
         run_podman inspect $ctr --format "{{.State.Status}} {{.Config.HealthcheckOnFailureAction}}"
 	if [[ $policy == "restart" ]];then
@@ -118,8 +117,7 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
             # Container is still running and health check still broken
             is "$output" "running $policy" "container continued running"
             run_podman 1 healthcheck run $ctr
-	    # FIXME: #15691 - `healthcheck run` may emit an error log that the timer already exists
-            is "$output" ".*unhealthy.*" "output from 'podman healthcheck run'"
+            is "$output" "unhealthy" "output from 'podman healthcheck run'"
 	else
 	    # kill and stop yield the container into a non-running state
             is "$output" ".* $policy" "container was stopped/killed"


### PR DESCRIPTION
Restart the health-check timers instead of starting them.  This will surpress annoying errors stating that an already running timer cannot be started anymore.

Fixes: #15691
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a misleading error log when restarting a container with running health checks.
```
