### PR TITLE
[CI:DOCS] Man pages: refactor common options: --rootfs

### DIFF
--- a/docs/source/markdown/options/rootfs.md
+++ b/docs/source/markdown/options/rootfs.md
@@ -1,0 +1,19 @@
+#### **--rootfs**
+
+If specified, the first argument refers to an exploded container on the file system.
+
+This is useful to run a container without requiring any image management, the rootfs
+of the container is assumed to be managed externally.
+
+  `Overlay Rootfs Mounts`
+
+   The `:O` flag tells Podman to mount the directory from the rootfs path as
+storage using the `overlay file system`. The container processes
+can modify content within the mount point which is stored in the
+container storage in a separate directory. In overlay terms, the source
+directory will be the lower, and the container storage directory will be the
+upper. Modifications to the mount point are destroyed when the container
+finishes executing, similar to a tmpfs mount point being unmounted.
+
+Note: On **SELinux** systems, the rootfs needs the correct label, which is by default
+**unconfined_u:object_r:container_file_t:s0**.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -418,22 +418,7 @@ Suppress output information when pulling images
 
 Automatically remove the container when it exits. The default is *false*.
 
-#### **--rootfs**
-
-If specified, the first argument refers to an exploded container on the file system.
-
-This is useful to run a container without requiring any image management, the rootfs
-of the container is assumed to be managed externally.
-
-  `Overlay Rootfs Mounts`
-
-   The `:O` flag tells Podman to mount the directory from the rootfs path as
-storage using the `overlay file system`. The container processes
-can modify content within the mount point which is stored in the
-container storage in a separate directory. In overlay terms, the source
-directory will be the lower, and the container storage directory will be the
-upper. Modifications to the mount point are destroyed when the container
-finishes executing, similar to a tmpfs mount point being unmounted.
+@@option rootfs
 
 @@option sdnotify
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -455,25 +455,7 @@ Automatically remove the container when it exits. The default is **false**.
 After exit of the container, remove the image unless another
 container is using it. The default is *false*.
 
-#### **--rootfs**
-
-If specified, the first argument refers to an exploded container on the file system.
-
-This is useful to run a container without requiring any image management, the rootfs
-of the container is assumed to be managed externally.
-
-  `Overlay Rootfs Mounts`
-
-   The `:O` flag tells Podman to mount the directory from the rootfs path as
-storage using the `overlay file system`. The container processes
-can modify content within the mount point which is stored in the
-container storage in a separate directory. In overlay terms, the source
-directory will be the lower, and the container storage directory will be the
-upper. Modifications to the mount point are destroyed when the container
-finishes executing, similar to a tmpfs mount point being unmounted.
-
-Note: On **SELinux** systems, the rootfs needs the correct label, which is by default
-**unconfined_u:object_r:container_file_t**.
+@@option rootfs
 
 @@option sdnotify
 


### PR DESCRIPTION
podman-create and -run only. The SELinux text was added
to podman-run (but not -create) in #3631, and reformatted
in #5192. I assume here that it also applies to podman-create.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```