### PR TITLE
Cirrus: Update CI VM images to F37beta

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,23 +27,23 @@ env:
     #### Cache-image names to test with (double-quotes around names are critical)
     #### Comment out fedora-35 for podman 4.x branches.
     ####
-    FEDORA_NAME: "fedora-36"
+    FEDORA_NAME: "fedora-37"
     FEDORA_AARCH64_NAME: "${FEDORA_NAME}-aarch64"
-    #PRIOR_FEDORA_NAME: "fedora-35"
+    PRIOR_FEDORA_NAME: "fedora-36"
     UBUNTU_NAME: "ubuntu-2204"
 
     # Image identifiers
-    IMAGE_SUFFIX: "c4678746211876864"
+    IMAGE_SUFFIX: "c5178639502278656"
     # EC2 images
     FEDORA_AMI: "fedora-aws-${IMAGE_SUFFIX}"
     FEDORA_AARCH64_AMI: "fedora-podman-aws-arm64-${IMAGE_SUFFIX}"
     # GCP Images
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
-    #PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
     # Container FQIN's
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
-    #PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
+    PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
     UBUNTU_CONTAINER_FQIN: "quay.io/libpod/ubuntu_podman:${IMAGE_SUFFIX}"
     WINDOWS_AMI: "win-server-wsl-c5138587457421312" # Replace with IMAGE_SUFFIX when aligned
     ####
@@ -104,11 +104,11 @@ build_task:
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
               # ID for re-use of build output
               CI_DESIRED_RUNTIME: crun
-        #- env: &priorfedora_envvars
-        #      DISTRO_NV: ${PRIOR_FEDORA_NAME}
-        #      VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-        #      CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
-        #      CI_DESIRED_RUNTIME: crun
+        - env: &priorfedora_envvars
+              DISTRO_NV: ${PRIOR_FEDORA_NAME}
+              VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
+              CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
+              CI_DESIRED_RUNTIME: crun
         - env: &ubuntu_envvars
               DISTRO_NV: ${UBUNTU_NAME}
               VM_IMAGE_NAME: ${UBUNTU_CACHE_IMAGE_NAME}
@@ -592,10 +592,11 @@ container_integration_test_task:
               VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
               CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
               CI_DESIRED_RUNTIME: crun
-        #- env:
-        #      DISTRO_NV: ${PRIOR_FEDORA_NAME}
-        #      VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-        #      CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
+        - env:
+              DISTRO_NV: ${PRIOR_FEDORA_NAME}
+              VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
+              CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
+              CI_DESIRED_RUNTIME: crun
     gce_instance: *standardvm
     timeout_in: 90m
     env:
@@ -949,9 +950,9 @@ meta_task:
         image: quay.io/libpod/imgts:latest
     env:
         # Space-separated list of images used by this repository state
-        # Disabled ${PRIOR_FEDORA_CACHE_IMAGE_NAME} for Fedora 35
         IMGNAMES: >-
             ${FEDORA_CACHE_IMAGE_NAME}
+            ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
             ${UBUNTU_CACHE_IMAGE_NAME}
             build-push-${IMAGE_SUFFIX}
         EC2IMGNAMES: >-

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,11 +40,10 @@ env:
     # GCP Images
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
+    #UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
     # Container FQIN's
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
     PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
-    UBUNTU_CONTAINER_FQIN: "quay.io/libpod/ubuntu_podman:${IMAGE_SUFFIX}"
     WINDOWS_AMI: "win-server-wsl-c5138587457421312" # Replace with IMAGE_SUFFIX when aligned
     ####
     #### Control variables that determine what to run and how to run it.
@@ -109,11 +108,11 @@ build_task:
               VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
               CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
               CI_DESIRED_RUNTIME: crun
-        - env: &ubuntu_envvars
-              DISTRO_NV: ${UBUNTU_NAME}
-              VM_IMAGE_NAME: ${UBUNTU_CACHE_IMAGE_NAME}
-              CTR_FQIN: ${UBUNTU_CONTAINER_FQIN}
-              CI_DESIRED_RUNTIME: runc
+        #- env: &ubuntu_envvars
+        #      DISTRO_NV: ${UBUNTU_NAME}
+        #      VM_IMAGE_NAME: ${UBUNTU_CACHE_IMAGE_NAME}
+        #      CTR_FQIN: ${UBUNTU_CONTAINER_FQIN}
+        #      CI_DESIRED_RUNTIME: runc
     env:
         TEST_FLAVOR: build
     # NOTE: The default way Cirrus-CI clones is *NOT* compatible with
@@ -836,32 +835,32 @@ buildah_bud_test_task:
     always: *int_logs_artifacts
 
 
-rootless_gitlab_test_task:
-    name: *std_name_fmt
-    alias: rootless_gitlab_test
-    # Docs: ./contrib/cirrus/CIModes.md
-    only_if: &cirrus_cron "${CIRRUS_CRON} == 'main'"
-    # Community-maintained downstream test may fail unexpectedly.
-    # Ref. repository: https://gitlab.com/gitlab-org/gitlab-runner
-    # If necessary, uncomment the next line and file issue(s) with details.
-    # allow_failures: $CI == $CI
-    depends_on:
-        - build
-        - rootless_integration_test
-    gce_instance: *standardvm
-    env:
-        <<: *ubuntu_envvars
-        TEST_FLAVOR: 'gitlab'
-        PRIV_NAME: rootless
-    clone_script: *get_gosrc
-    setup_script: *setup
-    main_script: *main
-    always:
-        <<: *logs_artifacts
-        junit_artifacts:
-            path: gitlab-runner-podman.xml
-            type: text/xml
-            format: junit
+#rootless_gitlab_test_task:
+#    name: *std_name_fmt
+#    alias: rootless_gitlab_test
+#    # Docs: ./contrib/cirrus/CIModes.md
+#    only_if: &cirrus_cron "${CIRRUS_CRON} == 'main'"
+#    # Community-maintained downstream test may fail unexpectedly.
+#    # Ref. repository: https://gitlab.com/gitlab-org/gitlab-runner
+#    # If necessary, uncomment the next line and file issue(s) with details.
+#    # allow_failures: $CI == $CI
+#    depends_on:
+#        - build
+#        - rootless_integration_test
+#    gce_instance: *standardvm
+#    env:
+#        <<: *ubuntu_envvars
+#        TEST_FLAVOR: 'gitlab'
+#        PRIV_NAME: rootless
+#    clone_script: *get_gosrc
+#    setup_script: *setup
+#    main_script: *main
+#    always:
+#        <<: *logs_artifacts
+#        junit_artifacts:
+#            path: gitlab-runner-podman.xml
+#            type: text/xml
+#            format: junit
 
 
 upgrade_test_task:
@@ -950,10 +949,11 @@ meta_task:
         image: quay.io/libpod/imgts:latest
     env:
         # Space-separated list of images used by this repository state
+        # DISABLED:
+        #   ${UBUNTU_CACHE_IMAGE_NAME}
         IMGNAMES: >-
             ${FEDORA_CACHE_IMAGE_NAME}
             ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
-            ${UBUNTU_CACHE_IMAGE_NAME}
             build-push-${IMAGE_SUFFIX}
         EC2IMGNAMES: >-
           ${FEDORA_AARCH64_AMI}
@@ -1004,7 +1004,7 @@ success_task:
         - rootless_remote_system_test
         - minikube_test
         - buildah_bud_test
-        - rootless_gitlab_test
+        #- rootless_gitlab_test
         - upgrade_test
         - image_build
         - meta

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -208,6 +208,7 @@ use_cni() {
     export -n NETWORK_BACKEND
     unset NETWORK_BACKEND
     msg "Installing default CNI configuration"
+    dnf install -y $PACKAGE_DOWNLOAD_DIR/podman-plugins*
     cd $GOSRC || exit 1
     rm -rvf /etc/cni/net.d
     mkdir -p /etc/cni/net.d

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -126,19 +126,19 @@ case "$OS_RELEASE_ID" in
             setsebool container_manage_cgroup true
         fi
 
-        # For release 36 and later, netavark/aardvark is the default
-        # networking stack for podman.  All previous releases only have
-        # CNI networking available.  Upgrading from one to the other is
-        # not supported at this time.  Support execution of the upgrade
-        # tests in F36 and later, by disabling Netavark and enabling CNI.
+        # For the latest Fedora CI VM images, netavark/aardvark is the
+        # intended networking stack for podman.  All previous VM images
+        # should use CNI networking.  Upgrading from one to the other is
+        # not supported at this time.  The only exception in CI is
+        # the "upgrade tests" which must always use CNI.
         #
         # OS_RELEASE_VER is defined by automation-library
         # shellcheck disable=SC2154
-        if [[ "$OS_RELEASE_VER" -ge 36 ]] && \
+        if [[ "$DISTRO_NV" != "$PRIOR_FEDORA_NAME" ]] && \
            [[ "$TEST_FLAVOR" != "upgrade_test" ]];
         then
             use_netavark
-        else # Fedora < 36, or upgrade testing.
+        else # Fedora N-1 or upgrade testing.
             use_cni
         fi
         ;;


### PR DESCRIPTION
Fixes: #15349
Depends on: https://github.com/containers/podman/pull/15871 https://github.com/containers/podman/pull/15890
Image build PR: https://github.com/containers/automation_images/pull/195

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
