### PR TITLE
generate systemd: warn on --restart without --new

### DIFF
--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -85,7 +85,9 @@ Set the systemd unit requires (`Requires=`) option. Similar to wants, but declar
 #### **--restart-policy**=*policy*
 
 Set the systemd restart policy.  The restart-policy must be one of: "no", "on-success", "on-failure", "on-abnormal",
-"on-watchdog", "on-abort", or "always".  The default policy is *on-failure*.
+"on-watchdog", "on-abort", or "always".  The default policy is *on-failure* unless the container was created with a custom restart policy.
+
+Note that generating a unit without `--new` on a container with a custom restart policy can lead to issues on shutdown; systemd will attempt to stop the unit while Podman tries to restart it.  It is recommended to to create the container without `--restart` and use the `--restart-policy` option instead when generating the unit file.
 
 #### **--restart-sec**=*time*
 

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -81,6 +81,13 @@ function service_cleanup() {
         skip "FIXME: 2022-09-01: requires conmon-2.1.4, ubuntu has 2.1.3"
     fi
 
+    # Warn when a custom restart policy is used without --new (see #15284)
+    run_podman create --restart=always $IMAGE
+    cid="$output"
+    run_podman generate systemd $cid
+    is "$output" ".*Container $cid has restart policy .*always.* which can lead to issues on shutdown.*" "generate systemd emits warning"
+    run_podman rm -f $cid
+
     cname=$(random_string)
     # See #7407 for --pull=always.
     run_podman create --pull=always --name $cname --label "io.containers.autoupdate=registry" $IMAGE \


### PR DESCRIPTION
Emit a warning to the user when generating a unit with --new on a container that was created with a custom --restart policy. As shown in #15284, a custom --restart policy in that case can lead to issues on system shutdown where systemd attempts to nuke the unit but Podman keeps on restarting the container.

Fixes: #15284
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Emit a warning on potential shutdown issues when using `podman generate systemd` without the `--new` flag on a container with custom restart policy.
```
