### PR TITLE
events: Fix spelling of newNullEventer

### DIFF
--- a/libpod/events/events_freebsd.go
+++ b/libpod/events/events_freebsd.go
@@ -14,7 +14,7 @@ func NewEventer(options EventerOptions) (Eventer, error) {
 	case strings.ToUpper(LogFile.String()):
 		return EventLogFile{options}, nil
 	case strings.ToUpper(Null.String()):
-		return NewNullEventer(), nil
+		return newNullEventer(), nil
 	case strings.ToUpper(Memory.String()):
 		return NewMemoryEventer(), nil
 	default:


### PR DESCRIPTION
This function changed from public to private which broke the FreeBSD build.

Sadly, adding FreeBSD to the cross build isn't currently possible since github.com/godbus/dbus relies on cgo on FreeBSD. I've tried to fix this upstream but my PR is going nowhere - I think this dependency is only needed for systemd which isn't a thing on FreeBSD so it might be possible to work around the problem in libpod by making the systemd code conditional on linux.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
