### PR TITLE
[CI:DOCS] Man pages: refactor common options: --ip

### DIFF
--- a/docs/source/markdown/options/ip.md
+++ b/docs/source/markdown/options/ip.md
@@ -1,0 +1,8 @@
+#### **--ip**=*ipv4*
+
+Specify a static IPv4 address for the <<container|pod>>, for example **10.88.64.128**.
+This option can only be used if the <<container|pod>> is joined to only a single network - i.e., **--network=network-name** is used at most once -
+and if the <<container|pod>> is not joining another container's network namespace via **--network=container:_id_**.
+The address must be within the network's IP address pool (default **10.88.0.0/16**).
+
+To specify multiple static IP addresses per <<container|pod>>, set multiple networks using the **--network** option with a static IP address specified for each using the `ip` mode for that option.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -228,14 +228,7 @@ pod when that pod is not running.
 
 Keep STDIN open even if not attached. The default is *false*.
 
-#### **--ip**=*ipv4*
-
-Specify a static IPv4 address for the container, for example **10.88.64.128**.
-This option can only be used if the container is joined to only a single network - i.e., **--network=network-name** is used at most once -
-and if the container is not joining another container's network namespace via **--network=container:_id_**.
-The address must be within the network's IP address pool (default **10.88.0.0/16**).
-
-To specify multiple static IP addresses per container, set multiple networks using the **--network** option with a static IP address specified for each using the `ip` mode for that option.
+@@option ip
 
 #### **--ip6**=*ipv6*
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -99,14 +99,7 @@ The custom image that will be used for the infra container.  Unless specified, P
 
 @@option infra-name
 
-#### **--ip**=*ip*
-
-Specify a static IP address for the pod, for example **10.88.64.128**.
-This option can only be used if the pod is joined to only a single network - i.e., **--network=network-name** is used at most once -
-and if the pod is not joining another container's network namespace via **--network=container:_id_**.
-The address must be within the network's IP address pool (default **10.88.0.0/16**).
-
-To specify multiple static IP addresses per pod, set multiple networks using the **--network** option with a static IP address specified for each using the `ip` mode for that option.
+@@option ip
 
 #### **--ip6**=*ipv6*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -249,14 +249,7 @@ Print usage statement
 
 When set to **true**, keep stdin open even if not attached. The default is **false**.
 
-#### **--ip**=*ipv4*
-
-Specify a static IPv4 address for the container, for example **10.88.64.128**.
-This option can only be used if the container is joined to only a single network - i.e., **--network=network-name** is used at most once -
-and if the container is not joining another container's network namespace via **--network=container:_id_**.
-The address must be within the network's IP address pool (default **10.88.0.0/16**).
-
-To specify multiple static IP addresses per container, set multiple networks using the **--network** option with a static IP address specified for each using the `ip` mode for that option.
+@@option ip
 
 #### **--ip6**=*ipv6*
 


### PR DESCRIPTION
Between podman-create, run, and pod-create. The big difference
is that I changed 'IP' to 'IPv4' in podman-pod-create, I believe
that was an oversight in #12611.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```