### PR TITLE
[CI:DOCS] Man pages: refactor common options: --os (pull)

### DIFF
--- a/docs/source/markdown/options/os.pull.md
+++ b/docs/source/markdown/options/os.pull.md
@@ -1,0 +1,4 @@
+#### **--os**=*OS*
+
+Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
+Unless overridden, subsequent lookups of the same image in the local storage will match this OS, regardless of the host.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -326,9 +326,7 @@ This option conflicts with **--add-host**.
 
 @@option oom-score-adj
 
-#### **--os**=*OS*
-Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
-Unless overridden, subsequent lookups of the same image in the local storage will match this OS, regardless of the host.
+@@option os.pull
 
 @@option passwd-entry
 

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -63,10 +63,7 @@ All tagged images in the repository will be pulled.
 
 Print the usage statement.
 
-#### **--os**=*OS*
-
-Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
-Unless overridden, subsequent lookups of the same image in the local storage will match this OS, regardless of the host.
+@@option os.pull
 
 @@option platform
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -346,9 +346,7 @@ This option conflicts with **--add-host**.
 
 @@option oom-score-adj
 
-#### **--os**=*OS*
-Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.
-Unless overridden, subsequent lookups of the same image in the local storage will match this OS, regardless of the host.
+@@option os.pull
 
 #### **--passwd**
 


### PR DESCRIPTION
Only shared by podman-create, -pull, -run. No changes
made other than whitespace, so this should be a gimme.

podman-build, import, and manifest-* also have --os options,
but those are unrelated and I can't find a way to combine
any two of them.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```