### PR TITLE
[CI:BUILD] Enable github labeler, use for api-change

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# Add labels based on file paths in PR
+#   https://github.com/actions/labeler
+kind/api-change:
+  - pkg/api/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+# https://github.com/actions/labeler
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Belated followup to #11829: use github labeler workflow[1] to
auto-add 'kind/api-change' label to PRs in which files are
touched under pkg/api

 [1] https://github.com/actions/labeler

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```