### PR TITLE
[CI:DOCS] Man pages: refactor common options: --publish-all

### DIFF
--- a/docs/source/markdown/options/publish-all.md
+++ b/docs/source/markdown/options/publish-all.md
@@ -1,0 +1,12 @@
+#### **--publish-all**, **-P**
+
+Publish all exposed ports to random ports on the host interfaces. The default is **false**.
+
+When set to **true**, publish all exposed ports to the host interfaces. The
+default is **false**. If the operator uses **-P** (or **-p**) then Podman will make the
+exposed port accessible on the host and the ports will be available to any
+client that can reach the host.
+
+When using this option, Podman will bind any exposed port to a random port on the host
+within an ephemeral port range defined by */proc/sys/net/ipv4/ip_local_port_range*.
+To find the mapping between the host ports and the exposed ports, use **podman port**.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -377,17 +377,7 @@ associated ports. If one container binds to a port, no other container can use t
 within the pod while it is in use. Containers in the pod can also communicate over localhost
 by having one container bind to localhost in the pod, and another connect to that port.
 
-#### **--publish-all**, **-P**
-
-Publish all exposed ports to random ports on the host interfaces. The default is *false*.
-
-When set to true publish all exposed ports to the host interfaces. The
-default is false. If the operator uses -P (or -p) then Podman will make the
-exposed port accessible on the host and the ports will be available to any
-client that can reach the host. When using -P, Podman will bind any exposed
-port to a random port on the host within an *ephemeral port range* defined by
-`/proc/sys/net/ipv4/ip_local_port_range`. To find the mapping between the host
-ports and the exposed ports, use `podman port`.
+@@option publish-all
 
 @@option pull
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -408,18 +408,7 @@ associated ports. If one container binds to a port, no other container can use t
 within the pod while it is in use. Containers in the pod can also communicate over localhost
 by having one container bind to localhost in the pod, and another connect to that port.
 
-#### **--publish-all**, **-P**
-
-Publish all exposed ports to random ports on the host interfaces. The default is **false**.
-
-When set to **true**, publish all exposed ports to the host interfaces. The
-default is **false**. If the operator uses **-P** (or **-p**) then Podman will make the
-exposed port accessible on the host and the ports will be available to any
-client that can reach the host.
-
-When using this option, Podman will bind any exposed port to a random port on the host
-within an ephemeral port range defined by */proc/sys/net/ipv4/ip_local_port_range*.
-To find the mapping between the host ports and the exposed ports, use **podman port**.
+@@option publish-all
 
 @@option pull
 


### PR DESCRIPTION
Only shared between podman-create and run. The latter was
updated in #5192, and that is the text I chose.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```