### PR TITLE
Cirrus: Move gitlab test to cirrus-cron "main"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -872,7 +872,7 @@ rootless_gitlab_test_task:
     name: *std_name_fmt
     alias: rootless_gitlab_test
     # Docs: ./contrib/cirrus/CIModes.md
-    only_if: *not_tag_branch_build_docs
+    only_if: &cirrus_cron "${CIRRUS_CRON} == 'main'"
     # Community-maintained downstream test may fail unexpectedly.
     # Ref. repository: https://gitlab.com/gitlab-org/gitlab-runner
     # If necessary, uncomment the next line and file issue(s) with details.


### PR DESCRIPTION
There's little need to execute this test for (nearly) every PR. Further, since it always executes the *latest* upstream tests, there's no need to run it on any branch other than `main`.  Arrange for it to only execute for the `main` cirrus-cron trigger.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
