### PR TITLE
Cirrus: Only run unit-testing on Fedora.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -503,8 +503,7 @@ docker-py_test_task:
     always: *runner_stats
 
 
-# Does exactly what it says, execute the podman unit-tests on all primary
-# platforms and release versions.
+# Does exactly what it says, execute the podman unit-tests on Fedora.
 unit_test_task:
     name: "Unit tests on $DISTRO_NV"
     alias: unit_test
@@ -515,9 +514,6 @@ unit_test_task:
         - validate
     matrix:
         - env: *stdenvars
-        # Fedora 35 skipped for podman4
-        #- env: *priorfedora_envvars
-        - env: *ubuntu_envvars
         # Special-case: Rootless on latest Fedora (standard) VM
         - name: "Rootless unit on $DISTRO_NV"
           env:


### PR DESCRIPTION
There's little practical reason to execute unit-level testing on multiple platforms, since there's so little platform interaction. Remove the unit-test runs on Ubuntu, only execute on root-full and root-less Fedora.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
