### PR TITLE
[CI:DOCS] Man pages: Refactor common options: --publish

### DIFF
--- a/docs/source/markdown/options/publish.md
+++ b/docs/source/markdown/options/publish.md
@@ -1,0 +1,19 @@
+#### **--publish**, **-p**=*[[ip:][hostPort]:]containerPort[/protocol]*
+
+Publish a container's port, or range of ports,<<| within this pod>> to the host.
+
+Both *hostPort* and *containerPort* can be specified as a range of ports.
+When specifying ranges for both, the number of container ports in the
+range must match the number of host ports in the range.
+
+If host IP is set to 0.0.0.0 or not set at all, the port will be bound on all IPs on the host.
+
+By default, Podman will publish TCP ports. To publish a UDP port instead, give
+`udp` as protocol. To publish both TCP and UDP ports, set `--publish` twice,
+with `tcp`, and `udp` as protocols respectively. Rootful containers can also
+publish ports using the `sctp` protocol.
+
+Host port does not have to be specified (e.g. `podman run -p 127.0.0.1::80`).
+If it is not, the container port will be randomly assigned a port on the host.
+
+Use **podman port** to see the actual mapping: `podman port $CONTAINER $CONTAINERPORT`.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -349,25 +349,7 @@ To make a pod with more granular options, use the `podman pod create` command be
 
 @@option privileged
 
-#### **--publish**, **-p**=*[[ip:][hostPort]:]containerPort[/protocol]*
-
-Publish a container's port, or range of ports, to the host.
-
-Both *hostPort* and *containerPort* can be specified as a range of ports.
-When specifying ranges for both, the number of container ports in the
-range must match the number of host ports in the range.
-
-If host IP is set to 0.0.0.0 or not set at all, the port will be bound on all IPs on the host.
-
-By default, Podman will publish TCP ports. To publish a UDP port instead, give
-`udp` as protocol. To publish both TCP and UDP ports, set `--publish` twice,
-with `tcp`, and `udp` as protocols respectively. Rootful containers can also
-publish ports using the `sctp` protocol.
-
-Host port does not have to be specified (e.g. `podman run -p 127.0.0.1::80`).
-If it is not, the container port will be randomly assigned a port on the host.
-
-Use **podman port** to see the actual mapping: `podman port $CONTAINER $CONTAINERPORT`.
+@@option publish
 
 **Note:** If a container will be run within a pod, it is not necessary to publish the port for
 the containers in the pod. The port must only be published by the pod itself. Pod network

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -169,25 +169,7 @@ This option conflicts with **--add-host**.
 
 Write the pod ID to the file.
 
-#### **--publish**, **-p**=*[[ip:][hostPort]:]containerPort[/protocol]*
-
-Publish a container's port, or range of ports, within this pod to the host.
-
-Both *hostPort* and *containerPort* can be specified as a range of ports.
-When specifying ranges for both, the number of container ports in the
-range must match the number of host ports in the range.
-
-If host IP is set to 0.0.0.0 or not set at all, the port will be bound on all IPs on the host.
-
-By default, Podman will publish TCP ports. To publish a UDP port instead, give
-`udp` as protocol. To publish both TCP and UDP ports, set `--publish` twice,
-with `tcp`, and `udp` as protocols respectively. Rootful containers can also
-publish ports using the `sctp` protocol.
-
-Host port does not have to be specified (e.g. `podman run -p 127.0.0.1::80`).
-If it is not, the container port will be randomly assigned a port on the host.
-
-Use **podman port** to see the actual mapping: `podman port $CONTAINER $CONTAINERPORT`.
+@@option publish
 
 **Note:** You must not publish ports of containers in the pod individually,
 but only by the pod itself.

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -380,25 +380,7 @@ The total FDs will be 3+N. (This option is not available with the remote Podman 
 
 @@option privileged
 
-#### **--publish**, **-p**=*[[ip:][hostPort]:]containerPort[/protocol]*
-
-Publish a container's port, or range of ports, to the host.
-
-Both *hostPort* and *containerPort* can be specified as a range of ports.
-When specifying ranges for both, the number of container ports in the
-range must match the number of host ports in the range.
-
-If host IP is set to 0.0.0.0 or not set at all, the port will be bound on all IPs on the host.
-
-By default, Podman will publish TCP ports. To publish a UDP port instead, give
-`udp` as protocol. To publish both TCP and UDP ports, set `--publish` twice,
-with `tcp`, and `udp` as protocols respectively. Rootful containers can also
-publish ports using the `sctp` protocol.
-
-Host port does not have to be specified (e.g. `podman run -p 127.0.0.1::80`).
-If it is not, the container port will be randomly assigned a port on the host.
-
-Use **podman port** to see the actual mapping: `podman port $CONTAINER $CONTAINERPORT`.
+@@option publish
 
 **Note:** If a container will be run within a pod, it is not necessary to publish the port for
 the containers in the pod. The port must only be published by the pod itself. Pod network


### PR DESCRIPTION
Almost identical between podman-create, run, and pod-create.
The "Notes" are different, so I left those duplicated between
podman-create and run, and left the different one in pod-create.

podman-container-restore also has --publish but it's unrelated.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```