### PR TITLE
Cirrus: Fix win_installer task clone failure

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1119,7 +1119,6 @@ win_installer_task:
     env:
         PATH: "${PATH};C:\\ProgramData\\chocolatey\\bin"
         CIRRUS_SHELL: powershell
-        CIRRUS_CLONE_DEPTH: 1
         # Fake version, we are only testing the installer functions, so version doesn't matter
         WIN_INST_VER: 9.9.9
         CIRRUS_WORKING_DIR: "${CIRRUS_DEFAULT_WORK}"


### PR DESCRIPTION
Fix error in this task happening on `main`:

    Failed to force reset to 5ab...6d4: object not found!

Ref: https://cirrus-ci.com/task/6674361678561280?logs=clone#L2

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
