### PR TITLE
all: stop using deprecated GenerateNonCryptoID

### DIFF
--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -182,7 +182,7 @@ func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
 	}
 
 	// Generate an ID for our new exec session
-	sessionID := stringid.GenerateNonCryptoID()
+	sessionID := stringid.GenerateRandomID()
 	found := true
 	// This really ought to be a do-while, but Go doesn't have those...
 	for found {
@@ -194,7 +194,7 @@ func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
 			}
 		}
 		if found {
-			sessionID = stringid.GenerateNonCryptoID()
+			sessionID = stringid.GenerateRandomID()
 		}
 	}
 

--- a/libpod/pod_internal.go
+++ b/libpod/pod_internal.go
@@ -16,7 +16,7 @@ import (
 func newPod(runtime *Runtime) *Pod {
 	pod := new(Pod)
 	pod.config = new(PodConfig)
-	pod.config.ID = stringid.GenerateNonCryptoID()
+	pod.config.ID = stringid.GenerateRandomID()
 	pod.config.Labels = make(map[string]string)
 	pod.config.CreatedTime = time.Now()
 	//	pod.config.InfraContainer = new(ContainerConfig)

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -169,7 +169,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 	ctr.state = new(ContainerState)
 
 	if config == nil {
-		ctr.config.ID = stringid.GenerateNonCryptoID()
+		ctr.config.ID = stringid.GenerateRandomID()
 		size, err := units.FromHumanSize(r.config.Containers.ShmSize)
 		if useDevShm {
 			if err != nil {
@@ -193,7 +193,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 		}
 		// If the ID is empty a new name for the restored container was requested
 		if ctr.config.ID == "" {
-			ctr.config.ID = stringid.GenerateNonCryptoID()
+			ctr.config.ID = stringid.GenerateRandomID()
 		}
 		// Reset the log path to point to the default
 		ctr.config.LogPath = ""
@@ -466,7 +466,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		if vol.Name == "" {
 			// Anonymous volume. We'll need to create it.
 			// It needs a name first.
-			vol.Name = stringid.GenerateNonCryptoID()
+			vol.Name = stringid.GenerateRandomID()
 			isAnonymous = true
 		} else {
 			// Check if it exists already

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -42,7 +42,7 @@ func (r *Runtime) newVolume(noCreatePluginVolume bool, options ...VolumeCreateOp
 	}
 
 	if volume.config.Name == "" {
-		volume.config.Name = stringid.GenerateNonCryptoID()
+		volume.config.Name = stringid.GenerateRandomID()
 	}
 	if volume.config.Driver == "" {
 		volume.config.Driver = define.VolumeDriverLocal

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -306,7 +306,7 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 		// happens. So, use a podman-%s.sock-lock empty file as a marker.
 		tries := 0
 		for {
-			uuid := stringid.GenerateNonCryptoID()
+			uuid := stringid.GenerateRandomID()
 			lockPath := fmt.Sprintf("%s-%s.sock-lock", pathPrefix, uuid)
 			lockFile, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0700)
 			if err == nil {
@@ -894,7 +894,7 @@ func generateNetworkConfig(p *PodmanTestIntegration) (string, string) {
 		conf string
 	)
 	// generate a random name to prevent conflicts with other tests
-	name := "net" + stringid.GenerateNonCryptoID()
+	name := "net" + stringid.GenerateRandomID()
 	if p.NetworkBackend != Netavark {
 		path = filepath.Join(p.NetworkConfigDir, fmt.Sprintf("%s.conflist", name))
 		conf = fmt.Sprintf(`{
@@ -1030,7 +1030,7 @@ func ncz(port int) bool {
 }
 
 func createNetworkName(name string) string {
-	return name + stringid.GenerateNonCryptoID()[:10]
+	return name + stringid.GenerateRandomID()[:10]
 }
 
 var IPRegex = `(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`

--- a/test/e2e/create_staticmac_test.go
+++ b/test/e2e/create_staticmac_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Podman run with --mac-address flag", func() {
 	})
 
 	It("Podman run --mac-address with custom network", func() {
-		net := "n1" + stringid.GenerateNonCryptoID()
+		net := "n1" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -595,7 +595,7 @@ var _ = Describe("Podman create", func() {
 		pod.WaitWithDefaultTimeout()
 		Expect(pod).Should(Exit(0))
 
-		netName := "pod" + stringid.GenerateNonCryptoID()
+		netName := "pod" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -93,9 +93,9 @@ var _ = Describe("Podman diff", func() {
 	})
 
 	It("podman image diff", func() {
-		file1 := "/" + stringid.GenerateNonCryptoID()
-		file2 := "/" + stringid.GenerateNonCryptoID()
-		file3 := "/" + stringid.GenerateNonCryptoID()
+		file1 := "/" + stringid.GenerateRandomID()
+		file2 := "/" + stringid.GenerateRandomID()
+		file3 := "/" + stringid.GenerateRandomID()
 
 		// Create container image with the files
 		containerfile := fmt.Sprintf(`
@@ -152,8 +152,8 @@ RUN echo test
 	})
 
 	It("podman diff container and image with same name", func() {
-		imagefile := "/" + stringid.GenerateNonCryptoID()
-		confile := "/" + stringid.GenerateNonCryptoID()
+		imagefile := "/" + stringid.GenerateRandomID()
+		confile := "/" + stringid.GenerateRandomID()
 
 		// Create container image with the files
 		containerfile := fmt.Sprintf(`

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -154,9 +154,9 @@ var _ = Describe("Podman events", func() {
 	})
 
 	It("podman events --until future", func() {
-		name1 := stringid.GenerateNonCryptoID()
-		name2 := stringid.GenerateNonCryptoID()
-		name3 := stringid.GenerateNonCryptoID()
+		name1 := stringid.GenerateRandomID()
+		name2 := stringid.GenerateRandomID()
+		name3 := stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"create", "--name", name1, ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -376,7 +376,7 @@ var _ = Describe("Podman logs", func() {
 			skipIfJournaldInContainer()
 
 			cname := "log-test"
-			content := stringid.GenerateNonCryptoID()
+			content := stringid.GenerateRandomID()
 			// use printf to print no extra newline
 			logc := podmanTest.Podman([]string{"run", "--log-driver", log, "--name", cname, ALPINE, "printf", content})
 			logc.WaitWithDefaultTimeout()

--- a/test/e2e/network_connect_disconnect_test.go
+++ b/test/e2e/network_connect_disconnect_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("bad container name in network disconnect should result in error", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -53,7 +53,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("network disconnect with net mode slirp4netns should result in error", func() {
-		netName := "slirp" + stringid.GenerateNonCryptoID()
+		netName := "slirp" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -72,7 +72,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 
 	It("podman network disconnect", func() {
 		SkipIfRootlessCgroupsV1("stats not supported under rootless CgroupsV1")
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -128,7 +128,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("bad container name in network connect should result in error", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -140,7 +140,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("network connect with net mode slirp4netns should result in error", func() {
-		netName := "slirp" + stringid.GenerateNonCryptoID()
+		netName := "slirp" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -158,7 +158,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman connect on a container that already is connected to the network should error after init", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -190,7 +190,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 
 	It("podman network connect", func() {
 		SkipIfRootlessCgroupsV1("stats not supported under rootless CgroupsV1")
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -206,7 +206,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(exec).Should(Exit(0))
 
 		// Create a second network
-		newNetName := "aliasTest" + stringid.GenerateNonCryptoID()
+		newNetName := "aliasTest" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", newNetName, "--subnet", "10.11.100.0/24"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -264,13 +264,13 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network connect when not running", func() {
-		netName1 := "connect1" + stringid.GenerateNonCryptoID()
+		netName1 := "connect1" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeNetwork(netName1)
 
-		netName2 := "connect2" + stringid.GenerateNonCryptoID()
+		netName2 := "connect2" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", netName2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -303,7 +303,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network connect and run with network ID", func() {
-		netName := "ID" + stringid.GenerateNonCryptoID()
+		netName := "ID" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -323,7 +323,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 		Expect(exec).Should(Exit(0))
 
 		// Create a second network
-		newNetName := "ID2" + stringid.GenerateNonCryptoID()
+		newNetName := "ID2" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", newNetName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -350,13 +350,13 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network disconnect when not running", func() {
-		netName1 := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName1 := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeNetwork(netName1)
 
-		netName2 := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName2 := "aliasTest" + stringid.GenerateRandomID()
 		session2 := podmanTest.Podman([]string{"network", "create", netName2})
 		session2.WaitWithDefaultTimeout()
 		Expect(session2).Should(Exit(0))
@@ -395,7 +395,7 @@ var _ = Describe("Podman network connect and disconnect", func() {
 	})
 
 	It("podman network disconnect and run with network ID", func() {
-		netName := "aliasTest" + stringid.GenerateNonCryptoID()
+		netName := "aliasTest" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with name and subnet", func() {
-		netName := "subnet-" + stringid.GenerateNonCryptoID()
+		netName := "subnet-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--ip-range", "10.11.12.0/26", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -84,7 +84,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with name and IPv6 subnet", func() {
-		netName := "ipv6-" + stringid.GenerateNonCryptoID()
+		netName := "ipv6-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:1:2:3:4::/64", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -123,7 +123,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with name and IPv6 flag (dual-stack)", func() {
-		netName := "dual-" + stringid.GenerateNonCryptoID()
+		netName := "dual-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:3:2::/64", "--ipv6", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -156,7 +156,7 @@ var _ = Describe("Podman network create", func() {
 
 		// create a second network to check the auto assigned ipv4 subnet does not overlap
 		// https://github.com/containers/podman/issues/11032
-		netName2 := "dual-" + stringid.GenerateNonCryptoID()
+		netName2 := "dual-" + stringid.GenerateRandomID()
 		nc = podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:10:3:2::/64", "--ipv6", netName2})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -204,13 +204,13 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with invalid subnet", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/17000", stringid.GenerateNonCryptoID()})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/17000", stringid.GenerateRandomID()})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create with ipv4 subnet and ipv6 flag", func() {
-		name := stringid.GenerateNonCryptoID()
+		name := stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--ipv6", name})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(Exit(0))
@@ -224,7 +224,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with empty subnet and ipv6 flag", func() {
-		name := stringid.GenerateNonCryptoID()
+		name := stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--ipv6", name})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(Exit(0))
@@ -238,19 +238,19 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with invalid IP", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.0/17000", stringid.GenerateNonCryptoID()})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.0/17000", stringid.GenerateRandomID()})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create with invalid gateway for subnet", func() {
-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--gateway", "192.168.1.1", stringid.GenerateNonCryptoID()})
+		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--gateway", "192.168.1.1", stringid.GenerateRandomID()})
 		nc.WaitWithDefaultTimeout()
 		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create two networks with same name should fail", func() {
-		netName := "same-" + stringid.GenerateNonCryptoID()
+		netName := "same-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", netName})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -262,13 +262,13 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create two networks with same subnet should fail", func() {
-		netName1 := "sub1-" + stringid.GenerateNonCryptoID()
+		netName1 := "sub1-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.13.0/24", netName1})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName1)
 		Expect(nc).Should(Exit(0))
 
-		netName2 := "sub2-" + stringid.GenerateNonCryptoID()
+		netName2 := "sub2-" + stringid.GenerateRandomID()
 		ncFail := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.13.0/24", netName2})
 		ncFail.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -276,13 +276,13 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create two IPv6 networks with same subnet should fail", func() {
-		netName1 := "subipv61-" + stringid.GenerateNonCryptoID()
+		netName1 := "subipv61-" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:4:4:4::/64", "--ipv6", netName1})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName1)
 		Expect(nc).Should(Exit(0))
 
-		netName2 := "subipv62-" + stringid.GenerateNonCryptoID()
+		netName2 := "subipv62-" + stringid.GenerateRandomID()
 		ncFail := podmanTest.Podman([]string{"network", "create", "--subnet", "fd00:4:4:4:4::/64", "--ipv6", netName2})
 		ncFail.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -296,7 +296,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with mtu option", func() {
-		net := "mtu-test" + stringid.GenerateNonCryptoID()
+		net := "mtu-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "mtu=9000", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -309,7 +309,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with vlan option", func() {
-		net := "vlan-test" + stringid.GenerateNonCryptoID()
+		net := "vlan-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "vlan=9", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -322,7 +322,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with invalid option", func() {
-		net := "invalid-test" + stringid.GenerateNonCryptoID()
+		net := "invalid-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--opt", "foo=bar", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -331,7 +331,7 @@ var _ = Describe("Podman network create", func() {
 
 	It("podman CNI network create with internal should not have dnsname", func() {
 		SkipIfNetavark(podmanTest)
-		net := "internal-test" + stringid.GenerateNonCryptoID()
+		net := "internal-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--internal", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -349,7 +349,7 @@ var _ = Describe("Podman network create", func() {
 
 	It("podman Netavark network create with internal should have dnsname", func() {
 		SkipIfCNI(podmanTest)
-		net := "internal-test" + stringid.GenerateNonCryptoID()
+		net := "internal-test" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--internal", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -375,7 +375,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with multiple subnets", func() {
-		name := "subnets-" + stringid.GenerateNonCryptoID()
+		name := "subnets-" + stringid.GenerateRandomID()
 		subnet1 := "10.10.0.0/24"
 		subnet2 := "10.10.1.0/24"
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", subnet1, "--subnet", subnet2, name})
@@ -393,7 +393,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with multiple subnets dual stack", func() {
-		name := "subnets-" + stringid.GenerateNonCryptoID()
+		name := "subnets-" + stringid.GenerateRandomID()
 		subnet1 := "10.10.2.0/24"
 		subnet2 := "fd52:2a5a:747e:3acd::/64"
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", subnet1, "--subnet", subnet2, name})
@@ -411,7 +411,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create with multiple subnets dual stack with gateway and range", func() {
-		name := "subnets-" + stringid.GenerateNonCryptoID()
+		name := "subnets-" + stringid.GenerateRandomID()
 		subnet1 := "10.10.3.0/24"
 		gw1 := "10.10.3.10"
 		range1 := "10.10.3.0/26"
@@ -436,7 +436,7 @@ var _ = Describe("Podman network create", func() {
 	})
 
 	It("podman network create invalid options with multiple subnets", func() {
-		name := "subnets-" + stringid.GenerateNonCryptoID()
+		name := "subnets-" + stringid.GenerateRandomID()
 		subnet1 := "10.10.3.0/24"
 		gw1 := "10.10.3.10"
 		gw2 := "fd52:2a5a:747e:3acf::10"

--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network list --filter labels", func() {
-		net1 := "labelnet" + stringid.GenerateNonCryptoID()
+		net1 := "labelnet" + stringid.GenerateRandomID()
 		label1 := "testlabel1=abc"
 		label2 := "abcdef"
 		session := podmanTest.Podman([]string{"network", "create", "--label", label1, net1})
@@ -121,7 +121,7 @@ var _ = Describe("Podman network", func() {
 		defer podmanTest.removeNetwork(net1)
 		Expect(session).Should(Exit(0))
 
-		net2 := "labelnet" + stringid.GenerateNonCryptoID()
+		net2 := "labelnet" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", "--label", label1, "--label", label2, net2})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net2)
@@ -141,7 +141,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network list --filter invalid value", func() {
-		net := "net" + stringid.GenerateNonCryptoID()
+		net := "net" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -294,7 +294,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman inspect container single CNI network", func() {
-		netName := "net-" + stringid.GenerateNonCryptoID()
+		netName := "net-" + stringid.GenerateRandomID()
 		network := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.50.0/24", netName})
 		network.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -324,13 +324,13 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman inspect container two CNI networks (container not running)", func() {
-		netName1 := "net1-" + stringid.GenerateNonCryptoID()
+		netName1 := "net1-" + stringid.GenerateRandomID()
 		network1 := podmanTest.Podman([]string{"network", "create", netName1})
 		network1.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName1)
 		Expect(network1).Should(Exit(0))
 
-		netName2 := "net2-" + stringid.GenerateNonCryptoID()
+		netName2 := "net2-" + stringid.GenerateRandomID()
 		network2 := podmanTest.Podman([]string{"network", "create", netName2})
 		network2.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -361,13 +361,13 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman inspect container two CNI networks", func() {
-		netName1 := "net1-" + stringid.GenerateNonCryptoID()
+		netName1 := "net1-" + stringid.GenerateRandomID()
 		network1 := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.51.0/25", netName1})
 		network1.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName1)
 		Expect(network1).Should(Exit(0))
 
-		netName2 := "net2-" + stringid.GenerateNonCryptoID()
+		netName2 := "net2-" + stringid.GenerateRandomID()
 		network2 := podmanTest.Podman([]string{"network", "create", "--subnet", "10.50.51.128/26", netName2})
 		network2.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -403,7 +403,7 @@ var _ = Describe("Podman network", func() {
 
 	It("podman network remove after disconnect when container initially created with the network", func() {
 		container := "test"
-		network := "foo" + stringid.GenerateNonCryptoID()
+		network := "foo" + stringid.GenerateRandomID()
 
 		session := podmanTest.Podman([]string{"network", "create", network})
 		session.WaitWithDefaultTimeout()
@@ -430,7 +430,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network remove --force with pod", func() {
-		netName := "net-" + stringid.GenerateNonCryptoID()
+		netName := "net-" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName)
@@ -466,13 +466,13 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network remove with two networks", func() {
-		netName1 := "net1-" + stringid.GenerateNonCryptoID()
+		netName1 := "net1-" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", netName1})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName1)
 		Expect(session).Should(Exit(0))
 
-		netName2 := "net2-" + stringid.GenerateNonCryptoID()
+		netName2 := "net2-" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", netName2})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(netName2)
@@ -591,7 +591,7 @@ var _ = Describe("Podman network", func() {
 	It("podman network create/remove macvlan", func() {
 		// Netavark currently does not do dhcp so the this test fails
 		SkipIfNetavark(podmanTest)
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "--macvlan", "lo", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -605,7 +605,7 @@ var _ = Describe("Podman network", func() {
 	It("podman network create/remove macvlan as driver (-d) no device name", func() {
 		// Netavark currently does not do dhcp so the this test fails
 		SkipIfNetavark(podmanTest)
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -632,7 +632,7 @@ var _ = Describe("Podman network", func() {
 	It("podman network create/remove macvlan as driver (-d) with device name", func() {
 		// Netavark currently does not do dhcp so the this test fails
 		SkipIfNetavark(podmanTest)
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", "parent=lo", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -659,7 +659,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network exists", func() {
-		net := "net" + stringid.GenerateNonCryptoID()
+		net := "net" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -669,13 +669,13 @@ var _ = Describe("Podman network", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"network", "exists", stringid.GenerateNonCryptoID()})
+		session = podmanTest.Podman([]string{"network", "exists", stringid.GenerateRandomID()})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(1))
 	})
 
 	It("podman network create macvlan with network info and options", func() {
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		nc := podmanTest.Podman([]string{"network", "create", "-d", "macvlan", "-o", "parent=lo", "-o", "mtu=1500", "--gateway", "192.168.1.254", "--subnet", "192.168.1.0/24", net})
 		nc.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -711,7 +711,7 @@ var _ = Describe("Podman network", func() {
 		if IsRemote() {
 			podmanTest.RestartRemoteService()
 		}
-		net1 := "macvlan" + stringid.GenerateNonCryptoID() + "net1"
+		net1 := "macvlan" + stringid.GenerateRandomID() + "net1"
 
 		nc := podmanTest.Podman([]string{"network", "create", net1})
 		nc.WaitWithDefaultTimeout()
@@ -764,7 +764,7 @@ var _ = Describe("Podman network", func() {
 		// Run a container on one of them
 		// Network Prune
 		// Check that one has been pruned, other remains
-		net := "macvlan" + stringid.GenerateNonCryptoID()
+		net := "macvlan" + stringid.GenerateRandomID()
 		net1 := net + "1"
 		net2 := net + "2"
 		nc := podmanTest.Podman([]string{"network", "create", net1})

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2433,7 +2433,7 @@ spec:
 		err := generateKubeYaml("deployment", deployment, kubeYaml)
 		Expect(err).To(BeNil())
 
-		net := "playkube" + stringid.GenerateNonCryptoID()
+		net := "playkube" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.31.0/24", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -2475,8 +2475,8 @@ spec:
 		err := generateKubeYaml("pod", pod, kubeYaml)
 		Expect(err).To(BeNil())
 
-		net1 := "net1" + stringid.GenerateNonCryptoID()
-		net2 := "net2" + stringid.GenerateNonCryptoID()
+		net1 := "net1" + stringid.GenerateRandomID()
+		net2 := "net2" + stringid.GenerateRandomID()
 
 		net := podmanTest.Podman([]string{"network", "create", "--subnet", "10.0.11.0/24", net1})
 		net.WaitWithDefaultTimeout()

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -294,7 +294,7 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman pod ps filter network", func() {
-		net := stringid.GenerateNonCryptoID()
+		net := stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -333,12 +333,12 @@ var _ = Describe("Podman ps", func() {
 			Expect(session.OutputToString()).To(Equal("podman"))
 		}
 
-		net1 := stringid.GenerateNonCryptoID()
+		net1 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeNetwork(net1)
-		net2 := stringid.GenerateNonCryptoID()
+		net2 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -817,7 +817,7 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman ps filter network", func() {
-		net := stringid.GenerateNonCryptoID()
+		net := stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", net})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -860,12 +860,12 @@ var _ = Describe("Podman ps", func() {
 			Expect(actual).To(Equal("podman"))
 		}
 
-		net1 := stringid.GenerateNonCryptoID()
+		net1 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		defer podmanTest.removeNetwork(net1)
-		net2 := stringid.GenerateNonCryptoID()
+		net2 := stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"network", "create", net2})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -869,7 +869,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 	})
 
 	It("podman run in custom CNI network with --static-ip", func() {
-		netName := stringid.GenerateNonCryptoID()
+		netName := stringid.GenerateRandomID()
 		ipAddr := "10.25.30.128"
 		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.30.0/24", netName})
 		create.WaitWithDefaultTimeout()
@@ -884,7 +884,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 	It("podman CNI network works across user ns", func() {
 		SkipIfNetavark(podmanTest)
-		netName := stringid.GenerateNonCryptoID()
+		netName := stringid.GenerateRandomID()
 		create := podmanTest.Podman([]string{"network", "create", netName})
 		create.WaitWithDefaultTimeout()
 		Expect(create).Should(Exit(0))
@@ -933,7 +933,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 	})
 
 	It("podman run with new:pod and static-ip", func() {
-		netName := stringid.GenerateNonCryptoID()
+		netName := stringid.GenerateRandomID()
 		ipAddr := "10.25.40.128"
 		podname := "testpod"
 		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.40.0/24", netName})
@@ -1121,7 +1121,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 
 	// see https://github.com/containers/podman/issues/12972
 	It("podman run check network-alias works on networks without dns", func() {
-		net := "dns" + stringid.GenerateNonCryptoID()
+		net := "dns" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", "--disable-dns", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)
@@ -1135,7 +1135,7 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 	It("podman run with ipam none driver", func() {
 		// Test fails, issue #13931
 		SkipIfNetavark(podmanTest)
-		net := "ipam" + stringid.GenerateNonCryptoID()
+		net := "ipam" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"network", "create", "--ipam-driver=none", net})
 		session.WaitWithDefaultTimeout()
 		defer podmanTest.removeNetwork(net)

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 	})
 
 	It("Podman run with specified static IPv6 has correct IP", func() {
-		netName := "ipv6-" + stringid.GenerateNonCryptoID()
+		netName := "ipv6-" + stringid.GenerateRandomID()
 		ipv6 := "fd46:db93:aa76:ac37::10"
 		net := podmanTest.Podman([]string{"network", "create", "--subnet", "fd46:db93:aa76:ac37::/64", netName})
 		net.WaitWithDefaultTimeout()

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Podman run", func() {
 	It("podman run a container with a --rootfs", func() {
 		rootfs := filepath.Join(tempdir, "rootfs")
 		uls := filepath.Join("/", "usr", "local", "share")
-		uniqueString := stringid.GenerateNonCryptoID()
+		uniqueString := stringid.GenerateRandomID()
 		testFilePath := filepath.Join(uls, uniqueString)
 		tarball := filepath.Join(tempdir, "rootfs.tar")
 
@@ -848,7 +848,7 @@ USER bin`, BB)
 		err = ioutil.WriteFile(hookJSONPath, []byte(hookJSON), 0644)
 		Expect(err).ToNot(HaveOccurred())
 
-		random := stringid.GenerateNonCryptoID()
+		random := stringid.GenerateRandomID()
 
 		hookScript := fmt.Sprintf(`#!/bin/sh
 echo -n %s >%s

--- a/test/e2e/volume_exists_test.go
+++ b/test/e2e/volume_exists_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Podman volume exists", func() {
 	})
 
 	It("podman volume exists", func() {
-		vol := "vol" + stringid.GenerateNonCryptoID()
+		vol := "vol" + stringid.GenerateRandomID()
 		session := podmanTest.Podman([]string{"volume", "create", vol})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
@@ -43,7 +43,7 @@ var _ = Describe("Podman volume exists", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		session = podmanTest.Podman([]string{"volume", "exists", stringid.GenerateNonCryptoID()})
+		session = podmanTest.Podman([]string{"volume", "exists", stringid.GenerateRandomID()})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(1))
 	})

--- a/test/e2e/volume_plugin_test.go
+++ b/test/e2e/volume_plugin_test.go
@@ -212,19 +212,19 @@ testvol5 = "/run/docker/plugins/testvol5.sock"`), 0o644)
 		plugin.WaitWithDefaultTimeout()
 		Expect(plugin).Should(Exit(0))
 
-		localvol := "local-" + stringid.GenerateNonCryptoID()
+		localvol := "local-" + stringid.GenerateRandomID()
 		// create local volume
 		session := podmanTest.Podman([]string{"volume", "create", localvol})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(Exit(0))
 
-		vol1 := "vol1-" + stringid.GenerateNonCryptoID()
+		vol1 := "vol1-" + stringid.GenerateRandomID()
 		session = podmanTest.Podman([]string{"volume", "create", "--driver", pluginName, vol1})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(Exit(0))
 
 		// now create volume in plugin without podman
-		vol2 := "vol2-" + stringid.GenerateNonCryptoID()
+		vol2 := "vol2-" + stringid.GenerateRandomID()
 		plugin = podmanTest.Podman([]string{"exec", ctrName, "/usr/local/bin/testvol", "--sock-name", pluginName, "create", vol2})
 		plugin.WaitWithDefaultTimeout()
 		Expect(plugin).Should(Exit(0))


### PR DESCRIPTION
In view of https://github.com/containers/storage/pull/1337, do this:
```bash
	for f in $(git grep -l stringid.GenerateNonCryptoID | grep -v '^vendor/'); do
		sed -i 's/stringid.GenerateNonCryptoID/stringid.GenerateRandomID/g' $f;
	done
```	
(Note that this PR does not depend on one in containers/storage).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
