### PR TITLE
System tests: fix three races

### DIFF
--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -517,7 +517,7 @@ func (ic *ContainerEngine) ContainerLogs(_ context.Context, nameOrIDs []string, 
 	stdout := opts.StdoutWriter != nil
 	stderr := opts.StderrWriter != nil
 	options := new(containers.LogOptions).WithFollow(opts.Follow).WithSince(since).WithUntil(until).WithStderr(stderr)
-	options.WithStdout(stdout).WithTail(tail)
+	options.WithStdout(stdout).WithTail(tail).WithTimestamps(opts.Timestamps)
 
 	var err error
 	stdoutCh := make(chan string)

--- a/test/system/045-start.bats
+++ b/test/system/045-start.bats
@@ -40,6 +40,8 @@ load helpers
 @test "podman start --filter - start only containers that match the filter" {
     run_podman run -d $IMAGE /bin/true
     cid="$output"
+    run_podman wait $cid
+
     run_podman start --filter restart-policy=always $cid
     is "$output" "" "CID of restart-policy=always container"
 

--- a/test/system/420-cgroups.bats
+++ b/test/system/420-cgroups.bats
@@ -19,6 +19,8 @@ load helpers
     esac
 
     run_podman --cgroup-manager=$other run --name myc $IMAGE true
+    assert "$output" = "" "run true, with cgroup-manager=$other, is silent"
+
     run_podman container inspect --format '{{.HostConfig.CgroupManager}}' myc
     is "$output" "$other" "podman preserved .HostConfig.CgroupManager"
 
@@ -29,7 +31,8 @@ load helpers
 
     # Restart the container, without --cgroup-manager option (ie use default)
     # Prior to #7970, this would fail with an OCI runtime error
-    run_podman start myc
+    run_podman start -a myc
+    assert "$output" = "" "restarted container emits no output"
 
     run_podman rm myc
 }


### PR DESCRIPTION
Three tests were running 'container rm' on 'start'ed containers
that might not yet have exited. Fix. Also, tighten up the
tests themselves, to make even more sure that they test
what they're supposed to test.

Discovered, in CI, that 'podman-remote logs --timestamps'
was unimplemented. Thanks to @Luap99 for the fix to that.
    
Fixes: #15783
Fixes: #15795

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
bug fix: podman-remote logs --timestamps now emits timestamps
```