### PR TITLE
[CI:DOCS] Man pages: refactor common options: --ip6

### DIFF
--- a/docs/source/markdown/options/ip6.md
+++ b/docs/source/markdown/options/ip6.md
@@ -1,0 +1,8 @@
+#### **--ip6**=*ipv6*
+
+Specify a static IPv6 address for the <<container|pod>>, for example **fd46:db93:aa76:ac37::10**.
+This option can only be used if the <<container|pod>> is joined to only a single network - i.e., **--network=network-name** is used at most once -
+and if the <<container|pod>> is not joining another container's network namespace via **--network=container:_id_**.
+The address must be within the network's IPv6 address pool.
+
+To specify multiple static IPv6 addresses per <<container|pod>>, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -230,15 +230,7 @@ Keep STDIN open even if not attached. The default is *false*.
 
 @@option ip
 
-#### **--ip6**=*ipv6*
-
-Specify a static IPv6 address for the container, for example **fd46:db93:aa76:ac37::10**.
-This option can only be used if the container is joined to only a single network - i.e., **--network=network-name** is used at most once -
-and if the container is not joining another container's network namespace via **--network=container:_id_**.
-The address must be within the network's IPv6 address pool.
-
-To specify multiple static IPv6 addresses per container, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
-
+@@option ip6
 
 @@option ipc
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -101,14 +101,7 @@ The custom image that will be used for the infra container.  Unless specified, P
 
 @@option ip
 
-#### **--ip6**=*ipv6*
-
-Specify a static IPv6 address for the pod, for example **fd46:db93:aa76:ac37::10**.
-This option can only be used if the pod is joined to only a single network - i.e., **--network=network-name** is used at most once -
-and if the pod is not joining another container's network namespace via **--network=container:_id_**.
-The address must be within the network's IPv6 address pool.
-
-To specify multiple static IPv6 addresses per pod, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
+@@option ip6
 
 @@option label
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -251,14 +251,7 @@ When set to **true**, keep stdin open even if not attached. The default is **fal
 
 @@option ip
 
-#### **--ip6**=*ipv6*
-
-Specify a static IPv6 address for the container, for example **fd46:db93:aa76:ac37::10**.
-This option can only be used if the container is joined to only a single network - i.e., **--network=network-name** is used at most once -
-and if the container is not joining another container's network namespace via **--network=container:_id_**.
-The address must be within the network's IPv6 address pool.
-
-To specify multiple static IPv6 addresses per container, set multiple networks using the **--network** option with a static IPv6 address specified for each using the `ip6` mode for that option.
+@@option ip6
 
 @@option ipc
 


### PR DESCRIPTION
Similar to yesterday's --ip. No changes to content, all I did
was variableize the instances of 'container'/'pod'.

Did not touch podman-network-connect file, but if someone
wants to look at that one and tell me whether all this long
text is applicable to it (or not), I'd appreciate it.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```