### PR TITLE
Ensure that a broken OCI spec does not break inspect

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -356,7 +356,9 @@ func (c *Container) specFromState() (*spec.Spec, error) {
 			return nil, fmt.Errorf("reading container config: %w", err)
 		}
 		if err := json.Unmarshal(content, &returnSpec); err != nil {
-			return nil, fmt.Errorf("unmarshalling container config: %w", err)
+			// Malformed spec, just use c.config.Spec instead
+			logrus.Warnf("Error unmarshalling container %s config: %v", c.ID(), err)
+			return c.config.Spec, nil
 		}
 	} else if !os.IsNotExist(err) {
 		// ignore when the file does not exist


### PR DESCRIPTION
The process of saving the OCI spec is not particularly reboot-safe. Normally, this doesn't matter, because we recreate the spec every time a container starts, but if one was to reboot (or SIGKILL, or otherwise fatally interrupt) Podman in the middle of writing the spec to disk, we can end up with a malformed spec that sticks around until the container is next started. Some Podman commands want to read the latest version of the spec off disk (to get information only populated after a container is started), and will break in the case that a partially populated spec is present. Swap to just ignoring these errors (with a logged warning, to let folks know something went wrong) so we don't break important commands like `podman inspect` in these cases.

[NO NEW TESTS NEEDED] Provided reproducer involves repeatedly rebooting the system


```release-note
NONE
```
