### PR TITLE
fix building pkg/rootless on musl

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -19,6 +19,15 @@
 #include <sys/select.h>
 #include <stdio.h>
 
+#ifndef TEMP_FAILURE_RETRY
+#define TEMP_FAILURE_RETRY(expression) \
+  (__extension__                                                              \
+    ({ long int __result;                                                     \
+       do __result = (long int) (expression);                                 \
+       while (__result == -1L && errno == EINTR);                             \
+       __result; }))
+#endif
+
 #define cleanup_free __attribute__ ((cleanup (cleanup_freep)))
 #define cleanup_close __attribute__ ((cleanup (cleanup_closep)))
 #define cleanup_dir __attribute__ ((cleanup (cleanup_dirp)))
@@ -71,15 +80,6 @@ int rename_noreplace (int olddirfd, const char *oldpath, int newdirfd, const cha
   /* We are sure we created the file, let's overwrite it.  */
   return rename (oldpath, newpath);
 }
-
-#ifndef TEMP_FAILURE_RETRY
-#define TEMP_FAILURE_RETRY(expression) \
-  (__extension__                                                              \
-    ({ long int __result;                                                     \
-       do __result = (long int) (expression);                                 \
-       while (__result == -1L && errno == EINTR);                             \
-       __result; }))
-#endif
 
 static const char *_max_user_namespaces = "/proc/sys/user/max_user_namespaces";
 static const char *_unprivileged_user_namespaces = "/proc/sys/kernel/unprivileged_userns_clone";


### PR DESCRIPTION
[NO NEW TESTS NEEDED]

PR following https://github.com/containers/podman/discussions/15685#discussioncomment-3642919 for the v3.4 branch.

Moves the optional definition of `TEMP_FAILURE_RETRY` before its first use, so that `pkg/rootless` can be successfully build on musl.

#### Does this PR introduce a user-facing change?

```release-note
None
```
