### PR TITLE
[CI:DOCS] Man pages: refactor common options: --user

### DIFF
--- a/docs/source/markdown/options/user.md
+++ b/docs/source/markdown/options/user.md
@@ -1,0 +1,7 @@
+#### **--user**, **-u**=*user[:group]*
+
+Sets the username or UID used and, optionally, the groupname or GID for the specified command. Both *user* and *group* may be symbolic or numeric.
+
+Without this argument, the command will run as the user specified in the container image. Unless overridden by a `USER` command in the Containerfile or by a value passed to this option, this user generally defaults to root.
+
+When a user namespace is not in use, the UID and GID used within the container and on the host will match. When user namespaces are in use, however, the UID and GID in the container may correspond to another UID and GID on the host. In rootless containers, for example, a user namespace is always used, and root in the container will by default correspond to the UID and GID of the user invoking Podman.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -450,14 +450,7 @@ When size is `0`, there is no limit on the amount of memory used for IPC by the 
 
 @@option unsetenv-all
 
-#### **--user**, **-u**=*user*
-
-Sets the username or UID used and optionally the groupname or GID for the specified command.
-
-The following examples are all valid:
---user [user | user:group | uid | uid:gid | user:gid | uid:group ]
-
-Without this argument the command will be run as root in the container.
+@@option user
 
 @@option userns.container
 

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -44,11 +44,7 @@ to run containers such as CRI-O, the last started container could be from either
 
 @@option tty
 
-#### **--user**, **-u**
-
-Sets the username or UID used and optionally the groupname or GID for the specified command.
-The following examples are all valid:
---user [user | user:group | uid | uid:gid | user:gid | uid:group ]
+@@option user
 
 @@option workdir
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -491,13 +491,7 @@ echo "asdf" | podman run --rm -i someimage /bin/cat
 
 @@option unsetenv-all
 
-#### **--user**, **-u**=*user[:group]*
-
-Sets the username or UID used and, optionally, the groupname or GID for the specified command. Both *user* and *group* may be symbolic or numeric.
-
-Without this argument, the command will run as the user specified in the container image. Unless overridden by a `USER` command in the Containerfile or by a value passed to this option, this user generally defaults to root.
-
-When a user namespace is not in use, the UID and GID used within the container and on the host will match. When user namespaces are in use, however, the UID and GID in the container may correspond to another UID and GID on the host. In rootless containers, for example, a user namespace is always used, and root in the container will by default correspond to the UID and GID of the user invoking Podman.
+@@option user
 
 @@option userns.container
 


### PR DESCRIPTION
In podman-create, exec, and run. Went with the podman-run version.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```