### PR TITLE
[CI:DOCS] Man pages: refactor common options: --shm-size

### DIFF
--- a/docs/source/markdown/options/shm-size.md
+++ b/docs/source/markdown/options/shm-size.md
@@ -1,0 +1,6 @@
+#### **--shm-size**=*number[unit]*
+
+Size of _/dev/shm_. A _unit_ can be **b** (bytes), **k** (kibibytes), **m** (mebibytes), or **g** (gibibytes).
+If you omit the unit, the system uses bytes. If you omit the size entirely, the default is **64m**.
+When _size_ is **0**, there is no limit on the amount of memory used for IPC by the <<container|pod>>.
+This option conflicts with **--ipc=host**.

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -564,13 +564,7 @@ container
 - `seccomp=profile.json` :  White listed syscalls seccomp Json file to be used
 as a seccomp filter
 
-#### **--shm-size**=*size*
-
-Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater
-than `0`.
-Unit is optional and can be `b` (bytes), `k` (kibibytes), `m`(mebibytes), or
-`g` (gibibytes). If you omit the unit, the system uses bytes. If you omit the
-size entirely, the system uses `64m`.
+@@option shm-size
 
 #### **--sign-by**=*fingerprint*
 

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -412,11 +412,7 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
 
-#### **--shm-size**=*size*
-
-Size of `/dev/shm` (format: `<number>[<unit>]`, where unit = b (bytes), k (kibibytes), m (mebibytes), or g (gibibytes))
-If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
-When size is `0`, there is no limit on the amount of memory used for IPC by the container.
+@@option shm-size
 
 @@option stop-signal
 

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -99,11 +99,7 @@ Note: Labeling can be disabled for all pods/containers by setting label=false in
 
 Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
 
-#### **--shm-size**=*size*
-
-Size of `/dev/shm` (format: `<number>[<unit>]`, where unit = b (bytes), k (kibibytes), m (mebibytes), or g (gibibytes))
-If the unit is omitted, the system uses bytes. If the size is omitted, the system uses `64m`.
-When size is `0`, there is no limit on the amount of memory used for IPC by the pod. This option conflicts with **--ipc=host** when running containers.
+@@option shm-size
 
 #### **--start**
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -213,11 +213,7 @@ This boolean determines whether or not all containers entering the pod will use 
 
 Note: This options conflict with **--share=cgroup** since that would set the pod as the cgroup parent but enter the container into the same cgroupNS as the infra container.
 
-#### **--shm-size**=*size*
-
-Size of `/dev/shm` (format: `<number>[<unit>]`, where unit = b (bytes), k (kibibytes), m (mebibytes), or g (gibibytes))
-If the unit is omitted, the system uses bytes. If the size is omitted, the system uses `64m`.
-When size is `0`, there is no limit on the amount of memory used for IPC by the pod. This option conflicts with **--ipc=host** when running containers.
+@@option shm-size
 
 @@option subgidname
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -445,11 +445,7 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 Note: Labeling can be disabled for all containers by setting **label=false** in the **containers.conf**(5) file.
 
-#### **--shm-size**=*number[unit]*
-
-Size of _/dev/shm_. A _unit_ can be **b** (bytes), **k** (kibibytes), **m** (mebibytes), or **g** (gibibytes).
-If you omit the unit, the system uses bytes. If you omit the size entirely, the default is **64m**.
-When _size_ is **0**, there is no limit on the amount of memory used for IPC by the container.
+@@option shm-size
 
 #### **--sig-proxy**
 


### PR DESCRIPTION
Mostly went with the podman-run version. For ease of review, I
kept the "you" word -- I will fix that in my in-progress
cleanup PR.

This affects lots of files, each of which had slightly different
wording, but this actually isn't as bad as it looks. The diffs
were minor, and I'm pretty sure the new refactored text applies
equally well to all the man pages.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```