### PR TITLE
stats: cap memory limit to the available memory

### DIFF
--- a/pkg/api/handlers/compat/containers_stats.go
+++ b/pkg/api/handlers/compat/containers_stats.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/api/handlers/utils"
 	api "github.com/containers/podman/v4/pkg/api/types"
+	"github.com/containers/storage/pkg/system"
 	docker "github.com/docker/docker/api/types"
 	"github.com/gorilla/schema"
 	runccgroups "github.com/opencontainers/runc/libcontainer/cgroups"
@@ -137,6 +138,16 @@ streamLabel: // A label to flatten the scope
 		memoryLimit := cgroupStat.MemoryStats.Usage.Limit
 		if cfg.Spec.Linux != nil && cfg.Spec.Linux.Resources != nil && cfg.Spec.Linux.Resources.Memory != nil && *cfg.Spec.Linux.Resources.Memory.Limit > 0 {
 			memoryLimit = uint64(*cfg.Spec.Linux.Resources.Memory.Limit)
+		}
+
+		memInfo, err := system.ReadMemInfo()
+		if err != nil {
+			logrus.Errorf("Unable to get cgroup stats: %v", err)
+			return
+		}
+		// cap the memory limit to the available memory.
+		if memInfo.MemTotal > 0 && memoryLimit > uint64(memInfo.MemTotal) {
+			memoryLimit = uint64(memInfo.MemTotal)
 		}
 
 		systemUsage, _ := cgroups.GetSystemCPUUsage()

--- a/pkg/api/handlers/compat/containers_stats.go
+++ b/pkg/api/handlers/compat/containers_stats.go
@@ -177,7 +177,7 @@ streamLabel: // A label to flatten the scope
 				PreCPUStats: preCPUStats,
 				MemoryStats: docker.MemoryStats{
 					Usage:             cgroupStat.MemoryStats.Usage.Usage,
-					MaxUsage:          cgroupStat.MemoryStats.Usage.Limit,
+					MaxUsage:          cgroupStat.MemoryStats.Usage.MaxUsage,
 					Stats:             nil,
 					Failcnt:           0,
 					Limit:             memoryLimit,

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -117,6 +117,17 @@ if root; then
     podman rm -f $CTRNAME
 fi
 
+# Issue #15765: make sure the memory limit is capped
+if root; then
+    CTRNAME=ctr-with-limit
+    podman run --name $CTRNAME -d -m 512m -v /tmp:/tmp $IMAGE top
+
+    t GET libpod/containers/$CTRNAME/stats?stream=false 200 \
+    .memory_stats.limit!=18446744073709552000
+
+    podman rm -f $CTRNAME
+fi
+
 # Issue #6799: it should be possible to start a container, even w/o args.
 t POST libpod/containers/create?name=test_noargs Image=${IMAGE} 201 \
   .Id~[0-9a-f]\\{64\\}

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -98,6 +98,12 @@ else
     fi
 fi
 
+# max_usage is not set for cgroupv2
+if have_cgroupsv2; then
+    t GET libpod/containers/stats?containers='[$cid]' 200 \
+    .memory_stats.max_usage=null
+fi
+
 t DELETE libpod/containers/$cid 200 .[0].Id=$cid
 
 # Issue #14676: make sure the stats show the memory limit specified for the container

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -107,6 +107,22 @@ function is() {
     _show_ok 0 "$testname" "$expect" "$actual"
 }
 
+############
+#  is_not  #  Simple disequality
+############
+function is_not() {
+    local actual=$1
+    local expect_not=$2
+    local testname=$3
+
+    if [ "$actual" != "$expect_not" ]; then
+        # On success, include expected value; this helps readers understand
+        _show_ok 1 "$testname!=$expect"
+        return
+    fi
+    _show_ok 0 "$testname" "!= $expect" "$actual"
+}
+
 ##########
 #  like  #  Compare, but allowing patterns
 ##########
@@ -377,7 +393,13 @@ function t() {
     fi
 
     for i; do
-        if expr "$i" : "[^=~]\+=.*" >/dev/null; then
+        if expr "$i" : '[^\!]\+\!=.\+' >/dev/null; then
+            # Disequality on json field
+            json_field=$(expr "$i" : '\([^!]*\)!')
+            expect_not=$(expr "$i" : '[^\!]*\!=\(.*\)')
+            actual=$(jq -r "$json_field" <<<"$output")
+            is_not "$actual" "$expect_not" "$testname : $json_field"
+        elif expr "$i" : "[^=~]\+=.*" >/dev/null; then
             # Exact match on json field
             json_field=$(expr "$i" : "\([^=]*\)=")
             expect=$(expr "$i" : '[^=]*=\(.*\)')


### PR DESCRIPTION
Docker compatibility: cap the memory limit reported by the cgroup to the maximum available memory.
    
Closes: https://github.com/containers/podman/issues/15765
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
compact API: Cap the memory limit to the total available memory
```
