### PR TITLE
[CI:BUILD] Contrib: Add containerfile to create podman-remote binary image

### DIFF
--- a/contrib/podmanremoteimage/Containerfile
+++ b/contrib/podmanremoteimage/Containerfile
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
+WORKDIR /opt/app-root/src
+COPY . .
+RUN make podman-remote-static
+RUN GOOS=windows make podman-remote
+RUN GOOS=darwin make podman-remote
+
+FROM scratch
+COPY --from=builder /opt/app-root/src/bin .
+ENTRYPOINT ["/podman-remote-static"]

--- a/contrib/podmanremoteimage/README.md
+++ b/contrib/podmanremoteimage/README.md
@@ -1,0 +1,25 @@
+podman-remote-images
+====================
+
+Overview
+--------
+
+This directory contains the containerfile for creating a container image which consist podman-remote binary
+for each platform (win/linux/mac).
+
+Users can copy those binaries onto the specific platforms using following instructions
+
+- For Windows binary
+```bash
+$ podman cp $(podman create --name remote-temp quay.io/containers/podman-remote-artifacts:latest):/windows/podman.exe . && podman rm remote-temp
+```
+
+- For Linux binary
+```bash
+$ podman cp $(podman create --name remote-temp quay.io/containers/podman-remote-artifacts:latest):/podman-remote-static . && podman rm remote-temp
+```
+
+- For Mac binary
+```bash
+$ podman cp $(podman create --name remote-temp quay.io/containers/podman-remote-artifacts:latest):/darwin/podman . && podman rm remote-temp
+```


### PR DESCRIPTION
Try to partial address #14664

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->


<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Add container file to build remote binary for each platform
- Add README.md file around same
```

Longer term plan is to have it attach either to quay and add github trigger to generate the image for each 4.x tag/branch. Only issue is as of now quay github trigger can only generate `amd64` images not the `arm64` one so may be we need to attach it to current cirrus CI to generate image for different arch and push to quay, same way we are doing for `quay.io/containers/podman`.

Another gap is created binaries for mac/windows are not signed one and we need to check if user try to copy those binary from the container image does it showing the signing warning.
