### PR TITLE
[CI:DOCS] Man pages: refactor common options: 2 stats opts

### DIFF
--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -20,6 +20,7 @@ podman-pod-kill.1.md
 podman-pod-logs.1.md
 podman-pod-rm.1.md
 podman-pod-start.1.md
+podman-pod-stats.1.md
 podman-pod-stop.1.md
 podman-pull.1.md
 podman-push.1.md
@@ -27,6 +28,7 @@ podman-rm.1.md
 podman-run.1.md
 podman-search.1.md
 podman-start.1.md
+podman-stats.1.md
 podman-stop.1.md
 podman-unpause.1.md
 podman-update.1.md

--- a/docs/source/markdown/options/no-reset.md
+++ b/docs/source/markdown/options/no-reset.md
@@ -1,0 +1,3 @@
+#### **--no-reset**
+
+Do not clear the terminal/screen in between reporting intervals

--- a/docs/source/markdown/options/no-stream.md
+++ b/docs/source/markdown/options/no-stream.md
@@ -1,0 +1,3 @@
+#### **--no-stream**
+
+Disable streaming <<|pod >>stats and only pull the first result, default setting is false

--- a/docs/source/markdown/podman-pod-stats.1.md.in
+++ b/docs/source/markdown/podman-pod-stats.1.md.in
@@ -40,13 +40,9 @@ When using a GO template, you may precede the format with `table` to print heade
 
 Instead of providing the pod name or ID, use the last created pod. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--no-reset**
+@@option no-reset
 
-Do not clear the terminal/screen in between reporting intervals
-
-#### **--no-stream**
-
-Disable streaming pod stats and only pull the first result, default setting is false
+@@option no-stream
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-stats.1.md.in
+++ b/docs/source/markdown/podman-stats.1.md.in
@@ -53,13 +53,9 @@ Time in seconds between stats reports, defaults to 5 seconds.
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--no-reset**
+@@option no-reset
 
-Do not clear the terminal/screen in between reporting intervals
-
-#### **--no-stream**
-
-Disable streaming stats and only pull the first result, default setting is false
+@@option no-stream
 
 #### **--no-trunc**
 


### PR DESCRIPTION
--no-reset and --no-stream, in podman-stats and pod-stats.

Very minor tweak to --no-stream to account for pods.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```