### PR TITLE
[CI:DOCS] Man pages: Refactor common options: --dns

### DIFF
--- a/docs/source/markdown/options/dns.md
+++ b/docs/source/markdown/options/dns.md
@@ -1,0 +1,11 @@
+#### **--dns**=*ipaddr*
+
+Set custom DNS servers.
+
+This option can be used to override the DNS
+configuration passed to the container. Typically this is necessary when the
+host DNS configuration is invalid for the container (e.g., **127.0.0.1**). When this
+is the case the **--dns** flag is necessary for every run.
+
+The special value **none** can be specified to disable creation of _/etc/resolv.conf_ in the container by Podman.
+The _/etc/resolv.conf_ file in the image will be used without changes.

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -223,18 +223,12 @@ specifying **--disable-compression=false**.
 
 @@option disable-content-trust
 
-#### **--dns**=*dns*
+@@option dns
 
-Set custom DNS servers to be used during the build.
+This option cannot be combined with **--network** that is set to **none**.
 
-This option can be used to override the DNS configuration passed to the
-container. Typically this is necessary when the host DNS configuration is
-invalid for the container (e.g., 127.0.0.1). When this is the case the `--dns`
-option is necessary for every run.
-
-The special value **none** can be specified to disable creation of
-/etc/resolv.conf in the container by Podman. The /etc/resolv.conf file in the
-image will be used without changes.
+Note: this option takes effect only during *RUN* instructions in the build.
+It does not affect _/etc/resolv.conf_ in the final image.
 
 #### **--dns-option**=*option*
 

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -141,17 +141,9 @@ flag to pass the user's supplementary group access into the container.
 
 @@option disable-content-trust
 
-#### **--dns**=*dns*
+@@option dns
 
-Set custom DNS servers. Invalid if using **--dns** and **--network** that is set to 'none' or `container:<name|id>`.
-
-This option can be used to override the DNS
-configuration passed to the container. Typically this is necessary when the
-host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this
-is the case the **--dns** flag is necessary for every run.
-
-The special value **none** can be specified to disable creation of **/etc/resolv.conf** in the container by Podman.
-The **/etc/resolv.conf** file in the image will be used without changes.
+This option cannot be combined with **--network** that is set to **none** or **container:**_id_.
 
 @@option dns-opt.container
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -177,17 +177,9 @@ flag to pass the user's supplementary group access into the container.
 
 @@option disable-content-trust
 
-#### **--dns**=*ipaddr*
+@@option dns
 
-Set custom DNS servers. Invalid if using **--dns** with **--network** that is set to **none** or **container:**_id_.
-
-This option can be used to override the DNS
-configuration passed to the container. Typically this is necessary when the
-host DNS configuration is invalid for the container (e.g., **127.0.0.1**). When this
-is the case the **--dns** flag is necessary for every run.
-
-The special value **none** can be specified to disable creation of _/etc/resolv.conf_ in the container by Podman.
-The _/etc/resolv.conf_ file in the image will be used without changes.
+This option cannot be combined with **--network** that is set to **none** or **container:**_id_.
 
 @@option dns-opt.container
 


### PR DESCRIPTION
Only between podman-build, create, and run. podman-pod-create
is too different.

As usual I went with the podman-run version. This means
keeping the word "flag" (which should be "option"), for
ease of review. I will fix in my in-progress cleanup PR.

For podman-build, I removed "during the build" and changed
it to a note for that man page only.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```