### PR TITLE
Default to --dns-option to match Docker and Buildah

### DIFF
--- a/cmd/podman/common/netflags.go
+++ b/cmd/podman/common/netflags.go
@@ -33,18 +33,12 @@ func DefineNetFlags(cmd *cobra.Command) {
 	)
 	_ = cmd.RegisterFlagCompletionFunc(dnsFlagName, completion.AutocompleteNone)
 
-	dnsOptFlagName := "dns-opt"
+	dnsOptFlagName := "dns-option"
 	netFlags.StringSlice(
 		dnsOptFlagName, containerConfig.DNSOptions(),
 		"Set custom DNS options",
 	)
 	_ = cmd.RegisterFlagCompletionFunc(dnsOptFlagName, completion.AutocompleteNone)
-	netFlags.StringSlice(
-		"dns-option", containerConfig.DNSOptions(),
-		"Docker compatibility option== --dns-opt",
-	)
-	_ = netFlags.MarkHidden("dns-option")
-
 	dnsSearchFlagName := "dns-search"
 	netFlags.StringSlice(
 		dnsSearchFlagName, containerConfig.DNSSearches(),
@@ -143,20 +137,12 @@ func NetFlagsToNetOptions(opts *entities.NetOptions, flags pflag.FlagSet) (*enti
 		}
 	}
 
-	if flags.Changed("dns-opt") {
-		options, err := flags.GetStringSlice("dns-opt")
-		if err != nil {
-			return nil, err
-		}
-		opts.DNSOptions = options
-	}
-
 	if flags.Changed("dns-option") {
 		options, err := flags.GetStringSlice("dns-option")
 		if err != nil {
 			return nil, err
 		}
-		opts.DNSOptions = append(opts.DNSOptions, options...)
+		opts.DNSOptions = options
 	}
 
 	if flags.Changed("dns-search") {

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -280,7 +280,7 @@ func CreateInit(c *cobra.Command, vals entities.ContainerCreateOptions, isInfra 
 	if c.Flag("shm-size").Changed {
 		vals.ShmSize = c.Flag("shm-size").Value.String()
 	}
-	if (c.Flag("dns").Changed || c.Flag("dns-opt").Changed || c.Flag("dns-search").Changed) && vals.Net != nil && (vals.Net.Network.NSMode == specgen.NoNetwork || vals.Net.Network.IsContainer()) {
+	if (c.Flag("dns").Changed || c.Flag("dns-option").Changed || c.Flag("dns-search").Changed) && vals.Net != nil && (vals.Net.Network.NSMode == specgen.NoNetwork || vals.Net.Network.IsContainer()) {
 		return vals, fmt.Errorf("conflicting options: dns and the network mode: " + string(vals.Net.Network.NSMode))
 	}
 	noHosts, err := c.Flags().GetBool("no-hosts")

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/containers"
 	"github.com/containers/podman/v4/cmd/podman/parse"
 	"github.com/containers/podman/v4/cmd/podman/registry"
+	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/errorhandling"
@@ -26,7 +27,6 @@ import (
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var (
@@ -99,14 +99,7 @@ func init() {
 	shareParentFlagName := "share-parent"
 	flags.BoolVar(&shareParent, shareParentFlagName, true, "Set the pod's cgroup as the cgroup parent for all containers joining the pod")
 
-	flags.SetNormalizeFunc(aliasNetworkFlag)
-}
-
-func aliasNetworkFlag(_ *pflag.FlagSet, name string) pflag.NormalizedName {
-	if name == "net" {
-		name = "network"
-	}
-	return pflag.NormalizedName(name)
+	flags.SetNormalizeFunc(utils.AliasFlags)
 }
 
 func create(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/utils/alias.go
+++ b/cmd/podman/utils/alias.go
@@ -5,6 +5,8 @@ import "github.com/spf13/pflag"
 // AliasFlags is a function to handle backwards compatibility with old flags
 func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 	switch name {
+	case "dns-opt":
+		name = "dns-option"
 	case "healthcheck-command":
 		name = "health-cmd"
 	case "healthcheck-interval":

--- a/docs/source/markdown/options/dns-opt.container.md
+++ b/docs/source/markdown/options/dns-opt.container.md
@@ -1,3 +1,0 @@
-#### **--dns-opt**=*option*
-
-Set custom DNS options. Invalid if using **--dns-opt** with **--network** that is set to **none** or **container:**_id_.

--- a/docs/source/markdown/options/dns-option.container.md
+++ b/docs/source/markdown/options/dns-option.container.md
@@ -1,0 +1,3 @@
+#### **--dns-option**=*option*
+
+Set custom DNS options. Invalid if using **--dns-option** with **--network** that is set to **none** or **container:**_id_.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -145,7 +145,7 @@ flag to pass the user's supplementary group access into the container.
 
 This option cannot be combined with **--network** that is set to **none** or **container:**_id_.
 
-@@option dns-opt.container
+@@option dns-option.container
 
 @@option dns-search.container
 
@@ -265,7 +265,7 @@ This option is currently supported only by the **journald** log driver.
 
 #### **--network**=*mode*, **--net**
 
-Set the network mode for the container. Invalid if using **--dns**, **--dns-opt**, or **--dns-search** with **--network** set to **none** or **container:**_id_. If used together with **--pod**, the container will not join the pod's network namespace.
+Set the network mode for the container. Invalid if using **--dns**, **--dns-option**, or **--dns-search** with **--network** set to **none** or **container:**_id_. If used together with **--pod**, the container will not join the pod's network namespace.
 
 Valid _mode_ values are:
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -60,7 +60,7 @@ Note: the pod implements devices by storing the initial configuration passed by 
 
 Set custom DNS servers in the /etc/resolv.conf file that will be shared between all containers in the pod. A special option, "none" is allowed which disables creation of /etc/resolv.conf for the pod.
 
-#### **--dns-opt**=*option*
+#### **--dns-option**=*option*
 
 Set custom DNS options in the /etc/resolv.conf file that will be shared between all containers in the pod.
 
@@ -119,7 +119,7 @@ Assign a name to the pod.
 
 #### **--network**=*mode*, **--net**
 
-Set the network mode for the pod. Invalid if using **--dns**, **--dns-opt**, or **--dns-search** with **--network** that is set to **none** or **container:**_id_.
+Set the network mode for the pod. Invalid if using **--dns**, **--dns-option**, or **--dns-search** with **--network** that is set to **none** or **container:**_id_.
 
 Valid _mode_ values are:
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -181,7 +181,7 @@ flag to pass the user's supplementary group access into the container.
 
 This option cannot be combined with **--network** that is set to **none** or **container:**_id_.
 
-@@option dns-opt.container
+@@option dns-option.container
 
 @@option dns-search.container
 
@@ -286,7 +286,7 @@ This option is currently supported only by the **journald** log driver.
 
 #### **--network**=*mode*, **--net**
 
-Set the network mode for the container. Invalid if using **--dns**, **--dns-opt**, or **--dns-search** with **--network** set to **none** or **container:**_id_. If used together with **--pod**, the container will not join the pod's network namespace.
+Set the network mode for the container. Invalid if using **--dns**, **--dns-option**, or **--dns-search** with **--network** set to **none** or **container:**_id_. If used together with **--pod**, the container will not join the pod's network namespace.
 
 Valid _mode_ values are:
 

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -912,7 +912,7 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman generate kube on a container with dns options", func() {
-		top := podmanTest.Podman([]string{"run", "-dt", "--name", "top", "--dns", "8.8.8.8", "--dns-search", "foobar.com", "--dns-opt", "color:blue", ALPINE, "top"})
+		top := podmanTest.Podman([]string{"run", "-dt", "--name", "top", "--dns", "8.8.8.8", "--dns-search", "foobar.com", "--dns-option", "color:blue", ALPINE, "top"})
 		top.WaitWithDefaultTimeout()
 		Expect(top).Should(Exit(0))
 

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -221,7 +221,7 @@ EOF
                --add-host   "$add_host_n:$add_host_ip"   \
                --dns        "$dns_server"                \
                --dns-search "$dns_search"                \
-               --dns-opt    "$dns_opt"                   \
+               --dns-option "$dns_opt"                   \
                --publish    "$port_out:$port_in"         \
                --label      "${labelname}=${labelvalue}" \
                --infra-image   "$infra_image"            \
@@ -262,7 +262,7 @@ EOF
     run_podman run --rm --pod mypod $IMAGE cat /etc/resolv.conf
     is "$output" ".*nameserver $dns_server"  "--dns [server] was added"
     is "$output" ".*search $dns_search"      "--dns-search was added"
-    is "$output" ".*options $dns_opt"        "--dns-opt was added"
+    is "$output" ".*options $dns_opt"        "--dns-option was added"
 
     # pod inspect
     run_podman pod inspect --format '{{.Name}}: {{.ID}} : {{.NumContainers}} : {{.Labels}}' mypod


### PR DESCRIPTION
[NO NEW TESTS NEEDED] Existing tests cover this.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman run/create/build now default to using --dns-option instead of --dns-opt, (--dns-opt is still supported but deprecated)
```
