### PR TITLE
[CI:DOCS] Fix broken titles on readthedocs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,6 @@ link on that page.
 | ------------------------------------ | --------------------------- |
 | Markdown source for man pages        | docs/source/markdown/       |
 | man pages aliases as .so files       | docs/source/markdown/links/ |
-| restructured text for readthedocs.io | docs/rst/                   |
 | target for output                    | docs/build                  |
 | man pages                            | docs/build/man              |
 | remote linux man pages               | docs/build/remote/linux     |
@@ -60,16 +59,24 @@ incorrect, or the file isn't accessible for some other reason.
 
 ## Local Testing
 
-Assuming that you have the [dependencies](https://podman.io/getting-started/installation#build-and-run-dependencies)
+To build standard man pages, run `make docs`. Results will be in `docs/build/man`.
+
+To build HTMLized man pages: Assuming that you have the
+[dependencies](https://podman.io/getting-started/installation#build-and-run-dependencies)
 installed, then also install (showing Fedora in the example):
 
 ```
-# dnf install python3-sphinx python3-recommonmark
-# pip install sphinx-markdown-tables
+$ sudo dnf install python3-sphinx python3-recommonmark
+$ pip install sphinx-markdown-tables myst_parser
 ```
+(The above dependencies are current as of 2022-09-15. If you experience problems,
+please see [requirements.txt](requirements.txt) in this directory, it will almost
+certainly be more up-to-date than this README.)
+
 After that completes, cd to the `docs` directory in your Podman sandbox and then do `make html`.
 
 You can then preview the html files in `docs/build/html` with:
 ```
 python -m http.server 8000 --directory build/html
 ```
+...and point your web browser at `http://localhost:8000/`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,12 +86,12 @@ def convert_markdown_title(app, docname, source):
     if docpath.endswith(".md"):
         # Convert pandoc title line into eval_rst block for myst_parser
         #
-        # Remove the ending "(1)" to avoid it from being displayed
+        # Remove the ending " 1" (section) to avoid it from being displayed
         # in the web tab. Often such a text indicates that
         # a web page got an update. For instance GitHub issues
         # shows the number of new comments that have been written
         # after the user's last visit.
-        source[0] = re.sub(r"^% (.*)(\(\d\))", r"```{title} \g<1>\n```", source[0])
+        source[0] = re.sub(r"^% (.*)\s(\d)", r"```{title} \g<1>\n```", source[0])
 
 def setup(app):
     app.connect("source-read", convert_markdown_title)


### PR DESCRIPTION
Followup to #15621, which (correctly) removed parentheses from
md files. Turns out, a hidden part of our readthedocs process
depended on those parentheses. Update that step so it handles
the new, correct, <space><section-number> format.

Also update local-testing documentation in README, and clean it up a little.

Fixes: #15822

~~Completely untested.~~ Now tested, and it works (at least on my laptop).

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
Fix broken HTML titles in readthedocs man pages
```