### PR TITLE
[WIP] [CI:DOCS] GHA: Fix labeler workflow to branch/tag context

### DIFF
--- a/.github/workflows/_labeler.yml
+++ b/.github/workflows/_labeler.yml
@@ -1,0 +1,27 @@
+---
+
+# This workflow is not intended to be used directly.  Please
+# see `labeler.yml` comments to understand why.
+on: workflow_call
+
+jobs:
+    triage:
+      permissions:
+        contents: read
+        # **WARNING** **WARNING** **WARNING** **WARNING** **WARNING**
+        #
+        # This workflow uses pull-request --> WRITE <-- Permissions.
+        # Please carefully review any/all changes proposed below,
+        # that they do not attempt to to perform a PR merge.
+        #
+        # **WARNING** **WARNING** **WARNING** **WARNING** **WARNING**
+        pull-requests: write
+      runs-on: ubuntu-latest
+      steps:
+        # https://github.com/actions/labeler
+        - uses: actions/labeler@v4
+          # The v4 code of this action reads the glob-YAML from the triggering
+          # PR context (via the `$GITHUB_SHA` value):
+          # https://github.com/actions/labeler/blob/v4/src/labeler.ts#L119
+          with:
+            repo-token: "${{secrets.GITHUB_TOKEN}}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,15 +1,25 @@
-# https://github.com/actions/labeler
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+    # IMPORTANT NOTE: The actual workflow YAML used for a run may not
+    # be what you expect!  Specifically, the `pull_request_target`
+    # trigger uses the workflow YAML as-is on the `main` branch at
+    # the time.
+    - pull_request_target
 
 jobs:
-  triage:
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/labeler@v4
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+    # Avoid any label-semantic conflicts between `main` and any PR's target
+    # branch, by redirecting execution to the workflow YAML as defined
+    # in the branch targeted by the PR (`github.base_ref`).  This also
+    # implies PR's cannot directly modify the workflow YAML (which has
+    # repository-write permissions) before being merged into a branch.
+    # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+    triage:
+        # Note `github.base_ref` is: "The base_ref or target branch of the pull
+        # request in a workflow run. This property is only available when the
+        # event that triggers a workflow run is either pull_request or
+        # pull_request_target"
+        uses: ${{github.repository}}/.github/workflows/_labeler.yml@${{github.base_ref}}
+        secrets: inherit
+        permissions:
+            contents: read
+            pull-requests: write


### PR DESCRIPTION
***WIP: FIXME: This can't be easily tested.  I'll need to run it on my fork's `main` branch and see what happens***

Unlike the vast majority of CI systems, GitHub Action workflow YAML
is sourced differently at runtime based on the trigger type.  This
can creates a "gotcha" for maintainers because the action is operating
on a PR but the job definition comes from `main`.  Therefore over-time,
with respect to the 'labeler' workflow, the semantics of both labels
and globs (in `.github/labeler.yml`) may diverge between release
branches and `main`.

Fix this by leveraging the "reusable workflows" feature in the
`labeler.yml` worflow (on `main`), to call the new `_labeler.yml`
workflow YAML on the target branch of the PR.  This allows changes to
both the `_labeler.yml` workflow and `.github/labeler.yml` globs
to follow branch-content instead of main.

Note: Any branch which does not contain `.github/workflows/_labeler.yml`
and `.github/labeler.yml` files will fail.  This can be corrected as
needed by backporting those files and making any needed branch-specific
updates.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
