### PR TITLE
Improve generate systemd format

### DIFF
--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -141,7 +141,8 @@ RequiresMountsFor=/var/run/container/storage
 [Service]
 Restart=always
 ExecStart=/usr/bin/podman start de1e3223b1b888bc02d0962dd6cb5855eb00734061013ffdd3479d225abacdc6
-ExecStop=/usr/bin/podman stop -t 1 de1e3223b1b888bc02d0962dd6cb5855eb00734061013ffdd3479d225abacdc6
+ExecStop=/usr/bin/podman stop \
+        -t 1 de1e3223b1b888bc02d0962dd6cb5855eb00734061013ffdd3479d225abacdc6
 KillMode=none
 Type=forking
 PIDFile=/run/user/1000/overlay-containers/de1e3223b1b888bc02d0962dd6cb5855eb00734061013ffdd3479d225abacdc6/userdata/conmon.pid
@@ -171,14 +172,19 @@ RequiresMountsFor=/var/run/container/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 ExecStartPre=/bin/rm -f %t/%n-pid %t/%n-cid
-ExecStart=/usr/local/bin/podman run
-	--conmon-pidfile %t/%n-pid
-	--cidfile %t/%n-cid
-	--cgroups=no-conmon
-	-d
+ExecStart=/usr/local/bin/podman run \
+        --conmon-pidfile %t/%n-pid \
+	--cidfile %t/%n-cid \
+	--cgroups=no-conmon \
+	-d \
 	-dit alpine
-ExecStop=/usr/local/bin/podman stop --ignore --cidfile %t/%n-cid -t 10
-ExecStopPost=/usr/local/bin/podman rm --ignore -f --cidfile %t/%n-cid
+ExecStop=/usr/local/bin/podman stop \
+        --ignore \
+        --cidfile %t/%n-cid -t 10
+ExecStopPost=/usr/local/bin/podman rm \
+        --ignore \
+        -f \
+	--cidfile %t/%n-cid
 PIDFile=%t/%n-pid
 KillMode=none
 Type=forking
@@ -217,7 +223,8 @@ RequiresMountsFor=/var/run/container/storage
 [Service]
 Restart=on-failure
 ExecStart=/usr/bin/podman start 77a818221650-infra
-ExecStop=/usr/bin/podman stop -t 10 77a818221650-infra
+ExecStop=/usr/bin/podman stop \
+        -t 10 77a818221650-infra
 KillMode=none
 Type=forking
 PIDFile=/run/user/1000/overlay-containers/ccfd5c71a088768774ca7bd05888d55cc287698dde06f475c8b02f696a25adcd/userdata/conmon.pid

--- a/pkg/systemd/generate/containers_test.go
+++ b/pkg/systemd/generate/containers_test.go
@@ -57,8 +57,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=82
 ExecStart=/usr/bin/podman start 639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401
-ExecStop=/usr/bin/podman stop -t 22 639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401
-ExecStopPost=/usr/bin/podman stop -t 22 639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401
+ExecStop=/usr/bin/podman stop  \
+	-t 22 639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401
+ExecStopPost=/usr/bin/podman stop  \
+	-t 22 639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -83,8 +85,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStart=/usr/bin/podman start foobar
-ExecStop=/usr/bin/podman stop -t 10 foobar
-ExecStopPost=/usr/bin/podman stop -t 10 foobar
+ExecStop=/usr/bin/podman stop  \
+	-t 10 foobar
+ExecStopPost=/usr/bin/podman stop  \
+	-t 10 foobar
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -107,8 +111,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStart=/usr/bin/podman start foobar
-ExecStop=/usr/bin/podman stop -t 10 foobar
-ExecStopPost=/usr/bin/podman stop -t 10 foobar
+ExecStop=/usr/bin/podman stop  \
+	-t 10 foobar
+ExecStopPost=/usr/bin/podman stop  \
+	-t 10 foobar
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -134,8 +140,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStart=/usr/bin/podman start foobar
-ExecStop=/usr/bin/podman stop -t 10 foobar
-ExecStopPost=/usr/bin/podman stop -t 10 foobar
+ExecStop=/usr/bin/podman stop  \
+	-t 10 foobar
+ExecStopPost=/usr/bin/podman stop  \
+	-t 10 foobar
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -161,8 +169,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStart=/usr/bin/podman start foobar
-ExecStop=/usr/bin/podman stop -t 10 foobar
-ExecStopPost=/usr/bin/podman stop -t 10 foobar
+ExecStop=/usr/bin/podman stop  \
+	-t 10 foobar
+ExecStopPost=/usr/bin/podman stop  \
+	-t 10 foobar
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -188,8 +198,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStart=/usr/bin/podman start foobar
-ExecStop=/usr/bin/podman stop -t 10 foobar
-ExecStopPost=/usr/bin/podman stop -t 10 foobar
+ExecStop=/usr/bin/podman stop  \
+	-t 10 foobar
+ExecStopPost=/usr/bin/podman stop  \
+	-t 10 foobar
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -217,8 +229,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStart=/usr/bin/podman start foobar
-ExecStop=/usr/bin/podman stop -t 10 foobar
-ExecStopPost=/usr/bin/podman stop -t 10 foobar
+ExecStop=/usr/bin/podman stop  \
+	-t 10 foobar
+ExecStopPost=/usr/bin/podman stop  \
+	-t 10 foobar
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -243,8 +257,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
 ExecStart=/usr/bin/podman start foobar
-ExecStop=/usr/bin/podman stop -t 10 foobar
-ExecStopPost=/usr/bin/podman stop -t 10 foobar
+ExecStop=/usr/bin/podman stop  \
+	-t 10 foobar
+ExecStopPost=/usr/bin/podman stop  \
+	-t 10 foobar
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -266,7 +282,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman container run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -276,8 +293,13 @@ ExecStart=/usr/bin/podman container run \
 	--replace \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN "foo=arg \"with \" space"
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -299,7 +321,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman container run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -309,8 +332,13 @@ ExecStart=/usr/bin/podman container run \
 	--sdnotify=container \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN "foo=arg \"with \" space"
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -332,7 +360,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman container run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -342,8 +371,13 @@ ExecStart=/usr/bin/podman container run \
 	--replace \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN "foo=arg \"with \" space"
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -365,7 +399,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -375,8 +410,13 @@ ExecStart=/usr/bin/podman run \
 	-d \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -398,7 +438,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -409,8 +450,13 @@ ExecStart=/usr/bin/podman run \
 	-d \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -432,7 +478,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -442,8 +489,13 @@ ExecStart=/usr/bin/podman run \
 	--detach \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -465,15 +517,21 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
 	--rm \
 	--sdnotify=conmon \
 	-d awesome-image:latest
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -496,7 +554,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=102
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -505,8 +564,13 @@ ExecStart=/usr/bin/podman run \
 	` +
 			detachparam +
 			` awesome-image:latest
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -530,7 +594,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=102
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -541,8 +606,13 @@ ExecStart=/usr/bin/podman run \
 	--name test \
 	-p 80:80 awesome-image:latest somecmd \
 	--detach=false
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -564,7 +634,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=102
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman \
 	--events-backend none \
 	--runroot /root run \
@@ -573,8 +644,13 @@ ExecStart=/usr/bin/podman \
 	--rm \
 	--sdnotify=conmon \
 	-d awesome-image:latest
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -596,15 +672,21 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman container run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
 	--rm \
 	--sdnotify=conmon \
 	-d awesome-image:latest
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -626,7 +708,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -637,8 +720,13 @@ ExecStart=/usr/bin/podman run \
 	--name test \
 	--log-driver=journald \
 	--log-opt=tag={{.Name}} awesome-image:latest
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -660,7 +748,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -670,8 +759,13 @@ ExecStart=/usr/bin/podman run \
 	--replace \
 	--name test awesome-image:latest sh \
 	-c "kill $$$$ && echo %%\\"
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -693,7 +787,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -704,8 +799,13 @@ ExecStart=/usr/bin/podman run \
 	--cgroups=foo \
 	--conmon-pidfile=foo \
 	--cidfile=foo alpine
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -727,7 +827,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -740,8 +841,13 @@ ExecStart=/usr/bin/podman run \
 	--conmon-pidfile=foo \
 	--cidfile=foo \
 	--pod-id-file /tmp/pod-foobar.pod-id-file alpine
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -764,7 +870,8 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Environment=FOO=abc "BAR=my test" USER=%%a
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -775,8 +882,13 @@ ExecStart=/usr/bin/podman run \
 	--env=BAR \
 	--env=MYENV=2 \
 	-e USER awesome-image:latest
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -802,8 +914,10 @@ Environment=USER=%%a
 Restart=on-failure
 TimeoutStopSec=70
 ExecStart=/usr/bin/podman start foobar
-ExecStop=/usr/bin/podman stop -t 10 foobar
-ExecStopPost=/usr/bin/podman stop -t 10 foobar
+ExecStop=/usr/bin/podman stop  \
+	-t 10 foobar
+ExecStopPost=/usr/bin/podman stop  \
+	-t 10 foobar
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -826,15 +940,21 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 StartLimitBurst=42
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
 	--rm \
 	--sdnotify=conmon \
 	-d awesome-image:latest
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -856,7 +976,8 @@ RequiresMountsFor=/var/run/containers/storage
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--cidfile=%t/%n.ctr-id \
 	--cgroups=no-conmon \
@@ -864,8 +985,13 @@ ExecStart=/usr/bin/podman run \
 	--sdnotify=conmon \
 	-d \
 	-h hostname awesome-image:latest
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 
@@ -888,7 +1014,8 @@ Environment=PODMAN_SYSTEMD_UNIT=%n-%i
 Restart=on-failure
 StartLimitBurst=42
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/rm \
+	-f %t/%n.ctr-id
 ExecStart=/usr/bin/podman run \
 	--name=container-foo-%i \
 	--cidfile=%t/%n.ctr-id \
@@ -896,8 +1023,13 @@ ExecStart=/usr/bin/podman run \
 	--rm \
 	--sdnotify=conmon \
 	-d awesome-image:latest
-ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
-ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+ExecStop=/usr/bin/podman stop \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm \
+	-f \
+	--ignore \
+	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
 

--- a/pkg/systemd/generate/pods.go
+++ b/pkg/systemd/generate/pods.go
@@ -294,9 +294,9 @@ func executePodTemplate(info *podInfo, options entities.GenerateSystemdOptions) 
 	}
 
 	info.EnvVariable = define.EnvVariable
-	info.ExecStart = "{{{{.Executable}}}} start {{{{.InfraNameOrID}}}}"
-	info.ExecStop = "{{{{.Executable}}}} stop {{{{if (ge .StopTimeout 0)}}}}-t {{{{.StopTimeout}}}}{{{{end}}}} {{{{.InfraNameOrID}}}}"
-	info.ExecStopPost = "{{{{.Executable}}}} stop {{{{if (ge .StopTimeout 0)}}}}-t {{{{.StopTimeout}}}}{{{{end}}}} {{{{.InfraNameOrID}}}}"
+	info.ExecStart = formatOptionsString("{{{{.Executable}}}} start {{{{.InfraNameOrID}}}}")
+	info.ExecStop = formatOptionsString("{{{{.Executable}}}} stop {{{{if (ge .StopTimeout 0)}}}} -t {{{{.StopTimeout}}}}{{{{end}}}} {{{{.InfraNameOrID}}}}")
+	info.ExecStopPost = formatOptionsString("{{{{.Executable}}}} stop {{{{if (ge .StopTimeout 0)}}}} -t {{{{.StopTimeout}}}}{{{{end}}}} {{{{.InfraNameOrID}}}}")
 
 	// Assemble the ExecStart command when creating a new pod.
 	//
@@ -371,11 +371,11 @@ func executePodTemplate(info *podInfo, options entities.GenerateSystemdOptions) 
 		startCommand = append(startCommand, podCreateArgs...)
 		startCommand = escapeSystemdArguments(startCommand)
 
-		info.ExecStartPre1 = "/bin/rm -f {{{{.PIDFile}}}} {{{{.PodIDFile}}}}"
-		info.ExecStartPre2 = strings.Join(startCommand, " ")
-		info.ExecStart = "{{{{.Executable}}}} {{{{if .RootFlags}}}}{{{{ .RootFlags}}}} {{{{end}}}}pod start --pod-id-file {{{{.PodIDFile}}}}"
-		info.ExecStop = "{{{{.Executable}}}} {{{{if .RootFlags}}}}{{{{ .RootFlags}}}} {{{{end}}}}pod stop --ignore --pod-id-file {{{{.PodIDFile}}}} {{{{if (ge .StopTimeout 0)}}}}-t {{{{.StopTimeout}}}}{{{{end}}}}"
-		info.ExecStopPost = "{{{{.Executable}}}} {{{{if .RootFlags}}}}{{{{ .RootFlags}}}} {{{{end}}}}pod rm --ignore -f --pod-id-file {{{{.PodIDFile}}}}"
+		info.ExecStartPre1 = formatOptionsString("/bin/rm -f {{{{.PIDFile}}}} {{{{.PodIDFile}}}}")
+		info.ExecStartPre2 = formatOptions(startCommand)
+		info.ExecStart = formatOptionsString("{{{{.Executable}}}} {{{{if .RootFlags}}}}{{{{ .RootFlags}}}} {{{{end}}}}pod start --pod-id-file {{{{.PodIDFile}}}}")
+		info.ExecStop = formatOptionsString("{{{{.Executable}}}} {{{{if .RootFlags}}}}{{{{ .RootFlags}}}} {{{{end}}}}pod stop --ignore --pod-id-file {{{{.PodIDFile}}}} {{{{if (ge .StopTimeout 0)}}}} -t {{{{.StopTimeout}}}}{{{{end}}}}")
+		info.ExecStopPost = formatOptionsString("{{{{.Executable}}}} {{{{if .RootFlags}}}}{{{{ .RootFlags}}}} {{{{end}}}}pod rm --ignore -f --pod-id-file {{{{.PodIDFile}}}}")
 	}
 	info.TimeoutStopSec = minTimeoutStopSec + info.StopTimeout
 

--- a/pkg/systemd/generate/pods_test.go
+++ b/pkg/systemd/generate/pods_test.go
@@ -79,8 +79,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=102
 ExecStart=/usr/bin/podman start jadda-jadda-infra
-ExecStop=/usr/bin/podman stop -t 42 jadda-jadda-infra
-ExecStopPost=/usr/bin/podman stop -t 42 jadda-jadda-infra
+ExecStop=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
+ExecStopPost=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -107,8 +109,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=102
 ExecStart=/usr/bin/podman start jadda-jadda-infra
-ExecStop=/usr/bin/podman stop -t 42 jadda-jadda-infra
-ExecStopPost=/usr/bin/podman stop -t 42 jadda-jadda-infra
+ExecStop=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
+ExecStopPost=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -136,8 +140,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=102
 ExecStart=/usr/bin/podman start jadda-jadda-infra
-ExecStop=/usr/bin/podman stop -t 42 jadda-jadda-infra
-ExecStopPost=/usr/bin/podman stop -t 42 jadda-jadda-infra
+ExecStop=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
+ExecStopPost=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -164,8 +170,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=102
 ExecStart=/usr/bin/podman start jadda-jadda-infra
-ExecStop=/usr/bin/podman stop -t 42 jadda-jadda-infra
-ExecStopPost=/usr/bin/podman stop -t 42 jadda-jadda-infra
+ExecStop=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
+ExecStopPost=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -192,8 +200,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=102
 ExecStart=/usr/bin/podman start jadda-jadda-infra
-ExecStop=/usr/bin/podman stop -t 42 jadda-jadda-infra
-ExecStopPost=/usr/bin/podman stop -t 42 jadda-jadda-infra
+ExecStop=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
+ExecStopPost=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -222,8 +232,10 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=102
 ExecStart=/usr/bin/podman start jadda-jadda-infra
-ExecStop=/usr/bin/podman stop -t 42 jadda-jadda-infra
-ExecStopPost=/usr/bin/podman stop -t 42 jadda-jadda-infra
+ExecStop=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
+ExecStopPost=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -246,11 +258,22 @@ Before=
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/pod-123abc.pid %t/pod-123abc.pod-id
-ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/pod-123abc.pid --pod-id-file %t/pod-123abc.pod-id --exit-policy=stop foo
-ExecStart=/usr/bin/podman pod start --pod-id-file %t/pod-123abc.pod-id
-ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/pod-123abc.pod-id -t 10
-ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/pod-123abc.pod-id
+ExecStartPre=/bin/rm \
+	-f %t/pod-123abc.pid %t/pod-123abc.pod-id
+ExecStartPre=/usr/bin/podman pod create \
+	--infra-conmon-pidfile %t/pod-123abc.pid \
+	--pod-id-file %t/pod-123abc.pod-id \
+	--exit-policy=stop foo
+ExecStart=/usr/bin/podman pod start \
+	--pod-id-file %t/pod-123abc.pod-id
+ExecStop=/usr/bin/podman pod stop \
+	--ignore \
+	--pod-id-file %t/pod-123abc.pod-id  \
+	-t 10
+ExecStopPost=/usr/bin/podman pod rm \
+	--ignore \
+	-f \
+	--pod-id-file %t/pod-123abc.pod-id
 PIDFile=%t/pod-123abc.pid
 Type=forking
 
@@ -276,8 +299,10 @@ Restart=on-failure
 RestartSec=15
 TimeoutStopSec=102
 ExecStart=/usr/bin/podman start jadda-jadda-infra
-ExecStop=/usr/bin/podman stop -t 42 jadda-jadda-infra
-ExecStopPost=/usr/bin/podman stop -t 42 jadda-jadda-infra
+ExecStop=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
+ExecStopPost=/usr/bin/podman stop  \
+	-t 42 jadda-jadda-infra
 PIDFile=/run/containers/storage/overlay-containers/639c53578af4d84b8800b4635fa4e680ee80fd67e0e6a2d4eea48d1e3230f401/userdata/conmon.pid
 Type=forking
 
@@ -301,11 +326,24 @@ Before=container-1.service container-2.service
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/pod-123abc.pid %t/pod-123abc.pod-id
-ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/pod-123abc.pid --pod-id-file %t/pod-123abc.pod-id --exit-policy=stop --name foo "bar=arg with space" --replace
-ExecStart=/usr/bin/podman pod start --pod-id-file %t/pod-123abc.pod-id
-ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/pod-123abc.pod-id -t 10
-ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/pod-123abc.pod-id
+ExecStartPre=/bin/rm \
+	-f %t/pod-123abc.pid %t/pod-123abc.pod-id
+ExecStartPre=/usr/bin/podman pod create \
+	--infra-conmon-pidfile %t/pod-123abc.pid \
+	--pod-id-file %t/pod-123abc.pod-id \
+	--exit-policy=stop \
+	--name foo "bar=arg with space" \
+	--replace
+ExecStart=/usr/bin/podman pod start \
+	--pod-id-file %t/pod-123abc.pod-id
+ExecStop=/usr/bin/podman pod stop \
+	--ignore \
+	--pod-id-file %t/pod-123abc.pod-id  \
+	-t 10
+ExecStopPost=/usr/bin/podman pod rm \
+	--ignore \
+	-f \
+	--pod-id-file %t/pod-123abc.pod-id
 PIDFile=%t/pod-123abc.pid
 Type=forking
 
@@ -329,11 +367,26 @@ Before=container-1.service container-2.service
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/pod-123abc.pid %t/pod-123abc.pod-id
-ExecStartPre=/usr/bin/podman --events-backend none --runroot /root pod create --infra-conmon-pidfile %t/pod-123abc.pid --pod-id-file %t/pod-123abc.pod-id --exit-policy=stop --name foo "bar=arg with space" --replace
-ExecStart=/usr/bin/podman --events-backend none --runroot /root pod start --pod-id-file %t/pod-123abc.pod-id
-ExecStop=/usr/bin/podman --events-backend none --runroot /root pod stop --ignore --pod-id-file %t/pod-123abc.pod-id -t 10
-ExecStopPost=/usr/bin/podman --events-backend none --runroot /root pod rm --ignore -f --pod-id-file %t/pod-123abc.pod-id
+ExecStartPre=/bin/rm \
+	-f %t/pod-123abc.pid %t/pod-123abc.pod-id
+ExecStartPre=/usr/bin/podman \
+	--events-backend none \
+	--runroot /root pod create \
+	--infra-conmon-pidfile %t/pod-123abc.pid \
+	--pod-id-file %t/pod-123abc.pod-id \
+	--exit-policy=stop \
+	--name foo "bar=arg with space" \
+	--replace
+ExecStart=/usr/bin/podman --events-backend none --runroot /root pod start \
+	--pod-id-file %t/pod-123abc.pod-id
+ExecStop=/usr/bin/podman --events-backend none --runroot /root pod stop \
+	--ignore \
+	--pod-id-file %t/pod-123abc.pod-id  \
+	-t 10
+ExecStopPost=/usr/bin/podman --events-backend none --runroot /root pod rm \
+	--ignore \
+	-f \
+	--pod-id-file %t/pod-123abc.pod-id
 PIDFile=%t/pod-123abc.pid
 Type=forking
 
@@ -357,11 +410,24 @@ Before=container-1.service container-2.service
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/pod-123abc.pid %t/pod-123abc.pod-id
-ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/pod-123abc.pid --pod-id-file %t/pod-123abc.pod-id --exit-policy=stop --name foo --replace
-ExecStart=/usr/bin/podman pod start --pod-id-file %t/pod-123abc.pod-id
-ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/pod-123abc.pod-id -t 10
-ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/pod-123abc.pod-id
+ExecStartPre=/bin/rm \
+	-f %t/pod-123abc.pid %t/pod-123abc.pod-id
+ExecStartPre=/usr/bin/podman pod create \
+	--infra-conmon-pidfile %t/pod-123abc.pid \
+	--pod-id-file %t/pod-123abc.pod-id \
+	--exit-policy=stop \
+	--name foo \
+	--replace
+ExecStart=/usr/bin/podman pod start \
+	--pod-id-file %t/pod-123abc.pod-id
+ExecStop=/usr/bin/podman pod stop \
+	--ignore \
+	--pod-id-file %t/pod-123abc.pod-id  \
+	-t 10
+ExecStopPost=/usr/bin/podman pod rm \
+	--ignore \
+	-f \
+	--pod-id-file %t/pod-123abc.pod-id
 PIDFile=%t/pod-123abc.pid
 Type=forking
 
@@ -385,11 +451,25 @@ Before=container-1.service container-2.service
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=70
-ExecStartPre=/bin/rm -f %t/pod-123abc.pid %t/pod-123abc.pod-id
-ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/pod-123abc.pid --pod-id-file %t/pod-123abc.pod-id --name foo --label key={{someval}} --exit-policy=continue --replace
-ExecStart=/usr/bin/podman pod start --pod-id-file %t/pod-123abc.pod-id
-ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/pod-123abc.pod-id -t 10
-ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/pod-123abc.pod-id
+ExecStartPre=/bin/rm \
+	-f %t/pod-123abc.pid %t/pod-123abc.pod-id
+ExecStartPre=/usr/bin/podman pod create \
+	--infra-conmon-pidfile %t/pod-123abc.pid \
+	--pod-id-file %t/pod-123abc.pod-id \
+	--name foo \
+	--label key={{someval}} \
+	--exit-policy=continue \
+	--replace
+ExecStart=/usr/bin/podman pod start \
+	--pod-id-file %t/pod-123abc.pod-id
+ExecStop=/usr/bin/podman pod stop \
+	--ignore \
+	--pod-id-file %t/pod-123abc.pod-id  \
+	-t 10
+ExecStopPost=/usr/bin/podman pod rm \
+	--ignore \
+	-f \
+	--pod-id-file %t/pod-123abc.pod-id
 PIDFile=%t/pod-123abc.pid
 Type=forking
 

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Podman generate systemd", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring("TimeoutStopSec=1294"))
-		Expect(session.OutputToString()).To(ContainSubstring(" stop -t 1234 "))
+		Expect(session.OutputToString()).To(ContainSubstring("-t 1234"))
 	})
 
 	It("podman generate systemd", func() {
@@ -149,14 +149,15 @@ var _ = Describe("Podman generate systemd", func() {
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring("TimeoutStopSec=65"))
 		Expect(session.OutputToString()).ToNot(ContainSubstring("TimeoutStartSec="))
-		Expect(session.OutputToString()).To(ContainSubstring("podman stop -t 5"))
+		Expect(session.OutputToString()).To(ContainSubstring("podman stop"))
+		Expect(session.OutputToString()).To(ContainSubstring("-t 5"))
 
 		session = podmanTest.Podman([]string{"generate", "systemd", "--stop-timeout", "5", "--start-timeout", "123", "nginx"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(ContainSubstring("TimeoutStartSec=123"))
 		Expect(session.OutputToString()).To(ContainSubstring("TimeoutStopSec=65"))
-		Expect(session.OutputToString()).To(ContainSubstring("podman stop -t 5"))
+		Expect(session.OutputToString()).To(ContainSubstring("-t 5"))
 	})
 
 	It("podman generate systemd with user-defined dependencies", func() {
@@ -228,7 +229,8 @@ var _ = Describe("Podman generate systemd", func() {
 		Expect(output).To(ContainSubstring(" start foo-1"))
 		Expect(output).To(ContainSubstring("-infra")) // infra container
 		Expect(output).To(ContainSubstring("# container-foo-2.service"))
-		Expect(output).To(ContainSubstring(" stop -t 42 foo-2"))
+		Expect(output).To(ContainSubstring("podman stop"))
+		Expect(output).To(ContainSubstring("-t 42 foo-2"))
 		Expect(output).To(ContainSubstring("BindsTo=pod-foo.service"))
 		Expect(output).To(ContainSubstring("PIDFile="))
 		Expect(output).To(ContainSubstring("/userdata/conmon.pid"))
@@ -564,10 +566,21 @@ var _ = Describe("Podman generate systemd", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("# pod-foo.service"))
 		Expect(session.OutputToString()).To(ContainSubstring("Wants=container-foo-1.service container-foo-2.service"))
 		Expect(session.OutputToString()).To(ContainSubstring("BindsTo=pod-foo.service"))
-		Expect(session.OutputToString()).To(ContainSubstring("pod create --infra-conmon-pidfile %t/pod-foo.pid --pod-id-file %t/pod-foo.pod-id --exit-policy=stop --name foo"))
-		Expect(session.OutputToString()).To(ContainSubstring("ExecStartPre=/bin/rm -f %t/pod-foo.pid %t/pod-foo.pod-id"))
-		Expect(session.OutputToString()).To(ContainSubstring("pod stop --ignore --pod-id-file %t/pod-foo.pod-id -t 10"))
-		Expect(session.OutputToString()).To(ContainSubstring("pod rm --ignore -f --pod-id-file %t/pod-foo.pod-id"))
+		Expect(session.OutputToString()).To(ContainSubstring("pod create"))
+		Expect(session.OutputToString()).To(ContainSubstring("--infra-conmon-pidfile %t/pod-foo.pid"))
+		Expect(session.OutputToString()).To(ContainSubstring("--pod-id-file %t/pod-foo.pod-id"))
+		Expect(session.OutputToString()).To(ContainSubstring("--exit-policy=stop"))
+		Expect(session.OutputToString()).To(ContainSubstring("--name foo"))
+		Expect(session.OutputToString()).To(ContainSubstring("ExecStartPre=/bin/rm"))
+		Expect(session.OutputToString()).To(ContainSubstring("-f %t/pod-foo.pid %t/pod-foo.pod-id"))
+		Expect(session.OutputToString()).To(ContainSubstring("pod stop"))
+		Expect(session.OutputToString()).To(ContainSubstring("--ignore"))
+		Expect(session.OutputToString()).To(ContainSubstring("--pod-id-file %t/pod-foo.pod-id"))
+		Expect(session.OutputToString()).To(ContainSubstring("-t 10"))
+		Expect(session.OutputToString()).To(ContainSubstring("pod rm"))
+		Expect(session.OutputToString()).To(ContainSubstring("--ignore"))
+		Expect(session.OutputToString()).To(ContainSubstring("-f"))
+		Expect(session.OutputToString()).To(ContainSubstring("--pod-id-file %t/pod-foo.pod-id"))
 	})
 
 	It("podman generate systemd --format json", func() {


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/14897

Followup to #13814

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman systemd generate output has been improved by adding newlines on options in the unit files.
```
