### PR TITLE
podman container clone env patch

### DIFF
--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -352,7 +352,7 @@ func ConfigToSpec(rt *libpod.Runtime, specg *specgen.SpecGenerator, contaierID s
 		if conf.Spec.Process != nil && conf.Spec.Process.Env != nil {
 			env := make(map[string]string)
 			for _, entry := range conf.Spec.Process.Env {
-				split := strings.Split(entry, "=")
+				split := strings.SplitN(entry, "=", 2)
 				if len(split) == 2 {
 					env[split[0]] = split[1]
 				}

--- a/test/e2e/container_clone_test.go
+++ b/test/e2e/container_clone_test.go
@@ -308,5 +308,18 @@ var _ = Describe("Podman container clone", func() {
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).Should(ContainSubstring("123"))
 
+		session = podmanTest.Podman([]string{"run", "--name", "env_ctr2", "-e", "ENV_TEST=12=3", ALPINE, "printenv", "ENV_TEST"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"container", "clone", "env_ctr2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"start", "-a", "env_ctr2-clone"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).Should(ContainSubstring("12=3"))
+
 	})
 })


### PR DESCRIPTION
podman container clone was failing when env variables had multiple `=` in them. Switch split to splitn

resolves #15836

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
users can specify env variables properly in container clone
```
