### PR TITLE
Allow setting sign-passphrase directly

### DIFF
--- a/cmd/podman/common/sign.go
+++ b/cmd/podman/common/sign.go
@@ -12,6 +12,15 @@ import (
 // and validates pushOpts.Sign* consistency.
 // It may interactively prompt for a passphrase if one is required and wasn’t provided otherwise.
 func PrepareSigningPassphrase(pushOpts *entities.ImagePushOptions, signPassphraseFile string) error {
+	// Allow users to specify passphrase directly
+	if pushOpts.SignPassphrase != "" {
+		if signPassphraseFile != "" {
+			return fmt.Errorf("only one of --sign-passphrase or --sign-passphrase-file can be used")
+		}
+
+		pushOpts.SignSigstorePrivateKeyPassphrase = []byte(pushOpts.SignPassphrase)
+		return nil
+	}
 	// c/common/libimage.Image does allow creating both simple signing and sigstore signatures simultaneously,
 	// with independent passphrases, but that would make the CLI probably too confusing.
 	// For now, use the passphrase with either, but only one of them.

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -115,6 +115,10 @@ func pushFlags(cmd *cobra.Command) {
 	flags.StringVar(&pushOptions.SignPassphraseFileCLI, signPassphraseFileFlagName, "", "Read a passphrase for signing an image from `PATH`")
 	_ = cmd.RegisterFlagCompletionFunc(signPassphraseFileFlagName, completion.AutocompleteDefault)
 
+	signPassphraseFlagName := "sign-passphrase"
+	flags.StringVar(&pushOptions.SignPassphrase, signPassphraseFlagName, "", "Passphrase to use for signing an image, overrides 'sign-passphrase-file'")
+	_ = pushCmd.RegisterFlagCompletionFunc(signPassphraseFlagName, completion.AutocompleteDefault)
+
 	flags.BoolVar(&pushOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 
 	compressionFormat := "compression-format"
@@ -128,6 +132,7 @@ func pushFlags(cmd *cobra.Command) {
 		_ = flags.MarkHidden("quiet")
 		_ = flags.MarkHidden(signByFlagName)
 		_ = flags.MarkHidden(signBySigstorePrivateKeyFlagName)
+		_ = flags.MarkHidden(signPassphraseFlagName)
 		_ = flags.MarkHidden(signPassphraseFileFlagName)
 	}
 	if !registry.IsRemote() {

--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -83,6 +83,10 @@ func init() {
 	flags.StringVar(&manifestPushOpts.SignPassphraseFileCLI, signPassphraseFileFlagName, "", "Read a passphrase for signing an image from `PATH`")
 	_ = pushCmd.RegisterFlagCompletionFunc(signPassphraseFileFlagName, completion.AutocompleteDefault)
 
+	signPassphraseFlagName := "sign-passphrase"
+	flags.StringVar(&manifestPushOpts.SignPassphrase, signPassphraseFlagName, "", "Passphrase to use for signing an image, overrides 'sign-passphrase-file'")
+	_ = pushCmd.RegisterFlagCompletionFunc(signPassphraseFlagName, completion.AutocompleteDefault)
+
 	flags.BoolVar(&manifestPushOpts.TLSVerifyCLI, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	flags.BoolVar(&manifestPushOpts.Insecure, "insecure", false, "neither require HTTPS nor verify certificates when accessing the registry")
 	_ = flags.MarkHidden("insecure")
@@ -97,6 +101,7 @@ func init() {
 		_ = flags.MarkHidden("cert-dir")
 		_ = flags.MarkHidden(signByFlagName)
 		_ = flags.MarkHidden(signBySigstorePrivateKeyFlagName)
+		_ = flags.MarkHidden(signPassphraseFlagName)
 		_ = flags.MarkHidden(signPassphraseFileFlagName)
 	}
 }

--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -55,6 +55,10 @@ Sign the pushed images with a “simple signing” signature using the specified
 
 Sign the pushed images with a sigstore signature using a private key at the specified path. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
+#### **--sign-passphrase**=*passphrase*
+
+If signing the image with **--sign-by**, set the signing passphrase. Conflicts with **-sign-passphrase-file** below.
+
 #### **--sign-passphrase-file**=*path*
 
 If signing the image (using either **--sign-by** or **--sign-by-sigstore-private-key**), read the passphrase to use from the specified path.

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -86,6 +86,10 @@ Add a “simple signing” signature at the destination using the specified key.
 
 Add a sigstore signature at the destination using a private key at the specified path. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
+#### **--sign-passphrase**=*passphrase*
+
+If signing the image with **--sign-by**, set the signing passphrase. Conflicts with **-sign-passphrase-file** below.
+
 #### **--sign-passphrase-file**=*path*
 
 If signing the image (using either **--sign-by** or **--sign-by-sigstore-private-key**), read the passphrase to use from the specified path.


### PR DESCRIPTION
Signed-off-by: Stephen Reaves <reaves735@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added the '--sign-passphrase' option to allow users to specify gpg signing passphrase directly.
```
