### PR TITLE
label.Relabel third option is shared not recurse

### DIFF
--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -2659,7 +2659,7 @@ func (c *Container) fixVolumePermissions(v *ContainerNamedVolume) error {
 	return nil
 }
 
-func (c *Container) relabel(src, mountLabel string, recurse bool) error {
+func (c *Container) relabel(src, mountLabel string, shared bool) error {
 	if !selinux.GetEnabled() || mountLabel == "" {
 		return nil
 	}
@@ -2674,7 +2674,7 @@ func (c *Container) relabel(src, mountLabel string, recurse bool) error {
 			return nil
 		}
 	}
-	return label.Relabel(src, mountLabel, recurse)
+	return label.Relabel(src, mountLabel, shared)
 }
 
 func (c *Container) ChangeHostPathOwnership(src string, recurse bool, uid, gid int) error {


### PR DESCRIPTION
There is no option in Selinux labeling to only relabel the top level of a directory. The option is to either label the path shared or not shared. Changing to make sure future engineers do not assume that recurse can work.

[NO NEW TESTS NEEDED]

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
