### PR TITLE
`podman pod logs -l` no longer panics

### DIFF
--- a/cmd/podman/pods/logs.go
+++ b/cmd/podman/pods/logs.go
@@ -121,5 +121,10 @@ func logs(_ *cobra.Command, args []string) error {
 
 	logsPodOptions.StdoutWriter = os.Stdout
 	logsPodOptions.StderrWriter = os.Stderr
-	return registry.ContainerEngine().PodLogs(registry.GetContext(), args[0], logsPodOptions.PodLogsOptions)
+
+	podName := ""
+	if len(args) > 0 {
+		podName = args[0]
+	}
+	return registry.ContainerEngine().PodLogs(registry.GetContext(), podName, logsPodOptions.PodLogsOptions)
 }

--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -70,7 +70,7 @@ func (ic *ContainerEngine) NetworkInspect(ctx context.Context, namesOrIds []stri
 }
 
 func (ic *ContainerEngine) NetworkReload(ctx context.Context, names []string, options entities.NetworkReloadOptions) ([]*entities.NetworkReloadReport, error) {
-	ctrs, err := getContainersByContext(options.All, options.Latest, names, ic.Libpod)
+	ctrs, err := getContainersByContext(options.All, options.Latest, false, names, ic.Libpod)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixed issue where executing the command `podman pod logs -l` would panic because it was indexing into an empty arguments array.

Fixes: #15556

Signed-off-by: Jake Correnti <jcorrenti13@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes bug where executing `podman pod logs -l` would panic
```
