### PR TITLE
pkginstaller: use path_helper to add podman and helpers to path

### DIFF
--- a/contrib/pkginstaller/scripts/postinstall
+++ b/contrib/pkginstaller/scripts/postinstall
@@ -2,26 +2,7 @@
 
 set -e
 
-BZSH_PODMAN_PATH_EXP='PATH="/opt/podman/bin:$PATH"'
-FISH_PODMAN_PATH_EXP='set PATH "/opt/podman/bin $PATH"'
-BASHRC_PATH="$HOME/.bash_profile"
-ZSHENV_PATH="$HOME/.zshenv"
-ZSHRC_PATH="$HOME/.zshrc"
-FSHCFG_PATH="$HOME/.config/fish/config.fish"
-
-# append /Applications/podman/bin to $PATH
-if [ -f "$BASHRC_PATH" ]; then
-    grep -Fxq "$BZSH_PODMAN_PATH_EXP" "$BASHRC_PATH" || echo "$BZSH_PODMAN_PATH_EXP" >> "$BASHRC_PATH"
-fi
-if [ -f "$ZSHENV_PATH" ]; then
-    grep -Fxq "$BZSH_PODMAN_PATH_EXP" "$ZSHENV_PATH" || echo "$BZSH_PODMAN_PATH_EXP" >> "$ZSHENV_PATH"
-fi
-if [ -f "$ZSHRC_PATH" ]; then
-    grep -Fxq "$BZSH_PODMAN_PATH_EXP" "$ZSHRC_PATH" || echo "$BZSH_PODMAN_PATH_EXP" >> "$ZSHRC_PATH"
-fi
-if [ -f "$FSHCFG_PATH" ]; then
-    grep -Fxq "$FISH_PODMAN_PATH_EXP" "$FSHCFG_PATH" || echo "$FISH_PODMAN_PATH_EXP" >> "$FSHCFG_PATH"
-fi
+echo "/opt/podman/bin" > /etc/paths.d/podman-pkg
 
 ln -s /opt/podman/bin/podman-mac-helper /opt/podman/qemu/bin/podman-mac-helper
 ln -s /opt/podman/bin/gvproxy /opt/podman/qemu/bin/gvproxy

--- a/contrib/pkginstaller/scripts/preinstall
+++ b/contrib/pkginstaller/scripts/preinstall
@@ -3,3 +3,7 @@
 set -e
 
 rm -rf /opt/podman
+
+if [ ! -d "/etc/paths.d" ]; then
+    mkdir -p /etc/paths.d
+fi


### PR DESCRIPTION
path_helper(8) appends the contents of /etc/paths.d/podman-pkg to the PATH env

[NO NEW TESTS NEEDED]

Signed-off-by: Anjan Nath <kaludios@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

Fixes #15831 

This makes use of the solution suggested by @cfergeau in https://github.com/containers/podman/issues/15831#issuecomment-1249117498