### PR TITLE
[CI:DOCS] man pages: document some --format options

### DIFF
--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -95,6 +95,20 @@ In the case where an ID is used, the ID may be in its full or shortened form.
 
 Format the output to JSON Lines or using the given Go template.
 
+| **Placeholder**    | **Description**                               |
+|--------------------|-----------------------------------------------|
+| .Attributes        | created_at, _by, labels, and more (map[])     |
+| .ContainerExitCode | Exit code (int)                               |
+| .Details ...       | Internal structure, not actually useful       |
+| .HealthStatus      | Health Status (string)                        |
+| .ID                | Container ID (full 64-bit SHA)                |
+| .Image             | Name of image being run (string)              |
+| .Name              | Container name (string)                       |
+| .Network           | Name of network being used (string)           |
+| .Status            | Event status (e.g., create, start, died, ...) |
+| .Time              | Event timestamp (string)                      |
+| .Type              | Event type (e.g., image, container, pod, ...) |
+
 #### **--help**
 
 Print usage statement.


### PR DESCRIPTION
Baby steps toward merging #14046: document Go format options
for podman events.

This is deliberately imperfect. I am not the right person
to document these. I am simply the person who is getting
a skeleton framework in place.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
man pages: document Go format values for podman-events
```