### PR TITLE
Fix: display online_cpus in compat REST API

### DIFF
--- a/libpod/stats_common.go
+++ b/libpod/stats_common.go
@@ -47,3 +47,8 @@ func (c *Container) GetContainerStats(previousStats *define.ContainerStats) (*de
 	}
 	return stats, nil
 }
+
+// GetOnlineCPUs returns the number of online CPUs as set in the container cpu-set using sched_getaffinity
+func GetOnlineCPUs(container *Container) (int, error) {
+	return getOnlineCPUs(container)
+}

--- a/libpod/stats_freebsd.go
+++ b/libpod/stats_freebsd.go
@@ -147,3 +147,7 @@ func calculateBlockIO(stats *cgroups.Metrics) (read uint64, write uint64) {
 	}
 	return
 }
+
+func getOnlineCPUs(container *Container) (int, error) {
+	return 0, nil
+}

--- a/pkg/api/handlers/compat/containers_stats.go
+++ b/pkg/api/handlers/compat/containers_stats.go
@@ -80,6 +80,11 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 			ThrottlingData: docker.ThrottlingData{},
 		}
 	}
+	onlineCPUs, err := libpod.GetOnlineCPUs(ctnr)
+	if err != nil {
+		utils.InternalServerError(w, err)
+		return
+	}
 
 streamLabel: // A label to flatten the scope
 	select {
@@ -178,7 +183,7 @@ streamLabel: // A label to flatten the scope
 					},
 					CPU:         stats.CPU,
 					SystemUsage: systemUsage,
-					OnlineCPUs:  uint32(len(cgroupStat.CpuStats.CpuUsage.PercpuUsage)),
+					OnlineCPUs:  uint32(onlineCPUs),
 					ThrottlingData: docker.ThrottlingData{
 						Periods:          0,
 						ThrottledPeriods: 0,

--- a/test/apiv2/19-stats.at
+++ b/test/apiv2/19-stats.at
@@ -1,0 +1,11 @@
+# -*- sh -*-
+#
+# test 'stats' endpoints
+#
+
+if root; then
+    podman run -dt --name container1 --cpuset-cpus=0 $IMAGE top &>/dev/null
+
+    # regression for https://github.com/containers/podman/issues/15754
+    t GET libpod/containers/container1/stats?stream=false 200 .cpu_stats.online_cpus=1
+fi


### PR DESCRIPTION
closes #15754 
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
