### PR TITLE
cmd/podman: add support for checkpoint images

### DIFF
--- a/cmd/podman/containers/restore.go
+++ b/cmd/podman/containers/restore.go
@@ -93,7 +93,7 @@ func init() {
 
 func restore(cmd *cobra.Command, args []string) error {
 	var (
-		e    error
+		err  error
 		errs utils.OutputErrors
 	)
 	podmanStart := time.Now()
@@ -104,9 +104,9 @@ func restore(cmd *cobra.Command, args []string) error {
 	// Check if the container exists (#15055)
 	exists := &entities.BoolReport{Value: false}
 	for _, ctr := range args {
-		exists, e = registry.ContainerEngine().ContainerExists(registry.GetContext(), ctr, entities.ContainerExistsOptions{})
-		if e != nil {
-			return e
+		exists, err = registry.ContainerEngine().ContainerExists(registry.GetContext(), ctr, entities.ContainerExistsOptions{})
+		if err != nil {
+			return err
 		}
 		if exists.Value {
 			break
@@ -115,9 +115,9 @@ func restore(cmd *cobra.Command, args []string) error {
 
 	if !exists.Value {
 		// Find out if this is an image
-		restoreOptions.CheckpointImage, e = utils.IsCheckpointImage(context.Background(), args)
-		if e != nil {
-			return e
+		restoreOptions.CheckpointImage, err = utils.IsCheckpointImage(context.Background(), args)
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
This pull request extends the podman run command with support for checkpoint images. When `podman run` is invoked with an image that contains a checkpoint, it would restore the container from that checkpoint.
    
Example:
```
podman run -d --name looper busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
podman container checkpoint --create-image checkpoint-image-1 looper
podman rm looper
podman run checkpoint-image-1
```

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman run` command has been extended with support for checkpoint images.
```
