### PR TITLE
podman-save: Add signature-policy flag

### DIFF
--- a/cmd/podman/images/save.go
+++ b/cmd/podman/images/save.go
@@ -96,6 +96,11 @@ func saveFlags(cmd *cobra.Command) {
 
 	flags.BoolVarP(&saveOpts.Quiet, "quiet", "q", false, "Suppress the output")
 	flags.BoolVarP(&saveOpts.MultiImageArchive, "multi-image-archive", "m", containerConfig.Engine.MultiImageArchive, "Interpret additional arguments as images not tags and create a multi-image-archive (only for docker-archive)")
+
+	if !registry.IsRemote() {
+		flags.StringVar(&saveOpts.SignaturePolicy, "signature-policy", "", "Path to a signature-policy file")
+		_ = flags.MarkHidden("signature-policy")
+	}
 }
 
 func save(cmd *cobra.Command, args []string) (finalErr error) {

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -335,7 +335,8 @@ type ImageSaveOptions struct {
 	// Output - write image to the specified path.
 	Output string
 	// Quiet - suppress output when copying images
-	Quiet bool
+	Quiet           bool
+	SignaturePolicy string
 }
 
 // ImageScpOptions provide options for securely copying images to and from a remote host

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -406,6 +406,7 @@ func (ir *ImageEngine) Save(ctx context.Context, nameOrID string, tags []string,
 	saveOptions := &libimage.SaveOptions{}
 	saveOptions.DirForceCompress = options.Compress
 	saveOptions.OciAcceptUncompressedLayers = options.OciAcceptUncompressedLayers
+	saveOptions.SignaturePolicyPath = options.SignaturePolicy
 
 	// Force signature removal to preserve backwards compat.
 	// See https://github.com/containers/podman/pull/11669#issuecomment-925250264

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -46,6 +46,15 @@ var _ = Describe("Podman save", func() {
 		Expect(save).Should(Exit(0))
 	})
 
+	It("podman save signature-policy flag", func() {
+		SkipIfRemote("--signature-policy N/A for remote")
+		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
+
+		save := podmanTest.Podman([]string{"save", "--signature-policy", "/etc/containers/policy.json", "-o", outfile, ALPINE})
+		save.WaitWithDefaultTimeout()
+		Expect(save).Should(Exit(0))
+	})
+
 	It("podman save oci flag", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 


### PR DESCRIPTION
Allow overwrite of the signature-policy file
similiar to other cli commands: podman load, podman pull, ...

Closes: https://github.com/containers/podman/issues/15869
Signed-off-by: 😎Mostafa Emami <mustafaemami@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman save supports `--signature-policy` flag
```
