### PR TITLE
Replace deprecated ioutil

### DIFF
--- a/cmd/podman-mac-helper/main.go
+++ b/cmd/podman-mac-helper/main.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -131,7 +130,7 @@ func readCapped(reader io.Reader) string {
 	// Cap output
 	buffer := make([]byte, 2048)
 	n, _ := io.ReadFull(reader, buffer)
-	_, _ = io.Copy(ioutil.Discard, reader)
+	_, _ = io.Copy(io.Discard, reader)
 	if n > 0 {
 		return string(buffer[:n])
 	}

--- a/cmd/podman/containers/commit.go
+++ b/cmd/podman/containers/commit.go
@@ -3,7 +3,6 @@ package containers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -107,7 +106,7 @@ func commit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if len(iidFile) > 0 {
-		if err = ioutil.WriteFile(iidFile, []byte(response.Id), 0644); err != nil {
+		if err = os.WriteFile(iidFile, []byte(response.Id), 0644); err != nil {
 			return fmt.Errorf("failed to write image ID: %w", err)
 		}
 	}

--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -3,7 +3,6 @@ package containers
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -379,7 +378,7 @@ func copyToContainer(container string, containerPath string, hostPath string) er
 		// Copy from stdin to a temporary file *before* throwing it
 		// over the wire.  This allows for proper client-side error
 		// reporting.
-		tmpFile, err := ioutil.TempFile("", "")
+		tmpFile, err := os.CreateTemp("", "")
 		if err != nil {
 			return err
 		}

--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
@@ -96,7 +96,7 @@ func kill(_ *cobra.Command, args []string) error {
 		return errors.New("valid signals are 1 through 64")
 	}
 	for _, cidFile := range killCidFiles {
-		content, err := ioutil.ReadFile(cidFile)
+		content, err := os.ReadFile(cidFile)
 		if err != nil {
 			return fmt.Errorf("reading CIDFile: %w", err)
 		}

--- a/cmd/podman/containers/pause.go
+++ b/cmd/podman/containers/pause.go
@@ -3,7 +3,7 @@ package containers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
@@ -92,7 +92,7 @@ func pause(cmd *cobra.Command, args []string) error {
 	)
 
 	for _, cidFile := range pauseCidFiles {
-		content, err := ioutil.ReadFile(cidFile)
+		content, err := os.ReadFile(cidFile)
 		if err != nil {
 			return fmt.Errorf("reading CIDFile: %w", err)
 		}

--- a/cmd/podman/containers/restart.go
+++ b/cmd/podman/containers/restart.go
@@ -3,7 +3,7 @@ package containers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
@@ -105,7 +105,7 @@ func restart(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, cidFile := range restartCidFiles {
-		content, err := ioutil.ReadFile(cidFile)
+		content, err := os.ReadFile(cidFile)
 		if err != nil {
 			return fmt.Errorf("reading CIDFile: %w", err)
 		}

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
@@ -108,7 +108,7 @@ func rm(cmd *cobra.Command, args []string) error {
 		rmOptions.Timeout = &stopTimeout
 	}
 	for _, cidFile := range rmCidFiles {
-		content, err := ioutil.ReadFile(cidFile)
+		content, err := os.ReadFile(cidFile)
 		if err != nil {
 			return fmt.Errorf("reading CIDFile: %w", err)
 		}

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -3,7 +3,7 @@ package containers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/containers/common/pkg/completion"
@@ -105,7 +105,7 @@ func stop(cmd *cobra.Command, args []string) error {
 		stopOptions.Timeout = &stopTimeout
 	}
 	for _, cidFile := range stopCidFiles {
-		content, err := ioutil.ReadFile(cidFile)
+		content, err := os.ReadFile(cidFile)
 		if err != nil {
 			return fmt.Errorf("reading CIDFile: %w", err)
 		}

--- a/cmd/podman/containers/unpause.go
+++ b/cmd/podman/containers/unpause.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/containers/common/pkg/cgroups"
@@ -99,7 +99,7 @@ func unpause(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, cidFile := range unpauseCidFiles {
-		content, err := ioutil.ReadFile(cidFile)
+		content, err := os.ReadFile(cidFile)
 		if err != nil {
 			return fmt.Errorf("reading CIDFile: %w", err)
 		}

--- a/cmd/podman/generate/spec.go
+++ b/cmd/podman/generate/spec.go
@@ -2,7 +2,7 @@ package generate
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/containers/common/pkg/completion"
 	"github.com/containers/podman/v4/cmd/podman/common"
@@ -59,7 +59,7 @@ func spec(cmd *cobra.Command, args []string) error {
 	// if we are looking to print the output, do not mess it up by printing the path
 	// if we are using -v the user probably expects to pipe the output somewhere else
 	if len(opts.FileName) > 0 {
-		err = ioutil.WriteFile(opts.FileName, report.Data, 0644)
+		err = os.WriteFile(opts.FileName, report.Data, 0644)
 		if err != nil {
 			return err
 		}

--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -635,7 +634,7 @@ func getDecryptConfig(decryptionKeys []string) (*encconfig.DecryptConfig, error)
 
 func parseDockerignore(ignoreFile string) ([]string, error) {
 	excludes := []string{}
-	ignore, err := ioutil.ReadFile(ignoreFile)
+	ignore, err := os.ReadFile(ignoreFile)
 	if err != nil {
 		return excludes, err
 	}

--- a/cmd/podman/images/import.go
+++ b/cmd/podman/images/import.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -116,7 +115,7 @@ func importCon(cmd *cobra.Command, args []string) error {
 	}
 
 	if source == "-" {
-		outFile, err := ioutil.TempFile("", "podman")
+		outFile, err := os.CreateTemp("", "podman")
 		if err != nil {
 			return fmt.Errorf("creating file %v", err)
 		}

--- a/cmd/podman/images/load.go
+++ b/cmd/podman/images/load.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -93,7 +92,7 @@ func load(cmd *cobra.Command, args []string) error {
 		if term.IsTerminal(int(os.Stdin.Fd())) {
 			return errors.New("cannot read from terminal, use command-line redirection or the --input flag")
 		}
-		outFile, err := ioutil.TempFile(util.Tmpdir(), "podman")
+		outFile, err := os.CreateTemp(util.Tmpdir(), "podman")
 		if err != nil {
 			return fmt.Errorf("creating file %v", err)
 		}

--- a/cmd/podman/images/utils_linux.go
+++ b/cmd/podman/images/utils_linux.go
@@ -3,7 +3,6 @@ package images
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -16,7 +15,7 @@ import (
 // the caller should use the returned function to clean up the pipeDir
 func setupPipe() (string, func() <-chan error, error) {
 	errc := make(chan error)
-	pipeDir, err := ioutil.TempDir(os.TempDir(), "pipeDir")
+	pipeDir, err := os.MkdirTemp(os.TempDir(), "pipeDir")
 	if err != nil {
 		return "", nil, err
 	}

--- a/cmd/podman/kube/generate.go
+++ b/cmd/podman/kube/generate.go
@@ -3,7 +3,6 @@ package kube
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/containers/common/pkg/completion"
@@ -77,7 +76,7 @@ func generateKube(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	content, err := ioutil.ReadAll(report.Reader)
+	content, err := io.ReadAll(report.Reader)
 	if err != nil {
 		return err
 	}
@@ -89,7 +88,7 @@ func generateKube(cmd *cobra.Command, args []string) error {
 		if _, err := os.Stat(generateFile); err == nil {
 			return fmt.Errorf("cannot write to %q; file exists", generateFile)
 		}
-		if err := ioutil.WriteFile(generateFile, content, 0644); err != nil {
+		if err := os.WriteFile(generateFile, content, 0644); err != nil {
 			return fmt.Errorf("cannot write to %q: %w", generateFile, err)
 		}
 		return nil

--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -284,7 +283,7 @@ func readerFromArg(fileName string) (*bytes.Reader, error) {
 		}
 		defer response.Body.Close()
 
-		data, err := ioutil.ReadAll(response.Body)
+		data, err := io.ReadAll(response.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -3,7 +3,6 @@ package manifest
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/containers/common/pkg/auth"
@@ -149,7 +148,7 @@ func push(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if manifestPushOpts.DigestFile != "" {
-		if err := ioutil.WriteFile(manifestPushOpts.DigestFile, []byte(digest), 0644); err != nil {
+		if err := os.WriteFile(manifestPushOpts.DigestFile, []byte(digest), 0644); err != nil {
 			return err
 		}
 	}

--- a/cmd/podman/parse/net_test.go
+++ b/cmd/podman/parse/net_test.go
@@ -3,7 +3,6 @@
 package parse
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -15,7 +14,7 @@ var (
 )
 
 func createTmpFile(content []byte) (string, error) {
-	tmpfile, err := ioutil.TempFile(os.TempDir(), "unittest")
+	tmpfile, err := os.CreateTemp(os.TempDir(), "unittest")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"sort"
@@ -300,7 +299,7 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(podIDFile) > 0 {
-		if err = ioutil.WriteFile(podIDFile, []byte(response.Id), 0644); err != nil {
+		if err = os.WriteFile(podIDFile, []byte(response.Id), 0644); err != nil {
 			return fmt.Errorf("failed to write pod ID to file: %w", err)
 		}
 	}

--- a/cmd/rootlessport/main.go
+++ b/cmd/rootlessport/main.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -50,7 +49,7 @@ func main() {
 }
 
 func loadConfig(r io.Reader) (*rootlessport.Config, io.ReadCloser, io.WriteCloser, error) {
-	stdin, err := ioutil.ReadAll(r)
+	stdin, err := io.ReadAll(r)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -92,7 +91,7 @@ func parent() error {
 	}
 
 	// create the parent driver
-	stateDir, err := ioutil.TempDir(cfg.TmpDir, "rootlessport")
+	stateDir, err := os.MkdirTemp(cfg.TmpDir, "rootlessport")
 	if err != nil {
 		return err
 	}
@@ -240,7 +239,7 @@ outer:
 
 	// wait for ExitFD to be closed
 	logrus.Info("Waiting for exitfd to be closed")
-	if _, err := ioutil.ReadAll(exitR); err != nil {
+	if _, err := io.ReadAll(exitR); err != nil {
 		return err
 	}
 	return nil
@@ -357,7 +356,7 @@ func child() error {
 	}()
 
 	// wait for stdin to be closed
-	if _, err := ioutil.ReadAll(os.Stdin); err != nil {
+	if _, err := io.ReadAll(os.Stdin); err != nil {
 		return err
 	}
 	return nil

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -3,7 +3,7 @@ package libpod
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -351,7 +351,7 @@ func (c *Container) specFromState() (*spec.Spec, error) {
 
 	if f, err := os.Open(c.state.ConfigPath); err == nil {
 		returnSpec = new(spec.Spec)
-		content, err := ioutil.ReadAll(f)
+		content, err := io.ReadAll(f)
 		if err != nil {
 			return nil, fmt.Errorf("reading container config: %w", err)
 		}
@@ -990,7 +990,7 @@ func (c *Container) cGroupPath() (string, error) {
 	// the lookup.
 	// See #10602 for more details.
 	procPath := fmt.Sprintf("/proc/%d/cgroup", c.state.PID)
-	lines, err := ioutil.ReadFile(procPath)
+	lines, err := os.ReadFile(procPath)
 	if err != nil {
 		// If the file doesn't exist, it means the container could have been terminated
 		// so report it.

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"sync"
@@ -479,7 +478,7 @@ func (c *Container) AddArtifact(name string, data []byte) error {
 		return define.ErrCtrRemoved
 	}
 
-	return ioutil.WriteFile(c.getArtifactPath(name), data, 0o740)
+	return os.WriteFile(c.getArtifactPath(name), data, 0o740)
 }
 
 // GetArtifact reads the specified artifact file from the container
@@ -488,7 +487,7 @@ func (c *Container) GetArtifact(name string) ([]byte, error) {
 		return nil, define.ErrCtrRemoved
 	}
 
-	return ioutil.ReadFile(c.getArtifactPath(name))
+	return os.ReadFile(c.getArtifactPath(name))
 }
 
 // RemoveArtifact deletes the specified artifacts file

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -928,7 +927,7 @@ func (c *Container) readExecExitCode(sessionID string) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	ec, err := ioutil.ReadFile(exitFile)
+	ec, err := os.ReadFile(exitFile)
 	if err != nil {
 		return -1, err
 	}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -201,7 +200,7 @@ func (c *Container) waitForExitFileAndSync() error {
 // This assumes the exit file already exists.
 func (c *Container) handleExitFile(exitFile string, fi os.FileInfo) error {
 	c.state.FinishedTime = ctime.Created(fi)
-	statusCodeStr, err := ioutil.ReadFile(exitFile)
+	statusCodeStr, err := os.ReadFile(exitFile)
 	if err != nil {
 		return fmt.Errorf("failed to read exit file for container %s: %w", c.ID(), err)
 	}
@@ -2089,7 +2088,7 @@ func (c *Container) saveSpec(spec *spec.Spec) error {
 	if err != nil {
 		return fmt.Errorf("exporting runtime spec for container %s to JSON: %w", c.ID(), err)
 	}
-	if err := ioutil.WriteFile(jsonPath, fileJSON, 0644); err != nil {
+	if err := os.WriteFile(jsonPath, fileJSON, 0644); err != nil {
 		return fmt.Errorf("writing runtime spec JSON for container %s to disk: %w", c.ID(), err)
 	}
 
@@ -2343,7 +2342,7 @@ func (c *Container) extractSecretToCtrStorage(secr *ContainerSecret) error {
 	if err != nil {
 		return fmt.Errorf("unable to extract secret: %w", err)
 	}
-	err = ioutil.WriteFile(secretFile, data, 0644)
+	err = os.WriteFile(secretFile, data, 0644)
 	if err != nil {
 		return fmt.Errorf("unable to create %s: %w", secretFile, err)
 	}

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"os/user"
@@ -788,7 +787,7 @@ func (c *Container) createCheckpointImage(ctx context.Context, options Container
 	}
 
 	// Export checkpoint into temporary tar file
-	tmpDir, err := ioutil.TempDir("", "checkpoint_image_")
+	tmpDir, err := os.MkdirTemp("", "checkpoint_image_")
 	if err != nil {
 		return err
 	}
@@ -2442,7 +2441,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 			if err != nil {
 				return "", "", fmt.Errorf("creating path to container %s /etc/passwd: %w", c.ID(), err)
 			}
-			orig, err := ioutil.ReadFile(originPasswdFile)
+			orig, err := os.ReadFile(originPasswdFile)
 			if err != nil && !os.IsNotExist(err) {
 				return "", "", err
 			}
@@ -2488,7 +2487,7 @@ func (c *Container) generatePasswdAndGroup() (string, string, error) {
 			if err != nil {
 				return "", "", fmt.Errorf("creating path to container %s /etc/group: %w", c.ID(), err)
 			}
-			orig, err := ioutil.ReadFile(originGroupFile)
+			orig, err := os.ReadFile(originGroupFile)
 			if err != nil && !os.IsNotExist(err) {
 				return "", "", err
 			}

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -3,7 +3,7 @@ package libpod
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -60,7 +60,7 @@ func TestPostDeleteHooks(t *testing.T) {
 	for _, p := range []string{statePath, copyPath} {
 		path := p
 		t.Run(path, func(t *testing.T) {
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -204,11 +203,11 @@ func truncate(filePath string) error {
 	size := origFinfo.Size()
 	threshold := size / 2
 
-	tmp, err := ioutil.TempFile(path.Dir(filePath), "")
+	tmp, err := os.CreateTemp(path.Dir(filePath), "")
 	if err != nil {
 		// Retry in /tmp in case creating a tmp file in the same
 		// directory has failed.
-		tmp, err = ioutil.TempFile("", "")
+		tmp, err = os.CreateTemp("", "")
 		if err != nil {
 			return err
 		}

--- a/libpod/events/logfile_test.go
+++ b/libpod/events/logfile_test.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestRotateLog(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tmp, err := ioutil.TempFile("", "log-rotation-")
+		tmp, err := os.CreateTemp("", "log-rotation-")
 		require.NoError(t, err)
 		defer os.Remove(tmp.Name())
 		defer tmp.Close()
@@ -84,7 +83,7 @@ func TestTruncationOutput(t *testing.T) {
 10
 `
 	// Create dummy file
-	tmp, err := ioutil.TempFile("", "log-rotation")
+	tmp, err := os.CreateTemp("", "log-rotation")
 	require.NoError(t, err)
 	defer os.Remove(tmp.Name())
 	defer tmp.Close()
@@ -94,11 +93,11 @@ func TestTruncationOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	// Truncate the file
-	beforeTruncation, err := ioutil.ReadFile(tmp.Name())
+	beforeTruncation, err := os.ReadFile(tmp.Name())
 	require.NoError(t, err)
 	err = truncate(tmp.Name())
 	require.NoError(t, err)
-	afterTruncation, err := ioutil.ReadFile(tmp.Name())
+	afterTruncation, err := os.ReadFile(tmp.Name())
 	require.NoError(t, err)
 
 	// Test if rotation was successful
@@ -116,9 +115,9 @@ func TestRenameLog(t *testing.T) {
 5
 `
 	// Create two dummy files
-	source, err := ioutil.TempFile("", "removing")
+	source, err := os.CreateTemp("", "removing")
 	require.NoError(t, err)
-	target, err := ioutil.TempFile("", "renaming")
+	target, err := os.CreateTemp("", "renaming")
 	require.NoError(t, err)
 
 	// Write to source dummy file
@@ -126,11 +125,11 @@ func TestRenameLog(t *testing.T) {
 	require.NoError(t, err)
 
 	// Rename the files
-	beforeRename, err := ioutil.ReadFile(source.Name())
+	beforeRename, err := os.ReadFile(source.Name())
 	require.NoError(t, err)
 	err = renameLog(source.Name(), target.Name())
 	require.NoError(t, err)
-	afterRename, err := ioutil.ReadFile(target.Name())
+	afterRename, err := os.ReadFile(target.Name())
 	require.NoError(t, err)
 
 	// Test if renaming was successful

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -208,7 +207,7 @@ func (c *Container) updateHealthStatus(status string) error {
 	if err != nil {
 		return fmt.Errorf("unable to marshall healthchecks for writing status: %w", err)
 	}
-	return ioutil.WriteFile(c.healthCheckLogPath(), newResults, 0700)
+	return os.WriteFile(c.healthCheckLogPath(), newResults, 0700)
 }
 
 // UpdateHealthCheckLog parses the health check results and writes the log
@@ -242,7 +241,7 @@ func (c *Container) updateHealthCheckLog(hcl define.HealthCheckLog, inStartPerio
 	if err != nil {
 		return fmt.Errorf("unable to marshall healthchecks for writing: %w", err)
 	}
-	return ioutil.WriteFile(c.healthCheckLogPath(), newResults, 0700)
+	return os.WriteFile(c.healthCheckLogPath(), newResults, 0700)
 }
 
 // HealthCheckLogPath returns the path for where the health check log is
@@ -259,7 +258,7 @@ func (c *Container) getHealthCheckLog() (define.HealthCheckResults, error) {
 	if _, err := os.Stat(c.healthCheckLogPath()); os.IsNotExist(err) {
 		return healthCheck, nil
 	}
-	b, err := ioutil.ReadFile(c.healthCheckLogPath())
+	b, err := os.ReadFile(c.healthCheckLogPath())
 	if err != nil {
 		return healthCheck, fmt.Errorf("failed to read health check log file: %w", err)
 	}

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -303,7 +302,7 @@ func (r *RootlessNetNS) Cleanup(runtime *Runtime) error {
 	if err != nil {
 		logrus.Error(err)
 	}
-	b, err := ioutil.ReadFile(r.getPath(rootlessNetNsSilrp4netnsPidFile))
+	b, err := os.ReadFile(r.getPath(rootlessNetNsSilrp4netnsPidFile))
 	if err == nil {
 		var i int
 		i, err = strconv.Atoi(string(b))
@@ -445,7 +444,7 @@ func (r *Runtime) GetRootlessNetNs(new bool) (*RootlessNetNS, error) {
 		// create pid file for the slirp4netns process
 		// this is need to kill the process in the cleanup
 		pid := strconv.Itoa(cmd.Process.Pid)
-		err = ioutil.WriteFile(filepath.Join(rootlessNetNsDir, rootlessNetNsSilrp4netnsPidFile), []byte(pid), 0700)
+		err = os.WriteFile(filepath.Join(rootlessNetNsDir, rootlessNetNsSilrp4netnsPidFile), []byte(pid), 0700)
 		if err != nil {
 			return nil, fmt.Errorf("unable to write rootless-netns slirp4netns pid file: %w", err)
 		}

--- a/libpod/networking_machine.go
+++ b/libpod/networking_machine.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strconv"
@@ -109,7 +108,7 @@ func makeMachineRequest(ctx context.Context, client *http.Client, url string, bu
 }
 
 func annotateGvproxyResponseError(r io.Reader) error {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err == nil && len(b) > 0 {
 		return fmt.Errorf("something went wrong with the request: %q", string(b))
 	}

--- a/libpod/networking_slirp4netns.go
+++ b/libpod/networking_slirp4netns.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -324,7 +323,7 @@ func (r *Runtime) setupSlirp4netns(ctr *Container, netns ns.NetNS) error {
 				// correct value assigned so DAD is disabled for it
 				// Also make sure to change this value back to the original after slirp4netns
 				// is ready in case users rely on this sysctl.
-				orgValue, err := ioutil.ReadFile(ipv6ConfDefaultAcceptDadSysctl)
+				orgValue, err := os.ReadFile(ipv6ConfDefaultAcceptDadSysctl)
 				if err != nil {
 					netnsReadyWg.Done()
 					// on ipv6 disabled systems the sysctl does not exists
@@ -334,7 +333,7 @@ func (r *Runtime) setupSlirp4netns(ctr *Container, netns ns.NetNS) error {
 					}
 					return err
 				}
-				err = ioutil.WriteFile(ipv6ConfDefaultAcceptDadSysctl, []byte("0"), 0644)
+				err = os.WriteFile(ipv6ConfDefaultAcceptDadSysctl, []byte("0"), 0644)
 				netnsReadyWg.Done()
 				if err != nil {
 					return err
@@ -342,7 +341,7 @@ func (r *Runtime) setupSlirp4netns(ctr *Container, netns ns.NetNS) error {
 
 				// wait until slirp4nets is ready before resetting this value
 				slirpReadyWg.Wait()
-				return ioutil.WriteFile(ipv6ConfDefaultAcceptDadSysctl, orgValue, 0644)
+				return os.WriteFile(ipv6ConfDefaultAcceptDadSysctl, orgValue, 0644)
 			})
 			if err != nil {
 				logrus.Warnf("failed to set net.ipv6.conf.default.accept_dad sysctl: %v", err)
@@ -486,7 +485,7 @@ func waitForSync(syncR *os.File, cmd *exec.Cmd, logFile io.ReadSeeker, timeout t
 					if _, err := logFile.Seek(0, 0); err != nil {
 						logrus.Errorf("Could not seek log file: %q", err)
 					}
-					logContent, err := ioutil.ReadAll(logFile)
+					logContent, err := io.ReadAll(logFile)
 					if err != nil {
 						return fmt.Errorf("%s failed: %w", prog, err)
 					}
@@ -730,7 +729,7 @@ func (c *Container) reloadRootlessRLKPortMapping() error {
 	if err != nil {
 		return fmt.Errorf("port reloading failed: %w", err)
 	}
-	b, err := ioutil.ReadAll(conn)
+	b, err := io.ReadAll(conn)
 	if err != nil {
 		return fmt.Errorf("port reloading failed: %w", err)
 	}

--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -232,7 +231,7 @@ func (r *ConmonOCIRuntime) UpdateContainerStatus(ctr *Container) error {
 	}
 
 	if err := cmd.Start(); err != nil {
-		out, err2 := ioutil.ReadAll(errPipe)
+		out, err2 := io.ReadAll(errPipe)
 		if err2 != nil {
 			return fmt.Errorf("getting container %s state: %w", ctr.ID(), err)
 		}
@@ -254,7 +253,7 @@ func (r *ConmonOCIRuntime) UpdateContainerStatus(ctr *Container) error {
 	if err := errPipe.Close(); err != nil {
 		return err
 	}
-	out, err := ioutil.ReadAll(outPipe)
+	out, err := io.ReadAll(outPipe)
 	if err != nil {
 		return fmt.Errorf("reading stdout: %s: %w", ctr.ID(), err)
 	}
@@ -335,7 +334,7 @@ func generateResourceFile(res *spec.LinuxResources) (string, []string, error) {
 		return "", flags, nil
 	}
 
-	f, err := ioutil.TempFile("", "podman")
+	f, err := os.CreateTemp("", "podman")
 	if err != nil {
 		return "", nil, err
 	}
@@ -1398,7 +1397,7 @@ func newPipe() (*os.File, *os.File, error) {
 func readConmonPidFile(pidFile string) (int, error) {
 	// Let's try reading the Conmon pid at the same time.
 	if pidFile != "" {
-		contents, err := ioutil.ReadFile(pidFile)
+		contents, err := os.ReadFile(pidFile)
 		if err != nil {
 			return -1, err
 		}
@@ -1447,7 +1446,7 @@ func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, 
 	case ss := <-ch:
 		if ss.err != nil {
 			if ociLog != "" {
-				ociLogData, err := ioutil.ReadFile(ociLog)
+				ociLogData, err := os.ReadFile(ociLog)
 				if err == nil {
 					var ociErr ociError
 					if err := json.Unmarshal(ociLogData, &ociErr); err == nil {
@@ -1460,7 +1459,7 @@ func readConmonPipeData(runtimeName string, pipe *os.File, ociLog string) (int, 
 		logrus.Debugf("Received: %d", ss.si.Data)
 		if ss.si.Data < 0 {
 			if ociLog != "" {
-				ociLogData, err := ioutil.ReadFile(ociLog)
+				ociLogData, err := os.ReadFile(ociLog)
 				if err == nil {
 					var ociErr ociError
 					if err := json.Unmarshal(ociLogData, &ociErr); err == nil {

--- a/libpod/oci_conmon_exec_common.go
+++ b/libpod/oci_conmon_exec_common.go
@@ -3,7 +3,6 @@ package libpod
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -665,7 +664,7 @@ func attachExecHTTP(c *Container, sessionID string, r *http.Request, w http.Resp
 // prepareProcessExec returns the path of the process.json used in runc exec -p
 // caller is responsible to close the returned *os.File if needed.
 func (c *Container) prepareProcessExec(options *ExecOptions, env []string, sessionID string) (*os.File, error) {
-	f, err := ioutil.TempFile(c.execBundlePath(sessionID), "exec-process-")
+	f, err := os.CreateTemp(c.execBundlePath(sessionID), "exec-process-")
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +763,7 @@ func (c *Container) prepareProcessExec(options *ExecOptions, env []string, sessi
 		return nil, err
 	}
 
-	if err := ioutil.WriteFile(f.Name(), processJSON, 0644); err != nil {
+	if err := os.WriteFile(f.Name(), processJSON, 0644); err != nil {
 		return nil, err
 	}
 	return f, nil

--- a/libpod/plugin/volume_api.go
+++ b/libpod/plugin/volume_api.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -95,7 +95,7 @@ func validatePlugin(newPlugin *VolumePlugin) error {
 	}
 
 	// Read and decode the body so we can tell if this is a volume plugin.
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("reading activation response body from plugin %s: %w", newPlugin.Name, err)
 	}
@@ -252,7 +252,7 @@ func (p *VolumePlugin) handleErrorResponse(resp *http.Response, endpoint, volNam
 	// Let's interpret anything other than 200 as an error.
 	// If there isn't an error, don't even bother decoding the response.
 	if resp.StatusCode != 200 {
-		errResp, err := ioutil.ReadAll(resp.Body)
+		errResp, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("reading response body from volume plugin %s: %w", p.Name, err)
 		}
@@ -307,7 +307,7 @@ func (p *VolumePlugin) ListVolumes() ([]*volume.Volume, error) {
 		return nil, err
 	}
 
-	volumeRespBytes, err := ioutil.ReadAll(resp.Body)
+	volumeRespBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading response body from volume plugin %s: %w", p.Name, err)
 	}
@@ -342,7 +342,7 @@ func (p *VolumePlugin) GetVolume(req *volume.GetRequest) (*volume.Volume, error)
 		return nil, err
 	}
 
-	getRespBytes, err := ioutil.ReadAll(resp.Body)
+	getRespBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading response body from volume plugin %s: %w", p.Name, err)
 	}
@@ -398,7 +398,7 @@ func (p *VolumePlugin) GetVolumePath(req *volume.PathRequest) (string, error) {
 		return "", err
 	}
 
-	pathRespBytes, err := ioutil.ReadAll(resp.Body)
+	pathRespBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("reading response body from volume plugin %s: %w", p.Name, err)
 	}
@@ -435,7 +435,7 @@ func (p *VolumePlugin) MountVolume(req *volume.MountRequest) (string, error) {
 		return "", err
 	}
 
-	mountRespBytes, err := ioutil.ReadAll(resp.Body)
+	mountRespBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("reading response body from volume plugin %s: %w", p.Name, err)
 	}

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	buildahDefine "github.com/containers/buildah/define"
@@ -105,7 +104,7 @@ func (r *Runtime) Build(ctx context.Context, options buildahDefine.BuildOptions,
 // DownloadFromFile reads all of the content from the reader and temporarily
 // saves in it $TMPDIR/importxyz, which is deleted after the image is imported
 func DownloadFromFile(reader *os.File) (string, error) {
-	outFile, err := ioutil.TempFile(util.Tmpdir(), "import")
+	outFile, err := os.CreateTemp(util.Tmpdir(), "import")
 	if err != nil {
 		return "", fmt.Errorf("creating file: %w", err)
 	}

--- a/libpod/runtime_migrate.go
+++ b/libpod/runtime_migrate.go
@@ -5,7 +5,6 @@ package libpod
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -23,7 +22,7 @@ func (r *Runtime) stopPauseProcess() error {
 		if err != nil {
 			return fmt.Errorf("could not get pause process pid file path: %w", err)
 		}
-		data, err := ioutil.ReadFile(pausePidPath)
+		data, err := os.ReadFile(pausePidPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -1,7 +1,6 @@
 package libpod
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,7 +34,7 @@ var (
 
 // Get an empty BoltDB state for use in tests
 func getEmptyBoltState() (_ State, _ string, _ lock.Manager, retErr error) {
-	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	tmpDir, err := os.MkdirTemp("", tmpDirPrefix)
 	if err != nil {
 		return nil, "", nil, err
 	}

--- a/pkg/api/handlers/compat/containers_export.go
+++ b/pkg/api/handlers/compat/containers_export.go
@@ -2,7 +2,6 @@ package compat
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -19,7 +18,7 @@ func ExportContainer(w http.ResponseWriter, r *http.Request) {
 		utils.ContainerNotFound(w, name, err)
 		return
 	}
-	tmpfile, err := ioutil.TempFile("", "api.tar")
+	tmpfile, err := os.CreateTemp("", "api.tar")
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 		return

--- a/pkg/api/handlers/compat/images.go
+++ b/pkg/api/handlers/compat/images.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -49,7 +48,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 	// 500 server
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 
-	tmpfile, err := ioutil.TempFile("", "api.tar")
+	tmpfile, err := os.CreateTemp("", "api.tar")
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 		return
@@ -193,7 +192,7 @@ func CreateImageFromSrc(w http.ResponseWriter, r *http.Request) {
 	// fromSrc – Source to import. The value may be a URL from which the image can be retrieved or - to read the image from the request body. This parameter may only be used when importing an image.
 	source := query.FromSrc
 	if source == "-" {
-		f, err := ioutil.TempFile("", "api_load.tar")
+		f, err := os.CreateTemp("", "api_load.tar")
 		if err != nil {
 			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to create tempfile: %w", err))
 			return
@@ -480,7 +479,7 @@ func LoadImages(w http.ResponseWriter, r *http.Request) {
 
 	// First write the body to a temporary file that we can later attempt
 	// to load.
-	f, err := ioutil.TempFile("", "api_load.tar")
+	f, err := os.CreateTemp("", "api_load.tar")
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("failed to create tempfile: %w", err))
 		return
@@ -547,7 +546,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 		images[i] = possiblyNormalizedName
 	}
 
-	tmpfile, err := ioutil.TempFile("", "api.tar")
+	tmpfile, err := os.CreateTemp("", "api.tar")
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 		return

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -182,7 +181,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	dockerFileSet := false
 	if utils.IsLibpodRequest(r) && query.Remote != "" {
 		// The context directory could be a URL.  Try to handle that.
-		anchorDir, err := ioutil.TempDir(parse.GetTempDir(), "libpod_builder")
+		anchorDir, err := os.MkdirTemp(parse.GetTempDir(), "libpod_builder")
 		if err != nil {
 			utils.InternalServerError(w, err)
 		}
@@ -730,7 +729,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		if v, found := os.LookupEnv("PODMAN_RETAIN_BUILD_ARTIFACT"); found {
 			if keep, _ := strconv.ParseBool(v); keep {
-				t, _ := ioutil.TempFile("", "build_*_server")
+				t, _ := os.CreateTemp("", "build_*_server")
 				defer t.Close()
 				body = io.MultiWriter(t, w)
 			}
@@ -852,7 +851,7 @@ func parseLibPodIsolation(isolation string) (buildah.Isolation, error) {
 
 func extractTarFile(r *http.Request) (string, error) {
 	// build a home for the request body
-	anchorDir, err := ioutil.TempDir("", "libpod_builder")
+	anchorDir, err := os.MkdirTemp("", "libpod_builder")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/api/handlers/compat/images_push.go
+++ b/pkg/api/handlers/compat/images_push.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/containers/image/v5/types"
@@ -26,7 +27,7 @@ func PushImage(w http.ResponseWriter, r *http.Request) {
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 
-	digestFile, err := ioutil.TempFile("", "digest.txt")
+	digestFile, err := os.CreateTemp("", "digest.txt")
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 		return
@@ -186,7 +187,7 @@ loop: // break out of for/select infinite loop
 				break loop
 			}
 
-			digestBytes, err := ioutil.ReadAll(digestFile)
+			digestBytes, err := io.ReadAll(digestFile)
 			if err != nil {
 				report.Error = &jsonmessage.JSONError{
 					Message: err.Error(),

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -248,7 +247,7 @@ func Checkpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if query.Export {
-		f, err := ioutil.TempFile("", "checkpoint")
+		f, err := os.CreateTemp("", "checkpoint")
 		if err != nil {
 			utils.InternalServerError(w, err)
 			return
@@ -329,7 +328,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 
 	var names []string
 	if query.Import {
-		t, err := ioutil.TempFile("", "restore")
+		t, err := os.CreateTemp("", "restore")
 		if err != nil {
 			utils.InternalServerError(w, err)
 			return

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -182,7 +181,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 
 	switch query.Format {
 	case define.OCIArchive, define.V2s2Archive:
-		tmpfile, err := ioutil.TempFile("", "api.tar")
+		tmpfile, err := os.CreateTemp("", "api.tar")
 		if err != nil {
 			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 			return
@@ -193,7 +192,7 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case define.OCIManifestDir, define.V2s2ManifestDir:
-		tmpdir, err := ioutil.TempDir("", "save")
+		tmpdir, err := os.MkdirTemp("", "save")
 		if err != nil {
 			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempdir: %w", err))
 			return
@@ -279,7 +278,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 
 	switch query.Format {
 	case define.V2s2Archive, define.OCIArchive:
-		tmpfile, err := ioutil.TempFile("", "api.tar")
+		tmpfile, err := os.CreateTemp("", "api.tar")
 		if err != nil {
 			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 			return
@@ -290,7 +289,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case define.OCIManifestDir, define.V2s2ManifestDir:
-		tmpdir, err := ioutil.TempDir("", "save")
+		tmpdir, err := os.MkdirTemp("", "save")
 		if err != nil {
 			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tmpdir: %w", err))
 			return
@@ -329,7 +328,7 @@ func ExportImages(w http.ResponseWriter, r *http.Request) {
 func ImagesLoad(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 
-	tmpfile, err := ioutil.TempFile("", "libpod-images-load.tar")
+	tmpfile, err := os.CreateTemp("", "libpod-images-load.tar")
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 		return
@@ -378,7 +377,7 @@ func ImagesImport(w http.ResponseWriter, r *http.Request) {
 	// Check if we need to load the image from a URL or from the request's body.
 	source := query.URL
 	if len(query.URL) == 0 {
-		tmpfile, err := ioutil.TempFile("", "libpod-images-import.tar")
+		tmpfile, err := os.CreateTemp("", "libpod-images-import.tar")
 		if err != nil {
 			utils.Error(w, http.StatusInternalServerError, fmt.Errorf("unable to create tempfile: %w", err))
 			return

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -83,7 +83,7 @@ func ManifestCreate(w http.ResponseWriter, r *http.Request) {
 		status = http.StatusCreated
 	}
 
-	buffer, err := ioutil.ReadAll(r.Body)
+	buffer, err := io.ReadAll(r.Body)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/api/server/handler_logging.go
+++ b/pkg/api/server/handler_logging.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -41,7 +40,7 @@ func loggingHandler() mux.MiddlewareFunc {
 				"API":            "request",
 				"X-Reference-Id": r.Header.Get("X-Reference-Id"),
 			})
-			r.Body = ioutil.NopCloser(
+			r.Body = io.NopCloser(
 				io.TeeReader(r.Body, annotated.WriterLevel(logrus.TraceLevel)))
 
 			w = responseWriter{ResponseWriter: w}

--- a/pkg/api/server/handler_rid.go
+++ b/pkg/api/server/handler_rid.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/containers/podman/v4/pkg/api/types"
@@ -17,7 +17,7 @@ import (
 func referenceIDHandler() mux.MiddlewareFunc {
 	return func(h http.Handler) http.Handler {
 		// Only log Apache access_log-like entries at Info level or below
-		out := ioutil.Discard
+		out := io.Discard
 		if logrus.IsLevelEnabled(logrus.InfoLevel) {
 			out = logrus.StandardLogger().Out
 		}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -233,7 +232,7 @@ func encodeMultiAuthConfigs(authConfigs map[string]types.DockerAuthConfig) (stri
 // TMPDIR will be used.
 func authConfigsToAuthFile(authConfigs map[string]types.DockerAuthConfig) (string, error) {
 	// Initialize an empty temporary JSON file.
-	tmpFile, err := ioutil.TempFile("", "auth.json.")
+	tmpFile, err := os.CreateTemp("", "auth.json.")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -37,10 +36,10 @@ func systemContextForAuthFile(t *testing.T, fileContents string) (*types.SystemC
 		return nil, func() {}
 	}
 
-	f, err := ioutil.TempFile("", "auth.json")
+	f, err := os.CreateTemp("", "auth.json")
 	require.NoError(t, err)
 	path := f.Name()
-	err = ioutil.WriteFile(path, []byte(fileContents), 0700)
+	err = os.WriteFile(path, []byte(fileContents), 0700)
 	require.NoError(t, err)
 	return &types.SystemContext{AuthFilePath: path}, func() { os.Remove(path) }
 }
@@ -347,7 +346,7 @@ func TestAuthConfigsToAuthFile(t *testing.T) {
 			assert.Empty(t, filePath)
 		} else {
 			assert.NoError(t, err)
-			content, err := ioutil.ReadFile(filePath)
+			content, err := os.ReadFile(filePath)
 			require.NoError(t, err)
 			assert.Contains(t, string(content), tc.expectedContains)
 			os.Remove(filePath)

--- a/pkg/bindings/errors.go
+++ b/pkg/bindings/errors.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/containers/podman/v4/pkg/errorhandling"
 )
@@ -29,7 +29,7 @@ func (h APIResponse) Process(unmarshalInto interface{}) error {
 // ProcessWithError drains the response body, and processes the HTTP status code
 // Note: Closing the response.Body is left to the caller
 func (h APIResponse) ProcessWithError(unmarshalInto interface{}, unmarshalErrorInto interface{}) error {
-	data, err := ioutil.ReadAll(h.Response.Body)
+	data, err := io.ReadAll(h.Response.Body)
 	if err != nil {
 		return fmt.Errorf("unable to process API response: %w", err)
 	}

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -257,7 +256,7 @@ func Modify(ctx context.Context, name string, images []string, options *ModifyOp
 	}
 	defer response.Body.Close()
 
-	data, err := ioutil.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", fmt.Errorf("unable to process API response: %w", err)
 	}

--- a/pkg/checkpoint/checkpoint_restore.go
+++ b/pkg/checkpoint/checkpoint_restore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	metadata "github.com/checkpoint-restore/checkpointctl/lib"
@@ -26,7 +25,7 @@ import (
 func CRImportCheckpointTar(ctx context.Context, runtime *libpod.Runtime, restoreOptions entities.RestoreOptions) ([]*libpod.Container, error) {
 	// First get the container definition from the
 	// tarball to a temporary directory
-	dir, err := ioutil.TempDir("", "checkpoint")
+	dir, err := os.MkdirTemp("", "checkpoint")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/checkpoint/crutils/checkpoint_restore_utils.go
+++ b/pkg/checkpoint/crutils/checkpoint_restore_utils.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -237,7 +236,7 @@ func CRRuntimeSupportsPodCheckpointRestore(runtimePath string) bool {
 // given checkpoint archive and returns the runtime used to create
 // the given checkpoint archive.
 func CRGetRuntimeFromArchive(input string) (*string, error) {
-	dir, err := ioutil.TempDir("", "checkpoint")
+	dir, err := os.MkdirTemp("", "checkpoint")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ctime/ctime_test.go
+++ b/pkg/ctime/ctime_test.go
@@ -1,7 +1,6 @@
 package ctime
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -10,13 +9,13 @@ import (
 func TestCreated(t *testing.T) {
 	before := time.Now()
 
-	fileA, err := ioutil.TempFile("", "ctime-test-")
+	fileA, err := os.CreateTemp("", "ctime-test-")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(fileA.Name())
 
-	fileB, err := ioutil.TempFile("", "ctime-test-")
+	fileB, err := os.CreateTemp("", "ctime-test-")
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -340,7 +339,7 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 				return err
 			}
 
-			if err := ioutil.WriteFile(options.DigestFile, []byte(manifestDigest.String()), 0644); err != nil {
+			if err := os.WriteFile(options.DigestFile, []byte(manifestDigest.String()), 0644); err != nil {
 				return err
 			}
 		}
@@ -910,5 +909,5 @@ func putSignature(manifestBlob []byte, mech signature.SigningMechanism, sigStore
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(signatureDir, sigFilename), newSig, 0644)
+	return os.WriteFile(filepath.Join(signatureDir, sigFilename), newSig, 0644)
 }

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -116,7 +115,7 @@ func (ic *ContainerEngine) PlayKube(ctx context.Context, body io.Reader, options
 	validKinds := 0
 
 	// read yaml document
-	content, err := ioutil.ReadAll(body)
+	content, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err
 	}
@@ -873,7 +872,7 @@ func (ic *ContainerEngine) playKubePVC(ctx context.Context, pvcYAML *v1.Persiste
 func readConfigMapFromFile(r io.Reader) (v1.ConfigMap, error) {
 	var cm v1.ConfigMap
 
-	content, err := ioutil.ReadAll(r)
+	content, err := io.ReadAll(r)
 	if err != nil {
 		return cm, fmt.Errorf("unable to read ConfigMap YAML content: %w", err)
 	}
@@ -1005,7 +1004,7 @@ func (ic *ContainerEngine) PlayKubeDown(ctx context.Context, body io.Reader, _ e
 	reports := new(entities.PlayKubeReport)
 
 	// read yaml document
-	content, err := ioutil.ReadAll(body)
+	content, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/infra/abi/secrets.go
+++ b/pkg/domain/infra/abi/secrets.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 
@@ -14,7 +13,7 @@ import (
 )
 
 func (ic *ContainerEngine) SecretCreate(ctx context.Context, name string, reader io.Reader, options entities.SecretCreateOptions) (*entities.SecretCreateReport, error) {
-	data, _ := ioutil.ReadAll(reader)
+	data, _ := io.ReadAll(reader)
 	secretsPath := ic.Libpod.GetSecretsStorageDir()
 	manager, err := ic.Libpod.SecretsManager()
 	if err != nil {

--- a/pkg/domain/infra/abi/trust.go
+++ b/pkg/domain/infra/abi/trust.go
@@ -3,7 +3,7 @@ package abi
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/containers/podman/v4/pkg/domain/entities"
 	"github.com/containers/podman/v4/pkg/trust"
@@ -18,7 +18,7 @@ func (ir *ImageEngine) ShowTrust(ctx context.Context, args []string, options ent
 	if len(options.PolicyPath) > 0 {
 		policyPath = options.PolicyPath
 	}
-	report.Raw, err = ioutil.ReadFile(policyPath)
+	report.Raw, err = os.ReadFile(policyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -264,7 +263,7 @@ func (ir *ImageEngine) Save(ctx context.Context, nameOrID string, tags []string,
 
 	switch opts.Format {
 	case "oci-dir", "docker-dir":
-		f, err = ioutil.TempFile("", "podman_save")
+		f, err = os.CreateTemp("", "podman_save")
 		if err == nil {
 			defer func() { _ = os.Remove(f.Name()) }()
 		}

--- a/pkg/domain/utils/scp.go
+++ b/pkg/domain/utils/scp.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -29,7 +28,7 @@ func ExecuteTransfer(src, dst string, parentFlags []string, quiet bool, sshMode 
 		return nil, nil, nil, nil, err
 	}
 
-	f, err := ioutil.TempFile("", "podman") // open temp file for load/save output
+	f, err := os.CreateTemp("", "podman") // open temp file for load/save output
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -5,7 +5,6 @@ package machine
 
 import (
 	"errors"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -283,7 +282,7 @@ func (m *VMFile) Delete() error {
 
 // Read the contents of a given file and return in []bytes
 func (m *VMFile) Read() ([]byte, error) {
-	return ioutil.ReadFile(m.GetPath())
+	return os.ReadFile(m.GetPath())
 }
 
 // NewMachineFile is a constructor for VMFile

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -1,7 +1,6 @@
 package e2e_test
 
 import (
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -138,9 +137,9 @@ var _ = Describe("podman machine init", func() {
 	})
 
 	It("machine init with volume", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
-		_, err = ioutil.TempFile(tmpDir, "example")
+		_, err = os.CreateTemp(tmpDir, "example")
 		Expect(err).To(BeNil())
 		mount := tmpDir + ":/testmountdir"
 		defer os.RemoveAll(tmpDir)

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -3,7 +3,6 @@ package e2e_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	url2 "net/url"
 	"os"
 	"path"
@@ -77,7 +76,7 @@ var _ = SynchronizedAfterSuite(func() {},
 
 func setup() (string, *machineTestBuilder) {
 	// Set TMPDIR if this needs a new directory
-	homeDir, err := ioutil.TempDir("", "podman_test")
+	homeDir, err := os.MkdirTemp("", "podman_test")
 	if err != nil {
 		Fail(fmt.Sprintf("failed to create home directory: %q", err))
 	}

--- a/pkg/machine/fcos.go
+++ b/pkg/machine/fcos.go
@@ -6,7 +6,7 @@ package machine
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	url2 "net/url"
 	"os"
@@ -175,7 +175,7 @@ func GetFCOSDownload(imageStream string) (*FcosDownloadInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -227,7 +226,7 @@ WantedBy=sysinit.target
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(ign.WritePath, b, 0644)
+	return os.WriteFile(ign.WritePath, b, 0644)
 }
 
 func getDirs(usrName string) []Directory {
@@ -559,7 +558,7 @@ func getCerts(certsDir string, isDir bool) []File {
 }
 
 func prepareCertFile(path string, name string) (File, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		logrus.Warnf("Unable to read cert file %v", err)
 		return File{}, err

--- a/pkg/machine/keys.go
+++ b/pkg/machine/keys.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,7 +26,7 @@ func CreateSSHKeys(writeLocation string) (string, error) {
 	if err := generatekeys(writeLocation); err != nil {
 		return "", err
 	}
-	b, err := ioutil.ReadFile(writeLocation + ".pub")
+	b, err := os.ReadFile(writeLocation + ".pub")
 	if err != nil {
 		return "", err
 	}
@@ -45,7 +44,7 @@ func CreateSSHKeysPrefix(dir string, file string, passThru bool, skipExisting bo
 	} else {
 		fmt.Println("Keys already exist, reusing")
 	}
-	b, err := ioutil.ReadFile(filepath.Join(dir, file) + ".pub")
+	b, err := os.ReadFile(filepath.Join(dir, file) + ".pub")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/machine/pull.go
+++ b/pkg/machine/pull.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	url2 "net/url"
 	"os"
@@ -191,7 +190,7 @@ func Decompress(localPath, uncompressedPath string) error {
 	if err != nil {
 		return err
 	}
-	sourceFile, err := ioutil.ReadFile(localPath)
+	sourceFile, err := os.ReadFile(localPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/machine/qemu/claim_darwin.go
+++ b/pkg/machine/qemu/claim_darwin.go
@@ -2,7 +2,7 @@ package qemu
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"os/user"
@@ -43,7 +43,7 @@ func claimDockerSock() bool {
 		return false
 	}
 	_ = con.SetReadDeadline(time.Now().Add(time.Second * 5))
-	read, err := ioutil.ReadAll(con)
+	read, err := io.ReadAll(con)
 
 	return err == nil && string(read) == "OK"
 }

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -391,11 +390,11 @@ func (v *MachineVM) Init(opts machine.InitOptions) (bool, error) {
 	// If the user provides an ignition file, we need to
 	// copy it into the conf dir
 	if len(opts.IgnitionPath) > 0 {
-		inputIgnition, err := ioutil.ReadFile(opts.IgnitionPath)
+		inputIgnition, err := os.ReadFile(opts.IgnitionPath)
 		if err != nil {
 			return false, err
 		}
-		return false, ioutil.WriteFile(v.getIgnitionFile(), inputIgnition, 0644)
+		return false, os.WriteFile(v.getIgnitionFile(), inputIgnition, 0644)
 	}
 	// Write the ignition file
 	ign := machine.DynamicIgnition{
@@ -1109,7 +1108,7 @@ func getVMInfos() ([]*machine.ListResponse, error) {
 		vm := new(MachineVM)
 		if strings.HasSuffix(d.Name(), ".json") {
 			fullPath := filepath.Join(vmConfigDir, d.Name())
-			b, err := ioutil.ReadFile(fullPath)
+			b, err := os.ReadFile(fullPath)
 			if err != nil {
 				return err
 			}
@@ -1539,7 +1538,7 @@ func (v *MachineVM) writeConfig() error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(v.ConfigPath.GetPath(), b, 0644); err != nil {
+	if err := os.WriteFile(v.ConfigPath.GetPath(), b, 0644); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -423,7 +422,7 @@ func (v *MachineVM) writeConfig() error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(jsonFile, b, 0644); err != nil {
+	if err := os.WriteFile(jsonFile, b, 0644); err != nil {
 		return fmt.Errorf("could not write machine json config: %w", err)
 	}
 
@@ -1285,7 +1284,7 @@ func readWinProxyTid(v *MachineVM) (uint32, uint32, string, error) {
 	}
 
 	tidFile := filepath.Join(stateDir, winSshProxyTid)
-	contents, err := ioutil.ReadFile(tidFile)
+	contents, err := os.ReadFile(tidFile)
 	if err != nil {
 		return 0, 0, "", err
 	}

--- a/pkg/machine/wsl/util_windows.go
+++ b/pkg/machine/wsl/util_windows.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -209,7 +208,7 @@ func reboot() error {
 		return fmt.Errorf("could not create data directory: %w", err)
 	}
 	commFile := filepath.Join(dataDir, "podman-relaunch.dat")
-	if err := ioutil.WriteFile(commFile, []byte(encoded), 0600); err != nil {
+	if err := os.WriteFile(commFile, []byte(encoded), 0600); err != nil {
 		return fmt.Errorf("could not serialize command state: %w", err)
 	}
 

--- a/pkg/specgen/generate/config_linux_cgo.go
+++ b/pkg/specgen/generate/config_linux_cgo.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/containers/common/libimage"
 	goSeccomp "github.com/containers/common/pkg/seccomp"
@@ -47,7 +47,7 @@ func getSeccompConfig(s *specgen.SpecGenerator, configSpec *spec.Spec, img *libi
 
 	if s.SeccompProfilePath != "" {
 		logrus.Debugf("Loading seccomp profile from %q", s.SeccompProfilePath)
-		seccompProfile, err := ioutil.ReadFile(s.SeccompProfilePath)
+		seccompProfile, err := os.ReadFile(s.SeccompProfilePath)
 		if err != nil {
 			return nil, fmt.Errorf("opening seccomp profile failed: %w", err)
 		}

--- a/pkg/specgen/generate/pause_image.go
+++ b/pkg/specgen/generate/pause_image.go
@@ -3,7 +3,6 @@ package generate
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	buildahDefine "github.com/containers/buildah/define"
@@ -62,7 +61,7 @@ func buildPauseImage(rt *libpod.Runtime, rtConfig *config.Config) (string, error
 COPY %s /catatonit
 ENTRYPOINT ["/catatonit", "-P"]`, catatonitPath)
 
-	tmpF, err := ioutil.TempFile("", "pause.containerfile")
+	tmpF, err := os.CreateTemp("", "pause.containerfile")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/specgen/generate/validate.go
+++ b/pkg/specgen/generate/validate.go
@@ -3,7 +3,6 @@ package generate
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -180,7 +179,7 @@ func verifyContainerResourcesCgroupV2(s *specgen.SpecGenerator) ([]string, error
 			// If running under the root cgroup try to create or reuse a "probe" cgroup to read memory values
 			own = "podman_probe"
 			_ = os.MkdirAll(filepath.Join("/sys/fs/cgroup", own), 0o755)
-			_ = ioutil.WriteFile("/sys/fs/cgroup/cgroup.subtree_control", []byte("+memory"), 0o644)
+			_ = os.WriteFile("/sys/fs/cgroup/cgroup.subtree_control", []byte("+memory"), 0o644)
 		}
 
 		memoryMax := filepath.Join("/sys/fs/cgroup", own, "memory.max")

--- a/pkg/specgenutil/util.go
+++ b/pkg/specgenutil/util.go
@@ -3,7 +3,6 @@ package specgenutil
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -18,7 +17,7 @@ import (
 // ReadPodIDFile reads the specified file and returns its content (i.e., first
 // line).
 func ReadPodIDFile(path string) (string, error) {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("reading pod ID file: %w", err)
 	}

--- a/pkg/systemd/notifyproxy/notifyproxy.go
+++ b/pkg/systemd/notifyproxy/notifyproxy.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -49,7 +48,7 @@ type NotifyProxy struct {
 
 // New creates a NotifyProxy.  The specified temp directory can be left empty.
 func New(tmpDir string) (*NotifyProxy, error) {
-	tempFile, err := ioutil.TempFile(tmpDir, "-podman-notify-proxy.sock")
+	tempFile, err := os.CreateTemp(tmpDir, "-podman-notify-proxy.sock")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/trust/policy.go
+++ b/pkg/trust/policy.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +71,7 @@ type gpgIDReader func(string) []string
 
 // createTmpFile creates a temp file under dir and writes the content into it
 func createTmpFile(dir, pattern string, content []byte) (string, error) {
-	tmpfile, err := ioutil.TempFile(dir, pattern)
+	tmpfile, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		return "", err
 	}
@@ -133,7 +132,7 @@ func parseUids(colonDelimitKeys []byte) []string {
 // getPolicy parses policy.json into policyContent.
 func getPolicy(policyPath string) (policyContent, error) {
 	var policyContentStruct policyContent
-	policyContent, err := ioutil.ReadFile(policyPath)
+	policyContent, err := os.ReadFile(policyPath)
 	if err != nil {
 		return policyContentStruct, fmt.Errorf("unable to read policy file: %w", err)
 	}
@@ -207,7 +206,7 @@ func AddPolicyEntries(policyPath string, input AddPolicyEntriesInput) error {
 
 	_, err = os.Stat(policyPath)
 	if !os.IsNotExist(err) {
-		policyContent, err := ioutil.ReadFile(policyPath)
+		policyContent, err := os.ReadFile(policyPath)
 		if err != nil {
 			return err
 		}
@@ -244,5 +243,5 @@ func AddPolicyEntries(policyPath string, input AddPolicyEntriesInput) error {
 	if err != nil {
 		return fmt.Errorf("setting trust policy: %w", err)
 	}
-	return ioutil.WriteFile(policyPath, data, 0644)
+	return os.WriteFile(policyPath, data, 0644)
 }

--- a/pkg/trust/registries.go
+++ b/pkg/trust/registries.go
@@ -2,7 +2,6 @@ package trust
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,7 +71,7 @@ func loadAndMergeConfig(dirPath string) (*registryConfiguration, error) {
 			continue
 		}
 		configPath := filepath.Join(dirPath, configName)
-		configBytes, err := ioutil.ReadFile(configPath)
+		configBytes, err := os.ReadFile(configPath)
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e/benchmarks_test.go
+++ b/test/e2e/benchmarks_test.go
@@ -5,7 +5,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -108,7 +107,7 @@ var _ = Describe("Podman Benchmark Suite", func() {
 			if f.IsDir() {
 				continue
 			}
-			raw, err := ioutil.ReadFile(path.Join(timedir, f.Name()))
+			raw, err := os.ReadFile(path.Join(timedir, f.Name()))
 			if err != nil {
 				Fail(fmt.Sprintf("Error reading timing file: %v", err))
 			}

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -219,10 +218,10 @@ var _ = Describe("Podman build", func() {
 		}
 
 		fakeFile := filepath.Join(os.TempDir(), "Containerfile")
-		Expect(ioutil.WriteFile(fakeFile, []byte(fmt.Sprintf("FROM %s", ALPINE)), 0755)).To(BeNil())
+		Expect(os.WriteFile(fakeFile, []byte(fmt.Sprintf("FROM %s", ALPINE)), 0755)).To(BeNil())
 
 		targetFile := filepath.Join(targetPath, "Containerfile")
-		Expect(ioutil.WriteFile(targetFile, []byte("FROM scratch"), 0755)).To(BeNil())
+		Expect(os.WriteFile(targetFile, []byte("FROM scratch"), 0755)).To(BeNil())
 
 		defer func() {
 			Expect(os.RemoveAll(fakeFile)).To(BeNil())
@@ -257,7 +256,7 @@ var _ = Describe("Podman build", func() {
 		session := podmanTest.Podman([]string{"build", "--pull-never", "build/basicalpine", "--iidfile", targetFile})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		id, _ := ioutil.ReadFile(targetFile)
+		id, _ := os.ReadFile(targetFile)
 
 		// Verify that id is correct
 		inspect := podmanTest.Podman([]string{"inspect", string(id)})
@@ -311,7 +310,7 @@ var _ = Describe("Podman build", func() {
 RUN printenv http_proxy`, ALPINE)
 
 		dockerfilePath := filepath.Join(podmanTest.TempDir, "Dockerfile")
-		err := ioutil.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
+		err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
 		Expect(err).To(BeNil())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "--http-proxy", "--file", dockerfilePath, podmanTest.TempDir})
 		session.Wait(120)
@@ -330,7 +329,7 @@ RUN printenv http_proxy`, ALPINE)
 RUN exit 5`, ALPINE)
 
 		dockerfilePath := filepath.Join(podmanTest.TempDir, "Dockerfile")
-		err := ioutil.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
+		err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
 		Expect(err).To(BeNil())
 		session := podmanTest.Podman([]string{"build", "-t", "error-test", "--file", dockerfilePath, podmanTest.TempDir})
 		session.Wait(120)
@@ -388,7 +387,7 @@ RUN exit 5`, ALPINE)
 		err = os.Mkdir(targetSubPath, 0755)
 		Expect(err).To(BeNil())
 		dummyFile := filepath.Join(targetSubPath, "dummy")
-		err = ioutil.WriteFile(dummyFile, []byte("dummy"), 0644)
+		err = os.WriteFile(dummyFile, []byte("dummy"), 0644)
 		Expect(err).To(BeNil())
 
 		containerfile := fmt.Sprintf(`FROM %s
@@ -396,7 +395,7 @@ ADD . /test
 RUN find /test`, ALPINE)
 
 		containerfilePath := filepath.Join(targetPath, "Containerfile")
-		err = ioutil.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).To(BeNil())
 
 		defer func() {
@@ -437,7 +436,7 @@ RUN find /test`, ALPINE)
 		containerfile := fmt.Sprintf("FROM %s", ALPINE)
 
 		containerfilePath := filepath.Join(targetSubPath, "Containerfile")
-		err = ioutil.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).To(BeNil())
 
 		defer func() {
@@ -476,7 +475,7 @@ ADD . /testfilter/
 RUN find /testfilter/`, ALPINE)
 
 		containerfilePath := filepath.Join(targetPath, "Containerfile")
-		err = ioutil.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).To(BeNil())
 
 		targetSubPath := filepath.Join(targetPath, "subdir")
@@ -484,15 +483,15 @@ RUN find /testfilter/`, ALPINE)
 		Expect(err).To(BeNil())
 
 		dummyFile1 := filepath.Join(targetPath, "dummy1")
-		err = ioutil.WriteFile(dummyFile1, []byte("dummy1"), 0644)
+		err = os.WriteFile(dummyFile1, []byte("dummy1"), 0644)
 		Expect(err).To(BeNil())
 
 		dummyFile2 := filepath.Join(targetPath, "dummy2")
-		err = ioutil.WriteFile(dummyFile2, []byte("dummy2"), 0644)
+		err = os.WriteFile(dummyFile2, []byte("dummy2"), 0644)
 		Expect(err).To(BeNil())
 
 		dummyFile3 := filepath.Join(targetSubPath, "dummy3")
-		err = ioutil.WriteFile(dummyFile3, []byte("dummy3"), 0644)
+		err = os.WriteFile(dummyFile3, []byte("dummy3"), 0644)
 		Expect(err).To(BeNil())
 
 		defer func() {
@@ -509,7 +508,7 @@ subdir**`
 
 		// test .dockerignore
 		By("Test .dockererignore")
-		err = ioutil.WriteFile(dockerignoreFile, []byte(dockerignoreContent), 0644)
+		err = os.WriteFile(dockerignoreFile, []byte(dockerignoreContent), 0644)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"build", "-t", "test", "."})
@@ -540,18 +539,18 @@ subdir**`
 		contents.WriteString("RUN find /testfilter/ -print\n")
 
 		containerfile := filepath.Join(tempdir, "Containerfile")
-		Expect(ioutil.WriteFile(containerfile, contents.Bytes(), 0644)).ToNot(HaveOccurred())
+		Expect(os.WriteFile(containerfile, contents.Bytes(), 0644)).ToNot(HaveOccurred())
 
 		contextDir, err := CreateTempDirInTempDir()
 		Expect(err).ToNot(HaveOccurred())
 		defer os.RemoveAll(contextDir)
 
-		Expect(ioutil.WriteFile(filepath.Join(contextDir, "expected"), contents.Bytes(), 0644)).
+		Expect(os.WriteFile(filepath.Join(contextDir, "expected"), contents.Bytes(), 0644)).
 			ToNot(HaveOccurred())
 
 		subdirPath := filepath.Join(contextDir, "subdir")
 		Expect(os.MkdirAll(subdirPath, 0755)).ToNot(HaveOccurred())
-		Expect(ioutil.WriteFile(filepath.Join(subdirPath, "extra"), contents.Bytes(), 0644)).
+		Expect(os.WriteFile(filepath.Join(subdirPath, "extra"), contents.Bytes(), 0644)).
 			ToNot(HaveOccurred())
 		randomFile := filepath.Join(subdirPath, "randomFile")
 		dd := exec.Command("dd", "if=/dev/urandom", "of="+randomFile, "bs=1G", "count=1")
@@ -567,7 +566,7 @@ subdir**`
 		}()
 
 		By("Test .containerignore filtering subdirectory")
-		err = ioutil.WriteFile(filepath.Join(contextDir, ".containerignore"), []byte(`subdir/`), 0644)
+		err = os.WriteFile(filepath.Join(contextDir, ".containerignore"), []byte(`subdir/`), 0644)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"build", "-f", containerfile, contextDir})
@@ -597,7 +596,7 @@ subdir**`
 		err = os.Mkdir(targetSubPath, 0755)
 		Expect(err).To(BeNil())
 		dummyFile := filepath.Join(targetSubPath, "dummy")
-		err = ioutil.WriteFile(dummyFile, []byte("dummy"), 0644)
+		err = os.WriteFile(dummyFile, []byte("dummy"), 0644)
 		Expect(err).To(BeNil())
 
 		emptyDir := filepath.Join(targetSubPath, "emptyDir")
@@ -612,7 +611,7 @@ RUN find /test
 RUN [[ -L /test/dummy-symlink ]] && echo SYMLNKOK || echo SYMLNKERR`, ALPINE)
 
 		containerfilePath := filepath.Join(targetSubPath, "Containerfile")
-		err = ioutil.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).To(BeNil())
 
 		defer func() {
@@ -641,7 +640,7 @@ RUN [[ -L /test/dummy-symlink ]] && echo SYMLNKOK || echo SYMLNKERR`, ALPINE)
 RUN cat /etc/hosts
 RUN grep CapEff /proc/self/status`
 
-		Expect(ioutil.WriteFile(containerFile, []byte(content), 0755)).To(BeNil())
+		Expect(os.WriteFile(containerFile, []byte(content), 0755)).To(BeNil())
 
 		defer func() {
 			Expect(os.RemoveAll(containerFile)).To(BeNil())
@@ -668,7 +667,7 @@ RUN grep CapEff /proc/self/status`
 		Expect(err).To(BeNil())
 
 		containerFile := filepath.Join(targetPath, "Containerfile")
-		Expect(ioutil.WriteFile(containerFile, []byte(fmt.Sprintf("FROM %s", ALPINE)), 0755)).To(BeNil())
+		Expect(os.WriteFile(containerFile, []byte(fmt.Sprintf("FROM %s", ALPINE)), 0755)).To(BeNil())
 
 		defer func() {
 			Expect(os.RemoveAll(containerFile)).To(BeNil())
@@ -712,7 +711,7 @@ RUN grep CapEff /proc/self/status`
 RUN echo hello`, ALPINE)
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := ioutil.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
 		Expect(err).To(BeNil())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--timestamp", "0", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -730,7 +729,7 @@ RUN echo hello`, ALPINE)
 		containerFile := filepath.Join(targetPath, "Containerfile")
 		content := `FROM scratch`
 
-		Expect(ioutil.WriteFile(containerFile, []byte(content), 0755)).To(BeNil())
+		Expect(os.WriteFile(containerFile, []byte(content), 0755)).To(BeNil())
 
 		session := podmanTest.Podman([]string{"build", "--log-rusage", "--pull-never", targetPath})
 		session.WaitWithDefaultTimeout()
@@ -743,7 +742,7 @@ RUN echo hello`, ALPINE)
 	It("podman build --arch --os flag", func() {
 		containerfile := `FROM scratch`
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := ioutil.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
 		Expect(err).To(BeNil())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--arch", "foo", "--os", "bar", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -762,7 +761,7 @@ RUN echo hello`, ALPINE)
 	It("podman build --os windows flag", func() {
 		containerfile := `FROM scratch`
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := ioutil.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
 		Expect(err).To(BeNil())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--os", "windows", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -785,7 +784,7 @@ RUN echo hello`, ALPINE)
 		containerfile := fmt.Sprintf(`FROM %s
 RUN ls /dev/fuse`, ALPINE)
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := ioutil.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
 		Expect(err).To(BeNil())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -801,7 +800,7 @@ RUN ls /dev/fuse`, ALPINE)
 		containerfile := fmt.Sprintf(`FROM %s
 RUN ls /dev/test1`, ALPINE)
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := ioutil.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
 		Expect(err).To(BeNil())
 		session := podmanTest.Podman([]string{"build", "--pull-never", "-t", "test", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -822,7 +821,7 @@ RUN ls /dev/test1`, ALPINE)
 		Expect(err).To(BeNil())
 		err = os.Mkdir(buildRoot, 0755)
 		Expect(err).To(BeNil())
-		err = ioutil.WriteFile(containerFilePath, []byte(containerFile), 0755)
+		err = os.WriteFile(containerFilePath, []byte(containerFile), 0755)
 		Expect(err).To(BeNil())
 		build := podmanTest.Podman([]string{"build", "-f", containerFilePath, buildRoot})
 		build.WaitWithDefaultTimeout()

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -287,7 +286,7 @@ var _ = Describe("Podman commit", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		id, _ := ioutil.ReadFile(targetFile)
+		id, _ := os.ReadFile(targetFile)
 		check := podmanTest.Podman([]string{"inspect", "foobar.com/test1-image:latest"})
 		check.WaitWithDefaultTimeout()
 		data := check.InspectImageJSON()
@@ -297,7 +296,7 @@ var _ = Describe("Podman commit", func() {
 	It("podman commit should not commit secret", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -322,7 +321,7 @@ var _ = Describe("Podman commit", func() {
 	It("podman commit should not commit env secret", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/url"
@@ -144,7 +143,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		}
 		f.Close()
 	}
-	path, err := ioutil.TempDir("", "libpodlock")
+	path, err := os.MkdirTemp("", "libpodlock")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -875,7 +874,7 @@ func writeConf(conf []byte, confPath string) {
 			fmt.Println(err)
 		}
 	}
-	if err := ioutil.WriteFile(confPath, conf, 0o777); err != nil {
+	if err := os.WriteFile(confPath, conf, 0o777); err != nil {
 		fmt.Println(err)
 	}
 }
@@ -967,7 +966,7 @@ func (s *PodmanSessionIntegration) jq(jqCommand string) (string, error) {
 
 func (p *PodmanTestIntegration) buildImage(dockerfile, imageName string, layers string, label string) string {
 	dockerfilePath := filepath.Join(p.TempDir, "Dockerfile")
-	err := ioutil.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
+	err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
 	Expect(err).To(BeNil())
 	cmd := []string{"build", "--pull-never", "--layers=" + layers, "--file", dockerfilePath}
 	if label != "" {

--- a/test/e2e/container_create_volume_test.go
+++ b/test/e2e/container_create_volume_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -15,7 +14,7 @@ import (
 func buildDataVolumeImage(pTest *PodmanTestIntegration, image, data, dest string) {
 	// Create a dummy file for data volume
 	dummyFile := filepath.Join(pTest.TempDir, data)
-	err := ioutil.WriteFile(dummyFile, []byte(data), 0644)
+	err := os.WriteFile(dummyFile, []byte(data), 0644)
 	Expect(err).To(BeNil())
 
 	// Create a data volume container image but no CMD binary in it
@@ -29,7 +28,7 @@ VOLUME %s/`, data, dest, dest)
 func createContainersConfFile(pTest *PodmanTestIntegration) {
 	configPath := filepath.Join(pTest.TempDir, "containers.conf")
 	containersConf := []byte("[containers]\nprepare_volume_on_create = true\n")
-	err := ioutil.WriteFile(configPath, containersConf, os.ModePerm)
+	err := os.WriteFile(configPath, containersConf, os.ModePerm)
 	Expect(err).To(BeNil())
 
 	// Set custom containers.conf file

--- a/test/e2e/containers_conf_test.go
+++ b/test/e2e/containers_conf_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -208,7 +207,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		tempdir, err = CreateTempDirInTempDir()
 		Expect(err).ToNot(HaveOccurred())
 
-		err := ioutil.WriteFile(conffile, []byte(fmt.Sprintf("[containers]\nvolumes=[\"%s:%s:Z\",]\n", tempdir, tempdir)), 0755)
+		err := os.WriteFile(conffile, []byte(fmt.Sprintf("[containers]\nvolumes=[\"%s:%s:Z\",]\n", tempdir, tempdir)), 0755)
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("CONTAINERS_CONF", conffile)
@@ -406,7 +405,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 
 		profile := filepath.Join(podmanTest.TempDir, "seccomp.json")
 		containersConf := []byte(fmt.Sprintf("[containers]\nseccomp_profile=\"%s\"", profile))
-		err = ioutil.WriteFile(configPath, containersConf, os.ModePerm)
+		err = os.WriteFile(configPath, containersConf, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
 
 		if IsRemote() {
@@ -430,7 +429,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		os.Setenv("CONTAINERS_CONF", configPath)
 
 		containersConf := []byte("[engine]\nimage_copy_tmp_dir=\"/foobar\"")
-		err = ioutil.WriteFile(configPath, containersConf, os.ModePerm)
+		err = os.WriteFile(configPath, containersConf, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
 
 		if IsRemote() {
@@ -443,7 +442,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		Expect(session.OutputToString()).To(Equal("/foobar"))
 
 		containersConf = []byte(fmt.Sprintf("[engine]\nimage_copy_tmp_dir=%q", storagePath))
-		err = ioutil.WriteFile(configPath, containersConf, os.ModePerm)
+		err = os.WriteFile(configPath, containersConf, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
 		if IsRemote() {
 			podmanTest.RestartRemoteService()
@@ -455,7 +454,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		Expect(session.Out.Contents()).To(ContainSubstring(storagePath))
 
 		containersConf = []byte("[engine]\nimage_copy_tmp_dir=\"storage1\"")
-		err = ioutil.WriteFile(configPath, containersConf, os.ModePerm)
+		err = os.WriteFile(configPath, containersConf, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
 
 		if !IsRemote() {
@@ -485,7 +484,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		os.Setenv("CONTAINERS_CONF", configPath)
 
 		containersConf := []byte("[engine]\ninfra_image=\"" + infra1 + "\"")
-		err = ioutil.WriteFile(configPath, containersConf, os.ModePerm)
+		err = os.WriteFile(configPath, containersConf, os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
 
 		if IsRemote() {
@@ -520,7 +519,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		os.Setenv("CONTAINERS_CONF", configPath)
 		defer os.Remove(configPath)
 
-		err := ioutil.WriteFile(configPath, []byte("[engine]\nremote=true"), os.ModePerm)
+		err := os.WriteFile(configPath, []byte("[engine]\nremote=true"), os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
 
 		// podmanTest.Podman() cannot be used as it was initialized remote==false
@@ -540,7 +539,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 		}
 
 		conffile := filepath.Join(podmanTest.TempDir, "container.conf")
-		err := ioutil.WriteFile(conffile, []byte("[containers]\ncgroups=\"disabled\"\n"), 0755)
+		err := os.WriteFile(conffile, []byte("[containers]\ncgroups=\"disabled\"\n"), 0755)
 		Expect(err).ToNot(HaveOccurred())
 
 		result := podmanTest.Podman([]string{"create", ALPINE, "true"})
@@ -572,7 +571,7 @@ var _ = Describe("Verify podman containers.conf usage", func() {
 	It("podman containers.conf runtime", func() {
 		SkipIfRemote("--runtime option is not available for remote commands")
 		conffile := filepath.Join(podmanTest.TempDir, "container.conf")
-		err := ioutil.WriteFile(conffile, []byte("[engine]\nruntime=\"testruntime\"\n"), 0755)
+		err := os.WriteFile(conffile, []byte("[engine]\nruntime=\"testruntime\"\n"), 0755)
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("CONTAINERS_CONF", conffile)

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -43,13 +42,13 @@ var _ = Describe("Podman cp", func() {
 	// Copy a file to the container, then back to the host and make sure
 	// that the contents match.
 	It("podman cp file", func() {
-		srcFile, err := ioutil.TempFile("", "")
+		srcFile, err := os.CreateTemp("", "")
 		Expect(err).To(BeNil())
 		defer srcFile.Close()
 		defer os.Remove(srcFile.Name())
 
 		originalContent := []byte("podman cp file test")
-		err = ioutil.WriteFile(srcFile.Name(), originalContent, 0644)
+		err = os.WriteFile(srcFile.Name(), originalContent, 0644)
 		Expect(err).To(BeNil())
 
 		// Create a container. NOTE that container mustn't be running for copying.
@@ -72,7 +71,7 @@ var _ = Describe("Podman cp", func() {
 
 		// Copy FROM the container.
 
-		destFile, err := ioutil.TempFile("", "")
+		destFile, err := os.CreateTemp("", "")
 		Expect(err).To(BeNil())
 		defer destFile.Close()
 		defer os.Remove(destFile.Name())
@@ -86,7 +85,7 @@ var _ = Describe("Podman cp", func() {
 		Expect(session).Should(Exit(0))
 
 		// Now make sure the content matches.
-		roundtripContent, err := ioutil.ReadFile(destFile.Name())
+		roundtripContent, err := os.ReadFile(destFile.Name())
 		Expect(err).To(BeNil())
 		Expect(roundtripContent).To(Equal(originalContent))
 	})
@@ -94,13 +93,13 @@ var _ = Describe("Podman cp", func() {
 	// Copy a file to the container, then back to the host in --pid=host
 	It("podman cp --pid=host file", func() {
 		SkipIfRootlessCgroupsV1("Not supported for rootless + CgroupsV1")
-		srcFile, err := ioutil.TempFile("", "")
+		srcFile, err := os.CreateTemp("", "")
 		Expect(err).To(BeNil())
 		defer srcFile.Close()
 		defer os.Remove(srcFile.Name())
 
 		originalContent := []byte("podman cp file test")
-		err = ioutil.WriteFile(srcFile.Name(), originalContent, 0644)
+		err = os.WriteFile(srcFile.Name(), originalContent, 0644)
 		Expect(err).To(BeNil())
 
 		// Create a container. NOTE that container mustn't be running for copying.
@@ -120,7 +119,7 @@ var _ = Describe("Podman cp", func() {
 
 		// Copy FROM the container.
 
-		destFile, err := ioutil.TempFile("", "")
+		destFile, err := os.CreateTemp("", "")
 		Expect(err).To(BeNil())
 		defer destFile.Close()
 		defer os.Remove(destFile.Name())
@@ -130,7 +129,7 @@ var _ = Describe("Podman cp", func() {
 		Expect(session).Should(Exit(0))
 
 		// Now make sure the content matches.
-		roundtripContent, err := ioutil.ReadFile(destFile.Name())
+		roundtripContent, err := os.ReadFile(destFile.Name())
 		Expect(err).To(BeNil())
 		Expect(roundtripContent).To(Equal(originalContent))
 	})
@@ -139,13 +138,13 @@ var _ = Describe("Podman cp", func() {
 	// make sure that the link and the resolved path are accessible and
 	// give the right content.
 	It("podman cp symlink", func() {
-		srcFile, err := ioutil.TempFile("", "")
+		srcFile, err := os.CreateTemp("", "")
 		Expect(err).To(BeNil())
 		defer srcFile.Close()
 		defer os.Remove(srcFile.Name())
 
 		originalContent := []byte("podman cp symlink test")
-		err = ioutil.WriteFile(srcFile.Name(), originalContent, 0644)
+		err = os.WriteFile(srcFile.Name(), originalContent, 0644)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"run", "-d", ALPINE, "top"})
@@ -178,13 +177,13 @@ var _ = Describe("Podman cp", func() {
 	// the path to the volume's mount point on the host, and 3) copy the
 	// data to the volume and not the container.
 	It("podman cp volume", func() {
-		srcFile, err := ioutil.TempFile("", "")
+		srcFile, err := os.CreateTemp("", "")
 		Expect(err).To(BeNil())
 		defer srcFile.Close()
 		defer os.Remove(srcFile.Name())
 
 		originalContent := []byte("podman cp volume")
-		err = ioutil.WriteFile(srcFile.Name(), originalContent, 0644)
+		err = os.WriteFile(srcFile.Name(), originalContent, 0644)
 		Expect(err).To(BeNil())
 		session := podmanTest.Podman([]string{"volume", "create", "data"})
 		session.WaitWithDefaultTimeout()
@@ -205,7 +204,7 @@ var _ = Describe("Podman cp", func() {
 		Expect(session).Should(Exit(0))
 
 		volumeMountPoint := session.OutputToString()
-		copiedContent, err := ioutil.ReadFile(filepath.Join(volumeMountPoint, "file.txt"))
+		copiedContent, err := os.ReadFile(filepath.Join(volumeMountPoint, "file.txt"))
 		Expect(err).To(BeNil())
 		Expect(copiedContent).To(Equal(originalContent))
 	})
@@ -214,7 +213,7 @@ var _ = Describe("Podman cp", func() {
 	// it to the host and back to the container and make sure that we can
 	// access it, and (roughly) the right users own it.
 	It("podman cp from ctr chown ", func() {
-		srcFile, err := ioutil.TempFile("", "")
+		srcFile, err := os.CreateTemp("", "")
 		Expect(err).To(BeNil())
 		defer srcFile.Close()
 		defer os.Remove(srcFile.Name())
@@ -265,7 +264,7 @@ var _ = Describe("Podman cp", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 
 		session = podmanTest.Podman([]string{"cp", container + ":/", tmpDir})

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -242,7 +241,7 @@ var _ = Describe("Podman create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(125))
 
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		defer os.RemoveAll(tmpDir)
 

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -545,7 +544,7 @@ RUN useradd -u 1000 auser`, fedoraMinimal)
 	It("podman exec with env var secret", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -278,7 +277,7 @@ var _ = Describe("Podman generate kube", func() {
 		if name == "root" {
 			name = "containers"
 		}
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}
@@ -752,7 +751,7 @@ var _ = Describe("Podman generate kube", func() {
 		kube.WaitWithDefaultTimeout()
 		Expect(kube).Should(Exit(0))
 
-		b, err := ioutil.ReadFile(outputFile)
+		b, err := os.ReadFile(outputFile)
 		Expect(err).ShouldNot(HaveOccurred())
 		pod := new(v1.Pod)
 		err = yaml.Unmarshal(b, pod)
@@ -1045,7 +1044,7 @@ ENTRYPOINT ["sleep"]`
 		targetPath, err := CreateTempDirInTempDir()
 		Expect(err).To(BeNil())
 		containerfilePath := filepath.Join(targetPath, "Containerfile")
-		err = ioutil.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).To(BeNil())
 
 		image := "generatekube:test"
@@ -1135,7 +1134,7 @@ USER test1`
 		targetPath, err := CreateTempDirInTempDir()
 		Expect(err).To(BeNil())
 		containerfilePath := filepath.Join(targetPath, "Containerfile")
-		err = ioutil.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).To(BeNil())
 
 		image := "generatekube:test"

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -539,7 +538,7 @@ var _ = Describe("Podman generate systemd", func() {
 	})
 
 	It("podman generate systemd pod with containers --new", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile := tmpDir + "podID"
 		defer os.RemoveAll(tmpDir)

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -303,7 +302,7 @@ var _ = Describe("Podman healthcheck run", func() {
 		containerfile := fmt.Sprintf(`FROM %s
 HEALTHCHECK CMD ls -l / 2>&1`, ALPINE)
 		containerfilePath := filepath.Join(targetPath, "Containerfile")
-		err = ioutil.WriteFile(containerfilePath, []byte(containerfile), 0644)
+		err = os.WriteFile(containerfilePath, []byte(containerfile), 0644)
 		Expect(err).To(BeNil())
 		defer func() {
 			Expect(os.Chdir(cwd)).To(BeNil())

--- a/test/e2e/image_scp_test.go
+++ b/test/e2e/image_scp_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -25,7 +24,7 @@ var _ = Describe("podman image scp", func() {
 
 	BeforeEach(func() {
 		ConfPath.Value, ConfPath.IsSet = os.LookupEnv("CONTAINERS_CONF")
-		conf, err := ioutil.TempFile("", "containersconf")
+		conf, err := os.CreateTemp("", "containersconf")
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("CONTAINERS_CONF", conf.Name())

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -104,7 +103,7 @@ var _ = Describe("Podman Info", func() {
 		driver := `"overlay"`
 		storageOpt := `"/usr/bin/fuse-overlayfs"`
 		storageConf := []byte(fmt.Sprintf("[storage]\ndriver=%s\nrootless_storage_path=%s\n[storage.options]\nmount_program=%s", driver, rootlessStoragePath, storageOpt))
-		err = ioutil.WriteFile(configPath, storageConf, os.ModePerm)
+		err = os.WriteFile(configPath, storageConf, os.ModePerm)
 		Expect(err).To(BeNil())
 
 		u, err := user.Current()

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/containers/podman/v4/test/utils"
@@ -150,7 +149,7 @@ var _ = Describe("Podman kill", func() {
 	})
 
 	It("podman kill --cidfile", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile := tmpDir + "cid"
 		defer os.RemoveAll(tmpDir)
@@ -170,12 +169,12 @@ var _ = Describe("Podman kill", func() {
 	})
 
 	It("podman kill multiple --cidfile", func() {
-		tmpDir1, err := ioutil.TempDir("", "")
+		tmpDir1, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile1 := tmpDir1 + "cid"
 		defer os.RemoveAll(tmpDir1)
 
-		tmpDir2, err := ioutil.TempDir("", "")
+		tmpDir2, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile2 := tmpDir2 + "cid"
 		defer os.RemoveAll(tmpDir2)

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -6,7 +6,6 @@ package integration
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -58,7 +57,7 @@ func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
 func (p *PodmanTestIntegration) setRegistriesConfigEnv(b []byte) {
 	outfile := filepath.Join(p.TempDir, "registries.conf")
 	os.Setenv("CONTAINERS_REGISTRIES_CONF", outfile)
-	err := ioutil.WriteFile(outfile, b, 0644)
+	err := os.WriteFile(outfile, b, 0644)
 	Expect(err).ToNot(HaveOccurred())
 }
 

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -101,7 +100,7 @@ var _ = Describe("Podman login and logout", func() {
 	})
 
 	readAuthInfo := func(filePath string) map[string]interface{} {
-		authBytes, err := ioutil.ReadFile(filePath)
+		authBytes, err := os.ReadFile(filePath)
 		Expect(err).To(BeNil())
 
 		var authInfo map[string]interface{}
@@ -137,12 +136,12 @@ var _ = Describe("Podman login and logout", func() {
 	})
 
 	It("podman login and logout without registry parameter", func() {
-		registriesConf, err := ioutil.TempFile("", "TestLoginWithoutParameter")
+		registriesConf, err := os.CreateTemp("", "TestLoginWithoutParameter")
 		Expect(err).To(BeNil())
 		defer registriesConf.Close()
 		defer os.Remove(registriesConf.Name())
 
-		err = ioutil.WriteFile(registriesConf.Name(), registriesConfWithSearch, os.ModePerm)
+		err = os.WriteFile(registriesConf.Name(), registriesConfWithSearch, os.ModePerm)
 		Expect(err).To(BeNil())
 
 		// Environment is per-process, so this looks very unsafe; actually it seems fine because tests are not
@@ -448,7 +447,7 @@ var _ = Describe("Podman login and logout", func() {
 	It("podman login and logout with repository push with invalid auth.json credentials", func() {
 		authFile := filepath.Join(podmanTest.TempDir, "auth.json")
 		// only `server` contains the correct login data
-		err := ioutil.WriteFile(authFile, []byte(fmt.Sprintf(`{"auths": {
+		err := os.WriteFile(authFile, []byte(fmt.Sprintf(`{"auths": {
 			"%s/podmantest": { "auth": "cG9kbWFudGVzdDp3cm9uZw==" },
 			"%s": { "auth": "cG9kbWFudGVzdDp0ZXN0" }
 		}}`, server, server)), 0644)
@@ -494,7 +493,7 @@ var _ = Describe("Podman login and logout", func() {
 		Expect(session).Should(Exit(0))
 
 		// only `server + /podmantest` and `server` have the correct login data
-		err := ioutil.WriteFile(authFile, []byte(fmt.Sprintf(`{"auths": {
+		err := os.WriteFile(authFile, []byte(fmt.Sprintf(`{"auths": {
 			"%s/podmantest/test-alpine": { "auth": "cG9kbWFudGVzdDp3cm9uZw==" },
 			"%s/podmantest": { "auth": "cG9kbWFudGVzdDp0ZXN0" },
 			"%s": { "auth": "cG9kbWFudGVzdDp0ZXN0" }

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -338,7 +337,7 @@ var _ = Describe("Podman manifest", func() {
 		for _, f := range blobs {
 			blobPath := filepath.Join(blobsDir, f.Name())
 
-			sourceFile, err := ioutil.ReadFile(blobPath)
+			sourceFile, err := os.ReadFile(blobPath)
 			Expect(err).To(BeNil())
 
 			compressionType := archive.DetectCompression(sourceFile)

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,7 +30,7 @@ var _ = Describe("Podman pause", func() {
 		}
 
 		if CGROUPSV2 {
-			b, err := ioutil.ReadFile("/proc/self/cgroup")
+			b, err := os.ReadFile("/proc/self/cgroup")
 			if err != nil {
 				Skip("cannot read self cgroup")
 			}
@@ -336,7 +335,7 @@ var _ = Describe("Podman pause", func() {
 	})
 
 	It("podman pause --cidfile", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile := tmpDir + "cid"
 
@@ -365,7 +364,7 @@ var _ = Describe("Podman pause", func() {
 	})
 
 	It("podman pause multiple --cidfile", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile1 := tmpDir + "cid-1"
 		tmpFile2 := tmpDir + "cid-2"

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -767,7 +766,7 @@ func generateMultiDocKubeYaml(kubeObjects []string, pathname string) error {
 
 func createSecret(podmanTest *PodmanTestIntegration, name string, value []byte) { //nolint:unparam
 	secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-	err := ioutil.WriteFile(secretFilePath, value, 0755)
+	err := os.WriteFile(secretFilePath, value, 0755)
 	Expect(err).To(BeNil())
 
 	secret := podmanTest.Podman([]string{"secret", "create", name, secretFilePath})
@@ -1442,7 +1441,7 @@ var _ = Describe("Podman play kube", func() {
 		conffile := filepath.Join(podmanTest.TempDir, "container.conf")
 
 		infraImage := "k8s.gcr.io/pause:3.2"
-		err := ioutil.WriteFile(conffile, []byte(fmt.Sprintf("[engine]\ninfra_image=\"%s\"\n", infraImage)), 0644)
+		err := os.WriteFile(conffile, []byte(fmt.Sprintf("[engine]\ninfra_image=\"%s\"\n", infraImage)), 0644)
 		Expect(err).To(BeNil())
 
 		os.Setenv("CONTAINERS_CONF", conffile)
@@ -2370,7 +2369,7 @@ spec:
 		tempdir, err = CreateTempDirInTempDir()
 		Expect(err).To(BeNil())
 
-		err := ioutil.WriteFile(conffile, []byte(testyaml), 0755)
+		err := os.WriteFile(conffile, []byte(testyaml), 0755)
 		Expect(err).To(BeNil())
 
 		kube := podmanTest.Podman([]string{"play", "kube", conffile})
@@ -3800,7 +3799,7 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 		if name == "root" {
 			name = "containers"
 		}
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}
@@ -3808,7 +3807,7 @@ ENV OPENJ9_JAVA_OPTIONS=%q
 			Skip("cannot find mappings for the current user")
 		}
 
-		initialUsernsConfig, err := ioutil.ReadFile("/proc/self/uid_map")
+		initialUsernsConfig, err := os.ReadFile("/proc/self/uid_map")
 		Expect(err).To(BeNil())
 		if os.Geteuid() != 0 {
 			unshare := podmanTest.Podman([]string{"unshare", "cat", "/proc/self/uid_map"})

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -332,7 +331,7 @@ var _ = Describe("Podman pod create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 
-		id, _ := ioutil.ReadFile(targetFile)
+		id, _ := os.ReadFile(targetFile)
 		check := podmanTest.Podman([]string{"pod", "inspect", "abc"})
 		check.WaitWithDefaultTimeout()
 		data := check.InspectPodToJSON()
@@ -707,7 +706,7 @@ ENTRYPOINT ["sleep","99999"]
 			name = "containers"
 		}
 
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}
@@ -742,7 +741,7 @@ ENTRYPOINT ["sleep","99999"]
 			name = "containers"
 		}
 
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}
@@ -778,7 +777,7 @@ ENTRYPOINT ["sleep","99999"]
 			name = "containers"
 		}
 
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}
@@ -815,7 +814,7 @@ ENTRYPOINT ["sleep","99999"]
 			name = "containers"
 		}
 
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}

--- a/test/e2e/pod_rm_test.go
+++ b/test/e2e/pod_rm_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -235,7 +234,7 @@ var _ = Describe("Podman pod rm", func() {
 	})
 
 	It("podman pod start/remove single pod via --pod-id-file", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile := tmpDir + "podID"
 		defer os.RemoveAll(tmpDir)
@@ -264,7 +263,7 @@ var _ = Describe("Podman pod rm", func() {
 	})
 
 	It("podman pod start/remove multiple pods via --pod-id-file", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		defer os.RemoveAll(tmpDir)
 

--- a/test/e2e/pod_start_test.go
+++ b/test/e2e/pod_start_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -175,7 +174,7 @@ var _ = Describe("Podman pod start", func() {
 	})
 
 	It("podman pod start single pod via --pod-id-file", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile := tmpDir + "podID"
 		defer os.RemoveAll(tmpDir)
@@ -199,7 +198,7 @@ var _ = Describe("Podman pod start", func() {
 	})
 
 	It("podman pod start multiple pods via --pod-id-file", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		defer os.RemoveAll(tmpDir)
 
@@ -231,7 +230,7 @@ var _ = Describe("Podman pod start", func() {
 	})
 
 	It("podman pod create --infra-conmon-pod create + start", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile := tmpDir + "podID"
 		defer os.RemoveAll(tmpDir)
@@ -248,7 +247,7 @@ var _ = Describe("Podman pod start", func() {
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1)) // infra
 
 		readFirstLine := func(path string) string {
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			Expect(err).To(BeNil())
 			return strings.Split(string(content), "\n")[0]
 		}

--- a/test/e2e/pod_stop_test.go
+++ b/test/e2e/pod_stop_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/containers/podman/v4/test/utils"
@@ -181,7 +180,7 @@ var _ = Describe("Podman pod stop", func() {
 	})
 
 	It("podman pod start/stop single pod via --pod-id-file", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile := tmpDir + "podID"
 		defer os.RemoveAll(tmpDir)
@@ -210,7 +209,7 @@ var _ = Describe("Podman pod stop", func() {
 	})
 
 	It("podman pod start/stop multiple pods via --pod-id-file", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		defer os.RemoveAll(tmpDir)
 

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -84,7 +83,7 @@ var _ = Describe("Podman push", func() {
 		for _, f := range blobs {
 			blobPath := filepath.Join(blobsDir, f.Name())
 
-			sourceFile, err := ioutil.ReadFile(blobPath)
+			sourceFile, err := os.ReadFile(blobPath)
 			Expect(err).To(BeNil())
 
 			compressionType := archive.DetectCompression(sourceFile)

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -251,7 +250,7 @@ var _ = Describe("Podman restart", func() {
 	})
 
 	It("podman restart --cidfile", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile := tmpDir + "cid"
 
@@ -274,7 +273,7 @@ var _ = Describe("Podman restart", func() {
 	})
 
 	It("podman restart multiple --cidfile", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile1 := tmpDir + "cid-1"
 		tmpFile2 := tmpDir + "cid-2"

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	. "github.com/containers/podman/v4/test/utils"
@@ -145,7 +144,7 @@ var _ = Describe("Podman rm", func() {
 	})
 
 	It("podman rm --cidfile", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile := tmpDir + "cid"
 
@@ -166,7 +165,7 @@ var _ = Describe("Podman rm", func() {
 	})
 
 	It("podman rm multiple --cidfile", func() {
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile1 := tmpDir + "cid-1"
 		tmpFile2 := tmpDir + "cid-2"

--- a/test/e2e/run_apparmor_test.go
+++ b/test/e2e/run_apparmor_test.go
@@ -5,7 +5,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -104,7 +103,7 @@ profile aa-test-profile flags=(attach_disconnected,mediate_deleted) {
 }
 `
 		aaFile := filepath.Join(os.TempDir(), "aaFile")
-		Expect(ioutil.WriteFile(aaFile, []byte(aaProfile), 0755)).To(BeNil())
+		Expect(os.WriteFile(aaFile, []byte(aaProfile), 0755)).To(BeNil())
 		parse := SystemExec("apparmor_parser", []string{"-Kr", aaFile})
 		Expect(parse).Should(Exit(0))
 

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,12 +85,12 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		containerCgroup := strings.TrimRight(strings.ReplaceAll(exec.OutputToString(), "0::", ""), "\n")
 
 		// Move the container process to a sub cgroup
-		content, err := ioutil.ReadFile(filepath.Join(cgroupRoot, containerCgroup, "cgroup.procs"))
+		content, err := os.ReadFile(filepath.Join(cgroupRoot, containerCgroup, "cgroup.procs"))
 		Expect(err).To(BeNil())
 		oldSubCgroupPath := filepath.Join(cgroupRoot, containerCgroup, "old-container")
 		err = os.MkdirAll(oldSubCgroupPath, 0755)
 		Expect(err).To(BeNil())
-		err = ioutil.WriteFile(filepath.Join(oldSubCgroupPath, "cgroup.procs"), content, 0644)
+		err = os.WriteFile(filepath.Join(oldSubCgroupPath, "cgroup.procs"), content, 0644)
 		Expect(err).To(BeNil())
 
 		newCgroup := fmt.Sprintf("%s/new-container", containerCgroup)

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/containers/podman/v4/test/utils"
@@ -26,7 +25,7 @@ var _ = Describe("Podman run cpu", func() {
 		}
 
 		if CGROUPSV2 {
-			if err := ioutil.WriteFile("/sys/fs/cgroup/cgroup.subtree_control", []byte("+cpuset"), 0644); err != nil {
+			if err := os.WriteFile("/sys/fs/cgroup/cgroup.subtree_control", []byte("+cpuset"), 0644); err != nil {
 				Skip("cpuset controller not available on the current kernel")
 			}
 		}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -638,7 +637,7 @@ USER bin`, BB)
 		Expect(session).Should(Exit(0))
 		Expect(session.OutputToString()).To(Equal("111"))
 
-		currentOOMScoreAdj, err := ioutil.ReadFile("/proc/self/oom_score_adj")
+		currentOOMScoreAdj, err := os.ReadFile("/proc/self/oom_score_adj")
 		Expect(err).To(BeNil())
 		session = podmanTest.Podman([]string{"run", "--rm", fedoraMinimal, "cat", "/proc/self/oom_score_adj"})
 		session.WaitWithDefaultTimeout()
@@ -845,7 +844,7 @@ USER bin`, BB)
 	"stage" : [ "prestart" ]
 }
 `, hookScriptPath)
-		err = ioutil.WriteFile(hookJSONPath, []byte(hookJSON), 0644)
+		err = os.WriteFile(hookJSONPath, []byte(hookJSON), 0644)
 		Expect(err).ToNot(HaveOccurred())
 
 		random := stringid.GenerateRandomID()
@@ -853,14 +852,14 @@ USER bin`, BB)
 		hookScript := fmt.Sprintf(`#!/bin/sh
 echo -n %s >%s
 `, random, targetFile)
-		err = ioutil.WriteFile(hookScriptPath, []byte(hookScript), 0755)
+		err = os.WriteFile(hookScriptPath, []byte(hookScript), 0755)
 		Expect(err).ToNot(HaveOccurred())
 
 		session := podmanTest.Podman([]string{"--hooks-dir", hooksDir, "run", ALPINE, "ls"})
 		session.Wait(10)
 		Expect(session).Should(Exit(0))
 
-		b, err := ioutil.ReadFile(targetFile)
+		b, err := os.ReadFile(targetFile)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(string(b)).To(Equal(random))
 	})
@@ -877,19 +876,19 @@ echo -n %s >%s
 
 		mountsFile := filepath.Join(containersDir, "mounts.conf")
 		mountString := secretsDir + ":/run/secrets"
-		err = ioutil.WriteFile(mountsFile, []byte(mountString), 0755)
+		err = os.WriteFile(mountsFile, []byte(mountString), 0755)
 		Expect(err).To(BeNil())
 
 		secretsFile := filepath.Join(secretsDir, "test.txt")
 		secretsString := "Testing secrets mount. I am mounted!"
-		err = ioutil.WriteFile(secretsFile, []byte(secretsString), 0755)
+		err = os.WriteFile(secretsFile, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		targetDir := tempdir + "/symlink/target"
 		err = os.MkdirAll(targetDir, 0755)
 		Expect(err).To(BeNil())
 		keyFile := filepath.Join(targetDir, "key.pem")
-		err = ioutil.WriteFile(keyFile, []byte(mountString), 0755)
+		err = os.WriteFile(keyFile, []byte(mountString), 0755)
 		Expect(err).To(BeNil())
 		execSession := SystemExec("ln", []string{"-s", targetDir, filepath.Join(secretsDir, "mysymlink")})
 		Expect(execSession).Should(Exit(0))
@@ -908,7 +907,7 @@ echo -n %s >%s
 	It("podman run with FIPS mode secrets", func() {
 		SkipIfRootless("rootless can not manipulate system-fips file")
 		fipsFile := "/etc/system-fips"
-		err = ioutil.WriteFile(fipsFile, []byte{}, 0755)
+		err = os.WriteFile(fipsFile, []byte{}, 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "ls", "/run/secrets"})
@@ -1070,7 +1069,7 @@ USER mail`, BB)
 		filename := "test.txt"
 		volFile := filepath.Join(vol, filename)
 		data := "Testing --volumes-from!!!"
-		err = ioutil.WriteFile(volFile, []byte(data), 0755)
+		err = os.WriteFile(volFile, []byte(data), 0755)
 		Expect(err).To(BeNil())
 		mountpoint := "/myvol/"
 
@@ -1102,7 +1101,7 @@ USER mail`, BB)
 		filename := "test.txt"
 		volFile := filepath.Join(vol, filename)
 		data := "Testing --volumes-from!!!"
-		err = ioutil.WriteFile(volFile, []byte(data), 0755)
+		err = os.WriteFile(volFile, []byte(data), 0755)
 		Expect(err).To(BeNil())
 		mountpoint := "/myvol/"
 
@@ -1469,7 +1468,7 @@ USER mail`, BB)
 			return strings.TrimSuffix(i, "\n")
 		}
 
-		curCgroupsBytes, err := ioutil.ReadFile("/proc/self/cgroup")
+		curCgroupsBytes, err := os.ReadFile("/proc/self/cgroup")
 		Expect(err).ShouldNot(HaveOccurred())
 		curCgroups := trim(string(curCgroupsBytes))
 		fmt.Printf("Output:\n%s\n", curCgroups)
@@ -1492,7 +1491,7 @@ USER mail`, BB)
 			Skip("Test only works on crun")
 		}
 
-		curCgroupsBytes, err := ioutil.ReadFile("/proc/self/cgroup")
+		curCgroupsBytes, err := os.ReadFile("/proc/self/cgroup")
 		Expect(err).To(BeNil())
 		var curCgroups string = string(curCgroupsBytes)
 		fmt.Printf("Output:\n%s\n", curCgroups)
@@ -1509,7 +1508,7 @@ USER mail`, BB)
 		pid := inspectOut[0].State.Pid
 		Expect(pid).To(Not(Equal(0)))
 
-		ctrCgroupsBytes, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+		ctrCgroupsBytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 		Expect(err).To(BeNil())
 		var ctrCgroups string = string(ctrCgroupsBytes)
 		fmt.Printf("Output\n:%s\n", ctrCgroups)
@@ -1740,7 +1739,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -1762,7 +1761,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret source=mysecret,type=mount", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -1784,7 +1783,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret source=mysecret,type=mount with target", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret_target", secretFilePath})
@@ -1806,7 +1805,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret source=mysecret,type=mount with target at /tmp", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret_target2", secretFilePath})
@@ -1828,7 +1827,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret source=mysecret,type=env", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -1844,7 +1843,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret target option", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -1860,7 +1859,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret mount with uid, gid, mode options", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -1887,7 +1886,7 @@ WORKDIR /madethis`, BB)
 	It("podman run --secret with --user", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -1903,7 +1902,7 @@ WORKDIR /madethis`, BB)
 	It("podman run invalid secret option", func() {
 		secretsString := "somesecretdata"
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte(secretsString), 0755)
+		err := os.WriteFile(secretFilePath, []byte(secretsString), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "mysecret", secretFilePath})
@@ -1968,7 +1967,7 @@ WORKDIR /madethis`, BB)
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		readFirstLine := func(path string) string {
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			Expect(err).To(BeNil())
 			return strings.Split(string(content), "\n")[0]
 		}

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"strings"
@@ -55,7 +54,7 @@ var _ = Describe("Podman UserNS support", func() {
 		if name == "root" {
 			name = "containers"
 		}
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}
@@ -181,7 +180,7 @@ var _ = Describe("Podman UserNS support", func() {
 			name = "containers"
 		}
 
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}
@@ -213,7 +212,7 @@ var _ = Describe("Podman UserNS support", func() {
 			name = "containers"
 		}
 
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}
@@ -251,7 +250,7 @@ var _ = Describe("Podman UserNS support", func() {
 			name = "containers"
 		}
 
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}
@@ -280,7 +279,7 @@ var _ = Describe("Podman UserNS support", func() {
 			name = "containers"
 		}
 
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -768,7 +767,7 @@ VOLUME /test/`, ALPINE)
 			name = "containers"
 		}
 
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}
@@ -815,7 +814,7 @@ VOLUME /test/`, ALPINE)
 			name = "containers"
 		}
 
-		content, err := ioutil.ReadFile("/etc/subuid")
+		content, err := os.ReadFile("/etc/subuid")
 		if err != nil {
 			Skip("cannot read /etc/subuid")
 		}

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -185,7 +184,7 @@ default-docker:
   sigstore: file:///var/lib/containers/sigstore
   sigstore-staging: file:///var/lib/containers/sigstore
 `
-		Expect(ioutil.WriteFile("/etc/containers/registries.d/default.yaml", []byte(sigstore), 0755)).To(BeNil())
+		Expect(os.WriteFile("/etc/containers/registries.d/default.yaml", []byte(sigstore), 0755)).To(BeNil())
 
 		session = podmanTest.Podman([]string{"tag", ALPINE, "localhost:5000/alpine"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"text/template"
@@ -288,7 +287,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		err = registryFileTmpl.Execute(&buffer, ep)
 		Expect(err).ToNot(HaveOccurred())
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
-		err = ioutil.WriteFile(fmt.Sprintf("%s/registry4.conf", tempdir), buffer.Bytes(), 0644)
+		err = os.WriteFile(fmt.Sprintf("%s/registry4.conf", tempdir), buffer.Bytes(), 0644)
 		Expect(err).ToNot(HaveOccurred())
 		if IsRemote() {
 			podmanTest.RestartRemoteService()
@@ -332,7 +331,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		err = registryFileTmpl.Execute(&buffer, ep)
 		Expect(err).ToNot(HaveOccurred())
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
-		err = ioutil.WriteFile(fmt.Sprintf("%s/registry5.conf", tempdir), buffer.Bytes(), 0644)
+		err = os.WriteFile(fmt.Sprintf("%s/registry5.conf", tempdir), buffer.Bytes(), 0644)
 		Expect(err).ToNot(HaveOccurred())
 
 		search := podmanTest.Podman([]string{"search", image, "--tls-verify=true"})
@@ -372,7 +371,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		err = registryFileBadTmpl.Execute(&buffer, ep)
 		Expect(err).ToNot(HaveOccurred())
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
-		err = ioutil.WriteFile(fmt.Sprintf("%s/registry6.conf", tempdir), buffer.Bytes(), 0644)
+		err = os.WriteFile(fmt.Sprintf("%s/registry6.conf", tempdir), buffer.Bytes(), 0644)
 		Expect(err).ToNot(HaveOccurred())
 
 		if IsRemote() {
@@ -428,7 +427,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		err = registryFileTwoTmpl.Execute(&buffer, ep3)
 		Expect(err).ToNot(HaveOccurred())
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
-		err = ioutil.WriteFile(fmt.Sprintf("%s/registry8.conf", tempdir), buffer.Bytes(), 0644)
+		err = os.WriteFile(fmt.Sprintf("%s/registry8.conf", tempdir), buffer.Bytes(), 0644)
 		Expect(err).ToNot(HaveOccurred())
 
 		if IsRemote() {

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -37,7 +36,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret create", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "-d", "file", "--driver-opts", "opt1=val", "a", secretFilePath})
@@ -57,7 +56,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret create bad name should fail", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "?!", secretFilePath})
@@ -67,7 +66,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret inspect", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -83,7 +82,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret inspect with --format", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -99,7 +98,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret inspect multiple secrets", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -120,7 +119,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret inspect bogus", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		inspect := podmanTest.Podman([]string{"secret", "inspect", "bogus"})
@@ -131,7 +130,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret ls", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -147,7 +146,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret ls --quiet", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		secretName := "a"
@@ -177,7 +176,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret ls with filters", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		secret1 := "Secret1"
@@ -231,7 +230,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret ls with Go template", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -247,7 +246,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret rm", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
@@ -268,7 +267,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret rm --all", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -204,7 +203,7 @@ var _ = Describe("Podman start", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		readFirstLine := func(path string) string {
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			Expect(err).To(BeNil())
 			return strings.Split(string(content), "\n")[0]
 		}

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -276,7 +275,7 @@ var _ = Describe("Podman stop", func() {
 
 	It("podman stop --cidfile", func() {
 
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile := tmpDir + "cid"
 
@@ -300,7 +299,7 @@ var _ = Describe("Podman stop", func() {
 
 	It("podman stop multiple --cidfile", func() {
 
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		Expect(err).To(BeNil())
 		tmpFile1 := tmpDir + "cid-1"
 		tmpFile2 := tmpDir + "cid-2"

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -27,7 +26,7 @@ var _ = Describe("podman system connection", func() {
 
 	BeforeEach(func() {
 		ConfPath.Value, ConfPath.IsSet = os.LookupEnv("CONTAINERS_CONF")
-		conf, err := ioutil.TempFile("", "containersconf")
+		conf, err := os.CreateTemp("", "containersconf")
 		Expect(err).ToNot(HaveOccurred())
 		os.Setenv("CONTAINERS_CONF", conf.Name())
 

--- a/test/e2e/system_service_test.go
+++ b/test/e2e/system_service_test.go
@@ -1,7 +1,7 @@
 package integration
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -89,7 +89,7 @@ var _ = Describe("podman system service", func() {
 			defer resp.Body.Close()
 			Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(body).ShouldNot(BeEmpty())
 

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,7 +50,7 @@ WantedBy=default.target
 		SkipIfRootless("rootless can not write to /etc")
 		SkipIfContainerized("test does not have systemd as pid 1")
 
-		sysFile := ioutil.WriteFile("/etc/systemd/system/redis.service", []byte(systemdUnitFile), 0644)
+		sysFile := os.WriteFile("/etc/systemd/system/redis.service", []byte(systemdUnitFile), 0644)
 		Expect(sysFile).To(BeNil())
 		defer func() {
 			stop := SystemExec("bash", []string{"-c", "systemctl stop redis"})
@@ -137,7 +136,7 @@ RUN mkdir -p /usr/lib/systemd/; touch /usr/lib/systemd/systemd
 CMD /usr/lib/systemd/systemd`, ALPINE)
 
 		containerfilePath := filepath.Join(podmanTest.TempDir, "Containerfile")
-		err := ioutil.WriteFile(containerfilePath, []byte(containerfile), 0755)
+		err := os.WriteFile(containerfilePath, []byte(containerfile), 0755)
 		Expect(err).To(BeNil())
 		session := podmanTest.Podman([]string{"build", "-t", "systemd", "--file", containerfilePath, podmanTest.TempDir})
 		session.WaitWithDefaultTimeout()
@@ -167,7 +166,7 @@ CMD /usr/lib/systemd/systemd`, ALPINE)
 		Expect(session).Should(Exit(0))
 
 		pidFile := strings.TrimSuffix(session.OutputToString(), "\n")
-		_, err := ioutil.ReadFile(pidFile)
+		_, err := os.ReadFile(pidFile)
 		Expect(err).To(BeNil())
 	})
 

--- a/test/e2e/trust_test.go
+++ b/test/e2e/trust_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -57,7 +56,7 @@ var _ = Describe("Podman trust", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		var teststruct map[string][]map[string]string
-		policyContent, err := ioutil.ReadFile(policyJSON)
+		policyContent, err := os.ReadFile(policyJSON)
 		if err != nil {
 			os.Exit(1)
 		}
@@ -111,7 +110,7 @@ var _ = Describe("Podman trust", func() {
 		session := podmanTest.Podman([]string{"image", "trust", "show", "--policypath", filepath.Join(INTEGRATION_ROOT, "test/policy.json"), "--raw"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		contents, err := ioutil.ReadFile(filepath.Join(INTEGRATION_ROOT, "test/policy.json"))
+		contents, err := os.ReadFile(filepath.Join(INTEGRATION_ROOT, "test/policy.json"))
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(session.OutputToString()).To(BeValidJSON())
 		Expect(string(session.Out.Contents())).To(Equal(string(contents) + "\n"))

--- a/test/testvol/main.go
+++ b/test/testvol/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -78,7 +77,7 @@ func startServer(socketPath string) error {
 	logrus.Debugf("Starting server...")
 
 	if config.path == "" {
-		path, err := ioutil.TempDir("", "test_volume_plugin")
+		path, err := os.MkdirTemp("", "test_volume_plugin")
 		if err != nil {
 			return fmt.Errorf("getting directory for plugin: %w", err)
 		}

--- a/test/utils/common_function_test.go
+++ b/test/utils/common_function_test.go
@@ -3,7 +3,7 @@ package utils_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"strings"
@@ -113,7 +113,7 @@ var _ = Describe("Common functions test", func() {
 		Expect(err).To(BeNil(), "Can not find the JSON file after we write it.")
 		defer read.Close()
 
-		bytes, err := ioutil.ReadAll(read)
+		bytes, err := io.ReadAll(read)
 		Expect(err).ToNot(HaveOccurred())
 		err = json.Unmarshal(bytes, compareData)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -100,7 +99,7 @@ func (p *PodmanTest) PodmanAsUserBase(args []string, uid, gid uint32, cwd string
 	}
 
 	if timeDir := os.Getenv(EnvTimeDir); timeDir != "" {
-		timeFile, err := ioutil.TempFile(timeDir, ".time")
+		timeFile, err := os.CreateTemp(timeDir, ".time")
 		if err != nil {
 			Fail(fmt.Sprintf("Error creating time file: %v", err))
 		}
@@ -374,7 +373,7 @@ func (s *PodmanSession) WaitWithTimeout(timeout int) {
 
 // CreateTempDirInTempDir create a temp dir with prefix podman_test
 func CreateTempDirInTempDir() (string, error) {
-	return ioutil.TempDir("", "podman_test")
+	return os.MkdirTemp("", "podman_test")
 }
 
 // SystemExec is used to exec a system command to check its exit code or output
@@ -497,7 +496,7 @@ func WriteJSONFile(data []byte, filePath string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filePath, formatJSON, 0644)
+	return os.WriteFile(filePath, formatJSON, 0644)
 }
 
 // Containerized check the podman command run inside container
@@ -506,7 +505,7 @@ func Containerized() bool {
 	if container != "" {
 		return true
 	}
-	b, err := ioutil.ReadFile(ProcessOneCgroupPath)
+	b, err := os.ReadFile(ProcessOneCgroupPath)
 	if err != nil {
 		// shrug, if we cannot read that file, return false
 		return false

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -114,7 +113,7 @@ var (
 // RunsOnSystemd returns whether the system is using systemd
 func RunsOnSystemd() bool {
 	runsOnSystemdOnce.Do(func() {
-		initCommand, err := ioutil.ReadFile("/proc/1/comm")
+		initCommand, err := os.ReadFile("/proc/1/comm")
 		// On errors, default to systemd
 		runsOnSystemd = err != nil || strings.TrimRight(string(initCommand), "\n") == "systemd"
 	})
@@ -122,7 +121,7 @@ func RunsOnSystemd() bool {
 }
 
 func moveProcessPIDFileToScope(pidPath, slice, scope string) error {
-	data, err := ioutil.ReadFile(pidPath)
+	data, err := os.ReadFile(pidPath)
 	if err != nil {
 		// do not raise an error if the file doesn't exist
 		if os.IsNotExist(err) {

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -181,7 +180,7 @@ func moveUnderCgroup(cgroup, subtree string, processes []uint32) error {
 				}
 			}
 		} else {
-			processesData, err := ioutil.ReadFile(filepath.Join(cgroupRoot, parts[2], "cgroup.procs"))
+			processesData, err := os.ReadFile(filepath.Join(cgroupRoot, parts[2], "cgroup.procs"))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Package `io/ioutil` was deprecated in golang 1.16, preventing podman from
building under Fedora 37.  Fortunately, functionality identical
replacements are provided by the packages `io` and `os`.  Replace all
usage of all `io/ioutil` symbols with appropriate substitutions
according to the golang docs.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Replace all use of io/ioutil (deprecated as of golang 1.16)
```
