### PR TITLE
Add --pretty to podman secret inspect

### DIFF
--- a/docs/source/markdown/podman-secret-inspect.1.md
+++ b/docs/source/markdown/podman-secret-inspect.1.md
@@ -34,6 +34,10 @@ Format secret output using Go template.
 
 Print usage statement.
 
+#### **--pretty**
+
+Print inspect output in human-readable format
+
 
 ## EXAMPLES
 

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -96,6 +96,23 @@ var _ = Describe("Podman secret", func() {
 		Expect(inspect.OutputToString()).To(Equal(secrID))
 	})
 
+	It("podman secret inspect with --pretty", func() {
+		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		Expect(err).To(BeNil())
+
+		session := podmanTest.Podman([]string{"secret", "create", "a", secretFilePath})
+		session.WaitWithDefaultTimeout()
+		secrID := session.OutputToString()
+		Expect(session).Should(Exit(0))
+
+		inspect := podmanTest.Podman([]string{"secret", "inspect", "--pretty", secrID})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		Expect(inspect.OutputToString()).To(ContainSubstring("Name:"))
+		Expect(inspect.OutputToString()).To(ContainSubstring(secrID))
+	})
+
 	It("podman secret inspect multiple secrets", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
 		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
@@ -125,7 +142,6 @@ var _ = Describe("Podman secret", func() {
 		inspect := podmanTest.Podman([]string{"secret", "inspect", "bogus"})
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect).To(ExitWithError())
-
 	})
 
 	It("podman secret ls", func() {


### PR DESCRIPTION
Pretty-print podman secret inspect output in a human-readable format

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Podman secret inspect now has a --pretty flag for human readable output

```
