### PR TITLE
DO NOT MERGE: see how aarch64 is doing

### DIFF
--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -311,7 +311,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret with labels", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "--label", "foo=bar", "a", secretFilePath})

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -579,7 +579,7 @@ function skip_if_root_ubuntu {
 
 function skip_if_aarch64 {
     if is_aarch64; then
-        skip "${msg:-Cannot run this test on aarch64 systems}"
+        echo "# HEADS-UP: this test is usually skipped on aarch64" >&3
     fi
 }
 


### PR DESCRIPTION
A lot of system tests fail on aarch64, and are being skipped.
Let's try disabling that skip, and see if they still fail.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```