### PR TITLE
Fix a few missed io/ioutil -> os updates

### DIFF
--- a/pkg/bindings/generator/generator.go
+++ b/pkg/bindings/generator/generator.go
@@ -12,7 +12,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -72,7 +71,7 @@ func main() {
 	)
 	srcFile := os.Getenv("GOFILE")
 	inputStructName := os.Args[1]
-	b, err := ioutil.ReadFile(srcFile)
+	b, err := os.ReadFile(srcFile)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/bindings/test/auth_test.go
+++ b/pkg/bindings/test/auth_test.go
@@ -1,7 +1,6 @@
 package bindings_test
 
 import (
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -76,7 +75,7 @@ var _ = Describe("Podman images", func() {
 		imageRef := imageRep + ":" + imageTag
 
 		// Create a temporary authentication file.
-		tmpFile, err := ioutil.TempFile("", "auth.json.")
+		tmpFile, err := os.CreateTemp("", "auth.json.")
 		Expect(err).To(BeNil())
 		_, err = tmpFile.Write([]byte{'{', '}'})
 		Expect(err).To(BeNil())

--- a/pkg/bindings/test/common_test.go
+++ b/pkg/bindings/test/common_test.go
@@ -3,7 +3,6 @@ package bindings_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -146,7 +145,7 @@ func newBindingTest() *bindingTest {
 
 // createTempDirinTempDir create a temp dir with prefix podman_test
 func createTempDirInTempDir() (string, error) {
-	return ioutil.TempDir("", "libpod_api")
+	return os.MkdirTemp("", "libpod_api")
 }
 
 func (b *bindingTest) startAPIService() *gexec.Session {
@@ -264,7 +263,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// If running localized tests, the cache dir is created and populated. if the
 	// tests are remote, this is a no-op
 	createCache()
-	path, err := ioutil.TempDir("", "libpodlock")
+	path, err := os.MkdirTemp("", "libpodlock")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -5,7 +5,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -48,7 +47,7 @@ func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
 func (p *PodmanTestIntegration) setRegistriesConfigEnv(b []byte) {
 	outfile := filepath.Join(p.TempDir, "registries.conf")
 	os.Setenv("CONTAINERS_REGISTRIES_CONF", outfile)
-	err := ioutil.WriteFile(outfile, b, 0644)
+	err := os.WriteFile(outfile, b, 0644)
 	Expect(err).ToNot(HaveOccurred())
 }
 

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -311,7 +311,7 @@ var _ = Describe("Podman secret", func() {
 
 	It("podman secret with labels", func() {
 		secretFilePath := filepath.Join(podmanTest.TempDir, "secret")
-		err := ioutil.WriteFile(secretFilePath, []byte("mysecret"), 0755)
+		err := os.WriteFile(secretFilePath, []byte("mysecret"), 0755)
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"secret", "create", "--label", "foo=bar", "a", secretFilePath})


### PR DESCRIPTION
Somehow these crept in or were missed by my grep.

Ref: https://github.com/containers/podman/pull/15871

Fixes: #15889

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Replace additional usage of io/ioutil (deprecated as of golang 1.16)
```
