### PR TITLE
[CI:BUILD] Cirrus: Catch use of deprecated ioutils package

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -233,6 +233,25 @@ function _run_consistency() {
     SUGGESTION="run 'make generate-bindings' and commit all changes" ./hack/tree_status.sh
     make completions
     SUGGESTION="run 'make completions' and commit all changes" ./hack/tree_status.sh
+
+    if  [[ -z "$CIRRUS_TAG" ]] && \
+        req_env_vars CIRRUS_CHANGE_IN_REPO CIRRUS_PR DEST_BRANCH
+    then
+        local base diffs regex i
+        # Prevent this check from detecting itself
+        i=i
+        msg "#####"
+        msg "Verifying no change adds new calls to ${i}o/${i}outil."
+        base=$(git merge-base $DEST_BRANCH $CIRRUS_CHANGE_IN_REPO)
+        diffs=$(git diff $base $CIRRUS_CHANGE_IN_REPO -- '*.go' ':^vendor/')
+        regex=$(echo -e "^(\\+.+${i}o/${i}outil)|(\\+.+${i}outil\\..+)")
+        if egrep -q "$regex"<<<"$diffs"; then
+            die "Found attempted use of deprecated ${i}outils:
+$(egrep -B 5 -A 5 "$regex"<<<"$diffs")"
+        fi
+    else
+        msg "Skipping check for ${i}o/${i}outil addition."
+    fi
 }
 
 function _run_build() {


### PR DESCRIPTION
At the time of this commit, there's no easier way to detect this using `golangci-lint` or the go tool (that I could find).

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
