### PR TITLE
CI: only make install.tools when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -850,11 +850,19 @@ endif
 
 .PHONY: install.tools
 install.tools: .install.ginkgo .install.golangci-lint ## Install needed tools
-	make -C test/tools
+	$(MAKE) -C test/tools
+
+.PHONY: .install.goimports
+.install.goimports:
+	$(MAKE) -C test/tools build/goimports
 
 .PHONY: .install.ginkgo
 .install.ginkgo:
 	$(GO) install $(BUILDFLAGS) ./vendor/github.com/onsi/ginkgo/ginkgo
+
+.PHONY: .install.gitvalidation
+.install.gitvalidation:
+	$(MAKE) -C test/tools build/git-validation
 
 .PHONY: .install.golangci-lint
 .install.golangci-lint:
@@ -863,7 +871,7 @@ install.tools: .install.ginkgo .install.golangci-lint ## Install needed tools
 .PHONY: .install.md2man
 .install.md2man:
 	if [ ! -x "$(GOMD2MAN)" ]; then \
-		make -C test/tools build/go-md2man ; \
+		$(MAKE) -C test/tools build/go-md2man ; \
 	fi
 
 .PHONY: .install.pre-commit

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -232,8 +232,7 @@ case "$TEST_FLAVOR" in
     validate)
         dnf install -y $PACKAGE_DOWNLOAD_DIR/python3*.rpm
         # For some reason, this is also needed for validation
-        make install.tools
-        make .install.pre-commit
+        make .install.pre-commit .install.gitvalidation
         ;;
     automation) ;;
     altbuild)
@@ -242,11 +241,9 @@ case "$TEST_FLAVOR" in
         if [[ "$ALT_NAME" =~ RPM ]]; then
             bigto dnf install -y glibc-minimal-langpack go-rpm-macros rpkg rpm-build shadow-utils-subid-devel
         fi
-        make install.tools
         ;;
     docker-py)
         remove_packaged_podman_files
-        make install.tools
         make install PREFIX=/usr ETCDIR=/etc
 
         msg "Installing previously downloaded/cached packages"
@@ -258,16 +255,14 @@ case "$TEST_FLAVOR" in
         ;;
     build) make clean ;;
     unit)
-        make install.tools
+        make .install.ginkgo
         ;;
     compose_v2)
-        make install.tools
         dnf -y remove docker-compose
         curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
         chmod +x /usr/local/bin/docker-compose
         ;& # Continue with next item
     apiv2)
-        make install.tools
         msg "Installing previously downloaded/cached packages"
         dnf install -y $PACKAGE_DOWNLOAD_DIR/python3*.rpm
         virtualenv .venv/requests
@@ -276,16 +271,16 @@ case "$TEST_FLAVOR" in
         pip install --requirement $GOSRC/test/apiv2/python/requirements.txt
         ;&  # continue with next item
     compose)
-        make install.tools
         dnf install -y $PACKAGE_DOWNLOAD_DIR/podman-docker*
         ;&  # continue with next item
-    int) ;&
+    int)
+        make .install.ginkgo
+        ;&
     sys) ;&
     upgrade_test) ;&
     bud) ;&
     bindings) ;&
     endpoint)
-        make install.tools
         # Use existing host bits when testing is to happen inside a container
         # since this script will run again in that environment.
         # shellcheck disable=SC2154
@@ -309,7 +304,6 @@ case "$TEST_FLAVOR" in
     machine)
         dnf install -y $PACKAGE_DOWNLOAD_DIR/podman-gvproxy*
         remove_packaged_podman_files
-        make install.tools
         make install PREFIX=/usr ETCDIR=/etc
         install_test_configs
         ;;
@@ -374,7 +368,7 @@ case "$TEST_FLAVOR" in
     swagger) ;&  # use next item
     consistency)
         make clean
-        make install.tools
+        make .install.goimports
         ;;
     release) ;;
     *) die_unknown TEST_FLAVOR

--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -6,7 +6,7 @@ die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
 
 function install() {
     echo "Installing golangci-lint v$VERSION into $BIN"
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$VERSION
+    curl -sSL --retry 5 https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$VERSION
 }
 
 # Undocumented behavior: golangci-lint installer requires $BINDIR in env,


### PR DESCRIPTION
Reintroduce .install.foo targets into Makefile, and invoke
only the bare-minimum ones needed for each individual CI
step in setup_environment.sh.

Also add a retry to the golangci-lint curl, in hopes of
dealing with network flakes. And remove the -f (fail)
because it produces unhelpful logs.

Reason: saw about 25% CI flakes yesterday due to the golangci-lint
fetch, something about a timeout, and this was especially frustrating
because none of the steps actually needed lint. Quick reminder:
avoid network fetches unless absolutely necessary.

Fixes: #15892

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```