### PR TITLE
compat API: network inspect do not show isolate option

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -118,6 +118,11 @@ func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, network *netty
 	if changeDefaultName && name == runtime.Network().DefaultNetworkName() {
 		name = nettypes.BridgeNetworkDriver
 	}
+	options := network.Options
+	// bridge always has isolate set in the compat API but we should not return it to not confuse callers
+	// https://github.com/containers/podman/issues/15580
+	delete(options, nettypes.IsolateOption)
+
 	report := types.NetworkResource{
 		Name:       name,
 		ID:         network.ID,
@@ -126,7 +131,7 @@ func convertLibpodNetworktoDockerNetwork(runtime *libpod.Runtime, network *netty
 		Internal:   network.Internal,
 		EnableIPv6: network.IPv6Enabled,
 		Labels:     network.Labels,
-		Options:    network.Options,
+		Options:    options,
 		IPAM:       ipam,
 		Scope:      "local",
 		Attachable: false,

--- a/test/compose/uptwice/docker-compose.yml
+++ b/test/compose/uptwice/docker-compose.yml
@@ -2,4 +2,5 @@ version: '3'
 services:
     app:
         build: .
-        command: sleep 10002
+        command: sleep 10001
+        stop_signal: SIGKILL # faster shutdown, no reason to wait 10 seconds

--- a/test/compose/uptwice/teardown.sh
+++ b/test/compose/uptwice/teardown.sh
@@ -1,0 +1,3 @@
+# -*- bash -*-
+
+mv docker-compose.yml.bak docker-compose.yml

--- a/test/compose/uptwice/tests.sh
+++ b/test/compose/uptwice/tests.sh
@@ -1,4 +1,17 @@
 # -*- bash -*-
 
+CR=$'\r'
+NL=$'\n'
+
+cp docker-compose.yml docker-compose.yml.bak
 sed -i -e 's/10001/10002/' docker-compose.yml
-docker-compose up -d
+output=$(docker-compose up -d 2>&1)
+
+# Horrible output check here but we really want to make sure that there are
+# no unexpected warning/errors and the normal messages are send on stderr as
+# well so we cannot check for an empty stderr.
+expected="Recreating uptwice_app_1 ... ${CR}${NL}Recreating uptwice_app_1 ... done$CR"
+if [ "$TEST_FLAVOR" = "compose_v2" ]; then
+    expected="Container uptwice-app-1  Recreate${NL}Container uptwice-app-1  Recreated${NL}Container uptwice-app-1  Starting${NL}Container uptwice-app-1  Started"
+fi
+is "$output" "$expected" "no error output in compose up (#15580)"


### PR DESCRIPTION
We force the isolate option on new newtworks because that is the docker behavior. However when we inspect them they should not be displayed to the caller since they have no idea about it and docker-compose throws an error because of that.

Fixes #15580

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug in the network inspect compat api where an incorrect network option was displayed which caused problems for docker-compose.
```
