### PR TITLE
fix restore API endpoint

### DIFF
--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -305,6 +305,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 		PrintStats      bool   `schema:"printStats"`
 		FileLocks       bool   `schema:"fileLocks"`
 		PublishPorts    string `schema:"publishPorts"`
+		Pod             string `schema:"pod"`
 	}{
 		// override any golang type defaults
 	}
@@ -324,6 +325,7 @@ func Restore(w http.ResponseWriter, r *http.Request) {
 		PrintStats:      query.PrintStats,
 		FileLocks:       query.FileLocks,
 		PublishPorts:    strings.Fields(query.PublishPorts),
+		Pod:             query.Pod,
 	}
 
 	var names []string

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -1516,6 +1516,10 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    name: printStats
 	//    type: boolean
 	//    description: add restore statistics to the returned RestoreReport
+	//  - in: query
+	//    name: pod
+	//    type: string
+	//    description: pod to restore into
 	// produces:
 	// - application/json
 	// responses:

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -1170,10 +1170,6 @@ var _ = Describe("Podman checkpoint", func() {
 		share := share // copy into local scope, for use inside function
 
 		It(testName, func() {
-			if podmanTest.Host.Distribution == "ubuntu" && IsRemote() {
-				Skip("FIXME: #15018. Cannot restore --pod under cgroupsV1 and remote")
-			}
-
 			if !criu.CheckForCriu(criu.PodCriuVersion) {
 				Skip("CRIU is missing or too old.")
 			}


### PR DESCRIPTION
restore endpoint was totally ignoring --pod, it was missing from the schema and from query handling on the api handlers side. add support for it here.

resolves #15018

Signed-off-by: cdoern <cbdoer23@g.holycross.edu>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman-remote restore now supports --pod properly
```
