### PR TITLE
Proof of concept: nightly dependency treadmill

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -139,6 +139,22 @@ build_task:
           _gc='git config --file /root/.gitconfig'
           $_gc user.email "TMcTestFace@example.com"
           $_gc user.name "Testy McTestface"
+          # Nightly dependency-bump job: fetch latest versions of the
+          # Big Three dependencies, and run full CI test suite. Notification
+          # email will go out to monitor-list upon failure.
+          if [[ "$CIRRUS_CRON" = "treadmill" ]]; then
+              for pkg in common image/v5 storage; do
+                  echo "go mod edit --require containers/$pkg@main"
+                  go mod edit --require github.com/containers/$pkg@main
+                  make vendor
+              done
+              git add vendor
+              # Show what changed.
+              echo "git diff go.mod, then git diff --stat:"
+              git diff go.mod
+              git diff --stat
+              HOME=/root git commit --allow-empty -asm"Bump containers/common,image,storage"
+          fi
     # Attempt to prevent flakes by confirming basic environment expectations,
     # network service connectivity and essential container image availability.
     prebuild_script: &prebuild $SCRIPT_BASE/prebuild.sh


### PR DESCRIPTION
As discussed in f2f: this is the cleanest, simplest mechanism
I can think of to auto-test the Big Three dependencies: simply
run go mod edit immediately after git checkout, then run the
entire CI test suite.

If this approach works, we can set up a new CIRRUS_CRON=treadmill
job. I'm expecting it not to work, because Murphy, but want to
see what the unexpected gotchas are.

This differs significantly from the buildah treadmill, in that
buildah is almost impossible to re-vendor without manual intervention.
(In practice, so are these, but let's dream of a world in which
this will run and pass every night). (I want a pony too).

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```