### PR TITLE
[v4.2.0-rhel] Backport #15799

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -357,7 +357,9 @@ func (c *Container) specFromState() (*spec.Spec, error) {
 			return nil, fmt.Errorf("error reading container config: %w", err)
 		}
 		if err := json.Unmarshal(content, &returnSpec); err != nil {
-			return nil, fmt.Errorf("error unmarshalling container config: %w", err)
+			// Malformed spec, just use c.config.Spec instead
+			logrus.Warnf("Error unmarshalling container %s config: %v", c.ID(), err)
+			return c.config.Spec, nil
 		}
 	} else if !os.IsNotExist(err) {
 		// ignore when the file does not exist


### PR DESCRIPTION
Backport of #15799 to v4.2.0-rhel for https://bugzilla.redhat.com/show_bug.cgi?id=2126697

```release-note
NONE
```
