### PR TITLE
[CI:DOCS] man page xref: verify page title

### DIFF
--- a/docs/source/markdown/podman-machine-list.1.md
+++ b/docs/source/markdown/podman-machine-list.1.md
@@ -1,4 +1,4 @@
-% podman-machine-ls 1
+% podman-machine-list 1
 
 ## NAME
 podman\-machine\-list - List virtual machines

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -292,6 +292,15 @@ sub podman_man {
         chomp $line;
         next unless $line;		# skip empty lines
 
+        # First line (page title) must match the command name.
+        if ($line =~ /^%\s+/) {
+            my $expect = "% $command 1";
+            if ($line ne $expect) {
+                warn "$ME: $subpath:$.: wrong title line '$line'; should be '$expect'\n";
+                ++$Errs;
+            }
+        }
+
         # .md files designate sections with leading double hash
         if ($line =~ /^##\s*(GLOBAL\s+)?OPTIONS/) {
             $section = 'flags';


### PR DESCRIPTION
Issue #15923 should have never happened: the problem should've
been autodetected. Make it so henceforth (and fix another
existing discrepancy)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```