### PR TITLE
[CI:DOCS] Man pages: Refactor common options: --sig-proxy

### DIFF
--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -1,3 +1,4 @@
+podman-attach.1.md
 podman-auto-update.1.md
 podman-build.1.md
 podman-container-clone.1.md

--- a/docs/source/markdown/options/sig-proxy.md
+++ b/docs/source/markdown/options/sig-proxy.md
@@ -1,0 +1,3 @@
+#### **--sig-proxy**
+
+Proxy received signals to the container process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied.

--- a/docs/source/markdown/podman-attach.1.md.in
+++ b/docs/source/markdown/podman-attach.1.md.in
@@ -28,9 +28,8 @@ The default is **false**.\
 
 Do not attach STDIN. The default is **false**.
 
-#### **--sig-proxy**
+@@option sig-proxy
 
-Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied.\
 The default is **true**.
 
 ## EXAMPLES

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -439,9 +439,9 @@ Note: Labeling can be disabled for all containers by setting **label=false** in 
 
 @@option shm-size
 
-#### **--sig-proxy**
+@@option sig-proxy
 
-Sets whether the signals sent to the **podman run** command are proxied to the container process. SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is **true**.
+The default is **true**.
 
 @@option stop-signal
 

--- a/docs/source/markdown/podman-start.1.md.in
+++ b/docs/source/markdown/podman-start.1.md.in
@@ -60,9 +60,9 @@ Valid filters are listed below:
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--sig-proxy**
+@@option sig-proxy
 
-Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true* when attaching, *false* otherwise.
+The default is **true** when attaching, **false** otherwise.
 
 ## EXAMPLE
 


### PR DESCRIPTION
Unusually, I discarded the podman-run version and went with
the one common to attach and start. (The defaults are left
out of the common file, because 'start' is different by
necessity). Please review extra-carefully to make sure
the new wording applies to podman-run, in particular
the "non-TTY mode" words.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```