### PR TITLE
[CI:DOCS] Add SELinux information about boolean for using random devices

### DIFF
--- a/docs/source/markdown/options/device.md
+++ b/docs/source/markdown/options/device.md
@@ -12,3 +12,11 @@ The <<container|pod>> will only store the major and minor numbers of the host de
 Podman may load kernel modules required for using the specified
 device. The devices that Podman will load modules for when necessary are:
 /dev/fuse.
+
+In rootless mode, the new device is bind mounted in the container from the host
+rather than Podman creating it within the container space. Because the bind
+mount retains its SELinux label on SELinux systems, the container can get
+permission denied when accessing the mounted device. Modify SELinux settings to
+allow containers to use all device labels via the following command:
+
+$ sudo setsebool -P  container_use_devices=true


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/15930

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update man pages to describe SELinux boolean for use of system devices.
```
