### PR TITLE
[CI:DOCS] Man pages: refactor common options: --env

### DIFF
--- a/docs/source/markdown/options/env.md
+++ b/docs/source/markdown/options/env.md
@@ -1,0 +1,5 @@
+#### **--env**, **-e**=*env*
+
+Set environment variables.
+
+This option allows arbitrary environment variables that are available for the process to be launched inside of the container. If an environment variable is specified without a value, Podman will check the host environment for a value and set the variable only if it is set on the host. As a special case, if an environment variable ending in __*__ is specified without a value, Podman will search the host environment for variables starting with the prefix and will add those variables to the container.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -151,11 +151,7 @@ This option cannot be combined with **--network** that is set to **none** or **c
 
 @@option entrypoint
 
-#### **--env**, **-e**=*env*
-
-Set environment variables
-
-This option allows arbitrary environment variables that are available for the process to be launched inside of the container. If an environment variable is specified without a value, Podman will check the host environment for a value and set the variable only if it is set on the host. As a special case, if an environment variable ending in __*__ is specified without a value, Podman will search the host environment for variables starting with the prefix and will add those variables to the container.
+@@option env
 
 See [**Environment**](#environment) note below for precedence and examples.
 

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -21,11 +21,7 @@ Start the exec session, but do not attach to it. The command will run in the bac
 
 Specify the key sequence for detaching a container. Format is a single character `[a-Z]` or one or more `ctrl-<value>` characters where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`. Specifying "" will disable this feature. The default is *ctrl-p,ctrl-q*.
 
-#### **--env**, **-e**=*env*
-
-Set environment variables.
-
-This option allows arbitrary environment variables that are available for the process to be launched inside of the container. If an environment variable is specified without a value, Podman will check the host environment for a value and set the variable only if it is set on the host. As a special case, if an environment variable ending in __*__ is specified without a value, Podman will search the host environment for variables starting with the prefix and will add those variables to the container.
+@@option env
 
 #### **--env-file**=*file*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -187,11 +187,7 @@ This option cannot be combined with **--network** that is set to **none** or **c
 
 @@option entrypoint
 
-#### **--env**, **-e**=*env*
-
-Set environment variables.
-
-This option allows arbitrary environment variables that are available for the process to be launched inside of the container. If an environment variable is specified without a value, Podman will check the host environment for a value and set the variable only if it is set on the host. As a special case, if an environment variable ending in __*__ is specified without a value, Podman will search the host environment for variables starting with the prefix and will add those variables to the container.
+@@option env
 
 See [**Environment**](#environment) note below for precedence and examples.
 


### PR DESCRIPTION
Only among podman create, exec, run. The same option in
podman build, generate-systemd, and secret-create is too
different.

Should be a trivial one to review, the only difference is
a period at the end of one sentence. And, of course, the
"See Environment note" applies only to podman-create and
run, not exec, so it can't be deduplicated.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```