### PR TITLE
[CI:DOCS] Man pages: refactor common options: --env-file

### DIFF
--- a/docs/source/markdown/options/env-file.md
+++ b/docs/source/markdown/options/env-file.md
@@ -1,0 +1,3 @@
+#### **--env-file**=*file*
+
+Read in a line-delimited file of environment variables.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -155,9 +155,9 @@ This option cannot be combined with **--network** that is set to **none** or **c
 
 See [**Environment**](#environment) note below for precedence and examples.
 
-#### **--env-file**=*file*
+@@option env-file
 
-Read in a line delimited file of environment variables. See **Environment** note below for precedence.
+See [**Environment**](#environment) note below for precedence and examples.
 
 @@option env-host
 

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -23,9 +23,7 @@ Specify the key sequence for detaching a container. Format is a single character
 
 @@option env
 
-#### **--env-file**=*file*
-
-Read in a line delimited file of environment variables.
+@@option env-file
 
 @@option interactive
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -191,9 +191,9 @@ This option cannot be combined with **--network** that is set to **none** or **c
 
 See [**Environment**](#environment) note below for precedence and examples.
 
-#### **--env-file**=*file*
+@@option env-file
 
-Read in a line delimited file of environment variables. See **Environment** note below for precedence.
+See [**Environment**](#environment) note below for precedence and examples.
 
 @@option env-host
 


### PR DESCRIPTION
Another easy one. Option is only present in these three man pages.

I took the liberty of changing the "See note" text, making it
the same as --env. I also took the liberty of hyphenating
"line-delimited" because that's the correct thing to do.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```