### PR TITLE
drivers/driver_linux: Show fstype in GetFSMagic() if debug logging is enabled

### DIFF
--- a/vendor/github.com/containers/storage/drivers/driver_linux.go
+++ b/vendor/github.com/containers/storage/drivers/driver_linux.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/storage/pkg/mount"
 	"golang.org/x/sys/unix"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -94,6 +95,10 @@ func GetFSMagic(rootpath string) (FsMagic, error) {
 	var buf unix.Statfs_t
 	if err := unix.Statfs(filepath.Dir(rootpath), &buf); err != nil {
 		return 0, err
+	}
+
+	if _, ok := FsNames[FsMagic(buf.Type)]; ok != true {
+		logrus.Debugf("Unknown file system type: %#x", buf.Type)
 	}
 	return FsMagic(buf.Type), nil
 }


### PR DESCRIPTION
In the context of github.com/containers/storage/drivers.GetFSMagic() when log-level debug is enabled show the filesystem type/or ID that is returned by the statfs(2) system call in particular when the ID is not known to podman. This might suggest an unsupported configuration.

Signed-off-by: Aaron Tomlin <atomlin@redhat.com>
