### PR TITLE
fix: kube play liveness probe http path

### DIFF
--- a/pkg/k8s.io/api/core/v1/types.go
+++ b/pkg/k8s.io/api/core/v1/types.go
@@ -939,15 +939,15 @@ type HTTPHeader struct {
 
 // HTTPGetAction describes an action based on HTTP Get requests.
 type HTTPGetAction struct {
-	// Path to access on the HTTP server.
+	// Path to access on the HTTP server. Defaults to /.
 	// +optional
 	Path string `json:"path,omitempty"`
 	// Name or number of the port to access on the container.
 	// Number must be in the range 1 to 65535.
 	// Name must be an IANA_SVC_NAME.
 	Port intstr.IntOrString `json:"port"`
-	// Host name to connect to, defaults to the pod IP. You probably want to set
-	// "Host" in httpHeaders instead.
+	// Host name to connect to. You probably want to set "Host" in httpHeaders instead.
+	// Defaults to the pod IP in Kubernetes, in case of Podman to localhost.
 	// +optional
 	Host string `json:"host,omitempty"`
 	// Scheme to use for connecting to the host.
@@ -964,9 +964,9 @@ type URIScheme string
 
 const (
 	// URISchemeHTTP means that the scheme used will be http://
-	URISchemeHTTP URIScheme = "HTTP"
+	URISchemeHTTP URIScheme = "http"
 	// URISchemeHTTPS means that the scheme used will be https://
-	URISchemeHTTPS URIScheme = "HTTPS"
+	URISchemeHTTPS URIScheme = "https"
 )
 
 // TCPSocketAction describes an action based on opening a socket

--- a/pkg/specgen/generate/kube/kube.go
+++ b/pkg/specgen/generate/kube/kube.go
@@ -507,7 +507,7 @@ func setupLivenessProbe(s *specgen.SpecGenerator, containerYAML v1.Container, re
 			commandString = fmt.Sprintf("%s || %s", execString, failureCmd)
 		case probeHandler.HTTPGet != nil:
 			// set defaults as in https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes
-			var uriScheme v1.URIScheme = "http"
+			uriScheme := v1.URISchemeHTTP
 			if probeHandler.HTTPGet.Scheme != "" {
 				uriScheme = probeHandler.HTTPGet.Scheme
 			}
@@ -515,7 +515,11 @@ func setupLivenessProbe(s *specgen.SpecGenerator, containerYAML v1.Container, re
 			if probeHandler.HTTPGet.Host != "" {
 				host = probeHandler.HTTPGet.Host
 			}
-			commandString = fmt.Sprintf("curl -f %s://%s:%d%s || %s", uriScheme, host, probeHandler.HTTPGet.Port.IntValue(), probeHandler.HTTPGet.Path, failureCmd)
+			path := "/"
+			if probeHandler.HTTPGet.Path != "" {
+				path = probeHandler.HTTPGet.Path
+			}
+			commandString = fmt.Sprintf("curl -f %s://%s:%d%s || %s", uriScheme, host, probeHandler.HTTPGet.Port.IntValue(), path, failureCmd)
 		case probeHandler.TCPSocket != nil:
 			commandString = fmt.Sprintf("nc -z -v %s %d || %s", probeHandler.TCPSocket.Host, probeHandler.TCPSocket.Port.IntValue(), failureCmd)
 		}

--- a/pkg/specgen/generate/kube/play_test.go
+++ b/pkg/specgen/generate/kube/play_test.go
@@ -897,7 +897,6 @@ func TestHttpLivenessProbe(t *testing.T) {
 					Handler: v1.Handler{
 						HTTPGet: &v1.HTTPGetAction{
 							Port: intstr.FromInt(80),
-							Path: "/",
 						},
 					},
 				},


### PR DESCRIPTION
Follow-up on the [15958](https://github.com/containers/podman/pull/15958).

- When a pod with HTTP liveness probe is created using podman kube play, ensure the [Kubernetes defaults value for path](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes) is set correctly.
- Update the URI scheme to use lowercase and use this value in code (not used otherwise, URI are lowercase)

Fixes #15855 for the final parameter. I am sorry that I missed this in the original pull request.

#### Does this PR introduce a user-facing change?

```release-note
None
```
