### PR TITLE
[CI:DOCS] Adds brew info podman to issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -61,7 +61,7 @@ Briefly describe the problem you are having in a few paragraphs.
 (paste your output here)
 ```
 
-**Package info (e.g. output of `rpm -q podman` or `apt list podman`):**
+**Package info (e.g. output of `rpm -q podman` or `apt list podman` or `brew info podman`):**
 
 ```
 (paste your output here)


### PR DESCRIPTION
Just a quick little addition to provide the command to get the package info from homebrew for those who might not know. I've added this as a CI:DOCS PR because there's no functional changes, even though it's not specifically docs.

Thanks for your time!

#### Does this PR introduce a user-facing change?

```release-note
None
```
