### PR TITLE
play kube: Allow the user to import the contents of a tar file into a volume

### DIFF
--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -44,6 +44,9 @@ A Kubernetes PersistentVolumeClaim represents a Podman named volume. Only the Pe
 - volume.podman.io/uid
 - volume.podman.io/gid
 - volume.podman.io/mount-options
+- volume.podman.io/import-source
+
+Use `volume.podman.io/import-source` to import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) specified in the annotation's value into the created Podman volume
 
 Kube play is capable of building images on the fly given the correct directory layout and Containerfiles. This
 option is not available for remote clients, including Mac and Windows (excluding WSL2) machines, yet. Consider the following excerpt from a YAML file:

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -280,3 +280,7 @@ func (v *Volume) Unmount() error {
 	defer v.lock.Unlock()
 	return v.unmount(false)
 }
+
+func (v *Volume) NeedsMount() bool {
+	return v.needsMount()
+}

--- a/pkg/api/handlers/libpod/kube.go
+++ b/pkg/api/handlers/libpod/kube.go
@@ -93,6 +93,7 @@ func KubePlay(w http.ResponseWriter, r *http.Request) {
 		LogOptions:  query.LogOptions,
 		StaticIPs:   staticIPs,
 		StaticMACs:  staticMACs,
+		IsRemote:    true,
 	}
 	if _, found := r.URL.Query()["tlsVerify"]; found {
 		options.SkipTLSVerify = types.NewOptionalBool(!query.TLSVerify)

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -58,6 +58,8 @@ type PlayKubeOptions struct {
 	ServiceContainer bool
 	// Userns - define the user namespace to use.
 	Userns string
+	// IsRemote - was the request triggered by running podman-remote
+	IsRemote bool
 }
 
 // PlayKubePod represents a single pod and associated containers created by play kube

--- a/pkg/util/kube.go
+++ b/pkg/util/kube.go
@@ -13,4 +13,6 @@ const (
 	VolumeGIDAnnotation = "volume.podman.io/gid"
 	// Kube annotation for podman volume mount options.
 	VolumeMountOptsAnnotation = "volume.podman.io/mount-options"
+	// Kube annotation for podman volume import source.
+	VolumeImportSourceAnnotation = "volume.podman.io/import-source"
 )


### PR DESCRIPTION
Add a new annotation to allow the user to point to a local tar file If the annotation is present, import the file's content into the volume Add the annotation to the documentation
Add an E2E test to the new annotation

Signed-off-by: Ygal Blum <ygal.blum@gmail.com>

```release-note
Play Kube - support volume import using a new annotation
```
