### PR TITLE
Revert "remote: fix manifest add --annotation"

### DIFF
--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containers/common/libimage"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v4/libpod"
 	"github.com/containers/podman/v4/pkg/api/handlers"
@@ -148,7 +148,7 @@ func ManifestInspect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var schema2List libimage.ManifestListData
+	var schema2List manifest.Schema2List
 	if err := json.Unmarshal(rawManifest, &schema2List); err != nil {
 		utils.Error(w, http.StatusInternalServerError, err)
 		return

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containers/common/libimage"
+	"github.com/containers/image/v5/manifest"
 	imageTypes "github.com/containers/image/v5/types"
 	"github.com/containers/podman/v4/pkg/auth"
 	"github.com/containers/podman/v4/pkg/bindings"
@@ -71,7 +71,7 @@ func Exists(ctx context.Context, name string, options *ExistsOptions) (bool, err
 }
 
 // Inspect returns a manifest list for a given name.
-func Inspect(ctx context.Context, name string, _ *InspectOptions) (*libimage.ManifestListData, error) {
+func Inspect(ctx context.Context, name string, _ *InspectOptions) (*manifest.Schema2List, error) {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func Inspect(ctx context.Context, name string, _ *InspectOptions) (*libimage.Man
 	}
 	defer response.Body.Close()
 
-	var list libimage.ManifestListData
+	var list manifest.Schema2List
 	return &list, response.Process(&list)
 }
 

--- a/pkg/bindings/manifests/types.go
+++ b/pkg/bindings/manifests/types.go
@@ -22,7 +22,7 @@ type ExistsOptions struct {
 // AddOptions are optional options for adding manifest lists
 type AddOptions struct {
 	All           *bool
-	Annotation    []string
+	Annotation    map[string]string
 	Arch          *string
 	Features      []string
 	Images        []string
@@ -46,12 +46,12 @@ type ModifyOptions struct {
 	// Operation values are "update", "remove" and "annotate". This allows the service to
 	//   efficiently perform each update on a manifest list.
 	Operation   *string
-	All         *bool    // All when true, operate on all images in a manifest list that may be included in Images
-	Annotations []string // Annotations to add to manifest list
-	Arch        *string  // Arch overrides the architecture for the image
-	Features    []string // Feature list for the image
-	Images      []string // Images is an optional list of images to add/remove to/from manifest list depending on operation
-	OS          *string  // OS overrides the operating system for the image
+	All         *bool             // All when true, operate on all images in a manifest list that may be included in Images
+	Annotations map[string]string // Annotations to add to manifest list
+	Arch        *string           // Arch overrides the architecture for the image
+	Features    []string          // Feature list for the image
+	Images      []string          // Images is an optional list of images to add/remove to/from manifest list depending on operation
+	OS          *string           // OS overrides the operating system for the image
 	// OS features for the image
 	OSFeatures []string `json:"os_features" schema:"os_features"`
 	// OSVersion overrides the operating system for the image

--- a/pkg/bindings/manifests/types_add_options.go
+++ b/pkg/bindings/manifests/types_add_options.go
@@ -33,15 +33,15 @@ func (o *AddOptions) GetAll() bool {
 }
 
 // WithAnnotation set field Annotation to given value
-func (o *AddOptions) WithAnnotation(value []string) *AddOptions {
+func (o *AddOptions) WithAnnotation(value map[string]string) *AddOptions {
 	o.Annotation = value
 	return o
 }
 
 // GetAnnotation returns value of field Annotation
-func (o *AddOptions) GetAnnotation() []string {
+func (o *AddOptions) GetAnnotation() map[string]string {
 	if o.Annotation == nil {
-		var z []string
+		var z map[string]string
 		return z
 	}
 	return o.Annotation

--- a/pkg/bindings/manifests/types_modify_options.go
+++ b/pkg/bindings/manifests/types_modify_options.go
@@ -48,15 +48,15 @@ func (o *ModifyOptions) GetAll() bool {
 }
 
 // WithAnnotations set annotations to add to manifest list
-func (o *ModifyOptions) WithAnnotations(value []string) *ModifyOptions {
+func (o *ModifyOptions) WithAnnotations(value map[string]string) *ModifyOptions {
 	o.Annotations = value
 	return o
 }
 
 // GetAnnotations returns value of annotations to add to manifest list
-func (o *ModifyOptions) GetAnnotations() []string {
+func (o *ModifyOptions) GetAnnotations() map[string]string {
 	if o.Annotations == nil {
-		var z []string
+		var z map[string]string
 		return z
 	}
 	return o.Annotations

--- a/pkg/domain/entities/manifest.go
+++ b/pkg/domain/entities/manifest.go
@@ -36,7 +36,7 @@ type ManifestAddOptions struct {
 // ManifestAnnotateOptions provides model for annotating manifest list
 type ManifestAnnotateOptions struct {
 	// Annotation to add to manifest list
-	Annotation []string `json:"annotations" schema:"annotations"`
+	Annotation []string `json:"annotation" schema:"annotation"`
 	// Arch overrides the architecture for the image
 	Arch string `json:"arch" schema:"arch"`
 	// Feature list for the image

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/containers/image/v5/types"
 	"github.com/containers/podman/v4/pkg/bindings/images"
@@ -47,9 +48,20 @@ func (ir *ImageEngine) ManifestInspect(_ context.Context, name string) ([]byte, 
 
 // ManifestAdd adds images to the manifest list
 func (ir *ImageEngine) ManifestAdd(_ context.Context, name string, imageNames []string, opts entities.ManifestAddOptions) (string, error) {
-	options := new(manifests.AddOptions).WithAll(opts.All).WithAnnotation(opts.Annotation).WithArch(opts.Arch)
-	options.WithVariant(opts.Variant).WithFeatures(opts.Features).WithImages(imageNames).WithOS(opts.OS)
-	options.WithOSVersion(opts.OSVersion).WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile)
+	options := new(manifests.AddOptions).WithAll(opts.All).WithArch(opts.Arch).WithVariant(opts.Variant)
+	options.WithFeatures(opts.Features).WithImages(imageNames).WithOS(opts.OS).WithOSVersion(opts.OSVersion)
+	options.WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile)
+	if len(opts.Annotation) != 0 {
+		annotations := make(map[string]string)
+		for _, annotationSpec := range opts.Annotation {
+			spec := strings.SplitN(annotationSpec, "=", 2)
+			if len(spec) != 2 {
+				return "", fmt.Errorf("no value given for annotation %q", spec[0])
+			}
+			annotations[spec[0]] = spec[1]
+		}
+		options.WithAnnotation(annotations)
+	}
 	if s := opts.SkipTLSVerify; s != types.OptionalBoolUndefined {
 		if s == types.OptionalBoolTrue {
 			options.WithSkipTLSVerify(true)

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -165,20 +165,6 @@ var _ = Describe("Podman manifest", func() {
 			))
 	})
 
-	It("add --annotation", func() {
-		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-		session = podmanTest.Podman([]string{"manifest", "add", "--annotation", "hoge=fuga", "foo", imageList})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-		session = podmanTest.Podman([]string{"manifest", "inspect", "foo"})
-		session.WaitWithDefaultTimeout()
-		Expect(session).Should(Exit(0))
-		Expect(session.OutputToString()).To(ContainSubstring(`"annotations"`))
-		Expect(session.OutputToString()).To(ContainSubstring(`"hoge": "fuga"`))
-	})
-
 	It("add --os", func() {
 		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
This reverts commit 32f54a81ed797597827123b671b6e73194354327.

`pkg/bindings` is supported outside of podman and we have to keep it stable.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
