### PR TITLE
fix "podman system prune networks" flake

### DIFF
--- a/test/e2e/network_test.go
+++ b/test/e2e/network_test.go
@@ -706,7 +706,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network prune --filter", func() {
-		// set custom cni directory to prevent flakes
+		// set custom network directory to prevent flakes since the dir is shared with all tests by default
 		podmanTest.NetworkConfigDir = tempdir
 		if IsRemote() {
 			podmanTest.RestartRemoteService()
@@ -754,7 +754,7 @@ var _ = Describe("Podman network", func() {
 	})
 
 	It("podman network prune", func() {
-		// set custom cni directory to prevent flakes
+		// set custom network directory to prevent flakes since the dir is shared with all tests by default
 		podmanTest.NetworkConfigDir = tempdir
 		if IsRemote() {
 			podmanTest.RestartRemoteService()

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -259,6 +259,12 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system prune networks", func() {
+		// set custom network directory to prevent flakes since the dir is shared with all tests by default
+		podmanTest.NetworkConfigDir = tempdir
+		if IsRemote() {
+			podmanTest.RestartRemoteService()
+		}
+
 		// Create new network.
 		session := podmanTest.Podman([]string{"network", "create", "test"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Since by default the network config dir is shared in the e2e tests any
other parallel running test could remove a network and cause this test to
fail.

Fixes #15990

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
