### PR TITLE
[CI:DOCS] Man pages: refactor common options: --log-opt

### DIFF
--- a/docs/source/markdown/options/log-opt.md
+++ b/docs/source/markdown/options/log-opt.md
@@ -1,0 +1,16 @@
+#### **--log-opt**=*name=value*
+
+Logging driver specific options.
+
+Set custom logging configuration. The following *name*s are supported:
+
+**path**: specify a path to the log file
+    (e.g. **--log-opt path=/var/log/container/mycontainer.json**);
+
+**max-size**: specify a max size of the log file
+    (e.g. **--log-opt max-size=10mb**);
+
+**tag**: specify a custom log tag for the container
+    (e.g. **--log-opt tag="{{.ImageName}}"**.
+It supports the same keys as **podman inspect --format**.
+This option is currently supported only by the **journald** log driver.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -228,22 +228,7 @@ pod when that pod is not running.
 
 @@option log-driver
 
-#### **--log-opt**=*name=value*
-
-Set custom logging configuration. The following *name*s are supported:
-
-- **path**: specify a path to the log file
-(e.g. **--log-opt path=/var/log/container/mycontainer.json**);
-
-- **max-size**: specify a max size of the log file
-(e.g. **--log-opt max-size=10mb**);
-
-- **tag**: specify a custom log tag for the container
-(e.g. **--log-opt tag="{{.ImageName}}"**.
-
-It supports the same keys as **podman inspect --format**.
-
-This option is currently supported only by the **journald** log driver.
+@@option log-opt
 
 @@option mac-address
 

--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -146,22 +146,7 @@ Note: When joining multiple networks you should use the **--network name:ip=\<ip
 
 Set logging driver for all created containers.
 
-#### **--log-opt**=*name=value*
-
-Set custom logging configuration. The following *name*s are supported:
-
-- **path**: specify a path to the log file
-(e.g. **--log-opt path=/var/log/container/mycontainer.json**);
-
-- **max-size**: specify a max size of the log file
-(e.g. **--log-opt max-size=10mb**);
-
-- **tag**: specify a custom log tag for the container
-(e.g. **--log-opt tag="{{.ImageName}}"**.
-
-It supports the same keys as **podman inspect --format**.
-
-This option is currently supported only by the **journald** log driver.
+@@option log-opt
 
 #### **--mac-address**=*MAC address*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -249,22 +249,7 @@ Print usage statement
 
 @@option log-driver
 
-#### **--log-opt**=*name=value*
-
-Logging driver specific options.
-
-Set custom logging configuration. The following *name*s are supported:
-
-**path**: specify a path to the log file
-    (e.g. **--log-opt path=/var/log/container/mycontainer.json**);
-
-**max-size**: specify a max size of the log file
-    (e.g. **--log-opt max-size=10mb**);
-
-**tag**: specify a custom log tag for the container
-   (e.g. **--log-opt tag="{{.ImageName}}"**.
-
-This option is currently supported only by the **journald** log driver.
+@@option log-opt
 
 @@option mac-address
 


### PR DESCRIPTION
Simple in reality, but hard to review due to lots of little diffs:

 - "Logging driver specific options" was only in podman-run; I added it
   to create and kube-play.
 - whitespace changes, the 'e.g.'s got consistent 4-space indentation
 - the "same keys" and "supported only" sentences, I moved up to be
   closer to **tag** and without intervening whitespace, because they
   were unclear as they were: I believe the intent is to apply those
   sentences only to **tag**, not to the **--log-opt** option itself.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```