### PR TITLE
[CI:DOCS] Man pages: Refactor common options: --sign-passphrase-file

### DIFF
--- a/docs/source/markdown/options/sign-passphrase-file.md
+++ b/docs/source/markdown/options/sign-passphrase-file.md
@@ -1,0 +1,3 @@
+#### **--sign-passphrase-file**=*path*
+
+If signing the image (using either **--sign-by** or **--sign-by-sigstore-private-key**), read the passphrase to use from the specified path.

--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -55,9 +55,7 @@ Sign the pushed images with a “simple signing” signature using the specified
 
 Sign the pushed images with a sigstore signature using a private key at the specified path. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--sign-passphrase-file**=*path*
-
-If signing the image (using either **--sign-by** or **--sign-by-sigstore-private-key**), read the passphrase to use from the specified path.
+@@option sign-passphrase-file
 
 @@option tls-verify
 

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -86,9 +86,7 @@ Add a “simple signing” signature at the destination using the specified key.
 
 Add a sigstore signature at the destination using a private key at the specified path. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--sign-passphrase-file**=*path*
-
-If signing the image (using either **--sign-by** or **--sign-by-sigstore-private-key**), read the passphrase to use from the specified path.
+@@option sign-passphrase-file
 
 @@option tls-verify
 


### PR DESCRIPTION
Trivial one: no human intervention needed, the man page text
was already identical between both files.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```