### PR TITLE
[CI:DOCS] Add quay-description update reminder

### DIFF
--- a/contrib/podmanimage/README.md
+++ b/contrib/podmanimage/README.md
@@ -1,3 +1,16 @@
+[comment]: <> (***ATTENTION*** ***WARNING*** ***ALERT*** ***CAUTION*** ***DANGER***)
+[comment]: <> ()
+[comment]: <> (ANY changes made to this file, once commited/merged must)
+[comment]: <> (be manually copy/pasted -in markdown- into the description)
+[comment]: <> (field on Quay at the following locations:)
+[comment]: <> ()
+[comment]: <> (https://quay.io/repository/containers/podman)
+[comment]: <> (https://quay.io/repository/podman/stable)
+[comment]: <> (https://quay.io/repository/podman/testing)
+[comment]: <> (https://quay.io/repository/podman/upstream)
+[comment]: <> ()
+[comment]: <> (***ATTENTION*** ***WARNING*** ***ALERT*** ***CAUTION*** ***DANGER***)
+
 ![PODMAN logo](https://raw.githubusercontent.com/containers/common/main/logos/podman-logo-full-vert.png)
 
 # podmanimage


### PR DESCRIPTION
Fixes: https://github.com/containers/podman/issues/15989

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
