### PR TITLE
Fix typo about e2e tests name

### DIFF
--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Podman kill", func() {
 		Expect(wait).Should(Exit(0))
 	})
 
-	It("podman stop --all", func() {
+	It("podman kill --all", func() {
 		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -321,7 +321,7 @@ var _ = Describe("Podman restart", func() {
 		Expect(result.ErrorToString()).To(ContainSubstring("cannot be used together"))
 	})
 
-	It("podman pause --filter", func() {
+	It("podman restart --filter", func() {
 		session1 := podmanTest.RunTopContainer("")
 		session1.WaitWithDefaultTimeout()
 		Expect(session1).Should(Exit(0))


### PR DESCRIPTION
* podman stop --all -> podman kill --all
* podman pause --filter -> podman restart --filter

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
