### PR TITLE
container inspect: include image digest

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -166,6 +166,15 @@ func (c *Container) getContainerInspectData(size bool, driverData *define.Driver
 		IsInfra:         c.IsInfra(),
 		IsService:       c.IsService(),
 	}
+
+	if config.RootfsImageID != "" { // May not be set if the container was created with --rootfs
+		image, _, err := c.runtime.libimageRuntime.LookupImage(config.RootfsImageID, nil)
+		if err != nil {
+			return nil, err
+		}
+		data.ImageDigest = image.Digest().String()
+	}
+
 	if ctrSpec.Process.Capabilities != nil {
 		data.EffectiveCaps = ctrSpec.Process.Capabilities.Effective
 		data.BoundingCaps = ctrSpec.Process.Capabilities.Bounding

--- a/libpod/define/container_inspect.go
+++ b/libpod/define/container_inspect.go
@@ -659,6 +659,7 @@ type InspectContainerData struct {
 	Args            []string                    `json:"Args"`
 	State           *InspectContainerState      `json:"State"`
 	Image           string                      `json:"Image"`
+	ImageDigest     string                      `json:"ImageDigest"`
 	ImageName       string                      `json:"ImageName"`
 	Rootfs          string                      `json:"Rootfs"`
 	Pod             string                      `json:"Pod"`


### PR DESCRIPTION
Include the digest of the image in `podman container inspect`. The image digest is a key information for auditing as it defines the identify of an image.  This way, it can be determined whether a container used an image with a given CVE etc.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
container inspect: include image digest
```

@baude PTAL