### PR TITLE
[CI:DOCS] Man pages: refactor common options: --compression-format

### DIFF
--- a/docs/source/markdown/options/compression-format.md
+++ b/docs/source/markdown/options/compression-format.md
@@ -1,0 +1,3 @@
+#### **--compression-format**=**gzip** | *zstd* | *zstd:chunked*
+
+Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip` unless overridden in the containers.conf file.

--- a/docs/source/markdown/podman-manifest-push.1.md.in
+++ b/docs/source/markdown/podman-manifest-push.1.md.in
@@ -23,9 +23,7 @@ the list or index itself. (Default true)
 
 @@option cert-dir
 
-#### **--compression-format**=**gzip** | *zstd* | *zstd:chunked*
-
-Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip` unless overridden in the containers.conf file.
+@@option compression-format
 
 @@option creds
 

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -56,9 +56,7 @@ $ podman push myimage oci-archive:/tmp/myimage
 Compress tarball image layers when pushing to a directory using the 'dir' transport. (default is same compression type, compressed or uncompressed, as source)
 Note: This flag can only be set when using the **dir** transport
 
-#### **--compression-format**=**gzip** | *zstd* | *zstd:chunked*
-
-Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip` unless overridden in the containers.conf file.
+@@option compression-format
 
 @@option creds
 


### PR DESCRIPTION
Easy one: text was already identical across both files.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```