### PR TITLE
Add pods created by play kube to a default network

### DIFF
--- a/docs/source/markdown/podman-kube-play.1.md.in
+++ b/docs/source/markdown/podman-kube-play.1.md.in
@@ -155,7 +155,7 @@ Note: When joining multiple networks you should use the **--network name:mac=\<m
 
 @@option network
 
-The *host* network mode should be configured in the YAML file.
+When no network option is specified and *host* network mode is not configured in the YAML file, a new network stack is created and pods are attached to it making possible pod to pod communication.
 
 @@option no-hosts
 

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -3000,6 +3000,21 @@ MemoryReservation: {{ .HostConfig.MemoryReservation }}`})
 		Expect(logs.OutputToString()).To(Equal(netns))
 	})
 
+	It("podman play kube test with kube default network", func() {
+		pod := getPod()
+		err := generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).To(BeNil())
+
+		kube := podmanTest.Podman([]string{"play", "kube", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(Exit(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", pod.Name, "--format", "{{ .InfraConfig.Networks }}"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect).Should(Exit(0))
+		Expect(inspect.OutputToString()).To(Equal("[podman-default-kube-network]"))
+	})
+
 	It("podman play kube persistentVolumeClaim", func() {
 		volName := "myvol"
 		volDevice := "tmpfs"


### PR DESCRIPTION
In order to allow pods to reach other pods (as in Kubernetes) they all need to be added to the same network. A network is created (if it doesn't exist) and pods created by play-kube are added to that network. When network options are passed to kube command the pods are not attached to the default kube network.

Signed-off-by: Andrei Natanael Cosma <andrei@intersect.ro>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Behavior of play-kube is changed to create a network (podman-kube) if it doesn't exists and adds pods created by kube-play to that network, which allows pods to reach other pods - as in Kubernetes.
```
It partially overlaps with #12965 