### PR TITLE
[CI:DOCS] Man pages: refactor common options: --variant

### DIFF
--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -12,6 +12,7 @@ podman-login.1.md
 podman-logout.1.md
 podman-logs.1.md
 podman-manifest-add.1.md
+podman-manifest-annotate.1.md
 podman-manifest-create.1.md
 podman-manifest-push.1.md
 podman-pause.1.md

--- a/docs/source/markdown/options/variant.container.md
+++ b/docs/source/markdown/options/variant.container.md
@@ -1,0 +1,3 @@
+#### **--variant**=*VARIANT*
+
+Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.

--- a/docs/source/markdown/options/variant.manifest.md
+++ b/docs/source/markdown/options/variant.manifest.md
@@ -1,0 +1,5 @@
+#### **--variant**
+
+Specify the variant which the list or index records for the image.  This option
+is typically used to distinguish between multiple entries which share the same
+architecture value, but which expect different versions of its instruction set.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -398,8 +398,7 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 @@option uts.container
 
-#### **--variant**=*VARIANT*
-Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
+@@option variant.container
 
 @@option volume
 

--- a/docs/source/markdown/podman-manifest-add.1.md.in
+++ b/docs/source/markdown/podman-manifest-add.1.md.in
@@ -58,11 +58,7 @@ image.  This option is rarely used.
 
 @@option tls-verify
 
-#### **--variant**
-
-Specify the variant which the list or index records for the image.  This option
-is typically used to distinguish between multiple entries which share the same
-architecture value, but which expect different versions of its instruction set.
+@@option variant.manifest
 
 ## Transport
 

--- a/docs/source/markdown/podman-manifest-annotate.1.md.in
+++ b/docs/source/markdown/podman-manifest-annotate.1.md.in
@@ -44,11 +44,7 @@ for the image.  This option is rarely used.
 Specify the OS version which the list or index records as a requirement for the
 image.  This option is rarely used.
 
-#### **--variant**
-
-Specify the variant which the list or index records for the image.  This option
-is typically used to distinguish between multiple entries which share the same
-architecture value, but which expect different versions of its instruction set.
+@@option variant.manifest
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -73,9 +73,7 @@ Suppress output information when pulling images
 
 @@option tls-verify
 
-#### **--variant**=*VARIANT*
-
-Use _VARIANT_ instead of the default architecture variant of the container image.  Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
+@@option variant.container
 
 ## FILES
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -439,8 +439,7 @@ echo "asdf" | podman run --rm -i someimage /bin/cat
 
 @@option uts.container
 
-#### **--variant**=*VARIANT*
-Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.
+@@option variant.container
 
 @@option volume
 


### PR DESCRIPTION
Two different texts, split into two .md files. Nontrivial, but still easy to review because the text is unchanged.

I was unable to reconcile either version with podman-build, so that file remains with a separate version.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
more man page deduplication
```
