### PR TITLE
[CI:DOCS] Man pages: refactor common options: --pod

### DIFF
--- a/docs/source/markdown/options/pod.run.md
+++ b/docs/source/markdown/options/pod.run.md
@@ -1,0 +1,5 @@
+#### **--pod**=*name*
+
+Run container in an existing pod. If you want Podman to make the pod for you, prefix the pod name with **new:**.
+To make a pod with more granular options, use the **podman pod create** command before creating a container.
+If a container is run with a pod, and the pod has an infra-container, the infra-container will be started before the container is.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -276,10 +276,7 @@ This option conflicts with **--add-host**.
 
 @@option platform
 
-#### **--pod**=*name*
-
-Run container in an existing pod. If you want Podman to make the pod for you, preference the pod name with `new:`.
-To make a pod with more granular options, use the `podman pod create` command before creating a container.
+@@option pod.run
 
 @@option pod-id-file.container
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -302,11 +302,7 @@ This is used to override the Podman provided user setup in favor of entrypoint c
 
 @@option platform
 
-#### **--pod**=*name*
-
-Run container in an existing pod. If you want Podman to make the pod for you, prefix the pod name with **new:**.
-To make a pod with more granular options, use the **podman pod create** command before creating a container.
-If a container is run with a pod, and the pod has an infra-container, the infra-container will be started before the container is.
+@@option pod.run
 
 @@option pod-id-file.container
 


### PR DESCRIPTION
Only between podman-create and -run; the other meanings of --pod are too different. This almost didn't feel worth refactoring, except the podman-run version fixed a word and added a possibly important note about infra containers. I went with the podman-run version.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
more man page deduplication
```
