### PR TITLE
Clean up when stopping pods

### DIFF
--- a/pkg/domain/infra/abi/pods.go
+++ b/pkg/domain/infra/abi/pods.go
@@ -195,7 +195,7 @@ func (ic *ContainerEngine) PodStop(ctx context.Context, namesOrIds []string, opt
 	}
 	for _, p := range pods {
 		report := entities.PodStopReport{Id: p.ID()}
-		errs, err := p.StopWithTimeout(ctx, false, options.Timeout)
+		errs, err := p.StopWithTimeout(ctx, true, options.Timeout)
 		if err != nil && !errors.Is(err, define.ErrPodPartialFail) {
 			report.Errs = []error{err}
 			reports = append(reports, &report)


### PR DESCRIPTION
We have a test to verify that init containers in pods are deleted when the `--init-ctr=once` option is specified. The test creates two containers, one of them an init container, starts the pod, stops the pod, and restarts the pod, checking for the presence of a file created by the init container during the second start. We're seeing a race where the file still exists, which I'm fairly certain comes down to the SHM mount not being cleaned up after the pod is stopped.

Fortunately, we already have code to do this - just flip the bool that controls cleanup from false to true.

[NO NEW TESTS NEEDED] Fixes a difficult to reproduce race condition.

Fixes #16046

```release-note
NONE
```
