### PR TITLE
[CI:DOCS] Man pages: refactor common options: --time

### DIFF
--- a/docs/source/markdown/.gitignore
+++ b/docs/source/markdown/.gitignore
@@ -26,6 +26,7 @@ podman-pod-stats.1.md
 podman-pod-stop.1.md
 podman-pull.1.md
 podman-push.1.md
+podman-restart.1.md
 podman-rm.1.md
 podman-run.1.md
 podman-search.1.md

--- a/docs/source/markdown/options/time.md
+++ b/docs/source/markdown/options/time.md
@@ -1,0 +1,3 @@
+#### **--time**, **-t**=*seconds*
+
+Seconds to wait before forcibly stopping <<the container|running containers within the pod>>.

--- a/docs/source/markdown/podman-pod-rm.1.md.in
+++ b/docs/source/markdown/podman-pod-rm.1.md.in
@@ -27,9 +27,9 @@ Instead of providing the pod name or ID, remove the last created pod. (This opti
 
 @@option pod-id-file.pod
 
-#### **--time**, **-t**=*seconds*
+@@option time
 
-Seconds to wait before forcibly stopping running containers within the pod. The --force option must be specified to use the --time option.
+The --force option must be specified to use the --time option.
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-pod-stop.1.md.in
+++ b/docs/source/markdown/podman-pod-stop.1.md.in
@@ -23,9 +23,7 @@ Instead of providing the pod name or ID, stop the last created pod. (This option
 
 @@option pod-id-file.pod
 
-#### **--time**, **-t**=*seconds*
-
-Seconds to wait before forcibly stopping the containers in the pod.
+@@option time
 
 ## EXAMPLE
 

--- a/docs/source/markdown/podman-restart.1.md.in
+++ b/docs/source/markdown/podman-restart.1.md.in
@@ -56,9 +56,7 @@ to run containers such as CRI-O, the last started container could be from either
 
 Restart all containers that are already in the *running* state.
 
-#### **--time**, **-t**=*seconds*
-
-Seconds to wait before forcibly stopping the container.
+@@option time
 
 ## EXAMPLES
 

--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -63,9 +63,9 @@ whose OCI runtime has become unavailable.
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--time**, **-t**=*seconds*
+@@option time
 
-Seconds to wait before forcibly stopping the container. The --force option must be specified to use the --time option.
+The --force option must be specified to use the --time option.
 
 #### **--volumes**, **-v**
 

--- a/docs/source/markdown/podman-stop.1.md.in
+++ b/docs/source/markdown/podman-stop.1.md.in
@@ -54,9 +54,7 @@ Valid filters are listed below:
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
-#### **--time**, **-t**=*seconds*
-
-Seconds to wait before forcibly stopping the container
+@@option time
 
 ## EXAMPLES
 


### PR DESCRIPTION
Only in container/pod stop/rm/restart man pages; the others
(volume-rm, network-rm, system-service) are too different to refactor.

Mostly an easy one, no manual reconciliation needed apart from
the pod-vs-container difference.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```