### PR TITLE
Create a full path to a directory when DirectoryOrCreate is used

### DIFF
--- a/pkg/specgen/generate/kube/volume.go
+++ b/pkg/specgen/generate/kube/volume.go
@@ -56,10 +56,8 @@ func VolumeFromHostPath(hostPath *v1.HostPathVolumeSource) (*KubeVolume, error) 
 	if hostPath.Type != nil {
 		switch *hostPath.Type {
 		case v1.HostPathDirectoryOrCreate:
-			if _, err := os.Stat(hostPath.Path); os.IsNotExist(err) {
-				if err := os.Mkdir(hostPath.Path, kubeDirectoryPermission); err != nil {
-					return nil, err
-				}
+			if err := os.MkdirAll(hostPath.Path, kubeDirectoryPermission); err != nil {
+				return nil, err
 			}
 			// Label a newly created volume
 			if err := libpod.LabelVolumePath(hostPath.Path); err != nil {

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -2604,6 +2604,36 @@ spec:
 		Expect(st.Mode().IsDir()).To(Equal(true))
 	})
 
+	It("podman play kube test with DirectoryOrCreate HostPath type volume and non-existent directory path", func() {
+		hostPathLocation := filepath.Join(filepath.Join(tempdir, "dir1"), "dir2")
+
+		pod := getPod(withVolume(getHostPathVolume("DirectoryOrCreate", hostPathLocation)))
+		err := generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).To(BeNil())
+
+		kube := podmanTest.Podman([]string{"play", "kube", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(Exit(0))
+
+		// the full path should have been created
+		st, err := os.Stat(hostPathLocation)
+		Expect(err).To(BeNil())
+		Expect(st.Mode().IsDir()).To(Equal(true))
+	})
+
+	It("podman play kube test with DirectoryOrCreate HostPath type volume and existent directory path", func() {
+		hostPathLocation := filepath.Join(filepath.Join(tempdir, "dir1"), "dir2")
+		Expect(os.MkdirAll(hostPathLocation, os.ModePerm)).To(BeNil())
+
+		pod := getPod(withVolume(getHostPathVolume("DirectoryOrCreate", hostPathLocation)))
+		err := generateKubeYaml("pod", pod, kubeYaml)
+		Expect(err).To(BeNil())
+
+		kube := podmanTest.Podman([]string{"play", "kube", kubeYaml})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube).Should(Exit(0))
+	})
+
 	It("podman play kube test with Socket HostPath type volume should fail if not socket", func() {
 		hostPathLocation := filepath.Join(tempdir, "file")
 		f, err := os.Create(hostPathLocation)


### PR DESCRIPTION
Consider empty directory /root and the following piece of Pod yaml:

```
  volumes:
  - name: my-sub-dir
    hostPath:
      path: /root/dir/subdir
      type: DirectoryOrCreate
```
Podman failed to play such Kube with error:

```
error playing YAML file: failed to create volume "my-sub-dir": mkdir /root/dir/subdir: no such file or directory
```

k8s sources: [one](https://github.com/elastisys/kubernetes/blob/6ce065dec0780e014c471f42dcd973d72540459c/pkg/volume/hostpath/host_path.go#L440), [two](https://github.com/kubernetes/kubernetes/blob/fbb6ccc0c62d2431dc3a18a4130d7fbae5c05acd/pkg/volume/hostpath/host_path.go#L493)

Signed-off-by: Mikhail Khachayants <tyler92@inbox.ru>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Create a full path to a directory when DirectoryOrCreate is used with play kube
```
