### PR TITLE
Fix slow IsCheckpointImage making podman run slow

### DIFF
--- a/cmd/podman/utils/utils.go
+++ b/cmd/podman/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/libpod/define"
@@ -123,17 +124,14 @@ func IsCheckpointImage(ctx context.Context, namesOrIDs []string) (bool, error) {
 	}
 	imgID := imgData[0].ID
 
-	hostInfo, err := registry.ContainerEngine().Info(ctx)
-	if err != nil {
-		return false, err
-	}
+	runtimeName := filepath.Base(registry.PodmanConfig().RuntimePath)
 
 	for i := range imgData {
 		checkpointRuntimeName, found := imgData[i].Annotations[define.CheckpointAnnotationRuntimeName]
 		if !found {
 			return false, fmt.Errorf("image is not a checkpoint: %s", imgID)
 		}
-		if hostInfo.Host.OCIRuntime.Name != checkpointRuntimeName {
+		if runtimeName != checkpointRuntimeName {
 			return false, fmt.Errorf("container image \"%s\" requires runtime: \"%s\"", imgID, checkpointRuntimeName)
 		}
 	}


### PR DESCRIPTION
IsCheckpointImage() currently calls registry.ContainerEngine().Info(ctx) in order to get the name of the oci runtime. However, this call is very slow, as it collects all sort of other (unnecessary) information.

In addition, this returns the *default* oci runtime, and really it seems to be more correct here to use the *currently-in-use* oci runtime.

So, we switch to getting the oci runtime name via:
 registry.PodmanConfig().RuntimePath

This seems to return the same value, and is much faster. The actual runtime is highly variable, so I'm taking the fastest run of 20 as a measure.

Before this change:

$ time  ./bin/podman run  fedora true
real	0m0,556s
user	0m0,155s
sys	0m0,090s

After the change:
$ time  ./bin/podman run  fedora true
real	0m0,456s
user	0m0,101s
sys	0m0,042s

So, this seems to be about a 100msec performance improvement.


