### PR TITLE
Return error in podman system service if URI scheme is not unix/tcp

### DIFF
--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -89,7 +89,7 @@ func restService(flags *pflag.FlagSet, cfg *entities.PodmanConfig, opts entities
 				return fmt.Errorf("unable to create socket %v: %w", host, err)
 			}
 		default:
-			logrus.Debugf("Attempting API Service endpoint scheme %q", uri.Scheme)
+			return fmt.Errorf("API Service endpoint scheme %q is not supported. Try tcp://%s or unix:/%s", uri.Scheme, opts.URI, opts.URI)
 		}
 		libpodRuntime.SetRemoteURI(uri.String())
 	}

--- a/test/system/251-system-service.bats
+++ b/test/system/251-system-service.bats
@@ -14,6 +14,14 @@ function teardown() {
     basic_teardown
 }
 
+@test "podman systerm service <bad_scheme_uri> returns error" {
+    skip_if_remote "podman system service unavailable over remote"
+    run_podman 125 system service localhost:9292
+    is "$output" "Error: API Service endpoint scheme \"localhost\" is not supported. Try tcp://localhost:9292 or unix:/localhost:9292"
+
+    run_podman 125 system service myunix.sock
+    is "$output" "Error: API Service endpoint scheme \"\" is not supported. Try tcp://myunix.sock or unix:/myunix.sock"
+}
 
 @test "podman-system-service containers survive service stop" {
     skip_if_remote "podman system service unavailable over remote"


### PR DESCRIPTION
If `tcp` or `unix` are missing from the URI `podman` panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x13fe9a1]

goroutine 1 [running]:
github.com/containers/podman/v4/pkg/api/server.newServer(0xc000296540, {0x0, 0x0}, {{0x0, 0x0}, {0x0, 0x0}, 0x0, {0x7ffca77de322, 0xe}})
	/home/b0/go/src/github.com/boaz0/podman/pkg/api/server/server.go:65 +0x41
github.com/containers/podman/v4/pkg/api/server.NewServerWithSettings(...)
	/home/b0/go/src/github.com/boaz0/podman/pkg/api/server/server.go:61
github.com/containers/podman/v4/cmd/podman/system.restService(0x7ffca77de322?, 0xe?, {{0x0, 0x0}, {0x0, 0x0}, 0x0, {0x7ffca77de322, 0xe}})
	/home/b0/go/src/github.com/boaz0/podman/cmd/podman/system/service_abi.go:115 +0x865
github.com/containers/podman/v4/cmd/podman/system.service(0x2410ee0?, {0xc0002c48a0?, 0x1?, 0x3?})
	/home/b0/go/src/github.com/boaz0/podman/cmd/podman/system/service.go:103 +0x26a
github.com/spf13/cobra.(*Command).execute(0x2410ee0, {0xc0001a6150, 0x3, 0x3})
	/home/b0/go/src/github.com/boaz0/podman/vendor/github.com/spf13/cobra/command.go:872 +0x694
github.com/spf13/cobra.(*Command).ExecuteC(0x2414fe0)
	/home/b0/go/src/github.com/boaz0/podman/vendor/github.com/spf13/cobra/command.go:990 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/home/b0/go/src/github.com/boaz0/podman/vendor/github.com/spf13/cobra/command.go:918
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/home/b0/go/src/github.com/boaz0/podman/vendor/github.com/spf13/cobra/command.go:911
main.Execute()
	/home/b0/go/src/github.com/boaz0/podman/cmd/podman/root.go:105 +0xc5
main.main()
	/home/b0/go/src/github.com/boaz0/podman/cmd/podman/main.go:40 +0x7c
```

The reason for that is because if the schema is not `unix` or `tcp` the listener is `nil` and at `server/server.go:65` `listener.Addr()` is being called but `listener` is `nil`

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
