### PR TITLE
[CI:DOCS] Man pages: refactor common options: --os-version

### DIFF
--- a/docs/source/markdown/options/os-version.md
+++ b/docs/source/markdown/options/os-version.md
@@ -1,0 +1,4 @@
+#### **--os-version**
+
+Specify the OS version which the list or index records as a requirement for the
+image.  This option is rarely used.

--- a/docs/source/markdown/podman-manifest-add.1.md.in
+++ b/docs/source/markdown/podman-manifest-add.1.md.in
@@ -48,10 +48,7 @@ If *imagename* refers to a manifest list or image index, the OS information
 will be retrieved from it.  Otherwise, it will be retrieved from the image's
 configuration information.
 
-#### **--os-version**
-
-Specify the OS version which the list or index records as a requirement for the
-image.  This option is rarely used.
+@@option os-version
 
 @@option tls-verify
 

--- a/docs/source/markdown/podman-manifest-annotate.1.md.in
+++ b/docs/source/markdown/podman-manifest-annotate.1.md.in
@@ -36,10 +36,7 @@ information, so it is rarely necessary to use this option.
 Specify the OS features list which the list or index records as requirements
 for the image.  This option is rarely used.
 
-#### **--os-version**
-
-Specify the OS version which the list or index records as a requirement for the
-image.  This option is rarely used.
+@@option os-version
 
 @@option variant.manifest
 


### PR DESCRIPTION
Only between the two podman-manifest-* commands. podman-build
is too different.

Easy one, text was already identical

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man page deduplication
```