### PR TITLE
libpod: Remove 100msec delay during shutdown

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -722,9 +722,10 @@ func (r *Runtime) libimageEvents() {
 
 	eventChannel := r.libimageRuntime.EventChannel()
 	go func() {
+		sawShutdown := false
 		for {
 			// Make sure to read and write all events before
-			// checking if we're about to shutdown.
+			// shutting down.
 			for len(eventChannel) > 0 {
 				libimageEvent := <-eventChannel
 				e := events.Event{
@@ -739,12 +740,15 @@ func (r *Runtime) libimageEvents() {
 				}
 			}
 
+			if sawShutdown {
+				close(r.libimageEventsShutdown)
+				return
+			}
+
 			select {
 			case <-r.libimageEventsShutdown:
-				return
-
-			default:
-				time.Sleep(100 * time.Millisecond)
+				sawShutdown = true
+			case <-time.After(100 * time.Millisecond):
 			}
 		}
 	}()
@@ -793,7 +797,10 @@ func (r *Runtime) Shutdown(force bool) error {
 	if r.store != nil {
 		// Wait for the events to be written.
 		if r.libimageEventsShutdown != nil {
+			// Tell loop to shutdown
 			r.libimageEventsShutdown <- true
+			// Wait for close to signal shutdown
+			<-r.libimageEventsShutdown
 		}
 
 		// Note that the libimage runtime shuts down the store.


### PR DESCRIPTION
When shutting down the image engine we always wait for the image even goroutine to finish writing any outstanding events. However, the loop for that always waits 100msec every iteration. This means that (depending on the phase) shutdown is always delayed up to 100msec.

This is delaying "podman run" extra much because podman is run twice (once for the run and once as cleanup via a conmon callback).

Changing the image loop to exit immediately when a libimageEventsShutdown (but first checking for any outstanding events to write) improves podman run times by about 100msec on average.

[NO NEW TESTS NEEDED]

Signed-off-by: Alexander Larsson <alexl@redhat.com>

