### PR TITLE
[CI:DOCS] MacOS contributing docs link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ the “In Progress” label be set and a member will do so for you.
 
 ## Contributing to Podman
 
-This section describes how to start a contribution to Podman.
+This section describes how to start a contribution to Podman. These instructions are geared towards using a Linux development machine, or doing development on the podman backend. For instructions on working on MacOS, read the [docs for building on osx](./build_osx.md).
 
 ### Prepare your environment
 


### PR DESCRIPTION
Adds a small bit of text and a link to the OSX page for MacOS devs who might otherwise think we can't build anything locally.

#### Does this PR introduce a user-facing change?
No

```release-note
None
```
