### PR TITLE
health checks: make on-failure action retry aware

### DIFF
--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -28,10 +28,11 @@ function _check_health {
                --health-cmd /healthcheck   \
                --health-interval 1s        \
                --health-retries 3          \
+               --health-on-failure=kill    \
                healthcheck_i
 
     run_podman inspect healthcheck_c --format "{{.Config.HealthcheckOnFailureAction}}"
-    is "$output" "none" "default on-failure action is none"
+    is "$output" "kill" "on-failure action is set to kill"
 
     # We can't check for 'starting' because a 1-second interval is too
     # short; it could run healthcheck before we get to our first check.
@@ -67,9 +68,8 @@ Log[-1].ExitCode | 1
 Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
 "
 
-    # healthcheck should now fail, with exit status 1 and 'unhealthy' output
-    run_podman 1 healthcheck run healthcheck_c
-    is "$output" "unhealthy" "output from 'podman healthcheck run'"
+    # now the on-failure should kick in and kill the container
+    podman wait healthcheck_c
 
     # Clean up
     run_podman rm -t 0 -f healthcheck_c
@@ -95,6 +95,7 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
         # Run that healthcheck image.
         run_podman run -d --name $ctr      \
                --health-cmd /healthcheck   \
+               --health-retries=1          \
                --health-on-failure=$policy \
                $img
 

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -318,6 +318,7 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
     run_podman create --name $cname      \
                --health-cmd /healthcheck \
                --health-on-failure=kill  \
+               --health-retries=1        \
                --restart=on-failure      \
                $img
 


### PR DESCRIPTION
Make sure that the on-failure actions only kick in once the health check has passed its retries.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make sure that the on-failure actions only kick in once the health check has passed its retries.
```
@mheon PTAL