### PR TITLE
[CI:DOCS] Man pages: Add mention of behavior due to XDG_CONFIG_HOME

### DIFF
--- a/docs/source/markdown/podman-machine-list.1.md
+++ b/docs/source/markdown/podman-machine-list.1.md
@@ -19,6 +19,11 @@ but can be optionally used on Linux.
 
 Rootless only.
 
+NOTE: The podman-machine configuration file is managed under the
+`$XDG_CONFIG_HOME/containers/podman/machine/` directory. Therefore, if you change the
+`$XDG_CONFIG_HOME` environment variable, the output of the `podman machine list` will also be changed.
+(see [podman(1)](podman.1.md))
+
 ## OPTIONS
 
 #### **--format**=*format*

--- a/docs/source/markdown/podman-machine.1.md
+++ b/docs/source/markdown/podman-machine.1.md
@@ -16,6 +16,10 @@ but can be optionally used on Linux.
 
 All `podman machine` commands are rootless only.
 
+NOTE: The configurations for the virtual machines are managed under the
+`$XDG_CONFIG_HOME/containers/podman/machine/` directory. If you change the `$XDG_CONFIG_HOME`
+environment variable while the virtual machine runs, unexpected behavior could occur.
+
 ## SUBCOMMANDS
 
 | Command | Man Page                                             | Description                       |


### PR DESCRIPTION
When the `XDG_CONFIG_HOME` environment variable is changed, for example, to switch development contexts, the behavior of the podman-machine can be confusing. The documentation had not mentioned this, and this commit adds these mentions.

Closes: https://github.com/containers/podman/issues/15577

Signed-off-by: Naoaki Ueda <nao@uedder.com>


I am not confident in my English, so if there are any strange expressions, please feel free to point them out to me.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
