### PR TITLE
increase timeout of on-failure=kill system test

### DIFF
--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -342,8 +342,8 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
     #  2) Systemd restarts the service as the restart policy is set to "on-failure"
     #  3) The /uh-oh file is gone and $cname has another ID
 
-    # Wait at most 10 seconds for the service to be restarted
-    local timeout=10
+    # Wait at most 20 seconds for the service to be restarted
+    local timeout=20
     while [[ $timeout -gt 1 ]]; do
         run_podman '?' container inspect $cname
         if [[ $status == 0 ]]; then


### PR DESCRIPTION
The on-failure=kill system tests turned out to be flaky. Once the container has been killed, the test waits for systemd to restart the service by running `container inspect` for 10 seconds.  The subsequent `healthcheck run` was the flake point which suggests the 10 seconds timeout to not be sufficiently high enough; presumably when the CI nodes are under pressure.

Fixes: #16075
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
