### PR TITLE
[v4.1.1-rhel] healthcheck: fix --on-failure=stop

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1440,6 +1440,11 @@ func (c *Container) restartWithTimeout(ctx context.Context, timeout uint) (retEr
 		if err := c.stop(timeout); err != nil {
 			return err
 		}
+		if c.config.HealthCheckConfig != nil {
+			if err := c.removeTransientFiles(context.Background()); err != nil {
+				logrus.Error(err.Error())
+			}
+		}
 		// Old versions of conmon have a bug where they create the exit file before
 		// closing open file descriptors causing a race condition when restarting
 		// containers with open ports since we cannot bind the ports as they're not

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -127,6 +127,9 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
             if [[ "$output" == "running $policy" ]]; then
                 die "container is still in running mode"
             fi
+            if [[ "$output" == "stopping $policy" ]]; then
+                die "container should not be in stopping state"
+            fi
         fi
 
         run_podman rm -f -t0 $ctr


### PR DESCRIPTION
Fix the "stop" on-failure action by not removing the transient systemd timer and service during container stop.  Removing the service will in turn cause systemd to terminate the Podman process attempting to stop the container and hence leave it in the "stopping" state.

Instead move the removal into the restart sequence.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix the "stop" on-failure action for health checks.
```
