### PR TITLE
[release-v3.0.1-rhel] vendor: bump buildah to `v1.19.11`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
-	github.com/containers/buildah v1.19.10
+	github.com/containers/buildah v1.19.11
 	github.com/containers/common v0.33.4
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.10.5

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/containernetworking/plugins v0.8.7/go.mod h1:R7lXeZaBzpfqapcAbHRW8/CYwm0dHzbz0XEjofx0uB0=
 github.com/containernetworking/plugins v0.9.1 h1:FD1tADPls2EEi3flPc2OegIY1M9pUa9r2Quag7HMLV8=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
-github.com/containers/buildah v1.19.10 h1:/poVOx408lvOY5MT6D3lCiub4Pw79Opm1PWtRBp45xE=
-github.com/containers/buildah v1.19.10/go.mod h1:bhECjPu6KOPWYLDajJ8FAVYpdcqSExA/0Z5QFjSNAMw=
+github.com/containers/buildah v1.19.11 h1:xXtwfFfQNdFPWsn19bGyqxITpYkbA4OPYcZwHVS62ec=
+github.com/containers/buildah v1.19.11/go.mod h1:bhECjPu6KOPWYLDajJ8FAVYpdcqSExA/0Z5QFjSNAMw=
 github.com/containers/common v0.33.4 h1:f1jowItfo6xw0bZGZq8oE5dw1pBIkldqB0FqW+HHzG8=
 github.com/containers/common v0.33.4/go.mod h1:PhgL71XuC4jJ/1BIqeP7doke3aMFkCP90YBXwDeUr9g=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -1,6 +1,11 @@
 ![buildah logo](https://cdn.rawgit.com/containers/buildah/master/logos/buildah-logo_large.png)
 
 # Changelog
+## v1.19.11 (2022-10-12)
+  * run: add container gid to additional groups
+  * imagebuilder.util.downloadToDirectory: fail early if bad HTTP response
+  * add: fail on bad http response instead of writing to container
+
 ## v1.19.10 (2022-09-09)
   * [release-1.19] github.com/prometheus/client_golang to v1.11.1
   * [release-1.19]Bump c/storage to 1.24.10

--- a/vendor/github.com/containers/buildah/add.go
+++ b/vendor/github.com/containers/buildah/add.go
@@ -82,6 +82,11 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 		return err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("invalid response status %d", response.StatusCode)
+	}
+
 	// Figure out what to name the new content.
 	name := renameTarget
 	if name == "" {

--- a/vendor/github.com/containers/buildah/buildah.go
+++ b/vendor/github.com/containers/buildah/buildah.go
@@ -28,7 +28,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.19.10"
+	Version = "1.19.11"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,8 @@
+- Changelog for v1.19.11 (2022-10-12)
+  * run: add container gid to additional groups
+  * imagebuilder.util.downloadToDirectory: fail early if bad HTTP response
+  * add: fail on bad http response instead of writing to container
+
 - Changelog for v1.19.10 (2022-09-09)
   * [release-1.19] github.com/prometheus/client_golang to v1.11.1
   * [release-1.19]Bump c/storage to 1.24.10

--- a/vendor/github.com/containers/buildah/imagebuildah/util.go
+++ b/vendor/github.com/containers/buildah/imagebuildah/util.go
@@ -43,6 +43,9 @@ func downloadToDirectory(url, dir string) error {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("invalid response status %d", resp.StatusCode)
+	}
 	if resp.ContentLength == 0 {
 		return errors.Errorf("no contents in %q", url)
 	}

--- a/vendor/github.com/containers/buildah/run_linux.go
+++ b/vendor/github.com/containers/buildah/run_linux.go
@@ -2002,6 +2002,7 @@ func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, opti
 	}
 	g.SetProcessUID(user.UID)
 	g.SetProcessGID(user.GID)
+	g.AddProcessAdditionalGid(user.GID)
 	for _, gid := range user.AdditionalGids {
 		g.AddProcessAdditionalGid(gid)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -72,7 +72,7 @@ github.com/containernetworking/plugins/pkg/utils/hwaddr
 github.com/containernetworking/plugins/pkg/utils/sysctl
 github.com/containernetworking/plugins/plugins/ipam/host-local/backend
 github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator
-# github.com/containers/buildah v1.19.10
+# github.com/containers/buildah v1.19.11
 github.com/containers/buildah
 github.com/containers/buildah/bind
 github.com/containers/buildah/chroot


### PR DESCRIPTION
Bump buildah to `v1.19.11` so it contains fix for https://github.com/advisories/GHSA-rc4r-wh2q-q6c4
Followup after: https://github.com/containers/podman/pull/16122

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]

Closes: https://github.com/containers/buildah/issues/4307


#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
vendor: bump buildah to v1.19.11
```
