### PR TITLE
system tests: health-on-failure: fix broken logic

### DIFF
--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -314,7 +314,7 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
     img="healthcheck_i"
     _build_health_check_image $img
 
-    cname=$(random_string)
+    cname=c_$(random_string)
     run_podman create --name $cname      \
                --health-cmd /healthcheck \
                --health-on-failure=kill  \
@@ -345,7 +345,11 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
     # Wait at most 10 seconds for the service to be restarted
     local timeout=10
     while [[ $timeout -gt 1 ]]; do
-        run_podman '?' container inspect $cname
+        # Possible outcomes:
+        #  - status 0, old container is still terminating: sleep and retry
+        #  - status 0, new CID: yay, break
+        #  - status 1, container not found: sleep and retry
+        run_podman '?' container inspect $cname --format '{{.ID}}'
         if [[ $status == 0 ]]; then
             if [[ "$output" != "$oldID" ]]; then
                 break


### PR DESCRIPTION
Basically, in the timeout loop where we checked for new CID
on the restarted container, we were running 'podman inspect'
(not 'inspect --format ID'), and comparing full hundred-line
output against single-line CID string.

While I'm in here, add 'c_' prefix to container to make it
easier for my old eyes to recognize "oh, that's a container name"
vs "is that a name? a SHA? a woozle?"

Signed-off-by: Ed Santiago <santiago@redhat.com>

Fixes: #16075 

```release-note
None
```