### PR TITLE
[CI:DOCS] Man pages: refactor common options: --annotation (manifest)

### DIFF
--- a/docs/source/markdown/options/annotation.manifest.md
+++ b/docs/source/markdown/options/annotation.manifest.md
@@ -1,0 +1,3 @@
+#### **--annotation**=*annotation=value*
+
+Set an annotation on the entry for the image.

--- a/docs/source/markdown/podman-manifest-add.1.md.in
+++ b/docs/source/markdown/podman-manifest-add.1.md.in
@@ -22,9 +22,7 @@ index, add all of the contents to the local list.  By default, only one image
 from such a list or index will be added to the list or index.  Combining
 *--all* with any of the other options described below is NOT recommended.
 
-#### **--annotation**=*annotation=value*
-
-Set an annotation on the entry for the newly-added image.
+@@option annotation.manifest
 
 #### **--arch**
 

--- a/docs/source/markdown/podman-manifest-annotate.1.md.in
+++ b/docs/source/markdown/podman-manifest-annotate.1.md.in
@@ -12,9 +12,7 @@ Adds or updates information about an image included in a manifest list or image 
 
 ## OPTIONS
 
-#### **--annotation**=*annotation=value*
-
-Set an annotation on the entry for the specified image.
+@@option annotation.manifest
 
 #### **--arch**
 


### PR DESCRIPTION
[Note: I already refactored --annotation for container-related
 commands; this one is for manifest-related commands]

This one needed reconciling: one man page said "newly added image",
the other said "specified image", I just reduced that to "image".
If that's not cool, any suggestions on how to make it better? Or,
just reject this PR, we can live with this duplication.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```