### PR TITLE
KillContainer: improve error message

### DIFF
--- a/libpod/oci_conmon_common.go
+++ b/libpod/oci_conmon_common.go
@@ -376,7 +376,7 @@ func (r *ConmonOCIRuntime) KillContainer(ctr *Container, signal uint, all bool) 
 			logrus.Infof("Error updating status for container %s: %v", ctr.ID(), err2)
 		}
 		if ctr.ensureState(define.ContainerStateStopped, define.ContainerStateExited) {
-			return define.ErrCtrStateInvalid
+			return fmt.Errorf("%w: %s", define.ErrCtrStateInvalid, ctr.state.State)
 		}
 		return fmt.Errorf("sending signal to container %s: %w", ctr.ID(), err)
 	}


### PR DESCRIPTION
To improve the error message reported in #16142 where the container is reported to be in the wrong state but we do not know which.  This is not a fix for #16142 but will hopefully aid in better understanding what's going on if it flakes again.

[NO NEW TESTS NEEDED] as hitting the condition is inherently racy.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improve an error message when killing a container.
```
