### PR TITLE
[CI:DOCS] Man pages: refactor common options: --attach

### DIFF
--- a/docs/source/markdown/options/attach.md
+++ b/docs/source/markdown/options/attach.md
@@ -1,0 +1,10 @@
+#### **--attach**, **-a**=*stdin* | *stdout* | *stderr*
+
+Attach to STDIN, STDOUT or STDERR.
+
+In foreground mode (the default when **-d**
+is not specified), **podman run** can start the process in the container
+and attach the console to the process's standard input, output, and
+error. It can even pretend to be a TTY (this is what most command-line
+executables expect) and pass along signals. The **-a** option can be set for
+each of **stdin**, **stdout**, and **stderr**.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -72,16 +72,7 @@ and specified with a _tag_.
 
 @@option arch
 
-#### **--attach**, **-a**=*location*
-
-Attach to STDIN, STDOUT or STDERR.
-
-In foreground mode (the default when **-d**
-is not specified), **podman run** can start the process in the container
-and attach the console to the process's standard input, output, and standard
-error. It can even pretend to be a TTY (this is what most command line
-executables expect) and pass along signals. The **-a** option can be set for
-each of stdin, stdout, and stderr.
+@@option attach
 
 @@option authfile
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -89,16 +89,7 @@ and specified with a _tag_.
 
 @@option arch
 
-#### **--attach**, **-a**=*stdin* | *stdout* | *stderr*
-
-Attach to STDIN, STDOUT or STDERR.
-
-In foreground mode (the default when **-d**
-is not specified), **podman run** can start the process in the container
-and attach the console to the process's standard input, output, and
-error. It can even pretend to be a TTY (this is what most commandline
-executables expect) and pass along signals. The **-a** option can be set for
-each of **stdin**, **stdout**, and **stderr**.
+@@option attach
 
 @@option authfile
 


### PR DESCRIPTION
Only between podman-create and -run; podman-start was too
different. (But please look into it, maybe there's a way
to reconcile the diffs).

Very minor formatting changes made to reconcile the two.
Easy to review using hack/markdown-preprocess-review

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```