### PR TITLE
[CI:DOCS] Man pages: Refactor common options: --detach-keys

### DIFF
--- a/docs/source/markdown/options/detach-keys.md
+++ b/docs/source/markdown/options/detach-keys.md
@@ -1,0 +1,5 @@
+#### **--detach-keys**=*sequence*
+
+Specify the key sequence for detaching a container. Format is a single character `[a-Z]` or one or more `ctrl-<value>` characters where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`. Specifying "" will disable this feature. The default is *ctrl-p,ctrl-q*.
+
+This option can also be set in **containers.conf**(5) file.

--- a/docs/source/markdown/podman-attach.1.md.in
+++ b/docs/source/markdown/podman-attach.1.md.in
@@ -13,10 +13,7 @@ podman\-attach - Attach to a running container
 The *container* can be detached from (and leave it running) using a configurable key sequence. The default sequence is `ctrl-p,ctrl-q`. Configure the keys sequence using the **--detach-keys** OPTION, or specifying it in the `containers.conf` file: see **[containers.conf(5)](https://github.com/containers/common/blob/master/docs/containers.conf.5.md)** for more information.
 
 ## OPTIONS
-#### **--detach-keys**=**sequence**
-
-Specify the key **sequence** for detaching a *container*. Format is a single character `[a-Z]` or one or more `ctrl-<value>` characters where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`. Specifying "" will disable this feature.\
-The default is `ctrl-p,ctrl-q`.
+@@option detach-keys
 
 #### **--latest**, **-l**
 

--- a/docs/source/markdown/podman-exec.1.md.in
+++ b/docs/source/markdown/podman-exec.1.md.in
@@ -17,9 +17,7 @@ podman\-exec - Execute a command in a running container
 
 Start the exec session, but do not attach to it. The command will run in the background and the exec session will be automatically removed when it completes. The **podman exec** command will print the ID of the exec session and exit immediately after it starts.
 
-#### **--detach-keys**=*sequence*
-
-Specify the key sequence for detaching a container. Format is a single character `[a-Z]` or one or more `ctrl-<value>` characters where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`. Specifying "" will disable this feature. The default is *ctrl-p,ctrl-q*.
+@@option detach-keys
 
 @@option env
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -144,11 +144,7 @@ running) using a configurable key sequence. The default sequence is `ctrl-p,ctrl
 Specify the key sequence using the **--detach-keys** option, or configure
 it in the **containers.conf** file: see **containers.conf(5)** for more information.
 
-#### **--detach-keys**=*sequence*
-
-Specify the key sequence for detaching a container. Format is a single character `[a-Z]` or one or more `ctrl-<value>` characters where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`. Specifying "" will set the sequence to the default value of *ctrl-p,ctrl-q*.
-
-This option can also be set in **containers.conf**(5) file.
+@@option detach-keys
 
 @@option device
 

--- a/docs/source/markdown/podman-start.1.md.in
+++ b/docs/source/markdown/podman-start.1.md.in
@@ -25,9 +25,7 @@ Start all the containers created by Podman, default is only running containers.
 Attach container's STDOUT and STDERR.  The default is false. This option cannot be used when
 starting multiple containers.
 
-#### **--detach-keys**=*sequence*
-
-Specify the key sequence for detaching a container. Format is a single character `[a-Z]` or one or more `ctrl-<value>` characters where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`. Specifying "" will disable this feature. The default is *ctrl-p,ctrl-q*.
+@@option detach-keys
 
 #### **--filter**, **-f**
 


### PR DESCRIPTION
Refactored among all files that mentioned it.

DANGER WILL ROBINSON! REVIEW CAREFULLY! Here are two major
decisions I made:

  1) Look at the text for podman-run, in particular the "" text.
     It currently says "will use the default". As best I can
     tell this is not true, so I changed it to "will disable"
     which matches all the other commands.

  2) The "containers.conf" text, I decided, applies to all
     commands, not just podman-run (it was only present in
     podman-run). If this is not the case, please yell.

Other changes are cosmetic formatting stuff, asterisks end newlines.
Hard to review with hack/markdown-preprocess-review, because all
the text is one horrible long line instead of 80-char breaks.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```