### PR TITLE
[CI:DOCS] Add swagger install + allow version updates in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,8 +14,6 @@ env:
     GOPATH: &gopath "/var/tmp/go"
     GOCACHE: "${GOPATH}/cache"
     GOSRC: &gosrc "/var/tmp/go/src/github.com/containers/podman"
-    # Store the unaltered default location, for tasks that need it
-    CIRRUS_DEFAULT_WORK: ${CIRRUS_WORKING_DIR}
     CIRRUS_WORKING_DIR: *gosrc
     # The default is 'sh' if unspecified
     CIRRUS_SHELL: "/bin/bash"
@@ -1053,7 +1051,7 @@ win_installer_task:
         CIRRUS_SHELL: powershell
         # Fake version, we are only testing the installer functions, so version doesn't matter
         WIN_INST_VER: 9.9.9
-        CIRRUS_WORKING_DIR: "${CIRRUS_DEFAULT_WORK}"
+        CIRRUS_WORKING_DIR: "${LOCALAPPDATA}\\Temp\\cirrus-ci-build"
     install_script: '.\contrib\cirrus\win-installer-install.ps1'
     main_script: '.\contrib\cirrus\win-installer-main.ps1'
 

--- a/Makefile
+++ b/Makefile
@@ -849,7 +849,7 @@ install.systemd:
 endif
 
 .PHONY: install.tools
-install.tools: .install.ginkgo .install.golangci-lint ## Install needed tools
+install.tools: .install.ginkgo .install.golangci-lint .install.swagger ## Install needed tools
 	$(MAKE) -C test/tools
 
 .PHONY: .install.goimports
@@ -867,6 +867,14 @@ install.tools: .install.ginkgo .install.golangci-lint ## Install needed tools
 .PHONY: .install.golangci-lint
 .install.golangci-lint:
 	VERSION=1.46.2 ./hack/install_golangci.sh
+
+.PHONY: .install.swagger
+.install.swagger:
+	env VERSION=0.30.3 \
+		BINDIR=$(BINDIR) \
+		GOOS=$(GOOS) \
+		GOARCH=$(GOARCH) \
+		./hack/install_swagger.sh
 
 .PHONY: .install.md2man
 .install.md2man:

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -363,7 +363,9 @@ case "$TEST_FLAVOR" in
         showrun $ssh podman tag $helper_fqin \
             docker.io/gitlab/gitlab-runner-helper:x86_64-latest-pwsh
         ;;
-    swagger) ;&  # use next item
+    swagger)
+        make .install.swagger
+        ;;
     release) ;;
     *) die_unknown TEST_FLAVOR
 esac

--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# This script is intended to be a convenience, to be called from the
+# Makefile `.install.golangci-lint` target.  Any other usage is not recommended.
+
 die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
 
 [ -n "$VERSION" ] || die "\$VERSION is empty or undefined"

--- a/hack/install_swagger.sh
+++ b/hack/install_swagger.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# This script is intended to be a convenience, to be called from the
+# Makefile `.install.swagger` target.  Any other usage is not recommended.
+
+BIN="$BINDIR/swagger"
+
+die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
+
+function install() {
+    echo "Installing swagger v$VERSION into $BIN"
+    curl -sS --retry 5 --location -o $BIN \
+        https://github.com/go-swagger/go-swagger/releases/download/v$VERSION/swagger_${GOOS}_${GOARCH}
+    chmod +x $BIN
+    $BIN version
+}
+
+for req_var in VERSION BINDIR GOOS GOARCH; do
+    [[ -n "${!req_var}" ]] || die "\$$req_var is empty or undefined"
+done
+
+if [ ! -x "$BIN" ]; then
+    install
+else
+    $BIN version | grep "$VERSION"
+    if [[ "$?" -eq 0 ]]; then
+        echo "Using existing $BIN"
+    else
+        install
+    fi
+fi


### PR DESCRIPTION
*Depends on:* #16169 

Support swagger testing and optional runtime updates similar to the current golangci-lint tool.  This allows developers to update the version of swagger at runtime if needed.  Otherwise new CI VM images will pick up the prescribed version at image build-time via `make install.tools`.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
