### PR TITLE
[CI:DOCS] Cirrus: Temp. ignore win_installer failures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1042,6 +1042,9 @@ artifacts_task:
 win_installer_task:
     name: "Verify Win Installer Build"
     alias: win_installer
+    # WORKAROUND: This task is failing in 'clone' everywhere due to apparent
+    # Cirrus-CI problem/bug.  Ignore this for the time being.
+    allow_failures: true     # TODO: Remove this when fixed
     # Don't run for multiarch container image cirrus-cron job.
     only_if: $CIRRUS_CRON != 'multiarch'
     depends_on:


### PR DESCRIPTION
Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
