### PR TITLE
[CI:DOCS] Cirrus: Fix win installer task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,8 +14,6 @@ env:
     GOPATH: &gopath "/var/tmp/go"
     GOCACHE: "${GOPATH}/cache"
     GOSRC: &gosrc "/var/tmp/go/src/github.com/containers/podman"
-    # Store the unaltered default location, for tasks that need it
-    CIRRUS_DEFAULT_WORK: ${CIRRUS_WORKING_DIR}
     CIRRUS_WORKING_DIR: *gosrc
     # The default is 'sh' if unspecified
     CIRRUS_SHELL: "/bin/bash"
@@ -1053,7 +1051,7 @@ win_installer_task:
         CIRRUS_SHELL: powershell
         # Fake version, we are only testing the installer functions, so version doesn't matter
         WIN_INST_VER: 9.9.9
-        CIRRUS_WORKING_DIR: "${CIRRUS_DEFAULT_WORK}"
+        CIRRUS_WORKING_DIR: "${LOCALAPPDATA}\\Temp\\cirrus-ci-build"
     install_script: '.\contrib\cirrus\win-installer-install.ps1'
     main_script: '.\contrib\cirrus\win-installer-main.ps1'
 


### PR DESCRIPTION
ref: https://github.com/containers/podman/pull/16167

According to Cirrus-support, defining and using `$CIRRUS_DEFAULT_WORK`
is responsible for causing a strange race condition on windows.  This is
impacting the agent's ability to clone with errors like:

```
Using built-in Git...
Cloning refs/heads/main...
Failed to clone: read ${CIRRUS_DEFAULT_WORK}\.git\HEAD: The process
cannot access the file because another process has locked a portion of
the file.!
```

Fix this by hard-coding a work directory for this windows task.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
