### PR TITLE
[CI:DOCS] Clarify that MacOSX docs are client specific

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ the “In Progress” label be set and a member will do so for you.
 
 ## Contributing to Podman
 
-This section describes how to start a contribution to Podman. These instructions are geared towards using a Linux development machine, or doing development on the podman backend. For instructions on working on MacOS, read the [docs for building on osx](./build_osx.md).
+This section describes how to start a contribution to Podman. These instructions are geared towards using a Linux development machine, which is required for doing development on the podman backend. Check out these instructions for [building the podman client on MacOSX](./build_osx.md).
 
 ### Prepare your environment
 


### PR DESCRIPTION
Seems helpful to mention here that only the client can be built directly on MacOSX.

Signed-off-by: Jesse Lang <jesse@jesselang.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
