### PR TITLE
hack/tree_status.sh: print diff at the end

### DIFF
--- a/hack/tree_status.sh
+++ b/hack/tree_status.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-SUGGESTION="${SUGGESTION:-sync the vendor.conf and commit all changes.}"
+SUGGESTION="${SUGGESTION:-run \"make vendor\" and commit all changes.}"
 
 STATUS=$(git status --porcelain)
 if [[ -z $STATUS ]]
@@ -11,5 +11,9 @@ else
 	echo "tree is dirty, please $SUGGESTION"
 	echo ""
 	echo "$STATUS"
+	echo ""
+	echo "---------------------- Diff below ----------------------"
+	echo ""
+	git --no-pager diff
 	exit 1
 fi


### PR DESCRIPTION
Print the diff at the end of the report to help better understand what's going on.

```
tree is dirty, please run "make vendor" and commit all changes.

 M go.mod
 M go.sum
 M hack/tree_status.sh
 M vendor/github.com/containers/storage/store.go
 M vendor/modules.txt

---------------------- Diff below ----------------------

diff --git a/go.mod b/go.mod
index e36d3fb95c57..167d769c378f 100644
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
        github.com/containers/image/v5 v5.23.0
        github.com/containers/ocicrypt v1.1.6
        github.com/containers/psgo v1.7.3
-       github.com/containers/storage v1.43.1-0.20221013143630-714f4fc6e80e
+       github.com/containers/storage v1.43.1-0.20221014072257-a144fee6f51c
        github.com/coreos/go-systemd/v22 v22.4.0
        github.com/coreos/stream-metadata-go v0.0.0-20210225230131-70edb9eb47b3
        github.com/cyphar/filepath-securejoin v0.2.3
```

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@containers/podman-maintainers PTAL