### PR TITLE
[wip] libpod: propogate custom DNS server to `/etc/resolv.conf` only when `dns_enabled` for network

### DIFF
--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -1006,6 +1006,34 @@ EXPOSE 2004-2005/tcp`, ALPINE)
 		pingTest("--net=private")
 	})
 
+	It("podman verify resolv.conf with --dns + --network", func() {
+		net := createNetworkName("IntTest")
+		session := podmanTest.Podman([]string{"network", "create", net})
+		session.WaitWithDefaultTimeout()
+		defer podmanTest.removeNetwork(net)
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"run", "--name", "con1", "--dns", "1.1.1.1", "--network", net, ALPINE, "cat", "/etc/resolv.conf"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		// Must not contain custom dns server in containers
+		// `/etc/resolv.conf` since custom dns-server is
+		// already expected to be present and processed by
+		// Podman's DNS resolver i.e ( aarvark-dns or dnsname ).
+		Expect(session.OutputToString()).ToNot(ContainSubstring("nameserver 1.1.1.1"))
+		// But /etc/resolve.conf must contain othe nameserver
+		// i.e dns server configured for network.
+		Expect(session.OutputToString()).To(ContainSubstring("nameserver"))
+
+		session = podmanTest.Podman([]string{"run", "--name", "con2", "--dns", "1.1.1.1", ALPINE, "cat", "/etc/resolv.conf"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		// All the networks being used by following container
+		// don't have dns_enabled in such scenario `/etc/resolv.conf`
+		// must contain nameserver which were specified via `--dns`.
+		Expect(session.OutputToString()).To(ContainSubstring("nameserver 1.1.1.1"))
+	})
+
 	It("podman run check dnsname plugin with CNI", func() {
 		SkipIfNetavark(podmanTest)
 		pod := "testpod"


### PR DESCRIPTION
Podman populates container's `/etc/resolv.conf` with custom DNS servers ( specified via `--dns` or `dns_server` in containers.conf ) even when container is connected to a network where `dns_enabled` is `true`.

Current behavior does not matches with docker, hence following commit ensures that podman only populates custom DNS server when container is not connected to any network where DNS is enabled and for the cases where `dns_enabled` is `true`
the resolution for custom DNS server will happen via ( `aardvark-dns` or `dnsname` ).

Reference: https://docs.docker.com/config/containers/container-networking/#dns-services
Closes: https://github.com/containers/podman/issues/16172

```release-note
container: `--dns` and `dns_server` behavior for containers connected to network matches with docker now 
```
