### PR TITLE
generate systemd: set --stop-timeout for stopping containers

### DIFF
--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -317,8 +317,8 @@ func executeContainerTemplate(info *containerInfo, options entities.GenerateSyst
 		info.PIDFile = ""
 		info.ContainerIDFile = "%t/%n.ctr-id"
 		info.ExecStartPre = formatOptionsString("/bin/rm -f {{{{.ContainerIDFile}}}}")
-		info.ExecStop = formatOptionsString("{{{{.Executable}}}} stop --ignore --cidfile={{{{.ContainerIDFile}}}}")
-		info.ExecStopPost = formatOptionsString("{{{{.Executable}}}} rm -f --ignore --cidfile={{{{.ContainerIDFile}}}}")
+		info.ExecStop = formatOptionsString("{{{{.Executable}}}} stop --ignore {{{{if (ge .StopTimeout 0)}}}}-t {{{{.StopTimeout}}}}{{{{end}}}} --cidfile={{{{.ContainerIDFile}}}}")
+		info.ExecStopPost = formatOptionsString("{{{{.Executable}}}} rm -f --ignore {{{{if (ge .StopTimeout 0)}}}}-t {{{{.StopTimeout}}}}{{{{end}}}} --cidfile={{{{.ContainerIDFile}}}}")
 		// The create command must at least have three arguments:
 		// 	/usr/bin/podman run $IMAGE
 		index := 0

--- a/pkg/systemd/generate/containers_test.go
+++ b/pkg/systemd/generate/containers_test.go
@@ -294,11 +294,11 @@ ExecStart=/usr/bin/podman container run \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN "foo=arg \"with \" space"
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -333,11 +333,11 @@ ExecStart=/usr/bin/podman container run \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN "foo=arg \"with \" space"
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -372,11 +372,11 @@ ExecStart=/usr/bin/podman container run \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN "foo=arg \"with \" space"
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -411,11 +411,11 @@ ExecStart=/usr/bin/podman run \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -451,11 +451,11 @@ ExecStart=/usr/bin/podman run \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -490,11 +490,11 @@ ExecStart=/usr/bin/podman run \
 	--name jadda-jadda \
 	--hostname hello-world awesome-image:latest command arg1 ... argN
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -526,11 +526,11 @@ ExecStart=/usr/bin/podman run \
 	--sdnotify=conmon \
 	-d awesome-image:latest
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -565,11 +565,11 @@ ExecStart=/usr/bin/podman run \
 			detachparam +
 			` awesome-image:latest
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 42 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 42 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -607,11 +607,11 @@ ExecStart=/usr/bin/podman run \
 	-p 80:80 awesome-image:latest somecmd \
 	--detach=false
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 42 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 42 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -645,11 +645,11 @@ ExecStart=/usr/bin/podman \
 	--sdnotify=conmon \
 	-d awesome-image:latest
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 42 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 42 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -681,11 +681,11 @@ ExecStart=/usr/bin/podman container run \
 	--sdnotify=conmon \
 	-d awesome-image:latest
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -721,11 +721,11 @@ ExecStart=/usr/bin/podman run \
 	--log-driver=journald \
 	--log-opt=tag={{.Name}} awesome-image:latest
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -760,11 +760,11 @@ ExecStart=/usr/bin/podman run \
 	--name test awesome-image:latest sh \
 	-c "kill $$$$ && echo %%\\"
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -800,11 +800,11 @@ ExecStart=/usr/bin/podman run \
 	--conmon-pidfile=foo \
 	--cidfile=foo alpine
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -842,11 +842,11 @@ ExecStart=/usr/bin/podman run \
 	--cidfile=foo \
 	--pod-id-file /tmp/pod-foobar.pod-id-file alpine
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -883,11 +883,11 @@ ExecStart=/usr/bin/podman run \
 	--env=MYENV=2 \
 	-e USER awesome-image:latest
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -949,11 +949,11 @@ ExecStart=/usr/bin/podman run \
 	--sdnotify=conmon \
 	-d awesome-image:latest
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -986,11 +986,11 @@ ExecStart=/usr/bin/podman run \
 	-d \
 	-h hostname awesome-image:latest
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all
@@ -1024,11 +1024,11 @@ ExecStart=/usr/bin/podman run \
 	--sdnotify=conmon \
 	-d awesome-image:latest
 ExecStop=/usr/bin/podman stop \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm \
 	-f \
-	--ignore \
+	--ignore -t 10 \
 	--cidfile=%t/%n.ctr-id
 Type=notify
 NotifyAccess=all


### PR DESCRIPTION
Make sure to always the stop timeout for unit generated via `--new`.

Fixes: #16149
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix `generate systemd --new` to set the --stop-timeout for stopping containers
```
