### PR TITLE
kill: wait for the container

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -244,7 +244,12 @@ func (c *Container) Kill(signal uint) error {
 
 	c.newContainerEvent(events.Kill)
 
-	return c.save()
+	// Make sure to wait for the container to exit in case of SIGKILL.
+	if signal == uint(unix.SIGKILL) {
+		return c.waitForConmonToExitAndSave()
+	}
+
+	return nil
 }
 
 // Attach attaches to a container.

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1325,7 +1325,10 @@ func (c *Container) stop(timeout uint) error {
 
 	c.newContainerEvent(events.Stop)
 	c.state.StoppedByUser = true
+	return c.waitForConmonToExitAndSave()
+}
 
+func (c *Container) waitForConmonToExitAndSave() error {
 	conmonAlive, err := c.ociRuntime.CheckConmonRunning(c)
 	if err != nil {
 		return err

--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Podman attach", func() {
 		Expect(results.OutputToString()).To(ContainSubstring("test"))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 	})
+
 	It("podman attach to the latest container", func() {
 		session := podmanTest.Podman([]string{"run", "-d", "--name", "test1", ALPINE, "/bin/sh", "-c", "while true; do echo test1; sleep 1; done"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Make sure to wait for the container to exit after kill. While the cleanup process will take care eventually of transitioning the state, we need to give a guarantee to the user to leave the container in the expected state once the (kill) command has finished.

The issue could be observed in a flaking test (#16142) where `podman rm -f -t0` failed because the preceding `podman kill` left the container in "running" state which ultimately confused the "stop" backend.

Note that we should only wait for the container to exit when SIGKILL is being used.  Other signals have different semantics.

[NO NEW TESTS NEEDED] as I do not know how to reliably reproduce the issue.  If #16142 stops flaking, we are good.

Fixes: #16142
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where `podman kill` would not transition the container to the exited state.
```
