### PR TITLE
Add --quiet and --no-info flags to podman machine start

### DIFF
--- a/docs/source/markdown/podman-machine-start.1.md
+++ b/docs/source/markdown/podman-machine-start.1.md
@@ -28,6 +28,14 @@ Only one Podman managed VM can be active at a time. If a VM is already running,
 
 Print usage statement.
 
+#### **--no-info**
+
+Suppress informational tips.
+
+#### **--quiet**, **-q**
+
+Suppress machine starting status output.
+
 ## EXAMPLES
 
 ```

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -114,7 +114,11 @@ type SSHOptions struct {
 	Username string
 	Args     []string
 }
-type StartOptions struct{}
+
+type StartOptions struct {
+	NoInfo bool
+	Quiet  bool
+}
 
 type StopOptions struct{}
 

--- a/pkg/machine/e2e/config_start_test.go
+++ b/pkg/machine/e2e/config_start_test.go
@@ -4,6 +4,8 @@ type startMachine struct {
 	/*
 		No command line args other than a machine vm name (also not required)
 	*/
+	quiet  bool
+	noInfo bool
 }
 
 func (s startMachine) buildCmd(m *machineTestBuilder) []string {
@@ -11,5 +13,21 @@ func (s startMachine) buildCmd(m *machineTestBuilder) []string {
 	if len(m.name) > 0 {
 		cmd = append(cmd, m.name)
 	}
+	if s.quiet {
+		cmd = append(cmd, "--quiet")
+	}
+	if s.noInfo {
+		cmd = append(cmd, "--no-info")
+	}
 	return cmd
+}
+
+func (s startMachine) withQuiet() startMachine {
+	s.quiet = true
+	return s
+}
+
+func (s startMachine) withNoInfo() startMachine {
+	s.noInfo = true
+	return s
 }

--- a/pkg/machine/e2e/start_test.go
+++ b/pkg/machine/e2e/start_test.go
@@ -33,5 +33,25 @@ var _ = Describe("podman machine start", func() {
 		Expect(err).To(BeNil())
 		Expect(ec).To(BeZero())
 		Expect(info[0].State).To(Equal(machine.Running))
+
+		stop := new(stopMachine)
+		stopSession, err := mb.setCmd(stop).run()
+		Expect(err).To(BeNil())
+		Expect(stopSession).To(Exit(0))
+
+		// suppress output
+		startSession, err = mb.setCmd(s.withNoInfo()).run()
+		Expect(err).To(BeNil())
+		Expect(startSession).To(Exit(0))
+		Expect(startSession.outputToString()).ToNot(ContainSubstring("API forwarding"))
+
+		stopSession, err = mb.setCmd(stop).run()
+		Expect(err).To(BeNil())
+		Expect(stopSession).To(Exit(0))
+
+		startSession, err = mb.setCmd(s.withQuiet()).run()
+		Expect(err).To(BeNil())
+		Expect(startSession).To(Exit(0))
+		Expect(len(startSession.outputToStringSlice())).To(Equal(1))
 	})
 })

--- a/pkg/machine/e2e/stop_test.go
+++ b/pkg/machine/e2e/stop_test.go
@@ -34,7 +34,6 @@ var _ = Describe("podman machine stop", func() {
 		Expect(session).To(Exit(0))
 
 		stop := new(stopMachine)
-		// Removing a running machine should fail
 		stopSession, err := mb.setCmd(stop).run()
 		Expect(err).To(BeNil())
 		Expect(stopSession).To(Exit(0))


### PR DESCRIPTION
Add quiet and no-info flags to podman machine start.
No-info suppresses helpful informational tips
Quiet suppresses machine start progress output, as well as informational
tips.
Signed-off-by: Ashley Cui <acui@redhat.com>

Closes: https://github.com/containers/podman/issues/15525
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add quiet and no-info flags to podman machine start
```
