### PR TITLE
adding regex support to the ancestor ps filter function

### DIFF
--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -52,7 +52,7 @@ Valid filters are listed below:
 | label           | [Key] or [Key=Value] Label assigned to a container                               |
 | exited          | [Int] Container's exit code                                                      |
 | status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
-| ancestor        | [ImageName] Image or descendant used to create container                         |
+| ancestor        | [ImageName] Image or descendant used to create container (accepts regex)         |
 | before          | [ID] or [Name] Containers created before this container                          |
 | since           | [ID] or [Name] Containers created since this container                           |
 | volume          | [VolumeName] or [MountpointDestination] Volume mounted in container              |

--- a/pkg/domain/filters/containers.go
+++ b/pkg/domain/filters/containers.go
@@ -96,8 +96,8 @@ func GenerateContainerFilterFuncs(filter string, filterValues []string, r *libpo
 				}
 
 				if (rootfsImageID == filterValue) ||
-					(rootfsImageName == filterValue) ||
-					(imageNameWithoutTag == filterValue && imageTag == "latest") {
+					util.StringMatchRegexSlice(rootfsImageName, filterValues) ||
+					(util.StringMatchRegexSlice(imageNameWithoutTag, filterValues) && imageTag == "latest") {
 					return true
 				}
 			}

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -313,8 +313,20 @@ var _ = Describe("Podman ps", func() {
 		Expect(result).Should(Exit(0))
 		Expect(result.OutputToString()).To(Equal(cid))
 
-		// Query by truncated image name should not match ( should return empty output )
+		// Query by truncated image name should match (regexp match)
 		result = podmanTest.Podman([]string{"ps", "-q", "--no-trunc", "-a", "--filter", "ancestor=quay.io/libpod/alpi"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(result.OutputToString()).To(Equal(cid))
+
+		// Query using regex by truncated image name should match (regexp match)
+		result = podmanTest.Podman([]string{"ps", "-q", "--no-trunc", "-a", "--filter", "ancestor=^(quay.io|docker.io)/libpod/alpine:[a-zA-Z]+"})
+		result.WaitWithDefaultTimeout()
+		Expect(result).Should(Exit(0))
+		Expect(result.OutputToString()).To(Equal(cid))
+
+		// Query for an non-existing image using regex should not match anything
+		result = podmanTest.Podman([]string{"ps", "-q", "--no-trunc", "-a", "--filter", "ancestor=^quai.io/libpod/alpi"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(Exit(0))
 		Expect(result.OutputToString()).To(Equal(""))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

Closes #16180

This PR adds regular expression support the ancestor ps filter by uisng `util.StringMatchRegexSlice` instead of comparing the exact string value.

The same function is used by the `name` filter.

#### Does this PR introduce a user-facing change?

Yes, it adds regular expression support when using the ancestor ps filter, examples:

```
podman ps --filter ancestor=registry.fedoraproject.org/fedora:latest
podman ps --filter ancestor=registry.fedoraproject.org
podman ps --filter ancestor=fedoraproject.*/fedora
```

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added: Regular expression support for "podman ps --filter ancestor"
```
