### PR TITLE
[CI:BUILD] copr: podman rpm should depend on containers-common-extra

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -78,13 +78,7 @@ BuildRequires: ostree-devel
 BuildRequires: systemd
 BuildRequires: systemd-devel
 Requires: conmon >= 2:2.0.30-2
-# containers-common pulled from podman-next copr for f34,
-# from the distro repos for f35+
-%if 0%{?fedora} <= 35
-Requires: containers-common >= 4:1-39
-%else
-Requires: containers-common >= 4:1-46
-%endif
+Requires: containers-common-extra >= 4:1-78
 Requires: iptables
 Requires: nftables
 Recommends: catatonit


### PR DESCRIPTION
containers-common now has a new `-extra` subpackage which handles dependencies common to podman and buildah and also depends on the main package `containers-common` itself.

The podman-next copr rebuilds containers-common from the rawhide branch
of dist-git so it will always have the latest version and will also
supersede the official containers-common packages (except on rawhide
where it will be equal).

Fixes: #16137

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@containers/podman-maintainers PTAL

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
