### PR TITLE
[CI:DOCS] Podman image: Set default_sysctls to empty for rootless containers

### DIFF
--- a/contrib/podmanimage/stable/podman-containers.conf
+++ b/contrib/podmanimage/stable/podman-containers.conf
@@ -2,3 +2,4 @@
 volumes = [
 	"/proc:/proc",
 ]
+default_sysctls = []


### PR DESCRIPTION
Avoids the error "Error: error preparing container xyz... for attach: crun: open /proc/sys/net/ipv4/ping_group_range: Read-only file system: OCI runtime error" when using `podman run --net bridge` inside Podman running without --security-opt unmask=ALL (or 'unmask=/proc/*')

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

No
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Set default_sysctls to empty for rootless podman in podman image
```
