### PR TITLE
WIP: Remove dangling layers

### DIFF
--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -88,6 +88,19 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 		numPreviouslyRemovedImages = numRemovedImages
 	}
 
+	removedLayers, rmErrors := ir.Libpod.LibimageRuntime().RemoveDanglingLayers(ctx)
+	if rmErrors != nil {
+		return nil, errorhandling.JoinErrors(rmErrors)
+	}
+
+	for _, rmReport := range removedLayers {
+		r := *rmReport
+		pruneReports = append(pruneReports, &reports.PruneReport{
+			Id:   "partial:" + r.ID,
+			Size: uint64(r.Size),
+		})
+	}
+
 	return pruneReports, nil
 }
 


### PR DESCRIPTION
**Note: this is a local fix we use for #16214 I know that this is probbably not a good way to integrate a fix for this issue, but as I have created is patch already for our use, so I thought I just share it. So feel free to simply discard it.**

When pulling an image, layers are unpacked as soon as they (and their parents) are ready. If we now interrupt this process, a layer may exists that is not associated with any image, as not all layers for that image have been pulled yet.

This is not really a problem when we later resume pulling the image. When resuming we will reuse the existing layer and attach to the image once done.

However if we don't resume then there is no way to remove this dangling layer (aside from the nuclear `system reset` way).

This patch adds an extra pass to the image prune operation, to also remove all layers that are not referenced. This way was chosen as layers itself are not exposed to the API/user as a resource.