### PR TITLE
Cirrus: Periodic Upgrade tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -846,8 +846,8 @@ rootless_gitlab_test_task:
 upgrade_test_task:
     name: "Upgrade test: from $PODMAN_UPGRADE_FROM"
     alias: upgrade_test
-    # Docs: ./contrib/cirrus/CIModes.md
-    only_if: *not_tag_branch_build_docs
+    # Only run under Cirrus-Cron, for a regular branches.
+    only_if: $CIRRUS_CRON == $CIRRUS_BRANCH
     depends_on:
         - build
         - local_system_test


### PR DESCRIPTION
There's little reason to run upgrade testing for every PR or branch push.  Switch to only running it on regular branches when the cron name matches the branch name exactly.  In other words, skip running it for the job named 'multiarch' (which runs on the `main` branch).

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
