### PR TITLE
[v4.3] system tests: fix broken bashisms

### DIFF
--- a/test/system/260-sdnotify.bats
+++ b/test/system/260-sdnotify.bats
@@ -41,7 +41,9 @@ function teardown() {
 function _start_socat() {
     _SOCAT_LOG="$PODMAN_TMPDIR/socat.log"
 
+    # Reset socat logfile to empty
     rm -f $_SOCAT_LOG
+    touch $_SOCAT_LOG
     # Execute in subshell so we can close fd3 (which BATS uses).
     # This is a superstitious ritual to try to avoid leaving processes behind,
     # and thus prevent CI hangs.

--- a/test/system/270-socket-activation.bats
+++ b/test/system/270-socket-activation.bats
@@ -101,7 +101,7 @@ function teardown() {
         die "Pause pid file does not exist: $pause_pid_file"
     fi
 
-    echo "kill -9 $(< pause_pid_file)"
+    echo "kill -9 $(< $pause_pid_file) [pause process]"
     kill -9 $(< $pause_pid_file)
 
     run curl -s --max-time 3 --unix-socket $SERVICE_SOCK_ADDR $_PING


### PR DESCRIPTION
gating tests failing on rawhide, and will probably fail on f36 and f37 due to long-broken bugs that are now caught by (bats, I think? new version of bash? who knows).

This is a partial cherry-pick of #16220, omitting the change to testimage (not needed here)

This fixes **some** of the broken gating tests. The rest (#16107, systemd pod cgroups) are beyond my control.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
Fix broken gating tests
```
