### PR TITLE
Fix `system df` issues with `-f` and `-v`

### DIFF
--- a/docs/source/markdown/podman-system-df.1.md
+++ b/docs/source/markdown/podman-system-df.1.md
@@ -12,7 +12,7 @@ Show podman disk usage
 ## OPTIONS
 #### **--format**=*format*
 
-Pretty-print images using a Go template
+Pretty-print images using a Go template or JSON. This flag is not allowed in combination with **--verbose**
 
 #### **--verbose**, **-v**
 Show detailed information on space usage

--- a/test/e2e/system_df_test.go
+++ b/test/e2e/system_df_test.go
@@ -106,8 +106,29 @@ var _ = Describe("podman system df", func() {
 		session = podmanTest.Podman([]string{"system", "df", "--format", "{{ json . }}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
-		Expect(session.LineInOutputContains("Size"))
-		Expect(session.LineInOutputContains("Reclaimable"))
-		Expect(session.IsJSONOutputValid())
+		Expect(session.OutputToString()).To(ContainSubstring("Size"))
+		Expect(session.OutputToString()).To(ContainSubstring("Reclaimable"))
+		Expect(session.OutputToString()).To(BeValidJSON())
 	})
+
+	It("podman system df --format with --verbose", func() {
+		session := podmanTest.Podman([]string{"system", "df", "--format", "json", "--verbose"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).To(ExitWithError())
+		Expect(session.ErrorToString()).To(Equal("Error: cannot combine --format and --verbose flags"))
+	})
+
+	It("podman system df --format json", func() {
+		session := podmanTest.Podman([]string{"create", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		session = podmanTest.Podman([]string{"system", "df", "--format", "json"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+		Expect(session.OutputToString()).To(ContainSubstring("Size"))
+		Expect(session.OutputToString()).To(ContainSubstring("Reclaimable"))
+		Expect(session.OutputToString()).To(BeValidJSON())
+	})
+
 })


### PR DESCRIPTION
Fixed the issue of `--format` and `--verbose` flags being allowed in combination with one another.

Implemented functionality for `--format json` or `--format '{{ json }}' `.

Implemented command-completion help for `--format`.

Fixes: #16204

Signed-off-by: Jake Correnti <jcorrenti13@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where `--format` and `--verbose` were allowed in the same command. 
Added functionality for `--format json`
Added functionality for command-completion help for `--format`
```
