### PR TITLE
[CI:DOCS] markdown-preprocess: cross-reference where opts are used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,7 +438,7 @@ pkg/api/swagger.yaml:
 	make -C pkg/api
 
 $(MANPAGES_MD_GENERATED): %.md: %.md.in $(MANPAGES_SOURCE_DIR)/options/*.md
-	hack/markdown-preprocess $<
+	hack/markdown-preprocess
 
 $(MANPAGES): %: %.md .install.md2man docdir
 

--- a/docs/source/markdown/options/add-host.md
+++ b/docs/source/markdown/options/add-host.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, create, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--add-host**=*host:ip*
 
 Add a custom host-to-IP mapping (host:ip)

--- a/docs/source/markdown/options/annotation.container.md
+++ b/docs/source/markdown/options/annotation.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, kube play, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--annotation**=*key=value*
 
 Add an annotation to the container<<| or pod>>. This option can be set multiple times.

--- a/docs/source/markdown/options/annotation.manifest.md
+++ b/docs/source/markdown/options/annotation.manifest.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman manifest add, manifest annotate
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--annotation**=*annotation=value*
 
 Set an annotation on the entry for the image.

--- a/docs/source/markdown/options/arch.md
+++ b/docs/source/markdown/options/arch.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pull, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--arch**=*ARCH*
 Override the architecture, defaults to hosts, of the image to be pulled. For example, `arm`.
 Unless overridden, subsequent lookups of the same image in the local storage will match this architecture, regardless of the host.

--- a/docs/source/markdown/options/attach.md
+++ b/docs/source/markdown/options/attach.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--attach**, **-a**=*stdin* | *stdout* | *stderr*
 
 Attach to STDIN, STDOUT or STDERR.

--- a/docs/source/markdown/options/authfile.md
+++ b/docs/source/markdown/options/authfile.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman auto update, build, container runlabel, create, image sign, kube play, login, logout, manifest add, manifest push, pull, push, run, search
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--authfile**=*path*
 
 Path of the authentication file. Default is `${XDG_RUNTIME_DIR}/containers/auth.json`, which is set using **[podman login](podman-login.1.md)**.

--- a/docs/source/markdown/options/blkio-weight-device.md
+++ b/docs/source/markdown/options/blkio-weight-device.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman container clone, create, pod clone, pod create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--blkio-weight-device**=*device:weight*
 
 Block IO relative device weight.

--- a/docs/source/markdown/options/blkio-weight.md
+++ b/docs/source/markdown/options/blkio-weight.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman container clone, create, pod clone, pod create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--blkio-weight**=*weight*
 
 Block IO relative weight. The _weight_ is a value between **10** and **1000**.

--- a/docs/source/markdown/options/cap-add.md
+++ b/docs/source/markdown/options/cap-add.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cap-add**=*capability*
 
 Add Linux capabilities.

--- a/docs/source/markdown/options/cap-drop.md
+++ b/docs/source/markdown/options/cap-drop.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cap-drop**=*capability*
 
 Drop Linux capabilities.

--- a/docs/source/markdown/options/cert-dir.md
+++ b/docs/source/markdown/options/cert-dir.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, container runlabel, image sign, kube play, login, manifest add, manifest push, pull, push
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry. (Default: /etc/containers/certs.d)

--- a/docs/source/markdown/options/cgroup-conf.md
+++ b/docs/source/markdown/options/cgroup-conf.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cgroup-conf**=*KEY=VALUE*
 
 When running on cgroup v2, specify the cgroup file to write to and its value. For example **--cgroup-conf=memory.high=1073741824** sets the memory.high limit to 1GB.

--- a/docs/source/markdown/options/cgroup-parent.md
+++ b/docs/source/markdown/options/cgroup-parent.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, create, pod clone, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cgroup-parent**=*path*
 
 Path to cgroups under which the cgroup for the <<container|pod>> will be created. If the

--- a/docs/source/markdown/options/cgroupns.md
+++ b/docs/source/markdown/options/cgroupns.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cgroupns**=*mode*
 
 Set the cgroup namespace mode for the container.

--- a/docs/source/markdown/options/cgroups.md
+++ b/docs/source/markdown/options/cgroups.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cgroups**=*how*
 
 Determines whether the container will create CGroups.

--- a/docs/source/markdown/options/chrootdirs.md
+++ b/docs/source/markdown/options/chrootdirs.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--chrootdirs**=*path*
 
 Path to a directory inside the container that should be treated as a `chroot` directory.

--- a/docs/source/markdown/options/cidfile.read.md
+++ b/docs/source/markdown/options/cidfile.read.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman kill, pause, rm, stop, unpause
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cidfile**=*file*
 
 Read container ID from the specified *file* and <<subcommand>> the container.

--- a/docs/source/markdown/options/cidfile.write.md
+++ b/docs/source/markdown/options/cidfile.write.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cidfile**=*file*
 
 Write the container ID to *file*.

--- a/docs/source/markdown/options/color.md
+++ b/docs/source/markdown/options/color.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman logs, pod logs
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--color**
 
 Output the containers with different colors in the log.

--- a/docs/source/markdown/options/compression-format.md
+++ b/docs/source/markdown/options/compression-format.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman manifest push, push
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--compression-format**=**gzip** | *zstd* | *zstd:chunked*
 
 Specifies the compression format to use.  Supported values are: `gzip`, `zstd` and `zstd:chunked`.  The default is `gzip` unless overridden in the containers.conf file.

--- a/docs/source/markdown/options/conmon-pidfile.md
+++ b/docs/source/markdown/options/conmon-pidfile.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--conmon-pidfile**=*file*
 
 Write the pid of the **conmon** process to a file. As **conmon** runs in a separate process than Podman, this is necessary when using systemd to restart Podman containers.

--- a/docs/source/markdown/options/cpu-period.md
+++ b/docs/source/markdown/options/cpu-period.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, container clone, create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cpu-period**=*limit*
 
 Set the CPU period for the Completely Fair Scheduler (CFS), which is a

--- a/docs/source/markdown/options/cpu-quota.md
+++ b/docs/source/markdown/options/cpu-quota.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, container clone, create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cpu-quota**=*limit*
 
 Limit the CPU Completely Fair Scheduler (CFS) quota.

--- a/docs/source/markdown/options/cpu-rt-period.md
+++ b/docs/source/markdown/options/cpu-rt-period.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman container clone, create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cpu-rt-period**=*microseconds*
 
 Limit the CPU real-time period in microseconds.

--- a/docs/source/markdown/options/cpu-rt-runtime.md
+++ b/docs/source/markdown/options/cpu-rt-runtime.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman container clone, create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cpu-rt-runtime**=*microseconds*
 
 Limit the CPU real-time runtime in microseconds.

--- a/docs/source/markdown/options/cpu-shares.md
+++ b/docs/source/markdown/options/cpu-shares.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, container clone, create, pod clone, pod create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cpu-shares**, **-c**=*shares*
 
 CPU shares (relative weight).

--- a/docs/source/markdown/options/cpus.container.md
+++ b/docs/source/markdown/options/cpus.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cpus**=*number*
 
 Number of CPUs. The default is *0.0* which means no limit. This is shorthand

--- a/docs/source/markdown/options/cpuset-cpus.md
+++ b/docs/source/markdown/options/cpuset-cpus.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, container clone, create, pod clone, pod create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cpuset-cpus**=*number*
 
 CPUs in which to allow execution. Can be specified as a comma-separated list

--- a/docs/source/markdown/options/cpuset-mems.md
+++ b/docs/source/markdown/options/cpuset-mems.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, container clone, create, pod clone, pod create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--cpuset-mems**=*nodes*
 
 Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on

--- a/docs/source/markdown/options/creds.md
+++ b/docs/source/markdown/options/creds.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, container runlabel, kube play, manifest add, manifest push, pull, push
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--creds**=*[username[:password]]*
 
 The [username[:password]] to use to authenticate with the registry, if required.

--- a/docs/source/markdown/options/destroy.md
+++ b/docs/source/markdown/options/destroy.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman container clone, pod clone
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--destroy**
 
 Remove the original <<container|pod>> that we are cloning once used to mimic the configuration.

--- a/docs/source/markdown/options/detach-keys.md
+++ b/docs/source/markdown/options/detach-keys.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman attach, exec, run, start
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--detach-keys**=*sequence*
 
 Specify the key sequence for detaching a container. Format is a single character `[a-Z]` or one or more `ctrl-<value>` characters where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`. Specifying "" will disable this feature. The default is *ctrl-p,ctrl-q*.

--- a/docs/source/markdown/options/device-cgroup-rule.md
+++ b/docs/source/markdown/options/device-cgroup-rule.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--device-cgroup-rule**=*"type major:minor mode"*
 
 Add a rule to the cgroup allowed devices list. The rule is expected to be in the format specified in the Linux kernel documentation (Documentation/cgroup-v1/devices.txt):

--- a/docs/source/markdown/options/device-read-bps.md
+++ b/docs/source/markdown/options/device-read-bps.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman container clone, create, pod clone, pod create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--device-read-bps**=*path:rate*
 
 Limit read rate (in bytes per second) from a device (e.g. **--device-read-bps=/dev/sda:1mb**).

--- a/docs/source/markdown/options/device-read-iops.md
+++ b/docs/source/markdown/options/device-read-iops.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--device-read-iops**=*path:rate*
 
 Limit read rate (in IO operations per second) from a device (e.g. **--device-read-iops=/dev/sda:1000**).

--- a/docs/source/markdown/options/device-write-bps.md
+++ b/docs/source/markdown/options/device-write-bps.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman container clone, create, pod clone, pod create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--device-write-bps**=*path:rate*
 
 Limit write rate (in bytes per second) to a device (e.g. **--device-write-bps=/dev/sda:1mb**).

--- a/docs/source/markdown/options/device-write-iops.md
+++ b/docs/source/markdown/options/device-write-iops.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--device-write-iops**=*path:rate*
 
 Limit write rate (in IO operations per second) to a device (e.g. **--device-write-iops=/dev/sda:1000**).

--- a/docs/source/markdown/options/device.md
+++ b/docs/source/markdown/options/device.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, create, pod clone, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--device**=*host-device[:container-device][:permissions]*
 
 Add a host device to the <<container|pod>>. Optional *permissions* parameter

--- a/docs/source/markdown/options/digestfile.md
+++ b/docs/source/markdown/options/digestfile.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman manifest push, push
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--digestfile**=*Digestfile*
 
 After copying the image, write the digest of the resulting image to the file.

--- a/docs/source/markdown/options/disable-content-trust.md
+++ b/docs/source/markdown/options/disable-content-trust.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, create, pull, push, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--disable-content-trust**
 
 This is a Docker-specific option to disable image verification to a container

--- a/docs/source/markdown/options/dns-option.container.md
+++ b/docs/source/markdown/options/dns-option.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--dns-option**=*option*
 
 Set custom DNS options. Invalid if using **--dns-option** with **--network** that is set to **none** or **container:**_id_.

--- a/docs/source/markdown/options/dns-search.container.md
+++ b/docs/source/markdown/options/dns-search.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--dns-search**=*domain*
 
 Set custom DNS search domains. Invalid if using **--dns-search** with **--network** that is set to **none** or **container:**_id_.

--- a/docs/source/markdown/options/dns.md
+++ b/docs/source/markdown/options/dns.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--dns**=*ipaddr*
 
 Set custom DNS servers.

--- a/docs/source/markdown/options/entrypoint.md
+++ b/docs/source/markdown/options/entrypoint.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--entrypoint**=*"command"* | *'["command", "arg1", ...]'*
 
 Overwrite the default ENTRYPOINT of the image.

--- a/docs/source/markdown/options/env-file.md
+++ b/docs/source/markdown/options/env-file.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, exec, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--env-file**=*file*
 
 Read in a line-delimited file of environment variables.

--- a/docs/source/markdown/options/env-host.md
+++ b/docs/source/markdown/options/env-host.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--env-host**
 
 Use host environment inside of the container. See **Environment** note below for precedence. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/options/env-merge.md
+++ b/docs/source/markdown/options/env-merge.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--env-merge**=*env*
 
 Preprocess default environment variables for the containers. For example

--- a/docs/source/markdown/options/env.md
+++ b/docs/source/markdown/options/env.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, exec, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--env**, **-e**=*env*
 
 Set environment variables.

--- a/docs/source/markdown/options/expose.md
+++ b/docs/source/markdown/options/expose.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--expose**=*port*
 
 Expose a port, or a range of ports (e.g. **--expose=3300-3310**) to set up port redirection

--- a/docs/source/markdown/options/features.md
+++ b/docs/source/markdown/options/features.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman manifest add, manifest annotate
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--features**
 
 Specify the features list which the list or index records as requirements for

--- a/docs/source/markdown/options/follow.md
+++ b/docs/source/markdown/options/follow.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman logs, pod logs
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--follow**, **-f**
 
 Follow log output.  Default is false.

--- a/docs/source/markdown/options/gidmap.container.md
+++ b/docs/source/markdown/options/gidmap.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--gidmap**=*container_gid:host_gid:amount*
 
 Run the container in a new user namespace using the supplied GID mapping. This

--- a/docs/source/markdown/options/gidmap.pod.md
+++ b/docs/source/markdown/options/gidmap.pod.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod clone, pod create
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--gidmap**=*pod_gid:host_gid:amount*
 
 GID map for the user namespace. Using this flag will run all containers in the pod with user namespace enabled.

--- a/docs/source/markdown/options/group-add.md
+++ b/docs/source/markdown/options/group-add.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--group-add**=*group* | *keep-groups*
 
 Assign additional groups to the primary user running within the container process.

--- a/docs/source/markdown/options/health-cmd.md
+++ b/docs/source/markdown/options/health-cmd.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--health-cmd**=*"command"* | *'["command", "arg1", ...]'*
 
 Set or alter a healthcheck command for a container. The command is a command to be executed inside your

--- a/docs/source/markdown/options/health-interval.md
+++ b/docs/source/markdown/options/health-interval.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--health-interval**=*interval*
 
 Set an interval for the healthchecks. An _interval_ of **disable** results in no automatic timer setup. The default is **30s**.

--- a/docs/source/markdown/options/health-on-failure.md
+++ b/docs/source/markdown/options/health-on-failure.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--health-on-failure**=*action*
 
 Action to take once the container transitions to an unhealthy state.  The default is **none**.

--- a/docs/source/markdown/options/health-retries.md
+++ b/docs/source/markdown/options/health-retries.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--health-retries**=*retries*
 
 The number of retries allowed before a healthcheck is considered to be unhealthy. The default value is **3**.

--- a/docs/source/markdown/options/health-start-period.md
+++ b/docs/source/markdown/options/health-start-period.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--health-start-period**=*period*
 
 The initialization time needed for a container to bootstrap. The value can be expressed in time format like

--- a/docs/source/markdown/options/health-timeout.md
+++ b/docs/source/markdown/options/health-timeout.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--health-timeout**=*timeout*
 
 The maximum time allowed to complete the healthcheck before an interval is considered failed. Like start-period, the

--- a/docs/source/markdown/options/hostname.container.md
+++ b/docs/source/markdown/options/hostname.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--hostname**, **-h**=*name*
 
 Container host name

--- a/docs/source/markdown/options/hostname.pod.md
+++ b/docs/source/markdown/options/hostname.pod.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod clone, pod create
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--hostname**=*name*
 
 Set a hostname to the pod.

--- a/docs/source/markdown/options/hostuser.md
+++ b/docs/source/markdown/options/hostuser.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--hostuser**=*name*
 
 Add a user account to /etc/passwd from the host to the container. The Username

--- a/docs/source/markdown/options/http-proxy.md
+++ b/docs/source/markdown/options/http-proxy.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--http-proxy**
 
 By default proxy environment variables are passed into the container if set

--- a/docs/source/markdown/options/ignore.md
+++ b/docs/source/markdown/options/ignore.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod rm, pod stop, rm, stop
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--ignore**, **-i**
 
 Ignore errors when specified <<containers|pods>> are not in the container store.  A user

--- a/docs/source/markdown/options/image-volume.md
+++ b/docs/source/markdown/options/image-volume.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--image-volume**=**bind** | *tmpfs* | *ignore*
 
 Tells Podman how to handle the builtin image volumes. Default is **bind**.

--- a/docs/source/markdown/options/infra-command.md
+++ b/docs/source/markdown/options/infra-command.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod clone, pod create
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--infra-command**=*command*
 
 The command that will be run to start the infra container. Default: "/pause".

--- a/docs/source/markdown/options/infra-conmon-pidfile.md
+++ b/docs/source/markdown/options/infra-conmon-pidfile.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod clone, pod create
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--infra-conmon-pidfile**=*file*
 
 Write the pid of the infra container's **conmon** process to a file. As **conmon** runs in a separate process than Podman, this is necessary when using systemd to manage Podman containers and pods.

--- a/docs/source/markdown/options/infra-name.md
+++ b/docs/source/markdown/options/infra-name.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod clone, pod create
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--infra-name**=*name*
 
 The name that will be used for the pod's infra container.

--- a/docs/source/markdown/options/init-path.md
+++ b/docs/source/markdown/options/init-path.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--init-path**=*path*
 
 Path to the container-init binary.

--- a/docs/source/markdown/options/init.md
+++ b/docs/source/markdown/options/init.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--init**
 
 Run an init inside the container that forwards signals and reaps processes.

--- a/docs/source/markdown/options/interactive.md
+++ b/docs/source/markdown/options/interactive.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, exec, run, start
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--interactive**, **-i**
 
 When set to **true**, keep stdin open even if not attached. The default is **false**.

--- a/docs/source/markdown/options/ip.md
+++ b/docs/source/markdown/options/ip.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--ip**=*ipv4*
 
 Specify a static IPv4 address for the <<container|pod>>, for example **10.88.64.128**.

--- a/docs/source/markdown/options/ip6.md
+++ b/docs/source/markdown/options/ip6.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--ip6**=*ipv6*
 
 Specify a static IPv6 address for the <<container|pod>>, for example **fd46:db93:aa76:ac37::10**.

--- a/docs/source/markdown/options/ipc.md
+++ b/docs/source/markdown/options/ipc.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--ipc**=*ipc*
 
 Set the IPC namespace mode for a container. The default is to create

--- a/docs/source/markdown/options/label-file.md
+++ b/docs/source/markdown/options/label-file.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod clone, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--label-file**=*file*
 
 Read in a line-delimited file of labels.

--- a/docs/source/markdown/options/label.md
+++ b/docs/source/markdown/options/label.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod clone, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--label**, **-l**=*key=value*
 
 Add metadata to a <<container|pod>>.

--- a/docs/source/markdown/options/link-local-ip.md
+++ b/docs/source/markdown/options/link-local-ip.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--link-local-ip**=*ip*
 
 Not implemented.

--- a/docs/source/markdown/options/log-driver.md
+++ b/docs/source/markdown/options/log-driver.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--log-driver**=*driver*
 
 Logging driver for the container. Currently available options are **k8s-file**, **journald**, **none** and **passthrough**, with **json-file** aliased to **k8s-file** for scripting compatibility. (Default **journald**).

--- a/docs/source/markdown/options/log-opt.md
+++ b/docs/source/markdown/options/log-opt.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, kube play, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--log-opt**=*name=value*
 
 Logging driver specific options.

--- a/docs/source/markdown/options/mac-address.md
+++ b/docs/source/markdown/options/mac-address.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--mac-address**=*address*
 
 <<Container|Pod>> network interface MAC address (e.g. 92:d0:c6:0a:29:33)

--- a/docs/source/markdown/options/memory-reservation.md
+++ b/docs/source/markdown/options/memory-reservation.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman container clone, create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--memory-reservation**=*number[unit]*
 
 Memory soft limit. A _unit_ can be **b** (bytes), **k** (kibibytes), **m** (mebibytes), or **g** (gibibytes).

--- a/docs/source/markdown/options/memory-swap.md
+++ b/docs/source/markdown/options/memory-swap.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, container clone, create, pod clone, pod create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--memory-swap**=*number[unit]*
 
 A limit value equal to memory plus swap.

--- a/docs/source/markdown/options/memory-swappiness.md
+++ b/docs/source/markdown/options/memory-swappiness.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman container clone, create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--memory-swappiness**=*number*
 
 Tune a container's memory swappiness behavior. Accepts an integer between *0* and *100*.

--- a/docs/source/markdown/options/memory.md
+++ b/docs/source/markdown/options/memory.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, container clone, create, pod clone, pod create, run, update
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--memory**, **-m**=*number[unit]*
 
 Memory limit. A _unit_ can be **b** (bytes), **k** (kibibytes), **m** (mebibytes), or **g** (gibibytes).

--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--mount**=*type=TYPE,TYPE-SPECIFIC-OPTION[,...]*
 
 Attach a filesystem mount to the container

--- a/docs/source/markdown/options/name.container.md
+++ b/docs/source/markdown/options/name.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--name**=*name*
 
 Assign a name to the container.

--- a/docs/source/markdown/options/names.md
+++ b/docs/source/markdown/options/names.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman logs, pod logs
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--names**, **-n**
 
 Output the container names instead of the container IDs in the log.

--- a/docs/source/markdown/options/network-alias.md
+++ b/docs/source/markdown/options/network-alias.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--network-alias**=*alias*
 
 Add a network-scoped alias for the <<container|pod>>, setting the alias for all networks that the container joins. To set a

--- a/docs/source/markdown/options/network.md
+++ b/docs/source/markdown/options/network.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, kube play, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--network**=*mode*, **--net**
 
 Set the network mode for the <<container|pod>>.

--- a/docs/source/markdown/options/no-healthcheck.md
+++ b/docs/source/markdown/options/no-healthcheck.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--no-healthcheck**
 
 Disable any defined healthchecks for container.

--- a/docs/source/markdown/options/no-hosts.md
+++ b/docs/source/markdown/options/no-hosts.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, create, kube play, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--no-hosts**
 
 Do not create _/etc/hosts_ for the <<container|pod>>.

--- a/docs/source/markdown/options/no-reset.md
+++ b/docs/source/markdown/options/no-reset.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod stats, stats
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--no-reset**
 
 Do not clear the terminal/screen in between reporting intervals

--- a/docs/source/markdown/options/no-stream.md
+++ b/docs/source/markdown/options/no-stream.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod stats, stats
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--no-stream**
 
 Disable streaming <<|pod >>stats and only pull the first result, default setting is false

--- a/docs/source/markdown/options/oom-kill-disable.md
+++ b/docs/source/markdown/options/oom-kill-disable.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--oom-kill-disable**
 
 Whether to disable OOM Killer for the container or not.

--- a/docs/source/markdown/options/oom-score-adj.md
+++ b/docs/source/markdown/options/oom-score-adj.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--oom-score-adj**=*num*
 
 Tune the host's OOM preferences for containers (accepts values from **-1000** to **1000**).

--- a/docs/source/markdown/options/os-version.md
+++ b/docs/source/markdown/options/os-version.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman manifest add, manifest annotate
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--os-version**
 
 Specify the OS version which the list or index records as a requirement for the

--- a/docs/source/markdown/options/os.pull.md
+++ b/docs/source/markdown/options/os.pull.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pull, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--os**=*OS*
 
 Override the OS, defaults to hosts, of the image to be pulled. For example, `windows`.

--- a/docs/source/markdown/options/passwd-entry.md
+++ b/docs/source/markdown/options/passwd-entry.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--passwd-entry**=*ENTRY*
 
 Customize the entry that is written to the `/etc/passwd` file within the container when `--passwd` is used.

--- a/docs/source/markdown/options/personality.md
+++ b/docs/source/markdown/options/personality.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--personality**=*persona*
 
 Personality sets the execution domain via Linux personality(2).

--- a/docs/source/markdown/options/pid.container.md
+++ b/docs/source/markdown/options/pid.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--pid**=*mode*
 
 Set the PID namespace mode for the container.

--- a/docs/source/markdown/options/pid.pod.md
+++ b/docs/source/markdown/options/pid.pod.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod clone, pod create
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--pid**=*pid*
 
 Set the PID mode for the pod. The default is to create a private PID namespace for the pod. Requires the PID namespace to be shared via --share.

--- a/docs/source/markdown/options/pidfile.md
+++ b/docs/source/markdown/options/pidfile.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--pidfile**=*path*
 
 When the pidfile location is specified, the container process' PID will be written to the pidfile. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)

--- a/docs/source/markdown/options/pids-limit.md
+++ b/docs/source/markdown/options/pids-limit.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--pids-limit**=*limit*
 
 Tune the container's pids limit. Set to **-1** to have unlimited pids for the container. The default is **4096** on systems that support "pids" cgroup controller.

--- a/docs/source/markdown/options/platform.md
+++ b/docs/source/markdown/options/platform.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pull, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--platform**=*OS/ARCH*
 
 Specify the platform for selecting the image.  (Conflicts with --arch and --os)

--- a/docs/source/markdown/options/pod-id-file.container.md
+++ b/docs/source/markdown/options/pod-id-file.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--pod-id-file**=*file*
 
 Run container in an existing pod and read the pod's ID from the specified *file*.

--- a/docs/source/markdown/options/pod-id-file.pod.md
+++ b/docs/source/markdown/options/pod-id-file.pod.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod rm, pod start, pod stop
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--pod-id-file**=*file*
 
 Read pod ID from the specified *file* and <<subcommand>> the pod. Can be specified multiple times.

--- a/docs/source/markdown/options/pod.run.md
+++ b/docs/source/markdown/options/pod.run.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--pod**=*name*
 
 Run container in an existing pod. If you want Podman to make the pod for you, prefix the pod name with **new:**.

--- a/docs/source/markdown/options/preserve-fds.md
+++ b/docs/source/markdown/options/preserve-fds.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman exec, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--preserve-fds**=*N*
 
 Pass down to the process N additional file descriptors (in addition to 0, 1, 2).

--- a/docs/source/markdown/options/privileged.md
+++ b/docs/source/markdown/options/privileged.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, exec, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--privileged**
 
 Give extended privileges to this container. The default is **false**.

--- a/docs/source/markdown/options/publish-all.md
+++ b/docs/source/markdown/options/publish-all.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--publish-all**, **-P**
 
 Publish all exposed ports to random ports on the host interfaces. The default is **false**.

--- a/docs/source/markdown/options/publish.md
+++ b/docs/source/markdown/options/publish.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--publish**, **-p**=*[[ip:][hostPort]:]containerPort[/protocol]*
 
 Publish a container's port, or range of ports,<<| within this pod>> to the host.

--- a/docs/source/markdown/options/pull.md
+++ b/docs/source/markdown/options/pull.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--pull**=*policy*
 
 Pull image policy. The default is **missing**.

--- a/docs/source/markdown/options/read-only-tmpfs.md
+++ b/docs/source/markdown/options/read-only-tmpfs.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--read-only-tmpfs**
 
 If container is running in **--read-only** mode, then mount a read-write tmpfs on _/run_, _/tmp_, and _/var/tmp_. The default is **true**.

--- a/docs/source/markdown/options/read-only.md
+++ b/docs/source/markdown/options/read-only.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--read-only**
 
 Mount the container's root filesystem as read-only.

--- a/docs/source/markdown/options/replace.md
+++ b/docs/source/markdown/options/replace.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--replace**
 
 If another <<container|pod>> with the same name already exists, replace and remove it. The default is **false**.

--- a/docs/source/markdown/options/requires.md
+++ b/docs/source/markdown/options/requires.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--requires**=*container*
 
 Specify one or more requirements.

--- a/docs/source/markdown/options/restart.md
+++ b/docs/source/markdown/options/restart.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--restart**=*policy*
 
 Restart policy to follow when containers exit.

--- a/docs/source/markdown/options/rootfs.md
+++ b/docs/source/markdown/options/rootfs.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--rootfs**
 
 If specified, the first argument refers to an exploded container on the file system.

--- a/docs/source/markdown/options/sdnotify.md
+++ b/docs/source/markdown/options/sdnotify.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--sdnotify**=**container** | *conmon* | *ignore*
 
 Determines how to use the NOTIFY_SOCKET, as passed with systemd and Type=notify.

--- a/docs/source/markdown/options/seccomp-policy.md
+++ b/docs/source/markdown/options/seccomp-policy.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--seccomp-policy**=*policy*
 
 Specify the policy to select the seccomp profile. If set to *image*, Podman will look for a "io.containers.seccomp.profile" label in the container-image config and use its value as a seccomp profile. Otherwise, Podman will follow the *default* policy by applying the default profile unless specified otherwise via *--security-opt seccomp* as described below.

--- a/docs/source/markdown/options/secret.md
+++ b/docs/source/markdown/options/secret.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--secret**=*secret[,opt=opt ...]*
 
 Give the container access to a secret. Can be specified multiple times.

--- a/docs/source/markdown/options/shm-size.md
+++ b/docs/source/markdown/options/shm-size.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, create, pod clone, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--shm-size**=*number[unit]*
 
 Size of _/dev/shm_. A _unit_ can be **b** (bytes), **k** (kibibytes), **m** (mebibytes), or **g** (gibibytes).

--- a/docs/source/markdown/options/sig-proxy.md
+++ b/docs/source/markdown/options/sig-proxy.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman attach, run, start
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--sig-proxy**
 
 Proxy received signals to the container process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied.

--- a/docs/source/markdown/options/sign-passphrase-file.md
+++ b/docs/source/markdown/options/sign-passphrase-file.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman manifest push, push
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--sign-passphrase-file**=*path*
 
 If signing the image (using either **--sign-by** or **--sign-by-sigstore-private-key**), read the passphrase to use from the specified path.

--- a/docs/source/markdown/options/signal.md
+++ b/docs/source/markdown/options/signal.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman kill, pod kill
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--signal**, **-s**=**signal**
 
 Signal to send to the container<<|s in the pod>>. For more information on Linux signals, refer to *signal(7)*.

--- a/docs/source/markdown/options/since.md
+++ b/docs/source/markdown/options/since.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman logs, pod logs
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--since**=*TIMESTAMP*
 
 Show logs since TIMESTAMP. The --since option can be Unix timestamps, date formatted timestamps, or Go duration

--- a/docs/source/markdown/options/stop-signal.md
+++ b/docs/source/markdown/options/stop-signal.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--stop-signal**=*signal*
 
 Signal to stop a container. Default is **SIGTERM**.

--- a/docs/source/markdown/options/stop-timeout.md
+++ b/docs/source/markdown/options/stop-timeout.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--stop-timeout**=*seconds*
 
 Timeout to stop a container. Default is **10**.

--- a/docs/source/markdown/options/subgidname.md
+++ b/docs/source/markdown/options/subgidname.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod clone, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--subgidname**=*name*
 
 Run the container in a new user namespace using the map with _name_ in the _/etc/subgid_ file.

--- a/docs/source/markdown/options/subuidname.md
+++ b/docs/source/markdown/options/subuidname.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod clone, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--subuidname**=*name*
 
 Run the container in a new user namespace using the map with _name_ in the _/etc/subuid_ file.

--- a/docs/source/markdown/options/sysctl.md
+++ b/docs/source/markdown/options/sysctl.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod clone, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--sysctl**=*name=value*
 
 Configure namespaced kernel parameters <<at runtime|for all containers in the pod>>.

--- a/docs/source/markdown/options/systemd.md
+++ b/docs/source/markdown/options/systemd.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--systemd**=*true* | *false* | *always*
 
 Run container in systemd mode. The default is **true**.

--- a/docs/source/markdown/options/tail.md
+++ b/docs/source/markdown/options/tail.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman logs, pod logs
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--tail**=*LINES*
 
 Output the specified number of LINES at the end of the logs.  LINES must be an integer.  Defaults to -1,

--- a/docs/source/markdown/options/time.md
+++ b/docs/source/markdown/options/time.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod rm, pod stop, restart, rm, stop
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--time**, **-t**=*seconds*
 
 Seconds to wait before forcibly stopping <<the container|running containers within the pod>>.

--- a/docs/source/markdown/options/timeout.md
+++ b/docs/source/markdown/options/timeout.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--timeout**=*seconds*
 
 Maximum time a container is allowed to run before conmon sends it the kill

--- a/docs/source/markdown/options/timestamps.md
+++ b/docs/source/markdown/options/timestamps.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman logs, pod logs
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--timestamps**, **-t**
 
 Show timestamps in the log outputs.  The default is false

--- a/docs/source/markdown/options/tls-verify.md
+++ b/docs/source/markdown/options/tls-verify.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman build, container runlabel, create, kube play, login, manifest add, manifest create, manifest push, pull, push, run, search
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: **true**).

--- a/docs/source/markdown/options/tmpfs.md
+++ b/docs/source/markdown/options/tmpfs.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--tmpfs**=*fs*
 
 Create a tmpfs mount.

--- a/docs/source/markdown/options/tty.md
+++ b/docs/source/markdown/options/tty.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, exec, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--tty**, **-t**
 
 Allocate a pseudo-TTY. The default is **false**.

--- a/docs/source/markdown/options/tz.md
+++ b/docs/source/markdown/options/tz.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--tz**=*timezone*
 
 Set timezone in container. This flag takes area-based timezones, GMT time, as well as `local`, which sets the timezone in the container to match the host machine. See `/usr/share/zoneinfo/` for valid timezones.

--- a/docs/source/markdown/options/uidmap.container.md
+++ b/docs/source/markdown/options/uidmap.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--uidmap**=*container_uid:from_uid:amount*
 
 Run the container in a new user namespace using the supplied UID mapping. This

--- a/docs/source/markdown/options/uidmap.pod.md
+++ b/docs/source/markdown/options/uidmap.pod.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod clone, pod create
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--uidmap**=*container_uid:from_uid:amount*
 
 Run all containers in the pod in a new user namespace using the supplied mapping. This

--- a/docs/source/markdown/options/ulimit.md
+++ b/docs/source/markdown/options/ulimit.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--ulimit**=*option*
 
 Ulimit options. You can use **host** to copy the current configuration from the host.

--- a/docs/source/markdown/options/umask.md
+++ b/docs/source/markdown/options/umask.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--umask**=*umask*
 
 Set the umask inside the container. Defaults to `0022`.

--- a/docs/source/markdown/options/unsetenv-all.md
+++ b/docs/source/markdown/options/unsetenv-all.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--unsetenv-all**
 
 Unset all default environment variables for the container. Default environment

--- a/docs/source/markdown/options/unsetenv.md
+++ b/docs/source/markdown/options/unsetenv.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--unsetenv**=*env*
 
 Unset default environment variables for the container. Default environment

--- a/docs/source/markdown/options/until.md
+++ b/docs/source/markdown/options/until.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman logs, pod logs
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--until**=*TIMESTAMP*
 
 Show logs until TIMESTAMP. The --until option can be Unix timestamps, date formatted timestamps, or Go duration

--- a/docs/source/markdown/options/user.md
+++ b/docs/source/markdown/options/user.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, exec, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--user**, **-u**=*user[:group]*
 
 Sets the username or UID used and, optionally, the groupname or GID for the specified command. Both *user* and *group* may be symbolic or numeric.

--- a/docs/source/markdown/options/userns.container.md
+++ b/docs/source/markdown/options/userns.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, kube play, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--userns**=*mode*
 
 Set the user namespace mode for the container. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled unless an explicit mapping is set with the **--uidmap** and **--gidmap** options.

--- a/docs/source/markdown/options/userns.pod.md
+++ b/docs/source/markdown/options/userns.pod.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod clone, pod create
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--userns**=*mode*
 
 Set the user namespace mode for all the containers in a pod. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled.

--- a/docs/source/markdown/options/uts.container.md
+++ b/docs/source/markdown/options/uts.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--uts**=*mode*
 
 Set the UTS namespace mode for the container. The following values are supported:

--- a/docs/source/markdown/options/uts.pod.md
+++ b/docs/source/markdown/options/uts.pod.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman pod clone, pod create
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--uts**=*mode*
 
 Set the UTS namespace mode for the pod. The following values are supported:

--- a/docs/source/markdown/options/variant.container.md
+++ b/docs/source/markdown/options/variant.container.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pull, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--variant**=*VARIANT*
 
 Use _VARIANT_ instead of the default architecture variant of the container image. Some images can use multiple variants of the arm architectures, such as arm/v5 and arm/v7.

--- a/docs/source/markdown/options/variant.manifest.md
+++ b/docs/source/markdown/options/variant.manifest.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman manifest add, manifest annotate
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--variant**
 
 Specify the variant which the list or index records for the image.  This option

--- a/docs/source/markdown/options/volume.md
+++ b/docs/source/markdown/options/volume.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod clone, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--volume**, **-v**=*[[SOURCE-VOLUME|HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*
 
 Create a bind mount. If `-v /HOST-DIR:/CONTAINER-DIR` is specified, Podman

--- a/docs/source/markdown/options/volumes-from.md
+++ b/docs/source/markdown/options/volumes-from.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, pod clone, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--volumes-from**=*CONTAINER[:OPTIONS]*
 
 Mount volumes from the specified container(s). Used to share volumes between

--- a/docs/source/markdown/options/workdir.md
+++ b/docs/source/markdown/options/workdir.md
@@ -1,3 +1,7 @@
+####> This option file is used in:
+####>   podman create, exec, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
 #### **--workdir**, **-w**=*dir*
 
 Working directory inside the container.

--- a/hack/markdown-preprocess
+++ b/hack/markdown-preprocess
@@ -6,6 +6,7 @@
 Simpleminded include mechanism for podman man pages.
 """
 
+import filecmp
 import glob
 import os
 import re
@@ -20,6 +21,7 @@ class Preprocessor():
     def __init__(self):
         self.infile = ''
         self.pod_or_container = ''
+        self.used_by = {}
 
     def process(self, infile:str):
         """
@@ -42,6 +44,7 @@ class Preprocessor():
                 if line.startswith('@@option '):
                     _, optionname = line.strip().split(" ")
                     optionfile = os.path.join("options", optionname + '.md')
+                    self.track_optionfile(optionfile)
                     self.insert_file(fh_out, optionfile)
                 # '@@include relative-path/must-exist.md'
                 elif line.startswith('@@include '):
@@ -52,6 +55,36 @@ class Preprocessor():
 
         os.chmod(outfile_tmp, 0o444)
         os.rename(outfile_tmp, outfile)
+
+    def track_optionfile(self, optionfile: str):
+        """
+        Keep track of which man pages use which option files
+        """
+        if optionfile not in self.used_by:
+            self.used_by[optionfile] = []
+        self.used_by[optionfile].append(self.podman_subcommand('full'))
+
+    def rewrite_optionfiles(self):
+        """
+        Rewrite all option files, such that they include header comments
+        cross-referencing all the man pages in which they're used.
+        """
+        for optionfile in self.used_by:
+            tmpfile = optionfile + '.tmp'
+            with open(optionfile, 'r') as fh_in, open(tmpfile, 'w') as fh_out:
+                fh_out.write("####> This option file is used in:\n")
+                used_by = ', '.join(x for x in self.used_by[optionfile])
+                fh_out.write(f"####>   podman {used_by}\n")
+                fh_out.write("####> If you edit this file, make sure your changes\n")
+                fh_out.write("####> are applicable to all of those.\n")
+                for line in fh_in:
+                    if not line.startswith('####>'):
+                        fh_out.write(line)
+            # Compare files; only rewrite if the new one differs
+            if not filecmp.cmp(optionfile, tmpfile):
+                os.rename(tmpfile, optionfile)
+            else:
+                os.unlink(tmpfile)
 
     def insert_file(self, fh_out, path: str):
         """
@@ -65,6 +98,8 @@ class Preprocessor():
         fh_out.write("\n[//]: # (BEGIN included file " + path + ")\n")
         with open(path, 'r') as fh_included:
             for opt_line in fh_included:
+                if opt_line.startswith('####>'):
+                    continue
                 opt_line = self.replace_type(opt_line)
                 opt_line = opt_line.replace('<<subcommand>>', self.podman_subcommand())
                 opt_line = opt_line.replace('<<fullsubcommand>>', self.podman_subcommand('full'))
@@ -133,15 +168,16 @@ def main():
     except FileNotFoundError as ex:
         raise Exception("Please invoke me from the base repo dir") from ex
 
-    # If called with args, process only those files
-    infiles = [ os.path.basename(x) for x in sys.argv[1:] ]
-    if len(infiles) == 0:
-        # Called without args: process all *.md.in files
-        infiles = glob.glob('*.md.in')
+    # No longer possible to invoke us with args: reject any such invocation
+    if len(sys.argv) > 1:
+        raise Exception("This script accepts no arguments")
 
     preprocessor = Preprocessor()
-    for infile in infiles:
+    for infile in sorted(glob.glob('*.md.in')):
         preprocessor.process(infile)
+
+    # Now rewrite all option files
+    preprocessor.rewrite_optionfiles()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
In each options/foo.md, keep a list of where the option is used.
This will be valuable to anyone making future edits, and to
those reviewing those edits.

This may be a controversial commit, because those crossref lists
are autogenerated as a side effect of the script that reads them.
It definitely violates POLA. And one day, some kind person will
reconcile (e.g.) --label, using it in more man pages, and maybe
forget to git-commit the rewritten file, and CI will fail.

I think this is a tough tradeoff, but worth doing. Without this,
it's much too easy for someone to change an option file in a way
that renders it inapplicable/misleading for some podman commands.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```