### PR TITLE
Only read containers.conf once.

### DIFF
--- a/cmd/podman/registry/config.go
+++ b/cmd/podman/registry/config.go
@@ -51,7 +51,7 @@ func newPodmanConfig() {
 		os.Exit(1)
 	}
 
-	cfg, err := config.NewConfig("")
+	cfg, err := config.Default()
 	if err != nil {
 		fmt.Fprint(os.Stderr, "Failed to obtain podman configuration: "+err.Error())
 		os.Exit(1)

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -449,7 +449,7 @@ func rootFlags(cmd *cobra.Command, opts *entities.PodmanConfig) {
 		_ = pFlags.MarkHidden(networkBackendFlagName)
 
 		rootFlagName := "root"
-		pFlags.StringVar(&cfg.Engine.StaticDir, rootFlagName, "", "Path to the root directory in which data, including images, is stored")
+		pFlags.StringVar(&cfg.Engine.StaticDir, rootFlagName, cfg.Engine.StaticDir, "Path to the root directory in which data, including images, is stored")
 		_ = cmd.RegisterFlagCompletionFunc(rootFlagName, completion.AutocompleteDefault)
 
 		pFlags.StringVar(&opts.RegistriesConf, "registries-conf", "", "Path to a registries.conf to use for image processing")
@@ -468,13 +468,13 @@ func rootFlags(cmd *cobra.Command, opts *entities.PodmanConfig) {
 		_ = cmd.RegisterFlagCompletionFunc(storageDriverFlagName, completion.AutocompleteNone)
 
 		tmpdirFlagName := "tmpdir"
-		pFlags.StringVar(&opts.Engine.TmpDir, tmpdirFlagName, "", "Path to the tmp directory for libpod state content.\n\nNote: use the environment variable 'TMPDIR' to change the temporary storage location for container images, '/var/tmp'.\n")
+		pFlags.StringVar(&opts.Engine.TmpDir, tmpdirFlagName, opts.Engine.TmpDir, "Path to the tmp directory for libpod state content.\n\nNote: use the environment variable 'TMPDIR' to change the temporary storage location for container images, '/var/tmp'.\n")
 		_ = cmd.RegisterFlagCompletionFunc(tmpdirFlagName, completion.AutocompleteDefault)
 
 		pFlags.BoolVar(&opts.Trace, "trace", false, "Enable opentracing output (default false)")
 
 		volumePathFlagName := "volumepath"
-		pFlags.StringVar(&opts.Engine.VolumePath, volumePathFlagName, "", "Path to the volume directory in which volume data is stored")
+		pFlags.StringVar(&opts.Engine.VolumePath, volumePathFlagName, opts.Engine.VolumePath, "Path to the volume directory in which volume data is stored")
 		_ = cmd.RegisterFlagCompletionFunc(volumePathFlagName, completion.AutocompleteDefault)
 
 		// Hide these flags for both ABI and Tunneling

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -165,7 +165,7 @@ func SetXdgDirs() error {
 // NewRuntime creates a new container runtime
 // Options can be passed to override the default configuration for the runtime
 func NewRuntime(ctx context.Context, options ...RuntimeOption) (*Runtime, error) {
-	conf, err := config.NewConfig("")
+	conf, err := config.Default()
 	if err != nil {
 		return nil, err
 	}
@@ -1168,4 +1168,9 @@ func (r *Runtime) RemoteURI() string {
 // SetRemoteURI records the API server URI
 func (r *Runtime) SetRemoteURI(uri string) {
 	r.config.Engine.RemoteURI = uri
+}
+
+// Config returns the system config
+func (r *Runtime) Config() *config.Config {
+	return r.config
 }

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -604,6 +604,7 @@ func ImagesRemove(w http.ResponseWriter, r *http.Request) {
 }
 
 func ImageScp(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value(api.RuntimeKey).(*libpod.Runtime)
 	decoder := r.Context().Value(api.DecoderKey).(*schema.Decoder)
 	query := struct {
 		Destination string `schema:"destination"`
@@ -618,7 +619,7 @@ func ImageScp(w http.ResponseWriter, r *http.Request) {
 
 	sourceArg := utils.GetName(r)
 
-	rep, source, dest, _, err := domainUtils.ExecuteTransfer(sourceArg, query.Destination, []string{}, query.Quiet, ssh.GolangMode)
+	rep, source, dest, _, err := domainUtils.ExecuteTransfer(sourceArg, query.Destination, []string{}, query.Quiet, ssh.GolangMode, runtime.Config())
 	if err != nil {
 		utils.Error(w, http.StatusInternalServerError, err)
 		return

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -685,7 +685,7 @@ func (ir *ImageEngine) Sign(ctx context.Context, names []string, options entitie
 }
 
 func (ir *ImageEngine) Scp(ctx context.Context, src, dst string, parentFlags []string, quiet bool, sshMode ssh.EngineMode) error {
-	rep, source, dest, flags, err := domainUtils.ExecuteTransfer(src, dst, parentFlags, quiet, sshMode)
+	rep, source, dest, flags, err := domainUtils.ExecuteTransfer(src, dst, parentFlags, quiet, sshMode, ir.Libpod.Config())
 	if err != nil {
 		return err
 	}

--- a/pkg/domain/utils/scp.go
+++ b/pkg/domain/utils/scp.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func ExecuteTransfer(src, dst string, parentFlags []string, quiet bool, sshMode ssh.EngineMode) (*entities.ImageLoadReport, *entities.ImageScpOptions, *entities.ImageScpOptions, []string, error) {
+func ExecuteTransfer(src, dst string, parentFlags []string, quiet bool, sshMode ssh.EngineMode, conf *config.Config) (*entities.ImageLoadReport, *entities.ImageScpOptions, *entities.ImageScpOptions, []string, error) {
 	source := entities.ImageScpOptions{}
 	dest := entities.ImageScpOptions{}
 	sshInfo := entities.ImageScpConnections{}
@@ -31,11 +31,6 @@ func ExecuteTransfer(src, dst string, parentFlags []string, quiet bool, sshMode 
 	f, err := os.CreateTemp("", "podman") // open temp file for load/save output
 	if err != nil {
 		return nil, nil, nil, nil, err
-	}
-
-	confR, err := config.NewConfig("") // create a hand made config for the remote engine since we might use remote and native at once
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("could not make config: %w", err)
 	}
 
 	locations := []*entities.ImageScpOptions{}
@@ -94,7 +89,7 @@ func ExecuteTransfer(src, dst string, parentFlags []string, quiet bool, sshMode 
 		return nil, nil, nil, nil, err
 	}
 
-	confR.Engine = config.EngineConfig{Remote: true, CgroupManager: "cgroupfs", ServiceDestinations: serv} // pass the service dest (either remote or something else) to engine
+	conf.Engine = config.EngineConfig{Remote: true, CgroupManager: "cgroupfs", ServiceDestinations: serv} // pass the service dest (either remote or something else) to engine
 	saveCmd, loadCmd := CreateCommands(source, dest, parentFlags, podman)
 
 	switch {


### PR DESCRIPTION
We should not be changing these fields on the client side unless the user specified them.

This patch drops strace mentions of containers.conf from 116 down to 26.

Fixes: https://github.com/containers/common/issues/1200

[NO NEW TESTS NEEDED] Existing tests should test this.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
