### PR TITLE
Add Windows Smoke Testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,7 +45,7 @@ env:
     FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
     #PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
     UBUNTU_CONTAINER_FQIN: "quay.io/libpod/ubuntu_podman:${IMAGE_SUFFIX}"
-
+    WINDOWS_AMI: "win-server-wsl-c5138587457421312" # Replace with IMAGE_SUFFIX when aligned
     ####
     #### Control variables that determine what to run and how to run it.
     #### N/B: Required ALL of these are set for every single task.
@@ -519,6 +519,26 @@ compose_test_task:
 
 
 # Execute the podman integration tests on all primary platforms and release
+windows_smoke_test_task:
+    name: "Windows Smoke Test"
+    alias: windows_smoke_test
+    # Don't run for multiarch/container image cirrus-cron job.
+    only_if: $CIRRUS_CRON != 'multiarch'
+    depends_on:
+      - alt_build
+    ec2_instance:
+        image: "${WINDOWS_AMI}"
+        type: m5zn.metal
+        region: us-east-1
+        platform: windows
+    env:
+        PATH: "${PATH};C:\\ProgramData\\chocolatey\\bin"
+        CIRRUS_SHELL: powershell
+        # Fake version, we are only testing the installer functions, so version doesn't matter
+        CIRRUS_WORKING_DIR: "${LOCALAPPDATA}\\Temp\\cirrus-ci-build"
+    main_script: 'contrib/cirrus/win-podman-machine-verify.ps1'
+
+
 # versions, as root, without involving the podman-remote client.
 local_integration_test_task: &local_integration_test_task
     # Integration-test task name convention:
@@ -964,6 +984,7 @@ success_task:
         - alt_build
         - osx_alt_build
         - win_installer
+        - windows_smoke_test
         - docker-py_test
         - unit_test
         - apiv2_test

--- a/contrib/cirrus/win-podman-machine-verify.ps1
+++ b/contrib/cirrus/win-podman-machine-verify.ps1
@@ -1,0 +1,47 @@
+# Powershell doesn't exit after command failures
+# Note, due to a bug in cirrus that does not correctly evaluate exit code,
+# errors conditions should always be thrown
+function CheckExit {
+    if ($LASTEXITCODE -ne 0) {
+        throw "Exit code failure = $LASTEXITCODE"
+    }
+}
+
+# Drop global envs which have unix paths, defaults are fine
+Remove-Item Env:\GOPATH
+Remove-Item Env:\GOSRC
+Remove-Item Env:\GOCACHE
+
+mkdir tmp
+Set-Location tmp
+
+# Download and extract alt_build win release zip
+$url = "${ENV:ART_URL}/Windows%20Cross/repo/repo.tbz"
+Write-Output "URL: $url"
+# Arc requires extension to be "tbz2"
+curl.exe -L -o repo.tbz2 "$url"; CheckExit
+arc unarchive repo.tbz2 .; CheckExit
+Set-Location repo
+Expand-Archive -Path "podman-remote-release-windows_amd64.zip" -DestinationPath extracted
+Set-Location extracted
+$x = Get-ChildItem -Path bin -Recurse
+Set-Location $x
+
+# Verify extracted podman binary
+Write-Output "Starting init..."
+.\podman machine init; CheckExit
+Write-Output "Starting podman machine..."
+.\podman machine start; CheckExit
+for ($i =0; $i -lt 60; $i++) {
+    .\podman info
+    if ($LASTEXITCODE -eq 0) {
+        break
+    }
+    Start-Sleep -Seconds 2
+}
+Write-Output "Running container..."
+.\podman run ubi8-micro sh -c "exit 123"
+if ($LASTEXITCODE -ne 123) {
+    throw  "Expected 123, got $LASTEXITCODE"
+}
+Exit 0


### PR DESCRIPTION
Add initial podman machine verification testing on Windows. 

A future PR will port the full linux machine testsuite. 

This PR should not be merged until https://github.com/containers/automation_images/pull/228 merges.

```release-note
NONE
```
[NO NEW TESTS NEEDED]