### PR TITLE
Closes: 15858 (podman system reset --force destroy machine)

### DIFF
--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -5,6 +5,7 @@ package machine
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/url"
 	"os"
@@ -235,6 +236,15 @@ func ConfDirPrefix() (string, error) {
 	}
 	confDir := filepath.Join(conf, "containers", "podman", "machine")
 	return confDir, nil
+}
+
+// GuardedRemoveAll functions much like os.RemoveAll but
+// will not delete certain catastrophic paths.
+func GuardedRemoveAll(path string) error {
+	if path == "" || path == "/" {
+		return fmt.Errorf("refusing to recusively delete `%s`", path)
+	}
+	return os.RemoveAll(path)
 }
 
 // ResourceConfig describes physical attributes of the machine

--- a/pkg/machine/e2e/init_test.go
+++ b/pkg/machine/e2e/init_test.go
@@ -142,7 +142,7 @@ var _ = Describe("podman machine init", func() {
 		_, err = os.CreateTemp(tmpDir, "example")
 		Expect(err).To(BeNil())
 		mount := tmpDir + ":/testmountdir"
-		defer os.RemoveAll(tmpDir)
+		defer func() { _ = machine.GuardedRemoveAll(tmpDir) }()
 
 		name := randomString()
 		i := new(initMachine)

--- a/pkg/machine/e2e/machine_test.go
+++ b/pkg/machine/e2e/machine_test.go
@@ -128,7 +128,7 @@ func teardown(origHomeDir string, testDir string, mb *machineTestBuilder) {
 			fmt.Printf("error occurred rm'ing machine: %q\n", err)
 		}
 	}
-	if err := os.RemoveAll(testDir); err != nil {
+	if err := machine.GuardedRemoveAll(testDir); err != nil {
 		Fail(fmt.Sprintf("failed to remove test dir: %q", err))
 	}
 	// this needs to be last in teardown

--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -1690,7 +1690,7 @@ func (p *Provider) RemoveAndCleanMachines() error {
 		}
 		prevErr = err
 	} else {
-		err := os.RemoveAll(dataDir)
+		err := machine.GuardedRemoveAll(dataDir)
 		if err != nil {
 			if prevErr != nil {
 				logrus.Error(prevErr)
@@ -1707,7 +1707,7 @@ func (p *Provider) RemoveAndCleanMachines() error {
 		}
 		prevErr = err
 	} else {
-		err := os.RemoveAll(confDir)
+		err := machine.GuardedRemoveAll(confDir)
 		if err != nil {
 			if prevErr != nil {
 				logrus.Error(prevErr)

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -1339,7 +1339,7 @@ func (v *MachineVM) Remove(name string, opts machine.RemoveOptions) (string, fun
 			logrus.Error(err)
 		}
 		for _, f := range files {
-			if err := os.RemoveAll(f); err != nil {
+			if err := machine.GuardedRemoveAll(f); err != nil {
 				logrus.Error(err)
 			}
 		}
@@ -1644,7 +1644,7 @@ func (p *Provider) RemoveAndCleanMachines() error {
 		}
 		prevErr = err
 	} else {
-		err := os.RemoveAll(dataDir)
+		err := machine.GuardedRemoveAll(dataDir)
 		if err != nil {
 			if prevErr != nil {
 				logrus.Error(prevErr)
@@ -1661,7 +1661,7 @@ func (p *Provider) RemoveAndCleanMachines() error {
 		}
 		prevErr = err
 	} else {
-		err := os.RemoveAll(confDir)
+		err := machine.GuardedRemoveAll(confDir)
 		if err != nil {
 			if prevErr != nil {
 				logrus.Error(prevErr)


### PR DESCRIPTION
Safe guards calls to os.RemoveAll in order to prevent calls from accidently deleting the root file system in very strange edge cases. Did this by creating GuardedRemoveAll and migrated machine os.RemoveAll calls to it.

Signed-off-by: Mike Perry <mike@bitbistro.org>

Closes #15858

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
