### PR TITLE
[skip ci] logcollector: include aardvark-dns

### DIFF
--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -56,7 +56,7 @@ case $1 in
                 cat /etc/fedora-release
                 PKG_LST_CMD='rpm -q --qf=%{N}-%{V}-%{R}-%{ARCH}\n'
                 PKG_NAMES+=(\
-                    aardvark
+                    aardvark-dns
                     container-selinux
                     libseccomp
                     netavark


### PR DESCRIPTION
(minor correction to package name)

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```