### PR TITLE
sig-proxy test: bump timeout

### DIFF
--- a/test/system/032-sig-proxy.bats
+++ b/test/system/032-sig-proxy.bats
@@ -24,7 +24,7 @@ load helpers
 
     # Signal, and wait for container to exit
     kill -INT $kidpid
-    local timeout=5
+    local timeout=10
     while :;do
           sleep 0.5
           run_podman logs foo


### PR DESCRIPTION
Bump the timeout waiting for the container to process the signal. The comparatively short timeout is most likely responsible for flakes in gating tests.

Fixes: #16091
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
