### PR TITLE
system tests: podman network create: use random port

### DIFF
--- a/test/system/500-networking.bats
+++ b/test/system/500-networking.bats
@@ -205,8 +205,7 @@ load helpers
 
 # "network create" now works rootless, with the help of a special container
 @test "podman network create" {
-    # Deliberately use a fixed port, not random_open_port, because of #10806
-    myport=54322
+    myport=$(random_free_port)
 
     local mynetname=testnet-$(random_string 10)
     local mysubnet=$(random_rfc1918_subnet)


### PR DESCRIPTION
One test was using a hardcoded fixed port, with a comment
referring to #10806. That issue seems fixed, so let's
try switching to a pseudorandom open port.

Does not actually fix #16289 but I'm going to close that
anyway, will reopen if it recurs.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```