### PR TITLE
system tests: runlabel: use podman-under-test

### DIFF
--- a/test/system/037-runlabel.bats
+++ b/test/system/037-runlabel.bats
@@ -12,7 +12,7 @@ load helpers
     rand3=$(random_string 30)
     cat >$containerfile <<EOF
 FROM $IMAGE
-LABEL  INSTALL  /usr/bin/podman  run  -t  -i  --rm  \\\${OPT1}  --privileged  -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=\\\${NAME} -e IMAGE=\\\${IMAGE} -e CONFDIR=/etc/\\\${NAME} -e LOGDIR=/var/log/\\\${NAME} -e DATADIR=/var/lib/\\\${NAME} \\\${IMAGE} \\\${OPT2} /bin/install.sh \\\${OPT3}
+LABEL  INSTALL  podman  run  -t  -i  --rm  \\\${OPT1}  --privileged  -v /:/host --net=host --ipc=host --pid=host -e HOST=/host -e NAME=\\\${NAME} -e IMAGE=\\\${IMAGE} -e CONFDIR=/etc/\\\${NAME} -e LOGDIR=/var/log/\\\${NAME} -e DATADIR=/var/lib/\\\${NAME} \\\${IMAGE} \\\${OPT2} /bin/install.sh \\\${OPT3}
 EOF
 
     run_podman build -t runlabel_image $tmpdir


### PR DESCRIPTION
I have no idea what this usage means, but the test fails
on a system with no /usr/bin/podman ... and that suggests
to me that the test is broken, in that it's been using
/usr/bin/podman instead of the $PODMAN we're testing.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```