### PR TITLE
quadlet: Warn in generator if using short names

### DIFF
--- a/cmd/quadlet/main_test.go
+++ b/cmd/quadlet/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsUnambiguousName(t *testing.T) {
+	tests := []struct {
+		input string
+		res   bool
+	}{
+		// Ambiguous names
+		{"fedora", false},
+		{"fedora:latest", false},
+		{"library/fedora", false},
+		{"library/fedora:latest", false},
+		{"busybox@sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a", false},
+		{"busybox:latest@sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a", false},
+		{"d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05", false},
+		{"d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05aa", false},
+
+		// Unambiguous names
+		{"quay.io/fedora", true},
+		{"docker.io/fedora", true},
+		{"docker.io/library/fedora:latest", true},
+		{"localhost/fedora", true},
+		{"localhost:5000/fedora:latest", true},
+		{"example.foo.this.may.be.garbage.but.maybe.not:1234/fedora:latest", true},
+		{"docker.io/library/busybox@sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a", true},
+		{"docker.io/library/busybox:latest@sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a", true},
+		{"docker.io/fedora@sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a", true},
+		{"sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a", true},
+		{"d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a", true},
+	}
+
+	for _, test := range tests {
+		res := isUnambiguousName(test.input)
+		assert.Equal(t, res, test.res, "%q", test.input)
+	}
+}

--- a/test/e2e/quadlet/annotation.container
+++ b/test/e2e/quadlet/annotation.container
@@ -1,11 +1,11 @@
-## assert-podman-final-args imagename
+## assert-podman-final-args localhost/imagename
 ## assert-podman-args "--annotation" "org.foo.Arg0=arg0"
 ## assert-podman-args "--annotation" "org.foo.Arg1=arg1"
 ## assert-podman-args "--annotation" "org.foo.Arg2=arg 2"
 ## assert-podman-args "--annotation" "org.foo.Arg3=arg3"
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 Annotation=org.foo.Arg1=arg1 "org.foo.Arg2=arg 2" \
   org.foo.Arg3=arg3
 

--- a/test/e2e/quadlet/basepodman.container
+++ b/test/e2e/quadlet/basepodman.container
@@ -1,7 +1,7 @@
-## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm -d --log-driver passthrough --pull=never --runtime /usr/bin/crun --cgroups=split --sdnotify=conmon imagename
+## assert-podman-final-args run --name=systemd-%N --cidfile=%t/%N.cid --replace --rm -d --log-driver passthrough --pull=never --runtime /usr/bin/crun --cgroups=split --sdnotify=conmon localhost/imagename
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 
 # Disable all default features to get as empty podman run command as we can
 ReadOnly=no

--- a/test/e2e/quadlet/basic.container
+++ b/test/e2e/quadlet/basic.container
@@ -1,4 +1,4 @@
-## assert-podman-final-args imagename
+## assert-podman-final-args localhost/imagename
 ## assert-podman-args "--name=systemd-%N"
 ## assert-podman-args "--cidfile=%t/%N.cid"
 ## assert-podman-args "--rm"
@@ -25,4 +25,4 @@
 ## assert-key-is "Service" "Environment" "PODMAN_SYSTEMD_UNIT=%n"
 
 [Container]
-Image=imagename
+Image=localhost/imagename

--- a/test/e2e/quadlet/capabilities.container
+++ b/test/e2e/quadlet/capabilities.container
@@ -4,7 +4,7 @@
 ## assert-podman-args "--cap-add=cap_ipc_owner"
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 # Verify that we can reset to the default cap set
 DropCapability=
 AddCapability=CAP_DAC_OVERRIDE CAP_AUDIT_WRITE

--- a/test/e2e/quadlet/env.container
+++ b/test/e2e/quadlet/env.container
@@ -1,4 +1,4 @@
-## assert-podman-final-args imagename
+## assert-podman-final-args localhost/imagename
 ## assert-podman-args --env "FOO1=foo1"
 ## assert-podman-args --env "FOO2=foo2 "
 ## assert-podman-args --env "FOO3=foo3"
@@ -6,7 +6,7 @@
 ## assert-podman-args --env "FOO4=foo\\nfoo"
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 Environment=FOO1=foo1 "FOO2=foo2 " \
                      FOO3=foo3 REPLACE=replace
 Environment=REPLACE=replaced 'FOO4=foo\nfoo'

--- a/test/e2e/quadlet/escapes.container
+++ b/test/e2e/quadlet/escapes.container
@@ -1,5 +1,5 @@
 ## assert-podman-final-args "/some/path" "an arg" "a;b\\nc\\td'e" "a;b\\nc\\td" "a\"b"
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 Exec=/some/path "an arg" "a;b\nc\td'e" a;b\nc\td 'a"b'

--- a/test/e2e/quadlet/exec.container
+++ b/test/e2e/quadlet/exec.container
@@ -1,6 +1,6 @@
-## assert-podman-final-args imagename "/some/binary file" "--arg1" "arg 2"
+## assert-podman-final-args localhost/imagename "/some/binary file" "--arg1" "arg 2"
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 Exec="/some/binary file" --arg1 \
   "arg 2"

--- a/test/e2e/quadlet/image.container
+++ b/test/e2e/quadlet/image.container
@@ -1,4 +1,4 @@
-## assert-podman-final-args imagename
+## assert-podman-final-args localhost/imagename
 
 [Container]
-Image=imagename
+Image=localhost/imagename

--- a/test/e2e/quadlet/install.container
+++ b/test/e2e/quadlet/install.container
@@ -9,7 +9,7 @@
 ## assert-symlink req3.service.requires/install.service ../install.service
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 
 [Install]
 Alias=alias.service \

--- a/test/e2e/quadlet/label.container
+++ b/test/e2e/quadlet/label.container
@@ -1,11 +1,11 @@
-## assert-podman-final-args imagename
+## assert-podman-final-args localhost/imagename
 ## assert-podman-args "--label" "org.foo.Arg0=arg0"
 ## assert-podman-args "--label" "org.foo.Arg1=arg1"
 ## assert-podman-args "--label" "org.foo.Arg2=arg 2"
 ## assert-podman-args "--label" "org.foo.Arg3=arg3"
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 Label=org.foo.Arg1=arg1 "org.foo.Arg2=arg 2" \
   org.foo.Arg3=arg3
 

--- a/test/e2e/quadlet/name.container
+++ b/test/e2e/quadlet/name.container
@@ -1,5 +1,5 @@
 ## assert-podman-args "--name=foobar"
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 ContainerName=foobar

--- a/test/e2e/quadlet/noremapuser.container
+++ b/test/e2e/quadlet/noremapuser.container
@@ -2,5 +2,5 @@
 ## !assert-podman-args --gidmap
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 RemapUsers=no

--- a/test/e2e/quadlet/noremapuser2.container
+++ b/test/e2e/quadlet/noremapuser2.container
@@ -20,7 +20,7 @@
 ## assert-podman-args --gidmap 1002:1002:4294966293
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 RemapUsers=no
 User=1000
 Group=1001

--- a/test/e2e/quadlet/notify.container
+++ b/test/e2e/quadlet/notify.container
@@ -1,5 +1,5 @@
 ## assert-podman-args "--sdnotify=container"
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 Notify=yes

--- a/test/e2e/quadlet/other-sections.container
+++ b/test/e2e/quadlet/other-sections.container
@@ -1,10 +1,10 @@
-## assert-podman-final-args imagename
+## assert-podman-final-args localhost/imagename
 ## assert-key-is "Unit" "Foo" "bar1" "bar2"
-## assert-key-is "X-Container" "Image" "imagename"
+## assert-key-is "X-Container" "Image" "localhost/imagename"
 
 [Unit]
 Foo=bar1
 Foo=bar2
 
 [Container]
-Image=imagename
+Image=localhost/imagename

--- a/test/e2e/quadlet/podmanargs.container
+++ b/test/e2e/quadlet/podmanargs.container
@@ -3,7 +3,7 @@
 ## assert-podman-args "--also"
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 PodmanArgs="--foo" \
   --bar
 PodmanArgs=--also

--- a/test/e2e/quadlet/ports.container
+++ b/test/e2e/quadlet/ports.container
@@ -1,5 +1,5 @@
 [Container]
-Image=imagename
+Image=localhost/imagename
 ## assert-podman-args --expose=1000
 ExposeHostPort=1000
 ## assert-podman-args --expose=2000-3000

--- a/test/e2e/quadlet/ports_ipv6.container
+++ b/test/e2e/quadlet/ports_ipv6.container
@@ -1,5 +1,5 @@
 [Container]
-Image=imagename
+Image=localhost/imagename
 ## assert-podman-args -p=[::1]:80:90
 PublishPort=[::1]:80:90
 

--- a/test/e2e/quadlet/shortname.container
+++ b/test/e2e/quadlet/shortname.container
@@ -1,0 +1,4 @@
+## assert-stderr-contains "not a fully qualified image name"
+
+[Container]
+Image=shortname

--- a/test/e2e/quadlet/socketactivated.container
+++ b/test/e2e/quadlet/socketactivated.container
@@ -5,5 +5,5 @@
 ## assert-key-is "Service" "NotifyAccess" "all"
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 SocketActivated=yes

--- a/test/e2e/quadlet/timezone.container
+++ b/test/e2e/quadlet/timezone.container
@@ -1,5 +1,5 @@
 ## assert-podman-args --tz=foo
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 Timezone=foo

--- a/test/e2e/quadlet/user-host.container
+++ b/test/e2e/quadlet/user-host.container
@@ -11,7 +11,7 @@
 ## assert-podman-args --gidmap 1002:101000:99000
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 User=1000
 HostUser=900
 Group=1001

--- a/test/e2e/quadlet/user-root1.container
+++ b/test/e2e/quadlet/user-root1.container
@@ -14,7 +14,7 @@
 # This means container root must map to something else
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 User=1000
 # Also test name parsing
 HostUser=root

--- a/test/e2e/quadlet/user-root2.container
+++ b/test/e2e/quadlet/user-root2.container
@@ -10,7 +10,7 @@
 # Map container uid root to host root
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 User=0
 # Also test name parsing
 HostUser=root

--- a/test/e2e/quadlet/user.container
+++ b/test/e2e/quadlet/user.container
@@ -1,7 +1,7 @@
-## assert-podman-final-args imagename
+## assert-podman-final-args localhost/imagename
 ## assert-podman-args "--user" "998:999"
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 User=998
 Group=999

--- a/test/e2e/quadlet/volume.container
+++ b/test/e2e/quadlet/volume.container
@@ -1,10 +1,10 @@
 ## assert-podman-args -v /host/dir:/container/volume
 ## assert-podman-args -v /host/dir2:/container/volume2:Z
 ## assert-podman-args -v named:/container/named
-## assert-podman-args -v systemd-quadlet:/container/quadlet imagename
+## assert-podman-args -v systemd-quadlet:/container/quadlet localhost/imagename
 
 [Container]
-Image=imagename
+Image=localhost/imagename
 Volume=/host/dir:/container/volume
 Volume=/host/dir2:/container/volume2:Z
 Volume=/container/empty

--- a/test/e2e/quadlet_test.go
+++ b/test/e2e/quadlet_test.go
@@ -291,6 +291,7 @@ var _ = Describe("quadlet system generator", func() {
 		Entry("readwrite.container", "readwrite.container"),
 		Entry("readwrite-notmpfs.container", "readwrite-notmpfs.container"),
 		Entry("seccomp.container", "seccomp.container"),
+		Entry("shortname.container", "shortname.container"),
 		Entry("timezone.container", "timezone.container"),
 		Entry("user.container", "user.container"),
 		Entry("user-host.container", "user-host.container"),


### PR DESCRIPTION
This was broken out of https://github.com/containers/podman/pull/16237 due to the discussions there. 

Basically, it isn't a fatal error to use a shortname as `Image=shortname` in a quadlet file, but it does have some non-obvious drawbacks:

 * Using a shortname will cause podman to load the shortname aliases file, which on rhel is 300k and takes > 70 msecs. This delay is non-obvious and unnecessary, but most sysadmins will not be aware of it, so logging a warning is helpfule
 * Shortnames do not uniquely define an image, so over time what is run by the service may change. For instance, if initially there was only `regitstry1.com/image`, but then someone installs `registry2.com/image`, then the service may switch to that.

So, the idea was to at least warn about this to ensure people are aware of the issue.

The second issue was that this PS uses a simple-minded re-implementation of isShortName(), even though there exist a `containers/image/pkg/shortnames.IsShortName()`. However, that one pulls in dependencies that make quadlet larger and slower, which is a problem because quadlet (being a systemd generator) is on the blocking path of system boot.

```release-note
NONE
```
