### PR TITLE
System tests: big glop o' cleanup

### DIFF
--- a/test/system/170-run-userns.bats
+++ b/test/system/170-run-userns.bats
@@ -44,7 +44,7 @@ function _require_crun() {
     run_podman pod create --uidmap 0:200000:5000 --name=$random_pod_name
     run_podman pod start $random_pod_name
     run_podman pod inspect --format '{{.InfraContainerID}}' $random_pod_name
-    run podman inspect --format '{{.HostConfig.IDMappings.UIDMap}}' $output
+    run_podman inspect --format '{{.HostConfig.IDMappings.UIDMap}}' $output
     is "$output" ".*0:200000:5000" "UID Map Successful"
 
     # Remove the pod and the pause image

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -69,7 +69,7 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
 "
 
     # now the on-failure should kick in and kill the container
-    podman wait healthcheck_c
+    run_podman wait healthcheck_c
 
     # Clean up
     run_podman rm -t 0 -f healthcheck_c

--- a/test/system/255-auto-update.bats
+++ b/test/system/255-auto-update.bats
@@ -241,9 +241,8 @@ function _confirm_update() {
 @test "podman auto-update - label io.containers.autoupdate=local" {
     generate_service localtest local
     image=quay.io/libpod/localtest:latest
-    podman commit --change CMD=/bin/bash $cname $image
-    podman image inspect --format "{{.ID}}" $image
-    imageID="$output"
+    run_podman commit --change CMD=/bin/bash $cname $image
+    run_podman image inspect --format "{{.ID}}" $image
 
     _wait_service_ready container-$cname.service
     run_podman auto-update --dry-run --format "{{.Unit}},{{.Image}},{{.Updated}},{{.Policy}}"
@@ -393,7 +392,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/podman auto-update
+ExecStart=$PODMAN auto-update
 Environment="http_proxy=${http_proxy}"
 Environment="HTTP_PROXY=${HTTP_PROXY}"
 Environment="https_proxy=${https_proxy}"

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -97,6 +97,7 @@ EOF
     run_podman rm c_mount
 
     run_podman rm c_uidmap c_uidmap_v
+    run_podman volume rm foo
 }
 
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -95,6 +95,7 @@ function basic_teardown() {
     run_podman '?' pod rm -t 0 --all --force --ignore
     run_podman '?'     rm -t 0 --all --force --ignore
     run_podman '?' network prune --force
+    run_podman '?' volume rm -a -f
 
     command rm -rf $PODMAN_TMPDIR
 }


### PR DESCRIPTION
One of the system tests was creating a volume and not cleaning up
after itself. Fix that: do cleanup in the test itself. And, add
a 'volume rm -af' to global teardown() to leave things clean for
the next tests.

While testing on a VM without `/usr/bin/podman`, found a bunch
of cases where system tests were invoking `podman` or `/usr/bin/podman`;
replaced those with `run_podman` or `$PODMAN` as appropriate.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```