### PR TITLE
Test runners: nuke podman from $PATH before tests

### DIFF
--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -253,6 +253,16 @@ var _ = Describe("podman system connection", func() {
 			u, err := user.Current()
 			Expect(err).ShouldNot(HaveOccurred())
 
+			// Ensure that the remote end uses our built podman
+			if os.Getenv("PODMAN_BINARY") == "" {
+				err = os.Setenv("PODMAN_BINARY", podmanTest.PodmanBinary)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				defer func() {
+					os.Unsetenv("PODMAN_BINARY")
+				}()
+			}
+
 			cmd := exec.Command(podmanTest.RemotePodmanBinary,
 				"system", "connection", "add",
 				"--default",

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -27,16 +27,16 @@ var _ = Describe("Podman systemd", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		systemdUnitFile = `[Unit]
+		systemdUnitFile = fmt.Sprintf(`[Unit]
 Description=redis container
 [Service]
 Restart=always
-ExecStart=/usr/bin/podman start -a redis
-ExecStop=/usr/bin/podman stop -t 10 redis
+ExecStart=%s start -a redis
+ExecStop=%s stop -t 10 redis
 KillMode=process
 [Install]
 WantedBy=default.target
-`
+`, podmanTest.PodmanBinary, podmanTest.PodmanBinary)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
We've had some oopsies in system tests:

    podman foo bar
    run podman foo bar

...all of which should be run_podman with underscore. Those
have been passing because /usr/bin/podman is the fallback
from $PATH. In those (few) cases, we haven't actually been
testing the podman we should be testing.

Solution: nuke /usr/bin/podman and podman-remote before
invoking system and unit tests. As an extra level of
paranoia, check for other podmans in $PATH and warn
about those. The warning will likely never be seen by
a human, but I may check for them periodically.

Also: in a few cases where runner.sh invokes podman for
containerized something-something, run bin/podman instead
of podman from $PATH.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```