### PR TITLE
Fix deadlock between 'podman ps' and 'container inspect' commands

### DIFF
--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -581,20 +581,15 @@ func (p *Pod) Status() (map[string]define.ContainerStatus, error) {
 }
 
 func containerStatusFromContainers(allCtrs []*Container) (map[string]define.ContainerStatus, error) {
-	// We need to lock all the containers
-	for _, ctr := range allCtrs {
-		ctr.lock.Lock()
-		defer ctr.lock.Unlock()
-	}
-
-	// Now that all containers are locked, get their status
 	status := make(map[string]define.ContainerStatus, len(allCtrs))
 	for _, ctr := range allCtrs {
-		if err := ctr.syncContainer(); err != nil {
+		state, err := ctr.State()
+
+		if err != nil {
 			return nil, err
 		}
 
-		status[ctr.ID()] = ctr.state.State
+		status[ctr.ID()] = state
 	}
 
 	return status, nil


### PR DESCRIPTION
Fixes: #16326

[NO NEW TESTS NEEDED]

Signed-off-by: Mikhail Khachayants <tyler92@inbox.ru>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix deadlock between 'podman ps' and 'container inspect' commands
```
