### PR TITLE
fix connection usage with containers.conf

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -198,6 +198,8 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 		if contextConn != nil && contextConn.Changed {
 			return fmt.Errorf("use of --connection and --context at the same time is not allowed")
 		}
+		// need to give our blank containers.conf all of the service destinations if we are using one.
+		podmanConfig.ContainersConf.Engine.ServiceDestinations = podmanConfig.ContainersConfDefaultsRO.Engine.ServiceDestinations
 		podmanConfig.ContainersConf.Engine.ActiveService = conn.Value.String()
 		if err := setupConnection(); err != nil {
 			return err

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -276,6 +276,11 @@ var _ = Describe("podman system connection", func() {
 			Expect(session.Out.Contents()).Should(BeEmpty())
 			Expect(session.Err.Contents()).Should(BeEmpty())
 
+			cmd = exec.Command(podmanTest.RemotePodmanBinary,
+				"--connection", "QA", "ps")
+			_, err = Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).ToNot(HaveOccurred())
+
 			uri := url.URL{
 				Scheme: "ssh",
 				User:   url.User(u.Username),


### PR DESCRIPTION
--connection was failing due to the servicedestinations array being empty on runtime. Fix by making sure the cached config is used and properly given to the empty config.

resolves #16282

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix --connection with cached containers.conf
```
