### PR TITLE
Add encryption decryption feature

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -571,9 +571,18 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		createFlags.StringVar(&cf.PasswdEntry, passwdEntryName, "", "Entry to write to /etc/passwd")
 		_ = cmd.RegisterFlagCompletionFunc(passwdEntryName, completion.AutocompleteNone)
 
+		decryptionKeysFlagName := "decryption-key"
+		createFlags.StringSliceVar(
+			&cf.DecryptionKeys,
+			decryptionKeysFlagName, []string{},
+			"Key needed to decrypt the image (e.g. /path/to/key.pem)",
+		)
+		_ = cmd.RegisterFlagCompletionFunc(decryptionKeysFlagName, completion.AutocompleteNone)
+
 		if registry.IsRemote() {
 			_ = createFlags.MarkHidden("env-host")
 			_ = createFlags.MarkHidden("http-proxy")
+			_ = createFlags.MarkHidden(decryptionKeysFlagName)
 		} else {
 			createFlags.StringVar(
 				&cf.SignaturePolicy,

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -334,15 +334,21 @@ func PullImage(imageName string, cliVals *entities.ContainerCreateOptions) (stri
 		skipTLSVerify = types.NewOptionalBool(!cliVals.TLSVerify.Value())
 	}
 
+	decConfig, err := util.DecryptConfig(cliVals.DecryptionKeys)
+	if err != nil {
+		return "unable to obtain decryption config", err
+	}
+
 	pullReport, pullErr := registry.ImageEngine().Pull(registry.GetContext(), imageName, entities.ImagePullOptions{
-		Authfile:        cliVals.Authfile,
-		Quiet:           cliVals.Quiet,
-		Arch:            cliVals.Arch,
-		OS:              cliVals.OS,
-		Variant:         cliVals.Variant,
-		SignaturePolicy: cliVals.SignaturePolicy,
-		PullPolicy:      pullPolicy,
-		SkipTLSVerify:   skipTLSVerify,
+		Authfile:         cliVals.Authfile,
+		Quiet:            cliVals.Quiet,
+		Arch:             cliVals.Arch,
+		OS:               cliVals.OS,
+		Variant:          cliVals.Variant,
+		SignaturePolicy:  cliVals.SignaturePolicy,
+		PullPolicy:       pullPolicy,
+		SkipTLSVerify:    skipTLSVerify,
+		OciDecryptConfig: decConfig,
 	})
 	if pullErr != nil {
 		return "", pullErr

--- a/docs/source/markdown/options/decryption-key.md
+++ b/docs/source/markdown/options/decryption-key.md
@@ -1,0 +1,7 @@
+####> This option file is used in:
+####>   podman create, pull, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
+#### **--decryption-key**=*key[:passphrase]*
+
+The [key[:passphrase]] to be used for decryption of images. Key can point to keys and/or certificates. Decryption will be tried with all keys. If the key is protected by a passphrase, it is required to be passed in the argument and omitted otherwise.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -114,6 +114,8 @@ and specified with a _tag_.
 
 @@option cpuset-mems
 
+@@option decryption-key
+
 @@option device
 
 Note: if the user only has access rights via a group, accessing the device

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -57,6 +57,8 @@ All tagged images in the repository will be pulled.
 
 @@option creds
 
+@@option decryption-key
+
 @@option disable-content-trust
 
 #### **--help**, **-h**

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -64,6 +64,14 @@ Note: This flag can only be set when using the **dir** transport
 
 @@option disable-content-trust
 
+#### **--encrypt-layer**=*layer(s)*
+
+Layer(s) to encrypt: 0-indexed layer indices with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer). If not defined, will encrypt all layers if encryption-key flag is specified.
+
+#### **--encryption-key**=*key*
+
+The [protocol:keyfile] specifies the encryption protocol, which can be JWE (RFC7516), PGP (RFC4880), and PKCS7 (RFC2315) and the key material required for image encryption. For instance, jwe:/path/to/key.pem or pgp:admin@example.com or pkcs7:/path/to/x509-file.
+
 #### **--format**, **-f**=*format*
 
 Manifest Type (oci, v2s2, or v2s1) to use when pushing an image.

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -131,6 +131,8 @@ and specified with a _tag_.
 
 @@option cpuset-mems
 
+@@option decryption-key
+
 #### **--detach**, **-d**
 
 Detached mode: run the container in the background and print the new container ID. The default is *false*.

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
+	encconfig "github.com/containers/ocicrypt/config"
 	"github.com/containers/podman/v4/pkg/inspect"
 	"github.com/containers/podman/v4/pkg/trust"
 	"github.com/docker/docker/api/types/container"
@@ -158,6 +159,9 @@ type ImagePullOptions struct {
 	PullPolicy config.PullPolicy
 	// Writer is used to display copy information including progress bars.
 	Writer io.Writer
+	// OciDecryptConfig contains the config that can be used to decrypt an image if it is
+	// encrypted if non-nil. If nil, it does not attempt to decrypt an image.
+	OciDecryptConfig *encconfig.DecryptConfig
 }
 
 // ImagePullReport is the response from pulling one or more images.
@@ -227,6 +231,15 @@ type ImagePushOptions struct {
 	CompressionFormat string
 	// Writer is used to display copy information including progress bars.
 	Writer io.Writer
+	// OciEncryptConfig when non-nil indicates that an image should be encrypted.
+	// The encryption options is derived from the construction of EncryptConfig object.
+	OciEncryptConfig *encconfig.EncryptConfig
+	// OciEncryptLayers represents the list of layers to encrypt.
+	// If nil, don't encrypt any layers.
+	// If non-nil and len==0, denotes encrypt all layers.
+	// integers in the slice represent 0-indexed layer indices, with support for negative
+	// indexing. i.e. 0 is the first layer, -1 is the last (top-most) layer.
+	OciEncryptLayers *[]int
 }
 
 // ImagePushReport is the response from pushing an image.

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -290,6 +290,7 @@ type ContainerCreateOptions struct {
 	ChrootDirs        []string
 	IsInfra           bool
 	IsClone           bool
+	DecryptionKeys    []string
 
 	Net *NetOptions `json:"net,omitempty"`
 

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -236,6 +236,7 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, options entiti
 	pullOptions.SignaturePolicyPath = options.SignaturePolicy
 	pullOptions.InsecureSkipTLSVerify = options.SkipTLSVerify
 	pullOptions.Writer = options.Writer
+	pullOptions.OciDecryptConfig = options.OciDecryptConfig
 
 	if !options.Quiet && pullOptions.Writer == nil {
 		pullOptions.Writer = os.Stderr
@@ -309,6 +310,8 @@ func (ir *ImageEngine) Push(ctx context.Context, source string, destination stri
 	pushOptions.SignSigstorePrivateKeyPassphrase = options.SignSigstorePrivateKeyPassphrase
 	pushOptions.InsecureSkipTLSVerify = options.SkipTLSVerify
 	pushOptions.Writer = options.Writer
+	pushOptions.OciEncryptConfig = options.OciEncryptConfig
+	pushOptions.OciEncryptLayers = options.OciEncryptLayers
 
 	compressionFormat := options.CompressionFormat
 	if compressionFormat == "" {

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -105,6 +105,10 @@ func (ir *ImageEngine) Prune(ctx context.Context, opts entities.ImagePruneOption
 }
 
 func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, opts entities.ImagePullOptions) (*entities.ImagePullReport, error) {
+	if opts.OciDecryptConfig != nil {
+		return nil, fmt.Errorf("decryption is not supported for remote clients")
+	}
+
 	options := new(images.PullOptions)
 	options.WithAllTags(opts.AllTags).WithAuthfile(opts.Authfile).WithArch(opts.Arch).WithOS(opts.OS)
 	options.WithVariant(opts.Variant).WithPassword(opts.Password)
@@ -240,6 +244,10 @@ func (ir *ImageEngine) Import(ctx context.Context, opts entities.ImageImportOpti
 }
 
 func (ir *ImageEngine) Push(ctx context.Context, source string, destination string, opts entities.ImagePushOptions) error {
+	if opts.OciEncryptConfig != nil {
+		return fmt.Errorf("encryption is not supported for remote clients")
+	}
+
 	options := new(images.PushOptions)
 	options.WithAll(opts.All).WithCompress(opts.Compress).WithUsername(opts.Username).WithPassword(opts.Password).WithAuthfile(opts.Authfile).WithFormat(opts.Format).WithRemoveSignatures(opts.RemoveSignatures).WithQuiet(opts.Quiet).WithCompressionFormat(opts.CompressionFormat).WithProgressWriter(opts.Writer)
 

--- a/test/utils/common_function_test.go
+++ b/test/utils/common_function_test.go
@@ -151,4 +151,20 @@ var _ = Describe("Common functions test", func() {
 		Entry("Docker not in cgroup file", "/tmp/cgroup.test", false, true, false),
 	)
 
+	It("Test WriteRSAKeyPair", func() {
+		fileName := "/tmp/test_key"
+		bitSize := 1024
+
+		publicKeyFileName, privateKeyFileName, err := WriteRSAKeyPair(fileName, bitSize)
+		Expect(err).To(BeNil(), "Failed to write RSA key pair to files.")
+
+		read, err := os.Open(publicKeyFileName)
+		Expect(err).To(BeNil(), "Cannot find the public key file after we write it.")
+		defer read.Close()
+
+		read, err = os.Open(privateKeyFileName)
+		Expect(err).To(BeNil(), "Cannot find the private key file after we write it.")
+		defer read.Close()
+	})
+
 })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

This PR adds encryption decryption functionality, just like those present in buildah and skopeo. `containers/common/libimage` already supports encryption-decryption of images, so its a Podman only change.

This would allow us to encrypt the image while pushing it to a registry and decrypt the image while pulling it from a registry.

The commands would be as follows:

```
podman push --encryption-key protocol:keyfile IMAGE
podman pull --decyrption-key protocol:keyfile IMAGE 
```

Additionally,

`podman run --decryption-key <key> IMAGE [command [arg …]]`
would automatically pull the image from a registry, decrypt it using decryption key and run the container.

Signed-off-by: Tarun Gupta [gupttaru@deshaw.com](mailto:gupttaru@deshaw.com)

#### Does this PR introduce a user-facing change?
<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Yes.

This PR adds the flag `--encryption-key` and `--encrypt-layer` to the push command, and `--decryption-key` to pull and run command.
```