### PR TITLE
Do not report that /usr/share/containers/storage.conf has been edited.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/container-orchestrated-devices/container-device-interface v0.5.2
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.1.1
-	github.com/containers/buildah v1.28.1-0.20221028091010-9f7a94f34a74
+	github.com/containers/buildah v1.28.1-0.20221029151733-c2cf9fa47ab6
 	github.com/containers/common v0.50.2-0.20221027091852-54845c3325e3
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.23.1-0.20221027111947-5f02f763c564

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHV
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containernetworking/plugins v1.1.1 h1:+AGfFigZ5TiQH00vhR8qPeSatj53eNGz0C1d3wVYlHE=
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
-github.com/containers/buildah v1.28.1-0.20221028091010-9f7a94f34a74 h1:LxNRZ4M/gEnDT4Guu4KqlTNWSlKyVHRQ4glzlIJUV1U=
-github.com/containers/buildah v1.28.1-0.20221028091010-9f7a94f34a74/go.mod h1:skMuWv4FIebpsAFT7fBv2Ll0e0w2j71IUWCIrw9iTV0=
+github.com/containers/buildah v1.28.1-0.20221029151733-c2cf9fa47ab6 h1:6bFoF3QIUzza8NWAsHS1ZGDDEr+r5do46dXEbzkZb3Y=
+github.com/containers/buildah v1.28.1-0.20221029151733-c2cf9fa47ab6/go.mod h1:skMuWv4FIebpsAFT7fBv2Ll0e0w2j71IUWCIrw9iTV0=
 github.com/containers/common v0.50.2-0.20221027091852-54845c3325e3 h1:BxeJsrqor6A6ze52vqCruQLjtklKYbpQgizxjA6D/qY=
 github.com/containers/common v0.50.2-0.20221027091852-54845c3325e3/go.mod h1:pc6mEke4ejIOQxHD8ag6myKkhIvhcfJ6RV+0UVosuBk=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=

--- a/libpod/reset.go
+++ b/libpod/reset.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/util"
 	"github.com/containers/storage"
+	stypes "github.com/containers/storage/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -209,9 +210,14 @@ func (r *Runtime) reset(ctx context.Context) error {
 		}
 	}
 	if storageConfPath, err := storage.DefaultConfigFile(rootless.IsRootless()); err == nil {
-		if _, err = os.Stat(storageConfPath); err == nil {
-			fmt.Printf("A storage.conf file exists at %s\n", storageConfPath)
-			fmt.Println("You should remove this file if you did not modify the configuration.")
+		switch storageConfPath {
+		case stypes.SystemConfigFile:
+			break
+		default:
+			if _, err = os.Stat(storageConfPath); err == nil {
+				fmt.Printf(" A %q config file exists.\n", storageConfPath)
+				fmt.Println("Remove this file if you did not modify the configuration.")
+			}
 		}
 	} else {
 		if prevError != nil {

--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -254,11 +254,6 @@ skip_if_remote "FIXME FIXME FIXME: find a way to clean up their podman calls" \
                "bud with run should not leave mounts behind cleanup test" \
                "bud with custom files in /run/ should persist cleanup test"
 
-# Under podman-remote, the "Ignoring <stdin>:5:2: error: #error" message
-# is never seen. (Not even as stdout/stderr on the server; Ed checked).
-skip_if_remote "FIXME FIXME FIXME: 'Ignoring' warning is never seen" \
-               "bud with preprocessor error"
-
 # END   tests which are skipped due to actual podman or podman-remote bugs.
 ###############################################################################
 

--- a/test/e2e/system_reset_test.go
+++ b/test/e2e/system_reset_test.go
@@ -69,6 +69,7 @@ var _ = Describe("podman system reset", func() {
 		Expect(session).Should(Exit(0))
 
 		Expect(session.ErrorToString()).To(Not(ContainSubstring("Failed to add pause process")))
+		Expect(session.ErrorToString()).To(Not(ContainSubstring("/usr/share/containers/storage.conf")))
 
 		session = podmanTest.Podman([]string{"images", "-n"})
 		session.WaitWithDefaultTimeout()

--- a/vendor/github.com/containers/buildah/run_freebsd.go
+++ b/vendor/github.com/containers/buildah/run_freebsd.go
@@ -253,10 +253,6 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		jconf.Set("devfs_ruleset", 4)
 		jconf.Set("allow.raw_sockets", true)
 		jconf.Set("allow.chflags", true)
-		jconf.Set("allow.mount", true)
-		jconf.Set("allow.mount.devfs", true)
-		jconf.Set("allow.mount.nullfs", true)
-		jconf.Set("allow.mount.fdescfs", true)
 		jconf.Set("securelevel", -1)
 		netjail, err := jail.Create(jconf)
 		if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -95,7 +95,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.1.1
 ## explicit; go 1.17
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.28.1-0.20221028091010-9f7a94f34a74
+# github.com/containers/buildah v1.28.1-0.20221029151733-c2cf9fa47ab6
 ## explicit; go 1.17
 github.com/containers/buildah
 github.com/containers/buildah/bind


### PR DESCRIPTION
Only want to report if user created local customized storage in /etc/containers/storage.conf or in
$HOME/.config/containers/storage.conf, when resetting storage.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `podman system reset` command will no longer prompt the user if /usr/share/containers/storage.conf file exists.

```
