### PR TITLE
[CI:DOCS] man pages: assorted underscore fixes

### DIFF
--- a/docs/source/markdown/options/userns.container.md
+++ b/docs/source/markdown/options/userns.container.md
@@ -31,9 +31,9 @@ The rootless option `--userns=keep-id` uses all the subuids and subgids of the u
 
   Valid `auto` options:
 
-  - *gidmapping*=_CONTAINER_GID:HOST_GID:SIZE_: to force a GID mapping to be present in the user namespace.
+  - *gidmapping*=_CONTAINER\_GID:HOST\_GID:SIZE_: to force a GID mapping to be present in the user namespace.
   - *size*=_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will estimate a size for the user namespace.
-  - *uidmapping*=_CONTAINER_UID:HOST_UID:SIZE_: to force a UID mapping to be present in the user namespace.
+  - *uidmapping*=_CONTAINER\_UID:HOST\_UID:SIZE_: to force a UID mapping to be present in the user namespace.
 
 **container:**_id_: join the user namespace of the specified container.
 

--- a/docs/source/markdown/options/userns.pod.md
+++ b/docs/source/markdown/options/userns.pod.md
@@ -4,7 +4,7 @@
 ####> are applicable to all of those.
 #### **--userns**=*mode*
 
-Set the user namespace mode for all the containers in a pod. It defaults to the **PODMAN_USERNS** environment variable. An empty value ("") means user namespaces are disabled.
+Set the user namespace mode for all the containers in a pod. It defaults to the `PODMAN_USERNS` environment variable. An empty value ("") means user namespaces are disabled.
 
 Rootless user --userns=Key mappings:
 
@@ -19,11 +19,11 @@ Valid _mode_ values are:
 
   - *auto[:*_OPTIONS,..._*]*: automatically create a namespace. It is possible to specify these options to `auto`:
 
-  - *gidmapping=*_CONTAINER_GID:HOST_GID:SIZE_ to force a GID mapping to be present in the user namespace.
+  - *gidmapping=*_CONTAINER\_GID:HOST\_GID:SIZE_ to force a GID mapping to be present in the user namespace.
 
   - *size=*_SIZE_: to specify an explicit size for the automatic user namespace. e.g. `--userns=auto:size=8192`. If `size` is not specified, `auto` will estimate a size for the user namespace.
 
-  - *uidmapping=*_CONTAINER_UID:HOST_UID:SIZE_ to force a UID mapping to be present in the user namespace.
+  - *uidmapping=*_CONTAINER\_UID:HOST\_UID:SIZE_ to force a UID mapping to be present in the user namespace.
 
   - *host*: run in the user namespace of the caller. The processes running in the container will have the same privileges on the host as any other process launched by the calling user (default).
 

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -12,7 +12,7 @@ By default, the command will print the content of the unit files to stdout.
 
 Generating unit files for a pod requires the pod to be created with an infra container (see `--infra=true`).  An infra container runs across the entire lifespan of a pod and is hence required for systemd to manage the life cycle of the pod's main unit.
 
-_Note: If you use this command with the remote client, including Mac and Windows (excluding WSL2) machines, you would still have to place the generated units on the remote system.  Moreover, please make sure that the XDG_RUNTIME_DIR environment variable is set.  If unset, you may set it via `export XDG_RUNTIME_DIR=/run/user/$(id -u)`._
+_Note: If you use this command with the remote client, including Mac and Windows (excluding WSL2) machines, you would still have to place the generated units on the remote system.  Moreover, please make sure that the `XDG_RUNTIME_DIR` environment variable is set.  If unset, you may set it via `export XDG_RUNTIME_DIR=/run/user/$(id -u)`._
 
 _Note: The generated `podman run` command contains an `--sdnotify` option with the value taken from the container.
 If the container does not have any explicitly set value or the value is set to __ignore__, the value __conmon__ is used.

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -353,7 +353,7 @@ Security Options
 - **label=role:**_ROLE_: Set the label role for the container processes
 - **label=type:**_TYPE_: Set the label process type for the container processes
 - **label=level:**_LEVEL_: Set the label level for the container processes
-- **label=filetype:**TYPE_: Set the label file type for the container files
+- **label=filetype:**_TYPE_: Set the label file type for the container files
 - **label=disable**: Turn off label separation for the container
 
 Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.


### PR DESCRIPTION
Underscore is special in markdown. We usually escape them
properly, but these are a few that we missed. Found using:

   $ ack '[A-Z]\\fI[A-Z]' docs/build/man

(plus one that I found by accident).

If anyone has ideas on how to add a commit check for these,
please speak up. I'm at a complete loss to automate this.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
Minor formatting fixes to man pages
```