### PR TITLE
Enable cross building for FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,9 @@ CROSS_BUILD_TARGETS := \
 	bin/podman.cross.linux.mips \
 	bin/podman.cross.linux.mipsle \
 	bin/podman.cross.linux.mips64 \
-	bin/podman.cross.linux.mips64le
+	bin/podman.cross.linux.mips64le \
+	bin/podman.cross.freebsd.amd64 \
+	bin/podman.cross.freebsd.arm64
 
 # Dereference variable $(1), return value if non-empty, otherwise raise an error.
 err_if_empty = $(if $(strip $($(1))),$(strip $($(1))),$(error Required variable $(1) value is undefined, whitespace, or empty))

--- a/pkg/machine/qemu/options_freebsd_arm64.go
+++ b/pkg/machine/qemu/options_freebsd_arm64.go
@@ -1,0 +1,21 @@
+package qemu
+
+var (
+	QemuCommand = "qemu-system-aarch64"
+)
+
+func (v *MachineVM) addArchOptions() []string {
+	opts := []string{
+		"-machine", "virt",
+		"-accel", "tcg",
+		"-cpu", "host"}
+	return opts
+}
+
+func (v *MachineVM) prepare() error {
+	return nil
+}
+
+func (v *MachineVM) archRemovalFiles() []string {
+	return []string{}
+}

--- a/pkg/rctl/rctl.go
+++ b/pkg/rctl/rctl.go
@@ -3,9 +3,6 @@
 
 package rctl
 
-// #include <sys/rctl.h>
-import "C"
-
 import (
 	"bytes"
 	"fmt"


### PR DESCRIPTION
This removes a stale use of cgo from pkg/rctl and adds a small change to allow podman to build on FreeBSD/arm64. Adding the cross build targets should help to detect FreeBSD build breaks early.

#### Does this PR introduce a user-facing change?

```release-note
None
```
