### PR TITLE
[CI:DOCS] Fix documentation on read-only-tmpfs

### DIFF
--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -470,9 +470,10 @@ content. Installing packages into _/usr_, for example. In production,
 applications seldom need to write to the image.  Container applications write
 to volumes if they need to write to file systems at all. Applications can be
 made more secure by running them in read-only mode using the **--read-only** switch.
-This protects the container's image from modification. Read-only containers may
-still need to write temporary data. The best way to handle this is to mount
-tmpfs directories on _/run_ and _/tmp_.
+This protects the container's image from modification. By default read-only
+containers can write to temporary data. Podman mounts a tmpfs on _/run_ and
+_/tmp_ within the container. If the container should not write to any file
+system within the container, including tmpfs, set --read-only-tmpfs=false.
 
 ```
 $ podman run --read-only -i -t fedora /bin/bash


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
