### PR TITLE
[CI:DOCS] offer advice on installing test dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -351,7 +351,7 @@ $ podman run -it --rm -e EPOCH_TEST_COMMIT -v $PWD:/usr/src/libpod:ro \
     validate
 ```
 
-### Integration Tests
+### Integration and Other Tests
 
 Our primary means of performing integration testing for Podman is with the
 [Ginkgo](https://github.com/onsi/ginkgo) BDD testing framework. This allows
@@ -360,7 +360,7 @@ between Ginkgo and the Go test framework.  Adequate test cases are expected to
 be provided with PRs.
 
 For details on how to run the tests for Podman in your test environment, see the
-Integration Tests [README.md](test/README.md).
+testing [README.md](test/README.md).
 
 ## Continuous Integration
 

--- a/test/README.md
+++ b/test/README.md
@@ -133,6 +133,10 @@ Make sure that `bats` binary (`bin/bats` in the repository) is in your `PATH`, i
 PATH=$PATH:~/tools/bats/bin
 ```
 
+System tests also rely on `jq`, `socat`, `nmap`, and other tools. For a
+comprehensive list, see the `%package tests` section in the
+[fedora specfile](https://src.fedoraproject.org/rpms/podman/blob/main/f/podman.spec).
+
 ## Running system tests
 When `bats` is installed and is in your `PATH`, you can run the test suite with following command:
 


### PR DESCRIPTION
Basically, acknowledge the need for dependencies and link to Fedora specfile which is the only sane place to find such a list.

Closes: #16365

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
Add note on finding system-test dependencies
```
