### PR TITLE
runtime: add check for valid pod systemd cgroup

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -382,6 +382,13 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 					if err != nil {
 						return nil, fmt.Errorf("retrieving pod %s cgroup: %w", pod.ID(), err)
 					}
+					expectPodCgroup, err := ctr.expectPodCgroup()
+					if err != nil {
+						return nil, err
+					}
+					if expectPodCgroup && podCgroup == "" {
+						return nil, fmt.Errorf("pod %s cgroup is not set: %w", pod.ID(), define.ErrInternal)
+					}
 					ctr.config.CgroupParent = podCgroup
 				case rootless.IsRootless() && ctr.config.CgroupsMode != cgroupSplit:
 					ctr.config.CgroupParent = SystemdDefaultRootlessCgroupParent

--- a/test/upgrade/test-upgrade.bats
+++ b/test/upgrade/test-upgrade.bats
@@ -320,6 +320,10 @@ failed    | exited     | 17
     run_podman pod start mypod
     is "$output" "[0-9a-f]\\{64\\}" "podman pod start"
 
+    # run a container in an existing pod
+    run_podman run --pod=mypod --ipc=host --rm $IMAGE echo it works
+    is "$output" ".*it works.*" "podman run --pod"
+
     run_podman pod ps
     is "$output" ".*mypod.*" "podman pod ps shows name"
     is "$output" ".*Running.*" "podman pod ps shows running state"


### PR DESCRIPTION
there is already the same check when using cgroupfs, but not when using the systemd cgroup backend.  The check is needed to avoid a confusing error from the OCI runtime.

Closes: https://github.com/containers/podman/issues/16376

[NO NEW TESTS NEEDED] it needs a pod created with an old Podman version.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
