### PR TITLE
compat,build: handle `docker's` preconfigured `cacheTo`,`cacheFrom`

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -189,6 +189,13 @@ tar --format=posix -C $TMPD -cvf ${CONTAINERFILE_TAR} containerfile &> /dev/null
 t POST "libpod/build?dockerfile=containerfile" $CONTAINERFILE_TAR 200 \
   .stream~"STEP 1/1: FROM $IMAGE"
 
+# Newer Docker client sets empty cacheFrom for every build command even if it is not used,
+# following commit makes sure we test such use-case. See https://github.com/containers/podman/pull/16380
+#TODO: This test should be extended when buildah's cache-from and cache-to functionally supports
+# multiple remote-repos
+t POST "libpod/build?dockerfile=containerfile&cachefrom=[]" $CONTAINERFILE_TAR 200 \
+  .stream~"STEP 1/1: FROM $IMAGE"
+
 # With -q, all we should get is image ID. Test both libpod & compat endpoints.
 t POST "libpod/build?dockerfile=containerfile&q=true" $CONTAINERFILE_TAR 200 \
   .stream~'^[0-9a-f]\{64\}$'


### PR DESCRIPTION
Docker's newer clients popuates `cacheFrom` and `cacheTo` parameter by default as empty array for all commands but buildah's design of distributed cache expects this to be a repo not image hence parse only the first populated repo and igore if empty array.

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]
All the remote-bud tests must pass for cacheTo and cacheFrom, docker-client is not present in CI hence cannot be tested.


```release-note
compat,build: make compat build api functional
```

Closes: https://github.com/containers/podman/issues/15928
