### PR TITLE
[CI:BUILD] copr: fix CentOS Stream 9 builds

### DIFF
--- a/podman.spec.rpkg
+++ b/podman.spec.rpkg
@@ -63,7 +63,6 @@ BuildRequires: go-md2man
 BuildRequires: go-rpm-macros
 %endif
 %if 0%{?rhel} <= 8
-BuildRequires: pkgconfig(devmapper)
 BuildRequires: python3
 %endif
 BuildRequires: gpgme-devel
@@ -171,9 +170,14 @@ CGO_CFLAGS=$(echo $CGO_CFLAGS | sed 's/-specs=\/usr\/lib\/rpm\/redhat\/redhat-an
 export CGO_CFLAGS+=" -m64 -mtune=generic -fcf-protection=full"
 %endif
 
+# exclude_graphdriver_devicemapper doesn't work anymore with golang v1.19. Get
+# rid of this file instead.
+rm -rf vendor/github.com/containers/storage/drivers/register/register_devicemapper.go
+
 %if 0%{?rhel}
 rm -rf vendor/github.com/containers/storage/drivers/register/register_btrfs.go
 %endif
+
 
 # build date. FIXME: Makefile uses '/v2/libpod', that doesn't work here?
 LDFLAGS="-X ./libpod/define.buildInfo=$(date +%s)"
@@ -182,7 +186,7 @@ LDFLAGS="-X ./libpod/define.buildInfo=$(date +%s)"
 %gobuild -o bin/rootlessport ./cmd/rootlessport
 
 # set base buildtags common to both %%{name} and %%{name}-remote
-export BASEBUILDTAGS="seccomp exclude_graphdriver_devicemapper $(hack/selinux_tag.sh) $(hack/systemd_tag.sh) $(hack/libsubid_tag.sh)"
+export BASEBUILDTAGS="seccomp $(hack/selinux_tag.sh) $(hack/systemd_tag.sh) $(hack/libsubid_tag.sh)"
 
 # build %%{name}
 export BUILDTAGS="$BASEBUILDTAGS $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh)"


### PR DESCRIPTION
On CentOS Stream 9, exclude_graphdriver_[btrfs,devicemapper] get ignored so it's necessary to remove
vendor/github.com/containers/storage/drivers/register/register_[btrfs,devicemapper].go to get a successful build.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

Builds before this change: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/4995362/

Builds with this change: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/5003255/
[Ignore the epel failures since they have an older golang]


@containers/podman-maintainers PTAL

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
