### PR TITLE
[v4.1.1-rhel] Skip failing pull-arch test

### DIFF
--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -231,6 +231,11 @@ skip_if_remote "Do envariables work with -remote? Please look into this." \
                "build proxy"
 
 ###############################################################################
+# BEGIN emergency skip, because #16308 is too hard to backport
+
+skip "Actual fix (#16308) is too hard to backport, and not worth the effort" \
+     "bud --pull=false --arch test"
+
 # Done.
 
 exit $RC


### PR DESCRIPTION
ubi8 broke our tests. Fix is #16308 (don't use images that we don't control), but it's too hard to backport to this old branch. Just skip the failing test.

Signed-off-by: Ed Santiago <santiago@redhat.com>

```release-note
None
```
