### PR TITLE
buildah bud tests: better handling of remote

### DIFF
--- a/test/buildah-bud/apply-podman-deltas
+++ b/test/buildah-bud/apply-podman-deltas
@@ -248,12 +248,6 @@ skip_if_remote "Explicit request in buildah PR 4190 to skip this on remote" \
 skip_if_remote "different error messages between podman & podman-remote" \
                "bud with .dockerignore #2"
 
-# These two tests, new in 2022-01, invoke podman (create, export) in ways
-# that don't work with podman-remote due to the use of --registries-conf
-skip_if_remote "FIXME FIXME FIXME: find a way to clean up their podman calls" \
-               "bud with run should not leave mounts behind cleanup test" \
-               "bud with custom files in /run/ should persist cleanup test"
-
 # END   tests which are skipped due to actual podman or podman-remote bugs.
 ###############################################################################
 

--- a/test/buildah-bud/buildah-tests.diff
+++ b/test/buildah-bud/buildah-tests.diff
@@ -1,15 +1,15 @@
-From 0e31bb3a189ecd3e3fca36d16bb29b5162cb7d5c Mon Sep 17 00:00:00 2001
+From e11d1f32577a8b0307789208c3a39b0ab2a026d8 Mon Sep 17 00:00:00 2001
 From: Ed Santiago <santiago@redhat.com>
 Date: Thu, 6 Oct 2022 17:32:59 -0600
 Subject: [PATCH] tweaks for running buildah tests under podman
 
 Signed-off-by: Ed Santiago <santiago@redhat.com>
 ---
- tests/helpers.bash | 70 ++++++++++++++++++++++++++++++++++++++++++++--
- 1 file changed, 67 insertions(+), 3 deletions(-)
+ tests/helpers.bash | 73 +++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 69 insertions(+), 4 deletions(-)
 
 diff --git a/tests/helpers.bash b/tests/helpers.bash
-index aab3f72e..fe02a6f1 100644
+index aab3f72e..6e3b0eb5 100644
 --- a/tests/helpers.bash
 +++ b/tests/helpers.bash
 @@ -70,6 +70,23 @@ EOF
@@ -49,18 +49,21 @@ index aab3f72e..fe02a6f1 100644
      # Workaround for #1991 - buildah + overlayfs leaks mount points.
      # Many tests leave behind /var/tmp/.../root/overlay and sub-mounts;
      # let's find those and clean them up, otherwise 'rm -rf' fails.
-@@ -205,6 +228,10 @@ function podman() {
-     command ${PODMAN_BINARY:-podman} ${PODMAN_REGISTRY_OPTS} ${ROOTDIR_OPTS} "$@"
+@@ -202,7 +225,12 @@ function copy() {
  }
  
-+function podman-remote() {
-+    command ${PODMAN_BINARY:-podman-remote} ${ROOTDIR_OPTS} "$@"
-+}
-+
+ function podman() {
+-    command ${PODMAN_BINARY:-podman} ${PODMAN_REGISTRY_OPTS} ${ROOTDIR_OPTS} "$@"
++    local cmd=${PODMAN_BINARY:-podman}
++    local opts="${PODMAN_REGISTRY_OPTS} ${ROOTDIR_OPTS}"
++    if [[ $cmd =~ remote ]]; then
++        opts=
++    fi
++    command $cmd $opts "$@"
+ }
+ 
  # There are various scenarios where we would like to execute `tests` as rootless user, however certain commands like `buildah mount`
- # do not work in rootless session since a normal user cannot mount a filesystem unless they're in a user namespace along with its
- # own mount namespace. In order to run such specific commands from a rootless session we must perform `buildah unshare`.
-@@ -266,8 +293,36 @@ function run_buildah() {
+@@ -266,8 +294,36 @@ function run_buildah() {
          --retry)         retry=3;        shift;;  # retry network flakes
      esac
  
@@ -98,7 +101,7 @@ index aab3f72e..fe02a6f1 100644
  
      # If session is rootless and `buildah mount` is invoked, perform unshare,
      # since normal user cannot mount a filesystem unless they're in a user namespace along with its own mount namespace.
-@@ -281,8 +336,8 @@ function run_buildah() {
+@@ -281,8 +337,8 @@ function run_buildah() {
          retry=$(( retry - 1 ))
  
          # stdout is only emitted upon error; this echo is to help a debugger
@@ -109,7 +112,7 @@ index aab3f72e..fe02a6f1 100644
          # without "quotes", multiple lines are glommed together into one
          if [ -n "$output" ]; then
              echo "$output"
-@@ -614,6 +669,15 @@ function skip_if_no_docker() {
+@@ -614,6 +670,15 @@ function skip_if_no_docker() {
    fi
  }
  
@@ -126,5 +129,5 @@ index aab3f72e..fe02a6f1 100644
    daemondir=${TEST_SCRATCH_DIR}/git-daemon
    mkdir -p ${daemondir}/repo
 -- 
-2.37.3
+2.38.1
 


### PR DESCRIPTION
When I first enabled buildah-bud tests under podman-remote (#9887),
I got one aspect all wrong: I added a podman-remote() helper function
to match the podman() one. Turns out it's never actually called,
even when $PODMAN_BINARY=podman-remote, because functions/aliases
don't work that way.

The way it works is, those few cases in which bud.bats runs
podman are not magically remapped to podman-remote, they use
the podman() function. That's where we need to check if
we're using podman-remote, and that's where we need to
remove the registry-and-rootdir options.

With this fix, we can reenable two previously-skipped bud tests.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```