### PR TITLE
podman-kube@ template: set restart policy

### DIFF
--- a/contrib/systemd/system/podman-kube@.service.in
+++ b/contrib/systemd/system/podman-kube@.service.in
@@ -7,6 +7,7 @@ RequiresMountsFor=%t/containers
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
+Restart=on-failure
 TimeoutStopSec=70
 ExecStart=@@PODMAN@@ play kube --replace --service-container=true %I
 ExecStop=@@PODMAN@@ play kube --down %I

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -394,7 +394,7 @@ EOF
 
     # Dispatch the YAML file
     service_name="podman-kube@$(systemd-escape $yaml_source).service"
-    systemctl start $service_name
+    systemctl start --property=Restart=on-failure $service_name
     systemctl is-active $service_name
 
     # The name of the service container is predictable: the first 12 characters


### PR DESCRIPTION
Set the restart policy to on-failure such that the unit gets restarted, for instance, on pull errors.

[NO NEW TESTS NEEDED]

Fixes: #16342
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Set the restart policy of the podman-kube@ systemd template to "on-failure".
```
