### PR TITLE
[CI:DOCS] Man pages: refactor common options: --security-opt

### DIFF
--- a/docs/source/markdown/options/security-opt.md
+++ b/docs/source/markdown/options/security-opt.md
@@ -1,0 +1,34 @@
+####> This option file is used in:
+####>   podman create, pod clone, pod create, run
+####> If you edit this file, make sure your changes
+####> are applicable to all of those.
+#### **--security-opt**=*option*
+
+Security Options
+
+- **apparmor=unconfined** : Turn off apparmor confinement for the <<container|pod>>
+- **apparmor**=_your-profile_ : Set the apparmor confinement profile for the <<container|pod>>
+
+- **label=user:**_USER_: Set the label user for the <<container|pod>> processes
+- **label=role:**_ROLE_: Set the label role for the <<container|pod>> processes
+- **label=type:**_TYPE_: Set the label process type for the <<container|pod>> processes
+- **label=level:**_LEVEL_: Set the label level for the <<container|pod>> processes
+- **label=filetype:**_TYPE_: Set the label file type for the <<container|pod>> files
+- **label=disable**: Turn off label separation for the <<container|pod>>
+
+Note: Labeling can be disabled for all <<|pods/>>containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
+
+- **mask**=_/path/1:/path/2_: The paths to mask separated by a colon. A masked path cannot be accessed inside the container<<s within the pod|>>.
+
+- **no-new-privileges**: Disable container processes from gaining additional privileges.
+
+- **seccomp=unconfined**: Turn off seccomp confinement for the <<container|pod>>.
+- **seccomp=profile.json**: JSON file to be used as a seccomp filter. Note that the `io.podman.annotations.seccomp` annotation is set with the specified value as shown in `podman inspect`.
+
+- **proc-opts**=_OPTIONS_ : Comma-separated list of options to use for the /proc mount. More details
+  for the possible mount options are specified in the **proc(5)** man page.
+
+- **unmask**=_ALL_ or _/path/1:/path/2_, or shell expanded paths (/proc/*): Paths to unmask separated by a colon. If set to **ALL**, it will unmask all the paths that are masked or made read-only by default.
+  The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux**.  The default paths that are read-only are **/proc/asound**, **/proc/bus**, **/proc/fs**, **/proc/irq**, **/proc/sys**, **/proc/sysrq-trigger**, **/sys/fs/cgroup**.
+
+Note: Labeling can be disabled for all containers by setting **label=false** in the **containers.conf**(5) file.

--- a/docs/source/markdown/podman-create.1.md.in
+++ b/docs/source/markdown/podman-create.1.md.in
@@ -313,38 +313,7 @@ Automatically remove the container when it exits. The default is *false*.
 
 @@option secret
 
-#### **--security-opt**=*option*
-
-Security Options
-
-- `apparmor=unconfined` : Turn off apparmor confinement for the container
-- `apparmor=your-profile` : Set the apparmor confinement profile for the container
-
-- `label=user:USER`     : Set the label user for the container processes
-- `label=role:ROLE`     : Set the label role for the container processes
-- `label=type:TYPE`     : Set the label process type for the container processes
-- `label=level:LEVEL`   : Set the label level for the container processes
-- `label=filetype:TYPE` : Set the label file type for the container files
-- `label=disable`       : Turn off label separation for the container
-
-Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
-
-- `mask=/path/1:/path/2` : The paths to mask separated by a colon. A masked path
-  cannot be accessed inside the container.
-
-- `no-new-privileges` : Disable container processes from gaining additional privileges
-
-- `seccomp=unconfined` : Turn off seccomp confinement for the container.
-- `seccomp=profile.json` : JSON file to be used as a seccomp filter. Note that the `io.podman.annotations.seccomp` annotation is set with the specified value as shown in `podman inspect`.
-
-- `proc-opts=OPTIONS` : Comma-separated list of options to use for the /proc mount. More details for the
-  possible mount options are specified in the **proc(5)** man page.
-
-
-- **unmask**=_ALL_ or _/path/1:/path/2_, or shell expanded paths (/proc/*): Paths to unmask separated by a colon. If set to **ALL**, it will unmask all the paths that are masked or made read-only by default.
-  The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.**  The default paths that are read-only are **/proc/asound, /proc/bus, /proc/fs, /proc/irq, /proc/sys, /proc/sysrq-trigger, /sys/fs/cgroup**.
-
-Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
+@@option security-opt
 
 @@option shm-size
 

--- a/docs/source/markdown/podman-pod-clone.1.md.in
+++ b/docs/source/markdown/podman-pod-clone.1.md.in
@@ -67,37 +67,7 @@ Set a custom name for the cloned pod. The default if not specified is of the syn
 
 @@option pid.pod
 
-#### **--security-opt**=*option*
-
-Security Options
-
-- `apparmor=unconfined` : Turn off apparmor confinement for the pod
-- `apparmor=your-profile` : Set the apparmor confinement profile for the pod
-
-- `label=user:USER`     : Set the label user for the pod processes
-- `label=role:ROLE`     : Set the label role for the pod processes
-- `label=type:TYPE`     : Set the label process type for the pod processes
-- `label=level:LEVEL`   : Set the label level for the pod processes
-- `label=filetype:TYPE` : Set the label file type for the pod files
-- `label=disable`       : Turn off label separation for the pod
-
-Note: Labeling can be disabled for all pods/containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
-
-- `mask=/path/1:/path/2` : The paths to mask separated by a colon. A masked path
-  cannot be accessed inside the containers within the pod.
-
-- `no-new-privileges` : Disable container processes from gaining additional privileges.
-
-- `seccomp=unconfined` : Turn off seccomp confinement for the pod
-- `seccomp=profile.json` :  Whitelisted syscalls seccomp Json file to be used as a seccomp filter
-
-- `proc-opts=OPTIONS` : Comma-separated list of options to use for the /proc mount. More details for the
-  possible mount options are specified in the **proc(5)** man page.
-
-- **unmask**=_ALL_ or _/path/1:/path/2_, or shell expanded paths (/proc/*): Paths to unmask separated by a colon. If set to **ALL**, it will unmask all the paths that are masked or made read-only by default.
-  The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.**  The default paths that are read-only are **/proc/asound, /proc/bus, /proc/fs, /proc/irq, /proc/sys, /proc/sysrq-trigger, /sys/fs/cgroup**.
-
-Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
+@@option security-opt
 
 @@option shm-size
 

--- a/docs/source/markdown/podman-pod-create.1.md.in
+++ b/docs/source/markdown/podman-pod-create.1.md.in
@@ -142,37 +142,7 @@ but only by the pod itself.
 
 @@option replace
 
-#### **--security-opt**=*option*
-
-Security Options
-
-- `apparmor=unconfined` : Turn off apparmor confinement for the pod
-- `apparmor=your-profile` : Set the apparmor confinement profile for the pod
-
-- `label=user:USER`     : Set the label user for the pod processes
-- `label=role:ROLE`     : Set the label role for the pod processes
-- `label=type:TYPE`     : Set the label process type for the pod processes
-- `label=level:LEVEL`   : Set the label level for the pod processes
-- `label=filetype:TYPE` : Set the label file type for the pod files
-- `label=disable`       : Turn off label separation for the pod
-
-Note: Labeling can be disabled for all pods/containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
-
-- `mask=/path/1:/path/2` : The paths to mask separated by a colon. A masked path
-  cannot be accessed inside the containers within the pod.
-
-- `no-new-privileges` : Disable container processes from gaining additional privileges
-
-- `seccomp=unconfined` : Turn off seccomp confinement for the pod
-- `seccomp=profile.json` :  Whitelisted syscalls seccomp Json file to be used as a seccomp filter
-
-- `proc-opts=OPTIONS` : Comma-separated list of options to use for the /proc mount. More details for the
-  possible mount options are specified in the **proc(5)** man page.
-
-- **unmask**=_ALL_ or _/path/1:/path/2_, or shell expanded paths (/proc/*): Paths to unmask separated by a colon. If set to **ALL**, it will unmask all the paths that are masked or made read-only by default.
-  The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.**  The default paths that are read-only are **/proc/asound, /proc/bus, /proc/fs, /proc/irq, /proc/sys, /proc/sysrq-trigger, /sys/fs/cgroup**.
-
-Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
+@@option security-opt
 
 #### **--share**=*namespace*
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -342,37 +342,7 @@ container is using it. The default is *false*.
 
 @@option secret
 
-#### **--security-opt**=*option*
-
-Security Options
-
-- **apparmor=unconfined** : Turn off apparmor confinement for the container
-- **apparmor**=_your-profile_ : Set the apparmor confinement profile for the container
-
-- **label=user:**_USER_: Set the label user for the container processes
-- **label=role:**_ROLE_: Set the label role for the container processes
-- **label=type:**_TYPE_: Set the label process type for the container processes
-- **label=level:**_LEVEL_: Set the label level for the container processes
-- **label=filetype:**_TYPE_: Set the label file type for the container files
-- **label=disable**: Turn off label separation for the container
-
-Note: Labeling can be disabled for all containers by setting label=false in the **containers.conf** (`/etc/containers/containers.conf` or `$HOME/.config/containers/containers.conf`) file.
-
-- **mask**=_/path/1:/path/2_: The paths to mask separated by a colon. A masked path
-  cannot be accessed inside the container.
-
-- **no-new-privileges**: Disable container processes from gaining additional privileges
-
-- **seccomp=unconfined**: Turn off seccomp confinement for the container.
-- **seccomp=profile.json**: JSON file to be used as a seccomp filter. Note that the `io.podman.annotations.seccomp` annotation is set with the specified value as shown in `podman inspect`.
-
-- **proc-opts**=_OPTIONS_ : Comma-separated list of options to use for the /proc mount. More details
-  for the possible mount options are specified in the **proc(5)** man page.
-
-- **unmask**=_ALL_ or _/path/1:/path/2_, or shell expanded paths (/proc/*): Paths to unmask separated by a colon. If set to **ALL**, it will unmask all the paths that are masked or made read-only by default.
-  The default masked paths are **/proc/acpi, /proc/kcore, /proc/keys, /proc/latency_stats, /proc/sched_debug, /proc/scsi, /proc/timer_list, /proc/timer_stats, /sys/firmware, and /sys/fs/selinux.**.  The default paths that are read-only are **/proc/asound**, **/proc/bus**, **/proc/fs**, **/proc/irq**, **/proc/sys**, **/proc/sysrq-trigger**, **/sys/fs/cgroup**.
-
-Note: Labeling can be disabled for all containers by setting **label=false** in the **containers.conf**(5) file.
+@@option security-opt
 
 @@option shm-size
 


### PR DESCRIPTION
This was a horrible one. I basically went with the podman-run
version, with a few minor changes. See PR for discussion of
diff review.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
more man-page deduplication
```