### PR TITLE
remove container/pod id file along with container/pod

### DIFF
--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -110,6 +110,9 @@ func rm(cmd *cobra.Command, args []string) error {
 	for _, cidFile := range rmCidFiles {
 		content, err := os.ReadFile(cidFile)
 		if err != nil {
+			if rmOptions.Ignore && errors.Is(err, os.ErrNotExist) {
+				continue
+			}
 			return fmt.Errorf("reading CIDFile: %w", err)
 		}
 		id := strings.Split(string(content), "\n")[0]

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -301,5 +301,6 @@ func replacePod(name string) error {
 		Force:  true, // stop and remove pod
 		Ignore: true, // ignore if pod doesn't exist
 	}
-	return removePods([]string{name}, rmOptions, false)
+	errs := removePods([]string{name}, rmOptions, false)
+	return errs.PrintErrors()
 }

--- a/docs/source/markdown/options/cidfile.write.md
+++ b/docs/source/markdown/options/cidfile.write.md
@@ -4,4 +4,4 @@
 ####> are applicable to all of those.
 #### **--cidfile**=*file*
 
-Write the container ID to *file*.
+Write the container ID to *file*.  The file will be removed along with the container.

--- a/docs/source/markdown/podman-pod-rm.1.md.in
+++ b/docs/source/markdown/podman-pod-rm.1.md.in
@@ -26,6 +26,7 @@ Stop running containers and delete all stopped containers before removal of pod.
 Instead of providing the pod name or ID, remove the last created pod. (This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines)
 
 @@option pod-id-file.pod
+If specified, the pod-id-file will be removed along with the pod.
 
 @@option time
 

--- a/docs/source/markdown/podman-rm.1.md.in
+++ b/docs/source/markdown/podman-rm.1.md.in
@@ -57,6 +57,8 @@ In addition, forcing can be used to remove unusable containers, e.g. containers
 whose OCI runtime has become unavailable.
 
 @@option ignore
+Further ignore when the specified `--cidfile` does not exist as it may have
+already been removed along with the container.
 
 #### **--latest**, **-l**
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -777,6 +777,16 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force, remo
 		}
 	}
 
+	// Remove the container's CID file on container removal.
+	if cidFile, ok := c.config.Spec.Annotations[define.InspectAnnotationCIDFile]; ok {
+		if err := os.Remove(cidFile); err != nil {
+			if cleanupErr == nil {
+				cleanupErr = err
+			} else {
+				logrus.Errorf("Cleaning up CID file: %v", err)
+			}
+		}
+	}
 	// Remove the container from the state
 	if c.config.Pod != "" {
 		// If we're removing the pod, the container will be evicted

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -222,6 +222,9 @@ echo $rand        |   0 | $rand
 
     # All OK. Kill container.
     run_podman rm -f $cid
+    if [[ -e $cidfile ]]; then
+        die "cidfile $cidfile should be removed along with container"
+    fi
 }
 
 @test "podman run docker-archive" {

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -314,7 +314,10 @@ EOF
 
     # Clean up
     run_podman rm $cid
-    run_podman pod rm -t 0 -f mypod
+    run_podman pod rm -t 0 -f --pod-id-file $pod_id_file
+    if [[ -e $pod_id_file ]]; then
+        die "pod-id-file $pod_id_file should be removed along with pod"
+    fi
     run_podman rmi $infra_image
 }
 


### PR DESCRIPTION
Remove the container/pod ID file along with the container/pod.  It's primarily used in the context of systemd and are not useful nor needed once a container/pod has ceased to exist.

Fixes: #16387
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remove container/pod ID file along with container/pod.
```
