### PR TITLE
test/e2e: do not use apk in builds

### DIFF
--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Podman images", func() {
 
 	It("podman images filter before image", func() {
 		dockerfile := `FROM quay.io/libpod/alpine:latest
-RUN apk update && apk add strace
+RUN echo hello > /hello
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "before=foobar.com/before:latest"})

--- a/test/e2e/play_build_test.go
+++ b/test/e2e/play_build_test.go
@@ -78,13 +78,11 @@ status: {}
 
 	var playBuildFile = `
 FROM quay.io/libpod/alpine_nginx:latest
-RUN apk update && apk add strace
 LABEL homer=dad
 COPY copyfile /copyfile
 `
 	var prebuiltImage = `
 FROM quay.io/libpod/alpine_nginx:latest
-RUN apk update && apk add strace
 LABEL marge=mom
 `
 

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -13,8 +13,8 @@ import (
 var pruneImage = fmt.Sprintf(`
 FROM  %s
 LABEL RUN podman --version
-RUN apk update
-RUN apk add bash`, ALPINE)
+RUN echo hello > /hello
+RUN echo hello2 > /hello2`, ALPINE)
 
 var emptyPruneImage = `
 FROM scratch


### PR DESCRIPTION
As far as I can tell there is no reason to use apk in these tests. They just build an image and check for it and never use the installed binary. Network calls are always unstable and therefore should be avoided when possible, this ensures no/less flakes.

Fixes #16391


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
