### PR TITLE
[v4.2.0-rhel] Bump c/storage to include #1423

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/containers/image/v5 v5.22.0
 	github.com/containers/ocicrypt v1.1.5
 	github.com/containers/psgo v1.7.2
-	github.com/containers/storage v1.42.0
+	github.com/containers/storage v1.42.1-0.20221104172635-d3b97ec7b760
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/coreos/stream-metadata-go v0.0.0-20210225230131-70edb9eb47b3
 	github.com/cyphar/filepath-securejoin v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,9 @@ github.com/containers/psgo v1.7.2 h1:WbCvsY9w+nCv3j4der0mbD3PSRUv/W8l+G0YrZrdSDc
 github.com/containers/psgo v1.7.2/go.mod h1:SLpqxsPOHtTqRygjutCPXmeU2PoEFzV3gzJplN4BMx0=
 github.com/containers/storage v1.37.0/go.mod h1:kqeJeS0b7DO2ZT1nVWs0XufrmPFbgV3c+Q/45RlH6r4=
 github.com/containers/storage v1.38.0/go.mod h1:lBzt28gAk5ADZuRtwdndRJyqX22vnRaXmlF+7ktfMYc=
-github.com/containers/storage v1.42.0 h1:zm2AQD4NDeTB3JQ8X+Wo5+VRqNB+b4ocEd7Qj6ylPJA=
 github.com/containers/storage v1.42.0/go.mod h1:JiUJwOgOo1dr2DdOUc1MRe2GCAXABYoYmOdPF8yvH78=
+github.com/containers/storage v1.42.1-0.20221104172635-d3b97ec7b760 h1:naITfBmiyK4M7lLBGwFc8ql6KCZFRDuqu6MQm2SjcoA=
+github.com/containers/storage v1.42.1-0.20221104172635-d3b97ec7b760/go.mod h1:JiUJwOgOo1dr2DdOUc1MRe2GCAXABYoYmOdPF8yvH78=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/vendor/github.com/containers/storage/drivers/overlay/idmapped_utils.go
+++ b/vendor/github.com/containers/storage/drivers/overlay/idmapped_utils.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"syscall"
 	"unsafe"
 
@@ -124,7 +125,14 @@ func createIDMappedMount(source, target string, pid int) error {
 // createUsernsProcess forks the current process and creates a user namespace using the specified
 // mappings.  It returns the pid of the new process.
 func createUsernsProcess(uidMaps []idtools.IDMap, gidMaps []idtools.IDMap) (int, func(), error) {
-	pid, _, err := syscall.Syscall6(uintptr(unix.SYS_CLONE), unix.CLONE_NEWUSER|uintptr(unix.SIGCHLD), 0, 0, 0, 0, 0)
+	var pid uintptr
+	var err syscall.Errno
+
+	if runtime.GOARCH == "s390x" {
+		pid, _, err = syscall.Syscall6(uintptr(unix.SYS_CLONE), 0, unix.CLONE_NEWUSER|uintptr(unix.SIGCHLD), 0, 0, 0, 0)
+	} else {
+		pid, _, err = syscall.Syscall6(uintptr(unix.SYS_CLONE), unix.CLONE_NEWUSER|uintptr(unix.SIGCHLD), 0, 0, 0, 0, 0)
+	}
 	if err != 0 {
 		return -1, nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,7 +258,7 @@ github.com/containers/psgo/internal/dev
 github.com/containers/psgo/internal/host
 github.com/containers/psgo/internal/proc
 github.com/containers/psgo/internal/process
-# github.com/containers/storage v1.42.0
+# github.com/containers/storage v1.42.1-0.20221104172635-d3b97ec7b760
 ## explicit
 github.com/containers/storage
 github.com/containers/storage/drivers


### PR DESCRIPTION
There was a bug on s390x related to clone syscall argument order. C/storage PR #1423 fixes it; this vendors into Podman to close the loop and complete the fix.

Fixes RHBZ 2140084

Signed-off-by: Matthew Heon <mheon@redhat.com>


```release-note
NONE
```
