### PR TITLE
Fix compat build API returning two JSON objects at once

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -804,6 +804,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 					if err := enc.Encode(m); err != nil {
 						logrus.Warnf("failed to json encode error %v", err)
 					}
+					flush()
 					m.Aux = nil
 					m.Stream = fmt.Sprintf("Successfully built %12.12s\n", imageID)
 					if err := enc.Encode(m); err != nil {

--- a/test/python/docker/compat/test_images.py
+++ b/test/python/docker/compat/test_images.py
@@ -4,6 +4,7 @@ Integration tests for exercising docker-py against Podman Service.
 import io
 import os
 import unittest
+import json
 
 from docker import errors
 
@@ -125,6 +126,14 @@ class TestImages(common.DockerTestCase):
         self.assertEqual(image.labels["apple"], labels["apple"])
         self.assertEqual(image.labels["grape"], labels["grape"])
 
+    def test_build_image_via_api_client(self):
+        api_client = self.docker.api
+        for line in api_client.build(path="test/python/docker/build_labels"):
+            try:
+                parsed = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError as e:
+                raise IOError(f"Line '{line}' was not JSON parsable")
+            assert "errorDetail" not in parsed
 
 if __name__ == "__main__":
     # Setup temporary space


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?
```release-note
Fix bug where if using compat API to build an image, reading the chunked response may include more JSON objects than expected per chunk.
```

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Signed-off-by: Jake Torrance [jaket1234@hotmail.com](mailto:jaket1234@hotmail.com)

Closes #16360 
