### PR TITLE
fix incorrect systemd booted check

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -113,9 +113,9 @@ var (
 // RunsOnSystemd returns whether the system is using systemd
 func RunsOnSystemd() bool {
 	runsOnSystemdOnce.Do(func() {
-		initCommand, err := os.ReadFile("/proc/1/comm")
-		// On errors, default to systemd
-		runsOnSystemd = err != nil || strings.TrimRight(string(initCommand), "\n") == "systemd"
+		// per sd_booted(3), check for this dir
+		fd, err := os.Stat("/run/systemd/system")
+		runsOnSystemd = err == nil && fd.IsDir()
 	})
 	return runsOnSystemd
 }


### PR DESCRIPTION
Check for the directory /run/systemd/system, this is described in sd_booted(3). Reading /proc/1/comm will fail when /proc is mounted with the `hidepid=2` option.

Fixes #16022


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes a bug with the systemd booted check when /proc is mounted with the `hidepid=2` option.
```
