### PR TITLE
specgen,wasm: switch to crun-wasm wherever applicable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.1.1
 	github.com/containers/buildah v1.28.1-0.20221029151733-c2cf9fa47ab6
-	github.com/containers/common v0.50.2-0.20221109162103-1e40f47dd90b
+	github.com/containers/common v0.50.2-0.20221111184705-791b83e1cdf1
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.23.1-0.20221101011818-2f770d6d5a0c
 	github.com/containers/ocicrypt v1.1.6
@@ -132,7 +132,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 // indirect
 	go.opencensus.io v0.23.0 // indirect
-	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/crypto v0.2.0 // indirect
 	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/tools v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/containernetworking/plugins v1.1.1 h1:+AGfFigZ5TiQH00vhR8qPeSatj53eNG
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
 github.com/containers/buildah v1.28.1-0.20221029151733-c2cf9fa47ab6 h1:6bFoF3QIUzza8NWAsHS1ZGDDEr+r5do46dXEbzkZb3Y=
 github.com/containers/buildah v1.28.1-0.20221029151733-c2cf9fa47ab6/go.mod h1:skMuWv4FIebpsAFT7fBv2Ll0e0w2j71IUWCIrw9iTV0=
-github.com/containers/common v0.50.2-0.20221109162103-1e40f47dd90b h1:Hnd2R1izztqrDJsyFSKvbzXW3jWxLyqjEmcCubeOIn0=
-github.com/containers/common v0.50.2-0.20221109162103-1e40f47dd90b/go.mod h1:Nbv796IlIsJ6h8zFhNAn2hTXzVUICfiKS8vi3og41oA=
+github.com/containers/common v0.50.2-0.20221111184705-791b83e1cdf1 h1:AmN1j+GzK4+fmtOljYVbxAEJeXKkPs3ofB/uxJt4SCU=
+github.com/containers/common v0.50.2-0.20221111184705-791b83e1cdf1/go.mod h1:VBycGm+y123zhrbvGu5GykZiYJbtSqm7kN2tXCu2INM=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.23.1-0.20221101011818-2f770d6d5a0c h1:Jm6GiccEre7O+KohztmIBlduJdYPvzEhhjUuUczZivQ=
@@ -1017,8 +1017,8 @@ golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
-golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/crypto v0.2.0 h1:BRXPfhNivWL5Yq0BGQ39a2sW6t44aODpfxkWjYdzewE=
+golang.org/x/crypto v0.2.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -142,6 +142,17 @@ func WithOCIRuntime(runtime string) RuntimeOption {
 	}
 }
 
+// WithCtrOCIRuntime specifies an OCI runtime in container's config.
+func WithCtrOCIRuntime(runtime string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+		ctr.config.OCIRuntime = runtime
+		return nil
+	}
+}
+
 // WithConmonPath specifies the path to the conmon binary which manages the
 // runtime.
 func WithConmonPath(path string) RuntimeOption {

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -122,6 +122,16 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
+	if imageData != nil {
+		ociRuntimeVariant := rtc.Engine.ImagePlatformToRuntime(imageData.Os, imageData.Architecture)
+		// Don't unnecessarily set and invoke additional libpod
+		// option if OCI runtime is still default.
+		if ociRuntimeVariant != rtc.Engine.OCIRuntime {
+			options = append(options, libpod.WithCtrOCIRuntime(ociRuntimeVariant))
+		}
+	}
+
 	if newImage != nil {
 		// If the input name changed, we could properly resolve the
 		// image. Otherwise, it must have been an ID where we're

--- a/vendor/github.com/containers/common/libnetwork/netavark/config.go
+++ b/vendor/github.com/containers/common/libnetwork/netavark/config.go
@@ -116,6 +116,11 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 				}
 				// rust only support "true" or "false" while go can parse 1 and 0 as well so we need to change it
 				newNetwork.Options[types.IsolateOption] = strconv.FormatBool(val)
+			case types.MetricOption:
+				_, err := strconv.ParseUint(value, 10, 32)
+				if err != nil {
+					return nil, err
+				}
 			default:
 				return nil, fmt.Errorf("unsupported bridge network option %s", key)
 			}

--- a/vendor/github.com/containers/common/libnetwork/types/const.go
+++ b/vendor/github.com/containers/common/libnetwork/types/const.go
@@ -40,6 +40,7 @@ const (
 	MTUOption     = "mtu"
 	ModeOption    = "mode"
 	IsolateOption = "isolate"
+	MetricOption  = "metric"
 )
 
 type NetworkBackend string

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -358,6 +358,9 @@ type EngineConfig struct {
 	// OCIRuntimes are the set of configured OCI runtimes (default is runc).
 	OCIRuntimes map[string][]string `toml:"runtimes,omitempty"`
 
+	// PlatformToOCIRuntime requests specific OCI runtime for a specified platform of image.
+	PlatformToOCIRuntime map[string]string `toml:"platform_to_oci_runtime,omitempty"`
+
 	// PodExitPolicy determines the behaviour when the last container of a pod exits.
 	PodExitPolicy PodExitPolicy `toml:"pod_exit_policy,omitempty"`
 
@@ -617,6 +620,16 @@ type Destination struct {
 
 	// isMachine describes if the remote destination is a machine.
 	IsMachine bool `toml:"is_machine,omitempty"`
+}
+
+// Consumes container image's os and arch and returns if any dedicated runtime was
+// configured otherwise returns default runtime.
+func (c *EngineConfig) ImagePlatformToRuntime(os string, arch string) string {
+	platformString := os + "/" + arch
+	if val, ok := c.PlatformToOCIRuntime[platformString]; ok {
+		return val
+	}
+	return c.OCIRuntime
 }
 
 // NewConfig creates a new Config. It starts with an empty config and, if

--- a/vendor/github.com/containers/common/pkg/config/config_darwin.go
+++ b/vendor/github.com/containers/common/pkg/config/config_darwin.go
@@ -10,6 +10,10 @@ const (
 
 	// DefaultContainersConfig holds the default containers config path
 	DefaultContainersConfig = "/usr/share/" + _configPath
+
+	// DefaultSignaturePolicyPath is the default value for the
+	// policy.json file.
+	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
 )
 
 // podman remote clients on darwin cannot use unshare.isRootless() to determine the configuration file locations.

--- a/vendor/github.com/containers/common/pkg/config/config_freebsd.go
+++ b/vendor/github.com/containers/common/pkg/config/config_freebsd.go
@@ -10,6 +10,10 @@ const (
 
 	// DefaultContainersConfig holds the default containers config path
 	DefaultContainersConfig = "/usr/local/share/" + _configPath
+
+	// DefaultSignaturePolicyPath is the default value for the
+	// policy.json file.
+	DefaultSignaturePolicyPath = "/usr/local/etc/containers/policy.json"
 )
 
 // podman remote clients on freebsd cannot use unshare.isRootless() to determine the configuration file locations.

--- a/vendor/github.com/containers/common/pkg/config/config_linux.go
+++ b/vendor/github.com/containers/common/pkg/config/config_linux.go
@@ -13,6 +13,10 @@ const (
 
 	// DefaultContainersConfig holds the default containers config path
 	DefaultContainersConfig = "/usr/share/" + _configPath
+
+	// DefaultSignaturePolicyPath is the default value for the
+	// policy.json file.
+	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
 )
 
 func selinuxEnabled() bool {

--- a/vendor/github.com/containers/common/pkg/config/config_windows.go
+++ b/vendor/github.com/containers/common/pkg/config/config_windows.go
@@ -8,6 +8,10 @@ const (
 
 	// DefaultContainersConfig holds the default containers config path
 	DefaultContainersConfig = "/usr/share/" + _configPath
+
+	// DefaultSignaturePolicyPath is the default value for the
+	// policy.json file.
+	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
 )
 
 // podman remote clients on windows cannot use unshare.isRootless() to determine the configuration file locations.

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -263,6 +263,11 @@ default_sysctls = [
 # If it is empty or commented out, no volumes will be added
 #
 #volumes = []
+#
+#[engine.platform_to_oci_runtime]
+#"wasi/wasm" = ["crun-wasm"]
+#"wasi/wasm32" = ["crun-wasm"]
+#"wasi/wasm64" = ["crun-wasm"]
 
 [secrets]
 #driver = "file"

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -149,9 +149,6 @@ const (
 	DefaultPidsLimit = 2048
 	// DefaultPullPolicy pulls the image if it does not exist locally.
 	DefaultPullPolicy = "missing"
-	// DefaultSignaturePolicyPath is the default value for the
-	// policy.json file.
-	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
 	// DefaultSubnet is the subnet that will be used for the default
 	// network.
 	DefaultSubnet = "10.88.0.0/16"
@@ -332,6 +329,15 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 			"/bin/crun",
 			"/run/current-system/sw/bin/crun",
 		},
+		"crun-wasm": {
+			"/usr/bin/crun-wasm",
+			"/usr/sbin/crun-wasm",
+			"/usr/local/bin/crun-wasm",
+			"/usr/local/sbin/crun-wasm",
+			"/sbin/crun-wasm",
+			"/bin/crun-wasm",
+			"/run/current-system/sw/bin/crun-wasm",
+		},
 		"runc": {
 			"/usr/bin/runc",
 			"/usr/sbin/runc",
@@ -377,6 +383,11 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 		"ocijail": {
 			"/usr/local/bin/ocijail",
 		},
+	}
+	c.PlatformToOCIRuntime = map[string]string{
+		"wasi/wasm":   "crun-wasm",
+		"wasi/wasm32": "crun-wasm",
+		"wasi/wasm64": "crun-wasm",
 	}
 	// Needs to be called after populating c.OCIRuntimes.
 	c.OCIRuntime = c.findRuntime()

--- a/vendor/golang.org/x/crypto/cast5/cast5.go
+++ b/vendor/golang.org/x/crypto/cast5/cast5.go
@@ -13,7 +13,10 @@
 // golang.org/x/crypto/chacha20poly1305).
 package cast5 // import "golang.org/x/crypto/cast5"
 
-import "errors"
+import (
+	"errors"
+	"math/bits"
+)
 
 const BlockSize = 8
 const KeySize = 16
@@ -241,19 +244,19 @@ func (c *Cipher) keySchedule(in []byte) {
 // These are the three 'f' functions. See RFC 2144, section 2.2.
 func f1(d, m uint32, r uint8) uint32 {
 	t := m + d
-	I := (t << r) | (t >> (32 - r))
+	I := bits.RotateLeft32(t, int(r))
 	return ((sBox[0][I>>24] ^ sBox[1][(I>>16)&0xff]) - sBox[2][(I>>8)&0xff]) + sBox[3][I&0xff]
 }
 
 func f2(d, m uint32, r uint8) uint32 {
 	t := m ^ d
-	I := (t << r) | (t >> (32 - r))
+	I := bits.RotateLeft32(t, int(r))
 	return ((sBox[0][I>>24] - sBox[1][(I>>16)&0xff]) + sBox[2][(I>>8)&0xff]) ^ sBox[3][I&0xff]
 }
 
 func f3(d, m uint32, r uint8) uint32 {
 	t := m - d
-	I := (t << r) | (t >> (32 - r))
+	I := bits.RotateLeft32(t, int(r))
 	return ((sBox[0][I>>24] + sBox[1][(I>>16)&0xff]) ^ sBox[2][(I>>8)&0xff]) - sBox[3][I&0xff]
 }
 

--- a/vendor/golang.org/x/crypto/salsa20/salsa/hsalsa20.go
+++ b/vendor/golang.org/x/crypto/salsa20/salsa/hsalsa20.go
@@ -5,6 +5,8 @@
 // Package salsa provides low-level access to functions in the Salsa family.
 package salsa // import "golang.org/x/crypto/salsa20/salsa"
 
+import "math/bits"
+
 // Sigma is the Salsa20 constant for 256-bit keys.
 var Sigma = [16]byte{'e', 'x', 'p', 'a', 'n', 'd', ' ', '3', '2', '-', 'b', 'y', 't', 'e', ' ', 'k'}
 
@@ -31,76 +33,76 @@ func HSalsa20(out *[32]byte, in *[16]byte, k *[32]byte, c *[16]byte) {
 
 	for i := 0; i < 20; i += 2 {
 		u := x0 + x12
-		x4 ^= u<<7 | u>>(32-7)
+		x4 ^= bits.RotateLeft32(u, 7)
 		u = x4 + x0
-		x8 ^= u<<9 | u>>(32-9)
+		x8 ^= bits.RotateLeft32(u, 9)
 		u = x8 + x4
-		x12 ^= u<<13 | u>>(32-13)
+		x12 ^= bits.RotateLeft32(u, 13)
 		u = x12 + x8
-		x0 ^= u<<18 | u>>(32-18)
+		x0 ^= bits.RotateLeft32(u, 18)
 
 		u = x5 + x1
-		x9 ^= u<<7 | u>>(32-7)
+		x9 ^= bits.RotateLeft32(u, 7)
 		u = x9 + x5
-		x13 ^= u<<9 | u>>(32-9)
+		x13 ^= bits.RotateLeft32(u, 9)
 		u = x13 + x9
-		x1 ^= u<<13 | u>>(32-13)
+		x1 ^= bits.RotateLeft32(u, 13)
 		u = x1 + x13
-		x5 ^= u<<18 | u>>(32-18)
+		x5 ^= bits.RotateLeft32(u, 18)
 
 		u = x10 + x6
-		x14 ^= u<<7 | u>>(32-7)
+		x14 ^= bits.RotateLeft32(u, 7)
 		u = x14 + x10
-		x2 ^= u<<9 | u>>(32-9)
+		x2 ^= bits.RotateLeft32(u, 9)
 		u = x2 + x14
-		x6 ^= u<<13 | u>>(32-13)
+		x6 ^= bits.RotateLeft32(u, 13)
 		u = x6 + x2
-		x10 ^= u<<18 | u>>(32-18)
+		x10 ^= bits.RotateLeft32(u, 18)
 
 		u = x15 + x11
-		x3 ^= u<<7 | u>>(32-7)
+		x3 ^= bits.RotateLeft32(u, 7)
 		u = x3 + x15
-		x7 ^= u<<9 | u>>(32-9)
+		x7 ^= bits.RotateLeft32(u, 9)
 		u = x7 + x3
-		x11 ^= u<<13 | u>>(32-13)
+		x11 ^= bits.RotateLeft32(u, 13)
 		u = x11 + x7
-		x15 ^= u<<18 | u>>(32-18)
+		x15 ^= bits.RotateLeft32(u, 18)
 
 		u = x0 + x3
-		x1 ^= u<<7 | u>>(32-7)
+		x1 ^= bits.RotateLeft32(u, 7)
 		u = x1 + x0
-		x2 ^= u<<9 | u>>(32-9)
+		x2 ^= bits.RotateLeft32(u, 9)
 		u = x2 + x1
-		x3 ^= u<<13 | u>>(32-13)
+		x3 ^= bits.RotateLeft32(u, 13)
 		u = x3 + x2
-		x0 ^= u<<18 | u>>(32-18)
+		x0 ^= bits.RotateLeft32(u, 18)
 
 		u = x5 + x4
-		x6 ^= u<<7 | u>>(32-7)
+		x6 ^= bits.RotateLeft32(u, 7)
 		u = x6 + x5
-		x7 ^= u<<9 | u>>(32-9)
+		x7 ^= bits.RotateLeft32(u, 9)
 		u = x7 + x6
-		x4 ^= u<<13 | u>>(32-13)
+		x4 ^= bits.RotateLeft32(u, 13)
 		u = x4 + x7
-		x5 ^= u<<18 | u>>(32-18)
+		x5 ^= bits.RotateLeft32(u, 18)
 
 		u = x10 + x9
-		x11 ^= u<<7 | u>>(32-7)
+		x11 ^= bits.RotateLeft32(u, 7)
 		u = x11 + x10
-		x8 ^= u<<9 | u>>(32-9)
+		x8 ^= bits.RotateLeft32(u, 9)
 		u = x8 + x11
-		x9 ^= u<<13 | u>>(32-13)
+		x9 ^= bits.RotateLeft32(u, 13)
 		u = x9 + x8
-		x10 ^= u<<18 | u>>(32-18)
+		x10 ^= bits.RotateLeft32(u, 18)
 
 		u = x15 + x14
-		x12 ^= u<<7 | u>>(32-7)
+		x12 ^= bits.RotateLeft32(u, 7)
 		u = x12 + x15
-		x13 ^= u<<9 | u>>(32-9)
+		x13 ^= bits.RotateLeft32(u, 9)
 		u = x13 + x12
-		x14 ^= u<<13 | u>>(32-13)
+		x14 ^= bits.RotateLeft32(u, 13)
 		u = x14 + x13
-		x15 ^= u<<18 | u>>(32-18)
+		x15 ^= bits.RotateLeft32(u, 18)
 	}
 	out[0] = byte(x0)
 	out[1] = byte(x0 >> 8)

--- a/vendor/golang.org/x/crypto/salsa20/salsa/salsa208.go
+++ b/vendor/golang.org/x/crypto/salsa20/salsa/salsa208.go
@@ -4,6 +4,8 @@
 
 package salsa
 
+import "math/bits"
+
 // Core208 applies the Salsa20/8 core function to the 64-byte array in and puts
 // the result into the 64-byte array out. The input and output may be the same array.
 func Core208(out *[64]byte, in *[64]byte) {
@@ -29,76 +31,76 @@ func Core208(out *[64]byte, in *[64]byte) {
 
 	for i := 0; i < 8; i += 2 {
 		u := x0 + x12
-		x4 ^= u<<7 | u>>(32-7)
+		x4 ^= bits.RotateLeft32(u, 7)
 		u = x4 + x0
-		x8 ^= u<<9 | u>>(32-9)
+		x8 ^= bits.RotateLeft32(u, 9)
 		u = x8 + x4
-		x12 ^= u<<13 | u>>(32-13)
+		x12 ^= bits.RotateLeft32(u, 13)
 		u = x12 + x8
-		x0 ^= u<<18 | u>>(32-18)
+		x0 ^= bits.RotateLeft32(u, 18)
 
 		u = x5 + x1
-		x9 ^= u<<7 | u>>(32-7)
+		x9 ^= bits.RotateLeft32(u, 7)
 		u = x9 + x5
-		x13 ^= u<<9 | u>>(32-9)
+		x13 ^= bits.RotateLeft32(u, 9)
 		u = x13 + x9
-		x1 ^= u<<13 | u>>(32-13)
+		x1 ^= bits.RotateLeft32(u, 13)
 		u = x1 + x13
-		x5 ^= u<<18 | u>>(32-18)
+		x5 ^= bits.RotateLeft32(u, 18)
 
 		u = x10 + x6
-		x14 ^= u<<7 | u>>(32-7)
+		x14 ^= bits.RotateLeft32(u, 7)
 		u = x14 + x10
-		x2 ^= u<<9 | u>>(32-9)
+		x2 ^= bits.RotateLeft32(u, 9)
 		u = x2 + x14
-		x6 ^= u<<13 | u>>(32-13)
+		x6 ^= bits.RotateLeft32(u, 13)
 		u = x6 + x2
-		x10 ^= u<<18 | u>>(32-18)
+		x10 ^= bits.RotateLeft32(u, 18)
 
 		u = x15 + x11
-		x3 ^= u<<7 | u>>(32-7)
+		x3 ^= bits.RotateLeft32(u, 7)
 		u = x3 + x15
-		x7 ^= u<<9 | u>>(32-9)
+		x7 ^= bits.RotateLeft32(u, 9)
 		u = x7 + x3
-		x11 ^= u<<13 | u>>(32-13)
+		x11 ^= bits.RotateLeft32(u, 13)
 		u = x11 + x7
-		x15 ^= u<<18 | u>>(32-18)
+		x15 ^= bits.RotateLeft32(u, 18)
 
 		u = x0 + x3
-		x1 ^= u<<7 | u>>(32-7)
+		x1 ^= bits.RotateLeft32(u, 7)
 		u = x1 + x0
-		x2 ^= u<<9 | u>>(32-9)
+		x2 ^= bits.RotateLeft32(u, 9)
 		u = x2 + x1
-		x3 ^= u<<13 | u>>(32-13)
+		x3 ^= bits.RotateLeft32(u, 13)
 		u = x3 + x2
-		x0 ^= u<<18 | u>>(32-18)
+		x0 ^= bits.RotateLeft32(u, 18)
 
 		u = x5 + x4
-		x6 ^= u<<7 | u>>(32-7)
+		x6 ^= bits.RotateLeft32(u, 7)
 		u = x6 + x5
-		x7 ^= u<<9 | u>>(32-9)
+		x7 ^= bits.RotateLeft32(u, 9)
 		u = x7 + x6
-		x4 ^= u<<13 | u>>(32-13)
+		x4 ^= bits.RotateLeft32(u, 13)
 		u = x4 + x7
-		x5 ^= u<<18 | u>>(32-18)
+		x5 ^= bits.RotateLeft32(u, 18)
 
 		u = x10 + x9
-		x11 ^= u<<7 | u>>(32-7)
+		x11 ^= bits.RotateLeft32(u, 7)
 		u = x11 + x10
-		x8 ^= u<<9 | u>>(32-9)
+		x8 ^= bits.RotateLeft32(u, 9)
 		u = x8 + x11
-		x9 ^= u<<13 | u>>(32-13)
+		x9 ^= bits.RotateLeft32(u, 13)
 		u = x9 + x8
-		x10 ^= u<<18 | u>>(32-18)
+		x10 ^= bits.RotateLeft32(u, 18)
 
 		u = x15 + x14
-		x12 ^= u<<7 | u>>(32-7)
+		x12 ^= bits.RotateLeft32(u, 7)
 		u = x12 + x15
-		x13 ^= u<<9 | u>>(32-9)
+		x13 ^= bits.RotateLeft32(u, 9)
 		u = x13 + x12
-		x14 ^= u<<13 | u>>(32-13)
+		x14 ^= bits.RotateLeft32(u, 13)
 		u = x14 + x13
-		x15 ^= u<<18 | u>>(32-18)
+		x15 ^= bits.RotateLeft32(u, 18)
 	}
 	x0 += j0
 	x1 += j1

--- a/vendor/golang.org/x/crypto/salsa20/salsa/salsa20_ref.go
+++ b/vendor/golang.org/x/crypto/salsa20/salsa/salsa20_ref.go
@@ -4,6 +4,8 @@
 
 package salsa
 
+import "math/bits"
+
 const rounds = 20
 
 // core applies the Salsa20 core function to 16-byte input in, 32-byte key k,
@@ -31,76 +33,76 @@ func core(out *[64]byte, in *[16]byte, k *[32]byte, c *[16]byte) {
 
 	for i := 0; i < rounds; i += 2 {
 		u := x0 + x12
-		x4 ^= u<<7 | u>>(32-7)
+		x4 ^= bits.RotateLeft32(u, 7)
 		u = x4 + x0
-		x8 ^= u<<9 | u>>(32-9)
+		x8 ^= bits.RotateLeft32(u, 9)
 		u = x8 + x4
-		x12 ^= u<<13 | u>>(32-13)
+		x12 ^= bits.RotateLeft32(u, 13)
 		u = x12 + x8
-		x0 ^= u<<18 | u>>(32-18)
+		x0 ^= bits.RotateLeft32(u, 18)
 
 		u = x5 + x1
-		x9 ^= u<<7 | u>>(32-7)
+		x9 ^= bits.RotateLeft32(u, 7)
 		u = x9 + x5
-		x13 ^= u<<9 | u>>(32-9)
+		x13 ^= bits.RotateLeft32(u, 9)
 		u = x13 + x9
-		x1 ^= u<<13 | u>>(32-13)
+		x1 ^= bits.RotateLeft32(u, 13)
 		u = x1 + x13
-		x5 ^= u<<18 | u>>(32-18)
+		x5 ^= bits.RotateLeft32(u, 18)
 
 		u = x10 + x6
-		x14 ^= u<<7 | u>>(32-7)
+		x14 ^= bits.RotateLeft32(u, 7)
 		u = x14 + x10
-		x2 ^= u<<9 | u>>(32-9)
+		x2 ^= bits.RotateLeft32(u, 9)
 		u = x2 + x14
-		x6 ^= u<<13 | u>>(32-13)
+		x6 ^= bits.RotateLeft32(u, 13)
 		u = x6 + x2
-		x10 ^= u<<18 | u>>(32-18)
+		x10 ^= bits.RotateLeft32(u, 18)
 
 		u = x15 + x11
-		x3 ^= u<<7 | u>>(32-7)
+		x3 ^= bits.RotateLeft32(u, 7)
 		u = x3 + x15
-		x7 ^= u<<9 | u>>(32-9)
+		x7 ^= bits.RotateLeft32(u, 9)
 		u = x7 + x3
-		x11 ^= u<<13 | u>>(32-13)
+		x11 ^= bits.RotateLeft32(u, 13)
 		u = x11 + x7
-		x15 ^= u<<18 | u>>(32-18)
+		x15 ^= bits.RotateLeft32(u, 18)
 
 		u = x0 + x3
-		x1 ^= u<<7 | u>>(32-7)
+		x1 ^= bits.RotateLeft32(u, 7)
 		u = x1 + x0
-		x2 ^= u<<9 | u>>(32-9)
+		x2 ^= bits.RotateLeft32(u, 9)
 		u = x2 + x1
-		x3 ^= u<<13 | u>>(32-13)
+		x3 ^= bits.RotateLeft32(u, 13)
 		u = x3 + x2
-		x0 ^= u<<18 | u>>(32-18)
+		x0 ^= bits.RotateLeft32(u, 18)
 
 		u = x5 + x4
-		x6 ^= u<<7 | u>>(32-7)
+		x6 ^= bits.RotateLeft32(u, 7)
 		u = x6 + x5
-		x7 ^= u<<9 | u>>(32-9)
+		x7 ^= bits.RotateLeft32(u, 9)
 		u = x7 + x6
-		x4 ^= u<<13 | u>>(32-13)
+		x4 ^= bits.RotateLeft32(u, 13)
 		u = x4 + x7
-		x5 ^= u<<18 | u>>(32-18)
+		x5 ^= bits.RotateLeft32(u, 18)
 
 		u = x10 + x9
-		x11 ^= u<<7 | u>>(32-7)
+		x11 ^= bits.RotateLeft32(u, 7)
 		u = x11 + x10
-		x8 ^= u<<9 | u>>(32-9)
+		x8 ^= bits.RotateLeft32(u, 9)
 		u = x8 + x11
-		x9 ^= u<<13 | u>>(32-13)
+		x9 ^= bits.RotateLeft32(u, 13)
 		u = x9 + x8
-		x10 ^= u<<18 | u>>(32-18)
+		x10 ^= bits.RotateLeft32(u, 18)
 
 		u = x15 + x14
-		x12 ^= u<<7 | u>>(32-7)
+		x12 ^= bits.RotateLeft32(u, 7)
 		u = x12 + x15
-		x13 ^= u<<9 | u>>(32-9)
+		x13 ^= bits.RotateLeft32(u, 9)
 		u = x13 + x12
-		x14 ^= u<<13 | u>>(32-13)
+		x14 ^= bits.RotateLeft32(u, 13)
 		u = x14 + x13
-		x15 ^= u<<18 | u>>(32-18)
+		x15 ^= bits.RotateLeft32(u, 18)
 	}
 	x0 += j0
 	x1 += j1

--- a/vendor/golang.org/x/crypto/sha3/keccakf.go
+++ b/vendor/golang.org/x/crypto/sha3/keccakf.go
@@ -7,6 +7,8 @@
 
 package sha3
 
+import "math/bits"
+
 // rc stores the round constants for use in the ι step.
 var rc = [24]uint64{
 	0x0000000000000001,
@@ -60,13 +62,13 @@ func keccakF1600(a *[25]uint64) {
 
 		bc0 = a[0] ^ d0
 		t = a[6] ^ d1
-		bc1 = t<<44 | t>>(64-44)
+		bc1 = bits.RotateLeft64(t, 44)
 		t = a[12] ^ d2
-		bc2 = t<<43 | t>>(64-43)
+		bc2 = bits.RotateLeft64(t, 43)
 		t = a[18] ^ d3
-		bc3 = t<<21 | t>>(64-21)
+		bc3 = bits.RotateLeft64(t, 21)
 		t = a[24] ^ d4
-		bc4 = t<<14 | t>>(64-14)
+		bc4 = bits.RotateLeft64(t, 14)
 		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i]
 		a[6] = bc1 ^ (bc3 &^ bc2)
 		a[12] = bc2 ^ (bc4 &^ bc3)
@@ -74,15 +76,15 @@ func keccakF1600(a *[25]uint64) {
 		a[24] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[10] ^ d0
-		bc2 = t<<3 | t>>(64-3)
+		bc2 = bits.RotateLeft64(t, 3)
 		t = a[16] ^ d1
-		bc3 = t<<45 | t>>(64-45)
+		bc3 = bits.RotateLeft64(t, 45)
 		t = a[22] ^ d2
-		bc4 = t<<61 | t>>(64-61)
+		bc4 = bits.RotateLeft64(t, 61)
 		t = a[3] ^ d3
-		bc0 = t<<28 | t>>(64-28)
+		bc0 = bits.RotateLeft64(t, 28)
 		t = a[9] ^ d4
-		bc1 = t<<20 | t>>(64-20)
+		bc1 = bits.RotateLeft64(t, 20)
 		a[10] = bc0 ^ (bc2 &^ bc1)
 		a[16] = bc1 ^ (bc3 &^ bc2)
 		a[22] = bc2 ^ (bc4 &^ bc3)
@@ -90,15 +92,15 @@ func keccakF1600(a *[25]uint64) {
 		a[9] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[20] ^ d0
-		bc4 = t<<18 | t>>(64-18)
+		bc4 = bits.RotateLeft64(t, 18)
 		t = a[1] ^ d1
-		bc0 = t<<1 | t>>(64-1)
+		bc0 = bits.RotateLeft64(t, 1)
 		t = a[7] ^ d2
-		bc1 = t<<6 | t>>(64-6)
+		bc1 = bits.RotateLeft64(t, 6)
 		t = a[13] ^ d3
-		bc2 = t<<25 | t>>(64-25)
+		bc2 = bits.RotateLeft64(t, 25)
 		t = a[19] ^ d4
-		bc3 = t<<8 | t>>(64-8)
+		bc3 = bits.RotateLeft64(t, 8)
 		a[20] = bc0 ^ (bc2 &^ bc1)
 		a[1] = bc1 ^ (bc3 &^ bc2)
 		a[7] = bc2 ^ (bc4 &^ bc3)
@@ -106,15 +108,15 @@ func keccakF1600(a *[25]uint64) {
 		a[19] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[5] ^ d0
-		bc1 = t<<36 | t>>(64-36)
+		bc1 = bits.RotateLeft64(t, 36)
 		t = a[11] ^ d1
-		bc2 = t<<10 | t>>(64-10)
+		bc2 = bits.RotateLeft64(t, 10)
 		t = a[17] ^ d2
-		bc3 = t<<15 | t>>(64-15)
+		bc3 = bits.RotateLeft64(t, 15)
 		t = a[23] ^ d3
-		bc4 = t<<56 | t>>(64-56)
+		bc4 = bits.RotateLeft64(t, 56)
 		t = a[4] ^ d4
-		bc0 = t<<27 | t>>(64-27)
+		bc0 = bits.RotateLeft64(t, 27)
 		a[5] = bc0 ^ (bc2 &^ bc1)
 		a[11] = bc1 ^ (bc3 &^ bc2)
 		a[17] = bc2 ^ (bc4 &^ bc3)
@@ -122,15 +124,15 @@ func keccakF1600(a *[25]uint64) {
 		a[4] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[15] ^ d0
-		bc3 = t<<41 | t>>(64-41)
+		bc3 = bits.RotateLeft64(t, 41)
 		t = a[21] ^ d1
-		bc4 = t<<2 | t>>(64-2)
+		bc4 = bits.RotateLeft64(t, 2)
 		t = a[2] ^ d2
-		bc0 = t<<62 | t>>(64-62)
+		bc0 = bits.RotateLeft64(t, 62)
 		t = a[8] ^ d3
-		bc1 = t<<55 | t>>(64-55)
+		bc1 = bits.RotateLeft64(t, 55)
 		t = a[14] ^ d4
-		bc2 = t<<39 | t>>(64-39)
+		bc2 = bits.RotateLeft64(t, 39)
 		a[15] = bc0 ^ (bc2 &^ bc1)
 		a[21] = bc1 ^ (bc3 &^ bc2)
 		a[2] = bc2 ^ (bc4 &^ bc3)
@@ -151,13 +153,13 @@ func keccakF1600(a *[25]uint64) {
 
 		bc0 = a[0] ^ d0
 		t = a[16] ^ d1
-		bc1 = t<<44 | t>>(64-44)
+		bc1 = bits.RotateLeft64(t, 44)
 		t = a[7] ^ d2
-		bc2 = t<<43 | t>>(64-43)
+		bc2 = bits.RotateLeft64(t, 43)
 		t = a[23] ^ d3
-		bc3 = t<<21 | t>>(64-21)
+		bc3 = bits.RotateLeft64(t, 21)
 		t = a[14] ^ d4
-		bc4 = t<<14 | t>>(64-14)
+		bc4 = bits.RotateLeft64(t, 14)
 		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i+1]
 		a[16] = bc1 ^ (bc3 &^ bc2)
 		a[7] = bc2 ^ (bc4 &^ bc3)
@@ -165,15 +167,15 @@ func keccakF1600(a *[25]uint64) {
 		a[14] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[20] ^ d0
-		bc2 = t<<3 | t>>(64-3)
+		bc2 = bits.RotateLeft64(t, 3)
 		t = a[11] ^ d1
-		bc3 = t<<45 | t>>(64-45)
+		bc3 = bits.RotateLeft64(t, 45)
 		t = a[2] ^ d2
-		bc4 = t<<61 | t>>(64-61)
+		bc4 = bits.RotateLeft64(t, 61)
 		t = a[18] ^ d3
-		bc0 = t<<28 | t>>(64-28)
+		bc0 = bits.RotateLeft64(t, 28)
 		t = a[9] ^ d4
-		bc1 = t<<20 | t>>(64-20)
+		bc1 = bits.RotateLeft64(t, 20)
 		a[20] = bc0 ^ (bc2 &^ bc1)
 		a[11] = bc1 ^ (bc3 &^ bc2)
 		a[2] = bc2 ^ (bc4 &^ bc3)
@@ -181,15 +183,15 @@ func keccakF1600(a *[25]uint64) {
 		a[9] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[15] ^ d0
-		bc4 = t<<18 | t>>(64-18)
+		bc4 = bits.RotateLeft64(t, 18)
 		t = a[6] ^ d1
-		bc0 = t<<1 | t>>(64-1)
+		bc0 = bits.RotateLeft64(t, 1)
 		t = a[22] ^ d2
-		bc1 = t<<6 | t>>(64-6)
+		bc1 = bits.RotateLeft64(t, 6)
 		t = a[13] ^ d3
-		bc2 = t<<25 | t>>(64-25)
+		bc2 = bits.RotateLeft64(t, 25)
 		t = a[4] ^ d4
-		bc3 = t<<8 | t>>(64-8)
+		bc3 = bits.RotateLeft64(t, 8)
 		a[15] = bc0 ^ (bc2 &^ bc1)
 		a[6] = bc1 ^ (bc3 &^ bc2)
 		a[22] = bc2 ^ (bc4 &^ bc3)
@@ -197,15 +199,15 @@ func keccakF1600(a *[25]uint64) {
 		a[4] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[10] ^ d0
-		bc1 = t<<36 | t>>(64-36)
+		bc1 = bits.RotateLeft64(t, 36)
 		t = a[1] ^ d1
-		bc2 = t<<10 | t>>(64-10)
+		bc2 = bits.RotateLeft64(t, 10)
 		t = a[17] ^ d2
-		bc3 = t<<15 | t>>(64-15)
+		bc3 = bits.RotateLeft64(t, 15)
 		t = a[8] ^ d3
-		bc4 = t<<56 | t>>(64-56)
+		bc4 = bits.RotateLeft64(t, 56)
 		t = a[24] ^ d4
-		bc0 = t<<27 | t>>(64-27)
+		bc0 = bits.RotateLeft64(t, 27)
 		a[10] = bc0 ^ (bc2 &^ bc1)
 		a[1] = bc1 ^ (bc3 &^ bc2)
 		a[17] = bc2 ^ (bc4 &^ bc3)
@@ -213,15 +215,15 @@ func keccakF1600(a *[25]uint64) {
 		a[24] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[5] ^ d0
-		bc3 = t<<41 | t>>(64-41)
+		bc3 = bits.RotateLeft64(t, 41)
 		t = a[21] ^ d1
-		bc4 = t<<2 | t>>(64-2)
+		bc4 = bits.RotateLeft64(t, 2)
 		t = a[12] ^ d2
-		bc0 = t<<62 | t>>(64-62)
+		bc0 = bits.RotateLeft64(t, 62)
 		t = a[3] ^ d3
-		bc1 = t<<55 | t>>(64-55)
+		bc1 = bits.RotateLeft64(t, 55)
 		t = a[19] ^ d4
-		bc2 = t<<39 | t>>(64-39)
+		bc2 = bits.RotateLeft64(t, 39)
 		a[5] = bc0 ^ (bc2 &^ bc1)
 		a[21] = bc1 ^ (bc3 &^ bc2)
 		a[12] = bc2 ^ (bc4 &^ bc3)
@@ -242,13 +244,13 @@ func keccakF1600(a *[25]uint64) {
 
 		bc0 = a[0] ^ d0
 		t = a[11] ^ d1
-		bc1 = t<<44 | t>>(64-44)
+		bc1 = bits.RotateLeft64(t, 44)
 		t = a[22] ^ d2
-		bc2 = t<<43 | t>>(64-43)
+		bc2 = bits.RotateLeft64(t, 43)
 		t = a[8] ^ d3
-		bc3 = t<<21 | t>>(64-21)
+		bc3 = bits.RotateLeft64(t, 21)
 		t = a[19] ^ d4
-		bc4 = t<<14 | t>>(64-14)
+		bc4 = bits.RotateLeft64(t, 14)
 		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i+2]
 		a[11] = bc1 ^ (bc3 &^ bc2)
 		a[22] = bc2 ^ (bc4 &^ bc3)
@@ -256,15 +258,15 @@ func keccakF1600(a *[25]uint64) {
 		a[19] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[15] ^ d0
-		bc2 = t<<3 | t>>(64-3)
+		bc2 = bits.RotateLeft64(t, 3)
 		t = a[1] ^ d1
-		bc3 = t<<45 | t>>(64-45)
+		bc3 = bits.RotateLeft64(t, 45)
 		t = a[12] ^ d2
-		bc4 = t<<61 | t>>(64-61)
+		bc4 = bits.RotateLeft64(t, 61)
 		t = a[23] ^ d3
-		bc0 = t<<28 | t>>(64-28)
+		bc0 = bits.RotateLeft64(t, 28)
 		t = a[9] ^ d4
-		bc1 = t<<20 | t>>(64-20)
+		bc1 = bits.RotateLeft64(t, 20)
 		a[15] = bc0 ^ (bc2 &^ bc1)
 		a[1] = bc1 ^ (bc3 &^ bc2)
 		a[12] = bc2 ^ (bc4 &^ bc3)
@@ -272,15 +274,15 @@ func keccakF1600(a *[25]uint64) {
 		a[9] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[5] ^ d0
-		bc4 = t<<18 | t>>(64-18)
+		bc4 = bits.RotateLeft64(t, 18)
 		t = a[16] ^ d1
-		bc0 = t<<1 | t>>(64-1)
+		bc0 = bits.RotateLeft64(t, 1)
 		t = a[2] ^ d2
-		bc1 = t<<6 | t>>(64-6)
+		bc1 = bits.RotateLeft64(t, 6)
 		t = a[13] ^ d3
-		bc2 = t<<25 | t>>(64-25)
+		bc2 = bits.RotateLeft64(t, 25)
 		t = a[24] ^ d4
-		bc3 = t<<8 | t>>(64-8)
+		bc3 = bits.RotateLeft64(t, 8)
 		a[5] = bc0 ^ (bc2 &^ bc1)
 		a[16] = bc1 ^ (bc3 &^ bc2)
 		a[2] = bc2 ^ (bc4 &^ bc3)
@@ -288,15 +290,15 @@ func keccakF1600(a *[25]uint64) {
 		a[24] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[20] ^ d0
-		bc1 = t<<36 | t>>(64-36)
+		bc1 = bits.RotateLeft64(t, 36)
 		t = a[6] ^ d1
-		bc2 = t<<10 | t>>(64-10)
+		bc2 = bits.RotateLeft64(t, 10)
 		t = a[17] ^ d2
-		bc3 = t<<15 | t>>(64-15)
+		bc3 = bits.RotateLeft64(t, 15)
 		t = a[3] ^ d3
-		bc4 = t<<56 | t>>(64-56)
+		bc4 = bits.RotateLeft64(t, 56)
 		t = a[14] ^ d4
-		bc0 = t<<27 | t>>(64-27)
+		bc0 = bits.RotateLeft64(t, 27)
 		a[20] = bc0 ^ (bc2 &^ bc1)
 		a[6] = bc1 ^ (bc3 &^ bc2)
 		a[17] = bc2 ^ (bc4 &^ bc3)
@@ -304,15 +306,15 @@ func keccakF1600(a *[25]uint64) {
 		a[14] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[10] ^ d0
-		bc3 = t<<41 | t>>(64-41)
+		bc3 = bits.RotateLeft64(t, 41)
 		t = a[21] ^ d1
-		bc4 = t<<2 | t>>(64-2)
+		bc4 = bits.RotateLeft64(t, 2)
 		t = a[7] ^ d2
-		bc0 = t<<62 | t>>(64-62)
+		bc0 = bits.RotateLeft64(t, 62)
 		t = a[18] ^ d3
-		bc1 = t<<55 | t>>(64-55)
+		bc1 = bits.RotateLeft64(t, 55)
 		t = a[4] ^ d4
-		bc2 = t<<39 | t>>(64-39)
+		bc2 = bits.RotateLeft64(t, 39)
 		a[10] = bc0 ^ (bc2 &^ bc1)
 		a[21] = bc1 ^ (bc3 &^ bc2)
 		a[7] = bc2 ^ (bc4 &^ bc3)
@@ -333,13 +335,13 @@ func keccakF1600(a *[25]uint64) {
 
 		bc0 = a[0] ^ d0
 		t = a[1] ^ d1
-		bc1 = t<<44 | t>>(64-44)
+		bc1 = bits.RotateLeft64(t, 44)
 		t = a[2] ^ d2
-		bc2 = t<<43 | t>>(64-43)
+		bc2 = bits.RotateLeft64(t, 43)
 		t = a[3] ^ d3
-		bc3 = t<<21 | t>>(64-21)
+		bc3 = bits.RotateLeft64(t, 21)
 		t = a[4] ^ d4
-		bc4 = t<<14 | t>>(64-14)
+		bc4 = bits.RotateLeft64(t, 14)
 		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i+3]
 		a[1] = bc1 ^ (bc3 &^ bc2)
 		a[2] = bc2 ^ (bc4 &^ bc3)
@@ -347,15 +349,15 @@ func keccakF1600(a *[25]uint64) {
 		a[4] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[5] ^ d0
-		bc2 = t<<3 | t>>(64-3)
+		bc2 = bits.RotateLeft64(t, 3)
 		t = a[6] ^ d1
-		bc3 = t<<45 | t>>(64-45)
+		bc3 = bits.RotateLeft64(t, 45)
 		t = a[7] ^ d2
-		bc4 = t<<61 | t>>(64-61)
+		bc4 = bits.RotateLeft64(t, 61)
 		t = a[8] ^ d3
-		bc0 = t<<28 | t>>(64-28)
+		bc0 = bits.RotateLeft64(t, 28)
 		t = a[9] ^ d4
-		bc1 = t<<20 | t>>(64-20)
+		bc1 = bits.RotateLeft64(t, 20)
 		a[5] = bc0 ^ (bc2 &^ bc1)
 		a[6] = bc1 ^ (bc3 &^ bc2)
 		a[7] = bc2 ^ (bc4 &^ bc3)
@@ -363,15 +365,15 @@ func keccakF1600(a *[25]uint64) {
 		a[9] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[10] ^ d0
-		bc4 = t<<18 | t>>(64-18)
+		bc4 = bits.RotateLeft64(t, 18)
 		t = a[11] ^ d1
-		bc0 = t<<1 | t>>(64-1)
+		bc0 = bits.RotateLeft64(t, 1)
 		t = a[12] ^ d2
-		bc1 = t<<6 | t>>(64-6)
+		bc1 = bits.RotateLeft64(t, 6)
 		t = a[13] ^ d3
-		bc2 = t<<25 | t>>(64-25)
+		bc2 = bits.RotateLeft64(t, 25)
 		t = a[14] ^ d4
-		bc3 = t<<8 | t>>(64-8)
+		bc3 = bits.RotateLeft64(t, 8)
 		a[10] = bc0 ^ (bc2 &^ bc1)
 		a[11] = bc1 ^ (bc3 &^ bc2)
 		a[12] = bc2 ^ (bc4 &^ bc3)
@@ -379,15 +381,15 @@ func keccakF1600(a *[25]uint64) {
 		a[14] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[15] ^ d0
-		bc1 = t<<36 | t>>(64-36)
+		bc1 = bits.RotateLeft64(t, 36)
 		t = a[16] ^ d1
-		bc2 = t<<10 | t>>(64-10)
+		bc2 = bits.RotateLeft64(t, 10)
 		t = a[17] ^ d2
-		bc3 = t<<15 | t>>(64-15)
+		bc3 = bits.RotateLeft64(t, 15)
 		t = a[18] ^ d3
-		bc4 = t<<56 | t>>(64-56)
+		bc4 = bits.RotateLeft64(t, 56)
 		t = a[19] ^ d4
-		bc0 = t<<27 | t>>(64-27)
+		bc0 = bits.RotateLeft64(t, 27)
 		a[15] = bc0 ^ (bc2 &^ bc1)
 		a[16] = bc1 ^ (bc3 &^ bc2)
 		a[17] = bc2 ^ (bc4 &^ bc3)
@@ -395,15 +397,15 @@ func keccakF1600(a *[25]uint64) {
 		a[19] = bc4 ^ (bc1 &^ bc0)
 
 		t = a[20] ^ d0
-		bc3 = t<<41 | t>>(64-41)
+		bc3 = bits.RotateLeft64(t, 41)
 		t = a[21] ^ d1
-		bc4 = t<<2 | t>>(64-2)
+		bc4 = bits.RotateLeft64(t, 2)
 		t = a[22] ^ d2
-		bc0 = t<<62 | t>>(64-62)
+		bc0 = bits.RotateLeft64(t, 62)
 		t = a[23] ^ d3
-		bc1 = t<<55 | t>>(64-55)
+		bc1 = bits.RotateLeft64(t, 55)
 		t = a[24] ^ d4
-		bc2 = t<<39 | t>>(64-39)
+		bc2 = bits.RotateLeft64(t, 39)
 		a[20] = bc0 ^ (bc2 &^ bc1)
 		a[21] = bc1 ^ (bc3 &^ bc2)
 		a[22] = bc2 ^ (bc4 &^ bc3)

--- a/vendor/golang.org/x/crypto/ssh/messages.go
+++ b/vendor/golang.org/x/crypto/ssh/messages.go
@@ -68,7 +68,7 @@ type kexInitMsg struct {
 
 // See RFC 4253, section 8.
 
-// Diffie-Helman
+// Diffie-Hellman
 const msgKexDHInit = 30
 
 type kexDHInitMsg struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -118,7 +118,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.50.2-0.20221109162103-1e40f47dd90b
+# github.com/containers/common v0.50.2-0.20221111184705-791b83e1cdf1
 ## explicit; go 1.17
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define
@@ -775,7 +775,7 @@ go.opencensus.io/internal
 go.opencensus.io/trace
 go.opencensus.io/trace/internal
 go.opencensus.io/trace/tracestate
-# golang.org/x/crypto v0.1.0
+# golang.org/x/crypto v0.2.0
 ## explicit; go 1.17
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/cast5


### PR DESCRIPTION
Whenever image has `arch` and `os` configured for `wasm/wasi` switch to `crun-wasm` as extension if applicable, following will only work if `podman` is using `crun` as default runtime.

[NO NEW TEST NEEDED]
[NO TESTS NEEDED]
A test for this can we added when `crun-wasm` package is part of the CI.

```release-note
specgen,wasm: switch to crun-wasm if image is a webassembly image
```
