### PR TITLE
system tests: fix a system test in proxy environment

### DIFF
--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -20,7 +20,7 @@ RUN echo $rand_content > /$rand_filename
 EOF
 
     # The 'apk' command can take a long time to fetch files; bump timeout
-    PODMAN_TIMEOUT=240 run_podman build -t build_test --format=docker $tmpdir
+    PODMAN_TIMEOUT=240 run_podman build -t build_test --format=docker --http-proxy $tmpdir
     is "$output" ".*COMMIT" "COMMIT seen in log"
 
     run_podman run --rm build_test cat /$rand_filename


### PR DESCRIPTION
When we are using a proxy, 'podman build - basic test' will be failed on remote.
This test needs to add the '--http-proxy' option.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<details>
<summary>’podman build - basic test’ is failed</summary>

```
not ok 1 podman build - basic test
# (from function `die' in file helpers.bash, line 595,
#  from function `run_podman' in file helpers.bash, line 215,
#  in test file 070-build.bats, line 23)
#   `PODMAN_TIMEOUT=240 run_podman build -t build_test --format=docker $tmpdir' failed
# # /usr/local/bin/podman-remote rm -t 0 --all --force --ignore
# # /usr/local/bin/podman-remote ps --all --external --format {{.ID}} {{.Names}}
# 7f1e2c9cfe17 testimage-working-container
# # /usr/local/bin/podman-remote rm -f 7f1e2c9cfe17
# 7f1e2c9cfe17
# # /usr/local/bin/podman-remote images --all --format {{.Repository}}:{{.Tag}} {{.ID}}
# quay.io/libpod/testimage:20221018 f5a99120db64
# # /usr/local/bin/podman-remote build -t build_test --format=docker /tmp/podman_bats.Le4P60/build-test
# STEP 1/3: FROM quay.io/libpod/testimage:20221018
# STEP 2/3: RUN apk add nginx
# fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
# ERROR: https://dl-cdn.alpinelinux.org/alpine/v3.16/main: DNS lookup error
# WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.16/main: No such file or directory
# fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
# ERROR: https://dl-cdn.alpinelinux.org/alpine/v3.16/community: DNS lookup error
# WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.16/community: No such file or directory
# ERROR: unable to select packages:
#   nginx (no such package):
#     required by: world[nginx]
# Error: building at STEP "RUN apk add nginx": while running runtime: exit status 1
# [ rc=1 (** EXPECTED 0 **) ]
# #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# #| FAIL: exit code is 1; expected 0
# #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# # /usr/local/bin/podman-remote rm -t 0 -a -f
# # /usr/local/bin/podman-remote rmi -f build_test
# # /usr/local/bin/podman-remote image prune -f
# # [teardown]
# # /usr/local/bin/podman-remote pod rm -t 0 --all --force --ignore
# # /usr/local/bin/podman-remote rm -t 0 --all --force --ignore
# # /usr/local/bin/podman-remote network prune --force
# # /usr/local/bin/podman-remote volume rm -a -f
```
</details>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
