### PR TITLE
Cirrus: Collect benchmarks on machine instances

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -666,7 +666,10 @@ podman_machine_task:
     clone_script: *get_gosrc
     setup_script: *setup
     main_script: *main
-    always: *int_logs_artifacts
+    always: &machine_logs_benchmarks
+      <<: *int_logs_artifacts
+      benchmark_artifacts:
+          path: ./data/*
 
 
 podman_machine_aarch64_task:
@@ -692,7 +695,7 @@ podman_machine_aarch64_task:
     clone_script: *get_gosrc_aarch64
     setup_script: *setup
     main_script: *main
-    always: *int_logs_artifacts
+    always: *machine_logs_benchmarks
 
 
 # Always run subsequent to integration tests.  While parallelism is lost
@@ -1087,6 +1090,12 @@ artifacts_task:
         - tar xjf repo.tbz
         - mv ./podman-remote-release-darwin_*.zip $CIRRUS_WORKING_DIR/
         - mv ./contrib/pkginstaller/out/podman-installer-macos-*.pkg $CIRRUS_WORKING_DIR/
+    benchmarks_script:
+        - mkdir -p /tmp/benchmarks
+        - cd /tmp/benchmarks
+        - $ARTCURL/podman_machine/benchmark.zip
+        - unzip benchmark.zip
+        - mv ./data/benchmarks.{env,csv} $CIRRUS_WORKING_DIR/
     always:
       contents_script: ls -la $CIRRUS_WORKING_DIR
       # Produce downloadable files and an automatic zip-file accessible

--- a/Makefile
+++ b/Makefile
@@ -577,11 +577,11 @@ localintegration: test-binaries ginkgo
 remoteintegration: test-binaries ginkgo-remote
 
 .PHONY: localmachine
-localmachine: test-binaries
+localmachine: test-binaries .install.ginkgo
 	$(MAKE) ginkgo-run GINKGONODES=1 GINKGOWHAT=pkg/machine/e2e/. HACK=
 
 .PHONY: localbenchmarks
-localbenchmarks: test-binaries
+localbenchmarks: install.tools test-binaries
 	PATH=$(PATH):$(shell pwd)/hack ACK_GINKGO_RC=true $(GINKGO) \
 		      -focus "Podman Benchmark Suite" \
 		      -tags "$(BUILDTAGS) benchmarks" -noColor \

--- a/contrib/cirrus/prebuild.sh
+++ b/contrib/cirrus/prebuild.sh
@@ -33,7 +33,7 @@ showrun $SCRIPT_BASE/cirrus_yaml_test.py
 if [[ "${DISTRO_NV}" =~ fedora ]]; then
     msg "Checking shell scripts"
     showrun ooe.sh dnf install -y ShellCheck  # small/quick addition
-    showrun shellcheck --color=always --format=tty \
+    showrun shellcheck --format=tty \
         --shell=bash --external-sources \
         --enable add-default-case,avoid-nullary-conditions,check-unassigned-uppercase \
         --exclude SC2046,SC2034,SC2090,SC2064 \

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -394,6 +394,9 @@ dotest() {
 }
 
 _run_machine() {
+    # This environment is convenient for executing some benchmarking
+    localbenchmarks
+
     # N/B: Can't use _bail_if_test_can_be_skipped here b/c content isn't under test/
     make localmachine |& logformatter
 }


### PR DESCRIPTION
The hardware used for podman-machine testing is fairly stable/predictable because it's bare-metal.  This is a nearly ideal environment for collection of benchmarking data.  Arrange for that to happen, and the resulting data to be collected.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
