### PR TITLE
Skip test if `--events-backend` is necessary with podman-remote

### DIFF
--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -135,6 +135,9 @@ ${cid[0]} d"   "Sequential output from logs"
 function _log_test_restarted() {
     local driver=$1
     local events_backend=$(_additional_events_backend $driver)
+    if [[ -n "${events_backend}" ]]; then
+        skip_if_remote "remote does not support --events-backend"
+    fi
     run_podman run --log-driver=$driver ${events_backend} --name logtest $IMAGE sh -c 'start=0; if test -s log; then start=`tail -n 1 log`; fi; seq `expr $start + 1` `expr $start + 10` | tee -a log'
     # FIXME: #9597
     # run/start is flaking for remote so let's wait for the container condition


### PR DESCRIPTION
`podman-remote` does not support `--events-backend`, which overrides a log driver. When `--events-backend` is necessary in a test for `podman-remote`, the test should be skipped.

We don't need to fix the other cases with
`_additional_events_backend()` because `_log_test_follow()` already has the same skipping logic and `_log_test_multi()` always skips a test when testing `podman-remote`.

Signed-off-by: Hironori Shiina <shiina.hironori@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
