### PR TITLE
podman machine: Propagate SSL_CERT_FILE and SSL_CERT_DIR to systemd e…

### DIFF
--- a/pkg/machine/qemu/machine.go
+++ b/pkg/machine/qemu/machine.go
@@ -560,18 +560,7 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 	attr.Files = files
 	cmdLine := v.CmdLine
 
-	// It is here for providing the ability to propagate
-	// proxy settings (e.g. HTTP_PROXY and others) on a start
-	// and avoid a need of re-creating/re-initiating a VM
-	if proxyOpts := machine.GetProxyVariables(); len(proxyOpts) > 0 {
-		proxyStr := "name=opt/com.coreos/environment,string="
-		var proxies string
-		for k, v := range proxyOpts {
-			proxies = fmt.Sprintf("%s%s=\"%s\"|", proxies, k, v)
-		}
-		proxyStr = fmt.Sprintf("%s%s", proxyStr, base64.StdEncoding.EncodeToString([]byte(proxies)))
-		cmdLine = append(cmdLine, "-fw_cfg", proxyStr)
-	}
+	cmdLine = propagateHostEnv(cmdLine)
 
 	// Disable graphic window when not in debug mode
 	// Done in start, so we're not suck with the debug level we used on init
@@ -694,6 +683,35 @@ func (v *MachineVM) Start(name string, _ machine.StartOptions) error {
 
 	v.waitAPIAndPrintInfo(forwardState, forwardSock)
 	return nil
+}
+
+// propagateHostEnv is here for providing the ability to propagate
+// proxy and SSL settings (e.g. HTTP_PROXY and others) on a start
+// and avoid a need of re-creating/re-initiating a VM
+func propagateHostEnv(cmdLine []string) []string {
+	varsToPropagate := make([]string, 0)
+
+	for k, v := range machine.GetProxyVariables() {
+		varsToPropagate = append(varsToPropagate, fmt.Sprintf("%s=%q", k, v))
+	}
+
+	if sslCertFile, ok := os.LookupEnv("SSL_CERT_FILE"); ok {
+		pathInVM := filepath.Join(machine.UserCertsTargetPath, filepath.Base(sslCertFile))
+		varsToPropagate = append(varsToPropagate, fmt.Sprintf("%s=%q", "SSL_CERT_FILE", pathInVM))
+	}
+
+	if _, ok := os.LookupEnv("SSL_CERT_DIR"); ok {
+		varsToPropagate = append(varsToPropagate, fmt.Sprintf("%s=%q", "SSL_CERT_DIR", machine.UserCertsTargetPath))
+	}
+
+	if len(varsToPropagate) > 0 {
+		prefix := "name=opt/com.coreos/environment,string="
+		envVarsJoined := strings.Join(varsToPropagate, "|")
+		fwCfgArg := prefix + base64.StdEncoding.EncodeToString([]byte(envVarsJoined))
+		return append(cmdLine, "-fw_cfg", fwCfgArg)
+	}
+
+	return cmdLine
 }
 
 func (v *MachineVM) checkStatus(monitor *qmp.SocketMonitor) (machine.Status, error) {

--- a/pkg/machine/qemu/machine_test.go
+++ b/pkg/machine/qemu/machine_test.go
@@ -4,8 +4,13 @@
 package qemu
 
 import (
+	"encoding/base64"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/containers/podman/v4/pkg/machine"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,4 +22,19 @@ func TestEditCmd(t *testing.T) {
 	vm.editCmdLine("-anotherflag", "anothervalue")
 
 	require.Equal(t, vm.CmdLine, []string{"command", "-flag", "newvalue", "-anotherflag", "anothervalue"})
+}
+
+func TestPropagateHostEnv(t *testing.T) {
+	t.Setenv("SSL_CERT_FILE", "/some/foo.cert")
+	t.Setenv("SSL_CERT_DIR", "/some/my/certs")
+	t.Setenv("HTTP_PROXY", "proxy")
+
+	cmdLine := propagateHostEnv(make([]string, 0))
+
+	assert.Len(t, cmdLine, 2)
+	assert.Equal(t, "-fw_cfg", cmdLine[0])
+	tokens := strings.Split(cmdLine[1], ",string=")
+	decodeString, err := base64.StdEncoding.DecodeString(tokens[1])
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("HTTP_PROXY=\"proxy\"|SSL_CERT_FILE=\"%s/foo.cert\"|SSL_CERT_DIR=%q", machine.UserCertsTargetPath, machine.UserCertsTargetPath), string(decodeString))
 }


### PR DESCRIPTION
…nvironment.

Fixes #16041.

Signed-off-by: Björn Mosler <dev@bjoern.mosler.ch>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
SSL_CERT_FILE and SSL_CERT_DIR are propagated to VM by podman machine. 
```
