### PR TITLE
Add hidden podman manifest inspect -v option

### DIFF
--- a/cmd/podman/manifest/inspect.go
+++ b/cmd/podman/manifest/inspect.go
@@ -30,7 +30,7 @@ func init() {
 	})
 	flags := inspectCmd.Flags()
 
-	flags.Bool("verbose", false, "Added for Docker compatibility")
+	flags.BoolP("verbose", "v", false, "Added for Docker compatibility")
 	_ = flags.MarkHidden("verbose")
 	flags.BoolVar(&tlsVerifyCLI, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry")
 	flags.Bool("insecure", false, "Purely for Docker compatibility")

--- a/test/system/012-manifest.bats
+++ b/test/system/012-manifest.bats
@@ -10,7 +10,10 @@ load helpers
     iid=$output
 
     run_podman manifest create test:1.0
-    run_podman manifest inspect --verbose $output
+    mid=$output
+    run_podman manifest inspect --verbose $mid
+    is "$output" ".*\"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\"" "--insecure is a noop want to make sure manifest inspect is successful"
+    run_podman manifest inspect -v $mid
     is "$output" ".*\"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\"" "--insecure is a noop want to make sure manifest inspect is successful"
     run_podman images --format '{{.ID}}' --no-trunc
     is "$output" ".*sha256:$iid" "Original image ID still shown in podman-images output"


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
