### PR TITLE
Add hidden trust command to alias existing trust commands

### DIFF
--- a/cmd/podman/images/trust.go
+++ b/cmd/podman/images/trust.go
@@ -16,9 +16,21 @@ var (
 		Long:        trustDescription,
 		RunE:        validate.SubCommandExists,
 	}
+
+	trustxCmd = &cobra.Command{
+		Annotations: trustCmd.Annotations,
+		Use:         trustCmd.Use,
+		Short:       trustCmd.Short,
+		Long:        trustCmd.Long,
+		RunE:        trustCmd.RunE,
+		Hidden:      true,
+	}
 )
 
 func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: trustxCmd,
+	})
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: trustCmd,
 		Parent:  imageCmd,

--- a/cmd/podman/images/trust_set.go
+++ b/cmd/podman/images/trust_set.go
@@ -34,6 +34,10 @@ var (
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: setTrustCommand,
+		Parent:  trustxCmd,
+	})
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: setTrustCommand,
 		Parent:  trustCmd,
 	})
 	setFlags := setTrustCommand.Flags()

--- a/cmd/podman/images/trust_show.go
+++ b/cmd/podman/images/trust_show.go
@@ -33,6 +33,10 @@ var (
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Command: showTrustCommand,
+		Parent:  trustxCmd,
+	})
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Command: showTrustCommand,
 		Parent:  trustCmd,
 	})
 	showFlags := showTrustCommand.Flags()

--- a/test/system/750-trust.bats
+++ b/test/system/750-trust.bats
@@ -15,8 +15,8 @@ load helpers
       run_podman image trust show --policypath=$policypath
       is "$output" ".*all  *default  *accept" "default policy should be accept"
 
-      run_podman image trust set --policypath=$policypath --type=reject default
-      run_podman image trust show --policypath=$policypath
+      run_podman trust set --policypath=$policypath --type=reject default
+      run_podman trust show --policypath=$policypath
       is "$output" ".*all  *default  *reject" "default policy should be reject"
 
       run_podman image trust set --policypath=$policypath --type=reject docker.io


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman trust hidden command added for docker compatibility.
```
