### PR TITLE
Add podman system events alias to podman events

### DIFF
--- a/commands-demo.md
+++ b/commands-demo.md
@@ -90,6 +90,7 @@
 | [podman-stop(1)](https://podman.readthedocs.io/en/latest/markdown/podman-stop.1.html)                                 | Stops one or more running containers                                       |
 | [podman-system(1)](https://podman.readthedocs.io/en/latest/system.html)                                               | Manage podman                                                              |
 | [podman-system-df(1)](https://podman.readthedocs.io/en/latest/markdown/podman-system-df.1.html)                       | Show podman disk usage.                                                    |
+| [podman-system-events(1)](https://podman.readthedocs.io/en/latest/markdown/podman-events.1.html)                          | Displays Podman related system events.                                |
 | [podman-system-info(1)](https://podman.readthedocs.io/en/latest/markdown/podman-info.1.html)                          | Displays Podman related system information.                                |
 | [podman-system-migrate(1)](https://podman.readthedocs.io/en/latest/markdown/podman-system-migrate.1.html)             | Migrate existing containers to a new podman version                        |
 | [podman-system-prune(1)](https://podman.readthedocs.io/en/latest/markdown/podman-system-prune.1.html)                 | Remove all unused container, image and volume data                         |

--- a/docs/source/markdown/links/podman-system-events.1
+++ b/docs/source/markdown/links/podman-system-events.1
@@ -1,0 +1,1 @@
+.so man1/podman-events.1

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -6,6 +6,8 @@ podman\-events - Monitor Podman events
 ## SYNOPSIS
 **podman events** [*options*]
 
+**podman system events** [*options*]
+
 ## DESCRIPTION
 
 Monitor and print events that occur in Podman. Each event will include a timestamp,

--- a/docs/source/markdown/podman-system.1.md
+++ b/docs/source/markdown/podman-system.1.md
@@ -15,6 +15,7 @@ The system command allows you to manage the podman systems
 | -------    | ------------------------------------------------------------ | ------------------------------------------------------------------------ |
 | connection | [podman-system-connection(1)](podman-system-connection.1.md) | Manage the destination(s) for Podman service(s)                          |
 | df         | [podman-system-df(1)](podman-system-df.1.md)                 | Show podman disk usage.                                                  |
+| events     | [podman-system-events(1)](podman-events.1.md)		    | Monitor Podman events                                                    |
 | info       | [podman-system-info(1)](podman-info.1.md)                    | Displays Podman related system information.                              |
 | migrate    | [podman-system-migrate(1)](podman-system-migrate.1.md)       | Migrate existing containers to a new podman version.                     |
 | prune      | [podman-system-prune(1)](podman-system-prune.1.md)           | Remove all unused pods, containers, images, networks, and volume data.   |

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -129,13 +129,13 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search format json list tags", func() {
-		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", "alpine"})
+		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", ALPINE})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
 		Expect(search.OutputToString()).To(BeValidJSON())
-		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
-		Expect(search.OutputToString()).To(ContainSubstring("3.10"))
-		Expect(search.OutputToString()).To(ContainSubstring("2.7"))
+		Expect(search.OutputToString()).To(ContainSubstring("quay.io/libpod/alpine"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.10.2"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.2"))
 	})
 
 	// Test for https://github.com/containers/podman/issues/11894

--- a/test/system/090-events.bats
+++ b/test/system/090-events.bats
@@ -17,7 +17,7 @@ load helpers
     is "$output" "$expect" "filtering by container name and label"
 
     # Same thing, but without the container-name filter
-    run_podman events -f type=container --filter label=${labelname}=${labelvalue} --filter event=start --stream=false
+    run_podman system events -f type=container --filter label=${labelname}=${labelvalue} --filter event=start --stream=false
     is "$output" "$expect" "filtering just by label"
 
     # Now filter just by container name, no label

--- a/test/system/610-format.bats
+++ b/test/system/610-format.bats
@@ -37,6 +37,7 @@ search            | $IMAGE
 pod inspect       | mypod
 
 events            | --stream=false --events-backend=file
+system events     | --stream=false --events-backend=file
 "
 
 # podman machine is finicky. Assume we can't run it, but see below for more.

--- a/transfer.md
+++ b/transfer.md
@@ -87,6 +87,7 @@ There are other equivalents for these tools
 | `docker stop`    | [`podman stop`](./docs/source/markdown/podman-stop.1.md)        |
 | `docker system ` | [`podman system`](./docs/source/markdown/podman-system.1.md)    |
 | `docker system df`     | [`podman system df`](./docs/source/markdown/podman-system-df.1.md)      |
+| `docker system events`   | [`podman system events`](./docs/source/markdown/podman-events.1.md)  |
 | `docker system info`   | [`podman system info`](./docs/source/markdown/podman-system-info.1.md)  |
 | `docker system prune`  | [`podman system prune`](./docs/source/markdown/podman-system-prune.1.md)|
 | `docker tag`     | [`podman tag`](./docs/source/markdown/podman-tag.1.md)          |


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman system events now alias to podman events for Docker compatibility
```
