### PR TITLE
Add podman volume create -d short option for driver

### DIFF
--- a/cmd/podman/volumes/create.go
+++ b/cmd/podman/volumes/create.go
@@ -44,7 +44,7 @@ func init() {
 	flags := createCommand.Flags()
 
 	driverFlagName := "driver"
-	flags.StringVar(&createOpts.Driver, driverFlagName, "local", "Specify volume driver name")
+	flags.StringVarP(&createOpts.Driver, driverFlagName, "d", "local", "Specify volume driver name")
 	_ = createCommand.RegisterFlagCompletionFunc(driverFlagName, completion.AutocompleteNone)
 
 	labelFlagName := "label"

--- a/docs/source/markdown/podman-volume-create.1.md
+++ b/docs/source/markdown/podman-volume-create.1.md
@@ -15,7 +15,7 @@ driver options can be set using the **--opt** flag.
 
 ## OPTIONS
 
-#### **--driver**=*driver*
+#### **--driver**, **-d**=*driver*
 
 Specify the volume driver name (default **local**).
 There are two drivers supported by Podman itself: **local** and **image**.

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -120,7 +120,7 @@ function teardown() {
     mylabel=$(random_string)
 
     # Create a named volume
-    run_podman volume create --label l=$mylabel  $myvolume
+    run_podman volume create -d local --label l=$mylabel  $myvolume
     is "$output" "$myvolume" "output from volume create"
 
     # Confirm that it shows up in 'volume ls', and confirm values
@@ -246,7 +246,7 @@ EOF
 # Podman volume import test
 @test "podman volume import test" {
     skip_if_remote "volumes import is not applicable on podman-remote"
-    run_podman volume create my_vol
+    run_podman volume create --driver local my_vol
     run_podman run --rm -v my_vol:/data $IMAGE sh -c "echo hello >> /data/test"
     run_podman volume create my_vol2
 


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
podman volume create -d option now supported.
```
