### PR TITLE
libpod: Add FreeBSD support in packageVersion

### DIFF
--- a/libpod/util.go
+++ b/libpod/util.go
@@ -171,11 +171,12 @@ func queryPackageVersion(cmdArg ...string) string {
 func packageVersion(program string) string { // program is full path
 	packagers := [][]string{
 		{"/usr/bin/rpm", "-q", "-f"},
-		{"/usr/bin/dpkg", "-S"},     // Debian, Ubuntu
-		{"/usr/bin/pacman", "-Qo"},  // Arch
-		{"/usr/bin/qfile", "-qv"},   // Gentoo (quick)
-		{"/usr/bin/equery", "b"},    // Gentoo (slow)
-		{"/sbin/apk", "info", "-W"}, // Alpine
+		{"/usr/bin/dpkg", "-S"},                // Debian, Ubuntu
+		{"/usr/bin/pacman", "-Qo"},             // Arch
+		{"/usr/bin/qfile", "-qv"},              // Gentoo (quick)
+		{"/usr/bin/equery", "b"},               // Gentoo (slow)
+		{"/sbin/apk", "info", "-W"},            // Alpine
+		{"/usr/local/sbin/pkg", "which", "-q"}, // FreeBSD
 	}
 
 	for _, cmd := range packagers {


### PR DESCRIPTION
This reports the correct package versions in 'podman info' for conmon and ociRuntime on FreeBSD which is needed for the 005-info system test.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### Does this PR introduce a user-facing change?

```release-note
None
```
