### PR TITLE
[CI:DOCS] GHA: Fix make_email-body script reference

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -42,7 +42,7 @@ jobs:
 
             - if: steps.cron.outputs.failures > 0
               shell: bash
-              run: './.github/actions/check_cirrus_cron/make_email_body'
+              run: './.github/actions/check_cirrus_cron/make_email_body.sh'
 
             - if: steps.cron.outputs.failures > 0
               name: Send failure notification e-mail


### PR DESCRIPTION
This component was recently migrated from being inline, into a dedicated script file.  This was necessary for testing.  However, it's hard to test the actual github-actions workflow YAML, and there was a typo.  Fix the reference to the script filename missing the `.sh` extension.

Ref: https://github.com/containers/podman/pull/16414

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
