### PR TITLE
[skip-ci] GHA: Fix undefined secret env. var.

### DIFF
--- a/.github/workflows/rerun_cirrus_cron.yml
+++ b/.github/workflows/rerun_cirrus_cron.yml
@@ -10,7 +10,7 @@ on:
     schedule:
         # N/B: This should fire about an hour prior to check_cirrus_cron
         # so the re-runs have a chance to complete.
-        - cron:  '59 22 * * 1-5'
+        - cron:  '05 22 * * 1-5'
     # Debug: Allow triggering job manually in github-actions WebUI
     workflow_dispatch: {}
 
@@ -42,6 +42,8 @@ jobs:
 
             - if: steps.cron.outputs.failures > 0
               shell: bash
+              env:
+                SECRET_CIRRUS_API_KEY: ${{ secrets.SECRET_CIRRUS_API_KEY }}
               run: './.github/actions/check_cirrus_cron/rerun_failed_tasks.sh'
 
             - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2


### PR DESCRIPTION
Because in github-actions, setting a secret variable isn't enough.  You ALSO have to set it again in your YAML.  I guess it's assumed in the name of "security" that the person with access to secrets, might not also have access to update YAML.  Crazy!

Also, while we're at it.  Bump up the execution schedule WRT the check_cirrus_cron workflow - this will give re-run jobs more time to complete.

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
