### PR TITLE
[CI:DOCS] docs: deprecate pasta network name

### DIFF
--- a/docs/source/markdown/options/network.md
+++ b/docs/source/markdown/options/network.md
@@ -74,3 +74,6 @@ Valid _mode_ values are:
     - **pasta:-T,5201**: enable forwarding of TCP port 5201 from container to
         host, using the loopback interface instead of the tap interface for improved
         performance
+
+    NOTE: For backward compatibility reasons, if you have a network named `pasta`,
+    Podman will use this instead of the pasta mode.

--- a/docs/source/markdown/podman-network-create.1.md
+++ b/docs/source/markdown/podman-network-create.1.md
@@ -15,6 +15,9 @@ If no options are provided, Podman will assign a free subnet and name for your n
 
 Upon completion of creating the network, Podman will display the name of the newly added network.
 
+NOTE: The support for the network name pasta is deprecated and will be removed in the next major
+release because it is used as a special network mode in **podman run/create --network**.
+
 ## OPTIONS
 #### **--disable-dns**
 


### PR DESCRIPTION
Since pasta is now considered a network mode using it as network name causes a conflict. For now we will prefer the named network but in a future major version bump we want to remove this and just use pasta(1).

The docs should reflect that this name is considered deprecated.

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The network name `pasta` is deprecated and support for it will be removed in the next major release.
```
