### PR TITLE
podman cp: fix copying with "." suffix

### DIFF
--- a/cmd/podman/containers/cp.go
+++ b/cmd/podman/containers/cp.go
@@ -158,7 +158,7 @@ func copyContainerToContainer(sourceContainer string, sourcePath string, destCon
 	// Hence, whenever "." is the source and the destination does not
 	// exist, we copy the source's parent and let the copier package create
 	// the destination via the Rename option.
-	if destResolvedToParentDir && sourceContainerInfo.IsDir && strings.HasSuffix(sourcePath, ".") {
+	if destResolvedToParentDir && sourceContainerInfo.IsDir && filepath.Base(sourcePath) == "." {
 		sourceContainerTarget = filepath.Dir(sourceContainerTarget)
 	}
 
@@ -261,7 +261,7 @@ func copyFromContainer(container string, containerPath string, hostPath string) 
 	// we copy the source's parent and let the copier package create the
 	// destination via the Rename option.
 	containerTarget := containerInfo.LinkTarget
-	if resolvedToHostParentDir && containerInfo.IsDir && strings.HasSuffix(containerTarget, ".") {
+	if resolvedToHostParentDir && containerInfo.IsDir && filepath.Base(containerTarget) == "." {
 		containerTarget = filepath.Dir(containerTarget)
 	}
 
@@ -365,7 +365,7 @@ func copyToContainer(container string, containerPath string, hostPath string) er
 	// exist, we copy the source's parent and let the copier package create
 	// the destination via the Rename option.
 	hostTarget := hostInfo.LinkTarget
-	if containerResolvedToParentDir && hostInfo.IsDir && strings.HasSuffix(hostTarget, ".") {
+	if containerResolvedToParentDir && hostInfo.IsDir && filepath.Base(hostTarget) == "." {
 		hostTarget = filepath.Dir(hostTarget)
 	}
 


### PR DESCRIPTION
Fix a bug for special-casing "." where Podman has mistakenly been looking for a "." suffix instead of interpreting it as a path.

Add regression tests for the host-to-container, container-to-host and container-to-container use cases.  Have separate tests for each to verify that previous Podman versions fail each case.

Fixes: #16421
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in `podman cp` when copying directories ending with a ".".
```
