### PR TITLE
Add support for --preserve-fds on FreeBSD for run and exec

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -870,7 +870,7 @@ func makeExecConfig(options entities.ExecOptions, rt *libpod.Runtime) (*libpod.E
 
 func checkExecPreserveFDs(options entities.ExecOptions) error {
 	if options.PreserveFDs > 0 {
-		entries, err := os.ReadDir("/proc/self/fd")
+		entries, err := os.ReadDir(processFileDescriptorsPath)
 		if err != nil {
 			return err
 		}
@@ -879,7 +879,7 @@ func checkExecPreserveFDs(options entities.ExecOptions) error {
 		for _, e := range entries {
 			i, err := strconv.Atoi(e.Name())
 			if err != nil {
-				return fmt.Errorf("cannot parse %s in /proc/self/fd: %w", e.Name(), err)
+				return fmt.Errorf("cannot parse %s in %s: %w", e.Name(), processFileDescriptorsPath, err)
 			}
 			m[i] = true
 		}

--- a/pkg/domain/infra/abi/containers_freebsd.go
+++ b/pkg/domain/infra/abi/containers_freebsd.go
@@ -1,0 +1,3 @@
+package abi
+
+const processFileDescriptorsPath = "/dev/fd"

--- a/pkg/domain/infra/abi/containers_linux.go
+++ b/pkg/domain/infra/abi/containers_linux.go
@@ -1,0 +1,3 @@
+package abi
+
+const processFileDescriptorsPath = "/proc/self/fd"

--- a/pkg/rootless/rootless_freebsd.c
+++ b/pkg/rootless/rootless_freebsd.c
@@ -1,0 +1,63 @@
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/select.h>
+
+static int open_files_max_fd;
+static fd_set *open_files_set;
+
+int
+is_fd_inherited(int fd)
+{
+  if (open_files_set == NULL || fd > open_files_max_fd || fd < 0)
+    return 0;
+
+  return FD_ISSET(fd % FD_SETSIZE, &(open_files_set[fd / FD_SETSIZE])) ? 1 : 0;
+}
+
+static void __attribute__((constructor)) init()
+{
+  /* Store how many FDs were open before the Go runtime kicked in.  */
+  DIR* d = opendir ("/dev/fd");
+  if (d)
+    {
+      struct dirent *ent;
+      size_t size = 0;
+
+      for (ent = readdir (d); ent; ent = readdir (d))
+        {
+          int fd;
+
+          if (ent->d_name[0] == '.')
+            continue;
+
+          fd = atoi (ent->d_name);
+          if (fd == dirfd (d)) {
+            continue;
+          }
+
+          if (fd >= size * FD_SETSIZE)
+            {
+              int i;
+              size_t new_size;
+
+              new_size = (fd / FD_SETSIZE) + 1;
+              open_files_set = realloc (open_files_set, new_size * sizeof (fd_set));
+              if (open_files_set == NULL)
+                _exit (EXIT_FAILURE);
+
+              for (i = size; i < new_size; i++)
+                FD_ZERO (&(open_files_set[i]));
+
+              size = new_size;
+            }
+
+          if (fd > open_files_max_fd) {
+            open_files_max_fd = fd;
+          }
+
+          FD_SET (fd % FD_SETSIZE, &(open_files_set[fd / FD_SETSIZE]));
+        }
+    }
+}

--- a/pkg/rootless/rootless_freebsd.go
+++ b/pkg/rootless/rootless_freebsd.go
@@ -1,23 +1,20 @@
-//go:build !(linux || freebsd) || !cgo
-// +build !linux,!freebsd !cgo
+//go:build freebsd && cgo
+// +build freebsd,cgo
 
 package rootless
 
 import (
 	"errors"
-	"os"
 
 	"github.com/containers/storage/pkg/idtools"
 )
 
+// extern int is_fd_inherited(int fd);
+import "C"
+
 // IsRootless returns whether the user is rootless
 func IsRootless() bool {
-	uid := os.Geteuid()
-	// os.Geteuid() on Windows returns -1
-	if uid == -1 {
-		return false
-	}
-	return uid != 0
+	return false
 }
 
 // BecomeRootInUserNS re-exec podman in a new userNS.  It returns whether podman was re-executed
@@ -68,5 +65,5 @@ func ReadMappingsProc(path string) ([]idtools.IDMap, error) {
 
 // IsFdInherited checks whether the fd is opened and valid to use
 func IsFdInherited(fd int) bool {
-	return false
+	return int(C.is_fd_inherited(C.int(fd))) > 0
 }


### PR DESCRIPTION
This mainly involved implementing enough of rootless to support IsFdInherited. The function checkExecPreserveFDs seems redundant - it repeats the work of IdFdInherited and could be removed entirely. This extra check only happens for exec, not run.

#### Does this PR introduce a user-facing change?

```release-note
None
```
