### PR TITLE
remove pod if creation has failed

### DIFF
--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -554,4 +554,17 @@ io.max          | $lomajmin rbps=1048576 wbps=1048576 riops=max wiops=max
     is "$output" "" "Should print no output"
 }
 
+@test "podman pod create on failure" {
+    podname=pod$(random_string)
+    nwname=pod$(random_string)
+
+    run_podman 125 pod create --network $nwname --name $podname
+    # FIXME: podman and podman-remote do not return the same error message
+    # but consistency would be nice
+    is "$output" "Error: .*unable to find network with name or ID $nwname: network not found"
+
+    # Make sure the pod doesn't get created on failure
+    run_podman 1 pod exists $podname
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Make sure to remove the pod if its creation has failed.

Fixes: #16502
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where a pod was partially created even when its creation has failed.
```
