### PR TITLE
Removing the RawInput from the API output

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -1024,7 +1024,7 @@ func (r *Runtime) RemoveDepend(ctx context.Context, rmCtr *Container, force bool
 			return nil, err
 		}
 		for _, cID := range podContainerIDS {
-			rmReports = append(rmReports, &reports.RmReport{Id: cID, RawInput: cID})
+			rmReports = append(rmReports, &reports.RmReport{Id: cID})
 		}
 		return rmReports, nil
 	}
@@ -1052,7 +1052,7 @@ func (r *Runtime) RemoveDepend(ctx context.Context, rmCtr *Container, force bool
 		rmReports = append(rmReports, reports...)
 	}
 
-	report := reports.RmReport{Id: rmCtr.ID(), RawInput: rmCtr.ID()}
+	report := reports.RmReport{Id: rmCtr.ID()}
 	report.Err = r.removeContainer(ctx, rmCtr, force, removeVolume, false, false, timeout)
 	return append(rmReports, &report), nil
 }

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -204,7 +204,7 @@ type CheckpointOptions struct {
 type CheckpointReport struct {
 	Err             error                                   `json:"-"`
 	Id              string                                  `json:"Id"` //nolint:revive,stylecheck
-	RawInput        string                                  `json:"RawInput"`
+	RawInput        string                                  `json:"-"`
 	RuntimeDuration int64                                   `json:"runtime_checkpoint_duration"`
 	CRIUStatistics  *define.CRIUCheckpointRestoreStatistics `json:"criu_statistics"`
 }
@@ -231,7 +231,7 @@ type RestoreOptions struct {
 type RestoreReport struct {
 	Err             error                                   `json:"-"`
 	Id              string                                  `json:"Id"` //nolint:revive,stylecheck
-	RawInput        string                                  `json:"RawInput"`
+	RawInput        string                                  `json:"-"`
 	RuntimeDuration int64                                   `json:"runtime_restore_duration"`
 	CRIUStatistics  *define.CRIUCheckpointRestoreStatistics `json:"criu_statistics"`
 }

--- a/pkg/domain/entities/reports/containers.go
+++ b/pkg/domain/entities/reports/containers.go
@@ -3,7 +3,7 @@ package reports
 type RmReport struct {
 	Id       string `json:"Id"` //nolint:revive,stylecheck
 	Err      error  `json:"Err,omitempty"`
-	RawInput string
+	RawInput string `json:"-"`
 }
 
 func RmReportsIds(r []*RmReport) []string {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -273,6 +273,7 @@ func (ic *ContainerEngine) ContainerRm(ctx context.Context, namesOrIds []string,
 		}
 		for i := range newReports {
 			alreadyRemoved[newReports[i].Id] = true
+			newReports[i].RawInput = idToRawInput[newReports[i].Id]
 			rmReports = append(rmReports, newReports[i])
 		}
 	}


### PR DESCRIPTION
Including the RawInput in the API output is meaningless.

Fixes: #16497

[NO NEW TESTS NEEDED]

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
