### PR TITLE
Fix podman --noout to suppress all output

### DIFF
--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -78,6 +78,7 @@ var (
 
 	useSyslog      bool
 	requireCleanup = true
+	noOut          = false
 )
 
 func init() {
@@ -87,6 +88,7 @@ func init() {
 		syslogHook,
 		earlyInitHook,
 		configHook,
+		noOutHook,
 	)
 
 	rootFlags(rootCmd, registry.PodmanConfig())
@@ -127,10 +129,6 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	podmanConfig := registry.PodmanConfig()
-	if podmanConfig.NoOut {
-		null, _ := os.Open(os.DevNull)
-		os.Stdout = null
-	}
 
 	// Currently it is only possible to restore a container with the same runtime
 	// as used for checkpointing. It should be possible to make crun and runc
@@ -368,6 +366,13 @@ func loggingHook() {
 	}
 }
 
+func noOutHook() {
+	if noOut {
+		null, _ := os.Open(os.DevNull)
+		os.Stdout = null
+	}
+}
+
 func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 	srv, uri, ident, machine := resolveDestination()
 
@@ -400,7 +405,7 @@ func rootFlags(cmd *cobra.Command, podmanConfig *entities.PodmanConfig) {
 	lFlags.StringVar(&podmanConfig.Identity, identityFlagName, ident, "path to SSH identity file, (CONTAINER_SSHKEY)")
 	_ = cmd.RegisterFlagCompletionFunc(identityFlagName, completion.AutocompleteDefault)
 
-	lFlags.BoolVar(&podmanConfig.NoOut, "noout", false, "do not output to stdout")
+	lFlags.BoolVar(&noOut, "noout", false, "do not output to stdout")
 	lFlags.BoolVarP(&podmanConfig.Remote, "remote", "r", registry.IsRemote(), "Access remote Podman service")
 	pFlags := cmd.PersistentFlags()
 	if registry.IsRemote() {

--- a/pkg/domain/entities/engine.go
+++ b/pkg/domain/entities/engine.go
@@ -42,7 +42,6 @@ type PodmanConfig struct {
 	Identity                 string         // ssh identity for connecting to server
 	MaxWorks                 int            // maximum number of parallel threads
 	MemoryProfile            string         // Hidden: Should memory profile be taken
-	NoOut                    bool           // Don't output to stdout
 	RegistriesConf           string         // allows for specifying a custom registries.conf
 	Remote                   bool           // Connection to Podman API Service will use RESTful API
 	RuntimePath              string         // --runtime flag will set Engine.RuntimePath

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -232,4 +232,10 @@ See 'podman version --help'" "podman version --remote"
     is "$output" "Setting --log-level and --debug is not allowed"
 }
 
+# Tests --noout for commands that do not enter the engine
+@test "podman --noout properly supresses output" {
+run_podman --noout system connection ls
+    is "$output" "" "output should be empty"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Podman --noout was not suppressing output from commands that do not create the podman engine. Now, podman --noout properly suppresses output from every command.

Fixes: https://github.com/containers/podman/issues/16201

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where `podman --noout` was not suppressing output from certain commands such as `podman machine` and `podman system connection`
```
