### PR TITLE
[release-v4.3] compat,build: handle docker's preconfigured `cacheTo`,`cacheFrom`

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -189,6 +189,13 @@ tar --format=posix -C $TMPD -cvf ${CONTAINERFILE_TAR} containerfile &> /dev/null
 t POST "libpod/build?dockerfile=containerfile" $CONTAINERFILE_TAR 200 \
   .stream~"STEP 1/1: FROM $IMAGE"
 
+# Newer Docker client sets empty cacheFrom for every build command even if it is not used,
+# following commit makes sure we test such use-case. See https://github.com/containers/podman/pull/16380
+#TODO: This test should be extended when buildah's cache-from and cache-to functionally supports
+# multiple remote-repos
+t POST "libpod/build?dockerfile=containerfile&cachefrom=[]" $CONTAINERFILE_TAR 200 \
+  .stream~"STEP 1/1: FROM $IMAGE"
+
 # With -q, all we should get is image ID. Test both libpod & compat endpoints.
 t POST "libpod/build?dockerfile=containerfile&q=true" $CONTAINERFILE_TAR 200 \
   .stream~'^[0-9a-f]\{64\}$'


### PR DESCRIPTION
Backport of https://github.com/containers/podman/pull/16380

Docker's newer clients popuates `cacheFrom` and `cacheTo` parameter by default as empty array for all commands but buildah's design of distributed cache expects this to be a repo not image hence parse only the first populated repo and ignore if empty array.

Note: Upstream will start using newer API as soon as buildah exposes new API

```release-note
compat,build: make compat build api functional for newer docker-clients
```
