### PR TITLE
e2e tests: fix restart race

### DIFF
--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Podman restart", func() {
 		startTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", cid})
 		startTime.WaitWithDefaultTimeout()
 
-		startSession := podmanTest.Podman([]string{"start", cid})
+		startSession := podmanTest.Podman([]string{"start", "--attach", cid})
 		startSession.WaitWithDefaultTimeout()
 		Expect(startSession).Should(Exit(0))
 


### PR DESCRIPTION
It's so easy to forget that "podman start" is nonblocking.
So podman create, start, restart has a race where "restart"
can run before the container actually starts.

Solution: start --attach. Thanks to @vrothberg for noticing that.

There are still a handful of other suspicious-looking restarts
in this test, but all involve "top" which of course has to be
detached. Since those don't have any flakes that I know of, I
choose to ignore them.

Fixes: #16505

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```