### PR TITLE
fix port issues for CONTAINER_HOST

### DIFF
--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -91,9 +91,12 @@ func NewConnectionWithIdentity(ctx context.Context, uri string, identity string,
 	var connection Connection
 	switch _url.Scheme {
 	case "ssh":
-		port, err := strconv.Atoi(_url.Port())
-		if err != nil {
-			return nil, err
+		port := 22
+		if _url.Port() != "" {
+			port, err = strconv.Atoi(_url.Port())
+			if err != nil {
+				return nil, err
+			}
 		}
 		conn, err := ssh.Dial(&ssh.ConnectionDialOptions{
 			Host:                        uri,

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -281,6 +281,15 @@ var _ = Describe("podman system connection", func() {
 			_, err = Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).ToNot(HaveOccurred())
 
+			// export the container_host env var and try again
+			err = os.Setenv("CONTAINER_HOST", fmt.Sprintf("ssh://%s@localhost", u.Username))
+			Expect(err).ToNot(HaveOccurred())
+			defer os.Unsetenv("CONTAINER_HOST")
+
+			cmd = exec.Command(podmanTest.RemotePodmanBinary, "ps")
+			_, err = Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).ToNot(HaveOccurred())
+
 			uri := url.URL{
 				Scheme: "ssh",
 				User:   url.User(u.Username),


### PR DESCRIPTION
if no port is specified for an ssh style url, default to 22

resolves #16509

Signed-off-by: Charlie Doern <cdoern@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix port validation for CONTAINER_HOST
```
