### PR TITLE
[CI:DOCS] CI: Package versions: run in the 'main' step

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -306,7 +306,6 @@ bindings_task:
         html_artifacts:
             path: ./*.html
             type: text/html
-        package_versions_script: '$SCRIPT_BASE/logcollector.sh packages'
         df_script: '$SCRIPT_BASE/logcollector.sh df'
         audit_log_script: '$SCRIPT_BASE/logcollector.sh audit'
         journal_script: '$SCRIPT_BASE/logcollector.sh journal'

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -497,6 +497,12 @@ if [[ "$PRIV_NAME" == "rootless" ]] && [[ "$UID" -eq 0 ]]; then
 fi
 # else: not running rootless, do nothing special
 
+# Dump important package versions. Before 2022-11-16 this took place as
+# a separate .cirrus.yml step, but it really belongs here.
+$(dirname $0)/logcollector.sh packages
+msg "************************************************************"
+
+
 cd "${GOSRC}/"
 
 handler="_run_${TEST_FLAVOR}"


### PR DESCRIPTION
...not as a separate post-main step. Reasons:

 1) If main test times out, Cirrus won't run subsequent steps
 2) It really belongs in the main log anyway, because when
    looking at test results, you want to have instant access
    to versions, you don't want to have to clickety-click
    ten steps.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```