### PR TITLE
[v4.3] More log-flake work

### DIFF
--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -65,7 +65,11 @@ var _ = Describe("Podman logs", func() {
 			Expect(logc).To(Exit(0))
 			cid := logc.OutputToString()
 
-			results := podmanTest.Podman([]string{"logs", cid})
+			results := podmanTest.Podman([]string{"wait", cid})
+			results.WaitWithDefaultTimeout()
+			Expect(results).To(Exit(0))
+
+			results = podmanTest.Podman([]string{"logs", cid})
 			results.WaitWithDefaultTimeout()
 			Expect(results).To(Exit(0))
 			Expect(results.OutputToStringArray()).To(HaveLen(3))

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -303,6 +303,7 @@ EOF
     echo "$teststring" | nc 127.0.0.1 $port_out
 
     # Confirm that the container log output is the string we sent it.
+    run_podman wait $cid
     run_podman logs $cid
     is "$output" "$teststring" "test string received on container"
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -257,6 +257,13 @@ function wait_for_output {
         if [ $output != "true" ]; then
             run_podman inspect --format '{{.State.ExitCode}}' $cid
             exitcode=$output
+
+            # One last chance: maybe the container exited just after logs cmd
+            run_podman logs $cid
+            if expr "$logs" : ".*$expect" >/dev/null; then
+                return
+            fi
+
             die "Container exited (status: $exitcode) before we saw '$expect': $logs"
         fi
 


### PR DESCRIPTION
[backport #16437]

It looks like #16132 was my fault: a missing 'wait' for a container to exit. Let's see if this fixes the flake.

And, while poking through flake logs, I found another missing wait.

And... in wait_for_output(), address a potential race.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
none
```
