### PR TITLE
[CI:DOCS] Add more documentation on UID/GID Mappings with --userns=keep-id

### DIFF
--- a/docs/source/markdown/options/userns.container.md
+++ b/docs/source/markdown/options/userns.container.md
@@ -12,10 +12,11 @@ Rootless user --userns=Key mappings:
 
 Key       | Host User |  Container User
 ----------|---------------|---------------------
-""        |$UID           |0 (Default User account mapped to root user in container.)
-keep-id   |$UID           |$UID (Map user account to same UID within container.)
-auto      |$UID           | nil (Host User UID is not mapped into container.)
-nomap     |$UID           | nil (Host User UID is not mapped into container.)
+""        |$UID         |0 (Default User account mapped to root user in container.)
+keep-id   |$UID         |$UID (Map user account to same UID within container.)
+keep-id:uid=200,gid=210 |$UID| 200:210 (Map user account to specified uid, gid value within container.)
+auto      |$UID         | nil (Host User UID is not mapped into container.)
+nomap     |$UID         | nil (Host User UID is not mapped into container.)
 
 Valid _mode_ values are:
 

--- a/docs/source/markdown/podman-run.1.md.in
+++ b/docs/source/markdown/podman-run.1.md.in
@@ -575,8 +575,19 @@ $ podman run -v /var/db:/data1 -i -t fedora bash
 $ podman run -v data:/data2 -i -t fedora bash
 
 $ podman run -v /var/cache/dnf:/var/cache/dnf:O -ti fedora dnf -y update
+```
 
+If the container needs a writeable mounted volume by a non root user inside the container, use the **U** option. This options tells Podman to chown the source volume to match the default UID and GID used within the container.
+```
 $ podman run -d -e MYSQL_ROOT_PASSWORD=root --user mysql --userns=keep-id -v ~/data:/var/lib/mysql:z,U mariadb
+```
+
+Alternativley if the container needs a writable volume by a non root
+user inside of the container, the --userns=keep-id option allows users to
+specify the UID and GID of the user executing Podman to specific UIDs and GIDs
+within the container. Since the processes running in the container run as the users UID, they can read/write files owned by the user.
+```
+$ podman run -d -e MYSQL_ROOT_PASSWORD=root --user mysql --userns=keep-id:uid=999,gid=999 -v ~/data:/var/lib/mysql:z mariadb
 ```
 
 Using **--mount** flags to mount a host directory as a container folder, specify


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Better documentation for --userns=keep-id:uid=X,gid=Y
```
