### PR TITLE
[CI:DOCS] Modify man page of "--pids-limit" option to correct a default value.

### DIFF
--- a/docs/source/markdown/options/pids-limit.md
+++ b/docs/source/markdown/options/pids-limit.md
@@ -4,4 +4,4 @@
 ####> are applicable to all of those.
 #### **--pids-limit**=*limit*
 
-Tune the container's pids limit. Set to **-1** to have unlimited pids for the container. The default is **4096** on systems that support "pids" cgroup controller.
+Tune the container's pids limit. Set to **-1** to have unlimited pids for the container. The default is **2048** on systems that support "pids" cgroup controller.


### PR DESCRIPTION
Correct the documented default number of pids limit from 4096 to 2048.

If 4096 is more reasonable as pids limit, the default value should be set to 4096.

https://github.com/containers/podman/blob/f7ac8a4213d71b13f358bcf1f1669d18b2d5f7e3/vendor/github.com/containers/common/pkg/config/default.go#L147-L149

Signed-off-by: Tsubasa Watanabe <w.tsubasa@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
