### PR TITLE
Add support for podman-remote manifest annotate

### DIFF
--- a/cmd/podman/manifest/annotate.go
+++ b/cmd/podman/manifest/annotate.go
@@ -13,7 +13,6 @@ import (
 var (
 	manifestAnnotateOpts = entities.ManifestAnnotateOptions{}
 	annotateCmd          = &cobra.Command{
-		Annotations:       map[string]string{registry.EngineMode: registry.ABIMode},
 		Use:               "annotate [options] LIST IMAGE",
 		Short:             "Add or update information about an entry in a manifest list or image index",
 		Long:              "Adds or updates information about an entry in a manifest list or image index.",

--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -530,13 +530,13 @@ func ManifestModify(w http.ResponseWriter, r *http.Request) {
 		}
 	case strings.EqualFold("annotate", body.Operation):
 		options := entities.ManifestAnnotateOptions{
-			Annotation: body.Annotation,
-			Arch:       body.Arch,
-			Features:   body.Features,
-			OS:         body.OS,
-			OSFeatures: body.OSFeatures,
-			OSVersion:  body.OSVersion,
-			Variant:    body.Variant,
+			Annotations: body.Annotations,
+			Arch:        body.Arch,
+			Features:    body.Features,
+			OS:          body.OS,
+			OSFeatures:  body.OSFeatures,
+			OSVersion:   body.OSVersion,
+			Variant:     body.Variant,
 		}
 		for _, image := range body.Images {
 			id, err := imageEngine.ManifestAnnotate(r.Context(), name, image, options)

--- a/test/apiv2/15-manifest.at
+++ b/test/apiv2/15-manifest.at
@@ -4,6 +4,7 @@
 
 start_registry
 
+# Creates the manifest list
 t POST /v3.4.0/libpod/manifests/create?name=abc 200 \
     .Id~[0-9a-f]\\{64\\}
 id_abc=$(jq -r '.Id' <<<"$output")
@@ -27,6 +28,7 @@ RUN >file2
 EOF
 )
 
+# manifest add --anotation tests
 t POST /v3.4.0/libpod/manifests/$id_abc/add images="[\"containers-storage:$id_abc_image\"]" 200
 t PUT /v4.0.0/libpod/manifests/$id_xyz operation='update' images="[\"containers-storage:$id_xyz_image\"]" annotations="{\"foo\":\"bar\"}" annotation="[\"hoge=fuga\"]" 400 \
     .cause='can not set both Annotation and Annotations'
@@ -39,6 +41,22 @@ t PUT /v4.0.0/libpod/manifests/$id_xyz operation='update' images="[\"containers-
 t GET /v4.0.0/libpod/manifests/$id_xyz/json 200 \
     .manifests[0].annotations.hoge="fuga"
 
+# manifest annotate tests
+t GET /v4.0.0/libpod/manifests/$id_xyz/json 200
+xyz_digest=$(jq -r '.manifests[0].digest' <<<"$output")
+
+t PUT /v4.0.0/libpod/manifests/$id_xyz operation='annotate' images="[\"containers-storage:$id_xyz_image\"]" annotations="{\"foo2\":\"bar2\"}" annotation="[\"hoge2=fuga2\"]" 400 \
+    .cause='can not set both Annotation and Annotations'
+
+t PUT /v4.0.0/libpod/manifests/$id_xyz operation='annotate' images="[\"$xyz_digest\"]" annotations="{\"foo2\":\"bar2\"}" 200
+t GET /v4.0.0/libpod/manifests/$id_xyz/json 200 \
+    .manifests[0].annotations.foo2="bar2"
+
+t PUT /v4.0.0/libpod/manifests/$id_xyz operation='annotate' images="[\"$xyz_digest\"]" annotation="[\"hoge2=fuga2\"]" 200
+t GET /v4.0.0/libpod/manifests/$id_xyz/json 200 \
+    .manifests[0].annotations.hoge2="fuga2"
+
+# registry-related tests
 t POST "/v3.4.0/libpod/manifests/abc:latest/push?destination=localhost:$REGISTRY_PORT%2Fabc:latest&tlsVerify=false&all=true" 200
 t POST "/v4.0.0/libpod/manifests/xyz:latest/registry/localhost:$REGISTRY_PORT%2Fxyz:latest?all=true" 400 \
   .cause='x509: certificate signed by unknown authority'

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -202,7 +202,6 @@ var _ = Describe("Podman manifest", func() {
 	})
 
 	It("annotate", func() {
-		SkipIfRemote("Not supporting annotate on remote connections")
 		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))


### PR DESCRIPTION
Now that podman manifest annotate is supported
in the remote environment.

Signed-off-by: Toshiki Sonoda <sonoda.toshiki@fujitsu.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Now that podman manifest annotate is supported in the remote environment.
```
