### PR TITLE
shell completion: fix hard coded network drivers

### DIFF
--- a/cmd/podman/common/completion.go
+++ b/cmd/podman/common/completion.go
@@ -1409,10 +1409,18 @@ func AutocompleteManifestFormat(cmd *cobra.Command, args []string, toComplete st
 }
 
 // AutocompleteNetworkDriver - Autocomplete network driver option.
-// -> "bridge", "macvlan"
 func AutocompleteNetworkDriver(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	drivers := []string{types.BridgeNetworkDriver, types.MacVLANNetworkDriver, types.IPVLANNetworkDriver}
-	return drivers, cobra.ShellCompDirectiveNoFileComp
+	engine, err := setupContainerEngine(cmd)
+	if err != nil {
+		cobra.CompErrorln(err.Error())
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	info, err := engine.Info(registry.Context())
+	if err != nil {
+		cobra.CompErrorln(err.Error())
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return info.Plugins.Network, cobra.ShellCompDirectiveNoFileComp
 }
 
 // AutocompleteNetworkIPAMDriver - Autocomplete network ipam driver option.


### PR DESCRIPTION
Depending on the backend (CNI, netavark) we support different drivers, the auto completion should only suggest the ones that are available.

This list is podman info so we can get the correct list for local and remote.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed incorrect shell completion suggestions for `podman network create --driver`.
```
