### PR TITLE
Quadlet: Add support for running podman kube play via .kube files

### DIFF
--- a/test/e2e/quadlet/basic.kube
+++ b/test/e2e/quadlet/basic.kube
@@ -1,0 +1,17 @@
+## assert-podman-args "kube"
+## assert-podman-args "play"
+## assert-podman-final-args deployment.yml
+## assert-podman-args "--replace"
+## assert-podman-args "--service-container=true"
+## assert-podman-stop-args "kube"
+## assert-podman-stop-args "down"
+## assert-podman-stop-final-args deployment.yml
+## assert-key-is "Unit" "RequiresMountsFor" "%t/containers"
+## assert-key-is "Service" "KillMode" "mixed"
+## assert-key-is "Service" "Type" "notify"
+## assert-key-is "Service" "NotifyAccess" "all"
+## assert-key-is "Service" "Environment" "PODMAN_SYSTEMD_UNIT=%n"
+
+
+[Kube]
+Yaml=deployment.yml


### PR DESCRIPTION
Currently, Quadlet support `.container` file which translated to a `podman run` call and `.volume` file which translates to `podman volume` call. This PR adds a new file type `.kube` which will translate to a `podman kube play` call. In its first version only one parameter is supported and that is the location of the K8S YAML file

#### Does this PR introduce a user-facing change?

```release-note
Quadlet: Add support for running podman kube play via .kube files
```

