### PR TITLE
pkginstaller: install podman-mac-helper by default

### DIFF
--- a/contrib/pkginstaller/scripts/postinstall
+++ b/contrib/pkginstaller/scripts/postinstall
@@ -6,3 +6,5 @@ echo "/opt/podman/bin" > /etc/paths.d/podman-pkg
 
 ln -s /opt/podman/bin/podman-mac-helper /opt/podman/qemu/bin/podman-mac-helper
 ln -s /opt/podman/bin/gvproxy /opt/podman/qemu/bin/gvproxy
+
+/opt/podman/bin/podman-mac-helper install


### PR DESCRIPTION
this runs the /opt/podman/bin/podman-mac-helper install in the postinstall script

[NO NEW TESTS NEEDED]

Signed-off-by: Anjan Nath <kaludios@gmail.com>

Fixes #16547 

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- macOS pkg installer now installs the podman-mac-helper tool by default
```
