### PR TITLE
E2E Tests: change the registry for the search test to avoid authentication

### DIFF
--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -454,7 +454,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search with wildcards", func() {
-		search := podmanTest.Podman([]string{"search", "registry.redhat.io/*openshift*"})
+		search := podmanTest.Podman([]string{"search", "registry.access.redhat.com/*openshift*"})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
 		Expect(len(search.OutputToStringArray())).To(BeNumerically(">", 1))


### PR DESCRIPTION
The current test uses registry.redhat.io which does not support unauthenticated access Replace the registry with registry.access.redhat.com which does.

See https://access.redhat.com/RegistryAuthentication for details

#### Does this PR introduce a user-facing change?

```release-note
None
```
