### PR TITLE
ssh system test: skip until it becomes a test

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -301,10 +301,6 @@ function wait_for_file() {
 # BEGIN miscellaneous tools
 
 # Shortcuts for common needs:
-function no_ssh() {
-    [ "$(man ssh)" -ne 0 ]
-}
-
 function is_ubuntu() {
     grep -qiw ubuntu /etc/os-release
 }


### PR DESCRIPTION
The 900-ssh test is not an actual test, and I'm unable to
figure out how to make it one. Skip it for now, but add a
bunch of FIXMEs some someone can come in later and actually
implement it.

Also removed lots of dead code and misleading comments.

Signed-off-by: Ed Santiago <santiago@redhat.com>
```release-note
None
```