### PR TITLE
[skip-ci] GHA: Fix cirrus re-run workflow for other repos.

### DIFF
--- a/.github/workflows/rerun_cirrus_cron.yml
+++ b/.github/workflows/rerun_cirrus_cron.yml
@@ -44,6 +44,9 @@ jobs:
         steps:
             - uses: actions/checkout@v3
               with:
+                  # All scripts used by this workflow live in podman repo.
+                  repository: "containers/podman"
+                  ref: "main"
                   persist-credentials: false
 
             - name: Get failed cron names and Build IDs


### PR DESCRIPTION
The checkout action by default, clones the current repository.  However, since this workflow is re-used by other repos, and it calls scripts in the podman repo, those calls will all fail.  Fix this by hard-coding the podman repo.

Ref: https://github.com/actions/checkout

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
