### PR TITLE
[CI:DOCS] Migrate OSX Cross to M1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -393,7 +393,7 @@ osx_alt_build_task:
         TEST_FLAVOR: "altbuild"
         ALT_NAME: 'OSX Cross'
     osx_instance:
-        image: 'big-sur-base'
+        image: ghcr.io/cirruslabs/macos-ventura-base:latest
     setup_script:
         - brew install go
         - brew install go-md2man

--- a/Makefile
+++ b/Makefile
@@ -268,8 +268,10 @@ volume-plugin-test-img:
 test/goecho/goecho: $(wildcard test/goecho/*.go)
 	$(GOCMD) build $(BUILDFLAGS) $(GO_LDFLAGS) '$(LDFLAGS_PODMAN)' -o $@ ./test/goecho
 
+# The ./test/version/version binary is executed in other make steps
+# so we have to make sure the version binary is built for NATIVE_GOARCH.
 test/version/version: version/version.go
-	$(GO) build -o $@ ./test/version/
+	GOARCH=$(NATIVE_GOARCH) $(GO) build -o $@ ./test/version/
 
 .PHONY: codespell
 codespell:


### PR DESCRIPTION
Migrate our OSX Cross build to a M1 instance, since Cirrus is sunsetting Intel-based macOS instances.

Signed-off-by: Ashley Cui <acui@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
