### PR TITLE
specgen: support CDI devices from containers.conf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.1.1
 	github.com/containers/buildah v1.28.1-0.20221122135051-c9f30d81ae37
-	github.com/containers/common v0.50.2-0.20221121202831-385be9a25125
+	github.com/containers/common v0.50.2-0.20221125103214-33a7a35ff671
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.23.1-0.20221121174826-d8eb9dd60533
 	github.com/containers/ocicrypt v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/containernetworking/plugins v1.1.1 h1:+AGfFigZ5TiQH00vhR8qPeSatj53eNG
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
 github.com/containers/buildah v1.28.1-0.20221122135051-c9f30d81ae37 h1:XwZSJY+6fHAFp+6/TnG6IowKSBCR2BRn4iHgrMi4ks4=
 github.com/containers/buildah v1.28.1-0.20221122135051-c9f30d81ae37/go.mod h1:0HcSoS6BHXWzMKqtxY1L0gupebEX33oPC+X62lPi6+c=
-github.com/containers/common v0.50.2-0.20221121202831-385be9a25125 h1:xNFc3vQA1QaqTKvjy0E4B7maflTTKMSzCgsScdlqETg=
-github.com/containers/common v0.50.2-0.20221121202831-385be9a25125/go.mod h1:Oq+8c+9jzXe/57g9A95jXD4gWRc9T1TW0uC0WGm07sk=
+github.com/containers/common v0.50.2-0.20221125103214-33a7a35ff671 h1:bwTTW4lq5fLvYBJcOxMovk3YX8FANhQzrZ0+1R7am4k=
+github.com/containers/common v0.50.2-0.20221125103214-33a7a35ff671/go.mod h1:rzuZglPq/5sz6n29nhyDPCXh44CZymkCR2sacEZb7zw=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.23.1-0.20221121174826-d8eb9dd60533 h1:VxrXA+okqhSOLOBtprMwbd1oJCUFTZowW3diaRmRGQw=

--- a/pkg/specgen/generate/config_linux.go
+++ b/pkg/specgen/generate/config_linux.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/rootless"
 	"github.com/containers/podman/v4/pkg/util"
@@ -19,6 +20,19 @@ import (
 
 // DevicesFromPath computes a list of devices
 func DevicesFromPath(g *generate.Generator, devicePath string) error {
+	if isCDIDevice(devicePath) {
+		registry := cdi.GetRegistry(
+			cdi.WithAutoRefresh(false),
+		)
+		if err := registry.Refresh(); err != nil {
+			logrus.Debugf("The following error was triggered when refreshing the CDI registry: %v", err)
+		}
+		_, err := registry.InjectDevices(g.Config, devicePath)
+		if err != nil {
+			return fmt.Errorf("setting up CDI devices: %w", err)
+		}
+		return nil
+	}
 	devs := strings.Split(devicePath, ":")
 	resolvedDevicePath := devs[0]
 	// check if it is a symbolic link

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -1,14 +1,29 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	. "github.com/containers/podman/v4/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 )
+
+func createContainersConfFileWithDevices(pTest *PodmanTestIntegration, devices string) {
+	configPath := filepath.Join(pTest.TempDir, "containers.conf")
+	containersConf := []byte(fmt.Sprintf("[containers]\ndevices = [%s]\n", devices))
+	err := os.WriteFile(configPath, containersConf, os.ModePerm)
+	Expect(err).To(BeNil())
+
+	// Set custom containers.conf file
+	os.Setenv("CONTAINERS_CONF", configPath)
+	if IsRemote() {
+		pTest.RestartRemoteService()
+	}
+}
 
 var _ = Describe("Podman run device", func() {
 	var (
@@ -30,7 +45,7 @@ var _ = Describe("Podman run device", func() {
 		podmanTest.Cleanup()
 		f := CurrentGinkgoTestDescription()
 		processTestResult(f)
-
+		os.Unsetenv("CONTAINERS_CONF")
 	})
 
 	It("podman run bad device test", func() {
@@ -114,6 +129,11 @@ var _ = Describe("Podman run device", func() {
 		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "vendor.com/device=myKmsg", ALPINE, "test", "-c", "/dev/kmsg1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(Exit(0))
+
+		createContainersConfFileWithDevices(podmanTest, "\"vendor.com/device=myKmsg\"")
+		session = podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", ALPINE, "test", "-c", "/dev/kmsg1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 	})

--- a/vendor/github.com/containers/common/libnetwork/cni/config.go
+++ b/vendor/github.com/containers/common/libnetwork/cni/config.go
@@ -36,6 +36,9 @@ func (n *cniNetwork) NetworkCreate(net types.Network) (types.Network, error) {
 // networkCreate will fill out the given network struct and return the new network entry.
 // If defaultNet is true it will not validate against used subnets and it will not write the cni config to disk.
 func (n *cniNetwork) networkCreate(newNetwork *types.Network, defaultNet bool) (*network, error) {
+	if len(newNetwork.NetworkDNSServers) > 0 {
+		return nil, fmt.Errorf("NetworkDNSServers cannot be configured for backend CNI: %w", types.ErrInvalidArg)
+	}
 	// if no driver is set use the default one
 	if newNetwork.Driver == "" {
 		newNetwork.Driver = types.DefaultNetworkDriver

--- a/vendor/github.com/containers/common/libnetwork/netavark/config.go
+++ b/vendor/github.com/containers/common/libnetwork/netavark/config.go
@@ -137,6 +137,17 @@ func (n *netavarkNetwork) networkCreate(newNetwork *types.Network, defaultNet bo
 	// when we do not have ipam we must disable dns
 	internalutil.IpamNoneDisableDNS(newNetwork)
 
+	// process NetworkDNSServers
+	if len(newNetwork.NetworkDNSServers) > 0 && !newNetwork.DNSEnabled {
+		return nil, fmt.Errorf("Cannot set NetworkDNSServers if DNS is not enabled for the network: %w", types.ErrInvalidArg)
+	}
+	// validate ip address
+	for _, dnsServer := range newNetwork.NetworkDNSServers {
+		if net.ParseIP(dnsServer) == nil {
+			return nil, fmt.Errorf("Unable to parse ip %s specified in NetworkDNSServers: %w", dnsServer, types.ErrInvalidArg)
+		}
+	}
+
 	// add gateway when not internal or dns enabled
 	addGateway := !newNetwork.Internal || newNetwork.DNSEnabled
 	err = internalutil.ValidateSubnets(newNetwork, addGateway, usedNetworks)

--- a/vendor/github.com/containers/common/libnetwork/types/network.go
+++ b/vendor/github.com/containers/common/libnetwork/types/network.go
@@ -56,6 +56,10 @@ type Network struct {
 	// DNSEnabled is whether name resolution is active for container on
 	// this Network. Only supported with the bridge driver.
 	DNSEnabled bool `json:"dns_enabled"`
+	// List of custom DNS server for podman's DNS resolver at network level,
+	// all the containers attached to this network will consider resolvers
+	// configured at network level.
+	NetworkDNSServers []string `json:"network_dns_servers,omitempty"`
 	// Labels is a set of key-value labels that have been applied to the
 	// Network.
 	Labels map[string]string `json:"labels,omitempty"`

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -214,6 +214,7 @@ type ContainersConfig struct {
 	UserNS string `toml:"userns,omitempty"`
 
 	// UserNSSize how many UIDs to allocate for automatically created UserNS
+	// Deprecated: no user of this field is known.
 	UserNSSize int `toml:"userns_size,omitempty,omitzero"`
 }
 

--- a/vendor/github.com/containers/common/pkg/config/config_local.go
+++ b/vendor/github.com/containers/common/pkg/config/config_local.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	units "github.com/docker/go-units"
 )
 
@@ -57,6 +58,9 @@ func (c *EngineConfig) validatePaths() error {
 
 func (c *ContainersConfig) validateDevices() error {
 	for _, d := range c.Devices {
+		if cdi.IsQualifiedName(d) {
+			continue
+		}
 		_, _, _, err := Device(d)
 		if err != nil {
 			return err

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -244,12 +244,6 @@ default_sysctls = [
 #
 #userns = "host"
 
-# Number of UIDs to allocate for the automatic container creation.
-# UIDs are allocated from the "container" UIDs listed in
-# /etc/subuid & /etc/subgid
-#
-#userns_size = 65536
-
 # Default way to to create a UTS namespace for the container
 # Options are:
 # `private`        Create private UTS Namespace for the container.

--- a/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf-freebsd
@@ -212,12 +212,6 @@ default_sysctls = [
 #
 #userns = "host"
 
-# Number of UIDs to allocate for the automatic container creation.
-# UIDs are allocated from the "container" UIDs listed in
-# /etc/subuid & /etc/subgid
-#
-#userns_size = 65536
-
 # Default way to to create a UTS namespace for the container
 # Options are:
 # `private`        Create private UTS Namespace for the container.

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -158,6 +158,7 @@ const (
 	// DefaultShmSize is the default upper limit on the size of tmpfs mounts.
 	DefaultShmSize = "65536k"
 	// DefaultUserNSSize indicates the default number of UIDs allocated for user namespace within a container.
+	// Deprecated: no user of this field is known.
 	DefaultUserNSSize = 65536
 	// OCIBufSize limits maximum LogSizeMax.
 	OCIBufSize = 8192
@@ -232,7 +233,7 @@ func DefaultConfig() (*Config, error) {
 			TZ:         "",
 			Umask:      "0022",
 			UTSNS:      "private",
-			UserNSSize: DefaultUserNSSize,
+			UserNSSize: DefaultUserNSSize, // Deprecated
 		},
 		Network: NetworkConfig{
 			DefaultNetwork:     "podman",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -118,7 +118,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.50.2-0.20221121202831-385be9a25125
+# github.com/containers/common v0.50.2-0.20221125103214-33a7a35ff671
 ## explicit; go 1.17
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define


### PR DESCRIPTION
Closes: https://github.com/containers/podman/issues/16232

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

Needs: https://github.com/containers/common/pull/1239

```release-note
It is now possible to specify CDI devices in the containers.conf file
```
