### PR TITLE
Kube Play: Add argument for default pod spec

### DIFF
--- a/cmd/podman/kube/down.go
+++ b/cmd/podman/kube/down.go
@@ -5,6 +5,7 @@ import (
 	"github.com/containers/podman/v4/cmd/podman/registry"
 	"github.com/containers/podman/v4/cmd/podman/utils"
 	"github.com/containers/podman/v4/pkg/domain/entities"
+	gUtils "github.com/containers/podman/v4/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +49,7 @@ func downFlags(cmd *cobra.Command) {
 }
 
 func down(cmd *cobra.Command, args []string) error {
-	reader, err := readerFromArg(args[0])
+	reader, err := gUtils.ReaderFromArg(args[0])
 	if err != nil {
 		return err
 	}

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -62,6 +62,8 @@ type PlayKubeOptions struct {
 	IsRemote bool
 	// Force - remove volumes on --down
 	Force bool
+	// PodDefaults - path to a YAML file with defaults values for pods
+	PodDefaults string
 }
 
 // PlayKubePod represents a single pod and associated containers created by play kube


### PR DESCRIPTION
The new argument `pod-defaults` is a path to a Pod Spec file for Podman to use to set default values for keys that were not set in the provided YAML file

#### Does this PR introduce a user-facing change?

```release-note
Kube Play: Add the argument pod-defaults for default pod spec to allow the caller to set default values for fields that are not set in the manifest file
```
