### PR TITLE
[CI:DOCS] Remove broken gate-container docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,49 +309,7 @@ podman build -t gate -f contrib/gate/Dockerfile .
 
 ***N/B:*** **don't miss the dot (.) at the end, it's really important**
 
-#### Local use of gate container
-
-The gate container's entry-point executes 'make' by default, on a copy of
-the repository made at runtime.  This avoids the container changing or
-leaving build artifacts in your hosts working directory.  It also guarantees
-every execution is based upon pristine code provided from the host.
-
-Execution does not require any special permissions from the host. However,
-your Podman repository clone's root must be bind-mounted to the container at
-'/usr/src/libpod'.  The copy will be made into /var/tmp/go (`$GOSRC` in container)
-before running your make target.  For example, running `make lint` from a
-repository clone at $HOME/devel/podman could be done with the commands:
-
-```bash
-$ cd $HOME/devel/podman
-$ podman run -it --rm -v $PWD:/usr/src/libpod:ro \
-    --security-opt label=disable quay.io/libpod/gate:master \
-    lint
-```
-
-***N/B:*** Depending on your clone's git remotes-configuration,
-(esp. for `validate` and `lint` targets), you may also need to reference the
-commit which was your upstream fork-point.  Otherwise you may receive an error
-similar to:
-
-```
-fatal: Not a valid object name master
-Makefile:152: *** Required variable EPOCH_TEST_COMMIT value is undefined, whitespace, or empty.  Stop.
-```
-
-For example, assuming your have a remote called `upstream` running the
-validate target should be done like this:
-
-```bash
-$ cd $HOME/devel/podman
-$ git remote update upstream
-$ export EPOCH_TEST_COMMIT=$(git merge-base upstream/master HEAD)
-$ podman run -it --rm -e EPOCH_TEST_COMMIT -v $PWD:/usr/src/libpod:ro \
-    --security-opt label=disable quay.io/libpod/gate:master \
-    validate
-```
-
-### Integration and Other Tests
+### Integration Tests
 
 Our primary means of performing integration testing for Podman is with the
 [Ginkgo](https://github.com/onsi/ginkgo) BDD testing framework. This allows


### PR DESCRIPTION
This container hasn't been used/maintained in ages, remove the related instructions from the contributions doc.

Fixes: #16415

Signed-off-by: Chris Evich <cevich@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
