### PR TITLE
[release-v4.3] vendor: bump buildah to `v1.28.1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/container-orchestrated-devices/container-device-interface v0.5.2
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.1.1
-	github.com/containers/buildah v1.28.0
+	github.com/containers/buildah v1.28.2
 	github.com/containers/common v0.50.1
 	github.com/containers/conmon v2.0.20+incompatible
 	github.com/containers/image/v5 v5.23.1

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRD
 github.com/containernetworking/plugins v1.0.1/go.mod h1:QHCfGpaTwYTbbH+nZXKVTxNBDZcxSOplJT5ico8/FLE=
 github.com/containernetworking/plugins v1.1.1 h1:+AGfFigZ5TiQH00vhR8qPeSatj53eNGz0C1d3wVYlHE=
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
-github.com/containers/buildah v1.28.0 h1:63Kpf9nAEJGsDEOArb5Q0dn5S3B9wFQc9kST4nU7+Pw=
-github.com/containers/buildah v1.28.0/go.mod h1:pTYSfpf+Ha/KbnMmwhhhEjkSF3NuhpxZfiDNDORLgqY=
+github.com/containers/buildah v1.28.2 h1:a7PyBE04nTbOtx/JQ12tnNLZJhPkSg7ePvR6FIgQZOE=
+github.com/containers/buildah v1.28.2/go.mod h1:pTYSfpf+Ha/KbnMmwhhhEjkSF3NuhpxZfiDNDORLgqY=
 github.com/containers/common v0.50.1 h1:AYRAf1xyahNVRez49KIkREInNf36SQx1lyLY9M95wQI=
 github.com/containers/common v0.50.1/go.mod h1:XnWlXPyE9Ky+8v8MfYWJZFnejkprAkUeo0DTWmSiwcY=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=

--- a/test/buildah-bud/run-buildah-bud-tests
+++ b/test/buildah-bud/run-buildah-bud-tests
@@ -183,18 +183,6 @@ You will want to:
 "
     (set -x;git am --reject <$PATCHES)
 
-    # FIXME FIXME FIXME! Remove this once buildah 4377 has made its way
-    # into this podman branch.
-    if ! grep -q SAFEIMAGE tests/helpers.bash; then
-        failhint="
-You are vendoring a new buildah. Please edit $0
-and remove the block between the FIXMEs.
-Also remove safeimage-patch.diff.
-"
-        (set -x;git am --reject <${BUD_TEST_DIR}/safeimage-patch.diff)
-    fi
-    # FIXME FIXME FIXME! Remove down to here.
-
     # Now apply our custom skips and error-message changes. This is maintained
     # in a custom script, not a .diff file, because diffs are WAY too hard for
     # humans to read and update.

--- a/vendor/github.com/containers/buildah/CHANGELOG.md
+++ b/vendor/github.com/containers/buildah/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 # Changelog
 
+## v1.28.2 (2022-11-23)
+
+   Define and use a safe, reliable test image
+   Stop using ubi8
+
+## v1.28.1 (2022-11-19)
+
+   copier.Put(): clear up os/syscall mode bit confusion
+
 ## v1.28.0 (2022-09-30)
 
     Update vendor containers/(common,image)

--- a/vendor/github.com/containers/buildah/changelog.txt
+++ b/vendor/github.com/containers/buildah/changelog.txt
@@ -1,3 +1,10 @@
+- Changelog for v1.28.2 (2022-11-23)
+  * Define and use a safe, reliable test image
+  * Stop using ubi8
+
+- Changelog for v1.28.1 (2022-11-19)
+  * copier.Put(): clear up os/syscall mode bit confusion
+
 - Changelog for v1.28.0 (2022-09-30)
   * Update vendor containers/(common,image)
   * [CI:DOCS] Add quay-description update reminder

--- a/vendor/github.com/containers/buildah/define/types.go
+++ b/vendor/github.com/containers/buildah/define/types.go
@@ -30,7 +30,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.28.0"
+	Version = "1.28.2"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -97,7 +97,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/containernetworking/plugins v1.1.1
 ## explicit; go 1.17
 github.com/containernetworking/plugins/pkg/ns
-# github.com/containers/buildah v1.28.0
+# github.com/containers/buildah v1.28.2
 ## explicit; go 1.17
 github.com/containers/buildah
 github.com/containers/buildah/bind


### PR DESCRIPTION
Contains backport of https://github.com/containers/buildah/pull/4411

[NO NEW TESTS NEEDED]
[NO TESTS NEEDED]