### PR TITLE
add support for --ssh=native in podman-remote

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -185,6 +185,8 @@ setup_rootless() {
     chmod -R 700 "$HOME/.ssh"
     chmod -R 700 "/home/$ROOTLESS_USER/.ssh"
     chown -R $ROOTLESS_USER:$ROOTLESS_USER "/home/$ROOTLESS_USER/.ssh"
+    cp /etc/ssh/ssh_config $HOME/.ssh/config
+    cp /etc/ssh/ssh_config /home/$ROOTLESS_USER/.ssh/config
 
     # N/B: We're clobbering the known_hosts here on purpose.  There should
     # never be any non-localhost connections made from tests (using strict-mode).

--- a/go.mod
+++ b/go.mod
@@ -144,3 +144,5 @@ require (
 )
 
 replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc
+
+replace github.com/containers/common => github.com/cdoern/common v0.38.5-0.20221221153746-3e46d5c7cc75

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/cdoern/common v0.38.5-0.20221221153746-3e46d5c7cc75 h1:CoI8N4HvWp/pI5CPmXNIIK5674sSNWgr3CKoiJQg50Q=
+github.com/cdoern/common v0.38.5-0.20221221153746-3e46d5c7cc75/go.mod h1:zOsh8liNqXFOnudQxZ4nsXl1oxbCQ69OxkwuQlmEQ2U=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -264,8 +266,6 @@ github.com/containernetworking/plugins v1.1.1 h1:+AGfFigZ5TiQH00vhR8qPeSatj53eNG
 github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
 github.com/containers/buildah v1.28.1-0.20221219201600-ca578b290144 h1:2RQIBdC4z6JeUysEBFmdyRjeQL+XHikWGxDoWiPDsAw=
 github.com/containers/buildah v1.28.1-0.20221219201600-ca578b290144/go.mod h1:UtGNHlAwNF1WV/Z63R/sPgxItTog/YPi/1gSfZ8ZdpE=
-github.com/containers/common v0.50.2-0.20221216120044-ef7e0d6f3002 h1:wvT0IrvGcZ0tEAvF1CYjaI6xjQjXr4vDnrlHRAYEo0Q=
-github.com/containers/common v0.50.2-0.20221216120044-ef7e0d6f3002/go.mod h1:EhEJRALj8qJWhnnzk6nY6wqDkSjfGpU2DwcLb9UpVoM=
 github.com/containers/conmon v2.0.20+incompatible h1:YbCVSFSCqFjjVwHTPINGdMX1F6JXHGTUje2ZYobNrkg=
 github.com/containers/conmon v2.0.20+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.23.1-0.20221216122512-3963f229df32 h1:buu4aAeaGmzQARE8fKCgrv8LozD7L1mmWR0NUvndUDE=

--- a/pkg/domain/infra/runtime_abi.go
+++ b/pkg/domain/infra/runtime_abi.go
@@ -21,7 +21,7 @@ func NewContainerEngine(facts *entities.PodmanConfig) (entities.ContainerEngine,
 		r, err := NewLibpodRuntime(facts.FlagSet, facts)
 		return r, err
 	case entities.TunnelMode:
-		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), facts.URI, facts.Identity, facts.MachineMode)
+		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), facts.URI, facts.Identity, facts.MachineMode, facts.SSHMode)
 		return &tunnel.ContainerEngine{ClientCtx: ctx}, err
 	}
 	return nil, fmt.Errorf("runtime mode '%v' is not supported", facts.EngineMode)
@@ -35,7 +35,7 @@ func NewImageEngine(facts *entities.PodmanConfig) (entities.ImageEngine, error) 
 		return r, err
 	case entities.TunnelMode:
 		// TODO: look at me!
-		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), facts.URI, facts.Identity, facts.MachineMode)
+		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), facts.URI, facts.Identity, facts.MachineMode, facts.SSHMode)
 		return &tunnel.ImageEngine{ClientCtx: ctx}, err
 	}
 	return nil, fmt.Errorf("runtime mode '%v' is not supported", facts.EngineMode)

--- a/pkg/domain/infra/runtime_tunnel.go
+++ b/pkg/domain/infra/runtime_tunnel.go
@@ -18,12 +18,12 @@ var (
 	connection      *context.Context
 )
 
-func newConnection(uri string, identity string, machine bool) (context.Context, error) {
+func newConnection(uri string, identity string, machine bool, sshMode string) (context.Context, error) {
 	connectionMutex.Lock()
 	defer connectionMutex.Unlock()
 
 	if connection == nil {
-		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), uri, identity, machine)
+		ctx, err := bindings.NewConnectionWithIdentity(context.Background(), uri, identity, machine, sshMode)
 		if err != nil {
 			return ctx, err
 		}
@@ -37,7 +37,7 @@ func NewContainerEngine(facts *entities.PodmanConfig) (entities.ContainerEngine,
 	case entities.ABIMode:
 		return nil, fmt.Errorf("direct runtime not supported")
 	case entities.TunnelMode:
-		ctx, err := newConnection(facts.URI, facts.Identity, facts.MachineMode)
+		ctx, err := newConnection(facts.URI, facts.Identity, facts.MachineMode, facts.SSHMode)
 		return &tunnel.ContainerEngine{ClientCtx: ctx}, err
 	}
 	return nil, fmt.Errorf("runtime mode '%v' is not supported", facts.EngineMode)
@@ -49,7 +49,7 @@ func NewImageEngine(facts *entities.PodmanConfig) (entities.ImageEngine, error) 
 	case entities.ABIMode:
 		return nil, fmt.Errorf("direct image runtime not supported")
 	case entities.TunnelMode:
-		ctx, err := newConnection(facts.URI, facts.Identity, facts.MachineMode)
+		ctx, err := newConnection(facts.URI, facts.Identity, facts.MachineMode, facts.SSHMode)
 		return &tunnel.ImageEngine{ClientCtx: ctx}, err
 	}
 	return nil, fmt.Errorf("runtime mode '%v' is not supported", facts.EngineMode)

--- a/test/e2e/system_connection_test.go
+++ b/test/e2e/system_connection_test.go
@@ -262,7 +262,6 @@ var _ = Describe("podman system connection", func() {
 					os.Unsetenv("PODMAN_BINARY")
 				}()
 			}
-
 			cmd := exec.Command(podmanTest.RemotePodmanBinary,
 				"system", "connection", "add",
 				"--default",
@@ -272,9 +271,14 @@ var _ = Describe("podman system connection", func() {
 
 			session, err := Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("%q failed to execute", podmanTest.RemotePodmanBinary))
-			Eventually(session, DefaultWaitTimeout).Should(Exit(0))
+			Eventually(session, DefaultWaitTimeout).Should(Exit(0), string(session.Err.Contents())+" "+string(session.Out.Contents()))
 			Expect(session.Out.Contents()).Should(BeEmpty())
 			Expect(session.Err.Contents()).Should(BeEmpty())
+
+			cmd = exec.Command(podmanTest.RemotePodmanBinary,
+				"--ssh", "native", "--connection", "QA", "ps")
+			_, err = Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).ToNot(HaveOccurred())
 
 			cmd = exec.Command(podmanTest.RemotePodmanBinary,
 				"--connection", "QA", "ps")

--- a/vendor/github.com/containers/common/pkg/ssh/connection_golang.go
+++ b/vendor/github.com/containers/common/pkg/ssh/connection_golang.go
@@ -82,7 +82,7 @@ func golangConnectionDial(options ConnectionDialOptions) (*ConnectionDialReport,
 		return nil, fmt.Errorf("failed to connect: %w", err)
 	}
 
-	return &ConnectionDialReport{dial}, nil
+	return &ConnectionDialReport{Client: dial}, nil
 }
 
 func golangConnectionExec(options ConnectionExecOptions) (*ConnectionExecReport, error) {

--- a/vendor/github.com/containers/common/pkg/ssh/ssh.go
+++ b/vendor/github.com/containers/common/pkg/ssh/ssh.go
@@ -1,11 +1,5 @@
 package ssh
 
-import (
-	"fmt"
-
-	"golang.org/x/crypto/ssh"
-)
-
 func Create(options *ConnectionCreateOptions, kind EngineMode) error {
 	if kind == NativeMode {
 		return nativeConnectionCreate(*options)
@@ -13,17 +7,18 @@ func Create(options *ConnectionCreateOptions, kind EngineMode) error {
 	return golangConnectionCreate(*options)
 }
 
-func Dial(options *ConnectionDialOptions, kind EngineMode) (*ssh.Client, error) {
+func Dial(options *ConnectionDialOptions, kind EngineMode) (*ConnectionDialReport, error) {
 	var rep *ConnectionDialReport
 	var err error
 	if kind == NativeMode {
-		return nil, fmt.Errorf("ssh dial failed: you cannot create a dial-able client with native ssh")
+		rep, err = nativeConnectionDial(*options)
+	} else {
+		rep, err = golangConnectionDial(*options)
 	}
-	rep, err = golangConnectionDial(*options)
 	if err != nil {
 		return nil, err
 	}
-	return rep.Client, nil
+	return rep, nil
 }
 
 func Exec(options *ConnectionExecOptions, kind EngineMode) (string, error) {
@@ -31,14 +26,11 @@ func Exec(options *ConnectionExecOptions, kind EngineMode) (string, error) {
 	var err error
 	if kind == NativeMode {
 		rep, err = nativeConnectionExec(*options)
-		if err != nil {
-			return "", err
-		}
 	} else {
 		rep, err = golangConnectionExec(*options)
-		if err != nil {
-			return "", err
-		}
+	}
+	if err != nil {
+		return "", err
 	}
 	return rep.Response, nil
 }

--- a/vendor/github.com/containers/common/pkg/ssh/types.go
+++ b/vendor/github.com/containers/common/pkg/ssh/types.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"net"
 	"net/url"
 	"time"
 
@@ -28,6 +29,7 @@ type ConnectionCreateOptions struct {
 
 type ConnectionDialOptions struct {
 	Host                        string
+	Unix                        *url.URL
 	Identity                    string
 	User                        *url.Userinfo
 	Port                        int
@@ -37,6 +39,7 @@ type ConnectionDialOptions struct {
 }
 
 type ConnectionDialReport struct {
+	Conn   net.Conn
 	Client *ssh.Client
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -118,7 +118,7 @@ github.com/containers/buildah/pkg/rusage
 github.com/containers/buildah/pkg/sshagent
 github.com/containers/buildah/pkg/util
 github.com/containers/buildah/util
-# github.com/containers/common v0.50.2-0.20221216120044-ef7e0d6f3002
+# github.com/containers/common v0.50.2-0.20221216120044-ef7e0d6f3002 => github.com/cdoern/common v0.38.5-0.20221221153746-3e46d5c7cc75
 ## explicit; go 1.17
 github.com/containers/common/libimage
 github.com/containers/common/libimage/define
@@ -971,3 +971,4 @@ gopkg.in/yaml.v3
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.1-0.20220617142545-8b9452f75cbc
+# github.com/containers/common => github.com/cdoern/common v0.38.5-0.20221221153746-3e46d5c7cc75


### PR DESCRIPTION
podman's new global flag --sah=native only works with scp and system connection add at the moment modify this so that --ssh=native can be used with podman-remote. This means users can plug in their custom ssh config and known_host files.

Signed-off-by: Charlie Doern <cbddoern@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add support for --ssh=native in all podman-remote use cases
```
