### PR TITLE
Documenting Hyper-V QEMU acceleration settings

### DIFF
--- a/pkg/machine/qemu/options_windows_amd64.go
+++ b/pkg/machine/qemu/options_windows_amd64.go
@@ -5,6 +5,10 @@ var (
 )
 
 func (v *MachineVM) addArchOptions() []string {
+	// "max" level is used, because "host" is not supported with "whpx" acceleration
+	// "vmx=off" disabled nested virtualization (not needed for podman)
+	// QEMU issue to track nested virtualization: https://gitlab.com/qemu-project/qemu/-/issues/628
+	// "monitor=off" needed to support hosts, which have mwait calls disabled in BIOS/UEFI
 	opts := []string{"-machine", "q35,accel=whpx:tcg", "-cpu", "max,vmx=off,monitor=off"}
 	return opts
 }


### PR DESCRIPTION
Follow up to #15851 as it was merged before I managed to update it.

Also, I did some more investigation on  mwait_idle kernel panic. It seems that some hardware goes with this flag disabled and it is known to cause issues for Hyper-V VMs (one case documented here (for Windows VMs though) https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000LV1aSAG).

I didn't manage to debug down if either Hyper-V, host or both wrongly detect MONITOR/MWAIT presence, but I think putting this to `monitor=off` is also good for improved portability and wider host support.

Signed-off-by: Arthur Sengileyev <arthur.sengileyev@gmail.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
[NO NEW TESTS NEEDED]