### PR TITLE
Add validate-in-container target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,13 +289,21 @@ vendor:
 	$(GO) mod vendor
 	$(GO) mod verify
 
-.PHONY: vendor-in-container
-vendor-in-container:
-	podman run --rm --env HOME=/root \
+
+# We define *-in-container targets for the following make targets. This allow the targets to be run in a container.
+# Note that the PODMANCMD can also be overridden to allow a different container CLI to be used on systems where podman is not already available.
+IN_CONTAINER_TARGETS = vendor validate
+PODMANCMD ?= podman
+IN_CONTAINER = $(patsubst %,%-in-container,$(IN_CONTAINER_TARGETS))
+
+.PHONY: $(IN_CONTAINER)
+$(IN_CONTAINER): %-in-container:
+	$(PODMANCMD) run --rm --env HOME=/root \
 		-v $(CURDIR):/src -w /src \
 		--security-opt label=disable \
 		docker.io/library/golang:1.17 \
-		make vendor
+		make $(*)
+
 
 ###
 ### Primary binary-build targets


### PR DESCRIPTION
This change adds a validate-in-container make target that can be used to run the make validate target in a container instead of requiring the dependencies to be available on the system. This mirrors what is already done for the vendor target and allows additional targets to be added.

A PODMANCMD make variable is also added to allow for the podman binary to be overridden in cases where this is not available.

Signed-off-by: Evan Lezar <elezar@nvidia.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
