### PR TITLE
pkg/trust: Take the default policy path from c/common/pkg/config

### DIFF
--- a/pkg/trust/policy.go
+++ b/pkg/trust/policy.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containers/common/pkg/config"
 	"github.com/containers/image/v5/types"
 	"github.com/sirupsen/logrus"
 )
@@ -53,7 +54,7 @@ type genericRepoMap map[string]json.RawMessage
 
 // DefaultPolicyPath returns a path to the default policy of the system.
 func DefaultPolicyPath(sys *types.SystemContext) string {
-	systemDefaultPolicyPath := "/etc/containers/policy.json"
+	systemDefaultPolicyPath := config.DefaultSignaturePolicyPath
 	if sys != nil {
 		if sys.SignaturePolicyPath != "" {
 			return sys.SignaturePolicyPath


### PR DESCRIPTION
This reduces the number of places default policy path is defined to two. Ideally there would be only one but that seems to be difficult - see https://github.com/containers/image/pull/1725 for some context.

#### Does this PR introduce a user-facing change?

```release-note
None
```
