### PR TITLE
Fix swapped NetInput/-Output stats

### DIFF
--- a/libpod/stats_freebsd.go
+++ b/libpod/stats_freebsd.go
@@ -82,8 +82,8 @@ func (c *Container) getPlatformContainerStats(stats *define.ContainerStats, prev
 
 	// Handle case where the container is not in a network namespace
 	if netStats != nil {
-		stats.NetInput = netStats.TxBytes
-		stats.NetOutput = netStats.RxBytes
+		stats.NetInput = netStats.RxBytes
+		stats.NetOutput = netStats.TxBytes
 	} else {
 		stats.NetInput = 0
 		stats.NetOutput = 0

--- a/libpod/stats_linux.go
+++ b/libpod/stats_linux.go
@@ -72,8 +72,8 @@ func (c *Container) getPlatformContainerStats(stats *define.ContainerStats, prev
 	stats.PerCPU = cgroupStats.CpuStats.CpuUsage.PercpuUsage
 	// Handle case where the container is not in a network namespace
 	if netStats != nil {
-		stats.NetInput = netStats.TxBytes
-		stats.NetOutput = netStats.RxBytes
+		stats.NetInput = netStats.RxBytes
+		stats.NetOutput = netStats.TxBytes
 	} else {
 		stats.NetInput = 0
 		stats.NetOutput = 0


### PR DESCRIPTION
Fix swapped NetInput and NetOutput container stats. This resulted in `podman stats` showing outgoing traffic as NetInput and incoming traffic as NetOutput. This change might be visible or cause problems for users who are actively relying on those stats for monitoring reasons.

Signed-off-by: Ingo Becker <ingo@orgizm.net>

#### Does this PR introduce a user-facing change?

```release-note
Container stats for the fields NetInput and NetOutput were swapped. NetInput was showing outgoing traffic and NetOutput incoming traffic which is fixed now.
```

[NO NEW TESTS NEEDED]