### PR TITLE
libpod: Use O_CLOEXEC for descriptors returned by (*Container).openDi…

### DIFF
--- a/libpod/container_internal_freebsd.go
+++ b/libpod/container_internal_freebsd.go
@@ -186,7 +186,7 @@ func (c *Container) getOCICgroupPath() (string, error) {
 
 func openDirectory(path string) (fd int, err error) {
 	const O_PATH = 0x00400000
-	return unix.Open(path, unix.O_RDONLY|O_PATH, 0)
+	return unix.Open(path, unix.O_RDONLY|O_PATH|unix.O_CLOEXEC, 0)
 }
 
 func (c *Container) addNetworkNamespace(g *generate.Generator) error {


### PR DESCRIPTION
…rectory

Since mountStorage and createNetNS run in parallel, the directory file descriptors used by mountStorage were (rarely) propagated to the CNI plugins. On FreeBSD, the CNI bridge plugin needs to make changes to the network jail. This fails if there are any descriptors to open directories to protect against host directories being visible to the jail's chroot.

Adding O_CLOEXEC to the unix.Open call in openDirectory ensures that these descriptors are not visible to podman's child processes.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>

#### Does this PR introduce a user-facing change?

```release-note
None
```
