### PR TITLE
[v4.2.0-rhel] container restart: clean up healthcheck state

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1081,6 +1081,15 @@ func (c *Container) init(ctx context.Context, retainRetries bool) error {
 		c.state.RestartCount = 0
 	}
 
+	// bugzilla.redhat.com/show_bug.cgi?id=2144754:
+	// In case of a restart, make sure to remove the healthcheck log to
+	// have a clean state.
+	if path := c.healthCheckLogPath(); path != "" {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logrus.Error(err)
+		}
+	}
+
 	if err := c.save(); err != nil {
 		return err
 	}

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -130,13 +130,13 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search format json list tags", func() {
-		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", "alpine"})
+		search := podmanTest.Podman([]string{"search", "--list-tags", "--format", "json", ALPINE})
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
 		Expect(search.OutputToString()).To(BeValidJSON())
-		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
-		Expect(search.OutputToString()).To(ContainSubstring("3.10"))
-		Expect(search.OutputToString()).To(ContainSubstring("2.7"))
+		Expect(search.OutputToString()).To(ContainSubstring("quay.io/libpod/alpine"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.10.2"))
+		Expect(search.OutputToString()).To(ContainSubstring("3.2"))
 	})
 
 	// Test for https://github.com/containers/podman/issues/11894

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -77,7 +77,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		search.WaitWithDefaultTimeout()
 		Expect(search).Should(Exit(0))
 		Expect(len(search.OutputToStringArray())).To(BeNumerically(">", 1))
-		Expect(search.OutputToString()).To(ContainSubstring("docker.io/library/alpine"))
+		Expect(search.OutputToString()).To(ContainSubstring("alpine"))
 	})
 
 	It("podman search single registry flag", func() {

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -76,6 +76,34 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
     run_podman rmi   healthcheck_i
 }
 
+@test "podman healthcheck - restart cleans up old state" {
+    ctr="healthcheck_c"
+    img="healthcheck_i"
+
+    _build_health_check_image $img cleanfile
+    run_podman run -d --name $ctr      \
+           --health-cmd /healthcheck   \
+           --health-retries=2          \
+           --health-interval=disable   \
+           $img
+
+    run_podman container inspect $ctr --format "{{.State.Healthcheck.FailingStreak}}"
+    is "$output" "0" "Failing streak of fresh container should be 0"
+
+    # Get the healthcheck to fail
+    run_podman exec $ctr touch /uh-oh
+    run_podman 1 healthcheck run $ctr
+    is "$output" "unhealthy" "output from 'podman healthcheck run'"
+    run_podman container inspect $ctr --format "{{.State.Healthcheck.FailingStreak}}"
+    is "$output" "1" "Failing streak after one failed healthcheck should be 1"
+
+    run_podman container restart $ctr
+    run_podman container inspect $ctr --format "{{.State.Healthcheck.FailingStreak}}"
+    is "$output" "0" "Failing streak of restarted container should be 0 again"
+
+    run_podman rm -f -t0 $ctr
+}
+
 @test "podman healthcheck --health-on-failure" {
     run_podman 125 create --health-on-failure=kill $IMAGE
     is "$output" "Error: cannot set on-failure action to kill without a health check"
@@ -114,6 +142,8 @@ Log[-1].Output   | \"Uh-oh on stdout!\\\nUh-oh on stderr!\"
 	if [[ $policy == "restart" ]];then
 	    # Container has been restarted and health check works again
             is "$output" "running $policy" "container has been restarted"
+            run_podman container inspect $ctr --format "{{.State.Healthcheck.FailingStreak}}"
+            is "$output" "0" "Failing streak of restarted container should be 0 again"
             run_podman healthcheck run $ctr
         elif [[ $policy == "none" ]];then
             # Container is still running and health check still broken


### PR DESCRIPTION
When restarting a container, clean up the healthcheck state by removing the old log on disk.  Carrying over the old state can lead to various issues, for instance, in a wrong failing streak and hence wrong behaviour after the restart.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2144754
Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]". That will prevent functional tests from running and save time and energy.

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Clean up old healthcheck state during container restart.
```
